### PR TITLE
Remote.Fetch: return a unique error type when ref not found

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -32,6 +32,19 @@ var (
 	ErrExactSHA1NotSupported = errors.New("server does not support exact SHA1 refspec")
 )
 
+type NoMatchingRefSpecError struct {
+	refSpec config.RefSpec
+}
+
+func (e NoMatchingRefSpecError) Error() string {
+	return fmt.Sprintf("couldn't find remote ref %q", e.refSpec.Src())
+}
+
+func (e NoMatchingRefSpecError) Is(target error) bool {
+	_, ok := target.(NoMatchingRefSpecError)
+	return ok
+}
+
 const (
 	// This describes the maximum number of commits to walk when
 	// computing the haves to send to a server, for each ref in the
@@ -751,7 +764,7 @@ func doCalculateRefs(
 	})
 
 	if !matched && !s.IsWildcard() {
-		return fmt.Errorf("couldn't find remote ref %q", s.Src())
+		return NoMatchingRefSpecError{refSpec: s}
 	}
 
 	return err

--- a/remote_test.go
+++ b/remote_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"io/ioutil"
 	"os"
@@ -145,6 +146,7 @@ func (s *RemoteSuite) TestFetchNonExistantReference(c *C) {
 	})
 
 	c.Assert(err, ErrorMatches, "couldn't find remote ref.*")
+	c.Assert(errors.Is(err, NoMatchingRefSpecError{}), Equals, true)
 }
 
 func (s *RemoteSuite) TestFetchContext(c *C) {


### PR DESCRIPTION
Small quality of life improvement - if Fetch can return a distinct error type
as opposed to fmt.Errorf("couldn't find remote ref") then it becomes very easy
for callers to determine what kind of failure occurred using the new-ish
errors.Is and errors.As api.

ref https://golang.org/pkg/errors/