### PR TITLE
plumbing: transport, handle IPv6 while parsing endpoint. Fixes #740

### DIFF
--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -227,11 +227,17 @@ func parseURL(endpoint string) (*Endpoint, error) {
 		pass, _ = u.User.Password()
 	}
 
+	host := u.Hostname()
+	if strings.Contains(host, ":") {
+		// IPv6 address
+		host = "[" + host + "]"
+	}
+
 	return &Endpoint{
 		Protocol: u.Scheme,
 		User:     user,
 		Password: pass,
-		Host:     u.Hostname(),
+		Host:     host,
 		Port:     getPort(u),
 		Path:     getPath(u),
 	}, nil

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -198,3 +198,15 @@ func (s *SuiteCommon) TestFilterUnsupportedCapabilities(c *C) {
 	FilterUnsupportedCapabilities(l)
 	c.Assert(l.Supports(capability.MultiACK), Equals, false)
 }
+
+func (s *SuiteCommon) TestNewEndpointIPv6(c *C) {
+	// see issue https://github.com/go-git/go-git/issues/740
+	//
+	//	IPv6 host names are not being properly handled, which results in unhelpful
+	//	error messages depending on the format used.
+	//
+	e, err := NewEndpoint("http://[::1]:8080/foo.git")
+	c.Assert(err, IsNil)
+	c.Assert(e.Host, Equals, "[::1]")
+	c.Assert(e.String(), Equals, "http://[::1]:8080/foo.git")
+}


### PR DESCRIPTION
Fix host formatting for IPv6 adresses