### PR TITLE
advrefs.addRefs: it's okay if HEAD can't be resolved.

### DIFF
--- a/plumbing/protocol/packp/advrefs.go
+++ b/plumbing/protocol/packp/advrefs.go
@@ -88,7 +88,13 @@ func (a *AdvRefs) addRefs(s storer.ReferenceStorer) error {
 		return a.addSymbolicRefs(s)
 	}
 
-	return a.resolveHead(s)
+	// It's unusual to not be able to resolve HEAD, but not unusual enough that we
+	// should consider this function to have failed.
+	if err := a.resolveHead(s); err != nil && err != plumbing.ErrReferenceNotFound {
+		return err
+	}
+
+	return nil
 }
 
 // If the server does not support symrefs capability,

--- a/plumbing/protocol/packp/advrefs_test.go
+++ b/plumbing/protocol/packp/advrefs_test.go
@@ -131,7 +131,7 @@ func (s *AdvRefSuite) TestNoSymRefCapabilityHeadToNoRef(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = a.AllReferences()
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 }
 
 func (s *AdvRefSuite) TestNoSymRefCapabilityHeadToNoMasterAlphabeticallyOrdered(c *C) {


### PR DESCRIPTION
The intention of this function is to add all references that exist, not
complain about references that don't exist. If HEAD can't be resolved
because it points at an invalid reference, just move on.

In original git, this situation prints a warning message but doesn't fail.