### PR TITLE
Repository: don't crash accessing invalid pathinfo

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -280,6 +280,9 @@ func dotGitToOSFilesystems(path string, detect bool) (dot, wt billy.Filesystem, 
 
 		pathinfo, err := fs.Stat("/")
 		if !os.IsNotExist(err) {
+			if pathinfo == nil {
+				return nil, nil, err
+			}
 			if !pathinfo.IsDir() && detect {
 				fs = osfs.New(filepath.Dir(path))
 			}

--- a/repository_test.go
+++ b/repository_test.go
@@ -2948,7 +2948,7 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func TestDotGitToOSFilesystemsInvalidPath(t *testing.T) {
+func (s *RepositorySuite) TestCreateTagLightweight(c *C) {
 	_, _, err := dotGitToOSFilesystems("\000", false)
 	c.Assert(err, NotNil)
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -2948,6 +2948,13 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func TestDotGitToOSFilesystems(t *testing.T) {
+	_, _, err := dotGitToOSFilesystems("\000", false)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
 func BenchmarkObjects(b *testing.B) {
 	defer fixtures.Clean()
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -2950,7 +2950,7 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch(c *C) {
 
 func TestDotGitToOSFilesystemsInvalidPath(t *testing.T) {
 	_, _, err := dotGitToOSFilesystems("\000", false)
-	c.Assert(r, NotNil)
+	c.Assert(err, NotNil)
 }
 
 func BenchmarkObjects(b *testing.B) {

--- a/repository_test.go
+++ b/repository_test.go
@@ -2948,11 +2948,9 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func TestDotGitToOSFilesystems(t *testing.T) {
+func TestDotGitToOSFilesystemsInvalidPath(t *testing.T) {
 	_, _, err := dotGitToOSFilesystems("\000", false)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
+	c.Assert(r, NotNil)
 }
 
 func BenchmarkObjects(b *testing.B) {

--- a/repository_test.go
+++ b/repository_test.go
@@ -2948,7 +2948,7 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *RepositorySuite) TestCreateTagLightweight(c *C) {
+func (s *RepositorySuite) TestDotGitToOSFilesystemsInvalidPath(c *C) {
 	_, _, err := dotGitToOSFilesystems("\000", false)
 	c.Assert(err, NotNil)
 }


### PR DESCRIPTION
When fs.Stat returns an error, pathinfo may be nil. In such situations
the only safe response seems to be to return the error to the caller.

Without this fix, accessing pathinfo.IsDir() below would lead to a crash
dereferencing a nil pointer.

This crash can be reproduced by trying to initialize a Git repo with an
invalid path name.

Also see: https://github.com/muesli/gitty/issues/36