### PR TITLE
git: Add support for deepening shallow clones

### DIFF
--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -233,7 +233,7 @@ func (s *session) handleAdvRefDecodeError(err error) error {
 // UploadPack performs a request to the server to fetch a packfile. A reader is
 // returned with the packfile content. The reader must be closed after reading.
 func (s *session) UploadPack(ctx context.Context, req *packp.UploadPackRequest) (*packp.UploadPackResponse, error) {
-	if req.IsEmpty() {
+	if req.IsEmpty() && len(req.Shallows) == 0 {
 		return nil, transport.ErrEmptyUploadPackRequest
 	}
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -233,6 +233,32 @@ func (s *RemoteSuite) TestFetchWithDepth(c *C) {
 	c.Assert(r.s.(*memory.Storage).Objects, HasLen, 18)
 }
 
+func (s *RemoteSuite) TestFetchWithDepthChange(c *C) {
+	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		URLs: []string{s.GetBasicLocalRepositoryURL()},
+	})
+
+	s.testFetch(c, r, &FetchOptions{
+		Depth: 1,
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("refs/heads/master:refs/heads/master"),
+		},
+	}, []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/heads/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+	})
+	c.Assert(r.s.(*memory.Storage).Commits, HasLen, 1)
+
+	s.testFetch(c, r, &FetchOptions{
+		Depth: 3,
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("refs/heads/master:refs/heads/master"),
+		},
+	}, []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/heads/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+	})
+	c.Assert(r.s.(*memory.Storage).Commits, HasLen, 3)
+}
+
 func (s *RemoteSuite) testFetch(c *C, r *Remote, o *FetchOptions, expected []*plumbing.Reference) {
 	err := r.Fetch(o)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
We'd previously get an error "object not found" when attempting to fetch a new depth on a shallow clone. This PR fixes the issue and adds a relevant test.

We could not get untouched tests to fully pass in our environment, with or without our changes. We're hoping your CI is properly configured to run the entire suite, if not we can investigate further.

Let me know if there are any changes you'd like to see before accepting this PR.

Thanks!