### PR TITLE
internal: Fix regression in scp-like match

### DIFF
--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -5,8 +5,10 @@ import (
 )
 
 var (
-	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?:\/|:))?(?P<path>[^\\].*\/[^\\].*)$`)
+	isSchemeRegExp = regexp.MustCompile(`^[^:]+://`)
+
+	// Ref: https://github.com/git/git/blob/master/Documentation/urls.txt#L37
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5}):)?(?P<path>[^\\].*)$`)
 )
 
 // MatchesScheme returns true if the given string matches a URL-like

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -13,11 +13,27 @@ type URLSuite struct{}
 var _ = Suite(&URLSuite{})
 
 func (s *URLSuite) TestMatchesScpLike(c *C) {
+	// See https://github.com/git/git/blob/master/Documentation/urls.txt#L37
 	examples := []string{
+		// Most-extended case
 		"git@github.com:james/bond",
-		"git@github.com:007/bond",
+		// Most-extended case with port
 		"git@github.com:22:james/bond",
+		// Most-extended case with numeric path
+		"git@github.com:007/bond",
+		// Most-extended case with port and numeric "username"
 		"git@github.com:22:007/bond",
+		// Single repo path
+		"git@github.com:bond",
+		// Single repo path with port
+		"git@github.com:22:bond",
+		// Single repo path with port and numeric repo
+		"git@github.com:22:007",
+		// Repo path ending with .git and starting with _
+		"git@github.com:22:_007.git",
+		"git@github.com:_007.git",
+		"git@github.com:_james.git",
+		"git@github.com:_james/bond.git",
 	}
 
 	for _, url := range examples {
@@ -26,35 +42,68 @@ func (s *URLSuite) TestMatchesScpLike(c *C) {
 }
 
 func (s *URLSuite) TestFindScpLikeComponents(c *C) {
-	url := "git@github.com:james/bond"
-	user, host, port, path := FindScpLikeComponents(url)
+	testCases := []struct {
+		url, user, host, port, path string
+	}{
+		{
+			// Most-extended case
+			url: "git@github.com:james/bond", user: "git", host: "github.com", port: "", path: "james/bond",
+		},
+		{
+			// Most-extended case with port
+			url: "git@github.com:22:james/bond", user: "git", host: "github.com", port: "22", path: "james/bond",
+		},
+		{
+			// Most-extended case with numeric path
+			url: "git@github.com:007/bond", user: "git", host: "github.com", port: "", path: "007/bond",
+		},
+		{
+			// Most-extended case with port and numeric path
+			url: "git@github.com:22:007/bond", user: "git", host: "github.com", port: "22", path: "007/bond",
+		},
+		{
+			// Single repo path
+			url: "git@github.com:bond", user: "git", host: "github.com", port: "", path: "bond",
+		},
+		{
+			// Single repo path with port
+			url: "git@github.com:22:bond", user: "git", host: "github.com", port: "22", path: "bond",
+		},
+		{
+			// Single repo path with port and numeric path
+			url: "git@github.com:22:007", user: "git", host: "github.com", port: "22", path: "007",
+		},
+		{
+			// Repo path ending with .git and starting with _
+			url: "git@github.com:22:_007.git", user: "git", host: "github.com", port: "22", path: "_007.git",
+		},
+		{
+			// Repo path ending with .git and starting with _
+			url: "git@github.com:_007.git", user: "git", host: "github.com", port: "", path: "_007.git",
+		},
+		{
+			// Repo path ending with .git and starting with _
+			url: "git@github.com:_james.git", user: "git", host: "github.com", port: "", path: "_james.git",
+		},
+		{
+			// Repo path ending with .git and starting with _
+			url: "git@github.com:_james/bond.git", user: "git", host: "github.com", port: "", path: "_james/bond.git",
+		},
+	}
 
-	c.Check(user, Equals, "git")
-	c.Check(host, Equals, "github.com")
-	c.Check(port, Equals, "")
-	c.Check(path, Equals, "james/bond")
+	for _, tc := range testCases {
+		user, host, port, path := FindScpLikeComponents(tc.url)
 
-	url = "git@github.com:007/bond"
-	user, host, port, path = FindScpLikeComponents(url)
+		logf := func(ok bool) {
+			if ok {
+				return
+			}
+			c.Logf("%q check failed", tc.url)
+		}
 
-	c.Check(user, Equals, "git")
-	c.Check(host, Equals, "github.com")
-	c.Check(port, Equals, "")
-	c.Check(path, Equals, "007/bond")
-
-	url = "git@github.com:22:james/bond"
-	user, host, port, path = FindScpLikeComponents(url)
-
-	c.Check(user, Equals, "git")
-	c.Check(host, Equals, "github.com")
-	c.Check(port, Equals, "22")
-	c.Check(path, Equals, "james/bond")
-
-	url = "git@github.com:22:007/bond"
-	user, host, port, path = FindScpLikeComponents(url)
-
-	c.Check(user, Equals, "git")
-	c.Check(host, Equals, "github.com")
-	c.Check(port, Equals, "22")
-	c.Check(path, Equals, "007/bond")
+		logf(c.Check(user, Equals, tc.user))
+		logf(c.Check(host, Equals, tc.host))
+		logf(c.Check(port, Equals, tc.port))
+		logf(c.Check(path, Equals, tc.path))
+	}
 }

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -95,16 +95,28 @@ func (s *SuiteCommon) TestNewEndpointSCPLike(c *C) {
 	c.Assert(e.String(), Equals, "ssh://git@github.com/user/repository.git")
 }
 
-func (s *SuiteCommon) TestNewEndpointSCPLikeWithPort(c *C) {
+func (s *SuiteCommon) TestNewEndpointSCPLikeWithNumericPath(c *C) {
 	e, err := NewEndpoint("git@github.com:9999/user/repository.git")
 	c.Assert(err, IsNil)
 	c.Assert(e.Protocol, Equals, "ssh")
 	c.Assert(e.User, Equals, "git")
 	c.Assert(e.Password, Equals, "")
 	c.Assert(e.Host, Equals, "github.com")
-	c.Assert(e.Port, Equals, 9999)
-	c.Assert(e.Path, Equals, "user/repository.git")
-	c.Assert(e.String(), Equals, "ssh://git@github.com:9999/user/repository.git")
+	c.Assert(e.Port, Equals, 22)
+	c.Assert(e.Path, Equals, "9999/user/repository.git")
+	c.Assert(e.String(), Equals, "ssh://git@github.com/9999/user/repository.git")
+}
+
+func (s *SuiteCommon) TestNewEndpointSCPLikeWithPort(c *C) {
+	e, err := NewEndpoint("git@github.com:8080:9999/user/repository.git")
+	c.Assert(err, IsNil)
+	c.Assert(e.Protocol, Equals, "ssh")
+	c.Assert(e.User, Equals, "git")
+	c.Assert(e.Password, Equals, "")
+	c.Assert(e.Host, Equals, "github.com")
+	c.Assert(e.Port, Equals, 8080)
+	c.Assert(e.Path, Equals, "9999/user/repository.git")
+	c.Assert(e.String(), Equals, "ssh://git@github.com:8080/9999/user/repository.git")
 }
 
 func (s *SuiteCommon) TestNewEndpointFileAbs(c *C) {


### PR DESCRIPTION
I found that a regression was added in this commit https://github.com/go-git/go-git/commit/db0e226d48285a0ae8cda7db05d2ca20d9000dc6.

Specifically, it dropped support for repositories without multipath (ex. `git@host:repo.git`). The package fails cloning this kind of repository with this error:

```
$ go run -- "git@host:repo.git"
Cloning "git@host:repo.git"...
Error: repository not found
```

This PR fixes it and it adds test cases to cover the intended functionality.