### PR TITLE
plumbing: format, .gitignore crlf fix

### DIFF
--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -1,6 +1,7 @@
 package gitignore
 
 import (
+	"bufio"
 	"bytes"
 	"io/ioutil"
 	"os"
@@ -15,7 +16,6 @@ import (
 const (
 	commentPrefix = "#"
 	coreSection   = "core"
-	eol           = "\n"
 	excludesfile  = "excludesfile"
 	gitDir        = ".git"
 	gitignoreFile = ".gitignore"
@@ -29,11 +29,11 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 	if err == nil {
 		defer f.Close()
 
-		if data, err := ioutil.ReadAll(f); err == nil {
-			for _, s := range strings.Split(string(data), eol) {
-				if !strings.HasPrefix(s, commentPrefix) && len(strings.TrimSpace(s)) > 0 {
-					ps = append(ps, ParsePattern(s, path))
-				}
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			s := scanner.Text()
+			if !strings.HasPrefix(s, commentPrefix) && len(strings.TrimSpace(s)) > 0 {
+				ps = append(ps, ParsePattern(s, path))
 			}
 		}
 	} else if !os.IsNotExist(err) {

--- a/plumbing/format/gitignore/dir_test.go
+++ b/plumbing/format/gitignore/dir_test.go
@@ -15,7 +15,7 @@ type MatcherSuite struct {
 	RFS  billy.Filesystem // root that contains user home
 	MCFS billy.Filesystem // root that contains user home, but missing ~/.gitconfig
 	MEFS billy.Filesystem // root that contains user home, but missing excludesfile entry
-	MIFS billy.Filesystem // root that contains user home, but missing .gitnignore
+	MIFS billy.Filesystem // root that contains user home, but missing .gitignore
 
 	SFS billy.Filesystem // root that contains /etc/gitconfig
 }

--- a/plumbing/format/gitignore/dir_test.go
+++ b/plumbing/format/gitignore/dir_test.go
@@ -29,6 +29,8 @@ func (s *MatcherSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	_, err = f.Write([]byte("vendor/g*/\n"))
 	c.Assert(err, IsNil)
+	_, err = f.Write([]byte("ignore.crlf\r\n"))
+	c.Assert(err, IsNil)
 	err = f.Close()
 	c.Assert(err, IsNil)
 
@@ -41,9 +43,14 @@ func (s *MatcherSuite) SetUpTest(c *C) {
 	err = f.Close()
 	c.Assert(err, IsNil)
 
-	fs.MkdirAll("another", os.ModePerm)
-	fs.MkdirAll("vendor/github.com", os.ModePerm)
-	fs.MkdirAll("vendor/gopkg.in", os.ModePerm)
+	err = fs.MkdirAll("another", os.ModePerm)
+	c.Assert(err, IsNil)
+	err = fs.MkdirAll("ignore.crlf", os.ModePerm)
+	c.Assert(err, IsNil)
+	err = fs.MkdirAll("vendor/github.com", os.ModePerm)
+	c.Assert(err, IsNil)
+	err = fs.MkdirAll("vendor/gopkg.in", os.ModePerm)
+	c.Assert(err, IsNil)
 
 	s.GFS = fs
 
@@ -167,9 +174,10 @@ func (s *MatcherSuite) SetUpTest(c *C) {
 func (s *MatcherSuite) TestDir_ReadPatterns(c *C) {
 	ps, err := ReadPatterns(s.GFS, nil)
 	c.Assert(err, IsNil)
-	c.Assert(ps, HasLen, 2)
+	c.Assert(ps, HasLen, 3)
 
 	m := NewMatcher(ps)
+	c.Assert(m.Match([]string{"ignore.crlf"}, true), Equals, true)
 	c.Assert(m.Match([]string{"vendor", "gopkg.in"}, true), Equals, true)
 	c.Assert(m.Match([]string{"vendor", "github.com"}, true), Equals, false)
 }


### PR DESCRIPTION
This PR

* Uses bufio.Scanner to read LF and CRLF interchangeable

Resolves #114 

Implements a different approach to #107 