### PR TITLE
remote: patch default timeout for `List` from 600ms to 10s

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1085,7 +1085,7 @@ func (r *Remote) ListContext(ctx context.Context, o *ListOptions) (rfs []*plumbi
 }
 
 func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return r.ListContext(ctx, o)
 }


### PR DESCRIPTION
It looks like a test value was shipped breaking a lot of the usage of the library.

Resulting very quickly in:
```
Error: context deadline exceeded
```

Apologies if this does not come in the right format, happy to provide more 