### PR TITLE
*: Add support for initializing SHA256 repositories

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Test
       run: make test-coverage
 
+    - name: Test SHA256
+      run: make test-sha256
+
     - name: Build go-git with CGO disabled
       run: go build ./...
       env:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ test:
 	@echo "running against `git version`"; \
 	$(GOTEST) -race ./...
 
+TEMP_REPO := $(shell mktemp)
+test-sha256:
+	$(GOCMD) run -tags sha256 _examples/sha256/main.go $(TEMP_REPO)
+	cd $(TEMP_REPO) && git fsck
+	rm -rf $(TEMP_REPO)
+
 test-coverage:
 	@echo "running against `git version`"; \
 	echo "" > $(COVERAGE_REPORT); \

--- a/_examples/sha256/main.go
+++ b/_examples/sha256/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	. "github.com/go-git/go-git/v5/_examples"
+	"github.com/go-git/go-git/v5/plumbing/format/config"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// This example requires building with the sha256 tag for it to work:
+// go run -tags sha256 main.go /tmp/repository
+
+// Basic example of how to initialise a repository using sha256 as the hashing algorithmn.
+func main() {
+	CheckArgs("<directory>")
+	directory := os.Args[1]
+
+	os.RemoveAll(directory)
+
+	// Init a new repository using the ObjectFormat SHA256.
+	r, err := git.PlainInitWithOptions(directory, &git.PlainInitOptions{ObjectFormat: config.SHA256})
+	CheckIfError(err)
+
+	w, err := r.Worktree()
+	CheckIfError(err)
+
+	// ... we need a file to commit so let's create a new file inside of the
+	// worktree of the project using the go standard library.
+	Info("echo \"hello world!\" > example-git-file")
+	filename := filepath.Join(directory, "example-git-file")
+	err = ioutil.WriteFile(filename, []byte("hello world!"), 0644)
+	CheckIfError(err)
+
+	// Adds the new file to the staging area.
+	Info("git add example-git-file")
+	_, err = w.Add("example-git-file")
+	CheckIfError(err)
+
+	// Commits the current staging area to the repository, with the new file
+	// just created. We should provide the object.Signature of Author of the
+	// commit Since version 5.0.1, we can omit the Author signature, being read
+	// from the git config files.
+	Info("git commit -m \"example go-git commit\"")
+	commit, err := w.Commit("example go-git commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "John Doe",
+			Email: "john@doe.org",
+			When:  time.Now(),
+		},
+	})
+
+	CheckIfError(err)
+
+	// Prints the current HEAD to verify that all worked well.
+	Info("git show -s")
+	obj, err := r.CommitObject(commit)
+	CheckIfError(err)
+
+	fmt.Println(obj)
+}

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	formatcfg "github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -672,3 +673,10 @@ type PlainOpenOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *PlainOpenOptions) Validate() error { return nil }
+
+type PlainInitOptions struct {
+	ObjectFormat formatcfg.ObjectFormat
+}
+
+// Validate validates the fields and sets the default values.
+func (o *PlainInitOptions) Validate() error { return nil }

--- a/plumbing/format/config/format.go
+++ b/plumbing/format/config/format.go
@@ -1,0 +1,53 @@
+package config
+
+// RepositoryFormatVersion represents the repository format version,
+// as per defined at:
+//
+//	https://git-scm.com/docs/repository-version
+type RepositoryFormatVersion string
+
+const (
+	// Version_0 is the format defined by the initial version of git,
+	// including but not limited to the format of the repository
+	// directory, the repository configuration file, and the object
+	// and ref storage.
+	//
+	// Specifying the complete behavior of git is beyond the scope
+	// of this document.
+	Version_0 = "0"
+
+	// Version_1 is identical to version 0, with the following exceptions:
+	//
+	//   1. When reading the core.repositoryformatversion variable, a git
+	//		implementation which supports version 1 MUST also read any
+	//		configuration keys found in the extensions section of the
+	//		configuration file.
+	//
+	//	 2. If a version-1 repository specifies any extensions.* keys that
+	//		the running git has not implemented, the operation MUST NOT proceed.
+	//		Similarly, if the value of any known key is not understood by the
+	//		implementation, the operation MUST NOT proceed.
+	//
+	// Note that if no extensions are specified in the config file, then
+	// core.repositoryformatversion SHOULD be set to 0 (setting it to 1 provides
+	// no benefit, and makes the repository incompatible with older
+	// implementations of git).
+	Version_1 = "1"
+
+	// DefaultRepositoryFormatVersion holds the default repository format version.
+	DefaultRepositoryFormatVersion = Version_0
+)
+
+// ObjectFormat defines the object format.
+type ObjectFormat string
+
+const (
+	// SHA1 represents the object format used for SHA1.
+	SHA1 ObjectFormat = "sha1"
+
+	// SHA256 represents the object format used for SHA256.
+	SHA256 ObjectFormat = "sha256"
+
+	// DefaultObjectFormat holds the default object format.
+	DefaultObjectFormat = SHA1
+)

