### PR TITLE
NoErrAlreadyUpToDate: Rename to ErrAlreadyUpToDate

### DIFF
--- a/_examples/tag-create-push/main.go
+++ b/_examples/tag-create-push/main.go
@@ -136,7 +136,7 @@ func pushTags(r *git.Repository, publicKeyPath string) error {
 	err := r.Push(po)
 
 	if err != nil {
-		if err == git.NoErrAlreadyUpToDate {
+		if err == git.ErrAlreadyUpToDate {
 			log.Print("origin remote was up to date, no push done")
 			return nil
 		}

--- a/remote.go
+++ b/remote.go
@@ -29,10 +29,13 @@ import (
 )
 
 var (
-	NoErrAlreadyUpToDate     = errors.New("already up-to-date")
+	ErrAlreadyUpToDate       = errors.New("already up-to-date")
 	ErrDeleteRefNotSupported = errors.New("server does not support delete-refs")
 	ErrForceNeeded           = errors.New("some refs were not updated")
 	ErrExactSHA1NotSupported = errors.New("server does not support exact SHA1 refspec")
+
+	// Deprecated: Use ErrAlreadyUpToDate.
+	NoErrAlreadyUpToDate = ErrAlreadyUpToDate
 )
 
 type NoMatchingRefSpecError struct {
@@ -84,13 +87,13 @@ func (r *Remote) String() string {
 	return fmt.Sprintf("%s\t%s (fetch)\n%[1]s\t%[3]s (push)", r.c.Name, fetch, push)
 }
 
-// Push performs a push to the remote. Returns NoErrAlreadyUpToDate if the
+// Push performs a push to the remote. Returns ErrAlreadyUpToDate if the
 // remote was already up-to-date.
 func (r *Remote) Push(o *PushOptions) error {
 	return r.PushContext(context.Background(), o)
 }
 
-// PushContext performs a push to the remote. Returns NoErrAlreadyUpToDate if
+// PushContext performs a push to the remote. Returns ErrAlreadyUpToDate if
 // the remote was already up-to-date.
 //
 // The provided Context must be non-nil. If the context expires before the
@@ -167,7 +170,7 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 	}
 
 	if len(req.Commands) == 0 {
-		return NoErrAlreadyUpToDate
+		return ErrAlreadyUpToDate
 	}
 
 	objects := objectsToPush(req.Commands)
@@ -371,7 +374,7 @@ func (r *Remote) updateRemoteReferenceStorage(
 // FetchContext fetches references along with the objects necessary to complete
 // their histories.
 //
-// Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
+// Returns nil if the operation is successful, ErrAlreadyUpToDate if there are
 // no changes to be fetched, or an error.
 //
 // The provided Context must be non-nil. If the context expires before the
@@ -385,7 +388,7 @@ func (r *Remote) FetchContext(ctx context.Context, o *FetchOptions) error {
 // Fetch fetches references along with the objects necessary to complete their
 // histories.
 //
-// Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
+// Returns nil if the operation is successful, ErrAlreadyUpToDate if there are
 // no changes to be fetched, or an error.
 func (r *Remote) Fetch(o *FetchOptions) error {
 	return r.FetchContext(context.Background(), o)
@@ -476,7 +479,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	}
 
 	if !updated {
-		return remoteRefs, NoErrAlreadyUpToDate
+		return remoteRefs, ErrAlreadyUpToDate
 	}
 
 	return remoteRefs, nil

--- a/remote_test.go
+++ b/remote_test.go
@@ -346,12 +346,12 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter(c *C) {
 	c.Assert(mock.PackfileWriterCalled, Equals, true)
 }
 
-func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDate(c *C) {
+func (s *RemoteSuite) TestFetchErrAlreadyUpToDate(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
-	s.doTestFetchNoErrAlreadyUpToDate(c, url)
+	s.doTestFetchErrAlreadyUpToDate(c, url)
 }
 
-func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDateButStillUpdateLocalRemoteRefs(c *C) {
+func (s *RemoteSuite) TestFetchErrAlreadyUpToDateButStillUpdateLocalRemoteRefs(c *C) {
 	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
@@ -382,13 +382,13 @@ func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDateButStillUpdateLocalRemoteRefs
 	c.Assert(exp.String(), Equals, ref.String())
 }
 
-func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDateWithNonCommitObjects(c *C) {
+func (s *RemoteSuite) TestFetchErrAlreadyUpToDateWithNonCommitObjects(c *C) {
 	fixture := fixtures.ByTag("tags").One()
 	url := s.GetLocalRepositoryURL(fixture)
-	s.doTestFetchNoErrAlreadyUpToDate(c, url)
+	s.doTestFetchErrAlreadyUpToDate(c, url)
 }
 
-func (s *RemoteSuite) doTestFetchNoErrAlreadyUpToDate(c *C, url string) {
+func (s *RemoteSuite) doTestFetchErrAlreadyUpToDate(c *C, url string) {
 	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{URLs: []string{url}})
 
 	o := &FetchOptions{
@@ -400,7 +400,7 @@ func (s *RemoteSuite) doTestFetchNoErrAlreadyUpToDate(c *C, url string) {
 	err := r.Fetch(o)
 	c.Assert(err, IsNil)
 	err = r.Fetch(o)
-	c.Assert(err, Equals, NoErrAlreadyUpToDate)
+	c.Assert(err, Equals, ErrAlreadyUpToDate)
 }
 
 func (s *RemoteSuite) testFetchFastForward(c *C, sto storage.Storer) {
@@ -661,7 +661,7 @@ func (s *RemoteSuite) TestPushFollowTags(c *C) {
 	})
 }
 
-func (s *RemoteSuite) TestPushNoErrAlreadyUpToDate(c *C) {
+func (s *RemoteSuite) TestPushErrAlreadyUpToDate(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
@@ -673,7 +673,7 @@ func (s *RemoteSuite) TestPushNoErrAlreadyUpToDate(c *C) {
 	err := r.Push(&PushOptions{
 		RefSpecs: []config.RefSpec{"refs/heads/*:refs/heads/*"},
 	})
-	c.Assert(err, Equals, NoErrAlreadyUpToDate)
+	c.Assert(err, Equals, ErrAlreadyUpToDate)
 }
 
 func (s *RemoteSuite) TestPushDeleteReference(c *C) {
@@ -853,7 +853,7 @@ func (s *RemoteSuite) TestPushPrune(c *C) {
 		},
 		Prune: true,
 	})
-	c.Assert(err, Equals, NoErrAlreadyUpToDate)
+	c.Assert(err, Equals, ErrAlreadyUpToDate)
 
 	AssertReferences(c, server, map[string]string{
 		"refs/tags/v1.0.0": tag.Hash().String(),

--- a/repository.go
+++ b/repository.go
@@ -959,7 +959,7 @@ func (r *Repository) fetchAndUpdateReferences(
 
 	objsUpdated := true
 	remoteRefs, err := remote.fetch(ctx, o)
-	if err == NoErrAlreadyUpToDate {
+	if err == ErrAlreadyUpToDate {
 		objsUpdated = false
 	} else if err == packfile.ErrEmptyPackfile {
 		return nil, ErrFetching
@@ -978,7 +978,7 @@ func (r *Repository) fetchAndUpdateReferences(
 	}
 
 	if !objsUpdated && !refsUpdated {
-		return nil, NoErrAlreadyUpToDate
+		return nil, ErrAlreadyUpToDate
 	}
 
 	return resolvedRef, nil
@@ -1071,7 +1071,7 @@ func updateReferenceStorerIfNeeded(
 // Fetch fetches references along with the objects necessary to complete
 // their histories, from the remote named as FetchOptions.RemoteName.
 //
-// Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
+// Returns nil if the operation is successful, ErrAlreadyUpToDate if there are
 // no changes to be fetched, or an error.
 func (r *Repository) Fetch(o *FetchOptions) error {
 	return r.FetchContext(context.Background(), o)
@@ -1080,7 +1080,7 @@ func (r *Repository) Fetch(o *FetchOptions) error {
 // FetchContext fetches references along with the objects necessary to complete
 // their histories, from the remote named as FetchOptions.RemoteName.
 //
-// Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
+// Returns nil if the operation is successful, ErrAlreadyUpToDate if there are
 // no changes to be fetched, or an error.
 //
 // The provided Context must be non-nil. If the context expires before the
@@ -1099,14 +1099,14 @@ func (r *Repository) FetchContext(ctx context.Context, o *FetchOptions) error {
 	return remote.FetchContext(ctx, o)
 }
 
-// Push performs a push to the remote. Returns NoErrAlreadyUpToDate if
+// Push performs a push to the remote. Returns ErrAlreadyUpToDate if
 // the remote was already up-to-date, from the remote named as
 // FetchOptions.RemoteName.
 func (r *Repository) Push(o *PushOptions) error {
 	return r.PushContext(context.Background(), o)
 }
 
-// PushContext performs a push to the remote. Returns NoErrAlreadyUpToDate if
+// PushContext performs a push to the remote. Returns ErrAlreadyUpToDate if
 // the remote was already up-to-date, from the remote named as
 // FetchOptions.RemoteName.
 //

--- a/submodule.go
+++ b/submodule.go
@@ -244,7 +244,7 @@ func (s *Submodule) fetchAndCheckout(
 ) error {
 	if !o.NoFetch {
 		err := r.FetchContext(ctx, &FetchOptions{Auth: o.Auth})
-		if err != nil && err != NoErrAlreadyUpToDate {
+		if err != nil && err != ErrAlreadyUpToDate {
 			return err
 		}
 	}
@@ -266,7 +266,7 @@ func (s *Submodule) fetchAndCheckout(
 				Auth:     o.Auth,
 				RefSpecs: []config.RefSpec{refSpec},
 			})
-			if err != nil && err != NoErrAlreadyUpToDate && err != ErrExactSHA1NotSupported {
+			if err != nil && err != ErrAlreadyUpToDate && err != ErrExactSHA1NotSupported {
 				return err
 			}
 		}

--- a/worktree.go
+++ b/worktree.go
@@ -44,7 +44,7 @@ type Worktree struct {
 }
 
 // Pull incorporates changes from a remote repository into the current branch.
-// Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
+// Returns nil if the operation is successful, ErrAlreadyUpToDate if there are
 // no changes to be fetched, or an error.
 //
 // Pull only supports merges where the can be resolved as a fast-forward.
@@ -53,7 +53,7 @@ func (w *Worktree) Pull(o *PullOptions) error {
 }
 
 // PullContext incorporates changes from a remote repository into the current
-// branch. Returns nil if the operation is successful, NoErrAlreadyUpToDate if
+// branch. Returns nil if the operation is successful, ErrAlreadyUpToDate if
 // there are no changes to be fetched, or an error.
 //
 // Pull only supports merges where the can be resolved as a fast-forward.
@@ -83,7 +83,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 	})
 
 	updated := true
-	if err == NoErrAlreadyUpToDate {
+	if err == ErrAlreadyUpToDate {
 		updated = false
 	} else if err != nil {
 		return err
@@ -102,7 +102,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		}
 
 		if !updated && headAheadOfRef {
-			return NoErrAlreadyUpToDate
+			return ErrAlreadyUpToDate
 		}
 
 		ff, err := isFastForward(w.r.Storer, head.Hash(), ref.Hash())

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -161,7 +161,7 @@ func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded(c *C) {
 	c.Assert(branch.Hash().String(), Equals, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 
 	err = w.Pull(&PullOptions{})
-	c.Assert(err, Equals, NoErrAlreadyUpToDate)
+	c.Assert(err, Equals, ErrAlreadyUpToDate)
 }
 
 func (s *WorktreeSuite) TestPullInSingleBranch(c *C) {
@@ -177,7 +177,7 @@ func (s *WorktreeSuite) TestPullInSingleBranch(c *C) {
 	c.Assert(err, IsNil)
 
 	err = w.Pull(&PullOptions{})
-	c.Assert(err, Equals, NoErrAlreadyUpToDate)
+	c.Assert(err, Equals, ErrAlreadyUpToDate)
 
 	branch, err := r.Reference("refs/heads/master", false)
 	c.Assert(err, IsNil)
@@ -292,7 +292,7 @@ func (s *WorktreeSuite) TestPullAlreadyUptodate(c *C) {
 	c.Assert(err, IsNil)
 
 	err = w.Pull(&PullOptions{})
-	c.Assert(err, Equals, NoErrAlreadyUpToDate)
+	c.Assert(err, Equals, ErrAlreadyUpToDate)
 }
 
 func (s *WorktreeSuite) TestCheckout(c *C) {


### PR DESCRIPTION
It's unclear why NoErrAlreadyUpToDate is named that
instead of following conventions from the rest of the code
and being named ErrAlreadyUpToDate.

This change renames NoErrAlreadyUpToDate to ErrAlreadyUpToDate.

In the interest of backwards compatibility,
we keep the NoErrAlreadyUpToDate variable around,
but mark it as deprecated in favor of ErrAlreadyUpToDate.

---

Feel free to reject this change if the name is intentional
and I've just been unable to find the reason why.
