### PR TITLE
Fix issue where you cannot checkout by tag commit hash.

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -70,7 +70,18 @@ type Commit struct {
 func GetCommit(s storer.EncodedObjectStorer, h plumbing.Hash) (*Commit, error) {
 	o, err := s.EncodedObject(plumbing.CommitObject, h)
 	if err != nil {
-		return nil, err
+		// Possible the commit object is tied to a tag.
+		o, e := s.EncodedObject(plumbing.TagObject, h)
+		if e != nil {
+			// Send back original error
+			return nil, err
+		}
+		t, e := DecodeTag(s, o)
+		if e != nil {
+			// Send back original error
+			return nil, err
+		}
+		return t.Commit()
 	}
 
 	return DecodeCommit(s, o)

--- a/repository_test.go
+++ b/repository_test.go
@@ -2420,6 +2420,14 @@ func (s *RepositorySuite) TestTagObject(c *C) {
 	c.Assert(tag.Hash.IsZero(), Equals, false)
 	c.Assert(tag.Hash, Equals, hash)
 	c.Assert(tag.Type(), Equals, plumbing.TagObject)
+
+	commit, err := r.CommitObject(hash)
+
+	c.Assert(err, IsNil)
+
+	c.Assert(commit.Hash.IsZero(), Equals, false)
+	c.Assert(commit.Hash, Equals, hash)
+	c.Assert(commit.Type(), Equals, plumbing.CommitObject)
 }
 
 func (s *RepositorySuite) TestTags(c *C) {


### PR DESCRIPTION
In the current state of go-git, checking out by a commit hash ID associated with a tag is not supported. This limitation arises from the fact that, under the hood, the hash is linked to a tag. The checkout process operates under the assumption that a CommitObject should always be obtained. However, if the commit is linked to a tag, the result is a TagObject, leading to an error during type checking.

To address this issue, my solution involves checking if the initial attempt to retrieve the commit using GetCommit fails. If it does, the code then examines whether the obtained object is a TagObject. If it is, the fix involves returning the CommitObject associated with the tag by utilizing the Commit method of the TagObject.
