### PR TITLE
cli: Refactor for simplicity and dependency removal

### DIFF
--- a/cli/go-git/main.go
+++ b/cli/go-git/main.go
@@ -1,42 +1,89 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/jessevdk/go-flags"
 )
 
 const (
-	bin            = "go-git"
-	receivePackBin = "git-receive-pack"
-	uploadPackBin  = "git-upload-pack"
+	bin = "go-git"
+
+	receivePackName = "receive-pack"
+	uploadPackName  = "upload-pack"
+	versionName     = "version"
+
+	receivePackBin      = "git-receive-pack"
+	uploadPackBin       = "git-upload-pack"
+	updateServerInfoBin = "update-server-info"
+	usage               = `Please specify one command of: receive-pack, upload-pack or version
+Usage:
+	go-git [OPTIONS] <receive-pack | upload-pack | version>
+
+Help Options:
+	-h, --help  Show this help message
+
+Available commands:
+	receive-pack
+	upload-pack
+	version       Show the version information.
+`
+
+	receiveUploadUsageFormat = "usage: %s <git-dir>\n"
+
+	// Exit codes are defined in api-error-handling upstream:
+	// https://github.com/git/git/blob/8be77c5de65442b331a28d63802c7a3b94a06c5a/Documentation/technical/api-error-handling.txt#L32-L46
+	cannotStartExitCode      = 129
+	fatalApplicationExitCode = 128
+	generalErrorExitCode     = -1
+)
+
+var (
+	// keeps a copy of the original command name, in case it was changed.
+	originalCommand = os.Args[0]
+
+	commands = map[string]func([]string) error{
+		updateServerInfoBin: updateServerInfoRun,
+		receivePackName:     receivePackRun,
+		uploadPackName:      uploadPackRun,
+		versionName:         versionRun,
+	}
 )
 
 func main() {
 	switch filepath.Base(os.Args[0]) {
 	case receivePackBin:
-		os.Args = append([]string{"git", "receive-pack"}, os.Args[1:]...)
+		os.Args = append([]string{"git", receivePackName}, os.Args[1:]...)
 	case uploadPackBin:
-		os.Args = append([]string{"git", "upload-pack"}, os.Args[1:]...)
+		os.Args = append([]string{"git", uploadPackName}, os.Args[1:]...)
 	}
 
-	parser := flags.NewNamedParser(bin, flags.Default)
-	parser.AddCommand("update-server-info", "", "", &CmdUpdateServerInfo{})
-	parser.AddCommand("receive-pack", "", "", &CmdReceivePack{})
-	parser.AddCommand("upload-pack", "", "", &CmdUploadPack{})
-	parser.AddCommand("version", "Show the version information.", "", &CmdVersion{})
+	if len(os.Args) < 2 {
+		showUsage()
+		os.Exit(cannotStartExitCode)
+	}
 
-	_, err := parser.Parse()
-	if err != nil {
-		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrCommandRequired {
-			parser.WriteHelp(os.Stdout)
-		}
+	var args []string
+	if len(os.Args) > 2 {
+		args = os.Args[2:]
+	}
 
-		os.Exit(1)
+	cmd, ok := commands[os.Args[1]]
+	if !ok {
+		showUsage()
+		os.Exit(cannotStartExitCode)
+	}
+
+	if err := cmd(args); err != nil {
+		fmt.Fprintln(os.Stderr, "ERR:", err)
+		os.Exit(generalErrorExitCode)
 	}
 }
 
-type cmd struct {
-	Verbose bool `short:"v" description:"Activates the verbose mode"`
+func showUsage() {
+	fmt.Print(usage)
+}
+
+func showReceiveUploadUsage() {
+	fmt.Printf(receiveUploadUsageFormat, originalCommand)
 }

--- a/cli/go-git/receive_pack.go
+++ b/cli/go-git/receive_pack.go
@@ -5,31 +5,30 @@ import (
 	"os"
 	"path/filepath"
 
+	"flag"
+
 	"github.com/go-git/go-git/v5/plumbing/transport/file"
 )
 
-type CmdReceivePack struct {
-	cmd
+func receivePackRun(args []string) error {
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	if err := f.Parse(args); err != nil {
+		return err
+	}
 
-	Args struct {
-		GitDir string `positional-arg-name:"git-dir" required:"true"`
-	} `positional-args:"yes"`
-}
+	if f.NArg() == 0 {
+		showReceiveUploadUsage()
+		os.Exit(cannotStartExitCode)
+	}
 
-func (CmdReceivePack) Usage() string {
-	//TODO: git-receive-pack returns error code 129 if arguments are invalid.
-	return fmt.Sprintf("usage: %s <git-dir>", os.Args[0])
-}
-
-func (c *CmdReceivePack) Execute(args []string) error {
-	gitDir, err := filepath.Abs(c.Args.GitDir)
+	gitDir, err := filepath.Abs(f.Arg(0))
 	if err != nil {
 		return err
 	}
 
 	if err := file.ServeReceivePack(gitDir); err != nil {
 		fmt.Fprintln(os.Stderr, "ERR:", err)
-		os.Exit(128)
+		os.Exit(fatalApplicationExitCode)
 	}
 
 	return nil

--- a/cli/go-git/update_server_info.go
+++ b/cli/go-git/update_server_info.go
@@ -1,34 +1,45 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/serverinfo"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 )
 
-// CmdUpdateServerInfo command updates the server info files in the repository.
+// updateServerInfoRun command updates the server info files in the repository.
 // This is used by git http transport (dumb) to generate a list of available
 // refs for the repository. See:
 // https://git-scm.com/docs/git-update-server-info
-type CmdUpdateServerInfo struct {
-	cmd
-}
+func updateServerInfoRun(args []string) error {
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	if err := f.Parse(args); err != nil {
+		return err
+	}
 
-// Usage returns the usage of the command.
-func (CmdUpdateServerInfo) Usage() string {
-	return fmt.Sprintf("within a git repository run: %s", os.Args[0])
-}
+	if f.NArg() == 0 {
+		showUpdateServerInfoUsage()
+		os.Exit(cannotStartExitCode)
+	}
 
-// Execute runs the command.
-func (c *CmdUpdateServerInfo) Execute(args []string) error {
-	r, err := git.PlainOpen(".")
+	gitDir, err := filepath.Abs(f.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	r, err := git.PlainOpen(gitDir)
 	if err != nil {
 		return err
 	}
 
 	fs := r.Storer.(*filesystem.Storage).Filesystem()
 	return serverinfo.UpdateServerInfo(r.Storer, fs)
+}
+
+func showUpdateServerInfoUsage() {
+	fmt.Printf("usage: %s <git-dir>\n", originalCommand)
 }

--- a/cli/go-git/upload_pack.go
+++ b/cli/go-git/upload_pack.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -8,29 +9,26 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/file"
 )
 
-type CmdUploadPack struct {
-	cmd
+// TODO: usage: git upload-pack [--strict] [--timeout=<n>] <dir>
+func uploadPackRun(args []string) error {
+	f := flag.NewFlagSet("", flag.ExitOnError)
+	if err := f.Parse(args); err != nil {
+		return err
+	}
 
-	Args struct {
-		GitDir string `positional-arg-name:"git-dir" required:"true"`
-	} `positional-args:"yes"`
-}
+	if f.NArg() == 0 {
+		showReceiveUploadUsage()
+		os.Exit(cannotStartExitCode)
+	}
 
-func (CmdUploadPack) Usage() string {
-	//TODO: usage: git upload-pack [--strict] [--timeout=<n>] <dir>
-	//TODO: git-upload-pack returns error code 129 if arguments are invalid.
-	return fmt.Sprintf("usage: %s <git-dir>", os.Args[0])
-}
-
-func (c *CmdUploadPack) Execute(args []string) error {
-	gitDir, err := filepath.Abs(c.Args.GitDir)
+	gitDir, err := filepath.Abs(f.Arg(0))
 	if err != nil {
 		return err
 	}
 
 	if err := file.ServeUploadPack(gitDir); err != nil {
 		fmt.Fprintln(os.Stderr, "ERR:", err)
-		os.Exit(128)
+		os.Exit(fatalApplicationExitCode)
 	}
 
 	return nil

--- a/cli/go-git/version.go
+++ b/cli/go-git/version.go
@@ -5,9 +5,7 @@ import "fmt"
 var version string
 var build string
 
-type CmdVersion struct{}
-
-func (c *CmdVersion) Execute(args []string) error {
+func versionRun(args []string) error {
 	fmt.Printf("%s (%s) - build %s\n", bin, version, build)
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/google/go-cmp v0.6.0
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
-	github.com/jessevdk/go-flags v1.5.0
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/pjbgf/sha1cd v0.3.0
 	github.com/sergi/go-diff v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
-github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -108,7 +106,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Remove third party dependency (`github.com/jessevdk/go-flags`) for flags handling to rely on the standard library instead.