### PR TITLE
Speading up PathFilter - checking date limits first then path

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -1147,17 +1147,17 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		return nil, err
 	}
 
+	if o.Since != nil || o.Until != nil {
+		limitOptions := object.LogLimitOptions{Since: o.Since, Until: o.Until}
+		it = r.logWithLimit(it, limitOptions)
+	}
+
 	if o.FileName != nil {
 		// for `git log --all` also check parent (if the next commit comes from the real parent)
 		it = r.logWithFile(*o.FileName, it, o.All)
 	}
 	if o.PathFilter != nil {
 		it = r.logWithPathFilter(o.PathFilter, it, o.All)
-	}
-
-	if o.Since != nil || o.Until != nil {
-		limitOptions := object.LogLimitOptions{Since: o.Since, Until: o.Until}
-		it = r.logWithLimit(it, limitOptions)
 	}
 
 	return it, nil


### PR DESCRIPTION
**General fact**
The commit walkers wrap each other, and each use their parent to get the next commit to examine and apply limits on.

**What this change does**
This change flips the order of date based limits and path based limits. With this change the `PathFilter` will get its next commit from the date based filters, so date filters take precedence.

**Why**
This limits the search space for the path filter by date. Before this change, the since filter was not applied for young paths: if a path was only matched on commits with dates well within the date filters, searching for the next commit by the path filter examined all commits since the creation of the repo. The date filter would have only applied if a commit on the path was returned. But for young paths, this date filter never got the chance to be evaluated, causing the whole commit tree to be examined by the path filter