### PR TITLE
git: add --follow-tags option for pushes

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -198,3 +198,11 @@ func AssertReferences(c *C, r *Repository, expected map[string]string) {
 		c.Assert(obtained, DeepEquals, expected)
 	}
 }
+
+func AssertReferencesMissing(c *C, r *Repository, expected []string) {
+	for _, name := range expected {
+		_, err := r.Reference(plumbing.ReferenceName(name), false)
+		c.Assert(err, NotNil)
+		c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -213,6 +213,9 @@ type PushOptions struct {
 	// RequireRemoteRefs only allows a remote ref to be updated if its current
 	// value is the one specified here.
 	RequireRemoteRefs []config.RefSpec
+	// FollowTags will send any annotated tags with a commit target reachable from
+	// the refs already being pushed
+	FollowTags bool
 }
 
 // Validate validates the fields and sets the default values.


### PR DESCRIPTION
This PR adds support for the --follow-tags option for pushes.