### PR TITLE
fix: don't use the `firstErrLine` when it is empty

### DIFF
--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -374,7 +374,7 @@ func (s *session) checkNotFoundError() error {
 	case <-t.C:
 		return ErrTimeoutExceeded
 	case line, ok := <-s.firstErrLine:
-		if !ok {
+		if !ok || len(line) == 0 {
 			return nil
 		}
 

--- a/plumbing/transport/internal/common/common_test.go
+++ b/plumbing/transport/internal/common/common_test.go
@@ -76,3 +76,17 @@ func (s *CommonSuite) TestIsRepoNotFoundErrorForGogsAccessDenied(c *C) {
 
 	c.Assert(isRepoNotFound, Equals, true)
 }
+
+func (s *CommonSuite) TestCheckNotFoundError(c *C) {
+	firstErrLine := make(chan string, 1)
+
+	session := session{
+		firstErrLine: firstErrLine,
+	}
+
+	firstErrLine <- ""
+
+	err := session.checkNotFoundError()
+
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Returning `nil` causes `handleAdvRefDecodeError` to fall back to `io.ErrUnexpectedEOF`.