### PR TITLE
Handle Wine Symlink Bug

### DIFF
--- a/filesystem_wine.go
+++ b/filesystem_wine.go
@@ -1,0 +1,146 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/go-git/go-billy/v5"
+)
+
+var (
+	errorWineSymlinkSyscallBroken = errors.New("Wine Symlink Syscall is broken")
+)
+
+type possibleWineSymlinkError struct {
+	text string
+	base error
+}
+
+func newPossibleWineSymlinkError(format string, a ...interface{}) *possibleWineSymlinkError {
+	return &possibleWineSymlinkError{
+		text: fmt.Sprintf(format, a...),
+		base: errorWineSymlinkSyscallBroken,
+	}
+}
+
+func (err *possibleWineSymlinkError) Error() string {
+	return err.text
+}
+
+func (err *possibleWineSymlinkError) Unwrap() error {
+	return err.base
+}
+
+type possibleWineFilesystem struct {
+	// Filsystem implementation which might call into wine
+	base billy.Filesystem
+	// Used to check whether we need to execute Symlink validation
+	hasCalledSymlinkSuccessfullyOnce bool
+	defaultError                     error
+}
+
+func (fs *possibleWineFilesystem) Create(filename string) (billy.File, error) {
+	return fs.base.Create(filename)
+}
+
+func (fs *possibleWineFilesystem) Open(filename string) (billy.File, error) {
+	return fs.base.Open(filename)
+}
+
+func (fs *possibleWineFilesystem) OpenFile(filename string, flag int, perm os.FileMode) (billy.File, error) {
+	return fs.base.OpenFile(filename, flag, perm)
+}
+
+func (fs *possibleWineFilesystem) Stat(filename string) (os.FileInfo, error) {
+	return fs.base.Stat(filename)
+}
+
+func (fs *possibleWineFilesystem) Rename(oldpath, newpath string) error {
+	return fs.base.Rename(oldpath, newpath)
+}
+
+func (fs *possibleWineFilesystem) Remove(filename string) error {
+	return fs.base.Remove(filename)
+}
+
+func (fs *possibleWineFilesystem) Join(elem ...string) string {
+	return fs.base.Join(elem...)
+}
+
+func (fs *possibleWineFilesystem) TempFile(dir, prefix string) (billy.File, error) {
+	return fs.base.TempFile(dir, prefix)
+}
+
+func (fs *possibleWineFilesystem) ReadDir(path string) ([]os.FileInfo, error) {
+	return fs.base.ReadDir(path)
+}
+
+func (fs *possibleWineFilesystem) MkdirAll(filename string, perm os.FileMode) error {
+	return fs.base.MkdirAll(filename, perm)
+}
+
+func (fs *possibleWineFilesystem) Lstat(filename string) (os.FileInfo, error) {
+	return fs.base.Lstat(filename)
+}
+
+func (fs *possibleWineFilesystem) Symlink(target, link string) error {
+
+	err := fs.base.Symlink(target, link)
+
+	if err != nil {
+		return err
+	}
+
+	// Due to Wine Bug we have to paranoia
+	// check whether the Symlink was actually
+	// created
+
+	if fs.hasCalledSymlinkSuccessfullyOnce {
+		// Reuse the result of the first call
+		return fs.defaultError
+	}
+
+	fs.hasCalledSymlinkSuccessfullyOnce = true
+
+	// We need to check whether Wine might have lied to us
+	_, err = fs.Readlink(link)
+	if err == nil {
+		// Everything seems fine
+		return nil
+	}
+
+	fs.defaultError = newPossibleWineSymlinkError("Wine detection triggered for: %s. Either your Symlink was immediately removed or you are running Wine with a broken Symlink syscall.", link)
+	return fs.defaultError
+}
+
+func (fs *possibleWineFilesystem) Readlink(link string) (string, error) {
+	return fs.base.Readlink(link)
+}
+
+func (fs *possibleWineFilesystem) Chroot(path string) (billy.Filesystem, error) {
+	return fs.base.Chroot(path)
+}
+
+func (fs *possibleWineFilesystem) Root() string {
+	return fs.base.Root()
+}
+
+// Wine Symlink syscalls are stubs. Sadly they are also broken in that they
+// always return TRUE. Thus for the first Symlink call check whether
+// the base implementation really did work or was lying.
+// If it was lying turn on "Wine" mode.
+func handleBrokenWineSymlinkStub(worktree billy.Filesystem) billy.Filesystem {
+	if worktree == nil {
+		return nil
+	}
+
+	if runtime.GOOS == "windows" {
+		// This might be Wine
+		return &possibleWineFilesystem{
+			base: worktree,
+		}
+	}
+	return worktree
+}

--- a/repository.go
+++ b/repository.go
@@ -427,7 +427,7 @@ func PlainCloneContext(ctx context.Context, path string, isBare bool, o *CloneOp
 func newRepository(s storage.Storer, worktree billy.Filesystem) *Repository {
 	return &Repository{
 		Storer: s,
-		wt:     worktree,
+		wt:     handleBrokenWineSymlinkStub(worktree),
 		r:      make(map[string]*Remote),
 	}
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -2619,7 +2619,7 @@ func (s *RepositorySuite) TestWorktree(c *C) {
 	r, _ := Init(memory.NewStorage(), def)
 	w, err := r.Worktree()
 	c.Assert(err, IsNil)
-	c.Assert(w.Filesystem, Equals, def)
+	c.Assert(w.Filesystem, DeepEquals, handleBrokenWineSymlinkStub(def))
 }
 
 func (s *RepositorySuite) TestWorktreeBare(c *C) {

--- a/worktree.go
+++ b/worktree.go
@@ -570,7 +570,7 @@ func (w *Worktree) checkoutFileSymlink(f *object.File) (err error) {
 
 	// On windows, this might fail.
 	// Follow Git on Windows behavior by writing the link as it is.
-	if err != nil && isSymlinkWindowsNonAdmin(err) {
+	if err != nil && (isSymlinkWindowsNonAdmin(err) || errors.Is(err, errorWineSymlinkSyscallBroken)) {
 		mode, _ := f.Mode.ToOSFileMode()
 
 		to, err := w.Filesystem.OpenFile(f.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())


### PR DESCRIPTION
Wine currently implements Symlink syscalls as Stubs. Sadly they also
always return TRUE. So for windows validate, that the first successful
Symlink call was indeed successful.
This does introduce a false positive if Symlinks get removed immediately
after creation. The error is very straight forward about that then.