### PR TITLE
plumbing: gitignore, Read .git/info/exclude file too.

### DIFF
--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -13,13 +13,14 @@ import (
 )
 
 const (
-	commentPrefix = "#"
-	coreSection   = "core"
-	excludesfile  = "excludesfile"
-	gitDir        = ".git"
-	gitignoreFile = ".gitignore"
-	gitconfigFile = ".gitconfig"
-	systemFile    = "/etc/gitconfig"
+	commentPrefix   = "#"
+	coreSection     = "core"
+	excludesfile    = "excludesfile"
+	gitDir          = ".git"
+	gitignoreFile   = ".gitignore"
+	gitconfigFile   = ".gitconfig"
+	systemFile      = "/etc/gitconfig"
+	infoExcludeFile = gitDir + "/info/exclude"
 )
 
 // readIgnoreFile reads a specific git ignore file.
@@ -42,10 +43,14 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 	return
 }
 
-// ReadPatterns reads gitignore patterns recursively traversing through the directory
-// structure. The result is in the ascending order of priority (last higher).
+// ReadPatterns reads the .git/info/exclude and then the gitignore patterns
+// recursively traversing through the directory structure. The result is in
+// the ascending order of priority (last higher).
 func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) {
-	ps, _ = readIgnoreFile(fs, path, gitignoreFile)
+	ps, _ = readIgnoreFile(fs, path, infoExcludeFile)
+
+	subps, _ := readIgnoreFile(fs, path, gitignoreFile)
+	ps = append(ps, subps...)
 
 	var fis []os.FileInfo
 	fis, err = fs.ReadDir(fs.Join(path...))

--- a/plumbing/format/gitignore/dir_test.go
+++ b/plumbing/format/gitignore/dir_test.go
@@ -11,7 +11,6 @@ import (
 
 type MatcherSuite struct {
 	GFS  billy.Filesystem // git repository root
-	IEFS billy.Filesystem // git repository root using info/exclude instead
 	RFS  billy.Filesystem // root that contains user home
 	MCFS billy.Filesystem // root that contains user home, but missing ~/.gitconfig
 	MEFS billy.Filesystem // root that contains user home, but missing excludesfile entry
@@ -25,7 +24,17 @@ var _ = Suite(&MatcherSuite{})
 func (s *MatcherSuite) SetUpTest(c *C) {
 	// setup generic git repository root
 	fs := memfs.New()
-	f, err := fs.Create(".gitignore")
+
+	err := fs.MkdirAll(".git/info", os.ModePerm)
+	c.Assert(err, IsNil)
+	f, err := fs.Create(".git/info/exclude")
+	c.Assert(err, IsNil)
+	_, err = f.Write([]byte("exclude.crlf\r\n"))
+	c.Assert(err, IsNil)
+	err = f.Close()
+	c.Assert(err, IsNil)
+
+	f, err = fs.Create(".gitignore")
 	c.Assert(err, IsNil)
 	_, err = f.Write([]byte("vendor/g*/\n"))
 	c.Assert(err, IsNil)
@@ -44,6 +53,8 @@ func (s *MatcherSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	err = fs.MkdirAll("another", os.ModePerm)
+	c.Assert(err, IsNil)
+	err = fs.MkdirAll("exclude.crlf", os.ModePerm)
 	c.Assert(err, IsNil)
 	err = fs.MkdirAll("ignore.crlf", os.ModePerm)
 	c.Assert(err, IsNil)
@@ -53,39 +64,6 @@ func (s *MatcherSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.GFS = fs
-
-	// setup generic git repository root using info/exclude instead
-	fs = memfs.New()
-	err = fs.MkdirAll(".git/info", os.ModePerm)
-	c.Assert(err, IsNil)
-	f, err = fs.Create(".git/info/exclude")
-	c.Assert(err, IsNil)
-	_, err = f.Write([]byte("vendor/g*/\n"))
-	c.Assert(err, IsNil)
-	_, err = f.Write([]byte("ignore.crlf\r\n"))
-	c.Assert(err, IsNil)
-	err = f.Close()
-	c.Assert(err, IsNil)
-
-	err = fs.MkdirAll("vendor", os.ModePerm)
-	c.Assert(err, IsNil)
-	f, err = fs.Create("vendor/.gitignore")
-	c.Assert(err, IsNil)
-	_, err = f.Write([]byte("!github.com/\n"))
-	c.Assert(err, IsNil)
-	err = f.Close()
-	c.Assert(err, IsNil)
-
-	err = fs.MkdirAll("another", os.ModePerm)
-	c.Assert(err, IsNil)
-	err = fs.MkdirAll("ignore.crlf", os.ModePerm)
-	c.Assert(err, IsNil)
-	err = fs.MkdirAll("vendor/github.com", os.ModePerm)
-	c.Assert(err, IsNil)
-	err = fs.MkdirAll("vendor/gopkg.in", os.ModePerm)
-	c.Assert(err, IsNil)
-
-	s.IEFS = fs
 
 	// setup root that contains user home
 	home, err := os.UserHomeDir()
@@ -207,18 +185,10 @@ func (s *MatcherSuite) SetUpTest(c *C) {
 func (s *MatcherSuite) TestDir_ReadPatterns(c *C) {
 	ps, err := ReadPatterns(s.GFS, nil)
 	c.Assert(err, IsNil)
-	c.Assert(ps, HasLen, 3)
+	c.Assert(ps, HasLen, 4)
 
 	m := NewMatcher(ps)
-	c.Assert(m.Match([]string{"ignore.crlf"}, true), Equals, true)
-	c.Assert(m.Match([]string{"vendor", "gopkg.in"}, true), Equals, true)
-	c.Assert(m.Match([]string{"vendor", "github.com"}, true), Equals, false)
-
-	ps, err = ReadPatterns(s.IEFS, nil)
-	c.Assert(err, IsNil)
-	c.Assert(ps, HasLen, 3)
-
-	m = NewMatcher(ps)
+	c.Assert(m.Match([]string{"exclude.crlf"}, true), Equals, true)
 	c.Assert(m.Match([]string{"ignore.crlf"}, true), Equals, true)
 	c.Assert(m.Match([]string{"vendor", "gopkg.in"}, true), Equals, true)
 	c.Assert(m.Match([]string{"vendor", "github.com"}, true), Equals, false)

--- a/plumbing/format/gitignore/dir_test.go
+++ b/plumbing/format/gitignore/dir_test.go
@@ -11,6 +11,7 @@ import (
 
 type MatcherSuite struct {
 	GFS  billy.Filesystem // git repository root
+	IEFS billy.Filesystem // git repository root using info/exclude instead
 	RFS  billy.Filesystem // root that contains user home
 	MCFS billy.Filesystem // root that contains user home, but missing ~/.gitconfig
 	MEFS billy.Filesystem // root that contains user home, but missing excludesfile entry
@@ -52,6 +53,39 @@ func (s *MatcherSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	s.GFS = fs
+
+	// setup generic git repository root using info/exclude instead
+	fs = memfs.New()
+	err = fs.MkdirAll(".git/info", os.ModePerm)
+	c.Assert(err, IsNil)
+	f, err = fs.Create(".git/info/exclude")
+	c.Assert(err, IsNil)
+	_, err = f.Write([]byte("vendor/g*/\n"))
+	c.Assert(err, IsNil)
+	_, err = f.Write([]byte("ignore.crlf\r\n"))
+	c.Assert(err, IsNil)
+	err = f.Close()
+	c.Assert(err, IsNil)
+
+	err = fs.MkdirAll("vendor", os.ModePerm)
+	c.Assert(err, IsNil)
+	f, err = fs.Create("vendor/.gitignore")
+	c.Assert(err, IsNil)
+	_, err = f.Write([]byte("!github.com/\n"))
+	c.Assert(err, IsNil)
+	err = f.Close()
+	c.Assert(err, IsNil)
+
+	err = fs.MkdirAll("another", os.ModePerm)
+	c.Assert(err, IsNil)
+	err = fs.MkdirAll("ignore.crlf", os.ModePerm)
+	c.Assert(err, IsNil)
+	err = fs.MkdirAll("vendor/github.com", os.ModePerm)
+	c.Assert(err, IsNil)
+	err = fs.MkdirAll("vendor/gopkg.in", os.ModePerm)
+	c.Assert(err, IsNil)
+
+	s.IEFS = fs
 
 	// setup root that contains user home
 	home, err := os.UserHomeDir()
@@ -176,6 +210,15 @@ func (s *MatcherSuite) TestDir_ReadPatterns(c *C) {
 	c.Assert(ps, HasLen, 3)
 
 	m := NewMatcher(ps)
+	c.Assert(m.Match([]string{"ignore.crlf"}, true), Equals, true)
+	c.Assert(m.Match([]string{"vendor", "gopkg.in"}, true), Equals, true)
+	c.Assert(m.Match([]string{"vendor", "github.com"}, true), Equals, false)
+
+	ps, err = ReadPatterns(s.IEFS, nil)
+	c.Assert(err, IsNil)
+	c.Assert(ps, HasLen, 3)
+
+	m = NewMatcher(ps)
 	c.Assert(m.Match([]string{"ignore.crlf"}, true), Equals, true)
 	c.Assert(m.Match([]string{"vendor", "gopkg.in"}, true), Equals, true)
 	c.Assert(m.Match([]string{"vendor", "github.com"}, true), Equals, false)


### PR DESCRIPTION
Read the `.git/info/exclude` file too, as per the official Git implementation.

> Patterns which are specific to a particular repository but which do not need to be shared with other related repositories (e.g., auxiliary files that live inside the repository but are specific to one user’s workflow) should go into the `$GIT_DIR/info/exclude` file.

References:
- https://git-scm.com/docs/gitignore
- https://github.com/git/git/blob/eb27b338a3e71c7c4079fbac8aeae3f8fbb5c687/Documentation/gitignore.txt