### PR TITLE
Adding "object-format" and "filter" capabilities

### DIFF
--- a/plumbing/protocol/packp/capability/capability.go
+++ b/plumbing/protocol/packp/capability/capability.go
@@ -230,6 +230,12 @@ const (
 	PushCert Capability = "push-cert"
 	// SymRef symbolic reference support for better negotiation.
 	SymRef Capability = "symref"
+	// ObjectFormat takes a hash algorithm as an argument, indicates that the
+	// server supports the given hash algorithms.
+	ObjectFormat Capability = "object-format"
+	// Filter if present, fetch-pack may send "filter" commands to request a
+	// partial clone or partial fetch and request that the server omit various objects from the packfile
+	Filter Capability = "filter"
 )
 
 const DefaultAgent = "go-git/4.x"
@@ -241,10 +247,11 @@ var known = map[Capability]bool{
 	NoProgress: true, IncludeTag: true, ReportStatus: true, DeleteRefs: true,
 	Quiet: true, Atomic: true, PushOptions: true, AllowTipSHA1InWant: true,
 	AllowReachableSHA1InWant: true, PushCert: true, SymRef: true,
+	ObjectFormat: true, Filter: true,
 }
 
 var requiresArgument = map[Capability]bool{
-	Agent: true, PushCert: true, SymRef: true,
+	Agent: true, PushCert: true, SymRef: true, ObjectFormat: true,
 }
 
 var multipleArgument = map[Capability]bool{


### PR DESCRIPTION
Adding the following capabilities, which seem to be part of the upload-pack in [latest git version](https://git-scm.com/docs/protocol-capabilities/):
- object-list
- filter