### PR TITLE
*: Handle paths starting with tilde

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -151,6 +151,26 @@ func (s *BaseSuite) TemporalDir() (path string, clean func()) {
 	return
 }
 
+func (s *BaseSuite) TemporalHomeDir() (path string, clean func()) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	fs := osfs.New(home)
+	relPath, err := util.TempDir(fs, "", "")
+	if err != nil {
+		panic(err)
+	}
+
+	path = fs.Join(fs.Root(), relPath)
+	clean = func() {
+		_ = util.RemoveAll(fs, relPath)
+	}
+
+	return
+}
+
 func (s *BaseSuite) TemporalFilesystem() (fs billy.Filesystem, clean func()) {
 	fs = osfs.New(os.TempDir())
 	path, err := util.TempDir(fs, "", "")

--- a/repository.go
+++ b/repository.go
@@ -322,8 +322,16 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 }
 
 func dotGitToOSFilesystems(path string, detect bool) (dot, wt billy.Filesystem, err error) {
-	if path, err = filepath.Abs(path); err != nil {
-		return nil, nil, err
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, nil, err
+		}
+		path = filepath.Join(home, path[2:])
+	} else {
+		if path, err = filepath.Abs(path); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	var fs billy.Filesystem

--- a/repository_test.go
+++ b/repository_test.go
@@ -543,6 +543,21 @@ func (s *RepositorySuite) TestPlainOpen(c *C) {
 	c.Assert(r, NotNil)
 }
 
+func (s *RepositorySuite) TestPlainOpenTildePath(c *C) {
+	dir, clean := s.TemporalHomeDir()
+	defer clean()
+
+	r, err := PlainInit(dir, false)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+
+	path := strings.Replace(dir, strings.Split(dir, ".tmp")[0], "~/", 1)
+
+	r, err = PlainOpen(path)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+}
+
 func (s *RepositorySuite) TestPlainOpenBare(c *C) {
 	dir, clean := s.TemporalDir()
 	defer clean()


### PR DESCRIPTION
Fixes #803.

Not much to say here, simply added a prefix "~/" check for path and handled the users home directory accordingly.