### PR TITLE
storage: filesystem/dotgit, Improve load packed-refs

### DIFF
--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -105,7 +105,7 @@ func (s *ReferenceSuite) TestIsTag(c *C) {
 
 func benchMarkReferenceString(r *Reference, b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		r.String()
+		_ = r.String()
 	}
 }
 


### PR DESCRIPTION
In this PR I tweaked the parsing strategy of packed-refs to not continue if it is a single reference if it has already been found, which is very useful for repositories with thousands of references.
This reduces one iteration of references for loading all references, and also reduces memory allocations for a large number of references.
