### PR TITLE
Fix nil pointer panic when omitting FetchOptions

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -302,6 +302,10 @@ func (r *Remote) Fetch(o *FetchOptions) error {
 }
 
 func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.ReferenceStorer, err error) {
+	if o == nil {
+		o = &FetchOptions{}
+	}
+	
 	if o.RemoteName == "" {
 		o.RemoteName = r.c.Name
 	}


### PR DESCRIPTION
When omitting `FetchOptions` when calling any of the fetch methods, a nil pointer dereference occurs. This PR fixes this by creating `FetchOptions` object when the parameter is `nil`.