### PR TITLE
Repository: Export Clone method

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -207,7 +207,7 @@ func CloneContext(
 		return nil, err
 	}
 
-	return r, r.clone(ctx, o)
+	return r, r.Clone(ctx, o)
 }
 
 // PlainInit create an empty git repository at the given path. isBare defines
@@ -412,7 +412,7 @@ func PlainCloneContext(ctx context.Context, path string, isBare bool, o *CloneOp
 		return nil, err
 	}
 
-	err = r.clone(ctx, o)
+	err = r.Clone(ctx, o)
 	if err != nil && err != ErrRepositoryAlreadyExists {
 		if cleanup {
 			_ = cleanUpDir(path, cleanupParent)
@@ -809,7 +809,7 @@ func (r *Repository) resolveToCommitHash(h plumbing.Hash) (plumbing.Hash, error)
 }
 
 // Clone clones a remote repository
-func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
+func (r *Repository) Clone(ctx context.Context, o *CloneOptions) error {
 	if err := o.Validate(); err != nil {
 		return err
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -934,7 +934,7 @@ func (s *RepositorySuite) TestCloneDeep(c *C) {
 	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
 	c.Assert(head, IsNil)
 
-	err = r.clone(context.Background(), &CloneOptions{
+	err = r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -973,7 +973,7 @@ func (s *RepositorySuite) TestCloneConfig(c *C) {
 	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
 	c.Assert(head, IsNil)
 
-	err = r.clone(context.Background(), &CloneOptions{
+	err = r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -997,7 +997,7 @@ func (s *RepositorySuite) TestCloneSingleBranchAndNonHEAD(c *C) {
 	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
 	c.Assert(head, IsNil)
 
-	err = r.clone(context.Background(), &CloneOptions{
+	err = r.Clone(context.Background(), &CloneOptions{
 		URL:           s.GetBasicLocalRepositoryURL(),
 		ReferenceName: plumbing.ReferenceName("refs/heads/branch"),
 		SingleBranch:  true,
@@ -1041,7 +1041,7 @@ func (s *RepositorySuite) TestCloneSingleBranch(c *C) {
 	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
 	c.Assert(head, IsNil)
 
-	err = r.clone(context.Background(), &CloneOptions{
+	err = r.Clone(context.Background(), &CloneOptions{
 		URL:          s.GetBasicLocalRepositoryURL(),
 		SingleBranch: true,
 	})
@@ -1084,7 +1084,7 @@ func (s *RepositorySuite) TestCloneSingleTag(c *C) {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL:           url,
 		SingleBranch:  true,
 		ReferenceName: plumbing.ReferenceName("refs/tags/commit-tag"),
@@ -1105,7 +1105,7 @@ func (s *RepositorySuite) TestCloneSingleTag(c *C) {
 
 func (s *RepositorySuite) TestCloneDetachedHEAD(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL:           s.GetBasicLocalRepositoryURL(),
 		ReferenceName: plumbing.ReferenceName("refs/tags/v1.0.0"),
 	})
@@ -1130,7 +1130,7 @@ func (s *RepositorySuite) TestCloneDetachedHEAD(c *C) {
 
 func (s *RepositorySuite) TestCloneDetachedHEADAndSingle(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL:           s.GetBasicLocalRepositoryURL(),
 		ReferenceName: plumbing.ReferenceName("refs/tags/v1.0.0"),
 		SingleBranch:  true,
@@ -1156,7 +1156,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndSingle(c *C) {
 
 func (s *RepositorySuite) TestCloneDetachedHEADAndShallow(c *C) {
 	r, _ := Init(memory.NewStorage(), memfs.New())
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL:           s.GetBasicLocalRepositoryURL(),
 		ReferenceName: plumbing.ReferenceName("refs/tags/v1.0.0"),
 		Depth:         1,
@@ -1183,7 +1183,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndShallow(c *C) {
 
 func (s *RepositorySuite) TestCloneDetachedHEADAnnotatedTag(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL:           s.GetLocalRepositoryURL(fixtures.ByTag("tags").One()),
 		ReferenceName: plumbing.ReferenceName("refs/tags/annotated-tag"),
 	})
@@ -1361,7 +1361,7 @@ func (s *RepositorySuite) TestPushNonExistentRemote(c *C) {
 
 func (s *RepositorySuite) TestLog(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1389,7 +1389,7 @@ func (s *RepositorySuite) TestLog(c *C) {
 
 func (s *RepositorySuite) TestLogAll(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1434,7 +1434,7 @@ func (s *RepositorySuite) TestLogAll(c *C) {
 
 func (s *RepositorySuite) TestLogAllMissingReferences(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1486,7 +1486,7 @@ func (s *RepositorySuite) TestLogAllMissingReferences(c *C) {
 
 func (s *RepositorySuite) TestLogAllOrderByTime(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1522,7 +1522,7 @@ func (s *RepositorySuite) TestLogAllOrderByTime(c *C) {
 
 func (s *RepositorySuite) TestLogHead(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1554,7 +1554,7 @@ func (s *RepositorySuite) TestLogHead(c *C) {
 
 func (s *RepositorySuite) TestLogError(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1568,7 +1568,7 @@ func (s *RepositorySuite) TestLogError(c *C) {
 
 func (s *RepositorySuite) TestLogFileNext(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1594,7 +1594,7 @@ func (s *RepositorySuite) TestLogFileNext(c *C) {
 
 func (s *RepositorySuite) TestLogFileForEach(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1622,7 +1622,7 @@ func (s *RepositorySuite) TestLogFileForEach(c *C) {
 
 func (s *RepositorySuite) TestLogNonHeadFile(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1639,7 +1639,7 @@ func (s *RepositorySuite) TestLogNonHeadFile(c *C) {
 
 func (s *RepositorySuite) TestLogAllFileForEach(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1667,7 +1667,7 @@ func (s *RepositorySuite) TestLogAllFileForEach(c *C) {
 
 func (s *RepositorySuite) TestLogInvalidFile(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1685,7 +1685,7 @@ func (s *RepositorySuite) TestLogInvalidFile(c *C) {
 
 func (s *RepositorySuite) TestLogFileInitialCommit(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1715,7 +1715,7 @@ func (s *RepositorySuite) TestLogFileInitialCommit(c *C) {
 
 func (s *RepositorySuite) TestLogFileWithOtherParamsFail(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1735,7 +1735,7 @@ func (s *RepositorySuite) TestLogFileWithOtherParamsFail(c *C) {
 
 func (s *RepositorySuite) TestLogFileWithOtherParamsPass(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1812,7 +1812,7 @@ func (s *RepositorySuite) TestLogPathFilterRegexp(c *C) {
 	}
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1843,7 +1843,7 @@ func (s *RepositorySuite) TestLogPathFilterRegexp(c *C) {
 
 func (s *RepositorySuite) TestLogLimitNext(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1869,7 +1869,7 @@ func (s *RepositorySuite) TestLogLimitNext(c *C) {
 
 func (s *RepositorySuite) TestLogLimitForEach(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1898,7 +1898,7 @@ func (s *RepositorySuite) TestLogLimitForEach(c *C) {
 
 func (s *RepositorySuite) TestLogAllLimitForEach(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -1928,7 +1928,7 @@ func (s *RepositorySuite) TestLogAllLimitForEach(c *C) {
 
 func (s *RepositorySuite) TestLogLimitWithOtherParamsFail(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1948,7 +1948,7 @@ func (s *RepositorySuite) TestLogLimitWithOtherParamsFail(c *C) {
 
 func (s *RepositorySuite) TestLogLimitWithOtherParamsPass(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1972,7 +1972,7 @@ func (s *RepositorySuite) TestLogLimitWithOtherParamsPass(c *C) {
 
 func (s *RepositorySuite) TestConfigScoped(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -1988,7 +1988,7 @@ func (s *RepositorySuite) TestConfigScoped(c *C) {
 
 func (s *RepositorySuite) TestCommit(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -2012,7 +2012,7 @@ func (s *RepositorySuite) TestCommit(c *C) {
 
 func (s *RepositorySuite) TestCommits(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	count := 0
@@ -2035,7 +2035,7 @@ func (s *RepositorySuite) TestCommits(c *C) {
 
 func (s *RepositorySuite) TestBlob(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -2057,7 +2057,7 @@ func (s *RepositorySuite) TestBlob(c *C) {
 
 func (s *RepositorySuite) TestBlobs(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	count := 0
@@ -2084,7 +2084,7 @@ func (s *RepositorySuite) TestTagObject(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	hash := plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc")
@@ -2102,7 +2102,7 @@ func (s *RepositorySuite) TestTags(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	count := 0
@@ -2125,7 +2125,7 @@ func (s *RepositorySuite) TestCreateTagLightweight(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	expected, err := r.Head()
@@ -2147,7 +2147,7 @@ func (s *RepositorySuite) TestCreateTagLightweightExists(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	expected, err := r.Head()
@@ -2164,7 +2164,7 @@ func (s *RepositorySuite) TestCreateTagAnnotated(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	h, err := r.Head()
@@ -2196,7 +2196,7 @@ func (s *RepositorySuite) TestCreateTagAnnotatedBadOpts(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	h, err := r.Head()
@@ -2215,7 +2215,7 @@ func (s *RepositorySuite) TestCreateTagAnnotatedBadHash(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	ref, err := r.CreateTag("foobar", plumbing.ZeroHash, &CreateTagOptions{
@@ -2232,7 +2232,7 @@ func (s *RepositorySuite) TestCreateTagSigned(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	h, err := r.Head()
@@ -2273,7 +2273,7 @@ func (s *RepositorySuite) TestCreateTagSignedBadKey(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	h, err := r.Head()
@@ -2294,7 +2294,7 @@ func (s *RepositorySuite) TestCreateTagCanonicalize(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	h, err := r.Head()
@@ -2338,7 +2338,7 @@ func (s *RepositorySuite) TestTagLightweight(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	expected := plumbing.NewHash("f7b877701fbf855b44c0a9e86f3fdce2c298b07f")
@@ -2356,7 +2356,7 @@ func (s *RepositorySuite) TestTagLightweightMissingTag(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	tag, err := r.Tag("lightweight-tag-tag")
@@ -2370,7 +2370,7 @@ func (s *RepositorySuite) TestDeleteTag(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	err = r.DeleteTag("lightweight-tag")
@@ -2386,7 +2386,7 @@ func (s *RepositorySuite) TestDeleteTagMissingTag(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	err = r.DeleteTag("lightweight-tag-tag")
@@ -2404,7 +2404,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotated(c *C) {
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
 	r, _ := Init(fss, nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	ref, err := r.Tag("annotated-tag")
@@ -2452,7 +2452,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotatedUnpacked(c *C) {
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
 	r, _ := Init(fss, nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	// Create a tag for the deletion test. This ensures that the ultimate loose
@@ -2521,7 +2521,7 @@ func (s *RepositorySuite) TestNotes(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	count := 0
@@ -2540,7 +2540,7 @@ func (s *RepositorySuite) TestNotes(c *C) {
 
 func (s *RepositorySuite) TestTree(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	c.Assert(err, IsNil)
@@ -2563,7 +2563,7 @@ func (s *RepositorySuite) TestTree(c *C) {
 
 func (s *RepositorySuite) TestTrees(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	count := 0
@@ -2591,7 +2591,7 @@ func (s *RepositorySuite) TestTagObjects(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	count := 0
@@ -2616,7 +2616,7 @@ func (s *RepositorySuite) TestTagObjects(c *C) {
 
 func (s *RepositorySuite) TestCommitIterClosePanic(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	commits, err := r.CommitObjects()
@@ -2626,7 +2626,7 @@ func (s *RepositorySuite) TestCommitIterClosePanic(c *C) {
 
 func (s *RepositorySuite) TestRef(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	ref, err := r.Reference(plumbing.HEAD, false)
@@ -2640,7 +2640,7 @@ func (s *RepositorySuite) TestRef(c *C) {
 
 func (s *RepositorySuite) TestRefs(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	c.Assert(err, IsNil)
@@ -2652,7 +2652,7 @@ func (s *RepositorySuite) TestRefs(c *C) {
 
 func (s *RepositorySuite) TestObject(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
@@ -2665,7 +2665,7 @@ func (s *RepositorySuite) TestObject(c *C) {
 
 func (s *RepositorySuite) TestObjects(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	count := 0
@@ -2687,7 +2687,7 @@ func (s *RepositorySuite) TestObjects(c *C) {
 
 func (s *RepositorySuite) TestObjectNotFound(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	err := r.Clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	c.Assert(err, IsNil)
 
 	hash := plumbing.NewHash("0a3fb06ff80156fb153bcdcc58b5e16c2d27625c")
@@ -2774,7 +2774,7 @@ func (s *RepositorySuite) TestResolveRevisionWithErrors(c *C) {
 	)
 
 	r, _ := Init(memory.NewStorage(), nil)
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
+	err := r.Clone(context.Background(), &CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	headRef, err := r.Head()

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -167,7 +167,7 @@ func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded(c *C) {
 
 func (s *WorktreeSuite) TestPullInSingleBranch(c *C) {
 	r, _ := Init(memory.NewStorage(), memfs.New())
-	err := r.clone(context.Background(), &CloneOptions{
+	err := r.Clone(context.Background(), &CloneOptions{
 		URL:          s.GetBasicLocalRepositoryURL(),
 		SingleBranch: true,
 	})


### PR DESCRIPTION
Export the Repository.Clone method, which was made private in a052498f23198ad1f2e9ca8f9943d2a48e274c06.

We want to be able to initialize a Git repository and schedule the clone to happen at a later time. Currently, that is not possible with go-git as the clone method is private. Making the clone method public would allow initializing a repository before initiating a clone.