### PR TITLE
Worktre: Pull, report "Already up to date" when local repository ahead of remote

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -93,9 +93,15 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 
 	head, err := w.r.Head()
 	if err == nil {
-		if !updated && head.Hash() == ref.Hash() {
+		headAheadOfRef,err := isFastForward(w.r.Storer, ref.Hash(), head.Hash())
+		if err != nil {
+			return err
+		}
+
+		if !updated && headAheadOfRef {
 			return NoErrAlreadyUpToDate
 		}
+
 
 		ff, err := isFastForward(w.r.Storer, head.Hash(), ref.Hash())
 		if err != nil {

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -265,6 +265,26 @@ func (s *RepositorySuite) TestPullAdd(c *C) {
 	c.Assert(branch.Hash().String(), Not(Equals), "6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 }
 
+func (s *WorktreeSuite) TestPullAlreadyUptodate(c *C) {
+	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
+
+	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
+		URL: filepath.Join(path, ".git"),
+	})
+
+	c.Assert(err, IsNil)
+
+	w, err := r.Worktree()
+	c.Assert(err, IsNil)
+	err = ioutil.WriteFile(filepath.Join(path, "bar"), []byte("bar"), 0755)
+	c.Assert(err, IsNil)
+	_, err = w.Commit("bar", &CommitOptions{Author: defaultSignature()})
+	c.Assert(err, IsNil)
+
+	err = w.Pull(&PullOptions{})
+	c.Assert(err, Equals, NoErrAlreadyUpToDate)
+}
+
 func (s *WorktreeSuite) TestCheckout(c *C) {
 	fs := memfs.New()
 	w := &Worktree{


### PR DESCRIPTION
If you run 'git pull', do a commit and run 'git pull' again git will
report "Already up to date" whereas go-git would report a reports
non-fast-forward update. This commit changes the behavior of go-git to
match that of git.