### PR TITLE
fix(ssh): unable to pass a custom HostKeyCallback func

### DIFF
--- a/plumbing/transport/ssh/auth_method.go
+++ b/plumbing/transport/ssh/auth_method.go
@@ -43,6 +43,7 @@ const (
 type KeyboardInteractive struct {
 	User      string
 	Challenge ssh.KeyboardInteractiveChallenge
+	HostKeyCallbackHelper
 }
 
 func (a *KeyboardInteractive) Name() string {
@@ -54,18 +55,19 @@ func (a *KeyboardInteractive) String() string {
 }
 
 func (a *KeyboardInteractive) ClientConfig() (*ssh.ClientConfig, error) {
-	return &ssh.ClientConfig{
+	return a.SetHostKeyCallback(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{
 			a.Challenge,
 		},
-	}, nil
+	})
 }
 
 // Password implements AuthMethod by using the given password.
 type Password struct {
 	User     string
 	Password string
+	HostKeyCallbackHelper
 }
 
 func (a *Password) Name() string {
@@ -77,10 +79,10 @@ func (a *Password) String() string {
 }
 
 func (a *Password) ClientConfig() (*ssh.ClientConfig, error) {
-	return &ssh.ClientConfig{
+	return a.SetHostKeyCallback(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.Password(a.Password)},
-	}, nil
+	})
 }
 
 // PasswordCallback implements AuthMethod by using a callback
@@ -88,6 +90,7 @@ func (a *Password) ClientConfig() (*ssh.ClientConfig, error) {
 type PasswordCallback struct {
 	User     string
 	Callback func() (pass string, err error)
+	HostKeyCallbackHelper
 }
 
 func (a *PasswordCallback) Name() string {
@@ -99,16 +102,17 @@ func (a *PasswordCallback) String() string {
 }
 
 func (a *PasswordCallback) ClientConfig() (*ssh.ClientConfig, error) {
-	return &ssh.ClientConfig{
+	return a.SetHostKeyCallback(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.PasswordCallback(a.Callback)},
-	}, nil
+	})
 }
 
 // PublicKeys implements AuthMethod by using the given key pairs.
 type PublicKeys struct {
 	User   string
 	Signer ssh.Signer
+	HostKeyCallbackHelper
 }
 
 // NewPublicKeys returns a PublicKeys from a PEM encoded private key. An
@@ -147,10 +151,10 @@ func (a *PublicKeys) String() string {
 }
 
 func (a *PublicKeys) ClientConfig() (*ssh.ClientConfig, error) {
-	return &ssh.ClientConfig{
+	return a.SetHostKeyCallback(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.PublicKeys(a.Signer)},
-	}, nil
+	})
 }
 
 func username() (string, error) {
@@ -173,6 +177,7 @@ func username() (string, error) {
 type PublicKeysCallback struct {
 	User     string
 	Callback func() (signers []ssh.Signer, err error)
+	HostKeyCallbackHelper
 }
 
 // NewSSHAgentAuth returns a PublicKeysCallback based on a SSH agent, it opens
@@ -207,10 +212,10 @@ func (a *PublicKeysCallback) String() string {
 }
 
 func (a *PublicKeysCallback) ClientConfig() (*ssh.ClientConfig, error) {
-	return &ssh.ClientConfig{
+	return a.SetHostKeyCallback(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.PublicKeysCallback(a.Callback)},
-	}, nil
+	})
 }
 
 // NewKnownHostsCallback returns ssh.HostKeyCallback based on a file based on a
@@ -286,9 +291,6 @@ func filterKnownHostsFiles(files ...string) ([]string, error) {
 
 // HostKeyCallbackHelper is a helper that provides common functionality to
 // configure HostKeyCallback into a ssh.ClientConfig.
-// Deprecated in favor of SetConfigHostKeyFields (see common.go) which provides
-// a mechanism for also setting ClientConfig.HostKeyAlgorithms for a specific
-// host.
 type HostKeyCallbackHelper struct {
 	// HostKeyCallback is the function type used for verifying server keys.
 	// If nil default callback will be create using NewKnownHostsCallback

--- a/plumbing/transport/ssh/upload_pack_test.go
+++ b/plumbing/transport/ssh/upload_pack_test.go
@@ -25,6 +25,7 @@ import (
 type UploadPackSuite struct {
 	test.UploadPackSuite
 	fixtures.Suite
+	opts []ssh.Option
 
 	port int
 	base string
@@ -57,6 +58,9 @@ func (s *UploadPackSuite) SetUpSuite(c *C) {
 	s.UploadPackSuite.NonExistentEndpoint = s.newEndpoint(c, "non-existent.git")
 
 	server := &ssh.Server{Handler: handlerSSH}
+	for _, opt := range s.opts {
+		opt(server)
+	}
 	go func() {
 		log.Fatal(server.Serve(l))
 	}()


### PR DESCRIPTION
Don't overwrite HostKeyCallback if one is provided.

Fixes: c35b8082c863 ("plumbing: transport/ssh, auto-populate ClientConfig.HostKeyAlgorithms. Fixes #411")
Fixes: https://github.com/go-git/go-git/issues/654
Signed-off-by: Ayman Bagabas <ayman.bagabas@gmail.com>