### PR TITLE
Worktree: Checkout, simplified sparse checkout

### DIFF
--- a/options.go
+++ b/options.go
@@ -291,6 +291,8 @@ type CheckoutOptions struct {
 	// target branch. Force and Keep are mutually exclusive, should not be both
 	// set to true.
 	Keep bool
+	// SparseCheckoutDirectories
+	SparseCheckoutDirectories []string
 }
 
 // Validate validates the fields and sets the default values.

--- a/plumbing/format/index/index.go
+++ b/plumbing/format/index/index.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -210,4 +211,21 @@ type EndOfIndexEntry struct {
 	// Hash is a SHA-1 over the extension types and their sizes (but not
 	//	their contents).
 	Hash plumbing.Hash
+}
+
+// SkipUnless applies patterns in the form of A, A/B, A/B/C
+// to the index to prevent the files from being checked out
+func (i *Index) SkipUnless(patterns []string) {
+	for _, e := range i.Entries {
+		var include bool
+		for _, pattern := range patterns {
+			if strings.HasPrefix(e.Name, pattern) {
+				include = true
+				break
+			}
+		}
+		if !include {
+			e.SkipWorktree = true
+		}
+	}
 }

--- a/plumbing/object/treenoder.go
+++ b/plumbing/object/treenoder.go
@@ -38,6 +38,10 @@ func NewTreeRootNode(t *Tree) noder.Noder {
 	}
 }
 
+func (t *treeNoder) Skip() bool {
+	return false
+}
+
 func (t *treeNoder) isRoot() bool {
 	return t.name == ""
 }

--- a/utils/merkletrie/difftree.go
+++ b/utils/merkletrie/difftree.go
@@ -304,13 +304,38 @@ func DiffTreeContext(ctx context.Context, fromTree, toTree noder.Noder,
 				return nil, err
 			}
 		case onlyToRemains:
-			if err = ret.AddRecursiveInsert(to); err != nil {
-				return nil, err
+			if to.Skip() {
+				if err = ret.AddRecursiveDelete(to); err != nil {
+					return nil, err
+				}
+			} else {
+				if err = ret.AddRecursiveInsert(to); err != nil {
+					return nil, err
+				}
 			}
 			if err = ii.nextTo(); err != nil {
 				return nil, err
 			}
 		case bothHaveNodes:
+			if from.Skip() {
+				if err = ret.AddRecursiveDelete(from); err != nil {
+					return nil, err
+				}
+				if err := ii.nextBoth(); err != nil {
+					return nil, err
+				}
+				break
+			}
+			if to.Skip() {
+				if err = ret.AddRecursiveDelete(to); err != nil {
+					return nil, err
+				}
+				if err := ii.nextBoth(); err != nil {
+					return nil, err
+				}
+				break
+			}
+
 			if err = diffNodes(&ret, ii); err != nil {
 				return nil, err
 			}

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -61,6 +61,10 @@ func (n *node) IsDir() bool {
 	return n.isDir
 }
 
+func (n *node) Skip() bool {
+	return false
+}
+
 func (n *node) Children() ([]noder.Noder, error) {
 	if err := n.calculateChildren(); err != nil {
 		return nil, err

--- a/utils/merkletrie/index/node.go
+++ b/utils/merkletrie/index/node.go
@@ -19,6 +19,7 @@ type node struct {
 	entry    *index.Entry
 	children []noder.Noder
 	isDir    bool
+	skip     bool
 }
 
 // NewRootNode returns the root node of a computed tree from a index.Index,
@@ -39,7 +40,7 @@ func NewRootNode(idx *index.Index) noder.Noder {
 				continue
 			}
 
-			n := &node{path: fullpath}
+			n := &node{path: fullpath, skip: e.SkipWorktree}
 			if fullpath == e.Name {
 				n.entry = e
 			} else {
@@ -56,6 +57,10 @@ func NewRootNode(idx *index.Index) noder.Noder {
 
 func (n *node) String() string {
 	return n.path
+}
+
+func (n *node) Skip() bool {
+	return n.skip
 }
 
 // Hash the hash of a filesystem is a 24-byte slice, is the result of

--- a/utils/merkletrie/internal/fsnoder/dir.go
+++ b/utils/merkletrie/internal/fsnoder/dir.go
@@ -112,6 +112,10 @@ func (d *dir) NumChildren() (int, error) {
 	return len(d.children), nil
 }
 
+func (d *dir) Skip() bool {
+	return false
+}
+
 const (
 	dirStartMark  = '('
 	dirEndMark    = ')'

--- a/utils/merkletrie/internal/fsnoder/file.go
+++ b/utils/merkletrie/internal/fsnoder/file.go
@@ -55,6 +55,10 @@ func (f *file) NumChildren() (int, error) {
 	return 0, nil
 }
 
+func (f *file) Skip() bool {
+	return false
+}
+
 const (
 	fileStartMark = '<'
 	fileEndMark   = '>'

--- a/utils/merkletrie/noder/noder.go
+++ b/utils/merkletrie/noder/noder.go
@@ -53,6 +53,7 @@ type Noder interface {
 	// implement NumChildren in O(1) while Children is usually more
 	// complex.
 	NumChildren() (int, error)
+	Skip()	bool
 }
 
 // NoChildren represents the children of a noder without children.

--- a/utils/merkletrie/noder/noder_test.go
+++ b/utils/merkletrie/noder/noder_test.go
@@ -25,6 +25,7 @@ func (n noderMock) Name() string               { return n.name }
 func (n noderMock) IsDir() bool                { return n.isDir }
 func (n noderMock) Children() ([]Noder, error) { return n.children, nil }
 func (n noderMock) NumChildren() (int, error)  { return len(n.children), nil }
+func (n noderMock) Skip() bool                 { return false }
 
 // Returns a sequence with the noders 3, 2, and 1 from the
 // following diagram:

--- a/utils/merkletrie/noder/path.go
+++ b/utils/merkletrie/noder/path.go
@@ -15,6 +15,14 @@ import (
 // not be used.
 type Path []Noder
 
+func (p Path) Skip() bool {
+	if len(p) > 0 {
+		return p.Last().Skip()
+	}
+
+	return false
+}
+
 // String returns the full path of the final noder as a string, using
 // "/" as the separator.
 func (p Path) String() string {


### PR DESCRIPTION
This is the initial logic to support a simple sparse checkout where
directories to be included can be specified in CheckoutOptions.
This change doesn't fully support the sparse patterns, nor does it
include optimizations in the index to collapse flie entries that are not
included into its parent directory.