### PR TITLE
Add initial colored diff support

### DIFF
--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,0 +1,38 @@
+package color
+
+// TODO read colors from a github.com/go-git/go-git/plumbing/format/config.Config struct
+// TODO implement color parsing, see https://github.com/git/git/blob/v2.26.2/color.c
+
+// Colors. See https://github.com/git/git/blob/v2.26.2/color.h#L24-L53.
+const (
+	Normal       = ""
+	Reset        = "\033[m"
+	Bold         = "\033[1m"
+	Red          = "\033[31m"
+	Green        = "\033[32m"
+	Yellow       = "\033[33m"
+	Blue         = "\033[34m"
+	Magenta      = "\033[35m"
+	Cyan         = "\033[36m"
+	BoldRed      = "\033[1;31m"
+	BoldGreen    = "\033[1;32m"
+	BoldYellow   = "\033[1;33m"
+	BoldBlue     = "\033[1;34m"
+	BoldMagenta  = "\033[1;35m"
+	BoldCyan     = "\033[1;36m"
+	FaintRed     = "\033[2;31m"
+	FaintGreen   = "\033[2;32m"
+	FaintYellow  = "\033[2;33m"
+	FaintBlue    = "\033[2;34m"
+	FaintMagenta = "\033[2;35m"
+	FaintCyan    = "\033[2;36m"
+	BgRed        = "\033[41m"
+	BgGreen      = "\033[42m"
+	BgYellow     = "\033[43m"
+	BgBlue       = "\033[44m"
+	BgMagenta    = "\033[45m"
+	BgCyan       = "\033[46m"
+	Faint        = "\033[2m"
+	FaintItalic  = "\033[2;3m"
+	Reverse      = "\033[7m"
+)

--- a/plumbing/format/diff/colorconfig.go
+++ b/plumbing/format/diff/colorconfig.go
@@ -1,0 +1,96 @@
+package diff
+
+import "github.com/go-git/go-git/v5/internal/color"
+
+// A ColorKey is a key into a ColorConfig map and also equal to the key in the
+// diff.color subsection of the config. See
+// https://github.com/git/git/blob/v2.26.2/diff.c#L83-L106.
+type ColorKey string
+
+// ColorKeys.
+const (
+	Context                   ColorKey = "context"
+	Meta                      ColorKey = "meta"
+	Frag                      ColorKey = "frag"
+	Old                       ColorKey = "old"
+	New                       ColorKey = "new"
+	Commit                    ColorKey = "commit"
+	Whitespace                ColorKey = "whitespace"
+	Func                      ColorKey = "func"
+	OldMoved                  ColorKey = "oldMoved"
+	OldMovedAlternative       ColorKey = "oldMovedAlternative"
+	OldMovedDimmed            ColorKey = "oldMovedDimmed"
+	OldMovedAlternativeDimmed ColorKey = "oldMovedAlternativeDimmed"
+	NewMoved                  ColorKey = "newMoved"
+	NewMovedAlternative       ColorKey = "newMovedAlternative"
+	NewMovedDimmed            ColorKey = "newMovedDimmed"
+	NewMovedAlternativeDimmed ColorKey = "newMovedAlternativeDimmed"
+	ContextDimmed             ColorKey = "contextDimmed"
+	OldDimmed                 ColorKey = "oldDimmed"
+	NewDimmed                 ColorKey = "newDimmed"
+	ContextBold               ColorKey = "contextBold"
+	OldBold                   ColorKey = "oldBold"
+	NewBold                   ColorKey = "newBold"
+)
+
+// A ColorConfig is a color configuration. A nil or empty ColorConfig
+// corresponds to no color.
+type ColorConfig map[ColorKey]string
+
+// A ColorConfigOption sets an option on a ColorConfig.
+type ColorConfigOption func(ColorConfig)
+
+// WithColor sets the color for key.
+func WithColor(key ColorKey, color string) ColorConfigOption {
+	return func(cc ColorConfig) {
+		cc[key] = color
+	}
+}
+
+// defaultColorConfig is the default color configuration. See
+// https://github.com/git/git/blob/v2.26.2/diff.c#L57-L81.
+var defaultColorConfig = ColorConfig{
+	Context:                   color.Normal,
+	Meta:                      color.Bold,
+	Frag:                      color.Cyan,
+	Old:                       color.Red,
+	New:                       color.Green,
+	Commit:                    color.Yellow,
+	Whitespace:                color.BgRed,
+	Func:                      color.Normal,
+	OldMoved:                  color.BoldMagenta,
+	OldMovedAlternative:       color.BoldBlue,
+	OldMovedDimmed:            color.Faint,
+	OldMovedAlternativeDimmed: color.FaintItalic,
+	NewMoved:                  color.BoldCyan,
+	NewMovedAlternative:       color.BoldYellow,
+	NewMovedDimmed:            color.Faint,
+	NewMovedAlternativeDimmed: color.FaintItalic,
+	ContextDimmed:             color.Faint,
+	OldDimmed:                 color.FaintRed,
+	NewDimmed:                 color.FaintGreen,
+	ContextBold:               color.Bold,
+	OldBold:                   color.BoldRed,
+	NewBold:                   color.BoldGreen,
+}
+
+// NewColorConfig returns a new ColorConfig.
+func NewColorConfig(options ...ColorConfigOption) ColorConfig {
+	cc := make(ColorConfig)
+	for key, value := range defaultColorConfig {
+		cc[key] = value
+	}
+	for _, option := range options {
+		option(cc)
+	}
+	return cc
+}
+
+// Reset returns the ANSI escape sequence to reset a color set from cc. If cc is
+// nil or empty then no reset is needed so it returns the empty string.
+func (cc ColorConfig) Reset() string {
+	if len(cc) == 0 {
+		return ""
+	}
+	return color.Reset
+}


### PR DESCRIPTION
Fixes #33.

This is a draft PR. Please tell me if it more-or-less follows the project's coding style and what changes are likely to be needed to make it more acceptable.

At the moment, it only supports the default git diff colors as defined by git 2.26.2. It should be extensible to reading custom colors from a git config file, if needed.

Before merging, this needs a few tweaks to ensure the output matches git's as far as reasonably possible.