### PR TITLE
examples: tag, Add create and push new tag

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -17,6 +17,7 @@ Here you can find a list of annotated _go-git_ examples:
 - [log](log/main.go) - Emulate `git log` command output iterating all the commit history from HEAD reference.
 - [branch](branch/main.go) - How to create and remove branches or any other kind of reference.
 - [tag](tag/main.go) - List/print repository tags.
+- [tag create and push](tag-create-push/main.go) - Create and push a new tag.
 - [remotes](remotes/main.go) - Working with remotes: adding, removing, etc.
 - [progress](progress/main.go) - Printing the progress information from the sideband.
 - [revision](revision/main.go) - Solve a revision into a commit.


### PR DESCRIPTION
Trying to reduce the cost of adopting the library for jobs happening on ci/cd systems. This is the one of the things we are doing before releasing into prod, set a common git tag for all our repos. It took me a couple of hours to make this example working, so hopefully it will save some time for others.