### PR TITLE
git: remote, Fix deleting references when force pushing.

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -126,7 +126,7 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 	if o.Force {
 		for i := 0; i < len(o.RefSpecs); i++ {
 			rs := &o.RefSpecs[i]
-			if !rs.IsForceUpdate() {
+			if !rs.IsForceUpdate() && !rs.IsDelete() {
 				o.RefSpecs[i] = config.RefSpec("+" + rs.String())
 			}
 		}

--- a/remote_test.go
+++ b/remote_test.go
@@ -558,6 +558,31 @@ func (s *RemoteSuite) TestPushDeleteReference(c *C) {
 	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
 }
 
+func (s *RemoteSuite) TestForcePushDeleteReference(c *C) {
+	fs := fixtures.Basic().One().DotGit()
+	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+
+	r, err := PlainClone(c.MkDir(), true, &CloneOptions{
+		URL: fs.Root(),
+	})
+	c.Assert(err, IsNil)
+
+	remote, err := r.Remote(DefaultRemoteName)
+	c.Assert(err, IsNil)
+
+	err = remote.Push(&PushOptions{
+		RefSpecs: []config.RefSpec{":refs/heads/branch"},
+		Force:    true,
+	})
+	c.Assert(err, IsNil)
+
+	_, err = sto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
+
+	_, err = r.Storer.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
+}
+
 func (s *RemoteSuite) TestPushRejectNonFastForward(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 	server := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())


### PR DESCRIPTION
This fixes a bug where attempting to delete a ref with `Force: true` in the `PushOptions` will not do anything.

This is because the `Force` push option prepends `+` to every refspec that doesn't already have it. This results in a refspec like `:refs/heads/branch` being turned in to `+:refs/heads/branch` which is not valid, so the ref does not get deleted.

To fix this, I've amended the check for whether to prepend `+` to a refspec to also make sure the refspec is not for a delete.