### PR TITLE
fix: crash when ForEach TagObjects

### DIFF
--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -109,6 +109,10 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 		}
 
 		split := bytes.SplitN(line, []byte{' '}, 2)
+		if len(split) < 2 {
+			// we need at least two elements
+			continue
+		}
 		switch string(split[0]) {
 		case "object":
 			t.Target = plumbing.NewHash(string(split[1]))


### PR DESCRIPTION
Got panic when ForEach TagObjects:
```golang
func testTagObjects(p string) {
	repo, err := git.PlainOpen(p)
	if err != nil {
		panic(err)
	}
	iter, err := repo.TagObjects()
	if err != nil {
		panic(err)
	}
	err = iter.ForEach(func(tag *object.Tag) error {
		return nil
	})
}
```
![image](https://user-images.githubusercontent.com/19310233/135194371-43c65ad5-89c7-4490-88a1-d78a094794cd.png)

![image (1)](https://user-images.githubusercontent.com/19310233/135194959-f91a4608-33f4-47d2-bb25-10de4ac15f80.png)

