### PR TITLE
storage: filesystem, support .git/commondir repository layout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gliderlabs/ssh v0.2.2
 	github.com/go-git/gcfg v1.5.0
 	github.com/go-git/go-billy/v5 v5.0.0
-	github.com/go-git/go-git-fixtures/v4 v4.0.1
+	github.com/go-git/go-git-fixtures/v4 v4.0.2-0.20200613231340-f56387b50c12
 	github.com/google/go-cmp v0.3.0
 	github.com/imdario/mergo v0.3.9
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/go-git/go-billy/v5 v5.0.0 h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agR
 github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.0.1 h1:q+IFMfLx200Q3scvt2hN79JsEzy4AmBTp/pqnefH+Bc=
 github.com/go-git/go-git-fixtures/v4 v4.0.1/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
+github.com/go-git/go-git-fixtures/v4 v4.0.2-0.20200613231340-f56387b50c12 h1:PbKy9zOy4aAKrJ5pibIRpVO2BXnK1Tlcg+caKI7Ox5M=
+github.com/go-git/go-git-fixtures/v4 v4.0.2-0.20200613231340-f56387b50c12/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=

--- a/options.go
+++ b/options.go
@@ -602,6 +602,9 @@ type PlainOpenOptions struct {
 	// DetectDotGit defines whether parent directories should be
 	// walked until a .git directory or file is found.
 	DetectDotGit bool
+	// Enable .git/commondir support (see https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt).
+	// NOTE: This option will only work with the filesystem storage.
+	EnableDotGitCommonDir bool
 }
 
 // Validate validates the fields and sets the default values.

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -30,6 +30,12 @@ const (
 	objectsPath    = "objects"
 	packPath       = "pack"
 	refsPath       = "refs"
+	branchesPath   = "branches"
+	hooksPath      = "hooks"
+	infoPath       = "info"
+	remotesPath    = "remotes"
+	logsPath       = "logs"
+	worktreesPath  = "worktrees"
 
 	tmpPackedRefsPrefix = "._packed-refs"
 

--- a/storage/filesystem/dotgit/repository_filesystem.go
+++ b/storage/filesystem/dotgit/repository_filesystem.go
@@ -1,0 +1,111 @@
+package dotgit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-billy/v5"
+)
+
+// RepositoryFilesystem is a billy.Filesystem compatible object wrapper
+// which handles dot-git filesystem operations and supports commondir according to git scm layout:
+// https://github.com/git/git/blob/master/Documentation/gitrepository-layout.txt
+type RepositoryFilesystem struct {
+	dotGitFs       billy.Filesystem
+	commonDotGitFs billy.Filesystem
+}
+
+func NewRepositoryFilesystem(dotGitFs, commonDotGitFs billy.Filesystem) *RepositoryFilesystem {
+	return &RepositoryFilesystem{
+		dotGitFs:       dotGitFs,
+		commonDotGitFs: commonDotGitFs,
+	}
+}
+
+func (fs *RepositoryFilesystem) mapToRepositoryFsByPath(path string) billy.Filesystem {
+	// Nothing to decide if commondir not defined
+	if fs.commonDotGitFs == nil {
+		return fs.dotGitFs
+	}
+
+	cleanPath := filepath.Clean(path)
+
+	// Check exceptions for commondir (https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt)
+	switch cleanPath {
+	case fs.dotGitFs.Join(logsPath, "HEAD"):
+		return fs.dotGitFs
+	case fs.dotGitFs.Join(refsPath, "bisect"), fs.dotGitFs.Join(refsPath, "rewritten"), fs.dotGitFs.Join(refsPath, "worktree"):
+		return fs.dotGitFs
+	}
+
+	// Determine dot-git root by first path element.
+	// There are some elements which should always use commondir when commondir defined.
+	// Usual dot-git root will be used for the rest of files.
+	switch strings.Split(cleanPath, string(filepath.Separator))[0] {
+	case objectsPath, refsPath, packedRefsPath, configPath, branchesPath, hooksPath, infoPath, remotesPath, logsPath, shallowPath, worktreesPath:
+		return fs.commonDotGitFs
+	default:
+		return fs.dotGitFs
+	}
+}
+
+func (fs *RepositoryFilesystem) Create(filename string) (billy.File, error) {
+	return fs.mapToRepositoryFsByPath(filename).Create(filename)
+}
+
+func (fs *RepositoryFilesystem) Open(filename string) (billy.File, error) {
+	return fs.mapToRepositoryFsByPath(filename).Open(filename)
+}
+
+func (fs *RepositoryFilesystem) OpenFile(filename string, flag int, perm os.FileMode) (billy.File, error) {
+	return fs.mapToRepositoryFsByPath(filename).OpenFile(filename, flag, perm)
+}
+
+func (fs *RepositoryFilesystem) Stat(filename string) (os.FileInfo, error) {
+	return fs.mapToRepositoryFsByPath(filename).Stat(filename)
+}
+
+func (fs *RepositoryFilesystem) Rename(oldpath, newpath string) error {
+	return fs.mapToRepositoryFsByPath(oldpath).Rename(oldpath, newpath)
+}
+
+func (fs *RepositoryFilesystem) Remove(filename string) error {
+	return fs.mapToRepositoryFsByPath(filename).Remove(filename)
+}
+
+func (fs *RepositoryFilesystem) Join(elem ...string) string {
+	return fs.dotGitFs.Join(elem...)
+}
+
+func (fs *RepositoryFilesystem) TempFile(dir, prefix string) (billy.File, error) {
+	return fs.mapToRepositoryFsByPath(dir).TempFile(dir, prefix)
+}
+
+func (fs *RepositoryFilesystem) ReadDir(path string) ([]os.FileInfo, error) {
+	return fs.mapToRepositoryFsByPath(path).ReadDir(path)
+}
+
+func (fs *RepositoryFilesystem) MkdirAll(filename string, perm os.FileMode) error {
+	return fs.mapToRepositoryFsByPath(filename).MkdirAll(filename, perm)
+}
+
+func (fs *RepositoryFilesystem) Lstat(filename string) (os.FileInfo, error) {
+	return fs.mapToRepositoryFsByPath(filename).Lstat(filename)
+}
+
+func (fs *RepositoryFilesystem) Symlink(target, link string) error {
+	return fs.mapToRepositoryFsByPath(target).Symlink(target, link)
+}
+
+func (fs *RepositoryFilesystem) Readlink(link string) (string, error) {
+	return fs.mapToRepositoryFsByPath(link).Readlink(link)
+}
+
+func (fs *RepositoryFilesystem) Chroot(path string) (billy.Filesystem, error) {
+	return fs.mapToRepositoryFsByPath(path).Chroot(path)
+}
+
+func (fs *RepositoryFilesystem) Root() string {
+	return fs.dotGitFs.Root()
+}

