### PR TITLE
internal/revision: Replace zero-width char with escape code

### DIFF
--- a/internal/revision/scanner_test.go
+++ b/internal/revision/scanner_test.go
@@ -86,7 +86,7 @@ func (s *ScannerSuite) TestReadSpace(c *C) {
 }
 
 func (s *ScannerSuite) TestReadControl(c *C) {
-	scanner := newScanner(bytes.NewBufferString(""))
+	scanner := newScanner(bytes.NewBufferString("\x01"))
 	tok, data, err := scanner.scan()
 
 	c.Assert(err, Equals, nil)


### PR DESCRIPTION
Replace zero-width character in string literal with corresponding escape
sequence so that there's a printable character in the source code.
