### PR TITLE
plumbing: http, Fix empty repos on Git v2.41+

### DIFF
--- a/plumbing/protocol/packp/advrefs_decode.go
+++ b/plumbing/protocol/packp/advrefs_decode.go
@@ -133,6 +133,7 @@ func decodeFirstHash(p *advRefsDecoder) decoderStateFn {
 		return nil
 	}
 
+	// TODO: Use object-format (when available) for hash size. Git 2.41+
 	if len(p.line) < hashSize {
 		p.error("cannot read hash, pkt-line too short")
 		return nil

--- a/plumbing/protocol/packp/advrefs_decode_test.go
+++ b/plumbing/protocol/packp/advrefs_decode_test.go
@@ -218,6 +218,16 @@ func (s *AdvRefsDecodeSuite) TestCaps(c *C) {
 			{Name: capability.SymRef, Values: []string{"HEAD:refs/heads/master"}},
 			{Name: capability.Agent, Values: []string{"foo=bar"}},
 		},
+	}, {
+		input: []string{
+			"0000000000000000000000000000000000000000 capabilities^{}\x00report-status report-status-v2 delete-refs side-band-64k quiet atomic ofs-delta object-format=sha1 agent=git/2.41.0\n",
+			pktline.FlushString,
+		},
+		capabilities: []entry{
+			{Name: capability.ReportStatus, Values: []string(nil)},
+			{Name: capability.ObjectFormat, Values: []string{"sha1"}},
+			{Name: capability.Agent, Values: []string{"git/2.41.0"}},
+		},
 	}} {
 		ar := s.testDecodeOK(c, test.input)
 		for _, fixCap := range test.capabilities {

--- a/remote.go
+++ b/remote.go
@@ -224,11 +224,13 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		return err
 	}
 
-	if err = rs.Error(); err != nil {
-		return err
+	if rs != nil {
+		if err = rs.Error(); err != nil {
+			return err
+		}
 	}
 
-	return r.updateRemoteReferenceStorage(req, rs)
+	return r.updateRemoteReferenceStorage(req)
 }
 
 func (r *Remote) useRefDeltas(ar *packp.AdvRefs) bool {
@@ -347,7 +349,6 @@ func (r *Remote) newReferenceUpdateRequest(
 
 func (r *Remote) updateRemoteReferenceStorage(
 	req *packp.ReferenceUpdateRequest,
-	result *packp.ReportStatus,
 ) error {
 
 	for _, spec := range r.c.Fetch {


### PR DESCRIPTION
Git `v2.41.0` comes with [changes](https://github.com/git/git/commit/933e3a4ee205353d8f093d5dfcd226fa432c4e58) that breaks go-git's assumptions for when detecting empty repositories in HTTP transport.

Go-git expects a flush instead of the first hash line. Instead, a dummy `capabilities^{}` with zero-id is returned. The upstream change aims to allow for identifying the `object-format` even when cloning empty repositories.

Fixes the currently broken CI.
Relates to #229.