### PR TITLE
Simplify writer for filesystem compatibility

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -955,6 +955,9 @@ func rmFileAndDirsIfEmpty(fs billy.Filesystem, name string) error {
 func removeDirIfEmpty(fs billy.Filesystem, dir string) (bool, error) {
 	files, err := fs.ReadDir(dir)
 	if err != nil {
+		if err == os.ErrNotExist {
+			return false, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
This simplifies the writer to fully flush the file to disk before reading. The issue was found when creating a billy.FS backed by a blob store, where the file isn't readable until written.  I'm not aware of any benchmarks that this could affect but would assume it to be slightly slower. 
