### PR TITLE
plumbing: publish Tree.Entry(), TreeEntryIter, minor TreeWalker optimization

### DIFF
--- a/plumbing/object/patch_test.go
+++ b/plumbing/object/patch_test.go
@@ -24,7 +24,7 @@ func (s *PatchSuite) TestStatsWithSubmodules(c *C) {
 	tree, err := commit.Tree()
 	c.Assert(err, IsNil)
 
-	e, err := tree.entry("basic")
+	e, err := tree.Entry("basic")
 	c.Assert(err, IsNil)
 
 	ch := &Change{


### PR DESCRIPTION
A TreeWalker in non-recursive mode is a backwards-compatible equivalent to TreeEntryIter, but is problematic for VFS implementations due to the eager fetching of subtree objects. Disable this eager fetching in non-recursive mode.