### PR TITLE
CommitOptions: AllowEmptyCommits, return error instead of creating empty commits

### DIFF
--- a/options.go
+++ b/options.go
@@ -458,6 +458,10 @@ type CommitOptions struct {
 	// All automatically stage files that have been modified and deleted, but
 	// new files you have not told Git about are not affected.
 	All bool
+	// AllowEmptyCommits enable empty commits to be created. An empty commit
+	// is when no changes to the tree were made, but a new commit message is
+	// provided. The default behavior is false, which results in ErrEmptyCommit.
+	AllowEmptyCommits bool
 	// Author is the author's signature of the commit. If Author is empty the
 	// Name and Email is read from the config, and time.Now it's used as When.
 	Author *object.Signature

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"path"
 	"sort"
 	"strings"
@@ -14,6 +15,12 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-billy/v5"
+)
+
+var (
+	// ErrEmptyCommit occurs when a commit is attempted using a clean
+	// working tree, with no changes to be committed.
+	ErrEmptyCommit = errors.New("cannot create empty commit: clean working tree")
 )
 
 // Commit stores the current contents of the index in a new commit along with
@@ -39,7 +46,7 @@ func (w *Worktree) Commit(msg string, opts *CommitOptions) (plumbing.Hash, error
 		s:  w.r.Storer,
 	}
 
-	tree, err := h.BuildTree(idx)
+	tree, err := h.BuildTree(idx, opts)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -145,7 +152,11 @@ type buildTreeHelper struct {
 
 // BuildTree builds the tree objects and push its to the storer, the hash
 // of the root tree is returned.
-func (h *buildTreeHelper) BuildTree(idx *index.Index) (plumbing.Hash, error) {
+func (h *buildTreeHelper) BuildTree(idx *index.Index, opts *CommitOptions) (plumbing.Hash, error) {
+	if len(idx.Entries) == 0 && (opts == nil || !opts.AllowEmptyCommits) {
+		return plumbing.ZeroHash, ErrEmptyCommit
+	}
+
 	const rootNode = ""
 	h.trees = map[string]*object.Tree{rootNode: {}}
 	h.entries = map[string]*object.TreeEntry{}


### PR DESCRIPTION
BuildTree now returns an `ErrEmptyCommit` error, when there are no changes to be committed, which can be opted-out via `CommitOptions.AllowEmptyCommits`.

This is a breaking change which enables applications to detect when empty commits are to be created.

Some instances in which this can occur is when the fs (e.g. `billy/osfs`) make changes to the underlying files, causing a conflict between what the previous Git worktree state was, and the current state. Changes to the fs implementations are orthogonal to this, and will be dealt with separately.

The new behaviour aligns with the Git CLI, in which empty commits returns the error message: `nothing to commit, working tree clean`.