### PR TITLE
plumbing: make the config entirely case insensitive for keys

### DIFF
--- a/plumbing/format/config/section.go
+++ b/plumbing/format/config/section.go
@@ -139,9 +139,9 @@ func (s *Section) RemoveOption(key string) *Section {
 	return s
 }
 
-// IsName checks if the name of the subsection is exactly the specified name.
+// IsName checks if the name provided is equals to the Subsection name, case insensitive.
 func (s *Subsection) IsName(name string) bool {
-	return s.Name == name
+	return strings.EqualFold(s.Name, name)
 }
 
 // Option returns an option with the specified key. If the option does not exists,

--- a/plumbing/format/config/section_test.go
+++ b/plumbing/format/config/section_test.go
@@ -57,6 +57,7 @@ func (s *SectionSuite) TestSection_IsName(c *C) {
 
 	c.Assert(sect.IsName("name1"), Equals, true)
 	c.Assert(sect.IsName("Name1"), Equals, true)
+	c.Assert(sect.IsName("otherkey"), Equals, false)
 }
 
 func (s *SectionSuite) TestSection_Subsection(c *C) {
@@ -221,7 +222,8 @@ func (s *SectionSuite) TestSubsection_IsName(c *C) {
 	}
 
 	c.Assert(sect.IsName("name1"), Equals, true)
-	c.Assert(sect.IsName("Name1"), Equals, false)
+	c.Assert(sect.IsName("Name1"), Equals, true)
+	c.Assert(sect.IsName("otherkey"), Equals, false)
 }
 
 func (s *SectionSuite) TestSubsection_Option(c *C) {


### PR DESCRIPTION
According to https://git-scm.com/docs/git-config/2.31.1:

> The variable names are case-insensitive, [...]

Other code path has been changed to be case insensitive but this one seems to have been overlooked.