### PR TITLE
git: worktree, add check to see if file already checked in. Fixes #718

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -169,7 +169,9 @@ func (w *Worktree) excludeIgnoredChanges(changes merkletrie.Changes) merkletrie.
 		if len(path) != 0 {
 			isDir := (len(ch.To) > 0 && ch.To.IsDir()) || (len(ch.From) > 0 && ch.From.IsDir())
 			if m.Match(path, isDir) {
-				continue
+				if len(ch.From) == 0 {
+					continue
+				}
 			}
 		}
 		res = append(res, ch)


### PR DESCRIPTION
Checks if an ignored file was previously checked in.  If it was, then the file is not ignored matching native git behavior. Fixes #718 