### PR TITLE
ci: Bump GitHub actions, enable go test race detection and stop using developer's GPG keys during test execution

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: 1.20.x
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install build dependencies
       run: sudo apt-get install gettext

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}   
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
   
     - name: Configure known hosts
       if: matrix.platform != 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build-git:
 
 test:
 	@echo "running against `git version`"; \
-	$(GOTEST) ./...
+	$(GOTEST) -race ./...
 
 test-coverage:
 	@echo "running against `git version`"; \

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -259,7 +259,7 @@ func (s *RepositorySuite) TestPullAdd(c *C) {
 	ExecuteOnPath(c, path,
 		"touch foo",
 		"git add foo",
-		"git commit -m foo foo",
+		"git commit --no-gpg-sign -m foo foo",
 	)
 
 	w, err := r.Worktree()


### PR DESCRIPTION
### tests: Avoid use of user's GPG keys during tests:
The `TestPullAdd` test uses `git` CLI to perform a commit.
Contributors with signing enabled globally would have their GPG
configuration being used to sign that test commit.

This behaviour was transparent for contributors that do not use
secure keys which requires physical confirmation.
The new behaviour disables GPG signing for that test, which was
not required as part of the test.

### ci: Bump GitHub actions
Removes the error messages: `Node.js 12 actions are deprecated`.

### ci: Enable race detection for go tests
After the fix of data races in go-billy (go-git/go-billy/pull/28)
race detection can be enabled in go-git to ensure no new issues
go undetected.