### PR TITLE
Correct parsing of git-ssh url without breaking backward compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ build-git:
 	else \
 		git clone $(GIT_REPOSITORY) -b $(GIT_VERSION) --depth 1 --single-branch $(GIT_DIST_PATH); \
 		cd $(GIT_DIST_PATH); \
-		make configure; \
+		$(MAKE) configure; \
 		./configure; \
-		make all; \
+		$(MAKE) all; \
 	fi
 
 test:

--- a/cli/go-git/clone.go
+++ b/cli/go-git/clone.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/go-git/go-git/v5"
+)
+
+type CmdClone struct {
+	cmd
+
+	Args struct {
+		RepoUrl string `positional-arg-name:"repo-url" required:"true"`
+		Output  string `positional-arg-name:"output-dir" required:"false"`
+	} `positional-args:"yes"`
+}
+
+func (CmdClone) Usage() string {
+	// TODO: git-receive-pack returns error code 129 if arguments are invalid.
+	return fmt.Sprintf("usage: %s <repo-url> <output-dir>", os.Args[0])
+}
+
+func (c *CmdClone) Execute(args []string) error {
+	if c.Args.Output == "" {
+		c.Args.Output = path.Base(c.Args.RepoUrl)
+	}
+
+	_, err := git.PlainClone(c.Args.Output, false, &git.CloneOptions{
+		URL:          c.Args.RepoUrl,
+		NewScpRegexp: true,
+	})
+	if err != nil {
+		return fmt.Errorf("clone repo %q failed: %w", c.Args.RepoUrl, err)
+	}
+
+	return nil
+}

--- a/cli/go-git/main.go
+++ b/cli/go-git/main.go
@@ -24,6 +24,7 @@ func main() {
 	parser := flags.NewNamedParser(bin, flags.Default)
 	parser.AddCommand("receive-pack", "", "", &CmdReceivePack{})
 	parser.AddCommand("upload-pack", "", "", &CmdUploadPack{})
+	parser.AddCommand("clone", "", "", &CmdClone{})
 	parser.AddCommand("version", "Show the version information.", "", &CmdVersion{})
 
 	_, err := parser.Parse()

--- a/config/config.go
+++ b/config/config.go
@@ -548,7 +548,8 @@ type RemoteConfig struct {
 	Name string
 	// URLs the URLs of a remote repository. It must be non-empty. Fetch will
 	// always use the first URL, while push will use all of them.
-	URLs []string
+	URLs         []string
+	NewScpRegexp bool
 
 	// insteadOfRulesApplied have urls been modified
 	insteadOfRulesApplied bool

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
 github.com/go-git/go-billy/v5 v5.2.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
-github.com/go-git/go-billy/v5 v5.3.0 h1:KZL1OFdS+afiIjN4hr/zpj5cEtC0OJhbmTA18PsBb8c=
-github.com/go-git/go-billy/v5 v5.3.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-billy/v5 v5.3.1 h1:CPiOUAzKtMRvolEKw+bG1PLRpT7D3LIs3/3ey4Aiu34=
 github.com/go-git/go-billy/v5 v5.3.1/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
 github.com/go-git/go-git-fixtures/v4 v4.2.1 h1:n9gGL1Ct/yIw+nfsfr8s4+sbhT+Ncu2SubfXjIWgci8=

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?:\/|:))?(?P<path>[^\\].*\/[^\\].*)$`)
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?::))?(?P<path>[^\\]+)$`)
 )
 
 // MatchesScheme returns true if the given string matches a URL-like

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?::))?(?P<path>[^\\]+)$`)
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[1-9][0-9]{1,4})(?::)?)?(?P<path>[^\\]+)$`)
 )
 
 // MatchesScheme returns true if the given string matches a URL-like

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -5,8 +5,10 @@ import (
 )
 
 var (
-	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[1-9][0-9]{1,4})(?::)?)?(?P<path>[^\\]+)$`)
+	isSchemeRegExp = regexp.MustCompile(`^[^:]+://`)
+	// deprecated, backward compatibility.
+	scpLikeUrlOldRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?:\/|:))?(?P<path>[^\\].*\/[^\\].*)$`)
+	scpLikeUrlNewRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[1-9][0-9]{1,4})(?::)?)?(?P<path>[^\\]+)$`)
 )
 
 // MatchesScheme returns true if the given string matches a URL-like
