### PR TITLE
Parse optimisations

### DIFF
--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -53,9 +53,10 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) (err error) {
 
 	target.SetSize(int64(dst.Len()))
 
-	b := byteSlicePool.Get().([]byte)
+	bufp := byteSlicePool.Get().(*[]byte)
+	b := *bufp
 	_, err = io.CopyBuffer(w, dst, b)
-	byteSlicePool.Put(b)
+	byteSlicePool.Put(bufp)
 	return err
 }
 

--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -204,6 +204,21 @@ func (r *Reference) Strings() [2]string {
 }
 
 func (r *Reference) String() string {
-	s := r.Strings()
-	return fmt.Sprintf("%s %s", s[1], s[0])
+	ref := ""
+	switch r.Type() {
+	case HashReference:
+		ref = r.Hash().String()
+	case SymbolicReference:
+		ref = symrefPrefix + r.Target().String()
+	default:
+		return ""
+	}
+
+	name := r.Name().String()
+	var v strings.Builder
+	v.Grow(len(ref) + len(name) + 1)
+	v.WriteString(ref)
+	v.WriteString(" ")
+	v.WriteString(name)
+	return v.String()
 }

--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -1,6 +1,10 @@
 package plumbing
 
-import . "gopkg.in/check.v1"
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
 
 type ReferenceSuite struct{}
 
@@ -97,4 +101,22 @@ func (s *ReferenceSuite) TestIsRemote(c *C) {
 func (s *ReferenceSuite) TestIsTag(c *C) {
 	r := ReferenceName("refs/tags/v3.1.")
 	c.Assert(r.IsTag(), Equals, true)
+}
+
+func benchMarkReferenceString(r *Reference, b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		r.String()
+	}
+}
+
+func BenchmarkReferenceStringSymbolic(b *testing.B) {
+	benchMarkReferenceString(NewSymbolicReference("v3.1.1", "refs/tags/v3.1.1"), b)
+}
+
+func BenchmarkReferenceStringHash(b *testing.B) {
+	benchMarkReferenceString(NewHashReference("v3.1.1", NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")), b)
+}
+
+func BenchmarkReferenceStringInvalid(b *testing.B) {
+	benchMarkReferenceString(&Reference{}, b)
 }

--- a/worktree.go
+++ b/worktree.go
@@ -534,7 +534,8 @@ func (w *Worktree) checkoutChangeRegularFile(name string,
 
 var copyBufferPool = sync.Pool{
 	New: func() interface{} {
-		return make([]byte, 32*1024)
+		b := make([]byte, 32*1024)
+		return &b
 	},
 }
 
@@ -561,9 +562,10 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 	}
 
 	defer ioutil.CheckClose(to, &err)
-	buf := copyBufferPool.Get().([]byte)
+	bufp := copyBufferPool.Get().(*[]byte)
+	buf := *bufp
 	_, err = io.CopyBuffer(to, from, buf)
-	copyBufferPool.Put(buf)
+	copyBufferPool.Put(bufp)
 	return
 }
 


### PR DESCRIPTION
[Recently we worked](https://github.com/fluxcd/go-git/pull/5) on some optimisations that could benefit upstream.

The changes improved benchmarks results across number of executions (`+60%`), time (`-4300000 ns/op`), memory (`-23200000 B/op`) and allocations (`-800 allocs/op`).


#### Parse changes Benchmark
```
name       old time/op    new time/op    delta
Parser-16    11.9ms ± 1%     7.4ms ± 1%  -37.77%  (p=0.008 n=5+5)

name       old alloc/op   new alloc/op   delta
Parser-16    30.7MB ± 0%     4.8MB ± 2%  -84.42%  (p=0.008 n=5+5)

name       old allocs/op  new allocs/op  delta
Parser-16     4.19k ± 0%     3.48k ± 0%  -16.84%  (p=0.008 n=5+5)
```

Comparing the memory profile of both executions, shows that the gains are primarily in the zlib writing code.
![image](https://user-images.githubusercontent.com/5452977/198091569-37c19480-2f98-458f-a090-f57742d4bcb1.png)

#### Reference.String() changes Benchmark
For bench mark delta on the ReferenceName optimisations:
```
name                        old time/op    new time/op    delta
ReferenceStringSymbolic-16     140ns ± 4%      40ns ± 9%  -71.19%  (p=0.008 n=5+5)
ReferenceStringHash-16         174ns ±14%      85ns ± 4%  -51.13%  (p=0.008 n=5+5)
ReferenceStringInvalid-16     48.9ns ± 2%     1.5ns ± 3%  -96.96%  (p=0.008 n=5+5)

name                        old alloc/op   new alloc/op   delta
ReferenceStringSymbolic-16     88.0B ± 0%     32.0B ± 0%  -63.64%  (p=0.008 n=5+5)
ReferenceStringHash-16          176B ± 0%      144B ± 0%  -18.18%  (p=0.008 n=5+5)
ReferenceStringInvalid-16      0.00B          0.00B          ~     (all equal)

name                        old allocs/op  new allocs/op  delta
ReferenceStringSymbolic-16      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.008 n=5+5)
ReferenceStringHash-16          5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.008 n=5+5)
ReferenceStringInvalid-16       0.00           0.00          ~     (all equal)
```

