### PR TITLE
worktree: Don't remove root directory when cleaning

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -769,7 +769,7 @@ func (w *Worktree) doClean(status Status, opts *CleanOptions, dir string, files 
 		}
 	}
 
-	if opts.Dir {
+	if opts.Dir && dir != "" {
 		return doCleanDirectories(w.Filesystem, dir)
 	}
 	return nil

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1826,7 +1826,39 @@ func (s *WorktreeSuite) TestClean(c *C) {
 	// An empty dir should be deleted, as well.
 	_, err = fs.Lstat("pkgA")
 	c.Assert(err, ErrorMatches, ".*(no such file or directory.*|.*file does not exist)*.")
+}
 
+func (s *WorktreeSuite) TestCleanBare(c *C) {
+	storer := memory.NewStorage()
+
+	r, err := Init(storer, nil)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+
+	wtfs := memfs.New()
+
+	err = wtfs.MkdirAll("worktree", os.ModePerm)
+	c.Assert(err, IsNil)
+
+	wtfs, err = wtfs.Chroot("worktree")
+	c.Assert(err, IsNil)
+
+	r, err = Open(storer, wtfs)
+	c.Assert(err, IsNil)
+
+	wt, err := r.Worktree()
+	c.Assert(err, IsNil)
+
+	_, err = wt.Filesystem.Lstat(".")
+	c.Assert(err, IsNil)
+
+	// Clean with Dir: true.
+	err = wt.Clean(&CleanOptions{Dir: true})
+	c.Assert(err, IsNil)
+
+	// Root worktree directory must remain after cleaning
+	_, err = wt.Filesystem.Lstat(".")
+	c.Assert(err, IsNil)
 }
 
 func (s *WorktreeSuite) TestAlternatesRepo(c *C) {


### PR DESCRIPTION
When using a separate worktree directory while working on a bare repository, cleaning with `CleanOptions{Dir: true}` would also remove the root worktree directory if empty.