### PR TITLE
*: remove unused unexported const

### DIFF
--- a/common.go
+++ b/common.go
@@ -2,8 +2,6 @@ package git
 
 import "strings"
 
-const defaultDotGitPath = ".git"
-
 // countLines returns the number of lines in a string à la git, this is
 // The newline character is assumed to be '\n'.  The empty string
 // contains 0 lines.  If the last line of the string doesn't end with a


### PR DESCRIPTION
This is never used in the code, and not available publicly, so safe to remove.