### PR TITLE
Remote: add RequireRemoteRefs to PushOptions

### DIFF
--- a/options.go
+++ b/options.go
@@ -210,6 +210,9 @@ type PushOptions struct {
 	InsecureSkipTLS bool
 	// CABundle specify additional ca bundle with system cert pool
 	CABundle []byte
+	// RequireRemoteRefs only allows a remote ref to be updated if its current
+	// value is the one specified here.
+	RequireRemoteRefs []config.RefSpec
 }
 
 // Validate validates the fields and sets the default values.


### PR DESCRIPTION
The git protocol itself uses a compare-and-swap mechanism, where changes
send the old and new values and the change is only applied if the old
value matches. This is used to implement the --force-with-lease feature
in git push.

go-git populates the `old` field with the current value of the ref that
is read from the remote. We can implement a convenient (albeit more
limited) form of the --force-with-lease feature just by allowing the
caller to specify particular values for this ref.

Callers can then implement complex multi-step atomic operations by
reading the ref themselves at the start of the process, and passing to
in RequireRemoteRefs at the end. This is also a suitable building block
for implementing --force-with-lease (#101), which is mostly an exercise
in computing the correct hash to require. Hence, this appears to be the
most reasonable API to expose.