### PR TITLE
replace os.IsErrNotExist with errors.Is

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -172,7 +172,7 @@ func LoadConfig(scope Scope) (*Config, error) {
 	for _, file := range files {
 		f, err := osfs.Default.Open(file)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
 

--- a/plumbing/format/gitattributes/dir.go
+++ b/plumbing/format/gitattributes/dir.go
@@ -1,6 +1,7 @@
 package gitattributes
 
 import (
+	"errors"
 	"os"
 
 	"github.com/go-git/go-billy/v5"
@@ -19,7 +20,7 @@ const (
 
 func ReadAttributesFile(fs billy.Filesystem, path []string, attributesFile string, allowMacro bool) ([]MatchAttribute, error) {
 	f, err := fs.Open(fs.Join(append(path, attributesFile)...))
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {
@@ -76,7 +77,7 @@ func walkDirectory(fs billy.Filesystem, root []string) (attributes []MatchAttrib
 
 func loadPatterns(fs billy.Filesystem, path string) ([]MatchAttribute, error) {
 	f, err := fs.Open(path)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {

--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -3,6 +3,7 @@ package gitignore
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"os/user"
@@ -54,7 +55,7 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 				ps = append(ps, ParsePattern(s, path))
 			}
 		}
-	} else if !os.IsNotExist(err) {
+	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, err
 	}
 
@@ -96,7 +97,7 @@ func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) 
 func loadPatterns(fs billy.Filesystem, path string) (ps []Pattern, err error) {
 	f, err := fs.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, err
@@ -123,7 +124,7 @@ func loadPatterns(fs billy.Filesystem, path string) (ps []Pattern, err error) {
 	}
 
 	ps, err = readIgnoreFile(fs, nil, efo)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 

--- a/plumbing/transport/file/receive_pack_test.go
+++ b/plumbing/transport/file/receive_pack_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"os"
 
 	"github.com/go-git/go-git/v5/plumbing/transport/test"
@@ -41,7 +42,7 @@ func (s *ReceivePackSuite) TearDownTest(c *C) {
 func (s *ReceivePackSuite) TestCommandNoOutput(c *C) {
 	c.Skip("failing test")
 
-	if _, err := os.Stat("/bin/true"); os.IsNotExist(err) {
+	if _, err := os.Stat("/bin/true"); errors.Is(err, os.ErrNotExist) {
 		c.Skip("/bin/true not found")
 	}
 
@@ -54,7 +55,7 @@ func (s *ReceivePackSuite) TestCommandNoOutput(c *C) {
 }
 
 func (s *ReceivePackSuite) TestMalformedInputNoErrors(c *C) {
-	if _, err := os.Stat("/usr/bin/yes"); os.IsNotExist(err) {
+	if _, err := os.Stat("/usr/bin/yes"); errors.Is(err, os.ErrNotExist) {
 		c.Skip("/usr/bin/yes not found")
 	}
 

--- a/plumbing/transport/file/upload_pack_test.go
+++ b/plumbing/transport/file/upload_pack_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"os"
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -43,7 +44,7 @@ func (s *UploadPackSuite) SetUpSuite(c *C) {
 func (s *UploadPackSuite) TestCommandNoOutput(c *C) {
 	c.Skip("failing test")
 
-	if _, err := os.Stat("/bin/true"); os.IsNotExist(err) {
+	if _, err := os.Stat("/bin/true"); errors.Is(err, os.ErrNotExist) {
 		c.Skip("/bin/true not found")
 	}
 
@@ -56,7 +57,7 @@ func (s *UploadPackSuite) TestCommandNoOutput(c *C) {
 }
 
 func (s *UploadPackSuite) TestMalformedInputNoErrors(c *C) {
-	if _, err := os.Stat("/usr/bin/yes"); os.IsNotExist(err) {
+	if _, err := os.Stat("/usr/bin/yes"); errors.Is(err, os.ErrNotExist) {
 		c.Skip("/usr/bin/yes not found")
 	}
 

--- a/plumbing/transport/ssh/auth_method.go
+++ b/plumbing/transport/ssh/auth_method.go
@@ -276,7 +276,7 @@ func filterKnownHostsFiles(files ...string) ([]string, error) {
 			continue
 		}
 
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
 	}

--- a/repository.go
+++ b/repository.go
@@ -297,7 +297,7 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 	}
 
 	if _, err := dot.Stat(""); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, ErrRepositoryNotExists
 		}
 
@@ -332,7 +332,7 @@ func dotGitToOSFilesystems(path string, detect bool) (dot, wt billy.Filesystem, 
 		fs = osfs.New(path)
 
 		pathinfo, err := fs.Stat("/")
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			if pathinfo == nil {
 				return nil, nil, err
 			}
@@ -346,7 +346,7 @@ func dotGitToOSFilesystems(path string, detect bool) (dot, wt billy.Filesystem, 
 			// no error; stop
 			break
 		}
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			// unknown error; stop
 			return nil, nil, err
 		}
@@ -405,7 +405,7 @@ func dotGitFileToOSFilesystem(path string, fs billy.Filesystem) (bfs billy.Files
 
 func dotGitCommonDirectory(fs billy.Filesystem) (commonDir billy.Filesystem, err error) {
 	f, err := fs.Open("commondir")
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
 	if err != nil {
@@ -424,7 +424,7 @@ func dotGitCommonDirectory(fs billy.Filesystem) (commonDir billy.Filesystem, err
 			commonDir = osfs.New(filepath.Join(fs.Root(), path))
 		}
 		if _, err := commonDir.Stat(""); err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				return nil, ErrRepositoryIncomplete
 			}
 
@@ -489,7 +489,7 @@ func newRepository(s storage.Storer, worktree billy.Filesystem) *Repository {
 func checkIfCleanupIsNeeded(path string) (cleanup bool, cleanParent bool, err error) {
 	fi, err := osfs.Default.Stat(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return true, true, nil
 		}
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -806,7 +806,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithExistentDir(c *C) 
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 
 	_, err = fs.Stat(dir)
-	c.Assert(os.IsNotExist(err), Equals, false)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, false)
 
 	names, err := fs.ReadDir(dir)
 	c.Assert(err, IsNil)
@@ -832,7 +832,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNonExistentDir(c *
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 
 	_, err = fs.Stat(repoDir)
-	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 }
 
 func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNotDir(c *C) {

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"errors"
 	"os"
 
 	"github.com/go-git/go-git/v5/config"
@@ -15,7 +16,7 @@ type ConfigStorage struct {
 func (c *ConfigStorage) Config() (conf *config.Config, err error) {
 	f, err := c.dir.Config()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return config.NewConfig(), nil
 		}
 

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -129,7 +129,7 @@ func (d *DotGit) Initialize() error {
 			continue
 		}
 
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 
@@ -192,7 +192,7 @@ func (d *DotGit) ShallowWriter() (billy.File, error) {
 func (d *DotGit) Shallow() (billy.File, error) {
 	f, err := d.fs.Open(shallowPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 
@@ -227,7 +227,7 @@ func (d *DotGit) objectPacks() ([]plumbing.Hash, error) {
 	packDir := d.fs.Join(objectsPath, packPath)
 	files, err := d.fs.ReadDir(packDir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 
@@ -276,7 +276,7 @@ func (d *DotGit) objectPackOpen(hash plumbing.Hash, extension string) (billy.Fil
 	path := d.objectPackPath(hash, extension)
 	pack, err := d.fs.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, ErrPackfileNotFound
 		}
 
@@ -433,7 +433,7 @@ func (d *DotGit) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 func (d *DotGit) forEachObjectHash(fun func(plumbing.Hash) error) error {
 	files, err := d.fs.ReadDir(objectsPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 
@@ -602,7 +602,7 @@ func (d *DotGit) Object(h plumbing.Hash) (billy.File, error) {
 	}
 
 	obj1, err1 := d.fs.Open(d.objectPath(h))
-	if os.IsNotExist(err1) && d.hasIncomingObjects() {
+	if errors.Is(err1, os.ErrNotExist) && d.hasIncomingObjects() {
 		obj2, err2 := d.fs.Open(d.incomingObjectPath(h))
 		if err2 != nil {
 			return obj1, err1
@@ -620,7 +620,7 @@ func (d *DotGit) ObjectStat(h plumbing.Hash) (os.FileInfo, error) {
 	}
 
 	obj1, err1 := d.fs.Stat(d.objectPath(h))
-	if os.IsNotExist(err1) && d.hasIncomingObjects() {
+	if errors.Is(err1, os.ErrNotExist) && d.hasIncomingObjects() {
 		obj2, err2 := d.fs.Stat(d.incomingObjectPath(h))
 		if err2 != nil {
 			return obj1, err1
@@ -635,7 +635,7 @@ func (d *DotGit) ObjectDelete(h plumbing.Hash) error {
 	d.cleanObjectList()
 
 	err1 := d.fs.Remove(d.objectPath(h))
-	if os.IsNotExist(err1) && d.hasIncomingObjects() {
+	if errors.Is(err1, os.ErrNotExist) && d.hasIncomingObjects() {
 		err2 := d.fs.Remove(d.incomingObjectPath(h))
 		if err2 != nil {
 			return err1
@@ -742,7 +742,7 @@ type refsRecv func(*plumbing.Reference) bool
 func (d *DotGit) findPackedRefs(recv refsRecv) error {
 	f, err := d.fs.Open(packedRefsPath)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err
@@ -779,7 +779,7 @@ func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
 		// Drop down to remove it from the packed refs file, too.
 	}
 
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
@@ -826,7 +826,7 @@ func (d *DotGit) openAndLockPackedRefs(doCreate bool) (
 	for {
 		f, err = d.fs.OpenFile(packedRefsPath, openFlags, 0600)
 		if err != nil {
-			if os.IsNotExist(err) && !doCreate {
+			if errors.Is(err, os.ErrNotExist) && !doCreate {
 				return nil, nil
 			}
 
@@ -939,7 +939,7 @@ func (d *DotGit) addRefsFromRefDir(refs *[]*plumbing.Reference, seen map[plumbin
 func (d *DotGit) walkReferencesTree(refs *[]*plumbing.Reference, relPath []string, seen map[plumbing.ReferenceName]bool) error {
 	files, err := d.fs.ReadDir(d.fs.Join(relPath...))
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			// a race happened, and our directory is gone now
 			return nil
 		}
@@ -958,7 +958,7 @@ func (d *DotGit) walkReferencesTree(refs *[]*plumbing.Reference, relPath []strin
 		}
 
 		ref, err := d.readReferenceFile(".", strings.Join(newRelPath, "/"))
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			// a race happened, and our file is gone now
 			continue
 		}
@@ -978,7 +978,7 @@ func (d *DotGit) walkReferencesTree(refs *[]*plumbing.Reference, relPath []strin
 func (d *DotGit) addRefFromHEAD(refs *[]*plumbing.Reference) error {
 	ref, err := d.readReferenceFile(".", "HEAD")
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 
@@ -1090,7 +1090,7 @@ func (d *DotGit) PackRefs() (err error) {
 	for _, ref := range refs[:numLooseRefs] {
 		path := d.fs.Join(".", ref.Name().String())
 		err = d.fs.Remove(path)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 	}

--- a/storage/filesystem/dotgit/reader.go
+++ b/storage/filesystem/dotgit/reader.go
@@ -1,6 +1,7 @@
 package dotgit
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,7 @@ func (e *EncodedObject) Hash() plumbing.Hash {
 func (e *EncodedObject) Reader() (io.ReadCloser, error) {
 	f, err := e.dir.Object(e.h)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, plumbing.ErrObjectNotFound
 		}
 

--- a/storage/filesystem/dotgit/repository_filesystem_test.go
+++ b/storage/filesystem/dotgit/repository_filesystem_test.go
@@ -1,6 +1,7 @@
 package dotgit
 
 import (
+	"errors"
 	"os"
 
 	. "gopkg.in/check.v1"
@@ -70,7 +71,7 @@ func (s *SuiteDotGit) TestRepositoryFilesystem(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = repositoryFs.Stat("somelink")
-	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 
 	dirs := []string{objectsPath, refsPath, packedRefsPath, configPath, branchesPath, hooksPath, infoPath, remotesPath, logsPath, shallowPath, worktreesPath}
 	for _, dir := range dirs {
@@ -79,7 +80,7 @@ func (s *SuiteDotGit) TestRepositoryFilesystem(c *C) {
 		_, err = commonDotGitFs.Stat(dir)
 		c.Assert(err, IsNil)
 		_, err = dotGitFs.Stat(dir)
-		c.Assert(os.IsNotExist(err), Equals, true)
+		c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 	}
 
 	exceptionsPaths := []string{repositoryFs.Join(logsPath, "HEAD"), repositoryFs.Join(refsPath, "bisect"), repositoryFs.Join(refsPath, "rewritten"), repositoryFs.Join(refsPath, "worktree")}
@@ -87,7 +88,7 @@ func (s *SuiteDotGit) TestRepositoryFilesystem(c *C) {
 		_, err := repositoryFs.Create(path)
 		c.Assert(err, IsNil)
 		_, err = commonDotGitFs.Stat(path)
-		c.Assert(os.IsNotExist(err), Equals, true)
+		c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 		_, err = dotGitFs.Stat(path)
 		c.Assert(err, IsNil)
 	}
@@ -97,19 +98,19 @@ func (s *SuiteDotGit) TestRepositoryFilesystem(c *C) {
 	_, err = commonDotGitFs.Stat("refs/heads")
 	c.Assert(err, IsNil)
 	_, err = dotGitFs.Stat("refs/heads")
-	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 
 	err = repositoryFs.MkdirAll("objects/pack", 0777)
 	c.Assert(err, IsNil)
 	_, err = commonDotGitFs.Stat("objects/pack")
 	c.Assert(err, IsNil)
 	_, err = dotGitFs.Stat("objects/pack")
-	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 
 	err = repositoryFs.MkdirAll("a/b/c", 0777)
 	c.Assert(err, IsNil)
 	_, err = commonDotGitFs.Stat("a/b/c")
-	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 	_, err = dotGitFs.Stat("a/b/c")
 	c.Assert(err, IsNil)
 }

--- a/storage/filesystem/index.go
+++ b/storage/filesystem/index.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"bufio"
+	"errors"
 	"os"
 
 	"github.com/go-git/go-git/v5/plumbing/format/index"
@@ -39,7 +40,7 @@ func (s *IndexStorage) Index() (i *index.Index, err error) {
 
 	f, err := s.dir.Index()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return idx, nil
 		}
 

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -152,7 +153,7 @@ func (s *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
 	// Check unpacked objects
 	f, err := s.dir.Object(h)
 	if err != nil {
-		if !os.IsNotExist(err) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 		// Fall through to check packed objects.
@@ -176,7 +177,7 @@ func (s *ObjectStorage) encodedObjectSizeFromUnpacked(h plumbing.Hash) (
 	size int64, err error) {
 	f, err := s.dir.Object(h)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return 0, plumbing.ErrObjectNotFound
 		}
 
@@ -378,7 +379,7 @@ func (s *ObjectStorage) DeltaObject(t plumbing.ObjectType,
 func (s *ObjectStorage) getFromUnpacked(h plumbing.Hash) (obj plumbing.EncodedObject, err error) {
 	f, err := s.dir.Object(h)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, plumbing.ErrObjectNotFound
 		}
 

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -92,7 +93,7 @@ func (n *node) calculateChildren() error {
 
 	files, err := n.fs.ReadDir(n.path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
 		return err

--- a/worktree.go
+++ b/worktree.go
@@ -709,7 +709,7 @@ func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
 
 	f, err := w.Filesystem.Open(gitmodulesFile)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -449,7 +449,7 @@ func (w *Worktree) doAddFile(idx *index.Index, s Status, path string, ignorePatt
 
 	h, err = w.copyFileToStorage(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			added = true
 			h, err = w.deleteFromIndex(idx, path)
 		}
@@ -645,7 +645,7 @@ func (w *Worktree) deleteFromIndex(idx *index.Index, path string) (plumbing.Hash
 
 func (w *Worktree) deleteFromFilesystem(path string) error {
 	err := w.Filesystem.Remove(path)
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 
@@ -668,7 +668,7 @@ func (w *Worktree) RemoveGlob(pattern string) error {
 
 	for _, e := range entries {
 		file := filepath.FromSlash(e.Name)
-		if _, err := w.Filesystem.Lstat(file); err != nil && !os.IsNotExist(err) {
+		if _, err := w.Filesystem.Lstat(file); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1735,7 +1735,7 @@ func (s *WorktreeSuite) TestRemoveDirectory(c *C) {
 	c.Assert(status.File("json/short.json").Staging, Equals, Deleted)
 
 	_, err = w.Filesystem.Stat("json")
-	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 }
 
 func (s *WorktreeSuite) TestRemoveDirectoryUntracked(c *C) {
@@ -1828,7 +1828,7 @@ func (s *WorktreeSuite) TestRemoveGlobDirectory(c *C) {
 	c.Assert(status.File("json/long.json").Staging, Equals, Deleted)
 
 	_, err = w.Filesystem.Stat("json")
-	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(errors.Is(err, os.ErrNotExist), Equals, true)
 }
 
 func (s *WorktreeSuite) TestRemoveGlobDirectoryDeleted(c *C) {


### PR DESCRIPTION
## What does this PR do?

It replaces all instances of `os.IsErrNotExist(err)` with `errors.Is(err, os.ErrNotExist)`.

## Why?

According to the doc comment on `os.IsErrNotExist`, this is the recommended way to check for specific errors.

In my case, I'm trying to inject a custom filesystem implementation into the default storer. I built a small wrapper which makes the filesystem implementation compatible to the `billy.Filesystem` interface.
However, for non-existing files, the filesystem implementation sometimes returns errors which are not recognized by `os.IsErrNotExist`, which makes the default storer implementation unusable with the filesystem implementation I'd like to use. I did some tests and found out that using `errors.Is` instead of `os.IsErrNotExist` solves the problem.