--- a/storage/filesystem/dotgit/repository_filesystem_test.go
+++ b/storage/filesystem/dotgit/repository_filesystem_test.go
@@ -1,0 +1,124 @@
+package dotgit
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/go-git/go-billy/v5/osfs"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *SuiteDotGit) TestRepositoryFilesystem(c *C) {
+	dir, err := ioutil.TempDir("", "repository_filesystem")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	fs := osfs.New(dir)
+
+	err = fs.MkdirAll("dotGit", 0777)
+	c.Assert(err, IsNil)
+	dotGitFs, err := fs.Chroot("dotGit")
+	c.Assert(err, IsNil)
+
+	err = fs.MkdirAll("commonDotGit", 0777)
+	c.Assert(err, IsNil)
+	commonDotGitFs, err := fs.Chroot("commonDotGit")
+	c.Assert(err, IsNil)
+
+	repositoryFs := NewRepositoryFilesystem(dotGitFs, commonDotGitFs)
+	c.Assert(repositoryFs.Root(), Equals, dotGitFs.Root())
+
+	somedir, err := repositoryFs.Chroot("somedir")
+	c.Assert(err, IsNil)
+	c.Assert(somedir.Root(), Equals, repositoryFs.Join(dotGitFs.Root(), "somedir"))
+
+	_, err = repositoryFs.Create("somefile")
+	c.Assert(err, IsNil)
+
+	_, err = repositoryFs.Stat("somefile")
+	c.Assert(err, IsNil)
+
+	file, err := repositoryFs.Open("somefile")
+	c.Assert(err, IsNil)
+	err = file.Close()
+	c.Assert(err, IsNil)
+
+	file, err = repositoryFs.OpenFile("somefile", os.O_RDONLY, 0666)
+	c.Assert(err, IsNil)
+	err = file.Close()
+	c.Assert(err, IsNil)
+
+	file, err = repositoryFs.Create("somefile2")
+	c.Assert(err, IsNil)
+	err = file.Close()
+	c.Assert(err, IsNil)
+	_, err = repositoryFs.Stat("somefile2")
+	c.Assert(err, IsNil)
+	err = repositoryFs.Rename("somefile2", "newfile")
+	c.Assert(err, IsNil)
+
+	tempDir, err := repositoryFs.TempFile("tmp", "myprefix")
+	c.Assert(err, IsNil)
+	c.Assert(repositoryFs.Join(repositoryFs.Root(), "tmp", tempDir.Name()), Equals, repositoryFs.Join(dotGitFs.Root(), "tmp", tempDir.Name()))
+
+	err = repositoryFs.Symlink("newfile", "somelink")
+	c.Assert(err, IsNil)
+
+	_, err = repositoryFs.Lstat("somelink")
+	c.Assert(err, IsNil)
+
+	link, err := repositoryFs.Readlink("somelink")
+	c.Assert(err, IsNil)
+	c.Assert(link, Equals, "newfile")
+
+	err = repositoryFs.Remove("somelink")
+	c.Assert(err, IsNil)
+
+	_, err = repositoryFs.Stat("somelink")
+	c.Assert(os.IsNotExist(err), Equals, true)
+
+	dirs := []string{objectsPath, refsPath, packedRefsPath, configPath, branchesPath, hooksPath, infoPath, remotesPath, logsPath, shallowPath, worktreesPath}
+	for _, dir := range dirs {
+		err := repositoryFs.MkdirAll(dir, 0777)
+		c.Assert(err, IsNil)
+		_, err = commonDotGitFs.Stat(dir)
+		c.Assert(err, IsNil)
+		_, err = dotGitFs.Stat(dir)
+		c.Assert(os.IsNotExist(err), Equals, true)
+	}
+
+	exceptionsPaths := []string{repositoryFs.Join(logsPath, "HEAD"), repositoryFs.Join(refsPath, "bisect"), repositoryFs.Join(refsPath, "rewritten"), repositoryFs.Join(refsPath, "worktree")}
+	for _, path := range exceptionsPaths {
+		_, err := repositoryFs.Create(path)
+		c.Assert(err, IsNil)
+		_, err = commonDotGitFs.Stat(path)
+		c.Assert(os.IsNotExist(err), Equals, true)
+		_, err = dotGitFs.Stat(path)
+		c.Assert(err, IsNil)
+	}
+
+	err = repositoryFs.MkdirAll("refs/heads", 0777)
+	c.Assert(err, IsNil)
+	_, err = commonDotGitFs.Stat("refs/heads")
+	c.Assert(err, IsNil)
+	_, err = dotGitFs.Stat("refs/heads")
+	c.Assert(os.IsNotExist(err), Equals, true)
+
+	err = repositoryFs.MkdirAll("objects/pack", 0777)
+	c.Assert(err, IsNil)
+	_, err = commonDotGitFs.Stat("objects/pack")
+	c.Assert(err, IsNil)
+	_, err = dotGitFs.Stat("objects/pack")
+	c.Assert(os.IsNotExist(err), Equals, true)
+
+	err = repositoryFs.MkdirAll("a/b/c", 0777)
+	c.Assert(err, IsNil)
+	_, err = commonDotGitFs.Stat("a/b/c")
+	c.Assert(os.IsNotExist(err), Equals, true)
+	_, err = dotGitFs.Stat("a/b/c")
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Adopted already existing older patch: https://github.com/src-d/go-git/pull/1098 — but with changes:
 - Has submodules support:
   - use WORKTREE_GIT_DIR/modules instead of COMMON_GIT_DIR/modules (!);
   - use COMMON_GIT_DIR/objects;
   - use COMMON_GIT_DIR/config.
 - More straithforward naming: explicitly use commonfs or fs in DotGit.

Possibly there can be more cases to catch. But our testing shows it works ok.

We use go-git library in [werf gitops tool](https://github.com/werf/werf) and your library is awesome. Hope it will receive future support! 