### PR TITLE
git: Add support to ls-remote with peeled references. Fixes #749

### DIFF
--- a/_examples/ls-remote/main.go
+++ b/_examples/ls-remote/main.go
@@ -2,25 +2,35 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/storage/memory"
+
+	. "github.com/go-git/go-git/v5/_examples"
 )
 
 // Retrieve remote tags without cloning repository
 func main() {
+	CheckArgs("<url>")
+	url := os.Args[1]
+
+	Info("git ls-remote --tags %s", url)
 
 	// Create the remote with repository URL
 	rem := git.NewRemote(memory.NewStorage(), &config.RemoteConfig{
 		Name: "origin",
-		URLs: []string{"https://github.com/Zenika/MARCEL"},
+		URLs: []string{url},
 	})
 
 	log.Print("Fetching tags...")
 
 	// We can then use every Remote functions to retrieve wanted information
-	refs, err := rem.List(&git.ListOptions{})
+	refs, err := rem.List(&git.ListOptions{
+		// Returns all references, including peeled references.
+		PeelingOption: git.AppendPeeled,
+	})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/options.go
+++ b/options.go
@@ -624,7 +624,27 @@ type ListOptions struct {
 	InsecureSkipTLS bool
 	// CABundle specify additional ca bundle with system cert pool
 	CABundle []byte
+
+	// PeelingOption defines how peeled objects are handled during a
+	// remote list.
+	PeelingOption PeelingOption
 }
+
+// PeelingOption represents the different ways to handle peeled references.
+//
+// Peeled references represent the underlying object of an annotated
+// (or signed) tag. Refer to upstream documentation for more info:
+// https://github.com/git/git/blob/master/Documentation/technical/reftable.txt
+type PeelingOption uint8
+
+const (
+	// IgnorePeeled ignores all peeled reference names. This is the default behavior.
+	IgnorePeeled PeelingOption = 0
+	// OnlyPeeled returns only peeled reference names.
+	OnlyPeeled PeelingOption = 1
+	// AppendPeeled appends peeled reference names to the reference list.
+	AppendPeeled PeelingOption = 2
+)
 
 // CleanOptions describes how a clean should be performed.
 type CleanOptions struct {


### PR DESCRIPTION
A new `PeelingOption` field was introduced into `ListOptions`. The new options
include the default (and backwards compatible) IgnorePeeled. Plus another
two variations which either only returns peeled references (`OnlyPeeled`), or
append peeled references to the list (`AppendPeeled`).

The ls-remote example was updated to align with upstream, in which peeled
references are appended to the results by default.

A new `ErrEmptyUrls` error is now returned when `List` or `ListContext` do not
receive a URL to work with, to improve overall execution flow.