### PR TITLE
storage: filesystem, switch from os.SEEK_* to io.Seek*

### DIFF
--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -3,6 +3,7 @@ package dotgit
 import (
 	"bufio"
 	"encoding/hex"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -510,13 +511,13 @@ func (s *SuiteDotGit) TestObjectPackWithKeepDescriptors(c *C) {
 	c.Assert(filepath.Ext(pack.Name()), Equals, ".pack")
 
 	// Move to an specific offset
-	pack.Seek(42, os.SEEK_SET)
+	pack.Seek(42, io.SeekStart)
 
 	pack2, err := dir.ObjectPack(plumbing.NewHash(f.PackfileHash))
 	c.Assert(err, IsNil)
 
 	// If the file is the same the offset should be the same
-	offset, err := pack2.Seek(0, os.SEEK_CUR)
+	offset, err := pack2.Seek(0, io.SeekCurrent)
 	c.Assert(err, IsNil)
 	c.Assert(offset, Equals, int64(42))
 
@@ -527,7 +528,7 @@ func (s *SuiteDotGit) TestObjectPackWithKeepDescriptors(c *C) {
 	c.Assert(err, IsNil)
 
 	// If the file is opened again its offset should be 0
-	offset, err = pack2.Seek(0, os.SEEK_CUR)
+	offset, err = pack2.Seek(0, io.SeekCurrent)
 	c.Assert(err, IsNil)
 	c.Assert(offset, Equals, int64(0))
 

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -71,7 +71,7 @@ func (s *FsSuite) TestGetFromPackfileKeepDescriptors(c *C) {
 		pack1, err := dg.ObjectPack(packfiles[0])
 		c.Assert(err, IsNil)
 
-		pack1.Seek(42, os.SEEK_SET)
+		pack1.Seek(42, io.SeekStart)
 
 		err = o.Close()
 		c.Assert(err, IsNil)
@@ -79,7 +79,7 @@ func (s *FsSuite) TestGetFromPackfileKeepDescriptors(c *C) {
 		pack2, err := dg.ObjectPack(packfiles[0])
 		c.Assert(err, IsNil)
 
-		offset, err := pack2.Seek(0, os.SEEK_CUR)
+		offset, err := pack2.Seek(0, io.SeekCurrent)
 		c.Assert(err, IsNil)
 		c.Assert(offset, Equals, int64(0))
 


### PR DESCRIPTION
The `os.SEEK_*` constants have been deprecated since Go 1.7.
It is now recommended to use the equivalent `io.Seek*` constants.

Switch `os.SEEK_CUR` to `io.SeekCurrent`,
and `os.SEEK_SET` to `io.SeekStart`.
