### PR TITLE
Fix type error in example

### DIFF
--- a/_examples/branch/main.go
+++ b/_examples/branch/main.go
@@ -32,7 +32,7 @@ func main() {
 	//
 	// For tags we should use `refs/tags/%s` instead of `refs/heads/%s` used
 	// for branches.
-	ref := plumbing.NewHashReference("refs/heads/my-branch", headRef.Hash())
+	ref := plumbing.NewHashReference(plumbing.ReferenceName("refs/heads/my-branch"), headRef.Hash())
 
 	// The created reference is saved in the storage.
 	err = r.Storer.SetReference(ref)


### PR DESCRIPTION
This change passes the type `plumbing.ReferenceName` to the `plumbing.NewHashReference`.

I stumbled upon this error while using the example. If this isn't
correct, I'm curious what I should do instead. It appears the type
`plumbing.ReferenceName` is just an type alias to `string`.