### PR TITLE
Advertise multi ack capabilities

### DIFF
--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -287,6 +287,7 @@ func (p *Parser) resolveDeltas() error {
 				if err := p.resolveObject(stdioutil.Discard, child, content); err != nil {
 					return err
 				}
+				p.resolveExternalRef(child)
 			}
 
 			// Remove the delta from the cache.
@@ -297,6 +298,16 @@ func (p *Parser) resolveDeltas() error {
 	}
 
 	return nil
+}
+
+func (p *Parser) resolveExternalRef(o *objectInfo) {
+	if ref, ok := p.oiByHash[o.SHA1]; ok && ref.ExternalRef {
+		p.oiByHash[o.SHA1] = o
+		o.Children = ref.Children
+		for _, c := range o.Children {
+			c.Parent = o
+		}
+	}
 }
 
 func (p *Parser) get(o *objectInfo, buf *bytes.Buffer) (err error) {

--- a/plumbing/protocol/packp/srvresp.go
+++ b/plumbing/protocol/packp/srvresp.go
@@ -21,11 +21,6 @@ type ServerResponse struct {
 // Decode decodes the response into the struct, isMultiACK should be true, if
 // the request was done with multi_ack or multi_ack_detailed capabilities.
 func (r *ServerResponse) Decode(reader *bufio.Reader, isMultiACK bool) error {
-	// TODO: implement support for multi_ack or multi_ack_detailed responses
-	if isMultiACK {
-		return errors.New("multi_ack and multi_ack_detailed are not supported")
-	}
-
 	s := pktline.NewScanner(reader)
 
 	for s.Scan() {

--- a/plumbing/protocol/packp/srvresp_test.go
+++ b/plumbing/protocol/packp/srvresp_test.go
@@ -75,5 +75,5 @@ func (s *ServerResponseSuite) TestDecodeMalformed(c *C) {
 func (s *ServerResponseSuite) TestDecodeMultiACK(c *C) {
 	sr := &ServerResponse{}
 	err := sr.Decode(bufio.NewReader(bytes.NewBuffer(nil)), true)
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 }

--- a/plumbing/protocol/packp/uppackresp_test.go
+++ b/plumbing/protocol/packp/uppackresp_test.go
@@ -2,6 +2,7 @@ package packp
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -67,7 +68,8 @@ func (s *UploadPackResponseSuite) TestDecodeMultiACK(c *C) {
 	defer res.Close()
 
 	err := res.Decode(ioutil.NopCloser(bytes.NewBuffer(nil)))
-	c.Assert(err, NotNil)
+	fmt.Println(err)
+	c.Assert(err, IsNil)
 }
 
 func (s *UploadPackResponseSuite) TestReadNoDecode(c *C) {

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -259,7 +259,6 @@ func parseFile(endpoint string) (*Endpoint, bool) {
 // UnsupportedCapabilities are the capabilities not supported by any client
 // implementation
 var UnsupportedCapabilities = []capability.Capability{
-	capability.MultiACK,
 	capability.MultiACKDetailed,
 	capability.ThinPack,
 }

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -181,8 +181,8 @@ func (s *SuiteCommon) TestNewEndpointInvalidURL(c *C) {
 
 func (s *SuiteCommon) TestFilterUnsupportedCapabilities(c *C) {
 	l := capability.NewList()
-	l.Set(capability.MultiACK)
+	l.Set(capability.MultiACKDetailed)
 
 	FilterUnsupportedCapabilities(l)
-	c.Assert(l.Supports(capability.MultiACK), Equals, false)
+	c.Assert(l.Supports(capability.MultiACKDetailed), Equals, false)
 }

--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -358,7 +358,7 @@ func (s *session) finish() error {
 func (s *session) Close() (err error) {
 	err = s.finish()
 
-	//defer ioutil.CheckClose(s.Command, &err)
+	defer ioutil.CheckClose(s.Command, &err)
 	return
 }
 

--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -358,7 +358,7 @@ func (s *session) finish() error {
 func (s *session) Close() (err error) {
 	err = s.finish()
 
-	defer ioutil.CheckClose(s.Command, &err)
+	//defer ioutil.CheckClose(s.Command, &err)
 	return
 }
 

--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -89,9 +89,18 @@ func (c *command) Close() error {
 
 	//XXX: If did read the full packfile, then the session might be already
 	//     closed.
-	_ = c.Session.Close()
+	serr := c.Session.Close()
 
-	return c.client.Close()
+	// Ignore errors when closing the client if the session has
+	// already been closed by the server. This has to be done
+	// as some git server will close the connection before the
+	// client does.
+	err := c.client.Close()
+	if serr.Error() == "EOF" {
+		return nil
+	}
+
+	return err
 }
 
 // connect connects to the SSH server, unless a AuthMethod was set with

--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -96,7 +96,7 @@ func (c *command) Close() error {
 	// as some git server will close the connection before the
 	// client does.
 	err := c.client.Close()
-	if serr.Error() == "EOF" {
+	if serr != nil && serr.Error() == "EOF" {
 		return nil
 	}
 

--- a/plumbing/transport/test/upload_pack.go
+++ b/plumbing/transport/test/upload_pack.go
@@ -88,7 +88,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported(c *C) {
 
 	info, err := r.AdvertisedReferences()
 	c.Assert(err, IsNil)
-	c.Assert(info.Capabilities.Supports(capability.MultiACK), Equals, false)
+	c.Assert(info.Capabilities.Supports(capability.MultiACKDetailed), Equals, false)
 }
 
 func (s *UploadPackSuite) TestCapabilities(c *C) {


### PR DESCRIPTION
This PR hopes to fix a long standing issue for go-git when communicating with servers that require multi-ack capability. The biggest source of that problem right now is Azure DevOps. Meaning that any project that uses go-git currently can't support it.

This first PR does not fully implement multi-ack but instead advertises the capability and then does the normal transaction. My hope is to get multi ack fully implemented in a later PR, but this is a first step to enable projects to work with Azure DevOps.

I had to make a small change to how ssh connections are closed as Azure DevOps will close the connection after sending all data, instead of waiting for the client to close the connection.

Fixes #64 #157 

The PR depends on @bashims PR #111, so it would be great if we could get that merged before to make sure he gets credit for his work.