### PR TITLE
Implement Ref Pruning on Fetch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -238,6 +238,7 @@ const (
 	initSection      = "init"
 	urlSection       = "url"
 	fetchKey         = "fetch"
+	pruneKey         = "prune"
 	urlKey           = "url"
 	bareKey          = "bare"
 	worktreeKey      = "worktree"
@@ -559,6 +560,9 @@ type RemoteConfig struct {
 	// Fetch the default set of "refspec" for fetch operation
 	Fetch []RefSpec
 
+	// Prune refs
+	Prune bool
+
 	// raw representation of the subsection, filled by marshal or unmarshal are
 	// called
 	raw *format.Subsection
@@ -603,6 +607,9 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 	c.Name = c.raw.Name
 	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
 	c.Fetch = fetch
+	if c.raw.Options.Get(pruneKey) == "true" {
+		c.Prune = true
+	}
 
 	return nil
 }
@@ -633,6 +640,12 @@ func (c *RemoteConfig) marshal() *format.Subsection {
 		}
 
 		c.raw.SetOption(fetchKey, values...)
+	}
+
+	if c.Prune {
+		c.raw.SetOption(pruneKey, "true")
+	} else if c.raw.HasOption(pruneKey) {
+		c.raw.SetOption(pruneKey, "false")
 	}
 
 	return c.raw

--- a/options.go
+++ b/options.go
@@ -145,6 +145,17 @@ const (
 	NoTags
 )
 
+type PruneMode int
+
+const (
+	// Use the prune setting from the remote configuration.
+	PruneUnspecified PruneMode = iota
+	// Prune tracking refs.
+	Prune
+	// Do not prune.
+	NoPrune
+)
+
 // FetchOptions describes how a fetch should be performed
 type FetchOptions struct {
 	// Name of the remote to fetch from. Defaults to origin.
@@ -164,6 +175,8 @@ type FetchOptions struct {
 	// Tags describe how the tags will be fetched from the remote repository,
 	// by default is TagFollowing.
 	Tags TagMode
+	// Prune tracking refs no longer present on the remote.
+	Prune PruneMode
 	// Force allows the fetch to update a local branch even when the remote
 	// branch does not descend from it.
 	Force bool


### PR DESCRIPTION
An implementation of post-fetch prune of refs
that no longer exist on the remote.
Support for boolean config value `remotes.*.prune`.
Does not yet support the `fetch.prune` config value.