### PR TITLE
remote: fetch, adds the prune option.

### DIFF
--- a/options.go
+++ b/options.go
@@ -166,7 +166,7 @@ const (
 	// AllTags fetch all tags from the remote (i.e., fetch remote tags
 	// refs/tags/* into local tags with the same name)
 	AllTags
-	//NoTags fetch no tags from the remote at all
+	// NoTags fetch no tags from the remote at all
 	NoTags
 )
 
@@ -198,6 +198,9 @@ type FetchOptions struct {
 	CABundle []byte
 	// ProxyOptions provides info required for connecting to a proxy.
 	ProxyOptions transport.ProxyOptions
+	// Prune specify that local refs that match given RefSpecs and that do
+	// not exist remotely will be removed.
+	Prune bool
 }
 
 // Validate validates the fields and sets the default values.

--- a/remote.go
+++ b/remote.go
@@ -470,6 +470,14 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		}
 	}
 
+	var updatedPrune bool
+	if o.Prune {
+		updatedPrune, err = r.pruneRemotes(o.RefSpecs, localRefs, remoteRefs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	updated, err := r.updateLocalReferenceStorage(o.RefSpecs, refs, remoteRefs, specToRefs, o.Tags, o.Force)
 	if err != nil {
 		return nil, err
@@ -482,7 +490,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		}
 	}
 
-	if !updated {
+	if !updated && !updatedPrune {
 		return remoteRefs, NoErrAlreadyUpToDate
 	}
 
@@ -572,6 +580,27 @@ func (r *Remote) fetchPack(ctx context.Context, o *FetchOptions, s transport.Upl
 	}
 
 	return err
+}
+
+func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Reference, remoteRefs memory.ReferenceStorage) (bool, error) {
+	var updatedPrune bool
+	for _, spec := range specs {
+		rev := spec.Reverse()
+		for _, ref := range localRefs {
+			if !rev.Match(ref.Name()) {
+				continue
+			}
+			_, err := remoteRefs.Reference(rev.Dst(ref.Name()))
+			if errors.Is(err, plumbing.ErrReferenceNotFound) {
+				updatedPrune = true
+				err := r.s.RemoveReference(ref.Name())
+				if err != nil {
+					return false, err
+				}
+			}
+		}
+	}
+	return updatedPrune, nil
 }
 
 func (r *Remote) addReferencesToUpdate(


### PR DESCRIPTION
This PR adds `prune` option to the `Fetch` command.

Fixes #316