### PR TITLE
plumbing: packp and server, Include the contents of `GO_GIT_USER_AGENT_EXTRA` as the git user agent. Fixes #529

### DIFF
--- a/plumbing/protocol/packp/capability/capability.go
+++ b/plumbing/protocol/packp/capability/capability.go
@@ -1,6 +1,11 @@
 // Package capability defines the server and client capabilities.
 package capability
 
+import (
+	"fmt"
+	"os"
+)
+
 // Capability describes a server or client capability.
 type Capability string
 
@@ -238,7 +243,15 @@ const (
 	Filter Capability = "filter"
 )
 
-const DefaultAgent = "go-git/5.x"
+const userAgent = "go-git/5.x"
+
+// DefaultAgent provides the user agent string.
+func DefaultAgent() string {
+	if envUserAgent, ok := os.LookupEnv("GO_GIT_USER_AGENT_EXTRA"); ok {
+		return fmt.Sprintf("%s %s", userAgent, envUserAgent)
+	}
+	return userAgent
+}
 
 var known = map[Capability]bool{
 	MultiACK: true, MultiACKDetailed: true, NoDone: true, ThinPack: true,

--- a/plumbing/protocol/packp/capability/capability_test.go
+++ b/plumbing/protocol/packp/capability/capability_test.go
@@ -1,0 +1,22 @@
+package capability
+
+import (
+	"fmt"
+	"os"
+
+	check "gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&SuiteCapabilities{})
+
+func (s *SuiteCapabilities) TestDefaultAgent(c *check.C) {
+	os.Unsetenv("GO_GIT_USER_AGENT_EXTRA")
+	ua := DefaultAgent()
+	c.Assert(ua, check.Equals, userAgent)
+}
+
+func (s *SuiteCapabilities) TestEnvAgent(c *check.C) {
+	os.Setenv("GO_GIT_USER_AGENT_EXTRA", "abc xyz")
+	ua := DefaultAgent()
+	c.Assert(ua, check.Equals, fmt.Sprintf("%s %s", userAgent, "abc xyz"))
+}

--- a/plumbing/protocol/packp/ulreq.go
+++ b/plumbing/protocol/packp/ulreq.go
@@ -95,7 +95,7 @@ func NewUploadRequestFromCapabilities(adv *capability.List) *UploadRequest {
 	}
 
 	if adv.Supports(capability.Agent) {
-		r.Capabilities.Set(capability.Agent, capability.DefaultAgent)
+		r.Capabilities.Set(capability.Agent, capability.DefaultAgent())
 	}
 
 	return r

--- a/plumbing/protocol/packp/updreq.go
+++ b/plumbing/protocol/packp/updreq.go
@@ -59,7 +59,7 @@ func NewReferenceUpdateRequestFromCapabilities(adv *capability.List) *ReferenceU
 	r := NewReferenceUpdateRequest()
 
 	if adv.Supports(capability.Agent) {
-		r.Capabilities.Set(capability.Agent, capability.DefaultAgent)
+		r.Capabilities.Set(capability.Agent, capability.DefaultAgent())
 	}
 
 	if adv.Supports(capability.ReportStatus) {

--- a/plumbing/transport/server/server.go
+++ b/plumbing/transport/server/server.go
@@ -189,7 +189,7 @@ func (s *upSession) objectsToUpload(req *packp.UploadPackRequest) ([]plumbing.Ha
 }
 
 func (*upSession) setSupportedCapabilities(c *capability.List) error {
-	if err := c.Set(capability.Agent, capability.DefaultAgent); err != nil {
+	if err := c.Set(capability.Agent, capability.DefaultAgent()); err != nil {
 		return err
 	}
 
@@ -355,7 +355,7 @@ func (s *rpSession) reportStatus() *packp.ReportStatus {
 }
 
 func (*rpSession) setSupportedCapabilities(c *capability.List) error {
-	if err := c.Set(capability.Agent, capability.DefaultAgent); err != nil {
+	if err := c.Set(capability.Agent, capability.DefaultAgent()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The `git` command allows users to specify custom content using the `GIT_USER_AGENT` environment variable. This is helpful when understanding demand and performance in large, complex environments. go-git currently has a static configuration specifying the library and version (i.e., `go-git/5.x`).  These changes allow go-git library users to specify  additional content in their user agent by specifying `GO_GIT_USER_AGENT_EXTRA` in their system's environment.