### PR TITLE
Add retry logic for git clone

### DIFF
--- a/plumbing/transport/http/receive_pack.go
+++ b/plumbing/transport/http/receive_pack.go
@@ -94,9 +94,8 @@ func (s *rpSession) doRequest(
 	}
 
 	applyHeadersToRequest(req, content, s.endpoint.Host, transport.ReceivePackServiceName)
-	s.ApplyAuthToRequest(req)
 
-	res, err := s.client.Do(req.WithContext(ctx))
+	res, err := doWithRetry(ctx, s.session, req)
 	if err != nil {
 		return nil, plumbing.NewUnexpectedError(err)
 	}

--- a/plumbing/transport/http/upload_pack.go
+++ b/plumbing/transport/http/upload_pack.go
@@ -92,9 +92,7 @@ func (s *upSession) doRequest(
 	}
 
 	applyHeadersToRequest(req, content, s.endpoint.Host, transport.UploadPackServiceName)
-	s.ApplyAuthToRequest(req)
-
-	res, err := s.client.Do(req.WithContext(ctx))
+	res, err := doWithRetry(ctx, s.session, req)
 	if err != nil {
 		return nil, plumbing.NewUnexpectedError(err)
 	}


### PR DESCRIPTION
Git clone was failing for public repository if a wrong authentication was provided which ideally should not happen because public repositories does not require authentication.

This change port the same behavior of git CLI that is always try cloning the repository without authentication, if it fails with 401 retry with authentication.

fixes https://github.com/go-git/go-git/issues/473

Signed-off-by: shahulsonhal <shahulsonhal@gmail.com>