### PR TITLE
Replace user dir in path

### DIFF
--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -25,6 +25,14 @@ const (
 
 // readIgnoreFile reads a specific git ignore file.
 func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps []Pattern, err error) {
+
+	if strings.HasPrefix(ignoreFile, "~") {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			ignoreFile = strings.Replace(ignoreFile, "~", home, 1)
+		}
+	}
+
 	f, err := fs.Open(fs.Join(append(path, ignoreFile)...))
 	if err == nil {
 		defer f.Close()

--- a/plumbing/format/gitignore/dir_test.go
+++ b/plumbing/format/gitignore/dir_test.go
@@ -96,7 +96,7 @@ func (s *MatcherSuite) SetUpTest(c *C) {
 
 	s.RFS = fs
 
-	// root that contains user home, but with with relative ~/.gitignore_global
+	// root that contains user home, but with relative ~/.gitignore_global
 	fs = memfs.New()
 	err = fs.MkdirAll(home, os.ModePerm)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
My `.gitconfig` looks like this:

```
[core]
	editor = nano
	excludesFile = ~/.gitignore
	autocrlf = input
	ignorecase = false
```

and it cant load `~/.gitignore` because it is not absolute.