### PR TITLE
Feature: user config attrs

### DIFF
--- a/plumbing/format/config/merged.go
+++ b/plumbing/format/config/merged.go
@@ -9,9 +9,10 @@ package config
 // resides in the /etc/gitconfig file.
 type Scope int
 const (
-	LocalScope Scope = iota
+	SystemScope Scope = iota
 	GlobalScope
-	SystemScope
+	LocalScope
+	NumScopes
 )
 
 type ScopedConfigs map[Scope]*Config
@@ -42,7 +43,7 @@ func NewMerged() *Merged {
 	cfg := &Merged{
 		scopedConfigs: make(ScopedConfigs),
 	}
-	for s := LocalScope; s <= SystemScope; s++ {
+	for s := SystemScope; s <= LocalScope; s++ {
 		cfg.scopedConfigs[s] = New()
 	}
 
@@ -112,7 +113,7 @@ func (c *Config) hasSection(name string) bool {
 func (m *Merged) Section(name string) *MergedSection {
 	var mergedSection *MergedSection
 
-	for s := SystemScope; s >= LocalScope; s-- {
+	for s := SystemScope; s <= LocalScope; s++ {
 		if m.scopedConfigs[s].hasSection(name) {
 			sec := m.scopedConfigs[s].Section(name)
 			if mergedSection == nil {


### PR DESCRIPTION
This builds on my earlier PR #20 to add top-level config attrs `User`, `Author`, and `Committer`. These work a little differently from the others by necessity because they are scoped (i.e. they can appear in local, global, and/or system config files). So this also demonstrates one way in which we could add more such scoped values to the top-level config.

These new config attributes store `ScopedString`s and (in the case of `User.UseConfigOnly`) a `ScopedBool`. These have `Value()` and `Set(scope, val)` methods. `Value` gets the effective value that git would use based on the config scope precedence and `Set` allows setting values w/ their scopes so we have that to keep track of.

I think ultimately this and #20 point towards a bigger config overhaul for a v6+ release that is centered around interfaces rather than structs. So, for example, calling a method like `cfg.User.Name()` could look up the effective name value from inside the scoped config data structures rather than having to copy values back and forth from the raw / merged backing data and the top-level config struct.