### PR TITLE
git: add a clone option to allow for shallow cloning of submodules

### DIFF
--- a/options.go
+++ b/options.go
@@ -62,6 +62,9 @@ type CloneOptions struct {
 	// within, using their default settings. This option is ignored if the
 	// cloned repository does not have a worktree.
 	RecurseSubmodules SubmoduleRescursivity
+	// ShallowSubmodules limit cloning submodules to the 1 level of depth.
+	// It matches the git command --shallow-submodules.
+	ShallowSubmodules bool
 	// Progress is where the human readable information sent by the server is
 	// stored, if nil nothing is stored and the capability (if supported)
 	// no-progress, is sent to the server to avoid send this information.

--- a/repository.go
+++ b/repository.go
@@ -900,7 +900,13 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		if o.RecurseSubmodules != NoRecurseSubmodules {
 			if err := w.updateSubmodules(&SubmoduleUpdateOptions{
 				RecurseSubmodules: o.RecurseSubmodules,
-				Auth:              o.Auth,
+				Depth: func() int {
+					if o.ShallowSubmodules {
+						return 1
+					}
+					return 0
+				}(),
+				Auth: o.Auth,
 			}); err != nil {
 				return err
 			}

--- a/repository_test.go
+++ b/repository_test.go
@@ -884,6 +884,43 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules(c *C) {
 	c.Assert(cfg.Submodules, HasLen, 2)
 }
 
+func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
+	dir, clean := s.TemporalDir()
+	defer clean()
+
+	path := fixtures.ByTag("submodule").One().Worktree().Root()
+	mainRepo, err := PlainClone(dir, false, &CloneOptions{
+		URL:               path,
+		RecurseSubmodules: 1,
+		ShallowSubmodules: true,
+	})
+	c.Assert(err, IsNil)
+
+	mainWorktree, err := mainRepo.Worktree()
+	c.Assert(err, IsNil)
+
+	submodule, err := mainWorktree.Submodule("basic")
+	c.Assert(err, IsNil)
+
+	subRepo, err := submodule.Repository()
+	c.Assert(err, IsNil)
+
+	lr, err := subRepo.Log(&LogOptions{})
+	c.Assert(err, IsNil)
+
+	commitCount := 0
+	for _, err := lr.Next(); err == nil; _, err = lr.Next() {
+		commitCount++
+	}
+	c.Assert(err, IsNil)
+
+	c.Assert(commitCount, Equals, 1)
+}
+
 func (s *RepositorySuite) TestPlainCloneNoCheckout(c *C) {
 	dir, clean := s.TemporalDir()
 	defer clean()


### PR DESCRIPTION
This option matches the git clone option --shallow-submodules. 
https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---no-shallow-submodules