### PR TITLE
git: validate reference names (#929)

### DIFF
--- a/config/branch.go
+++ b/config/branch.go
@@ -54,7 +54,7 @@ func (b *Branch) Validate() error {
 		return errBranchInvalidRebase
 	}
 
-	return nil
+	return plumbing.NewBranchReferenceName(b.Name).Validate()
 }
 
 func (b *Branch) marshal() *format.Subsection {

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5/internal/url"
+	"github.com/go-git/go-git/v5/plumbing"
 	format "github.com/go-git/go-git/v5/plumbing/format/config"
 )
 
@@ -614,7 +615,7 @@ func (c *RemoteConfig) Validate() error {
 		c.Fetch = []RefSpec{RefSpec(fmt.Sprintf(DefaultFetchRefSpec, c.Name))}
 	}
 
-	return nil
+	return plumbing.NewRemoteHEADReferenceName(c.Name).Validate()
 }
 
 func (c *RemoteConfig) unmarshal(s *format.Subsection) error {

--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -103,6 +103,65 @@ func (s *ReferenceSuite) TestIsTag(c *C) {
 	c.Assert(r.IsTag(), Equals, true)
 }
 
+func (s *ReferenceSuite) TestValidReferenceNames(c *C) {
+	valid := []ReferenceName{
+		"refs/heads/master",
+		"refs/notes/commits",
+		"refs/remotes/origin/master",
+		"HEAD",
+		"refs/tags/v3.1.1",
+		"refs/pulls/1/head",
+		"refs/pulls/1/merge",
+		"refs/pulls/1/abc.123",
+		"refs/pulls",
+		"refs/-", // should this be allowed?
+	}
+	for _, v := range valid {
+		c.Assert(v.Validate(), IsNil)
+	}
+
+	invalid := []ReferenceName{
+		"refs",
+		"refs/",
+		"refs//",
+		"refs/heads/\\",
+		"refs/heads/\\foo",
+		"refs/heads/\\foo/bar",
+		"abc",
+		"",
+		"refs/heads/ ",
+		"refs/heads/ /",
+		"refs/heads/ /foo",
+		"refs/heads/.",
+		"refs/heads/..",
+		"refs/heads/foo..",
+		"refs/heads/foo.lock",
+		"refs/heads/foo@{bar}",
+		"refs/heads/foo[",
+		"refs/heads/foo~",
+		"refs/heads/foo^",
+		"refs/heads/foo:",
+		"refs/heads/foo?",
+		"refs/heads/foo*",
+		"refs/heads/foo[bar",
+		"refs/heads/foo\t",
+		"refs/heads/@",
+		"refs/heads/@{bar}",
+		"refs/heads/\n",
+		"refs/heads/-foo",
+		"refs/heads/foo..bar",
+		"refs/heads/-",
+		"refs/tags/-",
+		"refs/tags/-foo",
+	}
+
+	for i, v := range invalid {
+		comment := Commentf("invalid reference name case %d: %s", i, v)
+		c.Assert(v.Validate(), NotNil, comment)
+		c.Assert(v.Validate(), ErrorMatches, "invalid reference name", comment)
+	}
+}
+
 func benchMarkReferenceString(r *Reference, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		_ = r.String()

--- a/repository.go
+++ b/repository.go
@@ -98,6 +98,10 @@ func InitWithOptions(s storage.Storer, worktree billy.Filesystem, options InitOp
 		options.DefaultBranch = plumbing.Master
 	}
 
+	if err := options.DefaultBranch.Validate(); err != nil {
+		return nil, err
+	}
+
 	r := newRepository(s, worktree)
 	_, err := r.Reference(plumbing.HEAD, false)
 	switch err {
@@ -724,7 +728,10 @@ func (r *Repository) DeleteBranch(name string) error {
 // CreateTag creates a tag. If opts is included, the tag is an annotated tag,
 // otherwise a lightweight tag is created.
 func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagOptions) (*plumbing.Reference, error) {
-	rname := plumbing.ReferenceName(path.Join("refs", "tags", name))
+	rname := plumbing.NewTagReferenceName(name)
+	if err := rname.Validate(); err != nil {
+		return nil, err
+	}
 
 	_, err := r.Storer.Reference(rname)
 	switch err {

--- a/worktree.go
+++ b/worktree.go
@@ -189,6 +189,10 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 	return w.Reset(ro)
 }
 func (w *Worktree) createBranch(opts *CheckoutOptions) error {
+	if err := opts.Branch.Validate(); err != nil {
+		return err
+	}
+
 	_, err := w.r.Storer.Reference(opts.Branch)
 	if err == nil {
 		return fmt.Errorf("a branch named %q already exists", opts.Branch)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -785,6 +785,30 @@ func (s *WorktreeSuite) TestCheckoutCreateMissingBranch(c *C) {
 	c.Assert(err, Equals, ErrCreateRequiresBranch)
 }
 
+func (s *WorktreeSuite) TestCheckoutCreateInvalidBranch(c *C) {
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: memfs.New(),
+	}
+
+	for _, name := range []plumbing.ReferenceName{
+		"foo",
+		"-",
+		"-foo",
+		"refs/heads//",
+		"refs/heads/..",
+		"refs/heads/a..b",
+		"refs/heads/.",
+	} {
+		err := w.Checkout(&CheckoutOptions{
+			Create: true,
+			Branch: name,
+		})
+
+		c.Assert(err, Equals, plumbing.ErrInvalidReferenceName)
+	}
+}
+
 func (s *WorktreeSuite) TestCheckoutTag(c *C) {
 	f := fixtures.ByTag("tags").One()
 	r := s.NewRepositoryWithEmptyWorktree(f)


### PR DESCRIPTION
Check reference names format before creating branches/tags/remotes.

This should probably be in a lower level somewhere in `plumbing`. Validating the names under `plumbing.NewReference*` is not possible since these functions don't return errors.

Fixes: https://github.com/go-git/go-git/issues/929

See https://git-scm.com/docs/git-check-ref-format