### PR TITLE
Remote.Fetch: support exact SHA1 refspecs

### DIFF
--- a/config/refspec.go
+++ b/config/refspec.go
@@ -25,7 +25,7 @@ var (
 // reference even if it isn’t a fast-forward.
 // eg.: "+refs/heads/*:refs/remotes/origin/*"
 //
-// https://git-scm.com/book/es/v2/Git-Internals-The-Refspec
+// https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
 type RefSpec string
 
 // Validate validates the RefSpec
@@ -59,6 +59,11 @@ func (s RefSpec) IsDelete() bool {
 	return s[0] == refSpecSeparator[0]
 }
 
+// IsExactSHA1 returns true if the source is a SHA1 hash.
+func (s RefSpec) IsExactSHA1() bool {
+	return plumbing.IsHash(s.Src())
+}
+
 // Src return the src side.
 func (s RefSpec) Src() string {
 	spec := string(s)
@@ -69,8 +74,8 @@ func (s RefSpec) Src() string {
 	} else {
 		start = 0
 	}
-	end := strings.Index(spec, refSpecSeparator)
 
+	end := strings.Index(spec, refSpecSeparator)
 	return spec[start:end]
 }
 

--- a/config/refspec_test.go
+++ b/config/refspec_test.go
@@ -3,8 +3,8 @@ package config
 import (
 	"testing"
 
-	. "gopkg.in/check.v1"
 	"github.com/go-git/go-git/v5/plumbing"
+	. "gopkg.in/check.v1"
 )
 
 type RefSpecSuite struct{}
@@ -37,6 +37,12 @@ func (s *RefSpecSuite) TestRefSpecIsValid(c *C) {
 
 	spec = RefSpec("refs/heads:")
 	c.Assert(spec.Validate(), Equals, ErrRefSpecMalformedSeparator)
+
+	spec = RefSpec("12039e008f9a4e3394f3f94f8ea897785cb09448:refs/heads/foo")
+	c.Assert(spec.Validate(), Equals, nil)
+
+	spec = RefSpec("12039e008f9a4e3394f3f94f8ea897785cb09448:refs/heads/*")
+	c.Assert(spec.Validate(), Equals, ErrRefSpecMalformedWildcard)
 }
 
 func (s *RefSpecSuite) TestRefSpecIsForceUpdate(c *C) {
@@ -56,6 +62,14 @@ func (s *RefSpecSuite) TestRefSpecIsDelete(c *C) {
 
 	spec = RefSpec("refs/heads/*:refs/remotes/origin/*")
 	c.Assert(spec.IsDelete(), Equals, false)
+}
+
+func (s *RefSpecSuite) TestRefSpecIsExactSHA1(c *C) {
+	spec := RefSpec("foo:refs/heads/master")
+	c.Assert(spec.IsExactSHA1(), Equals, false)
+
+	spec = RefSpec("12039e008f9a4e3394f3f94f8ea897785cb09448:refs/heads/foo")
+	c.Assert(spec.IsExactSHA1(), Equals, true)
 }
 
 func (s *RefSpecSuite) TestRefSpecSrc(c *C) {

--- a/plumbing/hash.go
+++ b/plumbing/hash.go
@@ -71,3 +71,13 @@ type HashSlice []Hash
 func (p HashSlice) Len() int           { return len(p) }
 func (p HashSlice) Less(i, j int) bool { return bytes.Compare(p[i][:], p[j][:]) < 0 }
 func (p HashSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
+// IsHash returns true if the given string is a valid hash.
+func IsHash(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+
+	_, err := hex.DecodeString(s)
+	return err == nil
+}

--- a/plumbing/hash_test.go
+++ b/plumbing/hash_test.go
@@ -52,3 +52,9 @@ func (s *HashSuite) TestHashesSort(c *C) {
 	c.Assert(i[0], Equals, NewHash("1111111111111111111111111111111111111111"))
 	c.Assert(i[1], Equals, NewHash("2222222222222222222222222222222222222222"))
 }
+
+func (s *HashSuite) TestIsHash(c *C) {
+	c.Assert(IsHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"), Equals, true)
+	c.Assert(IsHash("foo"), Equals, false)
+	c.Assert(IsHash("zab686eafeb1f44702738c8b0f24f2567c36da6d"), Equals, false)
+}

--- a/remote.go
+++ b/remote.go
@@ -29,6 +29,7 @@ var (
 	NoErrAlreadyUpToDate     = errors.New("already up-to-date")
 	ErrDeleteRefNotSupported = errors.New("server does not support delete-refs")
 	ErrForceNeeded           = errors.New("some refs were not updated")
+	ErrExactSHA1NotSupported = errors.New("server does not support exact SHA1 refspec")
 )
 
 const (
@@ -303,6 +304,10 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		return nil, err
 	}
 
+	if err := r.isSupportedRefSpec(o.RefSpecs, ar); err != nil {
+		return nil, err
+	}
+
 	remoteRefs, err := ar.AllReferences()
 	if err != nil {
 		return nil, err
@@ -546,6 +551,7 @@ func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
 
 func (r *Remote) references() ([]*plumbing.Reference, error) {
 	var localRefs []*plumbing.Reference
+
 	iter, err := r.s.IterReferences()
 	if err != nil {
 		return nil, err
@@ -701,6 +707,11 @@ func doCalculateRefs(
 		return err
 	}
 
+	if s.IsExactSHA1() {
+		ref := plumbing.NewHashReference(s.Dst(""), plumbing.NewHash(s.Src()))
+		return refs.SetReference(ref)
+	}
+
 	var matched bool
 	err = iter.ForEach(func(ref *plumbing.Reference) error {
 		if !s.Match(ref.Name()) {
@@ -850,6 +861,26 @@ func (r *Remote) newUploadPackRequest(o *FetchOptions,
 	return req, nil
 }
 
+func (r *Remote) isSupportedRefSpec(refs []config.RefSpec, ar *packp.AdvRefs) error {
+	var containsIsExact bool
+	for _, ref := range refs {
+		if ref.IsExactSHA1() {
+			containsIsExact = true
+		}
+	}
+
+	if !containsIsExact {
+		return nil
+	}
+
+	if ar.Capabilities.Supports(capability.AllowReachableSHA1InWant) ||
+		ar.Capabilities.Supports(capability.AllowTipSHA1InWant) {
+		return nil
+	}
+
+	return ErrExactSHA1NotSupported
+}
+
 func buildSidebandIfSupported(l *capability.List, reader io.Reader, p sideband.Progress) io.Reader {
 	var t sideband.Type
 
@@ -883,7 +914,7 @@ func (r *Remote) updateLocalReferenceStorage(
 		}
 
 		for _, ref := range fetchedRefs {
-			if !spec.Match(ref.Name()) {
+			if !spec.Match(ref.Name()) && !spec.IsExactSHA1() {
 				continue
 			}
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 
 	"github.com/go-git/go-billy/v5/osfs"
-	. "gopkg.in/check.v1"
 	fixtures "github.com/go-git/go-git-fixtures/v4"
+	. "gopkg.in/check.v1"
 )
 
 type RemoteSuite struct {
@@ -69,6 +69,35 @@ func (s *RemoteSuite) TestFetchWildcard(c *C) {
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/branch", "e8d3ffab552895c19b9fcf7aa264d277cde33881"),
 		plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
 	})
+}
+
+func (s *RemoteSuite) TestFetchExactSHA1(c *C) {
+	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		URLs: []string{"https://github.com/git-fixtures/basic.git"},
+	})
+
+	s.testFetch(c, r, &FetchOptions{
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("35e85108805c84807bc66a02d91535e1e24b38b9:refs/heads/foo"),
+		},
+	}, []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/heads/foo", "35e85108805c84807bc66a02d91535e1e24b38b9"),
+	})
+}
+
+func (s *RemoteSuite) TestFetchExactSHA1_NotSoported(c *C) {
+	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		URLs: []string{s.GetBasicLocalRepositoryURL()},
+	})
+
+	err := r.Fetch(&FetchOptions{
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("35e85108805c84807bc66a02d91535e1e24b38b9:refs/heads/foo"),
+		},
+	})
+
+	c.Assert(err, Equals, ErrExactSHA1NotSupported)
+
 }
 
 func (s *RemoteSuite) TestFetchWildcardTags(c *C) {


### PR DESCRIPTION
This implements the support of refspec with exact SHA1 in `Remote.Fetch`.

This may be only used on sever with the `AllowReachableSHA1InWant` or `AllowTipSHA1InWant`, otherwise `Remote.Fetch` returns `ErrExactSHA1NotSupported`. (GitHub supports it)

Closes https://github.com/go-git/go-git/issues/56