### PR TITLE
plumbing: object, fix date reading

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,3 +27,5 @@ require (
 	gopkg.in/src-d/go-git-fixtures.v3 v3.5.0
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
@@ -77,6 +78,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qq
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -138,17 +138,19 @@ func (s *Signature) decodeTimeAndTimeZone(b []byte) {
 		return
 	}
 
-	// Include a dummy year in this time.Parse() call to avoid a bug in Go:
-	// https://github.com/golang/go/issues/19750
-	//
-	// Parsing the timezone with no other details causes the tl.Location() call
-	// below to return time.Local instead of the parsed zone in some cases
-	tl, err := time.Parse("2006 -0700", "1970 "+string(b[tzStart:tzStart+timeZoneLength]))
-	if err != nil {
+	timezone := string(b[tzStart : tzStart+timeZoneLength])
+	tzhours, err1 := strconv.ParseInt(timezone[0:3], 10, 64)
+	tzmins, err2 := strconv.ParseInt(timezone[3:], 10, 64)
+	if err1 != nil || err2 != nil {
 		return
 	}
+	if tzhours < 0 {
+		tzmins *= -1
+	}
 
-	s.When = s.When.In(tl.Location())
+	tz := time.FixedZone("", int(tzhours*60*60+tzmins*60))
+
+	s.When = s.When.In(tz)
 }
 
 func (s *Signature) encodeTimeAndTimeZone(w io.Writer) error {


### PR DESCRIPTION
Original created by @zeripath at https://github.com/src-d/go-git/pull/1291

```
In the British TZ the following time:

1579639200 +0100
will be erroneously parsed as being with the GMT TZ.
This leads to multiple errors with GPG validation.

This PR fixes this by using the provided TZ information to
create a FixedZone and sets that as the TZ
```