### PR TITLE
git: Allow supplying a custom transport when performing various operations

### DIFF
--- a/options.go
+++ b/options.go
@@ -37,6 +37,9 @@ var (
 type CloneOptions struct {
 	// The (possibly remote) repository URL to clone from.
 	URL string
+	// Specify the transport to use. If nil, a default transport will
+	// be selected based on the URL's protocol.
+	Transport transport.Transport
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 	// Name of the remote to be added, by default `origin`.
@@ -97,6 +100,9 @@ type PullOptions struct {
 	SingleBranch bool
 	// Limit fetching to the specified number of commits.
 	Depth int
+	// Specify the transport to use. If nil, a default transport will
+	// be selected based on the URL's protocol.
+	Transport transport.Transport
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 	// RecurseSubmodules controls if new commits of all populated submodules
@@ -151,6 +157,9 @@ type FetchOptions struct {
 	// Depth limit fetching to the specified number of commits from the tip of
 	// each remote branch history.
 	Depth int
+	// Specify the transport to use. If nil, a default transport will
+	// be selected based on the URL's protocol.
+	Transport transport.Transport
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 	// Progress is where the human readable information sent by the server is
@@ -195,6 +204,9 @@ type PushOptions struct {
 	// RefSpecs specify what destination ref to update with what source
 	// object. A refspec with empty src can be used to delete a reference.
 	RefSpecs []config.RefSpec
+	// Specify the transport to use. If nil, a default transport will
+	// be selected based on the URL's protocol.
+	Transport transport.Transport
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 	// Progress is where the human readable information sent by the server is
@@ -247,6 +259,9 @@ type SubmoduleUpdateOptions struct {
 	// the current repository but also in any nested submodules inside those
 	// submodules (and so on). Until the SubmoduleRescursivity is reached.
 	RecurseSubmodules SubmoduleRescursivity
+	// Specify the transport to use. If nil, a default transport will
+	// be selected based on the URL's protocol.
+	Transport transport.Transport
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 }
@@ -569,6 +584,9 @@ func (o *CreateTagOptions) loadConfigTagger(r *Repository) error {
 
 // ListOptions describes how a remote list should be performed.
 type ListOptions struct {
+	// Specify the transport to use. If nil, a default transport will
+	// be selected based on the URL's protocol.
+	Transport transport.Transport
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 	// InsecureSkipTLS skips ssl verify if protocal is https

--- a/repository.go
+++ b/repository.go
@@ -824,6 +824,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 	ref, err := r.fetchAndUpdateReferences(ctx, &FetchOptions{
 		RefSpecs:        c.Fetch,
 		Depth:           o.Depth,
+		Transport:       o.Transport,
 		Auth:            o.Auth,
 		Progress:        o.Progress,
 		Tags:            o.Tags,

--- a/submodule.go
+++ b/submodule.go
@@ -243,7 +243,10 @@ func (s *Submodule) fetchAndCheckout(
 	ctx context.Context, r *Repository, o *SubmoduleUpdateOptions, hash plumbing.Hash,
 ) error {
 	if !o.NoFetch {
-		err := r.FetchContext(ctx, &FetchOptions{Auth: o.Auth})
+		err := r.FetchContext(ctx, &FetchOptions{
+			Transport: o.Transport,
+			Auth:      o.Auth,
+		})
 		if err != nil && err != NoErrAlreadyUpToDate {
 			return err
 		}
@@ -263,8 +266,9 @@ func (s *Submodule) fetchAndCheckout(
 			refSpec := config.RefSpec("+" + hash.String() + ":" + hash.String())
 
 			err := r.FetchContext(ctx, &FetchOptions{
-				Auth:     o.Auth,
-				RefSpecs: []config.RefSpec{refSpec},
+				Transport: o.Transport,
+				Auth:      o.Auth,
+				RefSpecs:  []config.RefSpec{refSpec},
 			})
 			if err != nil && err != NoErrAlreadyUpToDate && err != ErrExactSHA1NotSupported {
 				return err

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -91,6 +91,25 @@ func (s *SubmoduleSuite) TestUpdate(c *C) {
 	c.Assert(status.IsClean(), Equals, true)
 }
 
+func (s *SubmoduleSuite) TestUpdateWithTransport(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
+	sm, err := s.Worktree.Submodule("basic")
+	c.Assert(err, IsNil)
+
+	mock := newMockTransport(sm.Config().URL)
+
+	err = sm.Update(&SubmoduleUpdateOptions{
+		Init:      true,
+		Transport: mock,
+	})
+
+	c.Assert(err, IsNil)
+	c.Assert(mock.NewUploadPackSessionCalled, Equals, true)
+}
+
 func (s *SubmoduleSuite) TestRepositoryWithoutInit(c *C) {
 	sm, err := s.Worktree.Submodule("basic")
 	c.Assert(err, IsNil)

--- a/worktree.go
+++ b/worktree.go
@@ -74,6 +74,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 	fetchHead, err := remote.fetch(ctx, &FetchOptions{
 		RemoteName:      o.RemoteName,
 		Depth:           o.Depth,
+		Transport:       o.Transport,
 		Auth:            o.Auth,
 		Progress:        o.Progress,
 		Force:           o.Force,

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -239,6 +239,28 @@ func (s *WorktreeSuite) TestPullProgressWithRecursion(c *C) {
 	c.Assert(cfg.Submodules, HasLen, 2)
 }
 
+func (s *WorktreeSuite) TestPullWithTransport(c *C) {
+	url := s.GetBasicLocalRepositoryURL()
+	mock := newMockTransport(url)
+
+	r, _ := Init(memory.NewStorage(), memfs.New())
+
+	r.CreateRemote(&config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{url},
+	})
+
+	w, err := r.Worktree()
+	c.Assert(err, IsNil)
+
+	err = w.Pull(&PullOptions{
+		Transport: mock,
+	})
+
+	c.Assert(err, IsNil)
+	c.Assert(mock.NewUploadPackSessionCalled, Equals, true)
+}
+
 func (s *RepositorySuite) TestPullAdd(c *C) {
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 


### PR DESCRIPTION
Currently, custom transports are registered by protocol name, therefore it is cumbersome to use different transports for different remotes if they have the same protocol. This PR makes that easier by introducing an optional transport field in the option structs of various operations.