### PR TITLE
Issue #309 - Branch name containing hash can be cloned

### DIFF
--- a/plumbing/format/config/encoder.go
+++ b/plumbing/format/config/encoder.go
@@ -59,7 +59,7 @@ func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
 func (e *Encoder) encodeOptions(opts Options) error {
 	for _, o := range opts {
 		pattern := "\t%s = %s\n"
-		if strings.Contains(o.Value, "\\") {
+		if strings.ContainsAny(o.Value, "\\\"") {
 			pattern = "\t%s = %q\n"
 		}
 


### PR DESCRIPTION
This is a possible fix for [#309: Can't clone branch ref name with hash/number sign (#)](https://github.com/go-git/go-git/issues/309)
I looked at writing a test but I couldn't figure out how.