### PR TITLE
checkout-branch example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build-git:
 test:
 	@echo "running against `git version`"; \
 	$(GOTEST) -race ./...
+	$(GOTEST) -v _examples/common_test.go _examples/common.go --examples
 
 TEMP_REPO := $(shell mktemp)
 test-sha256:

--- a/_examples/checkout-branch/main.go
+++ b/_examples/checkout-branch/main.go
@@ -35,7 +35,7 @@ func main() {
 	// ... checking out branch
 	Info("git checkout %s", branch)
 
-	branchRefName := fmt.Sprintf("refs/heads/%s", branch)
+	branchRefName := plumbing.NewBranchReferenceName(branch)
 	branchCoOpts := git.CheckoutOptions{
 		Branch: plumbing.ReferenceName(branchRefName),
 		Force:  true,

--- a/_examples/checkout-branch/main.go
+++ b/_examples/checkout-branch/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-git/go-git/v5"
+	. "github.com/go-git/go-git/v5/_examples"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// Checkout a branch
+func main() {
+	CheckArgs("<url>", "<directory>", "<branch>")
+	url, directory, branch := os.Args[1], os.Args[2], os.Args[3]
+
+	// Clone the given repository to the given directory
+	Info("git clone %s %s", url, directory)
+	r, err := git.PlainClone(directory, false, &git.CloneOptions{
+		URL: url,
+	})
+	CheckIfError(err)
+
+	// ... retrieving the commit being pointed by HEAD
+	Info("git show-ref --head HEAD")
+	ref, err := r.Head()
+	CheckIfError(err)
+
+	fmt.Println(ref.Hash())
+
+	w, err := r.Worktree()
+	CheckIfError(err)
+
+	// ... checking out branch
+	Info("git checkout %s", branch)
+
+	branchRefName := fmt.Sprintf("refs/heads/%s", branch)
+	branchCoOpts := git.CheckoutOptions{
+		Branch: plumbing.ReferenceName(branchRefName),
+		Force:  true,
+	}
+	if err := w.Checkout(&branchCoOpts); err != nil {
+		Warning("local checkout of branch '%s' failed, will attempt to fetch remote branch of same name.", branch)
+		Warning("like `git checkout <branch>` defaulting to `git checkout -b <branch> --track <remote>/<branch>`")
+
+		mirrorRemoteBranchRefSpec := fmt.Sprintf("refs/heads/%s:refs/heads/%s", branch, branch)
+		err = fetchOrigin(r, mirrorRemoteBranchRefSpec)
+		CheckIfError(err)
+
+		err = w.Checkout(&branchCoOpts)
+		CheckIfError(err)
+	}
+	CheckIfError(err)
+
+	Info("checked out branch: %s", branch)
+
+	// ... retrieving the commit being pointed by HEAD (branch now)
+	Info("git show-ref --head HEAD")
+	ref, err = r.Head()
+	CheckIfError(err)
+	fmt.Println(ref.Hash())
+}
+
+func fetchOrigin(repo *git.Repository, refSpecStr string) error {
+	remote, err := repo.Remote("origin")
+	CheckIfError(err)
+
+	var refSpecs []config.RefSpec
+	if refSpecStr != "" {
+		refSpecs = []config.RefSpec{config.RefSpec(refSpecStr)}
+	}
+
+	if err = remote.Fetch(&git.FetchOptions{
+		RefSpecs: refSpecs,
+	}); err != nil {
+		if err == git.NoErrAlreadyUpToDate {
+			fmt.Print("refs already up to date")
+		} else {
+			return fmt.Errorf("fetch origin failed: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -14,6 +14,7 @@ var examplesTest = flag.Bool("examples", false, "run the examples tests")
 var defaultURL = "https://github.com/git-fixtures/basic.git"
 
 var args = map[string][]string{
+	"blame":                      {defaultURL, "CHANGELOG"},
 	"branch":                     {defaultURL, tempFolder()},
 	"checkout":                   {defaultURL, tempFolder(), "35e85108805c84807bc66a02d91535e1e24b38b9"},
 	"checkout-branch":            {defaultURL, tempFolder(), "branch"},
@@ -23,18 +24,23 @@ var args = map[string][]string{
 	"custom_http":                {defaultURL},
 	"find-if-any-tag-point-head": {cloneRepository(defaultURL, tempFolder())},
 	"ls":                         {cloneRepository(defaultURL, tempFolder()), "HEAD", "vendor"},
+	"ls-remote":                  {defaultURL},
 	"merge_base":                 {cloneRepository(defaultURL, tempFolder()), "--is-ancestor", "HEAD~3", "HEAD^"},
 	"open":                       {cloneRepository(defaultURL, tempFolder())},
 	"progress":                   {defaultURL, tempFolder()},
 	"pull":                       {createRepositoryWithRemote(tempFolder(), defaultURL)},
 	"push":                       {setEmptyRemote(cloneRepository(defaultURL, tempFolder()))},
 	"revision":                   {cloneRepository(defaultURL, tempFolder()), "master~2^"},
+	"sha256":                     {tempFolder()},
 	"showcase":                   {defaultURL, tempFolder()},
 	"tag":                        {cloneRepository(defaultURL, tempFolder())},
 }
 
 // tests not working / set-up
 var ignored = map[string]bool{
+	"azure_devops":    true,
+	"ls":              true,
+	"sha256":          true,
 	"submodule":       true,
 	"tag-create-push": true,
 }


### PR DESCRIPTION
This PR adds a `checkout-branch` example and some minor fixes for testing.

It took me a while to figure out how to check-out a branch in my cloned repo, and thought this might save some time and could be useful helping someone else to do so.
Originally, after some digging, I used the method used in this issue: https://github.com/src-d/go-git/issues/777
However, realised it was copying all references, and causes faulty HEAD references in some cases (git "refname HEAD is ambiguous" warning I think, but can't remember exactly now).  Couldn't find any examples of fetching a single branch, hence thought this might be useful.