### PR TITLE
Fix object not found error in OFS deltas

### DIFF
--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -75,7 +75,7 @@ func PatchDelta(src, delta []byte) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func ReaderFromDelta(h *ObjectHeader, base plumbing.EncodedObject, deltaRC io.ReadCloser) (io.ReadCloser, error) {
+func ReaderFromDelta(h *ObjectHeader, base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadCloser, error) {
 	deltaBuf := bufio.NewReaderSize(deltaRC, 1024)
 	srcSz, err := decodeLEB128ByteReader(deltaBuf)
 	if err != nil {


### PR DESCRIPTION
Unfortunately the code in #303 was incorrect for large objects in OFS deltas.

The underlying fault is that the seeker in the packfile was seeking away whilst the
delta was being read.

This PR simply reads the delta into a buffer.

Fix #323

Signed-off-by: Andrew Thornton <art27@cantab.net>