### PR TITLE
Add side-band(64k) capability to server upload-pack

### DIFF
--- a/plumbing/transport/server/server.go
+++ b/plumbing/transport/server/server.go
@@ -90,7 +90,7 @@ func (s *session) Close() error {
 }
 
 func (s *session) SetAuth(transport.AuthMethod) error {
-	//TODO: deprecate
+	// TODO: deprecate
 	return nil
 }
 
@@ -213,6 +213,10 @@ func (*upSession) setSupportedCapabilities(c *capability.List) error {
 		return err
 	}
 
+	if err := c.Set(capability.Shallow); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -261,7 +265,7 @@ func (s *rpSession) ReceivePack(ctx context.Context, req *packp.ReferenceUpdateR
 
 	s.caps = req.Capabilities
 
-	//TODO: Implement 'atomic' update of references.
+	// TODO: Implement 'atomic' update of references.
 
 	if req.Packfile != nil {
 		r := ioutil.NewContextReadCloser(ctx, req.Packfile)
@@ -418,7 +422,7 @@ func setHEAD(s storer.Storer, ar *packp.AdvRefs) error {
 }
 
 func setReferences(s storer.Storer, ar *packp.AdvRefs) error {
-	//TODO: add peeled references.
+	// TODO: add peeled references.
 	iter, err := s.IterReferences()
 	if err != nil {
 		return err


### PR DESCRIPTION
Have been working on an integration between https://isomorphic-git.org/ and `go-git` and encounter a limitation with the way the server transport is implemented. `isomorphic-git` requires packfile data be sent via side-band capability however the `go-git` implementation did not support that. Ended up implementing the support and this is the PR for it.