### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "build"


### PR DESCRIPTION
Configure dependabot to check for Go updates daily and GitHub actions weekly.

The configuration sets the commit prefix, so that it aligns with the contributing guidelines.