### PR TITLE
plumbing: protocol/pakp, update agent

### DIFF
--- a/plumbing/protocol/packp/capability/capability.go
+++ b/plumbing/protocol/packp/capability/capability.go
@@ -238,7 +238,7 @@ const (
 	Filter Capability = "filter"
 )
 
-const DefaultAgent = "go-git/4.x"
+const DefaultAgent = "go-git/5.x"
 
 var known = map[Capability]bool{
 	MultiACK: true, MultiACKDetailed: true, NoDone: true, ThinPack: true,

--- a/plumbing/protocol/packp/ulreq_test.go
+++ b/plumbing/protocol/packp/ulreq_test.go
@@ -25,7 +25,7 @@ func (s *UlReqSuite) TestNewUploadRequestFromCapabilities(c *C) {
 
 	r := NewUploadRequestFromCapabilities(cap)
 	c.Assert(r.Capabilities.String(), Equals,
-		"multi_ack_detailed side-band-64k thin-pack ofs-delta agent=go-git/4.x",
+		"multi_ack_detailed side-band-64k thin-pack ofs-delta agent=go-git/5.x",
 	)
 }
 

--- a/plumbing/protocol/packp/updreq_test.go
+++ b/plumbing/protocol/packp/updreq_test.go
@@ -23,14 +23,14 @@ func (s *UpdReqSuite) TestNewReferenceUpdateRequestFromCapabilities(c *C) {
 
 	r := NewReferenceUpdateRequestFromCapabilities(cap)
 	c.Assert(r.Capabilities.String(), Equals,
-		"agent=go-git/4.x report-status",
+		"agent=go-git/5.x report-status",
 	)
 
 	cap = capability.NewList()
 	cap.Set(capability.Agent, "foo")
 
 	r = NewReferenceUpdateRequestFromCapabilities(cap)
-	c.Assert(r.Capabilities.String(), Equals, "agent=go-git/4.x")
+	c.Assert(r.Capabilities.String(), Equals, "agent=go-git/5.x")
 
 	cap = capability.NewList()
 

--- a/plumbing/protocol/packp/uppackreq_test.go
+++ b/plumbing/protocol/packp/uppackreq_test.go
@@ -18,7 +18,7 @@ func (s *UploadPackRequestSuite) TestNewUploadPackRequestFromCapabilities(c *C) 
 	cap.Set(capability.Agent, "foo")
 
 	r := NewUploadPackRequestFromCapabilities(cap)
-	c.Assert(r.Capabilities.String(), Equals, "agent=go-git/4.x")
+	c.Assert(r.Capabilities.String(), Equals, "agent=go-git/5.x")
 }
 
 func (s *UploadPackRequestSuite) TestIsEmpty(c *C) {


### PR DESCRIPTION
was still using go-git 4.x as agent.