### PR TITLE
exp: plumbling/hasher, Add `ObjectHasher` and `ImmutableHash`

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check Package Prefix
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(\*|git|plumbing|utils|config|_examples|internal|storage|cli|build): .+'
+          pattern: '^(\*|exp|git|plumbing|utils|config|_examples|internal|storage|cli|build): .+'
           error: |
             Commit message(s) does not align with contribution acceptance criteria.
 

--- a/exp/doc.go
+++ b/exp/doc.go
@@ -1,0 +1,9 @@
+// The exp package holds experimental code only.
+//
+// Any code under this package (and its sub-packages) should not be
+// relied upon for production use.
+//
+// Beware: breaking changes on this package can happen within a
+// go-git minor release, as it does not provide hold the same API
+// stability assurances.
+package exp

--- a/exp/plumbing/hasher/hasher.go
+++ b/exp/plumbing/hasher/hasher.go
@@ -1,0 +1,135 @@
+package hasher
+
+import (
+	"crypto"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/hash"
+
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
+)
+
+// ObjectHasher computes hashes for Git objects. A few differences
+// it has when compared to plumbing.Hasher:
+//
+//   - ObjectType awareness: produces either SHA1 or SHA256 hashes
+//     depending on the format needed.
+//   - Thread-safety.
+//   - API restricts ability of generating invalid hashes.
+type ObjectHasher interface {
+	// Size returns the length of resulting hash.
+	Size() int
+	// Compute calculates the hash of a Git object. The process involves
+	// first writing the object header, which contains the object type
+	// and content size, followed by the content itself.
+	Compute(ot plumbing.ObjectType, d []byte) (ImmutableHash, error)
+}
+
+// FromObjectFormat returns the correct ObjectHasher for the given
+// ObjectFormat.
+//
+// If the format is not recognised, an ErrInvalidObjectFormat error
+// is returned.
+func FromObjectFormat(f format.ObjectFormat) (ObjectHasher, error) {
+	switch f {
+	case format.SHA1:
+		return newHasherSHA1(), nil
+	case format.SHA256:
+		return newHasherSHA256(), nil
+	default:
+		return nil, format.ErrInvalidObjectFormat
+	}
+}
+
+// FromHash returns the correct ObjectHasher for the given
+// Hash.
+//
+// If the hash type is not recognised, an ErrUnsupportedHashFunction
+// error is returned.
+func FromHash(h hash.Hash) (ObjectHasher, error) {
+	switch h.Size() {
+	case hash.SHA1_Size:
+		return newHasherSHA1(), nil
+	case hash.SHA256_Size:
+		return newHasherSHA256(), nil
+	default:
+		return nil, hash.ErrUnsupportedHashFunction
+	}
+}
+
+func newHasherSHA1() *objectHasherSHA1 {
+	return &objectHasherSHA1{
+		hasher: hash.New(crypto.SHA1),
+	}
+}
+
+type objectHasherSHA1 struct {
+	hasher hash.Hash
+	m      sync.Mutex
+}
+
+func (h *objectHasherSHA1) Compute(ot plumbing.ObjectType, d []byte) (ImmutableHash, error) {
+	h.m.Lock()
+	h.hasher.Reset()
+
+	writeHeader(h.hasher, ot, int64(len(d)))
+	_, err := h.hasher.Write(d)
+	if err != nil {
+		h.m.Unlock()
+		return nil, fmt.Errorf("failed to compute hash: %w", err)
+	}
+
+	var out immutableHashSHA1
+	copy(out[:], h.hasher.Sum(out[:0]))
+	h.m.Unlock()
+	return out, nil
+}
+
+func (h *objectHasherSHA1) Size() int {
+	return h.hasher.Size()
+}
+
+func newHasherSHA256() *objectHasherSHA256 {
+	return &objectHasherSHA256{
+		hasher: hash.New(crypto.SHA256),
+	}
+}
+
+type objectHasherSHA256 struct {
+	hasher hash.Hash
+	m      sync.Mutex
+}
+
+func (h *objectHasherSHA256) Compute(ot plumbing.ObjectType, d []byte) (ImmutableHash, error) {
+	h.m.Lock()
+	h.hasher.Reset()
+
+	writeHeader(h.hasher, ot, int64(len(d)))
+	_, err := h.hasher.Write(d)
+	if err != nil {
+		h.m.Unlock()
+		return nil, fmt.Errorf("failed to compute hash: %w", err)
+	}
+
+	out := immutableHashSHA256{}
+	copy(out[:], h.hasher.Sum(out[:0]))
+	h.m.Unlock()
+	return out, nil
+}
+
+func (h *objectHasherSHA256) Size() int {
+	return h.hasher.Size()
+}
+
+func writeHeader(h hash.Hash, ot plumbing.ObjectType, sz int64) {
+	// TODO: Optimise hasher.Write calls.
+	// Writing into hash in amounts smaller than oh.BlockSize() is
+	// sub-optimal.
+	h.Write(ot.Bytes())
+	h.Write([]byte(" "))
+	h.Write([]byte(strconv.FormatInt(sz, 10)))
+	h.Write([]byte{0})
+}

