### PR TITLE
plumbing: config, Branch name with hash can be cloned. Fixes #309

### DIFF
--- a/plumbing/format/config/encoder.go
+++ b/plumbing/format/config/encoder.go
@@ -11,6 +11,10 @@ type Encoder struct {
 	w io.Writer
 }
 
+var (
+	subsectionReplacer = strings.NewReplacer(`"`, `\"`, `\`, `\\`)
+	valueReplacer = strings.NewReplacer(`"`, `\"`, `\`, `\\`, "\n", `\n`, "\t", `\t`, "\b", `\b`)
+)
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{w}
@@ -48,8 +52,7 @@ func (e *Encoder) encodeSection(s *Section) error {
 }
 
 func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
-	//TODO: escape
-	if err := e.printf("[%s \"%s\"]\n", sectionName, s.Name); err != nil {
+	if err := e.printf("[%s \"%s\"]\n", sectionName, subsectionReplacer.Replace(s.Name)); err != nil {
 		return err
 	}
 
@@ -58,12 +61,14 @@ func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
 
 func (e *Encoder) encodeOptions(opts Options) error {
 	for _, o := range opts {
-		pattern := "\t%s = %s\n"
-		if strings.ContainsAny(o.Value, `"#\`) || strings.HasPrefix(o.Value, " ") || strings.HasSuffix(o.Value, " ") {
-			pattern = "\t%s = %q\n"
+		var value string
+		if strings.ContainsAny(o.Value, "#;\"\t\n\\") || strings.HasPrefix(o.Value, " ") || strings.HasSuffix(o.Value, " ") {
+			value = `"`+valueReplacer.Replace(o.Value)+`"`
+		} else {
+			value = o.Value
 		}
 
-		if err := e.printf(pattern, o.Key, o.Value); err != nil {
+		if err := e.printf("\t%s = %s\n", o.Key, value); err != nil {
 			return err
 		}
 	}

--- a/plumbing/format/config/encoder.go
+++ b/plumbing/format/config/encoder.go
@@ -59,7 +59,7 @@ func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
 func (e *Encoder) encodeOptions(opts Options) error {
 	for _, o := range opts {
 		pattern := "\t%s = %s\n"
-		if strings.Contains(o.Value, "\\") {
+		if strings.ContainsAny(o.Value, `"#\"`) || strings.HasPrefix(o.Value, " ") || strings.HasSuffix(o.Value, " ") {
 			pattern = "\t%s = %q\n"
 		}
 

--- a/plumbing/format/config/encoder.go
+++ b/plumbing/format/config/encoder.go
@@ -59,7 +59,7 @@ func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
 func (e *Encoder) encodeOptions(opts Options) error {
 	for _, o := range opts {
 		pattern := "\t%s = %s\n"
-		if strings.ContainsAny(o.Value, `"#\"`) || strings.HasPrefix(o.Value, " ") || strings.HasSuffix(o.Value, " ") {
+		if strings.ContainsAny(o.Value, `"#\`) || strings.HasPrefix(o.Value, " ") || strings.HasSuffix(o.Value, " ") {
 			pattern = "\t%s = %q\n"
 		}
 

--- a/plumbing/format/config/fixtures_test.go
+++ b/plumbing/format/config/fixtures_test.go
@@ -43,8 +43,7 @@ var fixtures = []*Fixture{
 		Config: New().AddOption("core", "", "repositoryformatversion", "0"),
 	},
 	{
-		Raw:    "[section]\n",
-		Text:   `[section]
+		Raw: `[section]
 	option1 = "has # hash"
 	option2 = "has \" quote"
 	option3 = "has \\ backslash"
@@ -54,7 +53,18 @@ var fixtures = []*Fixture{
 	option7 = "  has leading spaces"
 	option8 = "has trailing spaces  "
 	option9 = has no special characters
-`+"\toption10 = has unusual \x01\x7f\xc8\x80 characters\n",
+	option10 = has unusual ` + "\x01\x7f\xc8\x80 characters\n",
+		Text: `[section]
+	option1 = "has # hash"
+	option2 = "has \" quote"
+	option3 = "has \\ backslash"
+	option4 = "has ; semicolon"
+	option5 = "has \n line-feed"
+	option6 = "has \t tab"
+	option7 = "  has leading spaces"
+	option8 = "has trailing spaces  "
+	option9 = has no special characters
+	option10 = has unusual ` + "\x01\x7f\xc8\x80 characters\n",
 		Config: New().
 			AddOption("section", "", "option1", `has # hash`).
 			AddOption("section", "", "option2", `has " quote`).

--- a/plumbing/format/config/fixtures_test.go
+++ b/plumbing/format/config/fixtures_test.go
@@ -48,17 +48,24 @@ var fixtures = []*Fixture{
 	option1 = "has # hash"
 	option2 = "has \" quote"
 	option3 = "has \\ backslash"
-	option4 = "  has leading spaces"
-	option5 = "has trailing spaces  "
-	option6 = has no special characters
-`,
+	option4 = "has ; semicolon"
+	option5 = "has \n line-feed"
+	option6 = "has \t tab"
+	option7 = "  has leading spaces"
+	option8 = "has trailing spaces  "
+	option9 = has no special characters
+`+"\toption10 = has unusual \x01\x7f\xc8\x80 characters\n",
 		Config: New().
 			AddOption("section", "", "option1", `has # hash`).
 			AddOption("section", "", "option2", `has " quote`).
 			AddOption("section", "", "option3", `has \ backslash`).
-			AddOption("section", "", "option4", `  has leading spaces`).
-			AddOption("section", "", "option5", `has trailing spaces  `).
-			AddOption("section", "", "option6", `has no special characters`),
+			AddOption("section", "", "option4", `has ; semicolon`).
+			AddOption("section", "", "option5", "has \n line-feed").
+			AddOption("section", "", "option6", "has \t tab").
+			AddOption("section", "", "option7", `  has leading spaces`).
+			AddOption("section", "", "option8", `has trailing spaces  `).
+			AddOption("section", "", "option9", `has no special characters`).
+			AddOption("section", "", "option10", "has unusual \x01\x7f\u0200 characters"),
 	},
 	{
 		Raw: `

--- a/plumbing/format/config/fixtures_test.go
+++ b/plumbing/format/config/fixtures_test.go
@@ -43,6 +43,24 @@ var fixtures = []*Fixture{
 		Config: New().AddOption("core", "", "repositoryformatversion", "0"),
 	},
 	{
+		Raw:    "[section]\n",
+		Text:   `[section]
+	option1 = "has # hash"
+	option2 = "has \" quote"
+	option3 = "has \\ backslash"
+	option4 = "  has leading spaces"
+	option5 = "has trailing spaces  "
+	option6 = has no special characters
+`,
+		Config: New().
+			AddOption("section", "", "option1", `has # hash`).
+			AddOption("section", "", "option2", `has " quote`).
+			AddOption("section", "", "option3", `has \ backslash`).
+			AddOption("section", "", "option4", `  has leading spaces`).
+			AddOption("section", "", "option5", `has trailing spaces  `).
+			AddOption("section", "", "option6", `has no special characters`),
+	},
+	{
 		Raw: `
 			[sect1]
 			opt1 = value1


### PR DESCRIPTION
This is a fix for https://github.com/go-git/go-git/issues/309 'Can't clone branch ref name with hash/number sign (#)'

The problem is occurring because the # character in a git config file is interpreted as a comment. In fact, the config-file writer needs to escape a number of characters that would cause it to create an invalid config-file.

Following example copied from #611

When a repository is cloned a config file is created in the .git directory. I have mocked up an example below by hand:

```ini
[core]
	bare = false # This is just a comment so is ignored
[remote "origin"]
	url = https://https://github.com/myrepo.git
	fetch = +refs/heads/release/mybranchname:refs/remotes/origin/release/mybranchname

```
However, if there is a # character in the branch name like this:

```ini
[core]
	bare = false # This is just a comment so is ignored
[remote "origin"]
	url = https://https://github.com/myrepo.git
	fetch = +refs/heads/release/my#branchname:refs/remotes/origin/release/my#branchname

```
When go-git reads back the file it ignores everything after the # character, so the value read for the fetch option, rather than looking like this:

```
+refs/heads/release/my#branchname:refs/remotes/origin/release/my#branchname

```
It is read back from the file as this:

```
+refs/heads/release/my

```
go-git then returns an error 'malformed refspec, separators are wrong' because it is expecting at least one ':' separator character in that value.

The fix is to add quotes when encoding that file, so it looks like this:

```ini
[core]
	bare = false # This is just a comment so is ignored
[remote "origin"]
	url = https://https://github.com/myrepo.git
	fetch = "+refs/heads/release/my#branchname:refs/remotes/origin/release/my#branchname"

```
Then when reading and decoding that file go-git gets the correct value.