### PR TITLE
object not found when trying to pull a repository cloned with Depth: 1

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -859,6 +859,15 @@ func getHavesFromRef(
 	toVisit := maxHavesToVisitPerRef
 	return walker.ForEach(func(c *object.Commit) error {
 		haves[c.Hash] = true
+
+		if s, _ := s.Shallow(); len(s) > 0 {
+			for _, sh := range s {
+				if sh == c.Hash {
+					return storer.ErrStop
+				}
+			}
+		}
+
 		toVisit--
 		// If toVisit starts out at 0 (indicating there is no
 		// max), then it will be negative here and we won't stop


### PR DESCRIPTION
fixes #305

In fact setting `Depth` to any value which results in the clone being partial will lead to the same error.

The iterator used in the fastforward check wasn't prepared for the case when a commit might have a missing parent (as in shallow clones). Handling that case solved the problem of pulling on shallow clones.

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>