### PR TITLE
fix dropped worktree test error

### DIFF
--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1128,6 +1128,7 @@ func (s *WorktreeSuite) TestResetHardWithGitIgnore(c *C) {
 	f, err := fs.Create(".gitignore")
 	c.Assert(err, IsNil)
 	_, err = f.Write([]byte("foo\n"))
+	c.Assert(err, IsNil)
 	_, err = f.Write([]byte("newTestFile.txt\n"))
 	c.Assert(err, IsNil)
 	err = f.Close()


### PR DESCRIPTION
This fixes a dropped test `err` variable in `worktree_test.go`.