### PR TITLE
fuzzing :  fuzz testing support for oss-fuzz integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,13 @@ test-coverage:
 
 clean:
 	rm -rf $(GIT_DIST_PATH)
+
+fuzz:
+	@go test -fuzz=FuzzParser				$(PWD)/internal/revision
+	@go test -fuzz=FuzzParseSignedByte		$(PWD)/plumbing/object
+	@go test -fuzz=FuzzDecode				$(PWD)/plumbing/object
+	@go test -fuzz=FuzzNewEndpoint			$(PWD)/plumbing/transport
+	@go test -fuzz=FuzzDecoder				$(PWD)/plumbing/protocol/packp
+	@go test -fuzz=FuzzDecoder				$(PWD)/plumbing/format/config
+	@go test -fuzz=FuzzPatchDelta			$(PWD)/plumbing/format/packfile
+	@go test -fuzz=FuzzDecodeFile			$(PWD)/utils/merkletrie/internal/fsnoder

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -3,6 +3,7 @@ package revision
 import (
 	"bytes"
 	"regexp"
+	"testing"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -396,4 +397,12 @@ func (s *ParserSuite) TestParseRefWithInvalidName(c *C) {
 
 		c.Assert(err, DeepEquals, e)
 	}
+}
+
+func FuzzParser(f *testing.F) {
+
+	f.Fuzz(func(t *testing.T, input string) {
+		parser := NewParser(bytes.NewBufferString(input))
+		parser.Parse()
+	})
 }

--- a/plumbing/format/config/decoder_test.go
+++ b/plumbing/format/config/decoder_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"testing"
 
 	. "gopkg.in/check.v1"
 )
@@ -90,4 +91,14 @@ func decodeFails(c *C, text string) {
 	cfg := &Config{}
 	err := d.Decode(cfg)
 	c.Assert(err, NotNil)
+}
+
+func FuzzDecoder(f *testing.F) {
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+
+		d := NewDecoder(bytes.NewReader(input))
+		cfg := &Config{}
+		d.Decode(cfg)
+	})
 }

--- a/plumbing/format/packfile/delta_test.go
+++ b/plumbing/format/packfile/delta_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"math/rand"
+	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	. "gopkg.in/check.v1"
@@ -175,4 +176,15 @@ func (s *DeltaSuite) TestMaxCopySizeDeltaReader(c *C) {
 	err = resultRC.Close()
 	c.Assert(err, IsNil)
 	c.Assert(result, DeepEquals, targetBuf)
+}
+
+func FuzzPatchDelta(f *testing.F) {
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+
+		input_0 := input[:len(input)/2]
+		input_1 := input[len(input)/2:]
+
+		PatchDelta(input_0, input_1)
+	})
 }

--- a/plumbing/object/signature_test.go
+++ b/plumbing/object/signature_test.go
@@ -178,3 +178,10 @@ signed tag`),
 		})
 	}
 }
+
+func FuzzParseSignedBytes(f *testing.F) {
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		parseSignedBytes(input)
+	})
+}

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v4"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -1622,4 +1623,20 @@ func (s *TreeSuite) TestTreeDecodeReadBug(c *C) {
 	err := obtained.Decode(obj)
 	c.Assert(err, IsNil)
 	c.Assert(entriesEquals(obtained.Entries, expected.Entries), Equals, true)
+}
+
+func FuzzDecode(f *testing.F) {
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+
+		obj := &SortReadObject{
+			t:    plumbing.TreeObject,
+			h:    plumbing.ZeroHash,
+			cont: input,
+			sz:   int64(len(input)),
+		}
+
+		newTree := &Tree{}
+		newTree.Decode(obj)
+	})
 }

--- a/plumbing/protocol/packp/uppackresp_test.go
+++ b/plumbing/protocol/packp/uppackresp_test.go
@@ -3,6 +3,7 @@ package packp
 import (
 	"bytes"
 	"io"
+	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
@@ -127,4 +128,15 @@ func (s *UploadPackResponseSuite) TestEncodeMultiACK(c *C) {
 
 	b := bytes.NewBuffer(nil)
 	c.Assert(res.Encode(b), NotNil)
+}
+
+func FuzzDecoder(f *testing.F) {
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		req := NewUploadPackRequest()
+		res := NewUploadPackResponse(req)
+		defer res.Close()
+
+		res.Decode(io.NopCloser(bytes.NewReader(input)))
+	})
 }

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -210,3 +210,10 @@ func (s *SuiteCommon) TestNewEndpointIPv6(c *C) {
 	c.Assert(e.Host, Equals, "[::1]")
 	c.Assert(e.String(), Equals, "http://[::1]:8080/foo.git")
 }
+
+func FuzzNewEndpoint(f *testing.F) {
+
+	f.Fuzz(func(t *testing.T, input string) {
+		NewEndpoint(input)
+	})
+}

--- a/utils/merkletrie/internal/fsnoder/new_test.go
+++ b/utils/merkletrie/internal/fsnoder/new_test.go
@@ -1,6 +1,8 @@
 package fsnoder
 
 import (
+	"testing"
+
 	"github.com/go-git/go-git/v5/utils/merkletrie/noder"
 
 	. "gopkg.in/check.v1"
@@ -351,4 +353,11 @@ func (s *FSNoderSuite) TestHashEqual(c *C) {
 
 	c.Assert(HashEqual(t3, t1), Equals, false)
 	c.Assert(HashEqual(t1, t3), Equals, false)
+}
+
+func FuzzDecodeFile(f *testing.F) {
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		decodeFile(input)
+	})
 }


### PR DESCRIPTION
`Fuzz` testing support using [go-fuzz](https://go.dev/security/fuzz) .
