### PR TITLE
plumbing: fix empty uploadpack request error

### DIFF
--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -245,6 +245,12 @@ func (s *session) handleAdvRefDecodeError(err error) error {
 // returned with the packfile content. The reader must be closed after reading.
 func (s *session) UploadPack(ctx context.Context, req *packp.UploadPackRequest) (*packp.UploadPackResponse, error) {
 	if req.IsEmpty() {
+		// XXX: IsEmpty means haves are a subset of wants, in that case we have
+		// everything we asked for. Close the connection and return nil.
+		if err := s.finish(); err != nil {
+			return nil, err
+		}
+		// TODO:(v6) return nil here
 		return nil, transport.ErrEmptyUploadPackRequest
 	}
 

--- a/remote.go
+++ b/remote.go
@@ -552,6 +552,10 @@ func (r *Remote) fetchPack(ctx context.Context, o *FetchOptions, s transport.Upl
 
 	reader, err := s.UploadPack(ctx, req)
 	if err != nil {
+		if errors.Is(err, transport.ErrEmptyUploadPackRequest) {
+			// XXX: no packfile provided, everything is up-to-date.
+			return nil
+		}
 		return err
 	}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -299,6 +299,20 @@ func (s *WorktreeSuite) TestPullAlreadyUptodate(c *C) {
 	c.Assert(err, Equals, NoErrAlreadyUpToDate)
 }
 
+func (s *WorktreeSuite) TestPullDepth(c *C) {
+	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
+		URL:   fixtures.Basic().One().URL,
+		Depth: 1,
+	})
+
+	c.Assert(err, IsNil)
+
+	w, err := r.Worktree()
+	c.Assert(err, IsNil)
+	err = w.Pull(&PullOptions{})
+	c.Assert(err, Equals, nil)
+}
+
 func (s *WorktreeSuite) TestCheckout(c *C) {
 	fs := memfs.New()
 	w := &Worktree{


### PR DESCRIPTION
If we have all what we asked for, finish the session and handle error.

This is equivalent of git "Already up to date." message.

Fixes: https://github.com/go-git/go-git/issues/328
Fixes: https://github.com/go-git/go-git/issues/638
Fixes: https://github.com/go-git/go-git/issues/157