### PR TITLE
bugfix about index cache extension

### DIFF
--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -370,17 +370,17 @@ func (d *treeExtensionDecoder) readEntry() (*TreeEntry, error) {
 	if err != nil {
 		return nil, err
 	}
+	
+	e.Entries = i
+	trees, err := binary.ReadUntil(d.r, '\n')
+	if err != nil {
+		return nil, err
+	}
 
 	// An entry can be in an invalidated state and is represented by having a
 	// negative number in the entry_count field.
 	if i == -1 {
 		return nil, nil
-	}
-
-	e.Entries = i
-	trees, err := binary.ReadUntil(d.r, '\n')
-	if err != nil {
-		return nil, err
 	}
 
 	i, err = strconv.Atoi(string(trees))


### PR DESCRIPTION
--bugfix:
if e.Entries is -1. that i will not have the sha1 but it still have the space, subtree count and \n. we must read them or the next path name will be wrong.