### PR TITLE
Ignore ModeSocket files

### DIFF
--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -103,6 +103,10 @@ func (n *node) calculateChildren() error {
 			continue
 		}
 
+		if file.Mode()&os.ModeSocket != 0 {
+			continue
+		}
+
 		c, err := n.newChildNode(file)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixing #312.

I used `osfs.New(td)` in the tests with an os.MkdirTemp because I have no clue how to create a socket in the memfs.