### PR TITLE
plumbing/transport/ssh: do not override HostKeyCallback if set

### DIFF
--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -122,9 +122,11 @@ func (c *command) connect() error {
 		return err
 	}
 	hostWithPort := c.getHostWithPort()
-	config, err = SetConfigHostKeyFields(config, hostWithPort)
-	if err != nil {
-		return err
+	if config.HostKeyCallback == nil {
+		config, err = SetConfigHostKeyFields(config, hostWithPort)
+		if err != nil {
+			return err
+		}
 	}
 
 	overrideConfig(c.config, config)


### PR DESCRIPTION
We use the custom Auth method that returns `ClientConfig` with custom `HostKeyCallback` to check a host against known fingerprints (kind of white list), but the `SetConfigHostKeyFields` function always overrides the `HostKeyCallback` to read the fingerprints from the files and etc...

Added a simple check fixes the issue by calling the `SetConfigHostKeyFields` only if the `HostKeyCallback` is `nil`.