### PR TITLE
revision: fix endless looping in revision parser

### DIFF
--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -322,6 +322,8 @@ func (p *Parser) parseAt() (Revisioner, error) {
 				}
 
 				return AtDate{t}, nil
+			case tok == eof:
+				return nil, &ErrInvalidRevision{s: `missing "}" in @{<data>} structure`}
 			default:
 				date += lit
 			}
@@ -424,6 +426,8 @@ func (p *Parser) parseCaretBraces() (Revisioner, error) {
 			p.unscan()
 		case tok != slash && start:
 			return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a valid revision suffix brace component`, lit)}
+		case tok == eof:
+			return nil, &ErrInvalidRevision{s: `missing "}" in ^{<data>} structure`}
 		case tok != cbrace:
 			p.unscan()
 			re += lit

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -183,7 +183,7 @@ func (s *ParserSuite) TestParseWithValidExpression(c *C) {
 	}
 }
 
-func (s *ParserSuite) TestParseWithUnValidExpression(c *C) {
+func (s *ParserSuite) TestParseWithInvalidExpression(c *C) {
 	datas := map[string]error{
 		"..":                              &ErrInvalidRevision{`must not start with "."`},
 		"master^1master":                  &ErrInvalidRevision{`reference must be defined once at the beginning`},
@@ -198,6 +198,9 @@ func (s *ParserSuite) TestParseWithUnValidExpression(c *C) {
 		"~1":                              &ErrInvalidRevision{`"~" or "^" statement must have a reference defined at the beginning`},
 		"master:/test":                    &ErrInvalidRevision{`":" statement is not valid, could be : :/<regexp>`},
 		"master:0:README":                 &ErrInvalidRevision{`":" statement is not valid, could be : :<n>:<path>`},
+		"^{/":                             &ErrInvalidRevision{`missing "}" in ^{<data>} structure`},
+		"~@{":                             &ErrInvalidRevision{`missing "}" in @{<data>} structure`},
+		"@@{{0":                           &ErrInvalidRevision{`missing "}" in @{<data>} structure`},
 	}
 
 	for s, e := range datas {
@@ -230,7 +233,7 @@ func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 	}
 }
 
-func (s *ParserSuite) TestParseAtWithUnValidExpression(c *C) {
+func (s *ParserSuite) TestParseAtWithInvalidExpression(c *C) {
 	datas := map[string]error{
 		"{test}": &ErrInvalidRevision{`wrong date "test" must fit ISO-8601 format : 2006-01-02T15:04:05Z`},
 		"{-1":    &ErrInvalidRevision{`missing "}" in @{-n} structure`},


### PR DESCRIPTION
Hello there!

This PR fixes a bug in the revision parser which would cause an endless loop when parsing revisions containing opening braces `{` but no closing braces `}`.

The bug is fixed by adding a check that breaks the `for` loop if the token ends up as `eof` in situations where the loop is looking for the closing brace.

The bug was found with the help of [go-fuzz](https://github.com/dvyukov/go-fuzz). Let me know if you're interested in the fuzz test setup in case you want to exercise the parsing some more!