### PR TITLE
Worktree.Commit: speed up commit with all: true option

### DIFF
--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -58,17 +58,23 @@ func (w *Worktree) autoAddModifiedAndDeleted() error {
 		return err
 	}
 
+	idx, err := w.r.Storer.Index()
+	if err != nil {
+		return err
+	}
+
 	for path, fs := range s {
 		if fs.Worktree != Modified && fs.Worktree != Deleted {
 			continue
 		}
 
-		if _, err := w.Add(path); err != nil {
+		if _, _, err := w.doAddFile(idx, s, path, nil); err != nil {
 			return err
 		}
+
 	}
 
-	return nil
+	return w.r.Storer.SetIndex(idx)
 }
 
 func (w *Worktree) updateHEAD(commit plumbing.Hash) error {


### PR DESCRIPTION
Hello.

Partially fixes #113

Speeding up `worktree.Commit("message", &CommitOptions{All: true})` due to invoking `worktree.doAddFile(..)` directly and avoid invoking `worktree.Status()` every time.

In my case it speeds up commit from 70 sec to 2-5 seconds