### PR TITLE
storage: filesystem, handle submodule names with encoding

### DIFF
--- a/storage/filesystem/module.go
+++ b/storage/filesystem/module.go
@@ -1,6 +1,9 @@
 package filesystem
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/storage"
 	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
@@ -11,7 +14,12 @@ type ModuleStorage struct {
 }
 
 func (s *ModuleStorage) Module(name string) (storage.Storer, error) {
-	fs, err := s.dir.Module(name)
+	// Submodules can have names that Git URL encodes in the filesystem.
+	encodedName := url.PathEscape(name)
+	// Go's URL encoding uses uppercase, Git seems to use lowercase.
+	lowercasedName := strings.ReplaceAll(encodedName, "%2F", "%2f")   // Replace forward slashes.
+	lowercasedName = strings.ReplaceAll(lowercasedName, "%5C", "%5c") // Replace back slashes.
+	fs, err := s.dir.Module(lowercasedName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Whilst trying to get to the bottom of unexpected mutative behaviour from calling `submodule.Status()` it was determined that submodule names containing characters that Git URL encodes (such as forward slashes on Linux) were not being handled correctly, resulting in `submodule.Repository()` calling `Init()` with an incorrect submodule name.

Further, Go's URL encoding opts for uppercase hexadecimal characters, whereas Git appears to go for lowercase, so some hacky handling of this is required.

We haven't been able to locate canonical encoding/decoding behaviour in the Git source, so it is currently unknown how comprehensive this is. We have opted for the obvious suspects, being forward and backslashes.

As discussed in #373 