### PR TITLE
internal: url, support more scp-like URLs

### DIFF
--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?:\/|:))?(?P<path>[^\\].*\/[^\\].*)$`)
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?::))?(?P<path>[^\\]+)$`)
 )
 
 // MatchesScheme returns true if the given string matches a URL-like

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?::))?(?P<path>[^\\]+)$`)
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[1-9][0-9]{1,4})(?::)?)?(?P<path>[^\\]+)$`)
 )
 
 // MatchesScheme returns true if the given string matches a URL-like

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -18,6 +18,7 @@ func (s *URLSuite) TestMatchesScpLike(c *C) {
 		"git@github.com:007/bond",
 		"git@github.com:22:james/bond",
 		"git@github.com:22:007/bond",
+		"git@github:/bond",
 	}
 
 	for _, url := range examples {
@@ -57,4 +58,12 @@ func (s *URLSuite) TestFindScpLikeComponents(c *C) {
 	c.Check(host, Equals, "github.com")
 	c.Check(port, Equals, "22")
 	c.Check(path, Equals, "007/bond")
+
+	url = "git@github:/bond"
+	user, host, port, path = FindScpLikeComponents(url)
+
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github")
+	c.Check(port, Equals, "22")
+	c.Check(path, Equals, "/bond")
 }

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -64,6 +64,6 @@ func (s *URLSuite) TestFindScpLikeComponents(c *C) {
 
 	c.Check(user, Equals, "git")
 	c.Check(host, Equals, "github")
-	c.Check(port, Equals, "22")
+	c.Check(port, Equals, "")
 	c.Check(path, Equals, "/bond")
 }

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -103,7 +103,7 @@ func (s *SuiteCommon) TestNewEndpointSCPLikeWithPort(c *C) {
 	c.Assert(e.Password, Equals, "")
 	c.Assert(e.Host, Equals, "github.com")
 	c.Assert(e.Port, Equals, 9999)
-	c.Assert(e.Path, Equals, "user/repository.git")
+	c.Assert(e.Path, Equals, "/user/repository.git")
 	c.Assert(e.String(), Equals, "ssh://git@github.com:9999/user/repository.git")
 }
 


### PR DESCRIPTION
SCP-like URLs do not necessarily need to have a prefix followed by a `/` in the path.

For example, if a git repository is located at `/test-repo.git` on a remote, the following command is valid.

```shell
git clone user@remote:/test-repo.git
```

As long as `user` can use SSH to log into the remote (which might be described in SSH config), `git` will attempt to clone the repo at the given path.

----

I removed the `/` as separator for the port as it interfered with this URL scheme, but I might have missed the rationale for this. Feel free to explain, and I will update the PR accordingly.