### PR TITLE
Add insecureSkipTLS and cabundle

### DIFF
--- a/options.go
+++ b/options.go
@@ -60,6 +60,10 @@ type CloneOptions struct {
 	// Tags describe how the tags will be fetched from the remote repository,
 	// by default is AllTags.
 	Tags TagMode
+	// InsecureSkipTLS skips ssl verify if protocol is https
+	InsecureSkipTLS bool
+	// CABundle specify additional ca bundle with system cert pool
+	CABundle []byte
 }
 
 // Validate validates the fields and sets the default values.
@@ -105,6 +109,10 @@ type PullOptions struct {
 	// Force allows the pull to update a local branch even when the remote
 	// branch does not descend from it.
 	Force bool
+	// InsecureSkipTLS skips ssl verify if protocol is https
+	InsecureSkipTLS bool
+	// CABundle specify additional ca bundle with system cert pool
+	CABundle []byte
 }
 
 // Validate validates the fields and sets the default values.
@@ -155,6 +163,10 @@ type FetchOptions struct {
 	// Force allows the fetch to update a local branch even when the remote
 	// branch does not descend from it.
 	Force bool
+	// InsecureSkipTLS skips ssl verify if protocol is https
+	InsecureSkipTLS bool
+	// CABundle specify additional ca bundle with system cert pool
+	CABundle []byte
 }
 
 // Validate validates the fields and sets the default values.
@@ -194,6 +206,10 @@ type PushOptions struct {
 	// Force allows the push to update a remote branch even when the local
 	// branch does not descend from it.
 	Force bool
+	// InsecureSkipTLS skips ssl verify if protocal is https
+	InsecureSkipTLS bool
+	// CABundle specify additional ca bundle with system cert pool
+	CABundle []byte
 }
 
 // Validate validates the fields and sets the default values.
@@ -552,6 +568,10 @@ func (o *CreateTagOptions) loadConfigTagger(r *Repository) error {
 type ListOptions struct {
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
+	// InsecureSkipTLS skips ssl verify if protocal is https
+	InsecureSkipTLS bool
+	// CABundle specify additional ca bundle with system cert pool
+	CABundle []byte
 }
 
 // CleanOptions describes how a clean should be performed.

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -107,6 +107,10 @@ type Endpoint struct {
 	Port int
 	// Path is the repository path.
 	Path string
+	// InsecureSkipTLS skips ssl verify if protocal is https
+	InsecureSkipTLS bool
+	// CaBundle specify additional ca bundle with system cert pool
+	CaBundle []byte
 }
 
 var defaultPorts = map[string]int{

--- a/repository.go
+++ b/repository.go
@@ -841,12 +841,14 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 	}
 
 	ref, err := r.fetchAndUpdateReferences(ctx, &FetchOptions{
-		RefSpecs:   c.Fetch,
-		Depth:      o.Depth,
-		Auth:       o.Auth,
-		Progress:   o.Progress,
-		Tags:       o.Tags,
-		RemoteName: o.RemoteName,
+		RefSpecs:        c.Fetch,
+		Depth:           o.Depth,
+		Auth:            o.Auth,
+		Progress:        o.Progress,
+		Tags:            o.Tags,
+		RemoteName:      o.RemoteName,
+		InsecureSkipTLS: o.InsecureSkipTLS,
+		CABundle:        o.CABundle,
 	}, o.ReferenceName)
 	if err != nil {
 		return err

--- a/worktree.go
+++ b/worktree.go
@@ -72,11 +72,13 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 	}
 
 	fetchHead, err := remote.fetch(ctx, &FetchOptions{
-		RemoteName: o.RemoteName,
-		Depth:      o.Depth,
-		Auth:       o.Auth,
-		Progress:   o.Progress,
-		Force:      o.Force,
+		RemoteName:      o.RemoteName,
+		Depth:           o.Depth,
+		Auth:            o.Auth,
+		Progress:        o.Progress,
+		Force:           o.Force,
+		InsecureSkipTLS: o.InsecureSkipTLS,
+		CABundle:        o.CABundle,
 	})
 
 	updated := true


### PR DESCRIPTION
This PR add insecureSkipTLSVerify and cabundle to any remote http calls
so that https repo with private CA signed can be used. This is the
equivalent of https.sslVerify and GIT_SSL_CAINFO