### PR TITLE
*: Small fixes across the codebase

### DIFF
--- a/_examples/commit/main.go
+++ b/_examples/commit/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -29,7 +28,7 @@ func main() {
 	// worktree of the project using the go standard library.
 	Info("echo \"hello world!\" > example-git-file")
 	filename := filepath.Join(directory, "example-git-file")
-	err = ioutil.WriteFile(filename, []byte("hello world!"), 0644)
+	err = os.WriteFile(filename, []byte("hello world!"), 0644)
 	CheckIfError(err)
 
 	// Adds the new file to the staging area.

--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -3,7 +3,6 @@ package examples
 import (
 	"flag"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -65,7 +64,7 @@ func TestExamples(t *testing.T) {
 }
 
 func tempFolder() string {
-	path, err := ioutil.TempDir("", "")
+	path, err := os.MkdirTemp("", "")
 	CheckIfError(err)
 
 	tempFolders = append(tempFolders, path)

--- a/_examples/sha256/main.go
+++ b/_examples/sha256/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -34,7 +33,7 @@ func main() {
 	// worktree of the project using the go standard library.
 	Info("echo \"hello world!\" > example-git-file")
 	filename := filepath.Join(directory, "example-git-file")
-	err = ioutil.WriteFile(filename, []byte("hello world!"), 0644)
+	err = os.WriteFile(filename, []byte("hello world!"), 0644)
 	CheckIfError(err)
 
 	// Adds the new file to the staging area.

--- a/_examples/tag-create-push/main.go
+++ b/_examples/tag-create-push/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -67,7 +66,7 @@ func cloneRepo(url, dir, publicKeyPath string) (*git.Repository, error) {
 
 func publicKey(filePath string) (*ssh.PublicKeys, error) {
 	var publicKey *ssh.PublicKeys
-	sshKey, _ := ioutil.ReadFile(filePath)
+	sshKey, _ := os.ReadFile(filePath)
 	publicKey, err := ssh.NewPublicKeys("git", []byte(sshKey), "")
 	if err != nil {
 		return nil, err

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -144,7 +143,7 @@ func NewConfig() *Config {
 
 // ReadConfig reads a config file from a io.Reader.
 func ReadConfig(r io.Reader) (*Config, error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,6 @@ package git_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -44,7 +43,7 @@ func ExampleClone() {
 
 func ExamplePlainClone() {
 	// Tempdir to clone the repository
-	dir, err := ioutil.TempDir("", "clone-example")
+	dir, err := os.MkdirTemp("", "clone-example")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -72,7 +71,7 @@ func ExamplePlainClone() {
 
 func ExamplePlainClone_usernamePassword() {
 	// Tempdir to clone the repository
-	dir, err := ioutil.TempDir("", "clone-example")
+	dir, err := os.MkdirTemp("", "clone-example")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -95,7 +94,7 @@ func ExamplePlainClone_usernamePassword() {
 
 func ExamplePlainClone_accessToken() {
 	// Tempdir to clone the repository
-	dir, err := ioutil.TempDir("", "clone-example")
+	dir, err := os.MkdirTemp("", "clone-example")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/plumbing/format/gitattributes/attributes.go
+++ b/plumbing/format/gitattributes/attributes.go
@@ -3,7 +3,6 @@ package gitattributes
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 )
 
@@ -89,7 +88,7 @@ func (a attribute) String() string {
 
 // ReadAttributes reads patterns and attributes from the gitattributes format.
 func ReadAttributes(r io.Reader, domain []string, allowMacro bool) (attributes []MatchAttribute, err error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -3,7 +3,7 @@ package gitignore
 import (
 	"bufio"
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -86,7 +86,7 @@ func loadPatterns(fs billy.Filesystem, path string) (ps []Pattern, err error) {
 
 	defer gioutil.CheckClose(f, &err)
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return
 	}

--- a/plumbing/format/idxfile/decoder_test.go
+++ b/plumbing/format/idxfile/decoder_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -119,7 +118,7 @@ ch2xUA==
 
 func BenchmarkDecode(b *testing.B) {
 	f := fixtures.Basic().One()
-	fixture, err := ioutil.ReadAll(f.Idx())
+	fixture, err := io.ReadAll(f.Idx())
 	if err != nil {
 		b.Errorf("unexpected error reading idx file: %s", err)
 	}

--- a/plumbing/format/idxfile/encoder_test.go
+++ b/plumbing/format/idxfile/encoder_test.go
@@ -2,7 +2,7 @@ package idxfile_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 
 	. "github.com/go-git/go-git/v5/plumbing/format/idxfile"
 
@@ -12,7 +12,7 @@ import (
 
 func (s *IdxfileSuite) TestDecodeEncode(c *C) {
 	fixtures.ByTag("packfile").Test(c, func(f *fixtures.Fixture) {
-		expected, err := ioutil.ReadAll(f.Idx())
+		expected, err := io.ReadAll(f.Idx())
 		c.Assert(err, IsNil)
 
 		idx := new(MemoryIndex)

--- a/plumbing/format/idxfile/writer.go
+++ b/plumbing/format/idxfile/writer.go
@@ -84,11 +84,8 @@ func (w *Writer) OnFooter(h plumbing.Hash) error {
 	w.checksum = h
 	w.finished = true
 	_, err := w.createIndex()
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 // creatIndex returns a filled MemoryIndex with the information filled by

--- a/plumbing/format/idxfile/writer.go
+++ b/plumbing/format/idxfile/writer.go
@@ -136,15 +136,23 @@ func (w *Writer) createIndex() (*MemoryIndex, error) {
 
 		offset := o.Offset
 		if offset > math.MaxInt32 {
-			offset = w.addOffset64(offset)
+			var err error
+			offset, err = w.addOffset64(offset)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		buf.Truncate(0)
-		binary.WriteUint32(buf, uint32(offset))
+		if err := binary.WriteUint32(buf, uint32(offset)); err != nil {
+			return nil, err
+		}
 		idx.Offset32[bucket] = append(idx.Offset32[bucket], buf.Bytes()...)
 
 		buf.Truncate(0)
-		binary.WriteUint32(buf, o.CRC32)
+		if err := binary.WriteUint32(buf, o.CRC32); err != nil {
+			return nil, err
+		}
 		idx.CRC32[bucket] = append(idx.CRC32[bucket], buf.Bytes()...)
 	}
 
@@ -158,15 +166,17 @@ func (w *Writer) createIndex() (*MemoryIndex, error) {
 	return idx, nil
 }
 
-func (w *Writer) addOffset64(pos uint64) uint64 {
+func (w *Writer) addOffset64(pos uint64) (uint64, error) {
 	buf := new(bytes.Buffer)
-	binary.WriteUint64(buf, pos)
-	w.index.Offset64 = append(w.index.Offset64, buf.Bytes()...)
+	if err := binary.WriteUint64(buf, pos); err != nil {
+		return 0, err
+	}
 
+	w.index.Offset64 = append(w.index.Offset64, buf.Bytes()...)
 	index := uint64(w.offset64 | (1 << 31))
 	w.offset64++
 
-	return index
+	return index, nil
 }
 
 func (o objects) Len() int {

--- a/plumbing/format/idxfile/writer_test.go
+++ b/plumbing/format/idxfile/writer_test.go
@@ -3,7 +3,7 @@ package idxfile_test
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
@@ -34,7 +34,7 @@ func (s *WriterSuite) TestWriter(c *C) {
 	c.Assert(err, IsNil)
 
 	idxFile := f.Idx()
-	expected, err := ioutil.ReadAll(idxFile)
+	expected, err := io.ReadAll(idxFile)
 	c.Assert(err, IsNil)
 	idxFile.Close()
 
@@ -65,7 +65,7 @@ func (s *WriterSuite) TestWriterLarge(c *C) {
 
 	// load fixture index
 	f := bytes.NewBufferString(fixtureLarge4GB)
-	expected, err := ioutil.ReadAll(base64.NewDecoder(base64.StdEncoding, f))
+	expected, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, f))
 	c.Assert(err, IsNil)
 
 	buf := new(bytes.Buffer)

--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
+
 	"strconv"
 	"time"
 
@@ -201,7 +201,7 @@ func (d *Decoder) padEntry(idx *Index, e *Entry, read int) error {
 
 	entrySize := read + len(e.Name)
 	padLen := 8 - entrySize%8
-	_, err := io.CopyN(ioutil.Discard, d.r, int64(padLen))
+	_, err := io.CopyN(io.Discard, d.r, int64(padLen))
 	return err
 }
 

--- a/plumbing/format/objfile/reader_test.go
+++ b/plumbing/format/objfile/reader_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/go-git/go-git/v5/plumbing"
 
@@ -36,7 +35,7 @@ func testReader(c *C, source io.Reader, hash plumbing.Hash, t plumbing.ObjectTyp
 	c.Assert(typ, Equals, t)
 	c.Assert(content, HasLen, int(size))
 
-	rc, err := ioutil.ReadAll(r)
+	rc, err := io.ReadAll(r)
 	c.Assert(err, IsNil)
 	c.Assert(rc, DeepEquals, content, Commentf("%scontent=%s, expected=%s", base64.StdEncoding.EncodeToString(rc), base64.StdEncoding.EncodeToString(content)))
 

--- a/plumbing/format/packfile/delta_test.go
+++ b/plumbing/format/packfile/delta_test.go
@@ -2,7 +2,7 @@ package packfile
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"math/rand"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -109,14 +109,14 @@ func (s *DeltaSuite) TestAddDeltaReader(c *C) {
 		targetBuf := genBytes(t.target)
 
 		delta := DiffDelta(baseBuf, targetBuf)
-		deltaRC := ioutil.NopCloser(bytes.NewReader(delta))
+		deltaRC := io.NopCloser(bytes.NewReader(delta))
 
 		c.Log("Executing test case:", t.description)
 
 		resultRC, err := ReaderFromDelta(baseObj, deltaRC)
 		c.Assert(err, IsNil)
 
-		result, err := ioutil.ReadAll(resultRC)
+		result, err := io.ReadAll(resultRC)
 		c.Assert(err, IsNil)
 
 		err = resultRC.Close()
@@ -164,12 +164,12 @@ func (s *DeltaSuite) TestMaxCopySizeDeltaReader(c *C) {
 	targetBuf = append(targetBuf, byte(1))
 
 	delta := DiffDelta(baseBuf, targetBuf)
-	deltaRC := ioutil.NopCloser(bytes.NewReader(delta))
+	deltaRC := io.NopCloser(bytes.NewReader(delta))
 
 	resultRC, err := ReaderFromDelta(baseObj, deltaRC)
 	c.Assert(err, IsNil)
 
-	result, err := ioutil.ReadAll(resultRC)
+	result, err := io.ReadAll(resultRC)
 	c.Assert(err, IsNil)
 
 	err = resultRC.Close()

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -131,11 +131,7 @@ func (e *Encoder) entry(o *ObjectToPack) (err error) {
 	defer ioutil.CheckClose(or, &err)
 
 	_, err = io.Copy(e.zw, or)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (e *Encoder) writeBaseIfDelta(o *ObjectToPack) error {

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -3,7 +3,6 @@ package packfile
 import (
 	"bytes"
 	"io"
-	stdioutil "io/ioutil"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
@@ -278,13 +277,13 @@ func objectsEqual(c *C, o1, o2 plumbing.EncodedObject) {
 	r1, err := o1.Reader()
 	c.Assert(err, IsNil)
 
-	b1, err := stdioutil.ReadAll(r1)
+	b1, err := io.ReadAll(r1)
 	c.Assert(err, IsNil)
 
 	r2, err := o2.Reader()
 	c.Assert(err, IsNil)
 
-	b2, err := stdioutil.ReadAll(r2)
+	b2, err := io.ReadAll(r2)
 	c.Assert(err, IsNil)
 
 	c.Assert(bytes.Compare(b1, b2), Equals, 0)

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	stdioutil "io/ioutil"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
@@ -297,7 +296,7 @@ func (p *Parser) resolveDeltas() error {
 
 		if !obj.IsDelta() && len(obj.Children) > 0 {
 			for _, child := range obj.Children {
-				if err := p.resolveObject(stdioutil.Discard, child, content); err != nil {
+				if err := p.resolveObject(io.Discard, child, content); err != nil {
 					return err
 				}
 				p.resolveExternalRef(child)

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -7,7 +7,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
-	stdioutil "io/ioutil"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/utils/binary"
@@ -242,7 +241,7 @@ func (s *Scanner) discardObjectIfNeeded() error {
 	}
 
 	h := s.pendingObject
-	n, _, err := s.NextObject(stdioutil.Discard)
+	n, _, err := s.NextObject(io.Discard)
 	if err != nil {
 		return err
 	}
@@ -381,7 +380,7 @@ func (s *Scanner) Checksum() (plumbing.Hash, error) {
 // Close reads the reader until io.EOF
 func (s *Scanner) Close() error {
 	buf := sync.GetByteSlice()
-	_, err := io.CopyBuffer(stdioutil.Discard, s.r, *buf)
+	_, err := io.CopyBuffer(io.Discard, s.r, *buf)
 	sync.PutByteSlice(buf)
 
 	return err

--- a/plumbing/memory_test.go
+++ b/plumbing/memory_test.go
@@ -2,7 +2,6 @@ package plumbing
 
 import (
 	"io"
-	"io/ioutil"
 
 	. "gopkg.in/check.v1"
 )
@@ -52,7 +51,7 @@ func (s *MemoryObjectSuite) TestReader(c *C) {
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(reader.Close(), IsNil) }()
 
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	c.Assert(err, IsNil)
 	c.Assert(b, DeepEquals, []byte("foo"))
 }
@@ -75,7 +74,7 @@ func (s *MemoryObjectSuite) TestSeekableReader(c *C) {
 	_, err = rs.Seek(pageSize, io.SeekStart)
 	c.Assert(err, IsNil)
 
-	b, err := ioutil.ReadAll(rs)
+	b, err := io.ReadAll(rs)
 	c.Assert(err, IsNil)
 	c.Assert(b, DeepEquals, []byte(payload))
 

--- a/plumbing/object/blob_test.go
+++ b/plumbing/object/blob_test.go
@@ -3,7 +3,6 @@ package object
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/go-git/go-git/v5/plumbing"
 
@@ -37,7 +36,7 @@ func (s *BlobsSuite) TestBlobHash(c *C) {
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(reader.Close(), IsNil) }()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, "FOO")
 }
@@ -96,14 +95,14 @@ func (s *BlobsSuite) TestBlobIter(c *C) {
 		r1, err := b.Reader()
 		c.Assert(err, IsNil)
 
-		b1, err := ioutil.ReadAll(r1)
+		b1, err := io.ReadAll(r1)
 		c.Assert(err, IsNil)
 		c.Assert(r1.Close(), IsNil)
 
 		r2, err := blobs[i].Reader()
 		c.Assert(err, IsNil)
 
-		b2, err := ioutil.ReadAll(r2)
+		b2, err := io.ReadAll(r2)
 		c.Assert(err, IsNil)
 		c.Assert(r2.Close(), IsNil)
 

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -449,7 +448,7 @@ YIefGtzXfldDxg4=
 `
 
 	e, err := commit.Verify(armoredKeyRing)
-        c.Assert(err, IsNil)
+	c.Assert(err, IsNil)
 
 	_, ok := e.Identities["go-git test key"]
 	c.Assert(ok, Equals, true)
@@ -492,7 +491,7 @@ func (s *SuiteCommit) TestEncodeWithoutSignature(c *C) {
 	c.Assert(err, IsNil)
 	er, err := encoded.Reader()
 	c.Assert(err, IsNil)
-	payload, err := ioutil.ReadAll(er)
+	payload, err := io.ReadAll(er)
 	c.Assert(err, IsNil)
 
 	c.Assert(string(payload), Equals, ""+

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -2,7 +2,6 @@ package object
 
 import (
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -103,7 +102,7 @@ func (s *ObjectsSuite) TestParseTree(c *C) {
 			reader, err := f.Reader()
 			c.Assert(err, IsNil)
 			defer func() { c.Assert(reader.Close(), IsNil) }()
-			content, _ := ioutil.ReadAll(reader)
+			content, _ := io.ReadAll(reader)
 			c.Assert(content, HasLen, 2780)
 		}
 	}

--- a/plumbing/object/rename.go
+++ b/plumbing/object/rename.go
@@ -741,10 +741,7 @@ func (i *similarityIndex) add(key int, cnt uint64) error {
 			// It's the same key, so increment the counter.
 			var err error
 			i.hashes[j], err = newKeyCountPair(key, v.count()+cnt)
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		} else if j+1 >= len(i.hashes) {
 			j = 0
 		} else {

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -3,7 +3,6 @@ package object
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -466,7 +465,7 @@ func (s *TagSuite) TestEncodeWithoutSignature(c *C) {
 	c.Assert(err, IsNil)
 	er, err := encoded.Reader()
 	c.Assert(err, IsNil)
-	payload, err := ioutil.ReadAll(er)
+	payload, err := io.ReadAll(er)
 	c.Assert(err, IsNil)
 
 	c.Assert(string(payload), Equals, ""+

--- a/plumbing/protocol/packp/advrefs.go
+++ b/plumbing/protocol/packp/advrefs.go
@@ -57,7 +57,7 @@ func (a *AdvRefs) AddReference(r *plumbing.Reference) error {
 	switch r.Type() {
 	case plumbing.SymbolicReference:
 		v := fmt.Sprintf("%s:%s", r.Name().String(), r.Target().String())
-		a.Capabilities.Add(capability.SymRef, v)
+		return a.Capabilities.Add(capability.SymRef, v)
 	case plumbing.HashReference:
 		a.References[r.Name().String()] = r.Hash()
 	default:
@@ -96,12 +96,12 @@ func (a *AdvRefs) addRefs(s storer.ReferenceStorer) error {
 //
 // Git versions prior to 1.8.4.3 has an special procedure to get
 // the reference where is pointing to HEAD:
-// - Check if a reference called master exists. If exists and it
-//	 has the same hash as HEAD hash, we can say that HEAD is pointing to master
-// - If master does not exists or does not have the same hash as HEAD,
-//   order references and check in that order if that reference has the same
-//   hash than HEAD. If yes, set HEAD pointing to that branch hash
-// - If no reference is found, throw an error
+//   - Check if a reference called master exists. If exists and it
+//     has the same hash as HEAD hash, we can say that HEAD is pointing to master
+//   - If master does not exists or does not have the same hash as HEAD,
+//     order references and check in that order if that reference has the same
+//     hash than HEAD. If yes, set HEAD pointing to that branch hash
+//   - If no reference is found, throw an error
 func (a *AdvRefs) resolveHead(s storer.ReferenceStorer) error {
 	if a.Head == nil {
 		return nil

--- a/plumbing/protocol/packp/sideband/demux_test.go
+++ b/plumbing/protocol/packp/sideband/demux_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing/format/pktline"
@@ -101,7 +100,7 @@ func (s *SidebandSuite) TestDecodeWithProgress(c *C) {
 	c.Assert(n, Equals, 26)
 	c.Assert(content, DeepEquals, expected)
 
-	progress, err := ioutil.ReadAll(output)
+	progress, err := io.ReadAll(output)
 	c.Assert(err, IsNil)
 	c.Assert(progress, DeepEquals, []byte{'F', 'O', 'O', '\n'})
 }

--- a/plumbing/protocol/packp/updreq_decode.go
+++ b/plumbing/protocol/packp/updreq_decode.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/pktline"
@@ -81,7 +80,7 @@ func (req *ReferenceUpdateRequest) Decode(r io.Reader) error {
 	var ok bool
 	rc, ok = r.(io.ReadCloser)
 	if !ok {
-		rc = ioutil.NopCloser(r)
+		rc = io.NopCloser(r)
 	}
 
 	d := &updReqDecoder{r: rc, s: pktline.NewScanner(r)}

--- a/plumbing/protocol/packp/updreq_decode_test.go
+++ b/plumbing/protocol/packp/updreq_decode_test.go
@@ -3,7 +3,6 @@ package packp
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/pktline"
@@ -157,7 +156,7 @@ func (s *UpdReqDecodeSuite) TestOneUpdateCommand(c *C) {
 	expected.Commands = []*Command{
 		{Name: name, Old: hash1, New: hash2},
 	}
-	expected.Packfile = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	expected.Packfile = io.NopCloser(bytes.NewReader([]byte{}))
 
 	payloads := []string{
 		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00",
@@ -177,7 +176,7 @@ func (s *UpdReqDecodeSuite) TestMultipleCommands(c *C) {
 		{Name: plumbing.ReferenceName("myref2"), Old: plumbing.ZeroHash, New: hash2},
 		{Name: plumbing.ReferenceName("myref3"), Old: hash1, New: plumbing.ZeroHash},
 	}
-	expected.Packfile = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	expected.Packfile = io.NopCloser(bytes.NewReader([]byte{}))
 
 	payloads := []string{
 		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref1\x00",
@@ -200,7 +199,7 @@ func (s *UpdReqDecodeSuite) TestMultipleCommandsAndCapabilities(c *C) {
 		{Name: plumbing.ReferenceName("myref3"), Old: hash1, New: plumbing.ZeroHash},
 	}
 	expected.Capabilities.Add("shallow")
-	expected.Packfile = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	expected.Packfile = io.NopCloser(bytes.NewReader([]byte{}))
 
 	payloads := []string{
 		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref1\x00shallow",
@@ -224,7 +223,7 @@ func (s *UpdReqDecodeSuite) TestMultipleCommandsAndCapabilitiesShallow(c *C) {
 	}
 	expected.Capabilities.Add("shallow")
 	expected.Shallow = &hash1
-	expected.Packfile = ioutil.NopCloser(bytes.NewReader([]byte{}))
+	expected.Packfile = io.NopCloser(bytes.NewReader([]byte{}))
 
 	payloads := []string{
 		"shallow 1ecf0ef2c2dffb796033e5a02219af86ec6584e5",
@@ -247,7 +246,7 @@ func (s *UpdReqDecodeSuite) TestWithPackfile(c *C) {
 		{Name: name, Old: hash1, New: hash2},
 	}
 	packfileContent := []byte("PACKabc")
-	expected.Packfile = ioutil.NopCloser(bytes.NewReader(packfileContent))
+	expected.Packfile = io.NopCloser(bytes.NewReader(packfileContent))
 
 	payloads := []string{
 		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00",
@@ -298,10 +297,10 @@ func (s *UpdReqDecodeSuite) testDecodeOkExpected(c *C, expected *ReferenceUpdate
 }
 
 func (s *UpdReqDecodeSuite) compareReaders(c *C, a io.ReadCloser, b io.ReadCloser) {
-	pba, err := ioutil.ReadAll(a)
+	pba, err := io.ReadAll(a)
 	c.Assert(err, IsNil)
 	c.Assert(a.Close(), IsNil)
-	pbb, err := ioutil.ReadAll(b)
+	pbb, err := io.ReadAll(b)
 	c.Assert(err, IsNil)
 	c.Assert(b.Close(), IsNil)
 	c.Assert(pba, DeepEquals, pbb)

--- a/plumbing/protocol/packp/updreq_encode_test.go
+++ b/plumbing/protocol/packp/updreq_encode_test.go
@@ -2,12 +2,11 @@ package packp
 
 import (
 	"bytes"
+	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/pktline"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
-
-	"io/ioutil"
 
 	. "gopkg.in/check.v1"
 )
@@ -128,7 +127,7 @@ func (s *UpdReqEncodeSuite) TestWithPackfile(c *C) {
 
 	packfileContent := []byte("PACKabc")
 	packfileReader := bytes.NewReader(packfileContent)
-	packfileReadCloser := ioutil.NopCloser(packfileReader)
+	packfileReadCloser := io.NopCloser(packfileReader)
 
 	r := NewReferenceUpdateRequest()
 	r.Commands = []*Command{

--- a/plumbing/protocol/packp/uppackresp_test.go
+++ b/plumbing/protocol/packp/uppackresp_test.go
@@ -2,7 +2,7 @@ package packp
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
@@ -21,10 +21,10 @@ func (s *UploadPackResponseSuite) TestDecodeNAK(c *C) {
 	res := NewUploadPackResponse(req)
 	defer res.Close()
 
-	err := res.Decode(ioutil.NopCloser(bytes.NewBufferString(raw)))
+	err := res.Decode(io.NopCloser(bytes.NewBufferString(raw)))
 	c.Assert(err, IsNil)
 
-	pack, err := ioutil.ReadAll(res)
+	pack, err := io.ReadAll(res)
 	c.Assert(err, IsNil)
 	c.Assert(pack, DeepEquals, []byte("PACK"))
 }
@@ -38,10 +38,10 @@ func (s *UploadPackResponseSuite) TestDecodeDepth(c *C) {
 	res := NewUploadPackResponse(req)
 	defer res.Close()
 
-	err := res.Decode(ioutil.NopCloser(bytes.NewBufferString(raw)))
+	err := res.Decode(io.NopCloser(bytes.NewBufferString(raw)))
 	c.Assert(err, IsNil)
 
-	pack, err := ioutil.ReadAll(res)
+	pack, err := io.ReadAll(res)
 	c.Assert(err, IsNil)
 	c.Assert(pack, DeepEquals, []byte("PACK"))
 }
@@ -55,7 +55,7 @@ func (s *UploadPackResponseSuite) TestDecodeMalformed(c *C) {
 	res := NewUploadPackResponse(req)
 	defer res.Close()
 
-	err := res.Decode(ioutil.NopCloser(bytes.NewBufferString(raw)))
+	err := res.Decode(io.NopCloser(bytes.NewBufferString(raw)))
 	c.Assert(err, NotNil)
 }
 
@@ -70,7 +70,7 @@ func (s *UploadPackResponseSuite) TestDecodeMultiACK(c *C) {
 	res := NewUploadPackResponse(req)
 	defer res.Close()
 
-	err := res.Decode(ioutil.NopCloser(bytes.NewBuffer(nil)))
+	err := res.Decode(io.NopCloser(bytes.NewBuffer(nil)))
 	c.Assert(err, IsNil)
 }
 
@@ -87,7 +87,7 @@ func (s *UploadPackResponseSuite) TestReadNoDecode(c *C) {
 }
 
 func (s *UploadPackResponseSuite) TestEncodeNAK(c *C) {
-	pf := ioutil.NopCloser(bytes.NewBuffer([]byte("[PACK]")))
+	pf := io.NopCloser(bytes.NewBuffer([]byte("[PACK]")))
 	req := NewUploadPackRequest()
 	res := NewUploadPackResponseWithPackfile(req, pf)
 	defer func() { c.Assert(res.Close(), IsNil) }()
@@ -100,7 +100,7 @@ func (s *UploadPackResponseSuite) TestEncodeNAK(c *C) {
 }
 
 func (s *UploadPackResponseSuite) TestEncodeDepth(c *C) {
-	pf := ioutil.NopCloser(bytes.NewBuffer([]byte("PACK")))
+	pf := io.NopCloser(bytes.NewBuffer([]byte("PACK")))
 	req := NewUploadPackRequest()
 	req.Depth = DepthCommits(1)
 
@@ -115,7 +115,7 @@ func (s *UploadPackResponseSuite) TestEncodeDepth(c *C) {
 }
 
 func (s *UploadPackResponseSuite) TestEncodeMultiACK(c *C) {
-	pf := ioutil.NopCloser(bytes.NewBuffer([]byte("[PACK]")))
+	pf := io.NopCloser(bytes.NewBuffer([]byte("[PACK]")))
 	req := NewUploadPackRequest()
 
 	res := NewUploadPackResponseWithPackfile(req, pf)

--- a/plumbing/transport/file/common_test.go
+++ b/plumbing/transport/file/common_test.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -25,7 +24,7 @@ func (s *CommonSuite) SetUpSuite(c *C) {
 	}
 
 	var err error
-	s.tmpDir, err = ioutil.TempDir("", "")
+	s.tmpDir, err = os.MkdirTemp("", "")
 	c.Assert(err, IsNil)
 	s.ReceivePackBin = filepath.Join(s.tmpDir, "git-receive-pack")
 	s.UploadPackBin = filepath.Join(s.tmpDir, "git-upload-pack")

--- a/plumbing/transport/git/common.go
+++ b/plumbing/transport/git/common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strconv"
 
 	"github.com/go-git/go-git/v5/plumbing/format/pktline"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -69,7 +70,7 @@ func (c *command) getHostWithPort() string {
 		port = DefaultPort
 	}
 
-	return fmt.Sprintf("%s:%d", host, port)
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 // StderrPipe git protocol doesn't have any dedicated error channel
@@ -92,7 +93,7 @@ func (c *command) StdoutPipe() (io.Reader, error) {
 func endpointToCommand(cmd string, ep *transport.Endpoint) string {
 	host := ep.Host
 	if ep.Port != DefaultPort {
-		host = fmt.Sprintf("%s:%d", ep.Host, ep.Port)
+		host = net.JoinHostPort(ep.Host, strconv.Itoa(ep.Port))
 	}
 
 	return fmt.Sprintf("%s %s%chost=%s%c", cmd, ep.Path, 0, host, 0)

--- a/plumbing/transport/git/common_test.go
+++ b/plumbing/transport/git/common_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -37,7 +36,7 @@ func (s *BaseSuite) SetUpTest(c *C) {
 	s.port, err = freePort()
 	c.Assert(err, IsNil)
 
-	s.base, err = ioutil.TempDir(os.TempDir(), fmt.Sprintf("go-git-protocol-%d", s.port))
+	s.base, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-protocol-%d", s.port))
 	c.Assert(err, IsNil)
 }
 

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -3,7 +3,6 @@ package http
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -222,7 +221,7 @@ func (s *BaseSuite) SetUpTest(c *C) {
 	l, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, IsNil)
 
-	base, err := ioutil.TempDir(os.TempDir(), fmt.Sprintf("go-git-http-%d", s.port))
+	base, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-http-%d", s.port))
 	c.Assert(err, IsNil)
 
 	s.port = l.Addr().(*net.TCPAddr).Port

--- a/plumbing/transport/http/upload_pack_test.go
+++ b/plumbing/transport/http/upload_pack_test.go
@@ -3,7 +3,7 @@ package http
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -49,7 +49,7 @@ func (s *UploadPackSuite) TestuploadPackRequestToReader(c *C) {
 
 	sr, err := uploadPackRequestToReader(r)
 	c.Assert(err, IsNil)
-	b, _ := ioutil.ReadAll(sr)
+	b, _ := io.ReadAll(sr)
 	c.Assert(string(b), Equals,
 		"0032want 2b41ef280fdb67a9b250678686a0c3e03b0a9989\n"+
 			"0032want d82f291cde9987322c8a0c81a325e1ba6159684c\n0000"+

--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	stdioutil "io/ioutil"
 	"strings"
 	"time"
 
@@ -156,7 +155,7 @@ func (c *client) listenFirstError(r io.Reader) chan string {
 			close(errLine)
 		}
 
-		_, _ = io.Copy(stdioutil.Discard, r)
+		_, _ = io.Copy(io.Discard, r)
 	}()
 
 	return errLine

--- a/plumbing/transport/ssh/auth_method.go
+++ b/plumbing/transport/ssh/auth_method.go
@@ -3,7 +3,6 @@ package ssh
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -134,7 +133,7 @@ func NewPublicKeys(user string, pemBytes []byte, password string) (*PublicKeys, 
 // encoded private key. An encryption password should be given if the pemBytes
 // contains a password encrypted PEM block otherwise password should be empty.
 func NewPublicKeysFromFile(user, pemFile, password string) (*PublicKeys, error) {
-	bytes, err := ioutil.ReadFile(pemFile)
+	bytes, err := os.ReadFile(pemFile)
 	if err != nil {
 		return nil, err
 	}

--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -212,7 +212,7 @@ func (c *command) getHostWithPort() string {
 		port = DefaultPort
 	}
 
-	return fmt.Sprintf("%s:%d", host, port)
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func (c *command) doGetHostWithPortFromSSHConfig() (addr string, found bool) {
@@ -240,7 +240,7 @@ func (c *command) doGetHostWithPortFromSSHConfig() (addr string, found bool) {
 		}
 	}
 
-	addr = fmt.Sprintf("%s:%d", host, port)
+	addr = net.JoinHostPort(host, strconv.Itoa(port))
 	return
 }
 

--- a/plumbing/transport/ssh/internal/test/proxy_test.go
+++ b/plumbing/transport/ssh/internal/test/proxy_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -59,7 +58,7 @@ func (s *ProxyEnvSuite) TestCommand(c *C) {
 	}()
 
 	s.port = sshListener.Addr().(*net.TCPAddr).Port
-	s.base, err = ioutil.TempDir(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.port))
+	s.base, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.port))
 	c.Assert(err, IsNil)
 
 	ggssh.DefaultAuthBuilder = func(user string) (ggssh.AuthMethod, error) {

--- a/plumbing/transport/ssh/proxy_test.go
+++ b/plumbing/transport/ssh/proxy_test.go
@@ -3,7 +3,6 @@ package ssh
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -54,7 +53,7 @@ func (s *ProxySuite) TestCommand(c *C) {
 	}()
 
 	s.u.port = sshListener.Addr().(*net.TCPAddr).Port
-	s.u.base, err = ioutil.TempDir(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.u.port))
+	s.u.base, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.u.port))
 	c.Assert(err, IsNil)
 
 	DefaultAuthBuilder = func(user string) (AuthMethod, error) {

--- a/plumbing/transport/ssh/upload_pack_test.go
+++ b/plumbing/transport/ssh/upload_pack_test.go
@@ -3,7 +3,6 @@ package ssh
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -43,7 +42,7 @@ func (s *UploadPackSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 
 	s.port = l.Addr().(*net.TCPAddr).Port
-	s.base, err = ioutil.TempDir(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.port))
+	s.base, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.port))
 	c.Assert(err, IsNil)
 
 	DefaultAuthBuilder = func(user string) (AuthMethod, error) {

--- a/plumbing/transport/test/receive_pack.go
+++ b/plumbing/transport/test/receive_pack.go
@@ -1,13 +1,11 @@
 // Package test implements common test suite for different transport
 // implementations.
-//
 package test
 
 import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -235,7 +233,7 @@ func (s *ReceivePackSuite) receivePackNoCheck(c *C, ep *transport.Endpoint,
 
 	if rootPath != "" && err == nil && stat.IsDir() {
 		objectPath := filepath.Join(rootPath, "objects/pack")
-		files, err := ioutil.ReadDir(objectPath)
+		files, err := os.ReadDir(objectPath)
 		c.Assert(err, IsNil)
 
 		for _, file := range files {
@@ -371,5 +369,5 @@ func (s *ReceivePackSuite) emptyPackfile() io.ReadCloser {
 		panic(err)
 	}
 
-	return ioutil.NopCloser(&buf)
+	return io.NopCloser(&buf)
 }

--- a/plumbing/transport/test/upload_pack.go
+++ b/plumbing/transport/test/upload_pack.go
@@ -1,13 +1,11 @@
 // Package test implements common test suite for different transport
 // implementations.
-//
 package test
 
 import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -154,7 +152,7 @@ func (s *UploadPackSuite) TestUploadPackWithContextOnRead(c *C) {
 
 	cancel()
 
-	_, err = io.Copy(ioutil.Discard, reader)
+	_, err = io.Copy(io.Discard, reader)
 	c.Assert(err, NotNil)
 
 	err = reader.Close()
@@ -255,7 +253,7 @@ func (s *UploadPackSuite) TestFetchError(c *C) {
 }
 
 func (s *UploadPackSuite) checkObjectNumber(c *C, r io.Reader, n int) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	c.Assert(err, IsNil)
 	buf := bytes.NewBuffer(b)
 	storage := memory.NewStorage()

--- a/remote.go
+++ b/remote.go
@@ -1250,11 +1250,7 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 // operation is complete, an error is returned. The context only affects to the
 // transport operations.
 func (r *Remote) ListContext(ctx context.Context, o *ListOptions) (rfs []*plumbing.Reference, err error) {
-	refs, err := r.list(ctx, o)
-	if err != nil {
-		return refs, err
-	}
-	return refs, nil
+	return r.list(ctx, o)
 }
 
 func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {

--- a/remote_test.go
+++ b/remote_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -1387,7 +1386,7 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs(c *C) {
 }
 
 func (s *RemoteSuite) TestCanPushShasToReference(c *C) {
-	d, err := ioutil.TempDir("", "TestCanPushShasToReference")
+	d, err := os.MkdirTemp("", "TestCanPushShasToReference")
 	c.Assert(err, IsNil)
 	if err != nil {
 		return

--- a/repository.go
+++ b/repository.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	stdioutil "io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -367,7 +367,7 @@ func dotGitFileToOSFilesystem(path string, fs billy.Filesystem) (bfs billy.Files
 	}
 	defer ioutil.CheckClose(f, &err)
 
-	b, err := stdioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +396,7 @@ func dotGitCommonDirectory(fs billy.Filesystem) (commonDir billy.Filesystem, err
 		return nil, err
 	}
 
-	b, err := stdioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	stdioutil "io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -647,7 +646,7 @@ func (d *DotGit) ObjectDelete(h plumbing.Hash) error {
 }
 
 func (d *DotGit) readReferenceFrom(rd io.Reader, name string) (ref *plumbing.Reference, err error) {
-	b, err := stdioutil.ReadAll(rd)
+	b, err := io.ReadAll(rd)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -374,7 +373,7 @@ func (s *SuiteDotGit) TestConfigWriteAndConfig(c *C) {
 	f, err = dir.Config()
 	c.Assert(err, IsNil)
 
-	cnt, err := ioutil.ReadAll(f)
+	cnt, err := io.ReadAll(f)
 	c.Assert(err, IsNil)
 
 	c.Assert(string(cnt), Equals, "foo")
@@ -404,7 +403,7 @@ func (s *SuiteDotGit) TestIndexWriteAndIndex(c *C) {
 	f, err = dir.Index()
 	c.Assert(err, IsNil)
 
-	cnt, err := ioutil.ReadAll(f)
+	cnt, err := io.ReadAll(f)
 	c.Assert(err, IsNil)
 
 	c.Assert(string(cnt), Equals, "foo")
@@ -434,7 +433,7 @@ func (s *SuiteDotGit) TestShallowWriteAndShallow(c *C) {
 	f, err = dir.Shallow()
 	c.Assert(err, IsNil)
 
-	cnt, err := ioutil.ReadAll(f)
+	cnt, err := io.ReadAll(f)
 	c.Assert(err, IsNil)
 
 	c.Assert(string(cnt), Equals, "foo")

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -510,7 +509,7 @@ func BenchmarkPackfileIterReadContent(b *testing.B) {
 								b.Fatal(err)
 							}
 
-							if _, err := ioutil.ReadAll(r); err != nil {
+							if _, err := io.ReadAll(r); err != nil {
 								b.Fatal(err)
 							}
 

--- a/storage/test/storage_suite.go
+++ b/storage/test/storage_suite.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -502,12 +501,12 @@ func objectEquals(a plumbing.EncodedObject, b plumbing.EncodedObject) error {
 		return fmt.Errorf("can't get reader on b: %q", err)
 	}
 
-	ca, err := ioutil.ReadAll(ra)
+	ca, err := io.ReadAll(ra)
 	if err != nil {
 		return fmt.Errorf("error reading a: %q", err)
 	}
 
-	cb, err := ioutil.ReadAll(rb)
+	cb, err := io.ReadAll(rb)
 	if err != nil {
 		return fmt.Errorf("error reading b: %q", err)
 	}

--- a/utils/ioutil/common_test.go
+++ b/utils/ioutil/common_test.go
@@ -3,7 +3,7 @@ package ioutil
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -38,7 +38,7 @@ func (s *CommonSuite) TestNonEmptyReader_NonEmpty(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
 
-	read, err := ioutil.ReadAll(r)
+	read, err := io.ReadAll(r)
 	c.Assert(err, IsNil)
 	c.Assert(string(read), Equals, "1")
 }
@@ -48,7 +48,7 @@ func (s *CommonSuite) TestNewReadCloser(c *C) {
 	closer := &closer{}
 	r := NewReadCloser(buf, closer)
 
-	read, err := ioutil.ReadAll(r)
+	read, err := io.ReadAll(r)
 	c.Assert(err, IsNil)
 	c.Assert(string(read), Equals, "1")
 
@@ -160,7 +160,7 @@ func ExampleCheckClose() {
 	// CheckClose is commonly used with named return values
 	f := func() (err error) {
 		// Get a io.ReadCloser
-		r := ioutil.NopCloser(strings.NewReader("foo"))
+		r := io.NopCloser(strings.NewReader("foo"))
 
 		// defer CheckClose call with an io.Closer and pointer to error
 		defer CheckClose(r, &err)

--- a/worktree.go
+++ b/worktree.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	stdioutil "io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -569,7 +568,7 @@ func (w *Worktree) checkoutFileSymlink(f *object.File) (err error) {
 
 	defer ioutil.CheckClose(from, &err)
 
-	bytes, err := stdioutil.ReadAll(from)
+	bytes, err := io.ReadAll(from)
 	if err != nil {
 		return
 	}
@@ -718,7 +717,7 @@ func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
 	}
 
 	defer f.Close()
-	input, err := stdioutil.ReadAll(f)
+	input, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -81,7 +80,7 @@ func (s *WorktreeSuite) TestPullFastForward(c *C) {
 
 	w, err := server.Worktree()
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(path, "foo"), []byte("foo"), 0755)
+	err = os.WriteFile(filepath.Join(path, "foo"), []byte("foo"), 0755)
 	c.Assert(err, IsNil)
 	hash, err := w.Commit("foo", &CommitOptions{Author: defaultSignature()})
 	c.Assert(err, IsNil)
@@ -118,14 +117,14 @@ func (s *WorktreeSuite) TestPullNonFastForward(c *C) {
 
 	w, err := server.Worktree()
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(path, "foo"), []byte("foo"), 0755)
+	err = os.WriteFile(filepath.Join(path, "foo"), []byte("foo"), 0755)
 	c.Assert(err, IsNil)
 	_, err = w.Commit("foo", &CommitOptions{Author: defaultSignature()})
 	c.Assert(err, IsNil)
 
 	w, err = r.Worktree()
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(path, "bar"), []byte("bar"), 0755)
+	err = os.WriteFile(filepath.Join(path, "bar"), []byte("bar"), 0755)
 	c.Assert(err, IsNil)
 	_, err = w.Commit("bar", &CommitOptions{Author: defaultSignature()})
 	c.Assert(err, IsNil)
@@ -287,7 +286,7 @@ func (s *WorktreeSuite) TestPullAlreadyUptodate(c *C) {
 
 	w, err := r.Worktree()
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(path, "bar"), []byte("bar"), 0755)
+	err = os.WriteFile(filepath.Join(path, "bar"), []byte("bar"), 0755)
 	c.Assert(err, IsNil)
 	_, err = w.Commit("bar", &CommitOptions{Author: defaultSignature()})
 	c.Assert(err, IsNil)
@@ -315,7 +314,7 @@ func (s *WorktreeSuite) TestCheckout(c *C) {
 	ch, err := fs.Open("CHANGELOG")
 	c.Assert(err, IsNil)
 
-	content, err := ioutil.ReadAll(ch)
+	content, err := io.ReadAll(ch)
 	c.Assert(err, IsNil)
 	c.Assert(string(content), Equals, "Initial changelog\n")
 


### PR DESCRIPTION
This PR does 4 small fixes across the codebase:
- Remove redudant err `nil` checks.
- Remove use of deprecated `io/util`.
- Replace `fmt.Sprintf` with `net.JoinHostPort`.
- Add missing `error` checks.