### PR TITLE
make ListOptions timeout configurable

### DIFF
--- a/options.go
+++ b/options.go
@@ -575,6 +575,8 @@ type ListOptions struct {
 	InsecureSkipTLS bool
 	// CABundle specify additional ca bundle with system cert pool
 	CABundle []byte
+	// Timeout represents the context deadline of requests to the remote repository.
+	Timeout time.Duration
 }
 
 // CleanOptions describes how a clean should be performed.

--- a/remote.go
+++ b/remote.go
@@ -1085,7 +1085,10 @@ func (r *Remote) ListContext(ctx context.Context, o *ListOptions) (rfs []*plumbi
 }
 
 func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	if o.Timeout == 0*time.Second {
+		o.Timeout = 10*time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), o.Timeout)
 	defer cancel()
 	return r.ListContext(ctx, o)
 }


### PR DESCRIPTION
I appreciate the recent addition of `context.WithTimeout` in `remote.go`, however since then I have been regularly running into situations where `0.6s` was insufficient for the equivalent of `ls-remote`, so this PR bumps the context deadline to `10s` and makes it configurable should that not be sufficient.