--- a/exp/plumbing/hasher/hasher_test.go
+++ b/exp/plumbing/hasher/hasher_test.go
@@ -1,0 +1,186 @@
+package hasher_test
+
+import (
+	"bytes"
+	"crypto"
+	"fmt"
+	"hash"
+	"strings"
+	"sync"
+	"testing"
+
+	. "github.com/go-git/go-git/v5/exp/plumbing/hasher"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/pjbgf/sha1cd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		h       hash.Hash
+		ot      plumbing.ObjectType
+		content []byte
+		want    string
+	}{
+		{
+			"blob object sha1", crypto.SHA1.New(),
+			plumbing.BlobObject,
+			[]byte("hash object sample"),
+			"9f361d484fcebb869e1919dc7467b82ac6ca5fad",
+		},
+		{
+			"blob object sha256", crypto.SHA256.New(),
+			plumbing.BlobObject,
+			[]byte("hash object sample"),
+			"2c07a4773e3a957c77810e8cc5deb52cd70493803c048e48dcc0e01f94cbe677",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s:%q", tc.name, ""), func(t *testing.T) {
+			oh, err := FromHash(tc.h)
+			assert.NoError(t, err)
+
+			h, err := oh.Compute(tc.ot, tc.content)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, h.String())
+		})
+	}
+}
+
+func TestMultipleHashes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		h        hash.Hash
+		ot       plumbing.ObjectType
+		content1 []byte
+		content2 []byte
+		want1    string
+		want2    string
+	}{
+		{
+			"reuse sha1 hasher instance for two ops", crypto.SHA1.New(),
+			plumbing.BlobObject,
+			[]byte("hash object sample"),
+			[]byte("other object content"),
+			"9f361d484fcebb869e1919dc7467b82ac6ca5fad",
+			"e8bb453830a9efdfe4785275b92eb0766da3a73d",
+		},
+		{
+			"reuse sha256 hasher instance for two ops", crypto.SHA256.New(),
+			plumbing.BlobObject,
+			[]byte("hash object sample"),
+			[]byte("other object content"),
+			"2c07a4773e3a957c77810e8cc5deb52cd70493803c048e48dcc0e01f94cbe677",
+			"2f1eb67dc531a48962e741b61e88ef94cf70969bc6442a91cdcad7f5192e8c1d",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s:%q", tc.name, ""), func(t *testing.T) {
+			oh, err := FromHash(tc.h)
+			assert.NoError(t, err)
+
+			h, err := oh.Compute(tc.ot, tc.content1)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want1, h.String())
+
+			h, err = oh.Compute(tc.ot, tc.content2)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want2, h.String())
+		})
+	}
+}
+
+func TestThreadSatefy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		h       hash.Hash
+		ot      plumbing.ObjectType
+		content []byte
+		count   int
+		want    string
+	}{
+		{
+			"thread safety sha1", crypto.SHA1.New(),
+			plumbing.BlobObject,
+			bytes.Repeat([]byte{2}, 500),
+			20,
+			"147979c263be42345f0721a22c5339492aadd0bf",
+		},
+		{
+			"thread safety sha256", crypto.SHA256.New(),
+			plumbing.BlobObject,
+			bytes.Repeat([]byte{2}, 500),
+			20,
+			"43196946e1d64387caaac746132f22c2be6f9a16914dad0231b479e16b9c3a01",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oh, err := FromHash(tc.h)
+			assert.NoError(t, err)
+
+			var wg sync.WaitGroup
+			for i := 0; i < tc.count; i++ {
+				wg.Add(1)
+				go func() {
+					h, err := oh.Compute(tc.ot, tc.content)
+					assert.NoError(t, err)
+
+					got := h.String()
+					assert.Equal(t, tc.want, got, "resulting hash impacted by race condition")
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+		})
+	}
+}
+
+func BenchmarkHasher(b *testing.B) {
+	qtds := []int64{100, 5000}
+
+	for _, q := range qtds {
+		b.Run(fmt.Sprintf("hasher-sha1-%dB", q), func(b *testing.B) {
+			benchmarkHasher(b, q)
+		})
+		b.Run(fmt.Sprintf("objecthash-sha1-%dB", q), func(b *testing.B) {
+			benchmarkObjectHash(b, sha1cd.New(), q)
+		})
+		b.Run(fmt.Sprintf("objecthash-sha256-%dB", q), func(b *testing.B) {
+			benchmarkObjectHash(b, crypto.SHA256.New(), q)
+		})
+	}
+}
+
+func benchmarkHasher(b *testing.B, sz int64) {
+	content := strings.Repeat("s", int(sz))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h := plumbing.NewHasher(plumbing.BlobObject, sz)
+		_, _ = h.Write([]byte(content))
+		b.SetBytes(sz)
+	}
+}
+
+func benchmarkObjectHash(b *testing.B, h hash.Hash, sz int64) {
+	content := bytes.Repeat([]byte("s"), int(sz))
+	oh, err := FromHash(h)
+	assert.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = oh.Compute(plumbing.BlobObject, content)
+		b.SetBytes(sz)
+	}
+}

