### PR TITLE
plumbing: transport/ssh, Fix nil pointer dereference caused when an unreachable proxy server is set. Fixes #900

### DIFF
--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -168,7 +168,7 @@ func dial(network, addr string, proxyOpts transport.ProxyOptions, config *ssh.Cl
 	defer cancel()
 
 	var conn net.Conn
-	var err error
+	var dialErr error
 
 	if proxyOpts.URL != "" {
 		proxyUrl, err := proxyOpts.FullURL()
@@ -186,12 +186,12 @@ func dial(network, addr string, proxyOpts transport.ProxyOptions, config *ssh.Cl
 			return nil, fmt.Errorf("expected ssh proxy dialer to be of type %s; got %s",
 				reflect.TypeOf(ctxDialer), reflect.TypeOf(dialer))
 		}
-		conn, err = ctxDialer.DialContext(ctx, "tcp", addr)
+		conn, dialErr = ctxDialer.DialContext(ctx, "tcp", addr)
 	} else {
-		conn, err = proxy.Dial(ctx, network, addr)
+		conn, dialErr = proxy.Dial(ctx, network, addr)
 	}
-	if err != nil {
-		return nil, err
+	if dialErr != nil {
+		return nil, dialErr
 	}
 
 	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)

--- a/plumbing/transport/ssh/common_test.go
+++ b/plumbing/transport/ssh/common_test.go
@@ -172,6 +172,28 @@ func (s *SuiteCommon) TestIssue70(c *C) {
 	c.Assert(err, IsNil)
 }
 
+/*
+Given, an endpoint to a git server with a socks5 proxy URL,
+When, the socks5 proxy server is not reachable,
+Then, there should not be any panic and an error with appropriate message should be returned.
+Related issue : https://github.com/go-git/go-git/pull/900
+*/
+func (s *SuiteCommon) TestInvalidSocks5Proxy(c *C) {
+	ep, err := transport.NewEndpoint("git@github.com:foo/bar.git")
+	c.Assert(err, IsNil)
+	ep.Proxy.URL = "socks5://127.0.0.1:1080"
+
+	auth, err := NewPublicKeys("foo", testdata.PEMBytes["rsa"], "")
+	c.Assert(err, IsNil)
+	c.Assert(auth, NotNil)
+
+	ps, err := DefaultClient.NewUploadPackSession(ep, auth)
+	//Since the proxy server is not running, we expect an error.
+	c.Assert(ps, IsNil)
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "socks connect .* dial tcp 127.0.0.1:1080: .*")
+}
+
 type mockSSHConfig struct {
 	Values map[string]map[string]string
 }


### PR DESCRIPTION
Fixes #900 

Root Cause:
variable `err` is being shadaowed by another variable declaration inside the scope when proxy server url is set. When checking for any error during the `Dial` operation, the outer scope variable `err` is used and  it would always be `nil`. Thus the actual error gets ignored and this makes the code execution to proceed with a `nil` connection which eventually fails with a panic caused due to `nil` pointer dereference.

Fix:
Change the variable name for the error to `dialErr` in the outer scope, so that the variable shadowing does not happen.