### PR TITLE
git: error on empty tag name (#929)

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -51,6 +51,9 @@ var (
 	// ErrFetching is returned when the packfile could not be downloaded
 	ErrFetching = errors.New("unable to fetch packfile")
 
+	// ErrInvalidTagName is returned when the tag name is invalid.
+	ErrInvalidTagName = errors.New("invalid tag name")
+
 	ErrInvalidReference          = errors.New("invalid reference, should be a tag or a branch")
 	ErrRepositoryNotExists       = errors.New("repository does not exist")
 	ErrRepositoryIncomplete      = errors.New("repository's commondir path does not exist")
@@ -724,6 +727,10 @@ func (r *Repository) DeleteBranch(name string) error {
 // CreateTag creates a tag. If opts is included, the tag is an annotated tag,
 // otherwise a lightweight tag is created.
 func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagOptions) (*plumbing.Reference, error) {
+	if name == "" {
+		return nil, ErrInvalidTagName
+	}
+
 	rname := plumbing.ReferenceName(path.Join("refs", "tags", name))
 
 	_, err := r.Storer.Reference(rname)
@@ -757,6 +764,10 @@ func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagO
 }
 
 func (r *Repository) createTagObject(name string, hash plumbing.Hash, opts *CreateTagOptions) (plumbing.Hash, error) {
+	if name == "" {
+		return plumbing.ZeroHash, ErrInvalidTagName
+	}
+
 	if err := opts.Validate(r, hash); err != nil {
 		return plumbing.ZeroHash, err
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -3265,6 +3265,14 @@ func (s *RepositorySuite) TestIssue674(c *C) {
 	c.Check(h.IsZero(), Equals, true)
 }
 
+func (s *RepositorySuite) TestEmptyTagName(c *C) {
+	r, _ := Init(memory.NewStorage(), nil)
+	_, err := r.CreateTag("", plumbing.ZeroHash, nil)
+
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, "invalid tag name")
+}
+
 func BenchmarkObjects(b *testing.B) {
 	defer fixtures.Clean()
 


### PR DESCRIPTION
An empty tagname is an invalid tag.

Fixes: https://github.com/go-git/go-git/issues/929