### PR TITLE
Update worktree_status.go

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -393,6 +393,9 @@ func (w *Worktree) AddGlob(pattern string) error {
 
 	var saveIndex bool
 	for _, file := range files {
+		if file == ".git" {
+			continue
+		}
 		fi, err := w.Filesystem.Lstat(file)
 		if err != nil {
 			return err


### PR DESCRIPTION
Worktree.AddGlob will add.git/HEAD, causing push failure. Worktree.AddGlob will exclude ".git" when processing files, which can be solved. But I don't know if this is a reasonable place to exclude #571 