--- a/plumbing/format/idxfile/decoder.go
+++ b/plumbing/format/idxfile/decoder.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 
+	"github.com/go-git/go-git/v5/plumbing/hash"
 	"github.com/go-git/go-git/v5/utils/binary"
 )
 
@@ -19,7 +20,7 @@ var (
 
 const (
 	fanout         = 256
-	objectIDLength = 20
+	objectIDLength = hash.Size
 )
 
 // Decoder reads and decodes idx files from an input stream.

--- a/plumbing/format/idxfile/encoder.go
+++ b/plumbing/format/idxfile/encoder.go
@@ -1,7 +1,6 @@
 package idxfile
 
 import (
-	"crypto"
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing/hash"
@@ -16,7 +15,7 @@ type Encoder struct {
 
 // NewEncoder returns a new stream encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
-	h := hash.New(crypto.SHA1)
+	h := hash.New(hash.CryptoType)
 	mw := io.MultiWriter(w, h)
 	return &Encoder{mw, h}
 }
@@ -133,10 +132,10 @@ func (e *Encoder) encodeChecksums(idx *MemoryIndex) (int, error) {
 		return 0, err
 	}
 
-	copy(idx.IdxChecksum[:], e.hash.Sum(nil)[:20])
+	copy(idx.IdxChecksum[:], e.hash.Sum(nil)[:hash.Size])
 	if _, err := e.Write(idx.IdxChecksum[:]); err != nil {
 		return 0, err
 	}
 
-	return 40, nil
+	return hash.HexSize, nil
 }

--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -8,6 +8,7 @@ import (
 	encbin "encoding/binary"
 
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/hash"
 )
 
 const (
@@ -53,8 +54,8 @@ type MemoryIndex struct {
 	Offset32         [][]byte
 	CRC32            [][]byte
 	Offset64         []byte
-	PackfileChecksum [20]byte
-	IdxChecksum      [20]byte
+	PackfileChecksum [hash.Size]byte
+	IdxChecksum      [hash.Size]byte
 
 	offsetHash       map[int64]plumbing.Hash
 	offsetHashIsFull bool

--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -3,7 +3,6 @@ package index
 import (
 	"bufio"
 	"bytes"
-	"crypto"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -49,7 +48,7 @@ type Decoder struct {
 
 // NewDecoder returns a new decoder that reads from r.
 func NewDecoder(r io.Reader) *Decoder {
-	h := hash.New(crypto.SHA1)
+	h := hash.New(hash.CryptoType)
 	return &Decoder{
 		r:         io.TeeReader(r, h),
 		hash:      h,

--- a/plumbing/format/index/encoder.go
+++ b/plumbing/format/index/encoder.go
@@ -2,7 +2,6 @@ package index
 
 import (
 	"bytes"
-	"crypto"
 	"errors"
 	"io"
 	"sort"
@@ -29,7 +28,7 @@ type Encoder struct {
 
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
-	h := hash.New(crypto.SHA1)
+	h := hash.New(hash.CryptoType)
 	mw := io.MultiWriter(w, h)
 	return &Encoder{mw, h}
 }

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -2,7 +2,6 @@ package packfile
 
 import (
 	"compress/zlib"
-	"crypto"
 	"fmt"
 	"io"
 
@@ -29,7 +28,7 @@ type Encoder struct {
 // OFSDeltaObject. To use Reference deltas, set useRefDeltas to true.
 func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool) *Encoder {
 	h := plumbing.Hasher{
-		Hash: hash.New(crypto.SHA1),
+		Hash: hash.New(hash.CryptoType),
 	}
 	mw := io.MultiWriter(w, h)
 	ow := newOffsetWriter(mw)

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
+	"github.com/go-git/go-git/v5/plumbing/hash"
 	"github.com/go-git/go-git/v5/storage/memory"
 
 	"github.com/go-git/go-billy/v5/memfs"
@@ -30,10 +31,10 @@ func (s *EncoderSuite) SetUpTest(c *C) {
 }
 
 func (s *EncoderSuite) TestCorrectPackHeader(c *C) {
-	hash, err := s.enc.Encode([]plumbing.Hash{}, 10)
+	h, err := s.enc.Encode([]plumbing.Hash{}, 10)
 	c.Assert(err, IsNil)
 
-	hb := [20]byte(hash)
+	hb := [hash.Size]byte(h)
 
 	// PACK + VERSION + OBJECTS + HASH
 	expectedResult := []byte{'P', 'A', 'C', 'K', 0, 0, 0, 2, 0, 0, 0, 0}
@@ -51,7 +52,7 @@ func (s *EncoderSuite) TestCorrectPackWithOneEmptyObject(c *C) {
 	_, err := s.store.SetEncodedObject(o)
 	c.Assert(err, IsNil)
 
-	hash, err := s.enc.Encode([]plumbing.Hash{o.Hash()}, 10)
+	h, err := s.enc.Encode([]plumbing.Hash{o.Hash()}, 10)
 	c.Assert(err, IsNil)
 
 	// PACK + VERSION(2) + OBJECT NUMBER(1)
@@ -64,7 +65,7 @@ func (s *EncoderSuite) TestCorrectPackWithOneEmptyObject(c *C) {
 		[]byte{120, 156, 1, 0, 0, 255, 255, 0, 0, 0, 1}...)
 
 	// + HASH
-	hb := [20]byte(hash)
+	hb := [hash.Size]byte(h)
 	expectedResult = append(expectedResult, hb[:]...)
 
 	result := s.buf.Bytes()

--- a/plumbing/format/packfile/scanner_test.go
+++ b/plumbing/format/packfile/scanner_test.go
@@ -6,6 +6,7 @@ import (
 
 	fixtures "github.com/go-git/go-git-fixtures/v4"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/hash"
 
 	. "gopkg.in/check.v1"
 )
@@ -71,7 +72,7 @@ func (s *ScannerSuite) testNextObjectHeader(c *C, tag string,
 
 	n, err := p.Checksum()
 	c.Assert(err, IsNil)
-	c.Assert(n, HasLen, 20)
+	c.Assert(n, HasLen, hash.Size)
 }
 
 func (s *ScannerSuite) TestNextObjectHeaderWithOutReadObject(c *C) {

--- a/plumbing/hash.go
+++ b/plumbing/hash.go
@@ -2,7 +2,6 @@ package plumbing
 
 import (
 	"bytes"
-	"crypto"
 	"encoding/hex"
 	"sort"
 	"strconv"
@@ -11,7 +10,7 @@ import (
 )
 
 // Hash SHA1 hashed content
-type Hash [20]byte
+type Hash [hash.Size]byte
 
 // ZeroHash is Hash with value zero
 var ZeroHash Hash
@@ -47,7 +46,7 @@ type Hasher struct {
 }
 
 func NewHasher(t ObjectType, size int64) Hasher {
-	h := Hasher{hash.New(crypto.SHA1)}
+	h := Hasher{hash.New(hash.CryptoType)}
 	h.Write(t.Bytes())
 	h.Write([]byte(" "))
 	h.Write([]byte(strconv.FormatInt(size, 10)))
@@ -75,10 +74,11 @@ func (p HashSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // IsHash returns true if the given string is a valid hash.
 func IsHash(s string) bool {
-	if len(s) != 40 {
+	switch len(s) {
+	case hash.HexSize:
+		_, err := hex.DecodeString(s)
+		return err == nil
+	default:
 		return false
 	}
-
-	_, err := hex.DecodeString(s)
-	return err == nil
 }

--- a/plumbing/hash/hash.go
+++ b/plumbing/hash/hash.go
@@ -21,6 +21,7 @@ func init() {
 // that registers new algorithms to avoid side effects.
 func reset() {
 	algos[crypto.SHA1] = sha1cd.New
+	algos[crypto.SHA256] = crypto.SHA256.New
 }
 
 // RegisterHash allows for the hash algorithm used to be overriden.
@@ -33,6 +34,8 @@ func RegisterHash(h crypto.Hash, f func() hash.Hash) error {
 
 	switch h {
 	case crypto.SHA1:
+		algos[h] = f
+	case crypto.SHA256:
 		algos[h] = f
 	default:
 		return fmt.Errorf("unsupported hash function: %v", h)

--- a/plumbing/hash/hash_sha1.go
+++ b/plumbing/hash/hash_sha1.go
@@ -1,0 +1,15 @@
+//go:build !sha256
+// +build !sha256
+
+package hash
+
+import "crypto"
+
+const (
+	// CryptoType defines what hash algorithm is being used.
+	CryptoType = crypto.SHA1
+	// Size defines the amount of bytes the hash yields.
+	Size = 20
+	// HexSize defines the strings size of the hash when represented in hexadecimal.
+	HexSize = 40
+)

--- a/plumbing/hash/hash_sha256.go
+++ b/plumbing/hash/hash_sha256.go
@@ -1,0 +1,15 @@
+//go:build sha256
+// +build sha256
+
+package hash
+
+import "crypto"
+
+const (
+	// CryptoType defines what hash algorithm is being used.
+	CryptoType = crypto.SHA256
+	// Size defines the amount of bytes the hash yields.
+	Size = 32
+	// HexSize defines the strings size of the hash when represented in hexadecimal.
+	HexSize = 64
+)

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/pktline"
+	"github.com/go-git/go-git/v5/plumbing/hash"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 
 	. "gopkg.in/check.v1"
@@ -119,8 +120,8 @@ type byHash []plumbing.Hash
 func (a byHash) Len() int      { return len(a) }
 func (a byHash) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a byHash) Less(i, j int) bool {
-	ii := [20]byte(a[i])
-	jj := [20]byte(a[j])
+	ii := [hash.Size]byte(a[i])
+	jj := [hash.Size]byte(a[j])
 	return bytes.Compare(ii[:], jj[:]) < 0
 }
 

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/hash"
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/utils/ioutil"
 
@@ -552,8 +553,8 @@ func (d *DotGit) hasPack(h plumbing.Hash) error {
 }
 
 func (d *DotGit) objectPath(h plumbing.Hash) string {
-	hash := h.String()
-	return d.fs.Join(objectsPath, hash[0:2], hash[2:40])
+	hex := h.String()
+	return d.fs.Join(objectsPath, hex[0:2], hex[2:hash.HexSize])
 }
 
 // incomingObjectPath is intended to add support for a git pre-receive hook
@@ -563,15 +564,16 @@ func (d *DotGit) objectPath(h plumbing.Hash) string {
 //
 // More on git hooks found here : https://git-scm.com/docs/githooks
 // More on 'quarantine'/incoming directory here:
-//     https://git-scm.com/docs/git-receive-pack
+//
+//	https://git-scm.com/docs/git-receive-pack
 func (d *DotGit) incomingObjectPath(h plumbing.Hash) string {
 	hString := h.String()
 
 	if d.incomingDirName == "" {
-		return d.fs.Join(objectsPath, hString[0:2], hString[2:40])
+		return d.fs.Join(objectsPath, hString[0:2], hString[2:hash.HexSize])
 	}
 
-	return d.fs.Join(objectsPath, d.incomingDirName, hString[0:2], hString[2:40])
+	return d.fs.Join(objectsPath, d.incomingDirName, hString[0:2], hString[2:hash.HexSize])
 }
 
 // hasIncomingObjects searches for an incoming directory and keeps its name

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v5/plumbing/format/objfile"
 	"github.com/go-git/go-git/v5/plumbing/format/packfile"
+	"github.com/go-git/go-git/v5/plumbing/hash"
 
 	"github.com/go-git/go-billy/v5"
 )
@@ -277,8 +278,8 @@ func (w *ObjectWriter) Close() error {
 }
 
 func (w *ObjectWriter) save() error {
-	hash := w.Hash().String()
-	file := w.fs.Join(objectsPath, hash[0:2], hash[2:40])
+	hex := w.Hash().String()
+	file := w.fs.Join(objectsPath, hex[0:2], hex[2:hash.HexSize])
 
 	return w.fs.Rename(w.f.Name(), file)
 }


### PR DESCRIPTION
The implementation includes an example that initializes a Git repository that is compatible with `git fsck` and can be used interchangeably with `git`.

The variable length for `plumbing.Hash` is defined at build time, blocked by tag `sha256`. This approach was a trade-off between keeping backwards compatibility while making progress towards supporting SHA256 with a small amount of changes.

Relates to  #706.