### PR TITLE
Replace short field names with more descriptive ones.

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -91,9 +91,9 @@ func advertisedReferences(ctx context.Context, s *session, serviceName string) (
 }
 
 type client struct {
-	c          *http.Client
+	client     *http.Client
 	transports *lru.Cache
-	m          sync.RWMutex
+	mutex      sync.RWMutex
 }
 
 // ClientOptions holds user configurable options for the client.
@@ -147,7 +147,7 @@ func NewClientWithOptions(c *http.Client, opts *ClientOptions) transport.Transpo
 		}
 	}
 	cl := &client{
-		c: c,
+		client: c,
 	}
 
 	if opts != nil {
@@ -234,10 +234,10 @@ func newSession(c *client, ep *transport.Endpoint, auth transport.AuthMethod) (*
 		// if the client wasn't configured to have a cache for transports then just configure
 		// the transport and use it directly, otherwise try to use the cache.
 		if c.transports == nil {
-			tr, ok := c.c.Transport.(*http.Transport)
+			tr, ok := c.client.Transport.(*http.Transport)
 			if !ok {
 				return nil, fmt.Errorf("expected underlying client transport to be of type: %s; got: %s",
-					reflect.TypeOf(transport), reflect.TypeOf(c.c.Transport))
+					reflect.TypeOf(transport), reflect.TypeOf(c.client.Transport))
 			}
 
 			transport = tr.Clone()
@@ -258,7 +258,7 @@ func newSession(c *client, ep *transport.Endpoint, auth transport.AuthMethod) (*
 			transport, found = c.fetchTransport(transportOpts)
 
 			if !found {
-				transport = c.c.Transport.(*http.Transport).Clone()
+				transport = c.client.Transport.(*http.Transport).Clone()
 				configureTransport(transport, ep)
 				c.addTransport(transportOpts, transport)
 			}
@@ -266,12 +266,12 @@ func newSession(c *client, ep *transport.Endpoint, auth transport.AuthMethod) (*
 
 		httpClient = &http.Client{
 			Transport:     transport,
-			CheckRedirect: c.c.CheckRedirect,
-			Jar:           c.c.Jar,
-			Timeout:       c.c.Timeout,
+			CheckRedirect: c.client.CheckRedirect,
+			Jar:           c.client.Jar,
+			Timeout:       c.client.Timeout,
 		}
 	} else {
-		httpClient = c.c
+		httpClient = c.client
 	}
 
 	s := &session{

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -46,7 +46,7 @@ func (s *UploadPackSuite) TestNewClient(c *C) {
 	cl := &http.Client{Transport: roundTripper}
 	r, ok := NewClient(cl).(*client)
 	c.Assert(ok, Equals, true)
-	c.Assert(r.c, Equals, cl)
+	c.Assert(r.client, Equals, cl)
 }
 
 func (s *ClientSuite) TestNewBasicAuth(c *C) {

--- a/plumbing/transport/http/transport.go
+++ b/plumbing/transport/http/transport.go
@@ -14,21 +14,21 @@ type transportOptions struct {
 }
 
 func (c *client) addTransport(opts transportOptions, transport *http.Transport) {
-	c.m.Lock()
+	c.mutex.Lock()
 	c.transports.Add(opts, transport)
-	c.m.Unlock()
+	c.mutex.Unlock()
 }
 
 func (c *client) removeTransport(opts transportOptions) {
-	c.m.Lock()
+	c.mutex.Lock()
 	c.transports.Remove(opts)
-	c.m.Unlock()
+	c.mutex.Unlock()
 }
 
 func (c *client) fetchTransport(opts transportOptions) (*http.Transport, bool) {
-	c.m.RLock()
+	c.mutex.RLock()
 	t, ok := c.transports.Get(opts)
-	c.m.RUnlock()
+	c.mutex.RUnlock()
 	if !ok {
 		return nil, false
 	}


### PR DESCRIPTION
The decision to change the name of these fields came from reading the code further down in the scope and not being clear what `c.c` means.

This also aligns it with the convention from other structs in the same file like e.g. the `session` struct:
```
type session struct {
	auth     AuthMethod
	client   *http.Client
	endpoint *transport.Endpoint
	advRefs  *packp.AdvRefs
}
```