### PR TITLE
plumbing: match gitattributes in opposite order

### DIFF
--- a/plumbing/format/gitattributes/dir_test.go
+++ b/plumbing/format/gitattributes/dir_test.go
@@ -148,7 +148,7 @@ func (s *MatcherSuite) TestDir_ReadPatterns(c *C) {
 	c.Assert(results["foo"].Value(), Equals, "bar")
 
 	results, _ = m.Match([]string{"vendor", "github.com", "file"}, nil)
-	c.Assert(results["foo"].IsUnset(), Equals, false)
+	c.Assert(results["foo"].IsUnset(), Equals, true)
 }
 
 func (s *MatcherSuite) TestDir_LoadGlobalPatterns(c *C) {

--- a/plumbing/format/gitattributes/matcher.go
+++ b/plumbing/format/gitattributes/matcher.go
@@ -44,8 +44,7 @@ func (m *matcher) init() {
 func (m *matcher) Match(path []string, attributes []string) (results map[string]Attribute, matched bool) {
 	results = make(map[string]Attribute, len(attributes))
 
-	n := len(m.stack)
-	for i := n - 1; i >= 0; i-- {
+	for i, _ := range m.stack {
 		if len(attributes) > 0 && len(attributes) == len(results) {
 			return
 		}


### PR DESCRIPTION
The slice of gitattributes.MatchAttributes passed to gitattributes.NewMatcher should be looped through first-to-last. Because the results are stored in a map, this will ensure the attributes later in the slice will override the previous defined attributes.