### PR TITLE
plumbing: format, config.Merged to allow access to local and global config

### DIFF
--- a/_examples/config/main.go
+++ b/_examples/config/main.go
@@ -50,10 +50,10 @@ func main() {
 	// suffice for what you're trying to do.
 
 	// Set local custom config param
-	cfg.Merged.LocalConfig().AddOption("custom", format.NoSubsection, "name", "Local Name")
+	cfg.Merged.AddOption(format.LocalScope, "custom", format.NoSubsection, "name", "Local Name")
 
 	// Set global config param (~/.gitconfig)
-	cfg.Merged.GlobalConfig().AddOption("custom", format.NoSubsection, "name", "Global Name")
+	cfg.Merged.AddOption(format.GlobalScope, "custom", format.NoSubsection, "name", "Global Name")
 
 	// Get custom config param (merged in the same way git does: system -> global -> local)
 	Info("custom.name is %s", cfg.Merged.Section("custom").Option("name"))

--- a/_examples/config/main.go
+++ b/_examples/config/main.go
@@ -45,6 +45,10 @@ func main() {
 
 	Info("origin remote: %+v", cfg.Remotes["origin"])
 
+	// NOTE: The examples below show advanced usage of the config.Merged system, which should
+	// only be used as a last resort if the basic data defined on the Config struct don't
+	// suffice for what you're trying to do.
+
 	// Set local custom config param
 	cfg.Merged.LocalConfig().AddOption("custom", format.NoSubsection, "name", "Local Name")
 

--- a/_examples/config/main.go
+++ b/_examples/config/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"github.com/go-git/go-git/v5"
+	. "github.com/go-git/go-git/v5/_examples"
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
+
+	"github.com/go-git/go-git/v5/config"
+)
+
+// Example of how to:
+// - Access basic local (i.e. ./.git/config) configuration params
+// - Set basic local config params
+// - Set custom local config params
+// - Access custom local config params
+// - Set global config params
+// - Access global & system config params
+
+func main() {
+	// Open this repository
+	// Info("git init")
+	// r, err := git.Init(memory.NewStorage(), nil)
+	Info("open local git repo")
+	r, err := git.PlainOpen(".")
+	CheckIfError(err)
+
+	// Load the configuration
+	cfg, err := r.Config()
+	CheckIfError(err)
+
+	// Get core local config params
+	if cfg.Core.IsBare {
+		Info("repo is bare")
+	} else {
+		Info("repo is not bare")
+	}
+
+	Info("worktree is %s", cfg.Core.Worktree)
+
+	// Set basic local config params
+	cfg.Remotes["origin"] = &config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@github.com:mcuadros/go-git.git"},
+	}
+
+	Info("origin remote: %+v", cfg.Remotes["origin"])
+
+	// Set local custom config param
+	cfg.Merged.LocalConfig().AddOption("custom", format.NoSubsection, "name", "Local Name")
+
+	// Set global config param (~/.gitconfig)
+	cfg.Merged.GlobalConfig().AddOption("custom", format.NoSubsection, "name", "Global Name")
+
+	// Get custom config param (merged in the same way git does: system -> global -> local)
+	Info("custom.name is %s", cfg.Merged.Section("custom").Option("name"))
+
+	// Get system config params (/etc/gitconfig)
+	systemSections := cfg.Merged.SystemConfig().Sections
+	for _, ss := range systemSections {
+		Info("System section: %s", ss.Name)
+		for _, o := range ss.Options {
+			Info("\tOption: %s = %s", o.Key, o.Value)
+		}
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	. "gopkg.in/check.v1"
 	"github.com/go-git/go-git/v5/plumbing"
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
 )
 
 type ConfigSuite struct{}
@@ -58,6 +59,76 @@ func (s *ConfigSuite) TestUnmarshal(c *C) {
 	c.Assert(cfg.Submodules["qux"].Branch, Equals, "bar")
 	c.Assert(cfg.Branches["master"].Remote, Equals, "origin")
 	c.Assert(cfg.Branches["master"].Merge, Equals, plumbing.ReferenceName("refs/heads/master"))
+}
+
+func (s *ConfigSuite) TestMergedUnmarshal(c *C) {
+	localInput := []byte(`[core]
+        bare = true
+		worktree = foo
+		commentchar = bar
+[pack]
+		window = 20
+[remote "origin"]
+        url = git@github.com:mcuadros/go-git.git
+        fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "alt"]
+		url = git@github.com:mcuadros/go-git.git
+		url = git@github.com:src-d/go-git.git
+		fetch = +refs/heads/*:refs/remotes/origin/*
+		fetch = +refs/pull/*:refs/remotes/origin/pull/*
+[remote "win-local"]
+		url = X:\\Git\\
+[submodule "qux"]
+        path = qux
+        url = https://github.com/foo/qux.git
+		branch = bar
+[branch "master"]
+        remote = origin
+        merge = refs/heads/master
+[user]
+		name = Override
+`)
+
+	globalInput := []byte(`
+[user]
+		name = Soandso
+		email = soandso@example.com
+[core]
+        editor = nvim
+[push]
+        default = simple
+`)
+
+	cfg := NewConfig()
+
+	err := cfg.UnmarshalScoped(format.LocalScope, localInput)
+	c.Assert(err, IsNil)
+
+	err = cfg.UnmarshalScoped(format.GlobalScope, globalInput)
+	c.Assert(err, IsNil)
+
+	c.Assert(cfg.Core.IsBare, Equals, true)
+	c.Assert(cfg.Core.Worktree, Equals, "foo")
+	c.Assert(cfg.Core.CommentChar, Equals, "bar")
+	c.Assert(cfg.Pack.Window, Equals, uint(20))
+	c.Assert(cfg.Remotes, HasLen, 3)
+	c.Assert(cfg.Remotes["origin"].Name, Equals, "origin")
+	c.Assert(cfg.Remotes["origin"].URLs, DeepEquals, []string{"git@github.com:mcuadros/go-git.git"})
+	c.Assert(cfg.Remotes["origin"].Fetch, DeepEquals, []RefSpec{"+refs/heads/*:refs/remotes/origin/*"})
+	c.Assert(cfg.Remotes["alt"].Name, Equals, "alt")
+	c.Assert(cfg.Remotes["alt"].URLs, DeepEquals, []string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"})
+	c.Assert(cfg.Remotes["alt"].Fetch, DeepEquals, []RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"})
+	c.Assert(cfg.Remotes["win-local"].Name, Equals, "win-local")
+	c.Assert(cfg.Remotes["win-local"].URLs, DeepEquals, []string{"X:\\Git\\"})
+	c.Assert(cfg.Submodules, HasLen, 1)
+	c.Assert(cfg.Submodules["qux"].Name, Equals, "qux")
+	c.Assert(cfg.Submodules["qux"].URL, Equals, "https://github.com/foo/qux.git")
+	c.Assert(cfg.Submodules["qux"].Branch, Equals, "bar")
+	c.Assert(cfg.Branches["master"].Remote, Equals, "origin")
+	c.Assert(cfg.Branches["master"].Merge, Equals, plumbing.ReferenceName("refs/heads/master"))
+	c.Assert(cfg.Merged.Section("user").Option("name"), Equals, "Override")
+	c.Assert(cfg.Merged.Section("user").Option("email"), Equals, "soandso@example.com")
+	c.Assert(cfg.Merged.Section("push").Option("default"), Equals, "simple")
 }
 
 func (s *ConfigSuite) TestMarshal(c *C) {
@@ -117,6 +188,95 @@ func (s *ConfigSuite) TestMarshal(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(string(b), Equals, string(output))
+}
+
+func (s *ConfigSuite) TestMergedMarshal(c *C) {
+	localOutput := []byte(`[user]
+	name = Override
+[custom]
+	key = value
+[core]
+	bare = true
+	worktree = bar
+[pack]
+	window = 20
+[remote "alt"]
+	url = git@github.com:mcuadros/go-git.git
+	url = git@github.com:src-d/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/pull/*:refs/remotes/origin/pull/*
+[remote "origin"]
+	url = git@github.com:mcuadros/go-git.git
+[remote "win-local"]
+	url = "X:\\Git\\"
+[submodule "qux"]
+	url = https://github.com/foo/qux.git
+[branch "master"]
+	remote = origin
+	merge = refs/heads/master
+`)
+
+	globalOutput := []byte(`[user]
+	name = Soandso
+	email = soandso@example.com
+[core]
+	editor = nvim
+[push]
+	default = simple
+`)
+
+	cfg := NewConfig()
+
+	cfg.Core.IsBare = true
+	cfg.Core.Worktree = "bar"
+	cfg.Pack.Window = 20
+	cfg.Remotes["origin"] = &RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@github.com:mcuadros/go-git.git"},
+	}
+
+	cfg.Remotes["alt"] = &RemoteConfig{
+		Name:  "alt",
+		URLs:  []string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"},
+		Fetch: []RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"},
+	}
+
+	cfg.Remotes["win-local"] = &RemoteConfig{
+		Name: "win-local",
+		URLs: []string{"X:\\Git\\"},
+	}
+
+	cfg.Submodules["qux"] = &Submodule{
+		Name: "qux",
+		URL:  "https://github.com/foo/qux.git",
+	}
+
+	cfg.Branches["master"] = &Branch{
+		Name:   "master",
+		Remote: "origin",
+		Merge:  "refs/heads/master",
+	}
+
+	cfg.Merged.GlobalConfig().Section("user").SetOption("name", "Soandso")
+	cfg.Merged.LocalConfig().Section("user").SetOption("name", "Override")
+	cfg.Merged.GlobalConfig().Section("user").SetOption("email", "soandso@example.com")
+	cfg.Merged.GlobalConfig().Section("core").AddOption("editor", "nvim")
+	cfg.Merged.LocalConfig().Section("custom").SetOption("key", "value")
+	cfg.Merged.GlobalConfig().Section("push").AddOption("default", "simple")
+
+	c.Assert(cfg.Merged.Section("user").Option("name"), Equals, "Override")
+
+	localBytes, err := cfg.Marshal()
+	c.Assert(err, IsNil)
+	c.Assert(string(localBytes), Equals, string(localOutput))
+
+	globalBytes, err := cfg.MarshalScope(format.GlobalScope)
+	c.Assert(err, IsNil)
+	c.Assert(string(globalBytes), Equals, string(globalOutput))
+
+	systemBytes, err := cfg.MarshalScope(format.SystemScope)
+	c.Assert(err, IsNil)
+	c.Assert(string(systemBytes), Equals, "")
 }
 
 func (s *ConfigSuite) TestUnmarshalMarshal(c *C) {

--- a/plumbing/format/config/merged.go
+++ b/plumbing/format/config/merged.go
@@ -1,0 +1,215 @@
+package config
+
+type Scope int
+
+const (
+	LocalScope Scope = iota
+	GlobalScope
+	SystemScope
+)
+
+type ScopedConfigs map[Scope]*Config
+
+type Merged struct {
+	scopedConfigs ScopedConfigs
+}
+
+type MergedSection struct {
+	backingSection *Section
+}
+
+type MergedSubsection struct {
+	backingSubsection *Subsection
+}
+
+type MergedSubsections []*MergedSubsection
+
+func NewMerged() *Merged {
+	cfg := &Merged{
+		scopedConfigs: make(ScopedConfigs),
+	}
+	for s := LocalScope; s <= SystemScope; s++ {
+		cfg.scopedConfigs[s] = New()
+	}
+
+	return cfg
+}
+
+func (m *Merged) ResetScopedConfig(scope Scope) {
+	m.scopedConfigs[scope] = New()
+}
+
+func (m *Merged) ScopedConfig(scope Scope) *Config {
+	return m.scopedConfigs[scope]
+}
+
+func (m *Merged) LocalConfig() *Config {
+	return m.ScopedConfig(LocalScope)
+}
+
+func (m *Merged) GlobalConfig() *Config {
+	return m.ScopedConfig(GlobalScope)
+}
+
+func (m *Merged) SystemConfig() *Config {
+	return m.ScopedConfig(SystemScope)
+}
+
+// Config.Section creates the section if it doesn't exist, which is not
+// what we want in here.
+func (c *Config) hasSection(name string) bool {
+	sections := c.Sections
+	var found bool
+
+	for _, s := range sections {
+		if s.IsName(name) {
+			found = true
+			break
+		}
+	}
+
+	return found
+}
+
+func (m *Merged) Section(name string) *MergedSection {
+	var mergedSection *MergedSection
+
+	for s := SystemScope; s >= LocalScope; s-- {
+		if m.scopedConfigs[s].hasSection(name) {
+			sec := m.scopedConfigs[s].Section(name)
+			if mergedSection == nil {
+				mergedSection = NewMergedSection(sec)
+			}
+
+			if mergedSection.Options() == nil {
+				mergedSection.backingSection.Options = sec.Options
+			} else {
+				for _, o := range sec.Options {
+					mergedSection.backingSection.SetOption(o.Key, o.Value)
+				}
+			}
+
+			if mergedSection.Subsections() == nil {
+				mergedSection.backingSection.Subsections = sec.Subsections
+			} else {
+				for _, ss := range sec.Subsections {
+					if mergedSection.HasSubsection(ss.Name) {
+						for _, o := range ss.Options {
+							mergedSection.backingSection.Subsection(ss.Name).SetOption(o.Key, o.Value)
+						}
+					} else {
+						mergedSection.backingSection.Subsections = append(mergedSection.backingSection.Subsections, ss)
+					}
+				}
+			}
+		}
+	}
+
+	if mergedSection != nil {
+		mergedSection.backingSection.Name = name
+	}
+
+	return mergedSection
+}
+
+func (m *Merged) AddOption(scope Scope, section string, subsection string, key string, value string) *Config {
+	return m.ScopedConfig(scope).AddOption(section, subsection, key, value)
+}
+
+func (m *Merged) SetOption(scope Scope, section string, subsection string, key string, value string) *Config {
+	return m.ScopedConfig(scope).SetOption(section, subsection, key, value)
+}
+
+func (m *Merged) RemoveSection(scope Scope, name string) *Config {
+	return m.ScopedConfig(scope).RemoveSection(name)
+}
+
+func (m *Merged) RemoveSubsection(scope Scope, section string, subsection string) *Config {
+	return m.ScopedConfig(scope).RemoveSubsection(section, subsection)
+}
+
+func copyOptions(os Options) Options {
+	copiedOptions := make(Options, 0)
+
+	for _, o := range os {
+		copiedOptions = append(copiedOptions, o)
+	}
+
+	return copiedOptions
+}
+
+func copySubsections(ss Subsections) Subsections {
+	copiedSubsections := make(Subsections, 0)
+
+	for _, ss := range ss {
+		copiedSubsections = append(copiedSubsections, &Subsection{
+			Name:    ss.Name,
+			Options: copyOptions(ss.Options),
+		})
+	}
+
+	return copiedSubsections
+}
+
+func NewMergedSection(backing *Section) *MergedSection {
+	return &MergedSection{
+		backingSection: &Section{
+			Name: backing.Name,
+			Options: copyOptions(backing.Options),
+			Subsections: copySubsections(backing.Subsections),
+		},
+	}
+}
+
+func (ms *MergedSection) Name() string {
+	return ms.backingSection.Name
+}
+
+func (ms *MergedSection) IsName(name string) bool {
+	return ms.backingSection.IsName(name)
+}
+
+func (ms *MergedSection) Options() []*Option {
+	return ms.backingSection.Options
+}
+
+func (ms *MergedSection) Option(key string) string {
+	return ms.backingSection.Option(key)
+}
+
+func (ms *MergedSection) Subsections() MergedSubsections {
+	mss := make(MergedSubsections, 0)
+	for _, ss := range ms.backingSection.Subsections {
+		mss = append(mss, NewMergedSubsection(ss))
+	}
+	return mss
+}
+
+func (ms *MergedSection) Subsection(name string) *MergedSubsection {
+	return NewMergedSubsection(ms.backingSection.Subsection(name))
+}
+
+func (ms *MergedSection) HasSubsection(name string) bool {
+	return ms.backingSection.HasSubsection(name)
+}
+
+func NewMergedSubsection(backing *Subsection) *MergedSubsection {
+	return &MergedSubsection{backingSubsection: backing}
+}
+
+func (mss *MergedSubsection) Name() string {
+	return mss.backingSubsection.Name
+}
+
+func (mss *MergedSubsection) IsName(name string) bool {
+	return mss.backingSubsection.IsName(name)
+}
+
+func (mss *MergedSubsection) Options() []*Option {
+	return mss.backingSubsection.Options
+}
+
+func (mss *MergedSubsection) Option(key string) string {
+	return mss.backingSubsection.Option(key)
+}
+

--- a/plumbing/format/config/merged.go
+++ b/plumbing/format/config/merged.go
@@ -55,6 +55,14 @@ func (m *Merged) SystemConfig() *Config {
 	return m.ScopedConfig(SystemScope)
 }
 
+func (m *Merged) SetLocalConfig(c *Config) {
+	m.scopedConfigs[LocalScope] = c
+}
+
+func (m *Merged) SetGlobalConfig(c *Config) {
+	m.scopedConfigs[GlobalScope] = c
+}
+
 // Config.Section creates the section if it doesn't exist, which is not
 // what we want in here.
 func (c *Config) hasSection(name string) bool {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -21,15 +21,17 @@ import (
 )
 
 const (
-	suffix         = ".git"
-	packedRefsPath = "packed-refs"
-	configPath     = "config"
-	indexPath      = "index"
-	shallowPath    = "shallow"
-	modulePath     = "modules"
-	objectsPath    = "objects"
-	packPath       = "pack"
-	refsPath       = "refs"
+	suffix           = ".git"
+	packedRefsPath   = "packed-refs"
+	localConfigPath  = "config"
+	globalConfigPath = ".gitconfig"
+	systemConfigPath = "/etc/gitconfig"
+	indexPath        = "index"
+	shallowPath      = "shallow"
+	modulePath       = "modules"
+	objectsPath      = "objects"
+	packPath         = "pack"
+	refsPath         = "refs"
 
 	tmpPackedRefsPrefix = "._packed-refs"
 
@@ -152,14 +154,32 @@ func (d *DotGit) Close() error {
 	return nil
 }
 
-// ConfigWriter returns a file pointer for write to the config file
-func (d *DotGit) ConfigWriter() (billy.File, error) {
-	return d.fs.Create(configPath)
+// LocalConfigWriter returns a file pointer for write to the local config file
+func (d *DotGit) LocalConfigWriter() (billy.File, error) {
+	return d.fs.Create(localConfigPath)
 }
 
-// Config returns a file pointer for read to the config file
-func (d *DotGit) Config() (billy.File, error) {
-	return d.fs.Open(configPath)
+// LocalConfig returns a file pointer for read to the local config file
+func (d *DotGit) LocalConfig() (billy.File, error) {
+	return d.fs.Open(localConfigPath)
+}
+
+// GlobalConfigWriter returns a file pointer for write to the global config file
+func (d *DotGit) GlobalConfigWriter() (billy.File, error) {
+	return osfs.New(os.Getenv("HOME")).Create(globalConfigPath)
+}
+
+// GlobalConfig returns a file pointer for read to the global config file
+func (d *DotGit) GlobalConfig() (billy.File, error) {
+	return osfs.New(os.Getenv("HOME")).Open(globalConfigPath)
+}
+
+// SystemConfigWriter doesn't exist because we typically do not have permission
+// to write to files in /etc.
+
+// SystemConfig returns a file pointer for read to the system config file
+func (d *DotGit) SystemConfig() (billy.File, error) {
+	return osfs.New("/").Open(systemConfigPath)
 }
 
 // IndexWriter returns a file pointer for write to the index file

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -332,7 +332,7 @@ func (s *SuiteDotGit) TestConfig(c *C) {
 	fs := fixtures.Basic().ByTag(".git").One().DotGit()
 	dir := New(fs)
 
-	file, err := dir.Config()
+	file, err := dir.LocalConfig()
 	c.Assert(err, IsNil)
 	c.Assert(filepath.Base(file.Name()), Equals, "config")
 }
@@ -345,13 +345,13 @@ func (s *SuiteDotGit) TestConfigWriteAndConfig(c *C) {
 	fs := osfs.New(tmp)
 	dir := New(fs)
 
-	f, err := dir.ConfigWriter()
+	f, err := dir.LocalConfigWriter()
 	c.Assert(err, IsNil)
 
 	_, err = f.Write([]byte("foo"))
 	c.Assert(err, IsNil)
 
-	f, err = dir.Config()
+	f, err = dir.LocalConfig()
 	c.Assert(err, IsNil)
 
 	cnt, err := ioutil.ReadAll(f)


### PR DESCRIPTION
...for reading and writing global (`~/.gitconfig`) and reading system (`/etc/gitconfig`) configs in addition to local repo config.

This is heavily based on / inspired by @djgilcrease's PR on the original src-d repo: https://github.com/src-d/go-git/pull/1243. However, I ran into an issue using that code where if you ran `SetConfig` it would write out the merged system, global, and local config params all to your local `./.git/config` file, which was hard to fix under that architecture.

So, I tried to take a simpler starting approach with this PR but still allow it to accomplish my 2 goals:
1. Show a merged view of system (`/etc/gitconfig`), global (`~/.gitconfig`), and local (`./.git/config`) configs with the same precedence ordering that git itself uses (local overrides global overrides system).
1. Allow setting / changing options in any of these files (with the exception of setting system options b/c we typically won't have permission to write to that file).

The way I did this was basically to leave the higher-level config stuff (e.g. `.Remotes`, `.Core.IsBare`) alone and add a new `.Merged` param that works similarly to `.Raw` but brings in these other configs. So now you can see the merged view with things like `.Merged.Section("foo").Option("bar")` (which is all read-only) or set options with things like `.Merged.GlobalConfig().AddOption(...)`. `.Raw` now delegates to `.Merged.LocalConfig()`.

I added a config example to demonstrate some of the usage and a couple of tests of marshalling and unmarshalling the different configs.