### PR TITLE
Remote: PushOptions add push-options

### DIFF
--- a/options.go
+++ b/options.go
@@ -222,6 +222,8 @@ type PushOptions struct {
 	// FollowTags will send any annotated tags with a commit target reachable from
 	// the refs already being pushed
 	FollowTags bool
+	// PushOptions sets options to be transferred to the server during push.
+	Options map[string]string
 }
 
 // Validate validates the fields and sets the default values.

--- a/plumbing/protocol/packp/updreq.go
+++ b/plumbing/protocol/packp/updreq.go
@@ -19,6 +19,7 @@ var (
 type ReferenceUpdateRequest struct {
 	Capabilities *capability.List
 	Commands     []*Command
+	Options      []*Option
 	Shallow      *plumbing.Hash
 	// Packfile contains an optional packfile reader.
 	Packfile io.ReadCloser
@@ -119,4 +120,9 @@ func (c *Command) validate() error {
 	}
 
 	return nil
+}
+
+type Option struct {
+	Key   string
+	Value string
 }

--- a/plumbing/protocol/packp/updreq_encode.go
+++ b/plumbing/protocol/packp/updreq_encode.go
@@ -29,6 +29,12 @@ func (req *ReferenceUpdateRequest) Encode(w io.Writer) error {
 		return err
 	}
 
+	if req.Capabilities.Supports(capability.PushOptions) {
+		if err := req.encodeOptions(e, req.Options); err != nil {
+			return err
+		}
+	}
+
 	if req.Packfile != nil {
 		if _, err := io.Copy(w, req.Packfile); err != nil {
 			return err
@@ -72,4 +78,16 @@ func formatCommand(cmd *Command) string {
 	o := cmd.Old.String()
 	n := cmd.New.String()
 	return fmt.Sprintf("%s %s %s", o, n, cmd.Name)
+}
+
+func (req *ReferenceUpdateRequest) encodeOptions(e *pktline.Encoder,
+	opts []*Option) error {
+
+	for _, opt := range opts {
+		if err := e.Encodef("%s=%s", opt.Key, opt.Value); err != nil {
+			return err
+		}
+	}
+
+	return e.Flush()
 }

--- a/remote.go
+++ b/remote.go
@@ -319,6 +319,13 @@ func (r *Remote) newReferenceUpdateRequest(
 		}
 	}
 
+	if ar.Capabilities.Supports(capability.PushOptions) {
+		_ = req.Capabilities.Set(capability.PushOptions)
+		for k, v := range o.Options {
+			req.Options = append(req.Options, &packp.Option{Key: k, Value: v})
+		}
+	}
+
 	if err := r.addReferencesToUpdate(o.RefSpecs, localRefs, remoteRefs, req, o.Prune); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add possibility to send push-options to the server. This is the equivalent to `git push --push-option=SomeKey=SomeValue -o AnotherKey=AnotherOption`.

Fixes #268.