### PR TITLE
plumbing: object/patch, printStat strings.Repeat cause panic

### DIFF
--- a/plumbing/object/patch.go
+++ b/plumbing/object/patch.go
@@ -287,8 +287,16 @@ func printStat(fileStats []FileStat) string {
 	for _, fs := range fileStats {
 		addn := float64(fs.Addition)
 		deln := float64(fs.Deletion)
-		adds := strings.Repeat("+", int(math.Floor(addn/scaleFactor)))
-		dels := strings.Repeat("-", int(math.Floor(deln/scaleFactor)))
+		addc := int(math.Floor(addn/scaleFactor))
+		delc := int(math.Floor(deln/scaleFactor))
+		if addc < 0 {
+			addc = 0
+		}
+		if delc < 0 {
+			delc = 0
+		}
+		adds := strings.Repeat("+", addc)
+		dels := strings.Repeat("-", delc)
 		finalOutput += fmt.Sprintf(" %s | %d %s%s\n", fs.Name, (fs.Addition + fs.Deletion), adds, dels)
 	}
 


### PR DESCRIPTION
`int(math.Floor(deln / scaleFactor)) ` return negative value cause strings.Repeat panic

```
strings.Repeat(0x2322604, 0x1, 0xfffffffffffffff1, 0x0, 0x0)
 /usr/local/go/src/strings/strings.go:529 +0x5e5
github.com/go-git/go-git/v5/plumbing/object.printStat(0xc0003d0000, 0x1, 0x1, 0xc0003d0000, 0x1)
 /go/pkg/mod/github.com/go-git/go-git/v5@v5.3.0/plumbing/object/patch.go:291 +0x225
github.com/go-git/go-git/v5/plumbing/object.FileStats.String(...)
 /go/pkg/mod/github.com/go-git/go-git/v5@v5.3.0/plumbing/object/patch.go:238
dory.gitGetDiff(0xc00100b0b0, 0xc000c58780, 0x28, 0x0, 0x0, 0x0, 0x0, 0x0)
 /root/devops-dory-engine/Codes/Backend/dory-engine/dory/git.go:134 +0x7bd
```