### PR TITLE
Remote: new ListContext function

### DIFF
--- a/remote_test.go
+++ b/remote_test.go
@@ -944,6 +944,17 @@ func (s *RemoteSuite) TestList(c *C) {
 	}
 }
 
+func (s *RemoteSuite) TestListTimeout(c *C) {
+	remote := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{"https://deelay.me/60000/https://httpstat.us/503"},
+	})
+
+	_, err := remote.List(&ListOptions{})
+
+	c.Assert(err, NotNil)
+}
+
 func (s *RemoteSuite) TestUpdateShallows(c *C) {
 	hashes := []plumbing.Hash{
 		plumbing.NewHash("0000000000000000000000000000000000000001"),


### PR DESCRIPTION
It's from this discussion: https://github.com/go-git/go-git/pull/246#discussion_r592130087

When a user calls `go-git` package to do `git ls-remote` check, we should provide a timeout. Otherwise, this will be stuck in some situation, and cause a controller which is using `List` alway waits again and again.. This is not expected I think.

This pull request add a `ListContext` for `List` func and pass `context`. For context, I set `10s` timeout. If exceed 10s, then `List` func will exit. Maybe `10s` is too short, we can discuss a reasonable value about it.

Also I add a unit test to test timeout case. Locally, all unit tests passed.