### PR TITLE
Support adding multiple paths

### DIFF
--- a/options.go
+++ b/options.go
@@ -439,6 +439,8 @@ type AddOptions struct {
 	All bool
 	// Path is the exact filepath to the file or directory to be added.
 	Path string
+	// Paths are the exact filepaths to the files or directories to be added.
+	Paths []string
 	// Glob adds all paths, matching pattern, to the index. If pattern matches a
 	// directory path, all directory contents are added to the index recursively.
 	Glob string
@@ -446,7 +448,7 @@ type AddOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *AddOptions) Validate(r *Repository) error {
-	if o.Path != "" && o.Glob != "" {
+	if (o.Path != "" || len(o.Paths) > 0) && o.Glob != "" {
 		return fmt.Errorf("fields Path and Glob are mutual exclusive")
 	}
 

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -251,11 +251,13 @@ func (s *WorktreeSuite) TestCommitTreeSort(c *C) {
 	err = mfs.MkdirAll("delta", 0755)
 	c.Assert(err, IsNil)
 
-	for _, p := range []string{"delta_last", "Gamma", "delta/middle", "Beta", "delta-first", "alpha"} {
-		util.WriteFile(mfs, p, []byte("foo"), 0644)
-		_, err = w.Add(p)
+	paths := []string{"delta_last", "Gamma", "delta/middle", "Beta", "delta-first", "alpha"}
+	for _, p := range paths {
+		err = util.WriteFile(mfs, p, []byte("foo"), 0644)
 		c.Assert(err, IsNil)
 	}
+	_, err = w.Add(paths...)
+	c.Assert(err, IsNil)
 
 	_, err = w.Commit("foo\n", &CommitOptions{
 		All:    true,


### PR DESCRIPTION
It's mentioned in #610. Reusing status info when adding multiple paths may improve performance to some extent.