### PR TITLE
git: Allow Initial Branch to be configurable

### DIFF
--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -126,6 +126,7 @@ func (r ReferenceName) Short() string {
 const (
 	HEAD   ReferenceName = "HEAD"
 	Master ReferenceName = "refs/heads/master"
+	Main   ReferenceName = "refs/heads/main"
 )
 
 // Reference is a representation of git reference

--- a/repository_test.go
+++ b/repository_test.go
@@ -52,6 +52,54 @@ func (s *RepositorySuite) TestInit(c *C) {
 	cfg, err := r.Config()
 	c.Assert(err, IsNil)
 	c.Assert(cfg.Core.IsBare, Equals, false)
+
+	// check the HEAD to see what the default branch is
+	createCommit(c, r)
+	ref, err := r.Head()
+	c.Assert(err, IsNil)
+	c.Assert(ref.Name().String(), Equals, plumbing.Master.String())
+}
+
+func (s *RepositorySuite) TestInitWithOptions(c *C) {
+	r, err := InitWithOptions(memory.NewStorage(), memfs.New(), InitOptions{
+		DefaultBranch: "refs/heads/foo",
+	})
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+	createCommit(c, r)
+
+	ref, err := r.Head()
+	c.Assert(err, IsNil)
+	c.Assert(ref.Name().String(), Equals, "refs/heads/foo")
+
+}
+
+func createCommit(c *C, r *Repository) {
+	// Create a commit so there is a HEAD to check
+	wt, err := r.Worktree()
+	c.Assert(err, IsNil)
+
+	rm, err := wt.Filesystem.Create("foo.txt")
+	c.Assert(err, IsNil)
+
+	_, err = rm.Write([]byte("foo text"))
+	c.Assert(err, IsNil)
+
+	_, err = wt.Add("foo.txt")
+	c.Assert(err, IsNil)
+
+	author := object.Signature{
+		Name:  "go-git",
+		Email: "go-git@fake.local",
+		When:  time.Now(),
+	}
+	_, err = wt.Commit("test commit message", &CommitOptions{
+		All:       true,
+		Author:    &author,
+		Committer: &author,
+	})
+	c.Assert(err, IsNil)
+
 }
 
 func (s *RepositorySuite) TestInitNonStandardDotGit(c *C) {


### PR DESCRIPTION
Allow the initial branch of the repo to be configurable.

This also adds `plumbing.Main` as a convenience constant so that it could be used for anyone wishing to, instead of having to define themselves.

Replaces #727 as this is non-breaking.