### PR TITLE
Limiting search space, don't continue to earlier commits than the sin…

### DIFF
--- a/plumbing/object/commit_walker_limit.go
+++ b/plumbing/object/commit_walker_limit.go
@@ -32,7 +32,7 @@ func (c *commitLimitIter) Next() (*Commit, error) {
 		}
 
 		if c.limitOptions.Since != nil && commit.Committer.When.Before(*c.limitOptions.Since) {
-			continue
+			return nil, io.EOF
 		}
 		if c.limitOptions.Until != nil && commit.Committer.When.After(*c.limitOptions.Until) {
 			continue


### PR DESCRIPTION
The date based filter should just return with EOF if it sees the first commit that is earlier than the since limit.

Before this change, even with the since filter, all commits in the repo were examined. Causing a huge wait time for large repos to be traversed.