--- a/exp/plumbing/hasher/immutable.go
+++ b/exp/plumbing/hasher/immutable.go
@@ -1,0 +1,156 @@
+package hasher
+
+import (
+	"bytes"
+	"encoding/hex"
+
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
+	"github.com/go-git/go-git/v5/plumbing/hash"
+)
+
+// ImmutableHash represents a calculated hash.
+type ImmutableHash interface {
+	// Size returns the length of the resulting hash.
+	Size() int
+	// Empty returns true if the hash is zero.
+	Empty() bool
+	// Compare compares the hash's sum with a slice of bytes.
+	Compare([]byte) int
+	// String returns the hexadecimal representation of the hash's sum.
+	String() string
+	// Sum returns the slice of bytes containing the hash.
+	Sum() []byte
+}
+
+// FromHex parses a hexadecimal string and returns an ImmutableHash
+// and a boolean confirming whether the operation was successful.
+// The hash (and object format) is inferred from the length of the
+// input.
+//
+// If the operation was not successful, the resulting hash is nil
+// instead of a zeroed hash.
+func FromHex(in string) (ImmutableHash, bool) {
+	if len(in) < hash.SHA1_HexSize ||
+		len(in) > hash.SHA256_HexSize {
+		return nil, false
+	}
+
+	b, err := hex.DecodeString(in)
+	if err != nil {
+		return nil, false
+	}
+
+	switch len(in) {
+	case hash.SHA1_HexSize:
+		h := immutableHashSHA1{}
+		copy(h[:], b)
+		return h, true
+
+	case hash.SHA256_HexSize:
+		h := immutableHashSHA256{}
+		copy(h[:], b)
+		return h, true
+
+	default:
+		return nil, false
+	}
+}
+
+// FromBytes creates an ImmutableHash object based on the value its
+// Sum() should return.
+// The hash type (and object format) is inferred from the length of
+// the input.
+//
+// If the operation was not successful, the resulting hash is nil
+// instead of a zeroed hash.
+func FromBytes(in []byte) (ImmutableHash, bool) {
+	if len(in) < hash.SHA1_Size ||
+		len(in) > hash.SHA256_Size {
+		return nil, false
+	}
+
+	switch len(in) {
+	case hash.SHA1_Size:
+		h := immutableHashSHA1{}
+		copy(h[:], in)
+		return h, true
+
+	case hash.SHA256_Size:
+		h := immutableHashSHA256{}
+		copy(h[:], in)
+		return h, true
+
+	default:
+		return nil, false
+	}
+}
+
+// ZeroFromHash returns a zeroed hash based on the given hash.Hash.
+//
+// Defaults to SHA1-sized hash if the provided hash is not supported.
+func ZeroFromHash(h hash.Hash) ImmutableHash {
+	switch h.Size() {
+	case hash.SHA256_Size:
+		return immutableHashSHA256{}
+	default:
+		return immutableHashSHA1{}
+	}
+}
+
+// ZeroFromHash returns a zeroed hash based on the given ObjectFormat.
+//
+// Defaults to SHA1-sized hash if the provided format is not supported.
+func ZeroFromObjectFormat(f format.ObjectFormat) ImmutableHash {
+	switch f {
+	case format.SHA256:
+		return immutableHashSHA256{}
+	default:
+		return immutableHashSHA1{}
+	}
+}
+
+type immutableHashSHA1 [hash.SHA1_Size]byte
+
+func (ih immutableHashSHA1) Size() int {
+	return len(ih)
+}
+
+func (ih immutableHashSHA1) Empty() bool {
+	var empty immutableHashSHA1
+	return ih == empty
+}
+
+func (ih immutableHashSHA1) String() string {
+	return hex.EncodeToString(ih[:])
+}
+
+func (ih immutableHashSHA1) Sum() []byte {
+	return ih[:]
+}
+
+func (ih immutableHashSHA1) Compare(in []byte) int {
+	return bytes.Compare(ih[:], in)
+}
+
+type immutableHashSHA256 [hash.SHA256_Size]byte
+
+func (ih immutableHashSHA256) Size() int {
+	return len(ih)
+}
+
+func (ih immutableHashSHA256) Empty() bool {
+	var empty immutableHashSHA256
+	return ih == empty
+}
+
+func (ih immutableHashSHA256) String() string {
+	return hex.EncodeToString(ih[:])
+}
+
+func (ih immutableHashSHA256) Sum() []byte {
+	return ih[:]
+}
+
+func (ih immutableHashSHA256) Compare(in []byte) int {
+	return bytes.Compare(ih[:], in)
+}

