### PR TITLE
plumbing: exact renames detection could leave gaps in the changes

### DIFF
--- a/plumbing/object/rename.go
+++ b/plumbing/object/rename.go
@@ -177,14 +177,14 @@ func (d *renameDetector) detectExactRenames() {
 			}
 
 			for _, c := range added {
-				if _, ok := usedAdds[c]; !ok {
+				if _, ok := usedAdds[c]; !ok && c != nil {
 					addedLeft = append(addedLeft, c)
 				}
 			}
 
 			var newDeletes = make([]*Change, 0, len(deleted)-len(usedDeletes))
 			for _, c := range deleted {
-				if _, ok := usedDeletes[c]; !ok {
+				if _, ok := usedDeletes[c]; !ok && c != nil {
 					newDeletes = append(newDeletes, c)
 				}
 			}
@@ -197,11 +197,7 @@ func (d *renameDetector) detectExactRenames() {
 	d.added = addedLeft
 	d.deleted = nil
 	for _, dels := range deletes {
-		for _, del := range dels {
-			if del != nil {
-				d.deleted = append(d.deleted, del)
-			}
-		}
+		d.deleted = append(d.deleted, dels...)
 	}
 }
 
@@ -713,7 +709,7 @@ func (i *similarityIndex) common(dst *similarityIndex) uint64 {
 }
 
 func (i *similarityIndex) add(key int, cnt uint64) error {
-	key = int(uint32(key)*0x9e370001 >> 1)
+	key = int(uint32(key) * 0x9e370001 >> 1)
 
 	j := i.slot(key)
 	for {

--- a/plumbing/object/rename_test.go
+++ b/plumbing/object/rename_test.go
@@ -271,6 +271,32 @@ func (s *RenameSuite) TestRenameLimit(c *C) {
 	}
 }
 
+func (s *RenameSuite) TestRenameExactManyAddsManyDeletesNoGaps(c *C) {
+	content := "a"
+	detector := &renameDetector{
+		added: []*Change{
+			makeAdd(c, makeFile(c, pathA, filemode.Regular, content)),
+			makeAdd(c, makeFile(c, pathQ, filemode.Regular, content)),
+			makeAdd(c, makeFile(c, "something", filemode.Regular, content)),
+		},
+		deleted: []*Change{
+			makeDelete(c, makeFile(c, pathA, filemode.Regular, content)),
+			makeDelete(c, makeFile(c, pathB, filemode.Regular, content)),
+			makeDelete(c, makeFile(c, "foo/bar/other", filemode.Regular, content)),
+		},
+	}
+
+	detector.detectExactRenames()
+
+	for _, added := range detector.added {
+		c.Assert(added, NotNil)
+	}
+
+	for _, deleted := range detector.deleted {
+		c.Assert(deleted, NotNil)
+	}
+}
+
 func detectRenames(c *C, changes Changes, opts *DiffTreeOptions, expectedResults int) Changes {
 	result, err := DetectRenames(changes, opts)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This fixes an issue where exact renames detection could leave gaps
with nil changes in the added and deleted change slices. That could
lead to panics in the content rename detection and others if the
user had set OnlyExact to true.