### PR TITLE
config: add missing functions for completeness

### DIFF
--- a/plumbing/format/config/common.go
+++ b/plumbing/format/config/common.go
@@ -44,6 +44,46 @@ func (c *Config) Section(name string) *Section {
 	return s
 }
 
+// HasSection checks if the Config has a section with the specified name.
+func (c *Config) HasSection(name string) bool {
+	for _, s := range c.Sections {
+		if s.IsName(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveSection removes a section from a config file.
+func (c *Config) RemoveSection(name string) *Config {
+	result := Sections{}
+	for _, s := range c.Sections {
+		if !s.IsName(name) {
+			result = append(result, s)
+		}
+	}
+
+	c.Sections = result
+	return c
+}
+
+// RemoveSubsection remove a subsection from a config file.
+func (c *Config) RemoveSubsection(section string, subsection string) *Config {
+	for _, s := range c.Sections {
+		if s.IsName(section) {
+			result := Subsections{}
+			for _, ss := range s.Subsections {
+				if !ss.IsName(subsection) {
+					result = append(result, ss)
+				}
+			}
+			s.Subsections = result
+		}
+	}
+
+	return c
+}
+
 // AddOption adds an option to a given section and subsection. Use the
 // NoSubsection constant for the subsection argument if no subsection is wanted.
 func (c *Config) AddOption(section string, subsection string, key string, value string) *Config {
@@ -63,36 +103,6 @@ func (c *Config) SetOption(section string, subsection string, key string, value 
 		c.Section(section).SetOption(key, value)
 	} else {
 		c.Section(section).Subsection(subsection).SetOption(key, value)
-	}
-
-	return c
-}
-
-// RemoveSection removes a section from a config file.
-func (c *Config) RemoveSection(name string) *Config {
-	result := Sections{}
-	for _, s := range c.Sections {
-		if !s.IsName(name) {
-			result = append(result, s)
-		}
-	}
-
-	c.Sections = result
-	return c
-}
-
-// RemoveSubsection remove	s a subsection from a config file.
-func (c *Config) RemoveSubsection(section string, subsection string) *Config {
-	for _, s := range c.Sections {
-		if s.IsName(section) {
-			result := Subsections{}
-			for _, ss := range s.Subsections {
-				if !ss.IsName(subsection) {
-					result = append(result, ss)
-				}
-			}
-			s.Subsections = result
-		}
 	}
 
 	return c

--- a/plumbing/format/config/common_test.go
+++ b/plumbing/format/config/common_test.go
@@ -64,6 +64,14 @@ func (s *CommonSuite) TestConfig_AddOption(c *C) {
 	c.Assert(obtained, DeepEquals, expected)
 }
 
+func (s *CommonSuite) TestConfig_HasSection(c *C) {
+	sect := New().
+		AddOption("section1", "sub1", "key1", "value1").
+		AddOption("section1", "sub2", "key1", "value1")
+	c.Assert(sect.HasSection("section1"), Equals, true)
+	c.Assert(sect.HasSection("section2"), Equals, false)
+}
+
 func (s *CommonSuite) TestConfig_RemoveSection(c *C) {
 	sect := New().
 		AddOption("section1", NoSubsection, "key1", "value1").

--- a/plumbing/format/config/option.go
+++ b/plumbing/format/config/option.go
@@ -54,6 +54,16 @@ func (opts Options) Get(key string) string {
 	return ""
 }
 
+// Has checks if an Option exist with the given key.
+func (opts Options) Has(key string) bool {
+	for _, o := range opts {
+		if o.IsKey(key) {
+			return true
+		}
+	}
+	return false
+}
+
 // GetAll returns all possible values for the same key.
 func (opts Options) GetAll(key string) []string {
 	result := []string{}

--- a/plumbing/format/config/option_test.go
+++ b/plumbing/format/config/option_test.go
@@ -8,6 +8,21 @@ type OptionSuite struct{}
 
 var _ = Suite(&OptionSuite{})
 
+func (s *OptionSuite) TestOptions_Has(c *C) {
+	o := Options{
+		&Option{"k", "v"},
+		&Option{"ok", "v1"},
+		&Option{"K", "v2"},
+	}
+	c.Assert(o.Has("k"), Equals, true)
+	c.Assert(o.Has("K"), Equals, true)
+	c.Assert(o.Has("ok"), Equals, true)
+	c.Assert(o.Has("unexistant"), Equals, false)
+
+	o = Options{}
+	c.Assert(o.Has("k"), Equals, false)
+}
+
 func (s *OptionSuite) TestOptions_GetAll(c *C) {
 	o := Options{
 		&Option{"k", "v"},

--- a/plumbing/format/config/section.go
+++ b/plumbing/format/config/section.go
@@ -64,31 +64,6 @@ func (s *Section) IsName(name string) bool {
 	return strings.ToLower(s.Name) == strings.ToLower(name)
 }
 
-// Option return the value for the specified key. Empty string is returned if
-// key does not exists.
-func (s *Section) Option(key string) string {
-	return s.Options.Get(key)
-}
-
-// AddOption adds a new Option to the Section. The updated Section is returned.
-func (s *Section) AddOption(key string, value string) *Section {
-	s.Options = s.Options.withAddedOption(key, value)
-	return s
-}
-
-// SetOption adds a new Option to the Section. If the option already exists, is replaced.
-// The updated Section is returned.
-func (s *Section) SetOption(key string, value string) *Section {
-	s.Options = s.Options.withSettedOption(key, value)
-	return s
-}
-
-// Remove an option with the specified key. The updated Section is returned.
-func (s *Section) RemoveOption(key string) *Section {
-	s.Options = s.Options.withoutOption(key)
-	return s
-}
-
 // Subsection returns a Subsection from the specified Section. If the
 // Subsection does not exists, new one is created and added to Section.
 func (s *Section) Subsection(name string) *Subsection {
@@ -115,6 +90,55 @@ func (s *Section) HasSubsection(name string) bool {
 	return false
 }
 
+// RemoveSubsection removes a subsection from a Section.
+func (s *Section) RemoveSubsection(name string) *Section {
+	result := Subsections{}
+	for _, s := range s.Subsections {
+		if !s.IsName(name) {
+			result = append(result, s)
+		}
+	}
+
+	s.Subsections = result
+	return s
+}
+
+// Option return the value for the specified key. Empty string is returned if
+// key does not exists.
+func (s *Section) Option(key string) string {
+	return s.Options.Get(key)
+}
+
+// OptionAll returns all possible values for an option with the specified key.
+// If the option does not exists, an empty slice will be returned.
+func (s *Section) OptionAll(key string) []string {
+	return s.Options.GetAll(key)
+}
+
+// HasOption checks if the Section has an Option with the given key.
+func (s *Section) HasOption(key string) bool {
+	return s.Options.Has(key)
+}
+
+// AddOption adds a new Option to the Section. The updated Section is returned.
+func (s *Section) AddOption(key string, value string) *Section {
+	s.Options = s.Options.withAddedOption(key, value)
+	return s
+}
+
+// SetOption adds a new Option to the Section. If the option already exists, is replaced.
+// The updated Section is returned.
+func (s *Section) SetOption(key string, value string) *Section {
+	s.Options = s.Options.withSettedOption(key, value)
+	return s
+}
+
+// Remove an option with the specified key. The updated Section is returned.
+func (s *Section) RemoveOption(key string) *Section {
+	s.Options = s.Options.withoutOption(key)
+	return s
+}
+
 // IsName checks if the name of the subsection is exactly the specified name.
 func (s *Subsection) IsName(name string) bool {
 	return s.Name == name
@@ -124,6 +148,17 @@ func (s *Subsection) IsName(name string) bool {
 // empty spring will be returned.
 func (s *Subsection) Option(key string) string {
 	return s.Options.Get(key)
+}
+
+// OptionAll returns all possible values for an option with the specified key.
+// If the option does not exists, an empty slice will be returned.
+func (s *Subsection) OptionAll(key string) []string {
+	return s.Options.GetAll(key)
+}
+
+// HasOption checks if the Subsection has an Option with the given key.
+func (s *Subsection) HasOption(key string) bool {
+	return s.Options.Has(key)
 }
 
 // AddOption adds a new Option to the Subsection. The updated Subsection is returned.

--- a/plumbing/format/config/section_test.go
+++ b/plumbing/format/config/section_test.go
@@ -8,6 +8,115 @@ type SectionSuite struct{}
 
 var _ = Suite(&SectionSuite{})
 
+func (s *SectionSuite) TestSections_GoString(c *C) {
+	sects := Sections{
+		&Section{
+			Options: []*Option{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+			},
+		},
+		&Section{
+			Options: []*Option{
+				{Key: "key1", Value: "value3"},
+				{Key: "key2", Value: "value4"},
+			},
+		},
+	}
+
+	expected := "&config.Section{Name:\"\", Options:&config.Option{Key:\"key1\", Value:\"value1\"}, &config.Option{Key:\"key2\", Value:\"value2\"}, Subsections:}, &config.Section{Name:\"\", Options:&config.Option{Key:\"key1\", Value:\"value3\"}, &config.Option{Key:\"key2\", Value:\"value4\"}, Subsections:}"
+	c.Assert(sects.GoString(), Equals, expected)
+}
+
+func (s *SectionSuite) TestSubsections_GoString(c *C) {
+	sects := Subsections{
+		&Subsection{
+			Options: []*Option{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+				{Key: "key1", Value: "value3"},
+			},
+		},
+		&Subsection{
+			Options: []*Option{
+				{Key: "key1", Value: "value1"},
+				{Key: "key2", Value: "value2"},
+				{Key: "key1", Value: "value3"},
+			},
+		},
+	}
+
+	expected := "&config.Subsection{Name:\"\", Options:&config.Option{Key:\"key1\", Value:\"value1\"}, &config.Option{Key:\"key2\", Value:\"value2\"}, &config.Option{Key:\"key1\", Value:\"value3\"}}, &config.Subsection{Name:\"\", Options:&config.Option{Key:\"key1\", Value:\"value1\"}, &config.Option{Key:\"key2\", Value:\"value2\"}, &config.Option{Key:\"key1\", Value:\"value3\"}}"
+	c.Assert(sects.GoString(), Equals, expected)
+}
+
+func (s *SectionSuite) TestSection_IsName(c *C) {
+	sect := &Section{
+		Name: "name1",
+	}
+
+	c.Assert(sect.IsName("name1"), Equals, true)
+	c.Assert(sect.IsName("Name1"), Equals, true)
+}
+
+func (s *SectionSuite) TestSection_Subsection(c *C) {
+	subSect1 := &Subsection{
+		Name: "name1",
+		Options: Options{
+			&Option{Key: "key1", Value: "value1"},
+		},
+	}
+	sect := &Section{
+		Subsections: Subsections{
+			subSect1,
+		},
+	}
+
+	c.Assert(sect.Subsection("name1"), DeepEquals, subSect1)
+
+	subSect2 := &Subsection{
+		Name: "name2",
+	}
+	c.Assert(sect.Subsection("name2"), DeepEquals, subSect2)
+}
+
+func (s *SectionSuite) TestSection_HasSubsection(c *C) {
+	sect := &Section{
+		Subsections: Subsections{
+			&Subsection{
+				Name: "name1",
+			},
+		},
+	}
+
+	c.Assert(sect.HasSubsection("name1"), Equals, true)
+	c.Assert(sect.HasSubsection("name2"), Equals, false)
+}
+
+func (s *SectionSuite) TestSection_RemoveSubsection(c *C) {
+	sect := &Section{
+		Subsections: Subsections{
+			&Subsection{
+				Name: "name1",
+			},
+			&Subsection{
+				Name: "name2",
+			},
+		},
+	}
+
+	expected := &Section{
+		Subsections: Subsections{
+			&Subsection{
+				Name: "name2",
+			},
+		},
+	}
+	c.Assert(sect.RemoveSubsection("name1"), DeepEquals, expected)
+	c.Assert(sect.HasSubsection("name1"), Equals, false)
+	c.Assert(sect.HasSubsection("name2"), Equals, true)
+}
+
 func (s *SectionSuite) TestSection_Option(c *C) {
 	sect := &Section{
 		Options: []*Option{
@@ -21,17 +130,71 @@ func (s *SectionSuite) TestSection_Option(c *C) {
 	c.Assert(sect.Option("key1"), Equals, "value3")
 }
 
-func (s *SectionSuite) TestSubsection_Option(c *C) {
-	sect := &Subsection{
+func (s *SectionSuite) TestSection_OptionAll(c *C) {
+	sect := &Section{
 		Options: []*Option{
 			{Key: "key1", Value: "value1"},
 			{Key: "key2", Value: "value2"},
 			{Key: "key1", Value: "value3"},
 		},
 	}
-	c.Assert(sect.Option("otherkey"), Equals, "")
-	c.Assert(sect.Option("key2"), Equals, "value2")
-	c.Assert(sect.Option("key1"), Equals, "value3")
+	c.Assert(sect.OptionAll("otherkey"), DeepEquals, []string{})
+	c.Assert(sect.OptionAll("key2"), DeepEquals, []string{"value2"})
+	c.Assert(sect.OptionAll("key1"), DeepEquals, []string{"value1", "value3"})
+}
+
+func (s *SectionSuite) TestSection_HasOption(c *C) {
+	sect := &Section{
+		Options: []*Option{
+			{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"},
+			{Key: "key1", Value: "value3"},
+		},
+	}
+	c.Assert(sect.HasOption("otherkey"), Equals, false)
+	c.Assert(sect.HasOption("key2"), Equals, true)
+	c.Assert(sect.HasOption("key1"), Equals, true)
+}
+
+func (s *SectionSuite) TestSection_AddOption(c *C) {
+	sect := &Section{
+		Options: []*Option{
+			{"key1", "value1"},
+		},
+	}
+	sect1 := &Section{
+		Options: []*Option{
+			{"key1", "value1"},
+			{"key2", "value2"},
+		},
+	}
+	c.Assert(sect.AddOption("key2", "value2"), DeepEquals, sect1)
+
+	sect2 := &Section{
+		Options: []*Option{
+			{"key1", "value1"},
+			{"key2", "value2"},
+			{"key1", "value3"},
+		},
+	}
+	c.Assert(sect.AddOption("key1", "value3"), DeepEquals, sect2)
+}
+
+func (s *SectionSuite) TestSection_SetOption(c *C) {
+	sect := &Section{
+		Options: []*Option{
+			{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"},
+		},
+	}
+
+	expected := &Section{
+		Options: []*Option{
+			{Key: "key2", Value: "value2"},
+			{Key: "key1", Value: "value4"},
+		},
+	}
+	c.Assert(sect.SetOption("key1", "value4"), DeepEquals, expected)
 }
 
 func (s *SectionSuite) TestSection_RemoveOption(c *C) {
@@ -52,7 +215,16 @@ func (s *SectionSuite) TestSection_RemoveOption(c *C) {
 	c.Assert(sect.RemoveOption("key1"), DeepEquals, expected)
 }
 
-func (s *SectionSuite) TestSubsection_RemoveOption(c *C) {
+func (s *SectionSuite) TestSubsection_IsName(c *C) {
+	sect := &Subsection{
+		Name: "name1",
+	}
+
+	c.Assert(sect.IsName("name1"), Equals, true)
+	c.Assert(sect.IsName("Name1"), Equals, false)
+}
+
+func (s *SectionSuite) TestSubsection_Option(c *C) {
 	sect := &Subsection{
 		Options: []*Option{
 			{Key: "key1", Value: "value1"},
@@ -60,14 +232,59 @@ func (s *SectionSuite) TestSubsection_RemoveOption(c *C) {
 			{Key: "key1", Value: "value3"},
 		},
 	}
-	c.Assert(sect.RemoveOption("otherkey"), DeepEquals, sect)
+	c.Assert(sect.Option("otherkey"), Equals, "")
+	c.Assert(sect.Option("key2"), Equals, "value2")
+	c.Assert(sect.Option("key1"), Equals, "value3")
+}
 
-	expected := &Subsection{
+func (s *SectionSuite) TestSubsection_OptionAll(c *C) {
+	sect := &Subsection{
 		Options: []*Option{
+			{Key: "key1", Value: "value1"},
 			{Key: "key2", Value: "value2"},
+			{Key: "key1", Value: "value3"},
 		},
 	}
-	c.Assert(sect.RemoveOption("key1"), DeepEquals, expected)
+	c.Assert(sect.OptionAll("otherkey"), DeepEquals, []string{})
+	c.Assert(sect.OptionAll("key2"), DeepEquals, []string{"value2"})
+	c.Assert(sect.OptionAll("key1"), DeepEquals, []string{"value1", "value3"})
+}
+
+func (s *SectionSuite) TestSubsection_HasOption(c *C) {
+	sect := &Subsection{
+		Options: []*Option{
+			{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"},
+			{Key: "key1", Value: "value3"},
+		},
+	}
+	c.Assert(sect.HasOption("otherkey"), Equals, false)
+	c.Assert(sect.HasOption("key2"), Equals, true)
+	c.Assert(sect.HasOption("key1"), Equals, true)
+}
+
+func (s *SectionSuite) TestSubsection_AddOption(c *C) {
+	sect := &Subsection{
+		Options: []*Option{
+			{"key1", "value1"},
+		},
+	}
+	sect1 := &Subsection{
+		Options: []*Option{
+			{"key1", "value1"},
+			{"key2", "value2"},
+		},
+	}
+	c.Assert(sect.AddOption("key2", "value2"), DeepEquals, sect1)
+
+	sect2 := &Subsection{
+		Options: []*Option{
+			{"key1", "value1"},
+			{"key2", "value2"},
+			{"key1", "value3"},
+		},
+	}
+	c.Assert(sect.AddOption("key1", "value3"), DeepEquals, sect2)
 }
 
 func (s *SectionSuite) TestSubsection_SetOption(c *C) {
@@ -87,4 +304,22 @@ func (s *SectionSuite) TestSubsection_SetOption(c *C) {
 		},
 	}
 	c.Assert(sect.SetOption("key1", "value1", "value4"), DeepEquals, expected)
+}
+
+func (s *SectionSuite) TestSubsection_RemoveOption(c *C) {
+	sect := &Subsection{
+		Options: []*Option{
+			{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"},
+			{Key: "key1", Value: "value3"},
+		},
+	}
+	c.Assert(sect.RemoveOption("otherkey"), DeepEquals, sect)
+
+	expected := &Subsection{
+		Options: []*Option{
+			{Key: "key2", Value: "value2"},
+		},
+	}
+	c.Assert(sect.RemoveOption("key1"), DeepEquals, expected)
 }


### PR DESCRIPTION
This PR complete the Config functions.

Add Options.Has to check if an Option exist.

Wherever a collection of Option exist, make sure that the following functions exists as well:
- Option
- OptionAll (new, return all values)
- HasOption (new)
- AddOption
- SetOption
- RemoveOption

For Config and Section, make sure that the following exist to access the sublevel:
- X
- HasX (HasSection was missing)
- RemoveX (RemoveSubsection was missing)

This PR also does some shuffling to have a consistent ordering of functions.