### PR TITLE
Close Reader & Writer of EncodedObject after use

### DIFF
--- a/plumbing/format/packfile/diff_delta.go
+++ b/plumbing/format/packfile/diff_delta.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/utils/ioutil"
 )
 
 // See https://github.com/jelmer/dulwich/blob/master/dulwich/pack.py and
@@ -27,17 +28,20 @@ func GetDelta(base, target plumbing.EncodedObject) (plumbing.EncodedObject, erro
 	return getDelta(new(deltaIndex), base, target)
 }
 
-func getDelta(index *deltaIndex, base, target plumbing.EncodedObject) (plumbing.EncodedObject, error) {
+func getDelta(index *deltaIndex, base, target plumbing.EncodedObject) (o plumbing.EncodedObject, err error) {
 	br, err := base.Reader()
 	if err != nil {
 		return nil, err
 	}
-	defer br.Close()
+
+	defer ioutil.CheckClose(br, &err)
+
 	tr, err := target.Reader()
 	if err != nil {
 		return nil, err
 	}
-	defer tr.Close()
+
+	defer ioutil.CheckClose(tr, &err)
 
 	bb := bufPool.Get().(*bytes.Buffer)
 	defer bufPool.Put(bb)

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -287,6 +287,12 @@ func objectsEqual(c *C, o1, o2 plumbing.EncodedObject) {
 	c.Assert(err, IsNil)
 
 	c.Assert(bytes.Compare(b1, b2), Equals, 0)
+
+	err = r2.Close()
+	c.Assert(err, IsNil)
+
+	err = r1.Close()
+	c.Assert(err, IsNil)
 }
 
 func packfileFromReader(c *C, buf *bytes.Buffer) (*Packfile, func()) {

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/go-git/go-git/v5/utils/ioutil"
 )
 
 var (
@@ -307,11 +308,13 @@ func (p *Packfile) getNextMemoryObject(h *ObjectHeader) (plumbing.EncodedObject,
 	return obj, nil
 }
 
-func (p *Packfile) fillRegularObjectContent(obj plumbing.EncodedObject) error {
+func (p *Packfile) fillRegularObjectContent(obj plumbing.EncodedObject) (err error) {
 	w, err := obj.Writer()
 	if err != nil {
 		return err
 	}
+
+	defer ioutil.CheckClose(w, &err)
 
 	_, _, err = p.s.NextObject(w)
 	p.cachePut(obj)

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/utils/ioutil"
 )
 
 // See https://github.com/git/git/blob/49fa3dc76179e04b0833542fa52d0f287a4955ac/delta.h
@@ -16,16 +17,20 @@ import (
 const deltaSizeMin = 4
 
 // ApplyDelta writes to target the result of applying the modification deltas in delta to base.
-func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) error {
+func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) (err error) {
 	r, err := base.Reader()
 	if err != nil {
 		return err
 	}
 
+	defer ioutil.CheckClose(r, &err)
+
 	w, err := target.Writer()
 	if err != nil {
 		return err
 	}
+
+	defer ioutil.CheckClose(w, &err)
 
 	buf := bufPool.Get().(*bytes.Buffer)
 	defer bufPool.Put(buf)

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -408,6 +408,8 @@ func (s *ObjectStorage) getFromUnpacked(h plumbing.Hash) (obj plumbing.EncodedOb
 		return nil, err
 	}
 
+	defer ioutil.CheckClose(w, &err)
+
 	s.objectCache.Put(obj)
 
 	_, err = io.Copy(w, r)

--- a/storage/test/storage_suite.go
+++ b/storage/test/storage_suite.go
@@ -494,12 +494,12 @@ func objectEquals(a plumbing.EncodedObject, b plumbing.EncodedObject) error {
 
 	ra, err := a.Reader()
 	if err != nil {
-		return fmt.Errorf("can't get reader on b: %q", err)
+		return fmt.Errorf("can't get reader on a: %q", err)
 	}
 
 	rb, err := b.Reader()
 	if err != nil {
-		return fmt.Errorf("can't get reader on a: %q", err)
+		return fmt.Errorf("can't get reader on b: %q", err)
 	}
 
 	ca, err := ioutil.ReadAll(ra)
@@ -514,6 +514,16 @@ func objectEquals(a plumbing.EncodedObject, b plumbing.EncodedObject) error {
 
 	if hex.EncodeToString(ca) != hex.EncodeToString(cb) {
 		return errors.New("content does not match")
+	}
+
+	err = rb.Close()
+	if err != nil {
+		return fmt.Errorf("can't close reader on b: %q", err)
+	}
+
+	err = ra.Close()
+	if err != nil {
+		return fmt.Errorf("can't close reader on a: %q", err)
 	}
 
 	return nil


### PR DESCRIPTION
`Close()` method of `EncodedObject.Reader()` and `EncodedObject.Writer()` weren't called in some code paths, causing fd leak.
This commit closes all readers and writers used within this repo, along with `ioutil.CheckClose()`.