### PR TITLE
_examples: README.md , Remove broken Config link.

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -23,7 +23,6 @@ Here you can find a list of annotated _go-git_ examples:
 - [remotes](remotes/main.go) - Working with remotes: adding, removing, etc.
 - [progress](progress/main.go) - Printing the progress information from the sideband.
 - [revision](revision/main.go) - Solve a revision into a commit.
-- [config](config/main.go) - Explains how to work with config files.
 - [submodule](submodule/main.go) - Submodule update remote.
 
 ### Advanced


### PR DESCRIPTION
This link is broken and doesn't appear to map to anything current.  I propose We remove this link.