### PR TITLE
git: cli, fix module name

### DIFF
--- a/cli/go-git/go.mod
+++ b/cli/go-git/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-git/v5/go-git/cli/go-git
+module github.com/go-git/go-git/cli/go-git
 
 go 1.19
 


### PR DESCRIPTION
Fix the cli module package name

Fixes: https://github.com/go-git/go-git/issues/952
Fixes: https://github.com/go-git/go-git/pull/914