### PR TITLE
Fix SetRef ignoring packed references

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -1040,10 +1040,18 @@ func (d *DotGit) PackRefs() (err error) {
 	defer ioutil.CheckClose(f, &err)
 
 	// Gather all refs using addRefsFromRefDir and addRefsFromPackedRefs.
-	var refs []*plumbing.Reference
+	var allRefs []*plumbing.Reference
 	seen := make(map[plumbing.ReferenceName]bool)
-	if err = d.addRefsFromRefDir(&refs, seen); err != nil {
+	if err = d.addRefsFromRefDir(&allRefs, seen); err != nil {
 		return err
+	}
+	// Filter out all non-hash references, as packed-refs can only contain
+	// hash references.
+	var refs []*plumbing.Reference
+	for _, ref := range allRefs {
+		if ref.Type() == plumbing.HashReference {
+			refs = append(refs, ref)
+		}
 	}
 	if len(refs) == 0 {
 		// Nothing to do!

--- a/storage/filesystem/dotgit/dotgit_setref.go
+++ b/storage/filesystem/dotgit/dotgit_setref.go
@@ -1,10 +1,12 @@
 package dotgit
 
 import (
-	"fmt"
+	"errors"
+	"io"
 	"os"
 
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/utils/ioutil"
 
 	"github.com/go-git/go-billy/v5"
@@ -43,12 +45,103 @@ func (d *DotGit) setRefRwfs(fileName, content string, old *plumbing.Reference) (
 
 	// this is a no-op to call even when old is nil.
 	err = d.checkReferenceAndTruncate(f, old)
-	if err != nil {
+
+	// If the existing reference wasn't what we expected, then check if
+	// the reference is listed in packed-refs, and if so pull it out.
+	shouldScrubPackedRefs := false
+	if err == ErrEmptyRefFile {
+		if old == nil {
+			// Make sure we scrub this ref from packed-refs if
+			// it already exists
+			shouldScrubPackedRefs = true
+		} else {
+			return d.extractReplacePackedRef(f, old, content)
+		}
+	} else if err != nil {
 		return err
 	}
 
 	_, err = f.Write([]byte(content))
+	if err != nil {
+		return err
+	}
+	if shouldScrubPackedRefs {
+		err = d.rewritePackedRefsWithoutRef(plumbing.ReferenceName(f.Name()))
+	}
 	return err
+}
+
+func (d *DotGit) extractReplacePackedRef(f billy.File, old *plumbing.Reference, content string) (err error) {
+	// Set up a deferred action to delete the unpacked ref. If we
+	// encounter an error, we have to remove it to get back to the
+	// original state, not leaving an empty reference file behind.
+	shouldKeep := false
+	defer func() {
+		if shouldKeep {
+			return
+		}
+		_ = d.fs.Remove(f.Name())
+	}()
+
+	// At this point, we know that we're expecing a reference, but
+	// there isn't anything here. Thus try and get it out. It's
+	// complicated by the requirement that this is all atomic: we
+	// have to lock and check the packed refs, and if we find the
+	// correct old value, then write out the new value into the
+	// unpacked file before rewriting the packed refs.
+
+	// Open the packed refs
+	pr, err := d.openAndLockPackedRefs(false)
+	if err != nil {
+		return err
+	}
+	if pr == nil {
+		return storage.ErrReferenceHasChanged
+	}
+	defer ioutil.CheckClose(pr, &err)
+
+	// Search through the packed refs for the reference we expect
+	refs, err := d.findPackedRefsInFile(pr)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, ref := range refs {
+		if ref.Name() != old.Name() {
+			continue
+		}
+
+		// We found a packed ref, but it's not what we expected.
+		if ref.Hash() != old.Hash() {
+			return storage.ErrReferenceHasChanged
+		}
+
+		// We found the reference we were expecting
+		found = true
+		break
+	}
+
+	// Couldn't find it?
+	if !found {
+		return storage.ErrReferenceHasChanged
+	}
+
+	_, err = pr.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+
+	// At this point we know the correct reference is in there, so
+	// write thte new one into the non-packed reference file, and
+	// only then remove the old one from packed-refs.
+	_, err = f.Write([]byte(content))
+	if err != nil {
+		return err
+	}
+	shouldKeep = true
+
+	// And finally, scrub the old reference from packed-refs.
+	return d.rewritePackedRefsWithoutRefWhileLocked(pr, plumbing.ReferenceName(f.Name()))
 }
 
 // There are some filesystems that don't support opening files in RDWD mode.
@@ -60,6 +153,9 @@ func (d *DotGit) setRefRwfs(fileName, content string, old *plumbing.Reference) (
 // a problem as they should be accessed by only one process at a time.
 func (d *DotGit) setRefNorwfs(fileName, content string, old *plumbing.Reference) error {
 	_, err := d.fs.Stat(fileName)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
 	if err == nil && old != nil {
 		fRead, err := d.fs.Open(fileName)
 		if err != nil {
@@ -74,7 +170,43 @@ func (d *DotGit) setRefNorwfs(fileName, content string, old *plumbing.Reference)
 		}
 
 		if ref.Hash() != old.Hash() {
-			return fmt.Errorf("reference has changed concurrently")
+			return storage.ErrReferenceHasChanged
+		}
+	} else if old != nil {
+		// The ref file where we expected to find the old reference
+		// doesn't exist, so check packed-refs.
+		refs, err := d.findPackedRefs()
+		if err != nil {
+			return err
+		}
+
+		found := false
+		for _, ref := range refs {
+			if ref.Name() != old.Name() {
+				continue
+			}
+			found = true
+			if ref.Hash() != old.Hash() {
+				return storage.ErrReferenceHasChanged
+			}
+		}
+		if !found {
+			return storage.ErrReferenceHasChanged
+		}
+
+		err = d.rewritePackedRefsWithoutRef(old.Name())
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		// In this case we don't have an old ref, but the ref file
+		// didn't previously exist. In this case, remove this ref
+		// from packed-refs if it previously existed there, to
+		// prevent the same ref being duplicated in a file and
+		// in packed-refs.
+		err = d.rewritePackedRefsWithoutRef(plumbing.ReferenceName(fileName))
+		if err != nil {
+			return err
 		}
 	}
 

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -737,12 +737,18 @@ func (s *SuiteDotGit) TestPackRefs(c *C) {
 	), nil)
 	c.Assert(err, IsNil)
 
+	err = dir.SetRef(plumbing.NewReferenceFromStrings(
+		"refs/heads/symbolic",
+		"ref: refs/heads/foo",
+	), nil)
+	c.Assert(err, IsNil)
+
 	refs, err := dir.Refs()
 	c.Assert(err, IsNil)
-	c.Assert(refs, HasLen, 2)
+	c.Assert(refs, HasLen, 3)
 	looseCount, err := dir.CountLooseRefs()
 	c.Assert(err, IsNil)
-	c.Assert(looseCount, Equals, 2)
+	c.Assert(looseCount, Equals, 3)
 
 	err = dir.PackRefs()
 	c.Assert(err, IsNil)
@@ -750,10 +756,10 @@ func (s *SuiteDotGit) TestPackRefs(c *C) {
 	// Make sure the refs are still there, but no longer loose.
 	refs, err = dir.Refs()
 	c.Assert(err, IsNil)
-	c.Assert(refs, HasLen, 2)
+	c.Assert(refs, HasLen, 3)
 	looseCount, err = dir.CountLooseRefs()
 	c.Assert(err, IsNil)
-	c.Assert(looseCount, Equals, 0)
+	c.Assert(looseCount, Equals, 1) // The symbolic ref shouldn't be packed
 
 	ref, err := dir.Ref("refs/heads/foo")
 	c.Assert(err, IsNil)
@@ -772,17 +778,17 @@ func (s *SuiteDotGit) TestPackRefs(c *C) {
 	c.Assert(err, IsNil)
 	looseCount, err = dir.CountLooseRefs()
 	c.Assert(err, IsNil)
-	c.Assert(looseCount, Equals, 1)
+	c.Assert(looseCount, Equals, 2)
 	err = dir.PackRefs()
 	c.Assert(err, IsNil)
 
 	// Make sure the refs are still there, but no longer loose.
 	refs, err = dir.Refs()
 	c.Assert(err, IsNil)
-	c.Assert(refs, HasLen, 2)
+	c.Assert(refs, HasLen, 3)
 	looseCount, err = dir.CountLooseRefs()
 	c.Assert(err, IsNil)
-	c.Assert(looseCount, Equals, 0)
+	c.Assert(looseCount, Equals, 1)
 
 	ref, err = dir.Ref("refs/heads/foo")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Previously, setting a reference that was previously packed would ignore
the packed reference, and leave the reference both as a file and in
packed form.

It also couldn't read the packed refs when verifying the old commit:
this meant that any references that are packed can't be changed by code
that supplies an old reference.

This could easily be triggered by cloning a Git repo with C git, then
updating the repo with go-git. C git would leave most of the upstream
branches packed, and if they were updated on the upstream go-git would
be unable to update their references.

One can create such a repository as follows:

```sh
mkdir test-upstream
(cd test-upstream && git init)
(cd test-upstream && git commit -m first --allow-empty)
git clone test-upstream test-downstream
(cd test-downstream && git pack-refs --all)
(cd test-upstream && git commit -m second --allow-empty)
```

Fetching test-downstream prior to this patch would them exhibit this
issue.

This PR also fixes PackRefs packing symbolic refs, which C git doesn't do, and
go-git's parser can't handle. That patch is part of this PR since it's needed for
the main commit's tests.