### PR TITLE
plumbing: transport server check for nil Packfile, fixes ref deletes

### DIFF
--- a/plumbing/transport/server/receive_pack_test.go
+++ b/plumbing/transport/server/receive_pack_test.go
@@ -1,8 +1,13 @@
 package server_test
 
 import (
+	"context"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 
+	fixtures "github.com/go-git/go-git-fixtures/v4"
 	. "gopkg.in/check.v1"
 )
 
@@ -30,4 +35,29 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists(c *C) {
 	r, err := s.Client.NewReceivePackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 	c.Assert(r, IsNil)
+}
+
+func (s *ReceivePackSuite) TestReceivePackWithNilPackfile(c *C) {
+	endpoint := s.Endpoint
+	auth := s.EmptyAuth
+
+	fixture := fixtures.Basic().ByTag("packfile").One()
+	req := packp.NewReferenceUpdateRequest()
+	req.Commands = []*packp.Command{
+		{Name: "refs/heads/newbranch", Old: plumbing.NewHash(fixture.Head), New: plumbing.ZeroHash},
+	}
+	// default is already nil, but be explicit since this is what the test is for
+	req.Packfile = nil
+
+	comment := Commentf(
+		"failed with ep=%s fixture=%s",
+		endpoint.String(), fixture.URL,
+	)
+
+	r, err := s.Client.NewReceivePackSession(endpoint, auth)
+	c.Assert(err, IsNil, comment)
+	defer func() { c.Assert(r.Close(), IsNil, comment) }()
+
+	report, err := r.ReceivePack(context.Background(), req)
+	c.Assert(report, IsNil, comment)
 }

--- a/plumbing/transport/server/server.go
+++ b/plumbing/transport/server/server.go
@@ -243,11 +243,13 @@ func (s *rpSession) ReceivePack(ctx context.Context, req *packp.ReferenceUpdateR
 
 	//TODO: Implement 'atomic' update of references.
 
-	r := ioutil.NewContextReadCloser(ctx, req.Packfile)
-	if err := s.writePackfile(r); err != nil {
-		s.unpackErr = err
-		s.firstErr = err
-		return s.reportStatus(), err
+	if req.Packfile != nil {
+		r := ioutil.NewContextReadCloser(ctx, req.Packfile)
+		if err := s.writePackfile(r); err != nil {
+			s.unpackErr = err
+			s.firstErr = err
+			return s.reportStatus(), err
+		}
 	}
 
 	s.updateReferences(req)


### PR DESCRIPTION
When a `Remote` receives a push with only delete commands, it sends a `nil` value for `Packfile` ([related code](https://github.com/go-git/go-git/blob/661b1ace8b4d2a387e2ae130bbb034e62cc8ce11/remote.go#L1064-L1079)), which results in a a `panic: runtime error: invalid memory address or nil pointer dereference` in the code below. This simply fixes that by skipping the processing if its `nil`.

It does seem there is already a test case covering deletes inside the `ReceivePackSuite`, however the [test sends an empty packfile](https://github.com/go-git/go-git/blob/661b1ace8b4d2a387e2ae130bbb034e62cc8ce11/plumbing/transport/test/receive_pack.go#L262) rather than sending `nil`.

If it would be better to update `Remote` to send a similar empty packfile please let me know and I'll be happy to make the update.

Also thanks for all the work here, we've been using go-git heavily for the last few weeks and its fantastic.