### PR TITLE
add comment preventing people from creating invalid trees

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -271,6 +271,7 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 }
 
 // Encode transforms a Tree into a plumbing.EncodedObject.
+// The tree entries must be sorted by name.
 func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	o.SetType(plumbing.TreeObject)
 	w, err := o.Writer()


### PR DESCRIPTION
Resolves https://github.com/go-git/go-git/issues/725

I spent a few days trying to figure out why pushing produces an opaque error message from the remote.
It turned out that trees I had created needed to be sorted.

This PR adds a comment at the function used for encoding trees into a storer, which ensures that developers will encounter it when using the tree API.