### PR TITLE
remote: Flip clause for fast-forward only check

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check Package Prefix
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(\*|plumbing|utils|config|_examples|internal|storage|cli|build): .+'
+          pattern: '^(\*|git|plumbing|utils|config|_examples|internal|storage|cli|build): .+'
           error: |
             Commit message(s) does not align with contribution acceptance criteria.
 

--- a/remote.go
+++ b/remote.go
@@ -1198,9 +1198,9 @@ func (r *Remote) updateLocalReferenceStorage(
 			old, _ := storer.ResolveReference(r.s, localName)
 			new := plumbing.NewHashReference(localName, ref.Hash())
 
-			// If the ref exists locally as a branch and force is not specified,
-			// only update if the new ref is an ancestor of the old
-			if old != nil && old.Name().IsBranch() && !force && !spec.IsForceUpdate() {
+			// If the ref exists locally as a non-tag and force is not
+			// specified, only update if the new ref is an ancestor of the old
+			if old != nil && !old.Name().IsTag() && !force && !spec.IsForceUpdate() {
 				ff, err := isFastForward(r.s, old.Hash(), new.Hash())
 				if err != nil {
 					return updated, err


### PR DESCRIPTION
In remote.updateLocalReferenceStorage, this commit updates a check to see if the reference is for a branch (in refs/heads) to checking the reference is not a tag. This change ensures that the subsequent fast-forward only handling clauses apply to references that are not standard branches stored in refs/heads.

I'm still missing tests etc here. If this fix makes sense, happy to work towards that (though I might need some pointers again).

#874 