### PR TITLE
plumbing: object, check legitimacy in (*Tree).Encode

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -27,6 +28,7 @@ var (
 	ErrFileNotFound      = errors.New("file not found")
 	ErrDirectoryNotFound = errors.New("directory not found")
 	ErrEntryNotFound     = errors.New("entry not found")
+	ErrEntriesNotSorted  = errors.New("entries in tree are not sorted")
 )
 
 // Tree is basically like a directory - it references a bunch of other trees
@@ -270,6 +272,28 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	return nil
 }
 
+type TreeEntrySorter []TreeEntry
+
+func (s TreeEntrySorter) Len() int {
+	return len(s)
+}
+
+func (s TreeEntrySorter) Less(i, j int) bool {
+	name1 := s[i].Name
+	name2 := s[j].Name
+	if s[i].Mode == filemode.Dir {
+		name1 += "/"
+	}
+	if s[j].Mode == filemode.Dir {
+		name2 += "/"
+	}
+	return name1 < name2
+}
+
+func (s TreeEntrySorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
 // Encode transforms a Tree into a plumbing.EncodedObject.
 func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	o.SetType(plumbing.TreeObject)
@@ -279,6 +303,11 @@ func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	}
 
 	defer ioutil.CheckClose(w, &err)
+
+	if !sort.IsSorted(TreeEntrySorter(t.Entries)) {
+		return ErrEntriesNotSorted
+	}
+
 	for _, entry := range t.Entries {
 		if strings.IndexByte(entry.Name, 0) != -1 {
 			return fmt.Errorf("malformed filename %q", entry.Name)

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -280,6 +280,9 @@ func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 
 	defer ioutil.CheckClose(w, &err)
 	for _, entry := range t.Entries {
+		if strings.IndexByte(entry.Name, 0) != -1 {
+			return fmt.Errorf("malformed filename %q", entry.Name)
+		}
 		if _, err = fmt.Fprintf(w, "%o %s", entry.Mode, entry.Name); err != nil {
 			return err
 		}


### PR DESCRIPTION
if there is '\x00' in filename, Encode() will produce a malformed object.
also add some checks for entry order