### PR TITLE
Worktree: use syscall.Timespec.Unix

### DIFF
--- a/worktree_bsd.go
+++ b/worktree_bsd.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	fillSystemInfo = func(e *index.Entry, sys interface{}) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
-			e.CreatedAt = time.Unix(int64(os.Atimespec.Sec), int64(os.Atimespec.Nsec))
+			e.CreatedAt = time.Unix(os.Atimespec.Unix())
 			e.Dev = uint32(os.Dev)
 			e.Inode = uint32(os.Ino)
 			e.GID = os.Gid

--- a/worktree_linux.go
+++ b/worktree_linux.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	fillSystemInfo = func(e *index.Entry, sys interface{}) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
-			e.CreatedAt = time.Unix(int64(os.Ctim.Sec), int64(os.Ctim.Nsec))
+			e.CreatedAt = time.Unix(os.Ctim.Unix())
 			e.Dev = uint32(os.Dev)
 			e.Inode = uint32(os.Ino)
 			e.GID = os.Gid

--- a/worktree_unix_other.go
+++ b/worktree_unix_other.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	fillSystemInfo = func(e *index.Entry, sys interface{}) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
-			e.CreatedAt = time.Unix(int64(os.Atim.Sec), int64(os.Atim.Nsec))
+			e.CreatedAt = time.Unix(os.Atim.Unix())
 			e.Dev = uint32(os.Dev)
 			e.Inode = uint32(os.Ino)
 			e.GID = os.Gid


### PR DESCRIPTION
Use the syscall method instead of repeating the type conversions for
the syscall.Stat_t Atim/Atimespec/Ctim members.