### PR TITLE
plumbing: gitattributes, Avoid index out of range 

### DIFF
--- a/plumbing/format/gitattributes/pattern.go
+++ b/plumbing/format/gitattributes/pattern.go
@@ -52,6 +52,11 @@ func (p *pattern) Match(path []string) bool {
 	var match, doublestar bool
 	var err error
 	for _, part := range path {
+		// path is deeper than pattern
+		if len(pattern) == 0 {
+			return false
+		}
+
 		// skip empty
 		if pattern[0] == "" {
 			pattern = pattern[1:]

--- a/plumbing/format/gitattributes/pattern_test.go
+++ b/plumbing/format/gitattributes/pattern_test.go
@@ -174,6 +174,12 @@ func (s *PatternSuite) TestGlobMatch_tailingAsterisks_single(c *C) {
 	c.Assert(r, Equals, true)
 }
 
+func (s *PatternSuite) TestGlobMatch_tailingAsterisk_single(c *C) {
+	p := ParsePattern("/*lue/*", nil)
+	r := p.Match([]string{"value", "volcano", "tail"})
+	c.Assert(r, Equals, false)
+}
+
 func (s *PatternSuite) TestGlobMatch_tailingAsterisks_exactMatch(c *C) {
 	p := ParsePattern("/*lue/vol?ano/**", nil)
 	r := p.Match([]string{"value", "volcano"})


### PR DESCRIPTION
When a path is deeper than the single asterisk pattern the code would
crash with a "index out of range".

This change checks the length of the remaining pattern before it
references an element of that slice.

With a single trailing asterisk paths deeper than the pattern should not
get the attributes.

For example with the following `.gitattributes` file:

    thirdparty/* linguist-vendored

This is how git handles it:

    $ git check-attr --all thirdparty/README.md

    thirdparty/README.md: diff: markdown
    thirdparty/README.md: linguist-vendored: set

    $ git check-attr --all thirdparty/package/README.md

    thirdparty/package/README.md: diff: markdown
