### PR TITLE
apply insteadof on Remote.{fetch,pull,list} functions -- breaking change(?)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -351,7 +351,7 @@ func (c *Config) unmarshalRemotes() error {
 
 	// Apply insteadOf url rules
 	for _, r := range c.Remotes {
-		r.applyURLRules(c.URLs)
+		r.ApplyURLRules(c.URLs)
 	}
 
 	return nil
@@ -583,6 +583,7 @@ type RemoteConfig struct {
 
 	// insteadOfRulesApplied have urls been modified
 	insteadOfRulesApplied bool
+
 	// originalURLs are the urls before applying insteadOf rules
 	originalURLs []string
 
@@ -677,19 +678,18 @@ func (c *RemoteConfig) IsFirstURLLocal() bool {
 	return url.IsLocalEndpoint(c.URLs[0])
 }
 
-func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
-	// save original urls
-	originalURLs := make([]string, len(c.URLs))
-	copy(originalURLs, c.URLs)
+// ApplyURLRules() updates c.URLs by substituting the longest matching insteadOf value found in urlRules.
+func (c *RemoteConfig) ApplyURLRules(urlRules map[string]*URL) {
+	// save original urls if we haven't already
+	// never overwrite c.originalURLs on subsequent calls
+	if !c.insteadOfRulesApplied {
+		copy(c.originalURLs, c.URLs)
+	}
 
 	for i, url := range c.URLs {
 		if matchingURLRule := findLongestInsteadOfMatch(url, urlRules); matchingURLRule != nil {
 			c.URLs[i] = matchingURLRule.ApplyInsteadOf(c.URLs[i])
 			c.insteadOfRulesApplied = true
 		}
-	}
-
-	if c.insteadOfRulesApplied {
-		c.originalURLs = originalURLs
 	}
 }

--- a/options.go
+++ b/options.go
@@ -87,6 +87,8 @@ type CloneOptions struct {
 	//
 	// [Reference]: https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---shared
 	Shared bool
+	// URLRules are used to substitute urls details via the config's insteadOf sections
+	URLRules map[string]*config.URL
 }
 
 // Validate validates the fields and sets the default values.


### PR DESCRIPTION
Fixes https://github.com/go-git/go-git/issues/844

This applies `insteadOf` rules to `Remote.{fetch,pull,list}` functions.  This may be seen as a breaking change, as the current behavior _does not_ honor `insteadOf` values.  I believe _not_ applying `insteadOf` values is actually a bug (#844)...so I'm not sure if this is a "breaking change", or a "bugfix".

I'm open to a discussion on whether this should be gated via feature flag.  For example, adding a `CloneOptions.ApplyInsteadOf bool` -- defaulting to `false` (to preserve current behavior).

Thoughts?