### PR TITLE
plumbing/transport/http: NewErr should always return Err

### DIFF
--- a/plumbing/error.go
+++ b/plumbing/error.go
@@ -14,8 +14,14 @@ func NewPermanentError(err error) *PermanentError {
 	return &PermanentError{Err: err}
 }
 
+// Error implements Error interface and returns string representation of the error
 func (e *PermanentError) Error() string {
 	return fmt.Sprintf("permanent client error: %s", e.Err.Error())
+}
+
+// Unwrap implements the Unwrap interface and returns WrappedError
+func (e *PermanentError) Unwrap() error {
+	return e.Err
 }
 
 type UnexpectedError struct {
@@ -30,6 +36,12 @@ func NewUnexpectedError(err error) *UnexpectedError {
 	return &UnexpectedError{Err: err}
 }
 
+// Error implements Error interface and returns string representation of the error
 func (e *UnexpectedError) Error() string {
 	return fmt.Sprintf("unexpected client error: %s", e.Err.Error())
+}
+
+// Unwrap implements the Unwrap interface and returns WrappedError
+func (e *UnexpectedError) Unwrap() error {
+	return e.Err
 }

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -2,7 +2,9 @@ package http
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net"
@@ -72,6 +74,17 @@ func (s *ClientSuite) TestNewErrOK(c *C) {
 	res := &http.Response{StatusCode: http.StatusOK}
 	err := NewErr(res)
 	c.Assert(err, IsNil)
+}
+
+func (s *ClientSuite) TestNewErrResponseBody(c *C) {
+	res := &http.Response{StatusCode: http.StatusForbidden, Body: io.NopCloser(strings.NewReader("foo bar"))}
+	err := NewErr(res)
+	c.Assert(err, NotNil)
+
+	var e *Err
+	ok := errors.As(err, &e)
+	c.Assert(ok, Equals, true)
+	c.Assert(string(e.ResponseBody), Equals, "foo bar")
 }
 
 func (s *ClientSuite) TestNewErrUnauthorized(c *C) {

--- a/plumbing/transport/http/upload_pack_test.go
+++ b/plumbing/transport/http/upload_pack_test.go
@@ -37,7 +37,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesNotExists(c *C) {
 	r, err := s.Client.NewUploadPackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	info, err := r.AdvertisedReferences()
-	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
+	c.Assert(err, ErrorMatches, "repository not found")
 	c.Assert(info, IsNil)
 }
 

--- a/plumbing/transport/test/receive_pack.go
+++ b/plumbing/transport/test/receive_pack.go
@@ -1,6 +1,5 @@
 // Package test implements common test suite for different transport
 // implementations.
-//
 package test
 
 import (
@@ -44,7 +43,7 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists(c *C) {
 	r, err := s.Client.NewReceivePackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar, err := r.AdvertisedReferences()
-	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
+	c.Assert(err, ErrorMatches, "repository not found")
 	c.Assert(ar, IsNil)
 	c.Assert(r.Close(), IsNil)
 
@@ -56,7 +55,7 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists(c *C) {
 	}
 
 	writer, err := r.ReceivePack(context.Background(), req)
-	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
+	c.Assert(err, ErrorMatches, "repository not found")
 	c.Assert(writer, IsNil)
 	c.Assert(r.Close(), IsNil)
 }


### PR DESCRIPTION
* Change the `NewErr` function to always return the instance of Err struct for any responses with included responses body in `Err.ResponseBody` field.
* Extend the `Err` struct to wrap another error. It is needed to keep backward compatibility: `errors.Is(err, transport.ErrAuthenticationRequired)`.
* Extend the `UnexpectedError` and `PermanentError` with `Unwrap` function, so the `errors.As` can unwrap the error.
* Add `ResponseBody` field to `Err` struct and TestNewErrResponseBody test

For debbugging purpose we need to have as much as possible info from the response, some servers can include a valuable information in body in case of 4XX responses.