### PR TITLE
examples: config, Show how to save config changes

### DIFF
--- a/_examples/config/main.go
+++ b/_examples/config/main.go
@@ -58,6 +58,10 @@ func main() {
 	// Get custom config param (merged in the same way git does: system -> global -> local)
 	Info("custom.name is %s", cfg.Merged.Section("custom").Option("name"))
 
+	//In order to save the config file, you need to call SetConfig
+	//After calling this go to .git/config and see the custom.name added and the changes to the remote
+	r.Storer.SetConfig(cfg)
+
 	// Get system config params (/etc/gitconfig)
 	systemSections := cfg.Merged.SystemConfig().Sections
 	for _, ss := range systemSections {


### PR DESCRIPTION
It took me a few hours and going through the code of go-git to figure out I need to call `SetConfig` in order for the config changes to be applied to the local config file.
Especially that when doing `CreateRemote` the call to `SetConfig` is actually done behind the scene so the remote appeared in the file. While for the user local settings I had to actually call `SetConfig` myself.
Hope this will save someone a few hours or at least minutes of troubleshooting.