### PR TITLE
Add quotes around option values with hash in git config files

### DIFF
--- a/plumbing/format/config/encoder.go
+++ b/plumbing/format/config/encoder.go
@@ -59,7 +59,7 @@ func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
 func (e *Encoder) encodeOptions(opts Options) error {
 	for _, o := range opts {
 		pattern := "\t%s = %s\n"
-		if strings.Contains(o.Value, "\\") {
+		if strings.Contains(o.Value, "\\") || strings.Contains(o.Value, "#") {
 			pattern = "\t%s = %q\n"
 		}
 


### PR DESCRIPTION
This is a fix for #309 'Can't clone branch ref name with hash/number sign (#)'

The problem is occurring because the # character in a git config file is interpreted as a comment.

When a repository is cloned a config file is created in the .git directory. I have mocked up an example below by hand:
```
[core]
	bare = false # This is just a comment so is ignored
[remote "origin"]
	url = https://https://github.com/myrepo.git
	fetch = +refs/heads/release/mybranchname:refs/remotes/origin/release/mybranchname
```
However, if there is a # character in the branch name like this:
```
[core]
	bare = false # This is just a comment so is ignored
[remote "origin"]
	url = https://https://github.com/myrepo.git
	fetch = +refs/heads/release/my#branchname:refs/remotes/origin/release/my#branchname
```
When go-git reads back the file it ignores everything after the # character, so the value read for the fetch option, rather than looking like this:
```
+refs/heads/release/my#branchname:refs/remotes/origin/release/my#branchname
```
It is read back from the file as this:
```
+refs/heads/release/my
```
go-git then returns an error 'malformed refspec, separators are wrong' because it is expecting at least one ':' separator character in that value.

The fix is to add quotes when encoding that file, so it looks like this:
```
[core]
	bare = false # This is just a comment so is ignored
[remote "origin"]
	url = https://https://github.com/myrepo.git
	fetch = "+refs/heads/release/my#branchname:refs/remotes/origin/release/my#branchname"
```
Then when reading and decoding that file go-git gets the correct value.







