### PR TITLE
fix: git grep bare repositories

### DIFF
--- a/options.go
+++ b/options.go
@@ -642,7 +642,13 @@ var (
 )
 
 // Validate validates the fields and sets the default values.
+//
+// TODO: deprecate in favor of Validate(r *Repository) in v6.
 func (o *GrepOptions) Validate(w *Worktree) error {
+	return o.validate(w.r)
+}
+
+func (o *GrepOptions) validate(r *Repository) error {
 	if !o.CommitHash.IsZero() && o.ReferenceName != "" {
 		return ErrHashOrReference
 	}
@@ -650,7 +656,7 @@ func (o *GrepOptions) Validate(w *Worktree) error {
 	// If none of CommitHash and ReferenceName are provided, set commit hash of
 	// the repository's head.
 	if o.CommitHash.IsZero() && o.ReferenceName == "" {
-		ref, err := w.r.Head()
+		ref, err := r.Head()
 		if err != nil {
 			return err
 		}

--- a/worktree.go
+++ b/worktree.go
@@ -290,7 +290,7 @@ func (w *Worktree) ResetSparsely(opts *ResetOptions, dirs []string) error {
 		return nil
 	}
 
-	t, err := w.getTreeFromCommitHash(opts.Commit)
+	t, err := w.r.getTreeFromCommitHash(opts.Commit)
 	if err != nil {
 		return err
 	}
@@ -633,8 +633,8 @@ func (w *Worktree) addIndexFromFile(name string, h plumbing.Hash, idx *indexBuil
 	return nil
 }
 
-func (w *Worktree) getTreeFromCommitHash(commit plumbing.Hash) (*object.Tree, error) {
-	c, err := w.r.CommitObject(commit)
+func (r *Repository) getTreeFromCommitHash(commit plumbing.Hash) (*object.Tree, error) {
+	c, err := r.CommitObject(commit)
 	if err != nil {
 		return nil, err
 	}
@@ -802,9 +802,9 @@ func (gr GrepResult) String() string {
 	return fmt.Sprintf("%s:%s:%d:%s", gr.TreeName, gr.FileName, gr.LineNumber, gr.Content)
 }
 
-// Grep performs grep on a worktree.
-func (w *Worktree) Grep(opts *GrepOptions) ([]GrepResult, error) {
-	if err := opts.Validate(w); err != nil {
+// Grep performs grep on a repository.
+func (r *Repository) Grep(opts *GrepOptions) ([]GrepResult, error) {
+	if err := opts.validate(r); err != nil {
 		return nil, err
 	}
 
@@ -814,7 +814,7 @@ func (w *Worktree) Grep(opts *GrepOptions) ([]GrepResult, error) {
 	var treeName string
 
 	if opts.ReferenceName != "" {
-		ref, err := w.r.Reference(opts.ReferenceName, true)
+		ref, err := r.Reference(opts.ReferenceName, true)
 		if err != nil {
 			return nil, err
 		}
@@ -827,13 +827,18 @@ func (w *Worktree) Grep(opts *GrepOptions) ([]GrepResult, error) {
 
 	// Obtain a tree from the commit hash and get a tracked files iterator from
 	// the tree.
-	tree, err := w.getTreeFromCommitHash(commitHash)
+	tree, err := r.getTreeFromCommitHash(commitHash)
 	if err != nil {
 		return nil, err
 	}
 	fileiter := tree.Files()
 
 	return findMatchInFiles(fileiter, treeName, opts)
+}
+
+// Grep performs grep on a worktree.
+func (w *Worktree) Grep(opts *GrepOptions) ([]GrepResult, error) {
+	return w.r.Grep(opts)
 }
 
 // findMatchInFiles takes a FileIter, worktree name and GrepOptions, and


### PR DESCRIPTION
Perform grep on both `*Repository` or `*Worktree`.

Fixes: https://github.com/go-git/go-git/issues/68