### PR TITLE
plumbing: file patches, display stats summary

### DIFF
--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -393,6 +393,7 @@ func (s *SuiteCommit) TestStat(c *C) {
 	c.Assert(fileStats[0].Addition, Equals, 7)
 	c.Assert(fileStats[0].Deletion, Equals, 0)
 	c.Assert(fileStats[0].String(), Equals, " vendor/foo.go | 7 +++++++\n")
+	c.Assert(fileStats.String(), Equals, " vendor/foo.go | 7 +++++++\n 1 file changed, 7 insertions(+)")
 
 	// Stats for another commit.
 	aCommit = s.commit(c, plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
@@ -408,6 +409,12 @@ func (s *SuiteCommit) TestStat(c *C) {
 	c.Assert(fileStats[1].Addition, Equals, 259)
 	c.Assert(fileStats[1].Deletion, Equals, 0)
 	c.Assert(fileStats[1].String(), Equals, " php/crappy.php | 259 ++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
+
+	summary := ` go/example.go | 142 ++++++++++++++++++++++++++++
+ php/crappy.php | 259 ++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 401 insertions(+)`
+
+	c.Assert(fileStats.String(), Equals, summary)
 }
 
 func (s *SuiteCommit) TestVerify(c *C) {

--- a/plumbing/object/patch.go
+++ b/plumbing/object/patch.go
@@ -235,7 +235,44 @@ func (fs FileStat) String() string {
 type FileStats []FileStat
 
 func (fileStats FileStats) String() string {
-	return printStat(fileStats)
+	finalOutput := printStat(fileStats)
+
+	additions := 0
+	deletions := 0
+	for _, fs := range fileStats {
+		additions += fs.Addition
+		deletions += fs.Deletion
+	}
+
+	fileSummaryCount := "file"
+	additionsSummary := "insertion"
+	deletionsSummary := "deletion"
+
+	if len(fileStats) > 1 {
+		fileSummaryCount = "files"
+	}
+
+	if additions > 1 {
+		additionsSummary = "insertions"
+	}
+
+	if deletions > 1 {
+		deletionsSummary = "deletions"
+	}
+
+	summary := fmt.Sprintf("%d %s changed", len(fileStats), fileSummaryCount)
+
+	if additions != 0 {
+		summary += fmt.Sprintf(", %d %s(+)", additions, additionsSummary)
+	}
+
+	if deletions != 0 {
+		summary += fmt.Sprintf(", %d %s(-)", deletions, deletionsSummary)
+	}
+
+	finalOutput += fmt.Sprintf(" %s", summary)
+
+	return finalOutput
 }
 
 func printStat(fileStats []FileStat) string {
@@ -291,6 +328,7 @@ func printStat(fileStats []FileStat) string {
 		dels := strings.Repeat("-", int(math.Floor(deln/scaleFactor)))
 		finalOutput += fmt.Sprintf(" %s | %d %s%s\n", fs.Name, (fs.Addition + fs.Deletion), adds, dels)
 	}
+
 
 	return finalOutput
 }


### PR DESCRIPTION
This modifies behaviour of a collection of file patch's String() to
display the summary just like git show --stat or the patch itself does
when sent over git-send-email.

I honestly, don't know if we shouldn't expand this summary generator
somewhere else and how to land this on the codebase. A example of 
it's need would be all other commands that accepts the --stat option, 
`git show`, `git log`, `git diff` so on and so forth.