### PR TITLE
Pool *[]byte instead of []byte

### DIFF
--- a/internal/iocopy/copy.go
+++ b/internal/iocopy/copy.go
@@ -1,0 +1,27 @@
+package iocopy
+
+import (
+	"io"
+	"sync"
+)
+
+// Copy is a variant of io.Copy
+// that uses an internal buffer pool
+// for optimal copying performance.
+func Copy(w io.Writer, r io.Reader) (int64, error) {
+	buf := byteSlicePtrPool.Get().(*[]byte)
+	n, err := io.CopyBuffer(w, r, *buf)
+	byteSlicePtrPool.Put(buf)
+	return n, err
+}
+
+// Pool of *[]bytes.
+// We don't typically use pointers of slices,
+// but a sync.Pool prefers pointer-like values.
+// Otherwise, conversion from non-pointer to interface{} causes an allocation.
+var byteSlicePtrPool = sync.Pool{
+	New: func() interface{} {
+		buff := make([]byte, 32*1024)
+		return &buff
+	},
+}

--- a/internal/iocopy/copy_test.go
+++ b/internal/iocopy/copy_test.go
@@ -1,0 +1,22 @@
+package iocopy
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io/ioutil"
+	"testing"
+)
+
+func BenchmarkCopy(b *testing.B) {
+	data := make([]byte, 1024*1024) // 1 MB
+	rand.Read(data)
+
+	b.ResetTimer()
+
+	var src bytes.Reader
+	for i := 0; i < b.N; i++ {
+		src.Reset(data)
+
+		Copy(ioutil.Discard, &src)
+	}
+}

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 
+	"github.com/go-git/go-git/v5/internal/iocopy"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/utils/ioutil"
 )
@@ -53,9 +54,7 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) (err error) {
 
 	target.SetSize(int64(dst.Len()))
 
-	b := byteSlicePool.Get().([]byte)
-	_, err = io.CopyBuffer(w, dst, b)
-	byteSlicePool.Put(b)
+	_, err = iocopy.Copy(w, dst)
 	return err
 }
 


### PR DESCRIPTION
[staticcheck][1] reported for `sync.Pool`s based on byte slices (`[]byte`)
that the argument should be pointer-like:

    worktree.go:555:21: argument should be pointer-like to avoid allocations (SA6002)

[1]: https://staticcheck.io/

This is because converting a non-pointer type like `[]byte`
to `interface{}` costs an allocation.

To resolve this, we need to use a `sync.Pool` that produces
pointers to byte slices (`*[]byte`),
or a different pointer-like object (say, a custom `*Buffer` type).

In this change, I've added a new internal package `iocopy`
that maintains its own private pool of `*[]byte`s,
and switched existing `sync.Pool`s of `[]byte` over to it.

To verify the change, I added a basic benchmark for Copy and
ran it with a `[]byte`-based implementation and a `*[]byte`-based one.

```
$ go test -run '^$' -bench BenchmarkCopy -benchmem -count 10 | tee before.txt
[...]
$ go test -run '^$' -bench BenchmarkCopy -benchmem -count 10 | tee after.txt
```

Results (generated by [benchstat][2]):
There's a 55% drop in time, and a 100% drop in allocations
if the `sync.Pool` uses a `*[]byte` instead of a `[]byte`.

```
$ benchstat before.txt after.txt
name    old time/op    new time/op    delta
Copy-2     149ns ± 2%      66ns ± 1%   -55.68%  (p=0.000 n=9+10)

name    old alloc/op   new alloc/op   delta
Copy-2     24.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name    old allocs/op  new allocs/op  delta
Copy-2      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

[2]: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat

---

Ideas for future changes:
The iocopy.Copy function can be used for all other uses of `io.Copy`
across the code to re-use the same buffer pool.
We can also add an `io.CopyN`-equivalent (`iocopy.N`?)
built on the same pool for futher buffer re-use.
