### PR TITLE
git: fix the issue with submodules having the SCP style URL fail due to the wrong URL parsing

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 	"path"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/index"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 )
 
 var (
@@ -133,29 +133,29 @@ func (s *Submodule) Repository() (*Repository, error) {
 		return nil, err
 	}
 
-	moduleURL, err := url.Parse(s.c.URL)
+	moduleEndpoint, err := transport.NewEndpoint(s.c.URL)
 	if err != nil {
 		return nil, err
 	}
 
-	if !path.IsAbs(moduleURL.Path) {
+	if !path.IsAbs(moduleEndpoint.Path) && moduleEndpoint.Protocol == "file" {
 		remotes, err := s.w.r.Remotes()
 		if err != nil {
 			return nil, err
 		}
 
-		rootURL, err := url.Parse(remotes[0].c.URLs[0])
+		rootEndpoint, err := transport.NewEndpoint(remotes[0].c.URLs[0])
 		if err != nil {
 			return nil, err
 		}
 
-		rootURL.Path = path.Join(rootURL.Path, moduleURL.Path)
-		*moduleURL = *rootURL
+		rootEndpoint.Path = path.Join(rootEndpoint.Path, moduleEndpoint.Path)
+		*moduleEndpoint = *rootEndpoint
 	}
 
 	_, err = r.CreateRemote(&config.RemoteConfig{
 		Name: DefaultRemoteName,
-		URLs: []string{moduleURL.String()},
+		URLs: []string{moduleEndpoint.String()},
 	})
 
 	return r, err

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -6,7 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
 
 	fixtures "github.com/go-git/go-git-fixtures/v4"
 	. "gopkg.in/check.v1"
@@ -261,4 +264,27 @@ func (s *SubmoduleSuite) TestSubmodulesFetchDepth(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(commitCount, Equals, 1)
+}
+
+func (s *SubmoduleSuite) TestSubmoduleParseScp(c *C) {
+	repo := &Repository{
+		Storer: memory.NewStorage(),
+		wt:     memfs.New(),
+	}
+	worktree := &Worktree{
+		Filesystem: memfs.New(),
+		r:          repo,
+	}
+	submodule := &Submodule{
+		initialized: true,
+		c:           nil,
+		w:           worktree,
+	}
+
+	submodule.c = &config.Submodule{
+		URL: "git@github.com:username/submodule_repo",
+	}
+
+	_, err := submodule.Repository()
+	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
When doing update for a submodule that has an SCP style URL I'm getting the following error:
```
first path segment in URL cannot contain colon
```

The offender seems to be [this line of code](https://github.com/go-git/go-git/blob/7e345bb5e163a4badefb0c54da3a057dcde50ed6/submodule.go#L136). It tries to use the go standard library method for URL parsing which cannot parse SCP style URLs.

Testing:
I'll need a bit of help with writing an integration test (if needed) for this usecase - it seems we'll have to add an additional (change existing) submodule in one of the fixtures to use the SCP style URL.

Edit:
I've added a unit test that should be enough of a safety net for this small use case.