### PR TITLE
error strings: Don't capitalize, use periods, or newlines

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -150,7 +150,7 @@ func ReadConfig(r io.Reader) (*Config, error) {
 // config file to the given scope, a empty one is returned.
 func LoadConfig(scope Scope) (*Config, error) {
 	if scope == LocalScope {
-		return nil, fmt.Errorf("LocalScope should be read from the a ConfigStorer.")
+		return nil, fmt.Errorf("LocalScope should be read from the a ConfigStorer")
 	}
 
 	files, err := Paths(scope)

--- a/object_walker.go
+++ b/object_walker.go
@@ -60,7 +60,7 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 	// Fetch the object.
 	obj, err := object.GetObject(p.Storer, hash)
 	if err != nil {
-		return fmt.Errorf("Getting object %s failed: %v", hash, err)
+		return fmt.Errorf("getting object %s failed: %v", hash, err)
 	}
 	// Walk all children depending on object type.
 	switch obj := obj.(type) {
@@ -98,7 +98,7 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 		return p.walkObjectTree(obj.Target)
 	default:
 		// Error out on unhandled object types.
-		return fmt.Errorf("Unknown object %X %s %T\n", obj.ID(), obj.Type(), obj)
+		return fmt.Errorf("unknown object %X %s %T", obj.ID(), obj.Type(), obj)
 	}
 	return nil
 }

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -14,14 +14,14 @@ import (
 var (
 	// ErrUnsupportedVersion is returned by OpenFileIndex when the commit graph
 	// file version is not supported.
-	ErrUnsupportedVersion = errors.New("Unsupported version")
+	ErrUnsupportedVersion = errors.New("unsupported version")
 	// ErrUnsupportedHash is returned by OpenFileIndex when the commit graph
 	// hash function is not supported. Currently only SHA-1 is defined and
 	// supported
-	ErrUnsupportedHash = errors.New("Unsupported hash algorithm")
+	ErrUnsupportedHash = errors.New("unsupported hash algorithm")
 	// ErrMalformedCommitGraphFile is returned by OpenFileIndex when the commit
 	// graph file is corrupted.
-	ErrMalformedCommitGraphFile = errors.New("Malformed commit graph file")
+	ErrMalformedCommitGraphFile = errors.New("malformed commit graph file")
 
 	commitFileSignature    = []byte{'C', 'G', 'P', 'H'}
 	oidFanoutSignature     = []byte{'O', 'I', 'D', 'F'}

--- a/plumbing/format/gitattributes/attributes.go
+++ b/plumbing/format/gitattributes/attributes.go
@@ -15,7 +15,7 @@ const (
 
 var (
 	ErrMacroNotAllowed      = errors.New("macro not allowed")
-	ErrInvalidAttributeName = errors.New("Invalid attribute name")
+	ErrInvalidAttributeName = errors.New("invalid attribute name")
 )
 
 type MatchAttribute struct {

--- a/plumbing/format/idxfile/decoder.go
+++ b/plumbing/format/idxfile/decoder.go
@@ -12,9 +12,9 @@ import (
 var (
 	// ErrUnsupportedVersion is returned by Decode when the idx file version
 	// is not supported.
-	ErrUnsupportedVersion = errors.New("Unsupported version")
+	ErrUnsupportedVersion = errors.New("unsupported version")
 	// ErrMalformedIdxFile is returned by Decode when the idx file is corrupted.
-	ErrMalformedIdxFile = errors.New("Malformed IDX file")
+	ErrMalformedIdxFile = errors.New("malformed IDX file")
 )
 
 const (

--- a/plumbing/object/change_adaptor.go
+++ b/plumbing/object/change_adaptor.go
@@ -16,11 +16,11 @@ func newChange(c merkletrie.Change) (*Change, error) {
 
 	var err error
 	if ret.From, err = newChangeEntry(c.From); err != nil {
-		return nil, fmt.Errorf("From field: %s", err)
+		return nil, fmt.Errorf("from field: %s", err)
 	}
 
 	if ret.To, err = newChangeEntry(c.To); err != nil {
-		return nil, fmt.Errorf("To field: %s", err)
+		return nil, fmt.Errorf("to field: %s", err)
 	}
 
 	return ret, nil

--- a/prune.go
+++ b/prune.go
@@ -17,7 +17,7 @@ type PruneOptions struct {
 	Handler PruneHandler
 }
 
-var ErrLooseObjectsNotSupported = errors.New("Loose objects not supported")
+var ErrLooseObjectsNotSupported = errors.New("loose objects not supported")
 
 // DeleteObject deletes an object from a repository.
 // The type conveniently matches PruneHandler.

--- a/remote.go
+++ b/remote.go
@@ -260,7 +260,7 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 		tagObject, err := object.GetObject(r.s, tag.Hash())
 		var tagCommit *object.Commit
 		if err != nil {
-			return fmt.Errorf("get tag object: %w\n", err)
+			return fmt.Errorf("get tag object: %w", err)
 		}
 
 		if tagObject.Type() != plumbing.TagObject {
@@ -274,7 +274,7 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 
 		tagCommit, err = object.GetCommit(r.s, annotatedTag.Target)
 		if err != nil {
-			return fmt.Errorf("get annotated tag commit: %w\n", err)
+			return fmt.Errorf("get annotated tag commit: %w", err)
 		}
 
 		// only include tags that are reachable from one of the refs

--- a/repository.go
+++ b/repository.go
@@ -56,7 +56,7 @@ var (
 	ErrWorktreeNotProvided       = errors.New("worktree should be provided")
 	ErrIsBareRepository          = errors.New("worktree not available in a bare repository")
 	ErrUnableToResolveCommit     = errors.New("unable to resolve commit")
-	ErrPackedObjectsNotSupported = errors.New("Packed objects not supported")
+	ErrPackedObjectsNotSupported = errors.New("packed objects not supported")
 )
 
 // Repository represents a git repository
@@ -1547,7 +1547,7 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 			}
 
 			if c == nil {
-				return &plumbing.ZeroHash, fmt.Errorf(`No commit message match regexp : "%s"`, re.String())
+				return &plumbing.ZeroHash, fmt.Errorf("no commit message match regexp: %q", re.String())
 			}
 
 			commit = c

--- a/repository_test.go
+++ b/repository_test.go
@@ -2756,7 +2756,7 @@ func (s *RepositorySuite) TestResolveRevisionWithErrors(c *C) {
 	datas := map[string]string{
 		"efs/heads/master~": "reference not found",
 		"HEAD^3":            `Revision invalid : "3" found must be 0, 1 or 2 after "^"`,
-		"HEAD^{/whatever}":  `No commit message match regexp : "whatever"`,
+		"HEAD^{/whatever}":  `no commit message match regexp: "whatever"`,
 		"4e1243bd22c66e76c2ba9eddc1f91394e57f9f83": "reference not found",
 	}
 

--- a/storage/filesystem/dotgit/reader.go
+++ b/storage/filesystem/dotgit/reader.go
@@ -66,7 +66,7 @@ func (e *EncodedObject) Size() int64 {
 func (e *EncodedObject) SetSize(int64) {}
 
 func (e *EncodedObject) Writer() (io.WriteCloser, error) {
-	return nil, fmt.Errorf("Not supported")
+	return nil, fmt.Errorf("not supported")
 }
 
 func NewEncodedObject(dir *DotGit, h plumbing.Hash, t plumbing.ObjectType, size int64) *EncodedObject {

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -193,7 +193,7 @@ func (o *ObjectStorage) DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) er
 	return nil
 }
 
-var errNotSupported = fmt.Errorf("Not supported")
+var errNotSupported = fmt.Errorf("not supported")
 
 func (o *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {
 	return time.Time{}, errNotSupported


### PR DESCRIPTION
Per [Go Code Review Comments][1],

> Error strings should not be capitalized (unless beginning with proper
> nouns or acronyms) or end with punctuation

staticcheck's [ST1005][2] also complains about these. For example,

```
object_walker.go:63:10: error strings should not be capitalized (ST1005)
object_walker.go:101:10: error strings should not be capitalized (ST1005)
object_walker.go:101:10: error strings should not end with punctuation or a newline (ST1005)
plumbing/format/commitgraph/file.go:17:26: error strings should not be capitalized (ST1005)
```

This fixes all instances of this issue reported by staticcheck.

  [1]: https://github.com/golang/go/wiki/CodeReviewComments#error-strings
  [2]: https://staticcheck.io/docs/checks/#ST1005

---

Feel free to reject if you don't want the error strings changed.
