### PR TITLE
Remote: Push, add atomic to push options

### DIFF
--- a/options.go
+++ b/options.go
@@ -230,6 +230,8 @@ type PushOptions struct {
 	FollowTags bool
 	// PushOptions sets options to be transferred to the server during push.
 	Options map[string]string
+	// Atomic sets option to be an atomic push
+	Atomic bool
 }
 
 // Validate validates the fields and sets the default values.

--- a/plumbing/protocol/packp/updreq_encode_test.go
+++ b/plumbing/protocol/packp/updreq_encode_test.go
@@ -170,3 +170,22 @@ func (s *UpdReqEncodeSuite) TestPushOptions(c *C) {
 
 	s.testEncode(c, r, expected)
 }
+
+func (s *UpdReqEncodeSuite) TestPushAtomic(c *C) {
+	hash1 := plumbing.NewHash("1ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	hash2 := plumbing.NewHash("2ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	name := plumbing.ReferenceName("myref")
+
+	r := NewReferenceUpdateRequest()
+	r.Capabilities.Set(capability.Atomic)
+	r.Commands = []*Command{
+		{Name: name, Old: hash1, New: hash2},
+	}
+
+	expected := pktlines(c,
+		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00atomic",
+		pktline.FlushString,
+	)
+
+	s.testEncode(c, r, expected)
+}

--- a/remote.go
+++ b/remote.go
@@ -326,6 +326,10 @@ func (r *Remote) newReferenceUpdateRequest(
 		}
 	}
 
+	if o.Atomic && ar.Capabilities.Supports(capability.Atomic) {
+		_ = req.Capabilities.Set(capability.Atomic)
+	}
+
 	if err := r.addReferencesToUpdate(o.RefSpecs, localRefs, remoteRefs, req, o.Prune); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
push --atomic allows a push to succeed or fail atomically. If one ref
fails, the whole push fails. This commit allows the user to set Atomic
as an option for a push.