@@ -18,13 +20,26 @@ func MatchesScheme(url string) bool {
 // MatchesScpLike returns true if the given string matches an SCP-like
 // format scheme.
 func MatchesScpLike(url string) bool {
-	return scpLikeUrlRegExp.MatchString(url)
+	return scpLikeUrlOldRegExp.MatchString(url)
+}
+
+// MatchesScpLikeExtended returns true if the given string matches an SCP-like
+// format scheme.
+func MatchesScpLikeExtended(url string) bool {
+	return scpLikeUrlNewRegExp.MatchString(url)
 }
 
 // FindScpLikeComponents returns the user, host, port and path of the
 // given SCP-like URL.
 func FindScpLikeComponents(url string) (user, host, port, path string) {
-	m := scpLikeUrlRegExp.FindStringSubmatch(url)
+	m := scpLikeUrlOldRegExp.FindStringSubmatch(url)
+	return m[1], m[2], m[3], m[4]
+}
+
+// FindScpLikeComponentsExtended returns the user, host, port and path of the
+// given SCP-like URL with correct repository relative path.
+func FindScpLikeComponentsExtended(url string) (user, host, port, path string) {
+	m := scpLikeUrlNewRegExp.FindStringSubmatch(url)
 	return m[1], m[2], m[3], m[4]
 }
 

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -18,6 +18,7 @@ func (s *URLSuite) TestMatchesScpLike(c *C) {
 		"git@github.com:007/bond",
 		"git@github.com:22:james/bond",
 		"git@github.com:22:007/bond",
+		"git@github:/bond",
 	}
 
 	for _, url := range examples {
@@ -57,4 +58,12 @@ func (s *URLSuite) TestFindScpLikeComponents(c *C) {
 	c.Check(host, Equals, "github.com")
 	c.Check(port, Equals, "22")
 	c.Check(path, Equals, "007/bond")
+
+	url = "git@github:/bond"
+	user, host, port, path = FindScpLikeComponents(url)
+
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github")
+	c.Check(port, Equals, "22")
+	c.Check(path, Equals, "/bond")
 }

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -18,12 +18,19 @@ func (s *URLSuite) TestMatchesScpLike(c *C) {
 		"git@github.com:007/bond",
 		"git@github.com:22:james/bond",
 		"git@github.com:22:007/bond",
-		"git@github:/bond",
 	}
 
 	for _, url := range examples {
 		c.Check(MatchesScpLike(url), Equals, true)
 	}
+
+	for _, url := range examples {
+		c.Check(MatchesScpLikeExtended(url), Equals, true)
+	}
+
+	url := "lol@localhost:bond"
+	c.Check(MatchesScpLike(url), Equals, false)
+	c.Check(MatchesScpLikeExtended(url), Equals, true)
 }
 
 func (s *URLSuite) TestFindScpLikeComponents(c *C) {
@@ -58,12 +65,66 @@ func (s *URLSuite) TestFindScpLikeComponents(c *C) {
 	c.Check(host, Equals, "github.com")
 	c.Check(port, Equals, "22")
 	c.Check(path, Equals, "007/bond")
+}
+
+// new tests
+
+func (s *URLSuite) TestFindScpLikeComponentsNew(c *C) {
+	url := "git@github.com:james/bond"
+	user, host, port, path := FindScpLikeComponentsExtended(url)
+
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github.com")
+	c.Check(port, Equals, "")
+	c.Check(path, Equals, "james/bond")
+
+	url = "git@github.com:007/bond"
+	user, host, port, path = FindScpLikeComponentsExtended(url)
+
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github.com")
+	c.Check(port, Equals, "")
+	c.Check(path, Equals, "007/bond")
+
+	url = "git@github.com:22:james/bond"
+	user, host, port, path = FindScpLikeComponentsExtended(url)
+
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github.com")
+	c.Check(port, Equals, "22")
+	c.Check(path, Equals, "james/bond")
+
+	url = "git@github.com:22:007/bond"
+	user, host, port, path = FindScpLikeComponentsExtended(url)
+
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github.com")
+	c.Check(port, Equals, "22")
+	c.Check(path, Equals, "007/bond")
 
 	url = "git@github:/bond"
-	user, host, port, path = FindScpLikeComponents(url)
+	user, host, port, path = FindScpLikeComponentsExtended(url)
 
 	c.Check(user, Equals, "git")
 	c.Check(host, Equals, "github")
 	c.Check(port, Equals, "")
 	c.Check(path, Equals, "/bond")
+
+	// the most important tests
+
+	url = "lol@localhost:bond"
+	user, host, port, path = FindScpLikeComponentsExtended(url)
+
+	c.Check(user, Equals, "lol")
+	c.Check(host, Equals, "localhost")
+	c.Check(port, Equals, "")
+	c.Check(path, Equals, "bond")
+
+	url = "lol@localhost:22:bond"
+	user, host, port, path = FindScpLikeComponentsExtended(url)
+
+	c.Check(user, Equals, "lol")
+	c.Check(host, Equals, "localhost")
+	c.Check(port, Equals, "22")
+	c.Check(path, Equals, "bond")
 }

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -64,6 +64,6 @@ func (s *URLSuite) TestFindScpLikeComponents(c *C) {
 
 	c.Check(user, Equals, "git")
 	c.Check(host, Equals, "github")
-	c.Check(port, Equals, "22")
+	c.Check(port, Equals, "")
 	c.Check(path, Equals, "/bond")
 }

--- a/options.go
+++ b/options.go
@@ -29,14 +29,13 @@ const (
 	DefaultSubmoduleRecursionDepth SubmoduleRescursivity = 10
 )
 
-var (
-	ErrMissingURL = errors.New("URL field is required")
-)
+var ErrMissingURL = errors.New("URL field is required")
 
 // CloneOptions describes how a clone should be performed.
 type CloneOptions struct {
 	// The (possibly remote) repository URL to clone from.
-	URL string
+	URL          string
+	NewScpRegexp bool
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 	// Name of the remote to be added, by default `origin`.
@@ -139,7 +138,7 @@ const (
 	// AllTags fetch all tags from the remote (i.e., fetch remote tags
 	// refs/tags/* into local tags with the same name)
 	AllTags
-	//NoTags fetch no tags from the remote at all
+	// NoTags fetch no tags from the remote at all
 	NoTags
 )
 
@@ -389,9 +388,7 @@ type LogOptions struct {
 	Until *time.Time
 }
 
-var (
-	ErrMissingAuthor = errors.New("author field is required")
-)
+var ErrMissingAuthor = errors.New("author field is required")
 
 // AddOptions describes how an `add` operation should be performed
 type AddOptions struct {
@@ -596,9 +593,7 @@ type GrepOptions struct {
 	PathSpecs []*regexp.Regexp
 }
 
-var (
-	ErrHashOrReference = errors.New("ambiguous options, only one of CommitHash or ReferenceName can be passed")
-)
+var ErrHashOrReference = errors.New("ambiguous options, only one of CommitHash or ReferenceName can be passed")
 
 // Validate validates the fields and sets the default values.
 func (o *GrepOptions) Validate(w *Worktree) error {

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -178,6 +178,18 @@ func NewEndpoint(endpoint string) (*Endpoint, error) {
 	return parseURL(endpoint)
 }
 
+func NewEndpointScpCorrect(endpoint string) (*Endpoint, error) {
+	if e, ok := parseSCPLikeCorrect(endpoint); ok {
+		return e, nil
+	}
+
+	if e, ok := parseFile(endpoint); ok {
+		return e, nil
+	}
+
+	return parseURL(endpoint)
+}
+
 func parseURL(endpoint string) (*Endpoint, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
@@ -239,6 +251,26 @@ func parseSCPLike(endpoint string) (*Endpoint, bool) {
 	}
 
 	user, host, portStr, path := giturl.FindScpLikeComponents(endpoint)
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		port = 22
+	}
+
+	return &Endpoint{
+		Protocol: "ssh",
+		User:     user,
+		Host:     host,
+		Port:     port,
+		Path:     path,
+	}, true
+}
+
+func parseSCPLikeCorrect(endpoint string) (*Endpoint, bool) {
+	if giturl.MatchesScheme(endpoint) || !giturl.MatchesScpLikeExtended(endpoint) {
+		return nil, false
+	}
+
+	user, host, portStr, path := giturl.FindScpLikeComponentsExtended(endpoint)
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		port = 22

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -44,7 +44,6 @@ func (s *SuiteCommon) TestNewEndpointPorts(c *C) {
 	e, err = NewEndpoint("git://github.com:9418/user/repository.git?foo#bar")
 	c.Assert(err, IsNil)
 	c.Assert(e.String(), Equals, "git://github.com/user/repository.git?foo#bar")
-
 }
 
 func (s *SuiteCommon) TestNewEndpointSSH(c *C) {
@@ -103,7 +102,7 @@ func (s *SuiteCommon) TestNewEndpointSCPLikeWithPort(c *C) {
 	c.Assert(e.Password, Equals, "")
 	c.Assert(e.Host, Equals, "github.com")
 	c.Assert(e.Port, Equals, 9999)
-	c.Assert(e.Path, Equals, "/user/repository.git")
+	c.Assert(e.Path, Equals, "user/repository.git")
 	c.Assert(e.String(), Equals, "ssh://git@github.com:9999/user/repository.git")
 }
 

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -103,7 +103,7 @@ func (s *SuiteCommon) TestNewEndpointSCPLikeWithPort(c *C) {
 	c.Assert(e.Password, Equals, "")
 	c.Assert(e.Host, Equals, "github.com")
 	c.Assert(e.Port, Equals, 9999)
-	c.Assert(e.Path, Equals, "user/repository.git")
+	c.Assert(e.Path, Equals, "/user/repository.git")
 	c.Assert(e.String(), Equals, "ssh://git@github.com:9999/user/repository.git")
 }
 

--- a/plumbing/transport/file/server.go
+++ b/plumbing/transport/file/server.go
@@ -4,17 +4,25 @@ import (
 	"fmt"
 	"os"
 
+	urlparse "github.com/go-git/go-git/v5/internal/url"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/internal/common"
 	"github.com/go-git/go-git/v5/plumbing/transport/server"
 	"github.com/go-git/go-git/v5/utils/ioutil"
 )
 
+func newEndpoint(path string) (*transport.Endpoint, error) {
+	if !urlparse.MatchesScpLike(path) && !urlparse.MatchesScpLikeExtended(path) {
+		return transport.NewEndpointScpCorrect(path)
+	}
+	return transport.NewEndpoint(path)
+}
+
 // ServeUploadPack serves a git-upload-pack request using standard output, input
 // and error. This is meant to be used when implementing a git-upload-pack
 // command.
 func ServeUploadPack(path string) error {
-	ep, err := transport.NewEndpoint(path)
+	ep, err := newEndpoint(path)
 	if err != nil {
 		return err
 	}
@@ -32,7 +40,7 @@ func ServeUploadPack(path string) error {
 // input and error. This is meant to be used when implementing a
 // git-receive-pack command.
 func ServeReceivePack(path string) error {
-	ep, err := transport.NewEndpoint(path)
+	ep, err := newEndpoint(path)
 	if err != nil {
 		return err
 	}

--- a/remote.go
+++ b/remote.go
@@ -103,7 +103,12 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		return fmt.Errorf("remote names don't match: %s != %s", o.RemoteName, r.c.Name)
 	}
 
-	s, err := newSendPackSession(r.c.URLs[0], o.Auth, o.InsecureSkipTLS, o.CABundle)
+	ep, err := newEndpoint(r.c.URLs[0], r.c.NewScpRegexp)
+	if err != nil {
+		return err
+	}
+
+	s, err := newSendPackSession(ep, o.Auth, o.InsecureSkipTLS, o.CABundle)
 	if err != nil {
 		return err
 	}
@@ -314,7 +319,12 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		o.RefSpecs = r.c.Fetch
 	}
 
-	s, err := newUploadPackSession(r.c.URLs[0], o.Auth, o.InsecureSkipTLS, o.CABundle)
+	ep, err := newEndpoint(r.c.URLs[0], r.c.NewScpRegexp)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := newUploadPackSession(ep, o.Auth, o.InsecureSkipTLS, o.CABundle)
 	if err != nil {
 		return nil, err
 	}
@@ -411,8 +421,13 @@ func depthChanged(before []plumbing.Hash, s storage.Storer) (bool, error) {
 	return false, nil
 }
 
-func newUploadPackSession(url string, auth transport.AuthMethod, insecure bool, cabundle []byte) (transport.UploadPackSession, error) {
-	c, ep, err := newClient(url, auth, insecure, cabundle)
+func newUploadPackSession(
+	ep *transport.Endpoint,
+	auth transport.AuthMethod,
+	insecure bool,
+	cabundle []byte,
+) (transport.UploadPackSession, error) {
+	c, err := newClient(ep, auth, insecure, cabundle)
 	if err != nil {
 		return nil, err
 	}
@@ -420,8 +435,8 @@ func newUploadPackSession(url string, auth transport.AuthMethod, insecure bool, 
 	return c.NewUploadPackSession(ep, auth)
 }
 
-func newSendPackSession(url string, auth transport.AuthMethod, insecure bool, cabundle []byte) (transport.ReceivePackSession, error) {
-	c, ep, err := newClient(url, auth, insecure, cabundle)
+func newSendPackSession(ep *transport.Endpoint, auth transport.AuthMethod, insecure bool, cabundle []byte) (transport.ReceivePackSession, error) {
+	c, err := newClient(ep, auth, insecure, cabundle)
 	if err != nil {
 		return nil, err
 	}
@@ -429,20 +444,24 @@ func newSendPackSession(url string, auth transport.AuthMethod, insecure bool, ca
 	return c.NewReceivePackSession(ep, auth)
 }
 
-func newClient(url string, auth transport.AuthMethod, insecure bool, cabundle []byte) (transport.Transport, *transport.Endpoint, error) {
-	ep, err := transport.NewEndpoint(url)
-	if err != nil {
-		return nil, nil, err
+func newEndpoint(url string, newScpRegexp bool) (*transport.Endpoint, error) {
+	if newScpRegexp {
+		return transport.NewEndpointScpCorrect(url)
+	} else {
+		return transport.NewEndpoint(url)
 	}
+}
+
+func newClient(ep *transport.Endpoint, auth transport.AuthMethod, insecure bool, cabundle []byte) (transport.Transport, error) {
 	ep.InsecureSkipTLS = insecure
 	ep.CaBundle = cabundle
 
 	c, err := client.NewClient(ep)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return c, ep, err
+	return c, err
 }
 
 func (r *Remote) fetchPack(ctx context.Context, o *FetchOptions, s transport.UploadPackSession,
@@ -590,7 +609,7 @@ func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
 	remoteRef, err := remoteRefs.Reference(cmd.Name)
 	if err == nil {
 		if remoteRef.Type() != plumbing.HashReference {
-			//TODO: check actual git behavior here
+			// TODO: check actual git behavior here
 			return nil
 		}
 
@@ -1091,7 +1110,12 @@ func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {
 }
 
 func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Reference, err error) {
-	s, err := newUploadPackSession(r.c.URLs[0], o.Auth, o.InsecureSkipTLS, o.CABundle)
+	ep, err := newEndpoint(r.c.URLs[0], r.c.NewScpRegexp)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := newUploadPackSession(ep, o.Auth, o.InsecureSkipTLS, o.CABundle)
 	if err != nil {
 		return nil, err
 	}

--- a/repository.go
+++ b/repository.go
@@ -812,9 +812,10 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 	}
 
 	c := &config.RemoteConfig{
-		Name:  o.RemoteName,
-		URLs:  []string{o.URL},
-		Fetch: r.cloneRefSpec(o),
+		Name:         o.RemoteName,
+		URLs:         []string{o.URL},
+		NewScpRegexp: o.NewScpRegexp,
+		Fetch:        r.cloneRefSpec(o),
 	}
 
 	if _, err := r.CreateRemote(c); err != nil {
@@ -1425,7 +1426,6 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 	p := revision.NewParserFromString(string(rev))
 
 	items, err := p.Parse()
-
 	if err != nil {
 		return nil, err
 	}
@@ -1493,7 +1493,6 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 			iter := commit.Parents()
 
 			c, err := iter.Next()
-
 			if err != nil {
 				return &plumbing.ZeroHash, err
 			}
@@ -1514,7 +1513,6 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 		case revision.TildePath:
 			for i := 0; i < item.Depth; i++ {
 				c, err := commit.Parents().Next()
-
 				if err != nil {
 					return &plumbing.ZeroHash, err
 				}


### PR DESCRIPTION
I really miss the correct url handling in the git scp format.

I found this #324  merge request, but it complained about a lack of backward compatibility.

This is my attempt not to break backward compatibility and add the correct parsing of git url