### PR TITLE
git: fix cloning with branch name

### DIFF
--- a/repository_test.go
+++ b/repository_test.go
@@ -1020,6 +1020,14 @@ func (s *RepositorySuite) TestCloneConfig(c *C) {
 }
 
 func (s *RepositorySuite) TestCloneSingleBranchAndNonHEAD(c *C) {
+	s.testCloneSingleBranchAndNonHEADReference(c, "refs/heads/branch")
+}
+
+func (s *RepositorySuite) TestCloneSingleBranchAndNonHEADAndNonFull(c *C) {
+	s.testCloneSingleBranchAndNonHEADReference(c, "branch")
+}
+
+func (s *RepositorySuite) testCloneSingleBranchAndNonHEADReference(c *C, ref string) {
 	r, _ := Init(memory.NewStorage(), nil)
 
 	head, err := r.Head()
@@ -1028,7 +1036,7 @@ func (s *RepositorySuite) TestCloneSingleBranchAndNonHEAD(c *C) {
 
 	err = r.clone(context.Background(), &CloneOptions{
 		URL:           s.GetBasicLocalRepositoryURL(),
-		ReferenceName: plumbing.ReferenceName("refs/heads/branch"),
+		ReferenceName: plumbing.ReferenceName(ref),
 		SingleBranch:  true,
 	})
 


### PR DESCRIPTION
This fixes calling clone with a branch name rather than a full spec.

This is to match calling `git clone -b <name> <repository>`