### PR TITLE
storage/filesystem: dotgit, sanity check provided reference path 

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -59,6 +59,9 @@ var (
 	// targeting a non-existing object. This usually means the repository
 	// is corrupt.
 	ErrSymRefTargetNotFound = errors.New("symbolic reference target not found")
+	// ErrIsDir is returned when a reference file is attempting to be read,
+	// but the path specified is a directory.
+	ErrIsDir = errors.New("reference path is a directory")
 )
 
 // Options holds configuration for the storage.
@@ -946,6 +949,14 @@ func (d *DotGit) addRefFromHEAD(refs *[]*plumbing.Reference) error {
 
 func (d *DotGit) readReferenceFile(path, name string) (ref *plumbing.Reference, err error) {
 	path = d.fs.Join(path, d.fs.Join(strings.Split(name, "/")...))
+	st, err := d.fs.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if st.IsDir() {
+		return nil, ErrIsDir
+	}
+
 	f, err := d.fs.Open(path)
 	if err != nil {
 		return nil, err

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -93,9 +93,15 @@ func testSetRefs(c *C, dir *DotGit) {
 	), nil)
 	c.Assert(err, IsNil)
 
+	err = dir.SetRef(plumbing.NewReferenceFromStrings(
+		"refs/heads/feature/baz",
+		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
+	), nil)
+	c.Assert(err, IsNil)
+
 	refs, err := dir.Refs()
 	c.Assert(err, IsNil)
-	c.Assert(refs, HasLen, 2)
+	c.Assert(refs, HasLen, 3)
 
 	ref := findReference(refs, "refs/heads/foo")
 	c.Assert(ref, NotNil)
@@ -107,6 +113,12 @@ func testSetRefs(c *C, dir *DotGit) {
 
 	ref = findReference(refs, "bar")
 	c.Assert(ref, IsNil)
+
+	_, err = dir.readReferenceFile(".", "refs/heads/feature/baz")
+	c.Assert(err, IsNil)
+
+	_, err = dir.readReferenceFile(".", "refs/heads/feature")
+	c.Assert(err, NotNil)
 
 	ref, err = dir.Ref("refs/heads/foo")
 	c.Assert(err, IsNil)

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -118,7 +118,7 @@ func testSetRefs(c *C, dir *DotGit) {
 	c.Assert(err, IsNil)
 
 	_, err = dir.readReferenceFile(".", "refs/heads/feature")
-	c.Assert(err, NotNil)
+	c.Assert(err, Equals, ErrIsDir)
 
 	ref, err = dir.Ref("refs/heads/foo")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Described in finer detail in the commit messages, readReferenceFile() where the path resolves to a directory succeeds on FreeBSD. The root of the problem is that on the other platforms go-git operates on, read() on a dir fd will fail and thus readReferenceFile() will fail.

This small series amends an existing test to demonstrate the problem (the assert at dotgit_test.go:121 will fail the test on FreeBSD), then fixes it by sanity-checking with Stat() that we're not looking at a directory. The second commit fixes up the test to ensure that readReferenceFile() is returning the specific error we're adding, rather than just any error.

This was noticed when Gitea on FreeBSD would 500 while attempting to read a branch with a `/` in any part of the name, as it would split and readReferenceFile() at each component until it got success; which always happened immediately here, despite the first component being a directory.