### PR TITLE
git: Add Depth to SubmoduleUpdateOptions

### DIFF
--- a/options.go
+++ b/options.go
@@ -284,6 +284,9 @@ type SubmoduleUpdateOptions struct {
 	RecurseSubmodules SubmoduleRescursivity
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
+	// Depth limit fetching to the specified number of commits from the tip of
+	// each remote branch history.
+	Depth int
 }
 
 var (

--- a/submodule.go
+++ b/submodule.go
@@ -243,7 +243,7 @@ func (s *Submodule) fetchAndCheckout(
 	ctx context.Context, r *Repository, o *SubmoduleUpdateOptions, hash plumbing.Hash,
 ) error {
 	if !o.NoFetch {
-		err := r.FetchContext(ctx, &FetchOptions{Auth: o.Auth})
+		err := r.FetchContext(ctx, &FetchOptions{Auth: o.Auth, Depth: o.Depth})
 		if err != nil && err != NoErrAlreadyUpToDate {
 			return err
 		}
@@ -265,6 +265,7 @@ func (s *Submodule) fetchAndCheckout(
 			err := r.FetchContext(ctx, &FetchOptions{
 				Auth:     o.Auth,
 				RefSpecs: []config.RefSpec{refSpec},
+				Depth:    o.Depth,
 			})
 			if err != nil && err != NoErrAlreadyUpToDate && err != ErrExactSHA1NotSupported {
 				return err

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -233,3 +233,32 @@ func (s *SubmoduleSuite) TestSubmodulesUpdateContext(c *C) {
 	err = sm.UpdateContext(ctx, &SubmoduleUpdateOptions{Init: true})
 	c.Assert(err, NotNil)
 }
+
+func (s *SubmoduleSuite) TestSubmodulesFetchDepth(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
+	sm, err := s.Worktree.Submodule("basic")
+	c.Assert(err, IsNil)
+
+	err = sm.Update(&SubmoduleUpdateOptions{
+		Init:  true,
+		Depth: 1,
+	})
+	c.Assert(err, IsNil)
+
+	r, err := sm.Repository()
+	c.Assert(err, IsNil)
+
+	lr, err := r.Log(&LogOptions{})
+	c.Assert(err, IsNil)
+
+	commitCount := 0
+	for _, err := lr.Next(); err == nil; _, err = lr.Next() {
+		commitCount++
+	}
+	c.Assert(err, IsNil)
+
+	c.Assert(commitCount, Equals, 1)
+}


### PR DESCRIPTION
In order to allow shallow cloning for submodules we added the new depth option to the SubmoduleUpdateOptions. This option is then being used while fetching a submodule.