### PR TITLE
plumbing: packp, A request is not empty if it contains shallows. Fixes #328

### DIFF
--- a/plumbing/protocol/packp/uppackreq.go
+++ b/plumbing/protocol/packp/uppackreq.go
@@ -38,10 +38,10 @@ func NewUploadPackRequestFromCapabilities(adv *capability.List) *UploadPackReque
 	}
 }
 
-// IsEmpty a request if empty if Haves are contained in the Wants, or if Wants
-// length is zero
+// IsEmpty returns whether a request is empty - it is empty if Haves are contained
+// in the Wants, or if Wants length is zero, and we don't have any shallows
 func (r *UploadPackRequest) IsEmpty() bool {
-	return isSubset(r.Wants, r.Haves)
+	return isSubset(r.Wants, r.Haves) && len(r.Shallows) == 0
 }
 
 func isSubset(needle []plumbing.Hash, haystack []plumbing.Hash) bool {

--- a/plumbing/protocol/packp/uppackreq_test.go
+++ b/plumbing/protocol/packp/uppackreq_test.go
@@ -41,6 +41,13 @@ func (s *UploadPackRequestSuite) TestIsEmpty(c *C) {
 	r.Haves = append(r.Haves, plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
 
 	c.Assert(r.IsEmpty(), Equals, true)
+
+	r = NewUploadPackRequest()
+	r.Wants = append(r.Wants, plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
+	r.Haves = append(r.Haves, plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
+	r.Shallows = append(r.Shallows, plumbing.NewHash("2b41ef280fdb67a9b250678686a0c3e03b0a9989"))
+
+	c.Assert(r.IsEmpty(), Equals, false)
 }
 
 type UploadHavesSuite struct{}

--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -232,7 +232,7 @@ func (s *session) handleAdvRefDecodeError(err error) error {
 // UploadPack performs a request to the server to fetch a packfile. A reader is
 // returned with the packfile content. The reader must be closed after reading.
 func (s *session) UploadPack(ctx context.Context, req *packp.UploadPackRequest) (*packp.UploadPackResponse, error) {
-	if req.IsEmpty() && len(req.Shallows) == 0 {
+	if req.IsEmpty() {
 		return nil, transport.ErrEmptyUploadPackRequest
 	}
 


### PR DESCRIPTION
Note, this was broken in #311 where the check was only added to a single version of UploadPack (there are 3)