### PR TITLE
Add CustomRefSpec in the options for Clone()

### DIFF
--- a/options.go
+++ b/options.go
@@ -45,6 +45,10 @@ type CloneOptions struct {
 	ReferenceName plumbing.ReferenceName
 	// Fetch only ReferenceName if true.
 	SingleBranch bool
+	// Custom RefSpec defines the RefSpec used in the clone and overwrites the
+	// above ReferenceName and SingleBranch.  This is used to clone multiple
+	// references at once.
+	CustomRefSpec []config.RefSpec
 	// No checkout of HEAD after clone if true.
 	NoCheckout bool
 	// Limit fetching to the specified number of commits.

--- a/repository.go
+++ b/repository.go
@@ -907,7 +907,6 @@ func (r *Repository) cloneRefSpec(o *CloneOptions) []config.RefSpec {
 	case o.SingleBranch && o.ReferenceName == plumbing.HEAD:
 		return []config.RefSpec{
 			config.RefSpec(fmt.Sprintf(refspecSingleBranchHEAD, o.RemoteName)),
-			config.RefSpec(fmt.Sprintf(refspecSingleBranch, plumbing.Master.Short(), o.RemoteName)),
 		}
 	case o.SingleBranch:
 		return []config.RefSpec{

--- a/repository.go
+++ b/repository.go
@@ -899,6 +899,10 @@ const (
 )
 
 func (r *Repository) cloneRefSpec(o *CloneOptions) []config.RefSpec {
+	if len(o.CustomRefSpec) > 0 {
+		return append([]config.RefSpec{}, o.CustomRefSpec...)
+	}
+
 	switch {
 	case o.ReferenceName.IsTag():
 		return []config.RefSpec{
@@ -907,6 +911,7 @@ func (r *Repository) cloneRefSpec(o *CloneOptions) []config.RefSpec {
 	case o.SingleBranch && o.ReferenceName == plumbing.HEAD:
 		return []config.RefSpec{
 			config.RefSpec(fmt.Sprintf(refspecSingleBranchHEAD, o.RemoteName)),
+			config.RefSpec(fmt.Sprintf(refspecSingleBranch, plumbing.Master.Short(), o.RemoteName)),
 		}
 	case o.SingleBranch:
 		return []config.RefSpec{


### PR DESCRIPTION
When calling Clone and defining plumbing.HEAD and SingleBranch in the CloneOptions, the resultant request points to two RefSpecs... This extra reference causes trouble when the alternate HEADs' names differ from the standard.  This CustomRefSpec allows the caller to control what is passed to the git endpoint during a clone and define one or more as desired.

This is a non-breaking change of the existing capabilities of the module by adding a configuration to the option struct, which substitutes the RefSpec in the request.  This capability lets power users finely tune the query sent to the git repo.
