### PR TITLE
packp: Actions should have type Action

### DIFF
--- a/plumbing/protocol/packp/updreq.go
+++ b/plumbing/protocol/packp/updreq.go
@@ -87,9 +87,9 @@ type Action string
 
 const (
 	Create  Action = "create"
-	Update         = "update"
-	Delete         = "delete"
-	Invalid        = "invalid"
+	Update  Action = "update"
+	Delete  Action = "delete"
+	Invalid Action = "invalid"
 )
 
 type Command struct {


### PR DESCRIPTION
Per the [Go Spec](https://go.dev/ref/spec#Constant_declarations),
the following yields the type `Action` for `Bar` and `Baz`
only if there is no `=`.

    const (
        Foo Action = ...
        Bar
        Baz
    )

The following has the type `Action` for the first item,
but not the rest. Those are untyped constants
of the corresponding type.

    const (
        Foo Action = ...
        Bar        = ...
        Baz        = ...
    )

This means that `packp.{Update, Delete, Invalid}` are currently
untyped string constants, and not `Action` constants
as was intended here.

This change fixes these.
