### PR TITLE
Update COMPATIBILITY.md to reflect git binary usage for file protocol

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -101,7 +101,7 @@ is supported by go-git.
 | http(s):// (smart)                    | ✔ |
 | git://                                | ✔ |
 | ssh://                                | ✔ |
-| file://                               | ✔ |
+| file://                               | partial | Warning: this is not pure Golang. This shells out to the `git` binary. |
 | custom                                | ✔ |
 | **other features** |
 | gitignore                             | ✔ |


### PR DESCRIPTION
Copied from https://github.com/src-d/go-git/pull/1273

https://github.com/src-d/go-git/issues/847 should likely be re-filed - it would be great if this could be fixed, although I know it's a ton of work.