### PR TITLE
plumbing: object, make renames diff default

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -78,6 +78,9 @@ func (c *Commit) Tree() (*Tree, error) {
 
 // PatchContext returns the Patch between the actual commit and the provided one.
 // Error will be return if context expires. Provided context must be non-nil.
+//
+// NOTE: Since version 5.1.0 the renames are correctly handled, the settings
+// used are the recommended options DefaultDiffTreeOptions.
 func (c *Commit) PatchContext(ctx context.Context, to *Commit) (*Patch, error) {
 	fromTree, err := c.Tree()
 	if err != nil {
@@ -93,6 +96,9 @@ func (c *Commit) PatchContext(ctx context.Context, to *Commit) (*Patch, error) {
 }
 
 // Patch returns the Patch between the actual commit and the provided one.
+//
+// NOTE: Since version 5.1.0 the renames are correctly handled, the settings
+// used are the recommended options DefaultDiffTreeOptions.
 func (c *Commit) Patch(to *Commit) (*Patch, error) {
 	return c.PatchContext(context.Background(), to)
 }

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -304,29 +304,34 @@ func (t *Tree) buildMap() {
 }
 
 // Diff returns a list of changes between this tree and the provided one
-func (from *Tree) Diff(to *Tree) (Changes, error) {
-	return DiffTree(from, to)
+func (t *Tree) Diff(to *Tree) (Changes, error) {
+	return t.DiffContext(context.Background(), to)
 }
 
-// Diff returns a list of changes between this tree and the provided one
-// Error will be returned if context expires
-// Provided context must be non nil
-func (from *Tree) DiffContext(ctx context.Context, to *Tree) (Changes, error) {
-	return DiffTreeContext(ctx, from, to)
-}
-
-// Patch returns a slice of Patch objects with all the changes between trees
-// in chunks. This representation can be used to create several diff outputs.
-func (from *Tree) Patch(to *Tree) (*Patch, error) {
-	return from.PatchContext(context.Background(), to)
+// DiffContext returns a list of changes between this tree and the provided one
+// Error will be returned if context expires. Provided context must be non nil.
+//
+// NOTE: Since version 5.1.0 the renames are correctly handled, the settings
+// used are the recommended options DefaultDiffTreeOptions.
+func (t *Tree) DiffContext(ctx context.Context, to *Tree) (Changes, error) {
+	return DiffTreeWithOptions(ctx, t, to, DefaultDiffTreeOptions)
 }
 
 // Patch returns a slice of Patch objects with all the changes between trees
 // in chunks. This representation can be used to create several diff outputs.
-// If context expires, an error will be returned
-// Provided context must be non-nil
-func (from *Tree) PatchContext(ctx context.Context, to *Tree) (*Patch, error) {
-	changes, err := DiffTreeContext(ctx, from, to)
+func (t *Tree) Patch(to *Tree) (*Patch, error) {
+	return t.PatchContext(context.Background(), to)
+}
+
+// PatchContext returns a slice of Patch objects with all the changes between
+// trees in chunks. This representation can be used to create several diff
+// outputs. If context expires, an error will be returned. Provided context must
+// be non-nil.
+//
+// NOTE: Since version 5.1.0 the renames are correctly handled, the settings
+// used are the recommended options DefaultDiffTreeOptions.
+func (t *Tree) PatchContext(ctx context.Context, to *Tree) (*Patch, error) {
+	changes, err := t.DiffContext(ctx, to)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes the renames detect general available in the `Commit` and `Tree` objects. Making the old behavior optimal. This is a change of behavior than maybe consider breaking changes, but it's an improvement over the previous diff and aligns it with the expected behavior of the function. If still some need access to the old logic can be used.