### PR TITLE
Add crypto.Signer option to CommitOptions.

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"crypto"
 	"errors"
 	"fmt"
 	"regexp"
@@ -507,6 +508,10 @@ type CommitOptions struct {
 	// commit will not be signed. The private key must be present and already
 	// decrypted.
 	SignKey *openpgp.Entity
+	// Signer denotes a cryptographic signer to sign the commit with.
+	// A nil value here means the commit will not be signed.
+	// Takes precedence over SignKey.
+	Signer crypto.Signer
 	// Amend will create a new commit object and replace the commit that HEAD currently
 	// points to. Cannot be used with All nor Parents.
 	Amend bool

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -2,7 +2,10 @@ package git
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/rand"
 	"errors"
+	"io"
 	"path"
 	"sort"
 	"strings"
@@ -14,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v5/storage"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/go-git/go-billy/v5"
 )
 
@@ -125,12 +129,17 @@ func (w *Worktree) buildCommitObject(msg string, opts *CommitOptions, tree plumb
 		ParentHashes: opts.Parents,
 	}
 
-	if opts.SignKey != nil {
-		sig, err := w.buildCommitSignature(commit, opts.SignKey)
+	// Convert SignKey into a Signer if set. Existing Signer should take priority.
+	signer := opts.Signer
+	if signer == nil && opts.SignKey != nil {
+		signer = &gpgSigner{key: opts.SignKey}
+	}
+	if signer != nil {
+		sig, err := w.buildCommitSignature(commit, signer)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
-		commit.PGPSignature = sig
+		commit.PGPSignature = string(sig)
 	}
 
 	obj := w.r.Storer.NewEncodedObject()
@@ -140,20 +149,44 @@ func (w *Worktree) buildCommitObject(msg string, opts *CommitOptions, tree plumb
 	return w.r.Storer.SetEncodedObject(obj)
 }
 
-func (w *Worktree) buildCommitSignature(commit *object.Commit, signKey *openpgp.Entity) (string, error) {
+type gpgSigner struct {
+	key *openpgp.Entity
+}
+
+func (s *gpgSigner) Public() crypto.PublicKey {
+	return s.key.PrimaryKey
+}
+
+func (s *gpgSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	var cfg *packet.Config
+	if opts != nil {
+		cfg = &packet.Config{
+			DefaultHash: opts.HashFunc(),
+		}
+	}
+
+	var b bytes.Buffer
+	if err := openpgp.ArmoredDetachSign(&b, s.key, bytes.NewReader(digest), cfg); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func (w *Worktree) buildCommitSignature(commit *object.Commit, signer crypto.Signer) ([]byte, error) {
 	encoded := &plumbing.MemoryObject{}
 	if err := commit.Encode(encoded); err != nil {
-		return "", err
+		return nil, err
 	}
 	r, err := encoded.Reader()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	var b bytes.Buffer
-	if err := openpgp.ArmoredDetachSign(&b, signKey, r, nil); err != nil {
-		return "", err
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
 	}
-	return b.String(), nil
+
+	return signer.Sign(rand.Reader, b, nil)
 }
 
 // buildTreeHelper converts a given index.Index file into multiple git objects

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -131,7 +131,6 @@ func (s *WorktreeSuite) TestCommitAmend(c *C) {
 	_, err = w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
 	c.Assert(err, IsNil)
 
-
 	amendedHash, err := w.Commit("bar\n", &CommitOptions{Amend: true})
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
This change adds a new `crypto.Signer` option to `CommitOptions` as an alternative to `SignKey` to allow alternative commit signers to be used. This change does not add other signing or verification methods (e.g. ssh, x509, gitsign), but gives callers the ability to start adding their own signing implementations.

This differs from https://github.com/go-git/go-git/pull/705 by using the stdlib `crypto.Signer` interface instead of defining a new `ObjectSigner` interface. We could go with that approach if we want, but using a []byte based approach means that Signer implementations do not need to be aware of how commit encoding works (which is closer to [git's sign_buffer implementation](https://github.com/git/git/blob/a54a84b333adbecf7bc4483c0e36ed5878cac17b/gpg-interface.h#L71)).

Part of https://github.com/go-git/go-git/issues/400

cc @hiddeco 