### PR TITLE
Remove unused vars/types/funcs/fields

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/format/packfile"
-	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/memory"
 
@@ -25,8 +24,7 @@ type BaseSuite struct {
 	fixtures.Suite
 	Repository *Repository
 
-	backupProtocol transport.Transport
-	cache          map[string]*Repository
+	cache map[string]*Repository
 }
 
 func (s *BaseSuite) SetUpSuite(c *C) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -361,6 +361,7 @@ func (s *ConfigSuite) TestRemoveUrlOptions(c *C) {
 	cfg.Remotes["alt"].URLs = []string{}
 
 	buf, err = cfg.Marshal()
+	c.Assert(err, IsNil)
 	if strings.Contains(string(buf), "url") {
 		c.Fatal("conifg should not contain any url sections")
 	}

--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -13,7 +13,6 @@ import (
 // FSObject is an object from the packfile on the filesystem.
 type FSObject struct {
 	hash                 plumbing.Hash
-	h                    *ObjectHeader
 	offset               int64
 	size                 int64
 	typ                  plumbing.ObjectType
@@ -117,18 +116,4 @@ func (o *FSObject) Type() plumbing.ObjectType {
 // returns a nil writer.
 func (o *FSObject) Writer() (io.WriteCloser, error) {
 	return nil, nil
-}
-
-type objectReader struct {
-	io.ReadCloser
-	f billy.File
-}
-
-func (r *objectReader) Close() error {
-	if err := r.ReadCloser.Close(); err != nil {
-		_ = r.f.Close()
-		return err
-	}
-
-	return r.f.Close()
 }

--- a/plumbing/format/packfile/packfile_test.go
+++ b/plumbing/format/packfile/packfile_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v5/plumbing/format/packfile"
-	"github.com/go-git/go-git/v5/plumbing/storer"
 	. "gopkg.in/check.v1"
 )
 
@@ -234,22 +233,6 @@ var expectedHashes = []string{
 	"dbd3641b371024f44d0e469a9c8f5457b0660de1",
 	"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	"7e59600739c96546163833214c36459e324bad0a",
-}
-
-func assertObjects(c *C, s storer.EncodedObjectStorer, expects []string) {
-	i, err := s.IterEncodedObjects(plumbing.AnyObject)
-	c.Assert(err, IsNil)
-
-	var count int
-	err = i.ForEach(func(plumbing.EncodedObject) error { count++; return nil })
-	c.Assert(err, IsNil)
-	c.Assert(count, Equals, len(expects))
-
-	for _, exp := range expects {
-		obt, err := s.EncodedObject(plumbing.AnyObject, plumbing.NewHash(exp))
-		c.Assert(err, IsNil)
-		c.Assert(obt.Hash().String(), Equals, exp)
-	}
 }
 
 func getIndexFromIdxFile(r io.Reader) idxfile.Index {

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -46,7 +46,6 @@ type Parser struct {
 	oi         []*objectInfo
 	oiByHash   map[plumbing.Hash]*objectInfo
 	oiByOffset map[int64]*objectInfo
-	hashOffset map[plumbing.Hash]int64
 	checksum   plumbing.Hash
 
 	cache *cache.BufferLRU

--- a/plumbing/object/patch.go
+++ b/plumbing/object/patch.go
@@ -96,10 +96,6 @@ func filePatchWithContext(ctx context.Context, c *Change) (fdiff.FilePatch, erro
 
 }
 
-func filePatch(c *Change) (fdiff.FilePatch, error) {
-	return filePatchWithContext(context.Background(), c)
-}
-
 func fileContent(f *File) (content string, isBinary bool, err error) {
 	if f == nil {
 		return

--- a/plumbing/protocol/packp/common.go
+++ b/plumbing/protocol/packp/common.go
@@ -19,7 +19,6 @@ var (
 	// common
 	sp  = []byte(" ")
 	eol = []byte("\n")
-	eq  = []byte{'='}
 
 	// advertised-refs
 	null       = []byte("\x00")

--- a/plumbing/protocol/packp/updreq_encode.go
+++ b/plumbing/protocol/packp/updreq_encode.go
@@ -9,10 +9,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 )
 
-var (
-	zeroHashString = plumbing.ZeroHash.String()
-)
-
 // Encode writes the ReferenceUpdateRequest encoding to the stream.
 func (req *ReferenceUpdateRequest) Encode(w io.Writer) error {
 	if err := req.validate(); err != nil {

--- a/plumbing/protocol/packp/uppackresp.go
+++ b/plumbing/protocol/packp/uppackresp.go
@@ -24,7 +24,6 @@ type UploadPackResponse struct {
 	r          io.ReadCloser
 	isShallow  bool
 	isMultiACK bool
-	isOk       bool
 }
 
 // NewUploadPackResponse create a new UploadPackResponse instance, the request

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -55,12 +55,6 @@ func (s *RevListSuite) SetUpTest(c *C) {
 	s.Storer = sto
 }
 
-func (s *RevListSuite) commit(c *C, h plumbing.Hash) *object.Commit {
-	commit, err := object.GetCommit(s.Storer, h)
-	c.Assert(err, IsNil)
-	return commit
-}
-
 func (s *RevListSuite) TestRevListObjects_Submodules(c *C) {
 	submodules := map[string]bool{
 		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5": true,

--- a/plumbing/transport/client/client_test.go
+++ b/plumbing/transport/client/client_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -67,8 +66,4 @@ func (*dummyClient) NewUploadPackSession(*transport.Endpoint, transport.AuthMeth
 func (*dummyClient) NewReceivePackSession(*transport.Endpoint, transport.AuthMethod) (
 	transport.ReceivePackSession, error) {
 	return nil, nil
-}
-
-func typeAsString(v interface{}) string {
-	return fmt.Sprintf("%T", v)
 }

--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -428,11 +428,6 @@ func isRepoNotFoundError(s string) bool {
 	return false
 }
 
-var (
-	nak = []byte("NAK")
-	eol = []byte("\n")
-)
-
 // uploadPack implements the git-upload-pack protocol.
 func uploadPack(w io.WriteCloser, r io.Reader, req *packp.UploadPackRequest) error {
 	// TODO support multi_ack mode

--- a/plumbing/transport/ssh/common_test.go
+++ b/plumbing/transport/ssh/common_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/kevinburke/ssh_config"
 	"golang.org/x/crypto/ssh"
-	stdssh "golang.org/x/crypto/ssh"
 	. "gopkg.in/check.v1"
 )
 
@@ -99,7 +98,7 @@ func (s *SuiteCommon) TestIssue70(c *C) {
 	uploadPack.SetUpSuite(c)
 
 	config := &ssh.ClientConfig{
-		HostKeyCallback: stdssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 	r := &runner{
 		config: config,

--- a/remote.go
+++ b/remote.go
@@ -247,10 +247,7 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 
 	// remove any that are already on the remote
 	if err := remoteRefIter.ForEach(func(reference *plumbing.Reference) error {
-		if _, ok := tags[*reference]; ok {
-			delete(tags, *reference)
-		}
-
+		delete(tags, *reference)
 		return nil
 	}); err != nil {
 		return err

--- a/remote.go
+++ b/remote.go
@@ -256,7 +256,7 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 		return err
 	}
 
-	for tag, _ := range tags {
+	for tag := range tags {
 		tagObject, err := object.GetObject(r.s, tag.Hash())
 		var tagCommit *object.Commit
 		if err != nil {

--- a/remote_test.go
+++ b/remote_test.go
@@ -875,7 +875,7 @@ func (s *RemoteSuite) TestPushPrune(c *C) {
 		"refs/remotes/origin/master": ref.Hash().String(),
 	})
 
-	ref, err = server.Reference(plumbing.ReferenceName("refs/tags/v1.0.0"), true)
+	_, err = server.Reference(plumbing.ReferenceName("refs/tags/v1.0.0"), true)
 	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
 }
 

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -653,7 +653,7 @@ func (s *SuiteDotGit) TestObject(c *C) {
 	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
 	fs.Create(incomingFilePath)
 
-	file, err = dir.Object(plumbing.NewHash(incomingHash))
+	_, err = dir.Object(plumbing.NewHash(incomingHash))
 	c.Assert(err, IsNil)
 }
 

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -386,7 +386,7 @@ func (s *FsSuite) TestGetFromObjectFileSharedCache(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(obj.Hash(), Equals, expected)
 
-	obj, err = o2.EncodedObject(plumbing.CommitObject, expected)
+	_, err = o2.EncodedObject(plumbing.CommitObject, expected)
 	c.Assert(err, Equals, plumbing.ErrObjectNotFound)
 }
 

--- a/storage/transactional/config_test.go
+++ b/storage/transactional/config_test.go
@@ -54,7 +54,7 @@ func (s *ConfigSuite) TestSetConfigTemporal(c *C) {
 
 	cfg, err = cs.Config()
 	c.Assert(err, IsNil)
-	c.Assert(temporalCfg.Core.Worktree, Equals, "bar")
+	c.Assert(cfg.Core.Worktree, Equals, "bar")
 }
 
 func (s *ConfigSuite) TestCommit(c *C) {

--- a/storage/transactional/reference.go
+++ b/storage/transactional/reference.go
@@ -15,9 +15,6 @@ type ReferenceStorage struct {
 	// commit is requested, the entries are added when RemoveReference is called
 	// and deleted if SetReference is called.
 	deleted map[plumbing.ReferenceName]struct{}
-	// packRefs if true PackRefs is going to be called in the based storer when
-	// commit is called.
-	packRefs bool
 }
 
 // NewReferenceStorage returns a new ReferenceStorer based on a base storer and
@@ -108,7 +105,6 @@ func (r ReferenceStorage) CountLooseRefs() (int, error) {
 
 // PackRefs honors the storer.ReferenceStorer interface.
 func (r ReferenceStorage) PackRefs() error {
-	r.packRefs = true
 	return nil
 }
 

--- a/utils/merkletrie/noder/noder_test.go
+++ b/utils/merkletrie/noder/noder_test.go
@@ -57,20 +57,6 @@ func childrenFixture() []Noder {
 	return []Noder{c1, c2}
 }
 
-// Returns the same as nodersFixture but sorted by name, this is: "1",
-// "2" and then "3".
-func sortedNodersFixture() []Noder {
-	n1 := &noderMock{
-		name:     "1",
-		hash:     []byte{0x00, 0x01, 0x02},
-		isDir:    true,
-		children: childrenFixture(),
-	}
-	n2 := &noderMock{name: "2"}
-	n3 := &noderMock{name: "3"}
-	return []Noder{n1, n2, n3} // the same as nodersFixture but sorted by name
-}
-
 // returns nodersFixture as the path of "1".
 func pathFixture() Path {
 	return Path(nodersFixture())

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -212,10 +212,10 @@ func (s *WorktreeSuite) TestCommitTreeSort(c *C) {
 	defer clean()
 
 	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-	r, err := Init(st, nil)
+	_, err := Init(st, nil)
 	c.Assert(err, IsNil)
 
-	r, _ = Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
+	r, _ := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
 		URL: fs.Root(),
 	})
 
@@ -296,6 +296,7 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored(c *C) {
 		All:    true,
 		Author: defaultSignature(),
 	})
+	c.Assert(err, IsNil)
 	c.Assert(hash, Equals, plumbing.NewHash("97c0c5177e6ac57d10e8ea0017f2d39b91e2b364"))
 
 	// Step 3: Check

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -183,7 +183,7 @@ func (s *WorktreeSuite) TestPullInSingleBranch(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(branch.Hash().String(), Equals, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 
-	branch, err = r.Reference("refs/remotes/foo/branch", false)
+	_, err = r.Reference("refs/remotes/foo/branch", false)
 	c.Assert(err, NotNil)
 
 	storage := r.Storer.(*memory.Storage)
@@ -555,6 +555,7 @@ func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized(c *C) {
 
 	// test submodule path
 	modules, err := w.readGitmodulesFile()
+	c.Assert(err, IsNil)
 
 	c.Assert(modules.Submodules["basic"].URL, Equals, "../basic.git")
 	c.Assert(modules.Submodules["itself"].URL, Equals, "../submodule.git")


### PR DESCRIPTION
[staticcheck] reported a number of unused fields, functions, types, and
variables across the code.

  [staticcheck]: https://staticcheck.io/

Use them where possible (assert unchecked errors in tests, for example)
and remove them otherwise.

There were a few special cases that are on their own commits to
cherry-pick separate from the unused deletions.

- storage/transactional: The assertion appears to be intended to validate
  the unused `cfg` variable, not `temporalCfg` which was validated earlier.
- transactional/ReferenceStorage: `packRefs` is intended to be assigned to
  from the `PackRefs()` method but never read. Further, because the assignment
  happens inside a value receiver, not a pointer receiver, the value is never
  actually recorded (so it's a no-op).
- remote/addReachableTags: Membership check before `delete`-ing a key
  from a map is unnecessary; `delete` is a no-op if the key is absent.
