### PR TITLE
Replicate standard git path behaviour

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,11 @@ var (
 	ErrRemoteConfigNotFound  = errors.New("remote config not found")
 	ErrRemoteConfigEmptyURL  = errors.New("remote config: empty URL")
 	ErrRemoteConfigEmptyName = errors.New("remote config: empty name")
+	// GitPrefix adds an option to specify the %path compilation time
+	// variable of the git executable.
+	// so system configuration lookups are closer to git standard behaviour:
+	// https://git-scm.com/docs/git-config#Documentation/git-config.txt-pathname
+	GitPrefix = "/usr"
 )
 
 // Scope defines the scope of a config file, such as local, global or system.
@@ -210,8 +215,13 @@ func Paths(scope Scope) ([]string, error) {
 			// https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGSYSTEMcode
 			systemPath, ok := os.LookupEnv("GIT_CONFIG_SYSTEM")
 			if !ok {
-				// todo: implement %path
-				systemPath = "/etc/gitconfig"
+				if GitPrefix == "/usr" {
+					// When git is compiled with a prefix of /usr, the config path is hard-coded to /etc/gitconfig
+					// https://github.com/git/git/blob/master/Makefile#L1274
+					systemPath = "/etc/gitconfig"
+				} else {
+					systemPath = filepath.Join(GitPrefix, "etc/gitconfig")
+				}
 			}
 			if systemPath != "/dev/null" {
 				files = append(files, systemPath)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -371,3 +371,59 @@ func (s *ConfigSuite) TestRemoveUrlOptions(c *C) {
 	}
 	c.Assert(err, IsNil)
 }
+
+func (s *ConfigSuite) TestGitGlobalConfig(c *C) {
+	origGlobalConfig, origOk := os.LookupEnv("GIT_CONFIG_GLOBAL")
+	defer func() {
+		if origOk {
+			os.Setenv("GIT_CONFIG_GLOBAL", origGlobalConfig)
+		} else {
+			os.Unsetenv("GIT_CONFIG_GLOBAL")
+		}
+	}()
+
+	os.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	paths, err := Paths(GlobalScope)
+	c.Assert(err, IsNil)
+	c.Assert(paths, IsNil)
+
+	os.Setenv("GIT_CONFIG_GLOBAL", "./some-path")
+	paths, err = Paths(GlobalScope)
+	c.Assert(err, IsNil)
+	c.Assert(paths, DeepEquals, []string{"./some-path"})
+
+	os.Unsetenv("GIT_CONFIG_GLOBAL")
+
+	os.Setenv("XDG_CONFIG_HOME", "/some-path")
+	paths, err = Paths(GlobalScope)
+	c.Assert(err, IsNil)
+	c.Assert(paths, HasLen, 3)
+	c.Assert(paths[0], Equals, "/some-path/git/config")
+}
+
+func (s *ConfigSuite) TestGitSystemConfig(c *C) {
+	origGlobalConfig, origOk := os.LookupEnv("GIT_CONFIG_SYSTEM")
+	defer func() {
+		if origOk {
+			os.Setenv("GIT_CONFIG_SYSTEM", origGlobalConfig)
+		} else {
+			os.Unsetenv("GIT_CONFIG_SYSTEM")
+		}
+	}()
+
+	os.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	paths, err := Paths(SystemScope)
+	c.Assert(err, IsNil)
+	c.Assert(paths, IsNil)
+
+	os.Setenv("GIT_CONFIG_SYSTEM", "./some-path")
+	paths, err = Paths(SystemScope)
+	c.Assert(err, IsNil)
+	c.Assert(paths, DeepEquals, []string{"./some-path"})
+
+	os.Unsetenv("GIT_CONFIG_SYSTEM")
+	paths, err = Paths(SystemScope)
+	c.Assert(err, IsNil)
+	c.Assert(paths, DeepEquals, []string{"/etc/gitconfig"})
+
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -403,12 +403,14 @@ func (s *ConfigSuite) TestGitGlobalConfig(c *C) {
 
 func (s *ConfigSuite) TestGitSystemConfig(c *C) {
 	origGlobalConfig, origOk := os.LookupEnv("GIT_CONFIG_SYSTEM")
+	origGitPrefix := GitPrefix
 	defer func() {
 		if origOk {
 			os.Setenv("GIT_CONFIG_SYSTEM", origGlobalConfig)
 		} else {
 			os.Unsetenv("GIT_CONFIG_SYSTEM")
 		}
+		GitPrefix = origGitPrefix
 	}()
 
 	os.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
@@ -425,5 +427,15 @@ func (s *ConfigSuite) TestGitSystemConfig(c *C) {
 	paths, err = Paths(SystemScope)
 	c.Assert(err, IsNil)
 	c.Assert(paths, DeepEquals, []string{"/etc/gitconfig"})
+
+	GitPrefix = "/usr"
+	paths, err = Paths(SystemScope)
+	c.Assert(err, IsNil)
+	c.Assert(paths, DeepEquals, []string{"/etc/gitconfig"})
+
+	GitPrefix = "/usr/local"
+	paths, err = Paths(SystemScope)
+	c.Assert(err, IsNil)
+	c.Assert(paths, DeepEquals, []string{"/usr/local/etc/gitconfig"})
 
 }


### PR DESCRIPTION
There are cases where git has not been compiled for the `/usr` prefix, and hence, as [documented](https://git-scm.com/docs/git-config#Documentation/git-config.txt-pathname), considers different paths for the global and system config files.

The case is particularly visible in GitHub codespaces where git has been compiled for the `/usr/local` prefix.
With this, the current go implementation differs from the usual C implementation and considers `/etc/gitconfig` rather than `/usr/local/etc/gitconfig` git would try.

This PR aims at converging with git on how configuration paths are read