### PR TITLE
config:  Added signingkey & gpgsign fields.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,8 @@ type Config struct {
 		Name string
 		// Email is the email of the author and the commiter of a commit.
 		Email string
+		// SigningKey is the GPG key used to sign commits.
+		SigningKey string
 	}
 
 	Author struct {
@@ -73,6 +75,11 @@ type Config struct {
 		Name string
 		// Email is the email of the author of a commit.
 		Email string
+	}
+
+	Commit struct {
+		//GPGSign is the signature of the GPG key used to sign commits.
+		GPGSign bool
 	}
 
 	Committer struct {
@@ -229,6 +236,7 @@ const (
 	packSection      = "pack"
 	userSection      = "user"
 	authorSection    = "author"
+	commitSection    = "commit"
 	committerSection = "committer"
 	initSection      = "init"
 	fetchKey         = "fetch"
@@ -242,6 +250,8 @@ const (
 	nameKey          = "name"
 	emailKey         = "email"
 	defaultBranchKey = "defaultBranch"
+	signingKey       = "signingKey"
+	gpgSignKey       = "gpgSign"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.
@@ -287,10 +297,16 @@ func (c *Config) unmarshalUser() {
 	s := c.Raw.Section(userSection)
 	c.User.Name = s.Options.Get(nameKey)
 	c.User.Email = s.Options.Get(emailKey)
+	c.User.SigningKey = s.Options.Get(signingKey)
 
 	s = c.Raw.Section(authorSection)
 	c.Author.Name = s.Options.Get(nameKey)
 	c.Author.Email = s.Options.Get(emailKey)
+
+	s = c.Raw.Section(commitSection)
+	if s.Options.Get(gpgSignKey) == "true" {
+		c.Commit.GPGSign = true
+	}
 
 	s = c.Raw.Section(committerSection)
 	c.Committer.Name = s.Options.Get(nameKey)
@@ -396,6 +412,10 @@ func (c *Config) marshalUser() {
 		s.SetOption(emailKey, c.User.Email)
 	}
 
+	if c.User.SigningKey != "" {
+		s.SetOption(signingKey, c.User.SigningKey)
+	}
+
 	s = c.Raw.Section(authorSection)
 	if c.Author.Name != "" {
 		s.SetOption(nameKey, c.Author.Name)
@@ -403,6 +423,11 @@ func (c *Config) marshalUser() {
 
 	if c.Author.Email != "" {
 		s.SetOption(emailKey, c.Author.Email)
+	}
+
+	s = c.Raw.Section(commitSection)
+	if c.Commit.GPGSign {
+		s.SetOption(gpgSignKey, fmt.Sprintf("%t", c.Commit.GPGSign))
 	}
 
 	s = c.Raw.Section(committerSection)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,9 +22,12 @@ func (s *ConfigSuite) TestUnmarshal(c *C) {
 [user]
 		name = John Doe
 		email = john@example.com
+		signingKey = "12345"
 [author]
 		name = Jane Roe
 		email = jane@example.com
+[commit]
+		gpgSign = true
 [committer]
 		name = Richard Roe
 		email = richard@example.com
@@ -60,8 +63,10 @@ func (s *ConfigSuite) TestUnmarshal(c *C) {
 	c.Assert(cfg.Core.CommentChar, Equals, "bar")
 	c.Assert(cfg.User.Name, Equals, "John Doe")
 	c.Assert(cfg.User.Email, Equals, "john@example.com")
+	c.Assert(cfg.User.SigningKey, Equals, "12345")
 	c.Assert(cfg.Author.Name, Equals, "Jane Roe")
 	c.Assert(cfg.Author.Email, Equals, "jane@example.com")
+	c.Assert(cfg.Commit.GPGSign, Equals, true)
 	c.Assert(cfg.Committer.Name, Equals, "Richard Roe")
 	c.Assert(cfg.Committer.Email, Equals, "richard@example.com")
 	c.Assert(cfg.Pack.Window, Equals, uint(20))


### PR DESCRIPTION
Update to config/config.go to support:
- user.signingkey 
- commit.gpgsign

This adds a new section `Commit` to the config that needs to be handled by the marshal/unmarshalling logic (included in PR). 