### PR TITLE
Repository.ResolveRevision, support partial hashes

### DIFF
--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -28,7 +28,7 @@ func (e *ErrInvalidRevision) Error() string {
 type Revisioner interface {
 }
 
-// Ref represents a reference name : HEAD, master
+// Ref represents a reference name : HEAD, master, <hash>
 type Ref string
 
 // TildePath represents ~, ~{n}

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -354,6 +354,7 @@ func (s *ParserSuite) TestParseRefWithValidName(c *C) {
 		"refs/remotes/test",
 		"refs/remotes/origin/HEAD",
 		"refs/remotes/origin/master",
+		"0123abcd", // short hash
 	}
 
 	for _, d := range datas {

--- a/repository_test.go
+++ b/repository_test.go
@@ -2642,6 +2642,7 @@ func (s *RepositorySuite) TestResolveRevision(c *C) {
 		"v1.0.0~1":                   "918c48b83bd081e863dbe1b80f8998f058cd8294",
 		"master~1":                   "918c48b83bd081e863dbe1b80f8998f058cd8294",
 		"918c48b83bd081e863dbe1b80f8998f058cd8294": "918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"918c48b": "918c48b83bd081e863dbe1b80f8998f058cd8294", // odd number of hex digits
 	}
 
 	for rev, hash := range datas {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -3,12 +3,14 @@ package dotgit
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	stdioutil "io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -88,7 +90,7 @@ type DotGit struct {
 	incomingChecked bool
 	incomingDirName string
 
-	objectList []plumbing.Hash
+	objectList []plumbing.Hash // sorted
 	objectMap  map[plumbing.Hash]struct{}
 	packList   []plumbing.Hash
 	packMap    map[plumbing.Hash]struct{}
@@ -336,6 +338,53 @@ func (d *DotGit) NewObject() (*ObjectWriter, error) {
 	return newObjectWriter(d.fs)
 }
 
+// ObjectsWithPrefix returns the hashes of objects that have the given prefix.
+func (d *DotGit) ObjectsWithPrefix(prefix []byte) ([]plumbing.Hash, error) {
+	// Handle edge cases.
+	if len(prefix) < 1 {
+		return d.Objects()
+	} else if len(prefix) > len(plumbing.ZeroHash) {
+		return nil, nil
+	}
+
+	if d.options.ExclusiveAccess {
+		err := d.genObjectList()
+		if err != nil {
+			return nil, err
+		}
+
+		// Rely on d.objectList being sorted.
+		// Figure out the half-open interval defined by the prefix.
+		first := sort.Search(len(d.objectList), func(i int) bool {
+			// Same as plumbing.HashSlice.Less.
+			return bytes.Compare(d.objectList[i][:], prefix) >= 0
+		})
+		lim := len(d.objectList)
+		if limPrefix, overflow := incBytes(prefix); !overflow {
+			lim = sort.Search(len(d.objectList), func(i int) bool {
+				// Same as plumbing.HashSlice.Less.
+				return bytes.Compare(d.objectList[i][:], limPrefix) >= 0
+			})
+		}
+		return d.objectList[first:lim], nil
+	}
+
+	// This is the slow path.
+	var objects []plumbing.Hash
+	var n int
+	err := d.ForEachObjectHash(func(hash plumbing.Hash) error {
+		n++
+		if bytes.HasPrefix(hash[:], prefix) {
+			objects = append(objects, hash)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return objects, nil
+}
+
 // Objects returns a slice with the hashes of objects found under the
 // .git/objects/ directory.
 func (d *DotGit) Objects() ([]plumbing.Hash, error) {
@@ -427,12 +476,17 @@ func (d *DotGit) genObjectList() error {
 	}
 
 	d.objectMap = make(map[plumbing.Hash]struct{})
-	return d.forEachObjectHash(func(h plumbing.Hash) error {
+	populate := func(h plumbing.Hash) error {
 		d.objectList = append(d.objectList, h)
 		d.objectMap[h] = struct{}{}
 
 		return nil
-	})
+	}
+	if err := d.forEachObjectHash(populate); err != nil {
+		return err
+	}
+	plumbing.HashesSort(d.objectList)
+	return nil
 }
 
 func (d *DotGit) hasObject(h plumbing.Hash) error {
@@ -1114,4 +1168,21 @@ func isNum(b byte) bool {
 
 func isHexAlpha(b byte) bool {
 	return b >= 'a' && b <= 'f' || b >= 'A' && b <= 'F'
+}
+
+// incBytes increments a byte slice, which involves incrementing the
+// right-most byte, and following carry leftward.
+// It makes a copy so that the provided slice's underlying array is not modified.
+// If the overall operation overflows (e.g. incBytes(0xff, 0xff)), the second return parameter indicates that.
+func incBytes(in []byte) (out []byte, overflow bool) {
+	out = make([]byte, len(in))
+	copy(out, in)
+	for i := len(out) - 1; i >= 0; i-- {
+		out[i]++
+		if out[i] != 0 {
+			return // Didn't overflow.
+		}
+	}
+	overflow = true
+	return
 }

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -330,6 +331,22 @@ func (s *FsSuite) TestGetFromObjectFileSharedCache(c *C) {
 
 	obj, err = o2.EncodedObject(plumbing.CommitObject, expected)
 	c.Assert(err, Equals, plumbing.ErrObjectNotFound)
+}
+
+func (s *FsSuite) TestHashesWithPrefix(c *C) {
+	// Same setup as TestGetFromObjectFile.
+	fs := fixtures.ByTag(".git").ByTag("unpacked").One().DotGit()
+	o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
+	expected := plumbing.NewHash("f3dfe29d268303fc6e1bbce268605fc99573406e")
+	obj, err := o.EncodedObject(plumbing.AnyObject, expected)
+	c.Assert(err, IsNil)
+	c.Assert(obj.Hash(), Equals, expected)
+
+	prefix, _ := hex.DecodeString("f3dfe2")
+	hashes, err := o.HashesWithPrefix(prefix)
+	c.Assert(err, IsNil)
+	c.Assert(hashes, HasLen, 1)
+	c.Assert(hashes[0].String(), Equals, "f3dfe29d268303fc6e1bbce268605fc99573406e")
 }
 
 func BenchmarkPackfileIter(b *testing.B) {


### PR DESCRIPTION
Like `git rev-parse <prefix>`, this enumerates the hashes of objects
with the given prefix and adds them to the list of candidates for
resolution.

This has an exhaustive slow path, which requires enumerating all objects
and filtering each one, but also a couple of fast paths for common
cases. There's room for future work to make this faster; TODOs have been
left for that.

Fixes #135.