### PR TITLE
git: remote, add support for a configurable timeout.

### DIFF
--- a/options.go
+++ b/options.go
@@ -640,6 +640,8 @@ type ListOptions struct {
 	PeelingOption PeelingOption
 	// ProxyOptions provides info required for connecting to a proxy.
 	ProxyOptions transport.ProxyOptions
+	// Timeout specifies the timeout in seconds for list operations
+	Timeout int
 }
 
 // PeelingOption represents the different ways to handle peeled references.

--- a/remote.go
+++ b/remote.go
@@ -1258,7 +1258,15 @@ func (r *Remote) ListContext(ctx context.Context, o *ListOptions) (rfs []*plumbi
 }
 
 func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	timeout := o.Timeout
+	// Default to the old hardcoded 10s value if a timeout is not explicitly set.
+	if timeout == 0 {
+		timeout = 10
+	}
+	if timeout < 0 {
+		return nil, fmt.Errorf("invalid timeout: %d", timeout)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 	return r.ListContext(ctx, o)
 }


### PR DESCRIPTION
The previous hard-coded 10 second value is too short for listing large repositories like https://gitlab.com/gitlab-org/gitlab