### PR TITLE
Improve handling of remote errors

### DIFF
--- a/plumbing/transport/internal/common/mocks.go
+++ b/plumbing/transport/internal/common/mocks.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"bytes"
+	"io"
+
+	gogitioutil "github.com/go-git/go-git/v5/utils/ioutil"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+type MockCommand struct {
+	stdin  bytes.Buffer
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+}
+
+func (c MockCommand) StderrPipe() (io.Reader, error) {
+	return &c.stderr, nil
+}
+
+func (c MockCommand) StdinPipe() (io.WriteCloser, error) {
+	return gogitioutil.WriteNopCloser(&c.stdin), nil
+}
+
+func (c MockCommand) StdoutPipe() (io.Reader, error) {
+	return &c.stdout, nil
+}
+
+func (c MockCommand) Start() error {
+	return nil
+}
+
+func (c MockCommand) Close() error {
+	panic("not implemented")
+}
+
+type MockCommander struct {
+	stderr string
+}
+
+func (c MockCommander) Command(cmd string, ep *transport.Endpoint, auth transport.AuthMethod) (Command, error) {
+	return &MockCommand{
+		stderr: *bytes.NewBufferString(c.stderr),
+	}, nil
+}


### PR DESCRIPTION
Instead of simply returning the first line that the remote returned, go-git now actively searches all of stderr for lines that may contain a more actionable error message and returns that.

This is helpful in cases where the first line doesn't really indicate the actual issue, e.g. in the output of the GitLab server (over SSH):

```
$ ssh git@gitlab.com "git-receive-pack 'foo/bar'"
remote: 
remote: ========================================================================
remote: 
remote: ERROR: The project you were looking for could not be found or you don't have permission to view it.

remote: 
remote: ========================================================================
remote: 
```

In addition, this change adds a case to map the GitLab-specific error message to an ErrRepositoryNotFound error.