### PR TITLE
git: add PlainInitOptions.Bare and allow using InitOptions with PlainInitWithOptions

### DIFF
--- a/options.go
+++ b/options.go
@@ -737,6 +737,8 @@ type PlainOpenOptions struct {
 func (o *PlainOpenOptions) Validate() error { return nil }
 
 type PlainInitOptions struct {
+	// Determines if the repository will have a worktree (non-bare) or not (bare).
+	Bare         bool
 	ObjectFormat formatcfg.ObjectFormat
 }
 

--- a/options.go
+++ b/options.go
@@ -737,6 +737,7 @@ type PlainOpenOptions struct {
 func (o *PlainOpenOptions) Validate() error { return nil }
 
 type PlainInitOptions struct {
+	InitOptions
 	// Determines if the repository will have a worktree (non-bare) or not (bare).
 	Bare         bool
 	ObjectFormat formatcfg.ObjectFormat

--- a/repository.go
+++ b/repository.go
@@ -256,7 +256,7 @@ func PlainInitWithOptions(path string, opts *PlainInitOptions) (*Repository, err
 
 	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 
-	r, err := Init(s, wt)
+	r, err := InitWithOptions(s, wt, opts.InitOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -518,6 +518,21 @@ func (s *RepositorySuite) TestPlainInit(c *C) {
 	c.Assert(cfg.Core.IsBare, Equals, true)
 }
 
+func (s *RepositorySuite) TestPlainInitWithOptions(c *C) {
+	dir, clean := s.TemporalDir()
+	defer clean()
+
+	r, err := PlainInitWithOptions(dir, &PlainInitOptions{
+		Bare: true,
+	})
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+
+	cfg, err := r.Config()
+	c.Assert(err, IsNil)
+	c.Assert(cfg.Core.IsBare, Equals, true)
+}
+
 func (s *RepositorySuite) TestPlainInitAlreadyExists(c *C) {
 	dir, clean := s.TemporalDir()
 	defer clean()

--- a/repository_test.go
+++ b/repository_test.go
@@ -523,14 +523,23 @@ func (s *RepositorySuite) TestPlainInitWithOptions(c *C) {
 	defer clean()
 
 	r, err := PlainInitWithOptions(dir, &PlainInitOptions{
-		Bare: true,
+		InitOptions: InitOptions{
+			DefaultBranch: "refs/heads/foo",
+		},
+		Bare: false,
 	})
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
 
 	cfg, err := r.Config()
 	c.Assert(err, IsNil)
-	c.Assert(cfg.Core.IsBare, Equals, true)
+	c.Assert(cfg.Core.IsBare, Equals, false)
+
+	createCommit(c, r)
+
+	ref, err := r.Head()
+	c.Assert(err, IsNil)
+	c.Assert(ref.Name().String(), Equals, "refs/heads/foo")
 }
 
 func (s *RepositorySuite) TestPlainInitAlreadyExists(c *C) {


### PR DESCRIPTION
Refactor `PlainInit` to call `PlainInitWithOptions`, and make `InitOptions` usable there.

Basically allows using the `DefaultBranch` option from #764  with `PlainInit`.