--- a/exp/plumbing/hasher/immutable_test.go
+++ b/exp/plumbing/hasher/immutable_test.go
@@ -1,0 +1,174 @@
+package hasher_test
+
+import (
+	"crypto"
+	"fmt"
+	"hash"
+	"strings"
+	"testing"
+
+	. "github.com/go-git/go-git/v5/exp/plumbing/hasher"
+	"github.com/go-git/go-git/v5/plumbing"
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
+	"github.com/pjbgf/sha1cd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromHex(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		ok    bool
+		empty bool
+	}{
+		{"valid sha1", "8ab686eafeb1f44702738c8b0f24f2567c36da6d", true, false},
+		{"valid sha256", "edeaaff3f1774ad2888673770c6d64097e391bc362d7d6fb34982ddf0efd18cb", true, false},
+		{"empty sha1", "0000000000000000000000000000000000000000", true, true},
+		{"empty sha256", "0000000000000000000000000000000000000000000000000000000000000000", true, true},
+		{"partial sha1", "8ab686eafeb1f44702738", false, true},
+		{"partial sha256", "edeaaff3f1774ad28886", false, true},
+		{"invalid sha1", "8ab686eafeb1f44702738x", false, true},
+		{"invalid sha256", "edeaaff3f1774ad28886x", false, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s:%q", tc.name, tc.in), func(t *testing.T) {
+			h, ok := FromHex(tc.in)
+
+			assert.Equal(t, tc.ok, ok, "OK did not match")
+			if tc.ok {
+				assert.Equal(t, tc.empty, h.Empty(), "Empty did not match expectations")
+			} else {
+				assert.Nil(t, h)
+			}
+		})
+	}
+}
+
+func TestZeroFromHash(t *testing.T) {
+	tests := []struct {
+		name string
+		h    hash.Hash
+		want string
+	}{
+		{"valid sha1", crypto.SHA1.New(), strings.Repeat("0", 40)},
+		{"valid sha1cd", sha1cd.New(), strings.Repeat("0", 40)},
+		{"valid sha256", crypto.SHA256.New(), strings.Repeat("0", 64)},
+		{"unsupported hash", crypto.SHA384.New(), strings.Repeat("0", 40)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ZeroFromHash(tc.h)
+			assert.Equal(t, tc.want, got.String())
+			assert.True(t, got.Empty(), "should be empty")
+		})
+	}
+}
+
+func TestZeroFromObjectFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		of   format.ObjectFormat
+		want string
+	}{
+		{"valid sha1", format.SHA1, strings.Repeat("0", 40)},
+		{"valid sha256", format.SHA256, strings.Repeat("0", 64)},
+		{"invalid format", "invalid", strings.Repeat("0", 40)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ZeroFromObjectFormat(tc.of)
+			assert.Equal(t, tc.want, got.String())
+			assert.True(t, got.Empty(), "should be empty")
+		})
+	}
+}
+
+func TestNotLeakingBackingArray(t *testing.T) {
+	tests := []struct {
+		in  string
+		sum []byte
+	}{
+		{
+			"9f361d484fcebb869e1919dc7467b82ac6ca5fad",
+			[]byte{
+				0x9f, 0x36, 0x1d, 0x48, 0x4f, 0xce, 0xbb, 0x86, 0x9e, 0x19,
+				0x19, 0xdc, 0x74, 0x67, 0xb8, 0x2a, 0xc6, 0xca, 0x5f, 0xad,
+			},
+		},
+		{
+			"2c07a4773e3a957c77810e8cc5deb52cd70493803c048e48dcc0e01f94cbe677",
+			[]byte{
+				0x2c, 0x07, 0xa4, 0x77, 0x3e, 0x3a, 0x95, 0x7c, 0x77, 0x81,
+				0x0e, 0x8c, 0xc5, 0xde, 0xb5, 0x2c, 0xd7, 0x04, 0x93, 0x80,
+				0x3c, 0x04, 0x8e, 0x48, 0xdc, 0xc0, 0xe0, 0x1f, 0x94, 0xcb,
+				0xe6, 0x77,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		h, ok := FromHex(tc.in)
+		assert.True(t, ok)
+		assert.Equal(t, tc.in, h.String())
+		assert.Equal(t, tc.sum, h.Sum())
+
+		sum := h.Sum()
+		for i := range sum {
+			sum[i] = 0
+		}
+		assert.Equal(t, tc.sum, h.Sum())
+	}
+}
+
+func BenchmarkHashFromHex(b *testing.B) {
+	tests := []struct {
+		name   string
+		sha1   string
+		sha256 string
+	}{
+		{
+			name:   "valid",
+			sha1:   "9f361d484fcebb869e1919dc7467b82ac6ca5fad",
+			sha256: "2c07a4773e3a957c77810e8cc5deb52cd70493803c048e48dcc0e01f94cbe677",
+		},
+		{
+			name:   "invalid",
+			sha1:   "9f361d484fcebb869e1919dc7467b82ac6ca5fxf",
+			sha256: "2c07a4773e3a957c77810e8cc5deb52cd70493803c048e48dcc0e01f94cbe6xd",
+		},
+		{
+			name:   "zero",
+			sha1:   "0000000000000000000000000000000000000000",
+			sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+		},
+	}
+
+	for _, tc := range tests {
+		b.Run(fmt.Sprintf("hasher-parse-sha1-%s", tc.name), func(b *testing.B) {
+			benchmarkHashParse(b, tc.sha1)
+		})
+		b.Run(fmt.Sprintf("objecthash-fromhex-sha1-%s", tc.name), func(b *testing.B) {
+			benchmarkObjectHashParse(b, tc.sha1)
+		})
+		b.Run(fmt.Sprintf("objecthash-fromhex-sha256-%s", tc.name), func(b *testing.B) {
+			benchmarkObjectHashParse(b, tc.sha256)
+		})
+	}
+}
+
+func benchmarkHashParse(b *testing.B, in string) {
+	for i := 0; i < b.N; i++ {
+		_ = plumbing.NewHash(in)
+		b.SetBytes(int64(len(in)))
+	}
+}
+
+func benchmarkObjectHashParse(b *testing.B, in string) {
+	for i := 0; i < b.N; i++ {
+		_, _ = FromHex(in)
+		b.SetBytes(int64(len(in)))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0
 	github.com/sergi/go-diff v1.1.0
 	github.com/skeema/knownhosts v1.2.1
+	github.com/stretchr/testify v1.8.4
 	github.com/xanzy/ssh-agent v0.3.3
 	golang.org/x/crypto v0.15.0
 	golang.org/x/net v0.18.0
@@ -34,10 +35,13 @@ require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/plumbing/format/config/format.go
+++ b/plumbing/format/config/format.go
@@ -1,5 +1,7 @@
 package config
 
+import "errors"
+
 // RepositoryFormatVersion represents the repository format version,
 // as per defined at:
 //
@@ -51,3 +53,6 @@ const (
 	// DefaultObjectFormat holds the default object format.
 	DefaultObjectFormat = SHA1
 )
+
+// ErrInvalidObjectFormat is returned when an invalid ObjectFormat is used.
+var ErrInvalidObjectFormat = errors.New("invalid object format")

--- a/plumbing/hash/hash.go
+++ b/plumbing/hash/hash.go
@@ -4,6 +4,7 @@ package hash
 
 import (
 	"crypto"
+	"errors"
 	"fmt"
 	"hash"
 
@@ -15,6 +16,10 @@ const (
 	SHA1_HexSize   = SHA1_Size * 2
 	SHA256_Size    = 32
 	SHA256_HexSize = SHA256_Size * 2
+)
+
+var (
+	ErrUnsupportedHashFunction = errors.New("unsupported hash function")
 )
 
 // algos is a map of hash algorithms.
@@ -45,7 +50,7 @@ func RegisterHash(h crypto.Hash, f func() hash.Hash) error {
 	case crypto.SHA256:
 		algos[h] = f
 	default:
-		return fmt.Errorf("unsupported hash function: %v", h)
+		return fmt.Errorf("%w: %v", ErrUnsupportedHashFunction, h)
 	}
 	return nil
 }

--- a/plumbing/hash/hash.go
+++ b/plumbing/hash/hash.go
@@ -10,6 +10,13 @@ import (
 	"github.com/pjbgf/sha1cd"
 )
 
+const (
+	SHA1_Size      = 20
+	SHA1_HexSize   = SHA1_Size * 2
+	SHA256_Size    = 32
+	SHA256_HexSize = SHA256_Size * 2
+)
+
 // algos is a map of hash algorithms.
 var algos = map[crypto.Hash]func() hash.Hash{}
 

--- a/plumbing/hash/hash.go
+++ b/plumbing/hash/hash.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hash"
 
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/pjbgf/sha1cd"
 )
 
@@ -69,4 +70,18 @@ func New(h crypto.Hash) Hash {
 		panic(fmt.Sprintf("hash algorithm not registered: %v", h))
 	}
 	return hh()
+}
+
+// FromObjectFormat returns the correct Hash to be used based on the
+// ObjectFormat being used.
+// If the ObjectFormat is not recognised, returns ErrInvalidObjectFormat.
+func FromObjectFormat(f format.ObjectFormat) (hash.Hash, error) {
+	switch f {
+	case format.SHA1:
+		return New(crypto.SHA1), nil
+	case format.SHA256:
+		return New(crypto.SHA256), nil
+	default:
+		return nil, format.ErrInvalidObjectFormat
+	}
 }

--- a/plumbing/hash/hash_sha1.go
+++ b/plumbing/hash/hash_sha1.go
@@ -9,7 +9,7 @@ const (
 	// CryptoType defines what hash algorithm is being used.
 	CryptoType = crypto.SHA1
 	// Size defines the amount of bytes the hash yields.
-	Size = 20
+	Size = SHA1_Size
 	// HexSize defines the strings size of the hash when represented in hexadecimal.
-	HexSize = 40
+	HexSize = SHA1_HexSize
 )

--- a/plumbing/hash/hash_sha256.go
+++ b/plumbing/hash/hash_sha256.go
@@ -9,7 +9,7 @@ const (
 	// CryptoType defines what hash algorithm is being used.
 	CryptoType = crypto.SHA256
 	// Size defines the amount of bytes the hash yields.
-	Size = 32
+	Size = SHA256_Size
 	// HexSize defines the strings size of the hash when represented in hexadecimal.
-	HexSize = 64
+	HexSize = SHA256_HexSize
 )


### PR DESCRIPTION
The introduction of both new types are a stepping stone to enable SHA256 support concurrently - without the need for a build tag.

ImmutableHash provides a way to represent varied sized hashes (for SHA1 or SHA256) with a single type, while keeping similar performance of the existing `plumbing.Hash`.

The names were picked in order to provide a clearer distinction on what they do. `ImmutableHash` is the result of a hash operation and can't be changed once calculated. `ObjectHasher`, adds the Git object header before a normal hash operation that `hash.Hash` or `plumbing/hash.Hash` do.

The performance results shows that SHA1 operations could be slower, however for SHA256 it can be over 3 times faster:

```
~Hasher/hasher-sha1-100B-16         	            2202226	     574.7 ns/op	 174.00 MB/s     272 B/op     7 allocs/op
~Hasher/objecthash-sha1-100B-16     	            1511851	     772.6 ns/op	 129.43 MB/s     272 B/op     9 allocs/op
~Hasher/objecthash-sha256-100B-16   	            5057584	     247.4 ns/op	 404.21 MB/s      96 B/op     7 allocs/op
~Hasher/hasher-sha1-5000B-16        	              96476	     12523 ns/op	 399.25 MB/s    5536 B/op     7 allocs/op
~Hasher/objecthash-sha1-5000B-16    	             105376	     10983 ns/op	 455.27 MB/s     272 B/op     9 allocs/op
~Hasher/objecthash-sha256-5000B-16  	             420741	      2828 ns/op	1767.77 MB/s      96 B/op     7 allocs/op
~HashFromHex/hasher-parse-sha1-valid-16         	23243548     64.65 ns/op	 618.69 MB/s      48 B/op     1 allocs/op
~HashFromHex/objecthash-fromhex-sha1-valid-16   	18120699     79.62 ns/op	 502.36 MB/s      72 B/op     2 allocs/op
~HashFromHex/objecthash-fromhex-sha256-valid-16 	 8969871    124.2 ns/op	     515.22 MB/s      96 B/op     2 allocs/op
```

Relates to #229 #899 

--- 
The other commits (together with the one described above) lay the foundations for a follow-up PR which introduces a `exp/plumbing/format/idxfile` which supports both SHA1 and SHA256.