### PR TITLE
object: tree, empty tree object. Fixes #281

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -61,6 +61,20 @@ func DecodeTree(s storer.EncodedObjectStorer, o plumbing.EncodedObject) (*Tree, 
 	return t, nil
 }
 
+// GetEmptyTree creates the empty tree
+func GetEmptyTree(s storer.EncodedObjectStorer) *Tree {
+	emptyTreeHash := plumbing.NewHash("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
+
+	return &Tree{
+		Entries: make([]TreeEntry, 0),
+		Hash:    emptyTreeHash,
+
+		s: s,
+		m: make(map[string]*TreeEntry),
+		t: make(map[string]*Tree),
+	}
+}
+
 // TreeEntry represents a file
 type TreeEntry struct {
 	Name string

--- a/repository.go
+++ b/repository.go
@@ -1330,6 +1330,11 @@ func (r *Repository) TreeObjects() (*object.TreeIter, error) {
 	return object.NewTreeIter(r.Storer, iter), nil
 }
 
+// EmptyTreeObject returns empty tree object
+func (r *Repository) EmptyTreeObject() *object.Tree {
+	return object.GetEmptyTree(r.Storer)
+}
+
 // CommitObject return a Commit with the given hash. If not found
 // plumbing.ErrObjectNotFound is returned.
 func (r *Repository) CommitObject(h plumbing.Hash) (*object.Commit, error) {


### PR DESCRIPTION
In git there is empty tree with `4b825dc642cb6eb9a060e54bf8d69288fbee49041` hash. It is needed for generating diffs for first commits.