### PR TITLE
plumbing: commitgraph, add function to build graphs

### DIFF
--- a/plumbing/format/commitgraph/v2/file.go
+++ b/plumbing/format/commitgraph/v2/file.go
@@ -353,6 +353,9 @@ func (fi *fileIndex) GetHashByIndex(idx uint32) (found plumbing.Hash, err error)
 }
 
 func (fi *fileIndex) getHashesFromIndexes(indexes []uint32) ([]plumbing.Hash, error) {
+	if len(indexes) == 0 {
+		return nil, nil
+	}
 	hashes := make([]plumbing.Hash, len(indexes))
 
 	for i, idx := range indexes {

--- a/plumbing/format/commitgraph/v2/memory.go
+++ b/plumbing/format/commitgraph/v2/memory.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"math"
+	"sort"
 
 	"github.com/go-git/go-git/v5/plumbing"
 )
@@ -9,9 +10,11 @@ import (
 // MemoryIndex provides a way to build the commit-graph in memory
 // for later encoding to file.
 type MemoryIndex struct {
-	commitData      []commitData
-	indexMap        map[plumbing.Hash]uint32
-	hasGenerationV2 bool
+	commitData            []commitData
+	indexMap              map[plumbing.Hash]uint32
+	hasGenerationV2       bool
+	minimumNumberOfHashes uint32
+	parent                Index
 }
 
 type commitData struct {
@@ -21,9 +24,21 @@ type commitData struct {
 
 // NewMemoryIndex creates in-memory commit graph representation
 func NewMemoryIndex() *MemoryIndex {
+	return NewMemoryIndexWithParent(nil)
+}
+
+func NewMemoryIndexWithParent(parent Index) *MemoryIndex {
+	minimumNumberOfHashes := uint32(0)
+	hasGenerationV2 := true
+	if parent != nil {
+		minimumNumberOfHashes = parent.MaximumNumberOfHashes()
+		hasGenerationV2 = parent.HasGenerationV2()
+	}
 	return &MemoryIndex{
-		indexMap:        make(map[plumbing.Hash]uint32),
-		hasGenerationV2: true,
+		indexMap:              make(map[plumbing.Hash]uint32),
+		hasGenerationV2:       hasGenerationV2,
+		minimumNumberOfHashes: minimumNumberOfHashes,
+		parent:                parent,
 	}
 }
 
@@ -34,11 +49,19 @@ func (mi *MemoryIndex) GetIndexByHash(h plumbing.Hash) (uint32, error) {
 		return i, nil
 	}
 
+	if mi.parent != nil {
+		return mi.parent.GetIndexByHash(h)
+	}
+
 	return 0, plumbing.ErrObjectNotFound
 }
 
 // GetHashByIndex gets the hash given an index in the commit graph
 func (mi *MemoryIndex) GetHashByIndex(i uint32) (plumbing.Hash, error) {
+	if i < mi.minimumNumberOfHashes {
+		return mi.parent.GetHashByIndex(i)
+	}
+	i -= mi.minimumNumberOfHashes
 	if i >= uint32(len(mi.commitData)) {
 		return plumbing.ZeroHash, plumbing.ErrObjectNotFound
 	}
@@ -49,6 +72,11 @@ func (mi *MemoryIndex) GetHashByIndex(i uint32) (plumbing.Hash, error) {
 // GetCommitDataByIndex gets the commit node from the commit graph using index
 // obtained from child node, if available
 func (mi *MemoryIndex) GetCommitDataByIndex(i uint32) (*CommitData, error) {
+	if i < mi.minimumNumberOfHashes {
+		return mi.parent.GetCommitDataByIndex(i)
+	}
+	i -= mi.minimumNumberOfHashes
+
 	if i >= uint32(len(mi.commitData)) {
 		return nil, plumbing.ErrObjectNotFound
 	}
@@ -72,7 +100,10 @@ func (mi *MemoryIndex) GetCommitDataByIndex(i uint32) (*CommitData, error) {
 
 // Hashes returns all the hashes that are available in the index
 func (mi *MemoryIndex) Hashes() []plumbing.Hash {
-	hashes := make([]plumbing.Hash, 0, len(mi.indexMap))
+	hashes := make([]plumbing.Hash, 0, len(mi.indexMap)+int(mi.minimumNumberOfHashes))
+	if mi.parent != nil {
+		hashes = append(hashes, mi.parent.Hashes()...)
+	}
 	for k := range mi.indexMap {
 		hashes = append(hashes, k)
 	}
@@ -85,7 +116,7 @@ func (mi *MemoryIndex) Add(hash plumbing.Hash, data *CommitData) {
 	// which allows adding nodes out of order as long as all parents
 	// are eventually resolved
 	data.ParentIndexes = nil
-	mi.indexMap[hash] = uint32(len(mi.commitData))
+	mi.indexMap[hash] = uint32(len(mi.commitData)) + mi.minimumNumberOfHashes
 	mi.commitData = append(mi.commitData, commitData{Hash: hash, CommitData: data})
 	if data.GenerationV2 == math.MaxUint64 { // if GenerationV2 is not available reset it to zero
 		data.GenerationV2 = 0
@@ -103,5 +134,15 @@ func (mi *MemoryIndex) Close() error {
 }
 
 func (mi *MemoryIndex) MaximumNumberOfHashes() uint32 {
-	return uint32(len(mi.indexMap))
+	return uint32(len(mi.indexMap)) + mi.minimumNumberOfHashes
+}
+
+func (mi *MemoryIndex) Sort() {
+	sort.Slice(mi.commitData, func(i, j int) bool {
+		return mi.commitData[i].Hash.String() < mi.commitData[j].Hash.String()
+	})
+	for i, commitData := range mi.commitData {
+		commitData.ParentIndexes = nil
+		mi.indexMap[commitData.Hash] = uint32(i) + mi.minimumNumberOfHashes
+	}
 }

--- a/plumbing/object/commitgraph/commitnode.go
+++ b/plumbing/object/commitgraph/commitnode.go
@@ -16,6 +16,8 @@ type CommitNode interface {
 	ID() plumbing.Hash
 	// Tree returns the Tree referenced by the commit graph node.
 	Tree() (*object.Tree, error)
+	// TreeHash returns the Tree hash referenced by the commit graph node.
+	TreeHash() plumbing.Hash
 	// CommitTime returns the Committer.When time of the Commit referenced by the commit graph node.
 	CommitTime() time.Time
 	// NumParents returns the number of parents in a commit.

--- a/plumbing/object/commitgraph/commitnode_graph.go
+++ b/plumbing/object/commitgraph/commitnode_graph.go
@@ -131,6 +131,10 @@ func (c *graphCommitNode) Commit() (*object.Commit, error) {
 	return object.GetCommit(c.gci.s, c.hash)
 }
 
+func (c *graphCommitNode) TreeHash() plumbing.Hash {
+	return c.commitData.TreeHash
+}
+
 func (c *graphCommitNode) String() string {
 	return fmt.Sprintf(
 		"%s %s\nDate:   %s",

--- a/plumbing/object/commitgraph/commitnode_graph_builder.go
+++ b/plumbing/object/commitgraph/commitnode_graph_builder.go
@@ -1,0 +1,275 @@
+package commitgraph
+
+import (
+	"errors"
+	"math"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	commitgraph "github.com/go-git/go-git/v5/plumbing/format/commitgraph/v2"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+)
+
+type CreateCommitNodeGraphOptions struct {
+	Commits object.CommitIter // If nil then all commits in the storage are used as potential heads, otherwise only the commits in the iter are used
+	Append  bool              // Append all commits in the old index to the new index
+	Chain   bool              // Chain the new index to the old index (only valid if Append is false and the old index has generation v2)
+}
+
+// CreateCommitGraph takes a provided storage and possible old Index and creates a new commit graph.
+// To create a pack specific graph pass in a storer that is restricted to the packfile.
+func CreateCommitGraph(s storer.EncodedObjectStorer, old commitgraph.Index, opts CreateCommitNodeGraphOptions) (commitgraph.Index, error) {
+	commitIndex := NewGraphCommitNodeIndex(old, s)
+
+	var parent commitgraph.Index
+	if opts.Chain && old != nil && old.HasGenerationV2() {
+		parent = old
+	}
+
+	index := commitgraph.NewMemoryIndexWithParent(parent)
+	heads := opts.Commits
+
+	if heads == nil {
+		objIter, err := s.IterEncodedObjects(plumbing.CommitObject)
+		if err != nil {
+			return nil, err
+		}
+		heads = object.NewCommitIter(s, objIter)
+	}
+
+	builder := &commitGraphBuilder{
+		index:       index,
+		toWalk:      make([]*object.Commit, 0, 32),
+		commitIndex: commitIndex,
+	}
+
+	if opts.Append && old != nil {
+		for i := uint32(0); i < old.MaximumNumberOfHashes(); i++ {
+			hash, err := old.GetHashByIndex(i)
+			if err != nil {
+				return nil, err
+			}
+			commitNode, err := commitIndex.Get(hash)
+			if err != nil {
+				return nil, err
+			}
+			if err := builder.AddCommitNode(commitNode); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	err := heads.ForEach(builder.AddCommit)
+	if err != nil {
+		return nil, err
+	}
+	builder.index.Sort()
+
+	return builder.index, nil
+}
+
+var errParentsNotInGraph = errors.New("parents not in graph")
+
+type commitGraphBuilder struct {
+	index       *commitgraph.MemoryIndex
+	toWalk      []*object.Commit // Stack of commits being walked - this may get as large as the longest chain
+	commitIndex CommitNodeIndex
+}
+
+// AddCommitNode adds a commitnode read from a provided graph to the new graph
+func (c *commitGraphBuilder) AddCommitNode(commitNode CommitNode) error {
+	if c.has(commitNode.ID()) {
+		return nil
+	}
+	if generationDataIsSet(commitNode) {
+		// we can just copy this into the index
+		c.copyCommitNode(commitNode.ID(), commitNode)
+		return nil
+	}
+
+	// The provied commit node doesn't have valid generation data - treat it as a commit
+	commit, err := commitNode.Commit()
+	if err != nil {
+		return err
+	}
+	return c.AddCommit(commit)
+}
+
+// AddCommit adds a commit and its parents to the new graph
+func (c *commitGraphBuilder) AddCommit(commit *object.Commit) error {
+	if c.has(commit.Hash) {
+		return nil
+	}
+
+	c.push(commit)
+	for {
+		commit := c.peek()
+		if commit == nil {
+			break
+		}
+		if err := c.tryToAdd(commit); err == errParentsNotInGraph {
+			continue
+		} else if err != nil {
+			return err
+		}
+		c.pop()
+	}
+	return nil
+}
+
+// peek returns the top of the stack of commits waiting to be added without removing it
+func (c *commitGraphBuilder) peek() *object.Commit {
+	if len(c.toWalk) == 0 {
+		return nil
+	}
+	return c.toWalk[len(c.toWalk)-1]
+}
+
+// pop returns and removes the top of the stack of commits waiting to be added
+func (c *commitGraphBuilder) pop() *object.Commit {
+	if len(c.toWalk) == 0 {
+		return nil
+	}
+	commit := c.toWalk[len(c.toWalk)-1]
+	c.toWalk = c.toWalk[:len(c.toWalk)-1]
+	if len(c.toWalk) == 0 && cap(c.toWalk) > 32 {
+		// reset the stack to a small size to avoid keeping memory around
+		c.toWalk = make([]*object.Commit, 0, 32)
+	}
+	return commit
+}
+
+// push adds a commit to the top of the stack of commits waiting to be added
+func (c *commitGraphBuilder) push(commit *object.Commit) {
+	c.toWalk = append(c.toWalk, commit)
+}
+
+// has returns true if the provided hash is already in the graph
+func (c *commitGraphBuilder) has(hash plumbing.Hash) bool {
+	_, err := c.index.GetIndexByHash(hash)
+	return err == nil
+}
+
+// copyCommitNode copies a commitnode from the old graph to the new graph
+func (c *commitGraphBuilder) copyCommitNode(hash plumbing.Hash, commitNode CommitNode) {
+	c.index.Add(hash, &commitgraph.CommitData{
+		TreeHash:     commitNode.TreeHash(),
+		ParentHashes: commitNode.ParentHashes(),
+		Generation:   commitNode.Generation(),
+		GenerationV2: commitNode.GenerationV2(),
+		When:         commitNode.CommitTime(),
+	})
+}
+
+// generationDataIsSet returns true if the provided commitnode has valid generation data
+func generationDataIsSet(commitNode CommitNode) bool {
+	return commitNode.Generation() != math.MaxUint64 &&
+		(commitNode.GenerationV2() != 0 || commitNode.CommitTime().Unix() == 0)
+}
+
+// tryToAdd will try to add a commit to the graph. If the parents of the commit are not already in
+// the graph it will push them to the stack to be added and return errParentsNotInGraph.
+func (c *commitGraphBuilder) tryToAdd(commit *object.Commit) error {
+	if c.has(commit.Hash) {
+		// Already in the graph and nothing to do
+		return nil
+	}
+
+	// Get a commit node for this commit from the old index
+	// - this will usually be a simple wrapper around the commit with invalid and unset generation data.
+	// - but if the commit is in the old graph it will return valid generation data and we can add that directly
+	commitNode, err := c.commitIndex.Get(commit.Hash)
+	if err != nil {
+		return err
+	}
+	if generationDataIsSet(commitNode) {
+		// commitData can be copied in to the graph
+		c.copyCommitNode(commit.Hash, commitNode)
+		return nil
+	}
+
+	// If the generation data isn't set then the node is not in the graph yet
+	// - therefore we should try to convert the commit into a valid commitdata
+	// - this will return errParentsNotInGraph if the parents are not in the graph
+	//   meaning we wiil need to walk this commit again later.
+	commitData, err := c.convertToCommitData(commit, commitNode)
+	if err != nil { // this includes errParentsNotInGraph
+		return err
+	}
+	c.index.Add(commit.Hash, commitData)
+	return nil
+}
+
+// convertToCommitData will convert a provided object.Commit and its wrapped graph CommitNode
+// into a raw commitgraph CommitData to be added to the graph.
+//
+// Recall the generation of a Commit is the maximum generation of its parents + 1, and the
+// generationV2 is the maximum of its commitTime as unix time, or its parents generationV2s + 1.
+//
+// Therefore we need the parents of this provided commit to be in the graph already.
+// If they are not in the graph we need to add the parents to the stack and then walk them before
+// we can add this commit to the graph.
+func (c *commitGraphBuilder) convertToCommitData(commit *object.Commit, commitData CommitNode) (*commitgraph.CommitData, error) {
+	// Default values for generation and generationV2
+	generation, generationV2 := uint64(1), uint64(commitData.CommitTime().Unix())
+
+	// Flag to label that all parents are in the graph
+	parentsInGraph := true
+
+	// Walk the parents of the commit
+	err := commitData.ParentNodes().ForEach(func(parent CommitNode) error {
+		// Get the index of the parent in the graph
+		parentIdx, err := c.index.GetIndexByHash(parent.ID())
+		if err != nil {
+			// This parent is not in the graph yet...
+			parentsInGraph = false
+
+			// get the parent commit and push it to our stack to add next
+			parentCommit, err := parent.Commit()
+			if err != nil {
+				return err
+			}
+			c.push(parentCommit)
+
+			return nil
+		}
+
+		if !parentsInGraph { // no point loading the commit data from the index at this point
+			return nil
+		}
+
+		// Load the data for this parent
+		parentData, err := c.index.GetCommitDataByIndex(parentIdx)
+		if err != nil {
+			return err
+		}
+
+		// Update the generation and generationV2 if needed
+		if generation <= parentData.Generation {
+			generation = parentData.Generation + 1
+		}
+		if generationV2 <= parentData.GenerationV2 {
+			generationV2 = parentData.GenerationV2 + 1
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// If all of our parents are not in the graph we need to abort and walk those
+	// parents first.
+	if !parentsInGraph {
+		return nil, errParentsNotInGraph
+	}
+
+	// We can now create the commitData
+	return &commitgraph.CommitData{
+		TreeHash:     commitData.TreeHash(),
+		ParentHashes: commitData.ParentHashes(),
+		Generation:   generation,
+		GenerationV2: generationV2,
+		When:         commitData.CommitTime(),
+	}, nil
+}

--- a/plumbing/object/commitgraph/commitnode_graph_builder_test.go
+++ b/plumbing/object/commitgraph/commitnode_graph_builder_test.go
@@ -1,0 +1,154 @@
+package commitgraph
+
+import (
+	"reflect"
+
+	fixtures "github.com/go-git/go-git-fixtures/v4"
+	commitgraph "github.com/go-git/go-git/v5/plumbing/format/commitgraph/v2"
+	. "gopkg.in/check.v1"
+)
+
+type noGenerationDataIndex struct {
+	commitgraph.Index
+}
+
+func (f *noGenerationDataIndex) GetCommitDataByIndex(i uint32) (*commitgraph.CommitData, error) {
+	data, err := f.Index.GetCommitDataByIndex(i)
+	if err != nil {
+		return data, err
+	}
+	return &commitgraph.CommitData{
+		TreeHash:      data.TreeHash,
+		ParentIndexes: data.ParentIndexes,
+		ParentHashes:  data.ParentHashes,
+		Generation:    data.Generation,
+		GenerationV2:  0,
+		When:          data.When,
+	}, err
+}
+
+func (f *noGenerationDataIndex) HasGenerationV2() bool {
+	return false
+}
+
+func (s *CommitNodeSuite) TestCreateCommitNodeGraph(c *C) {
+	f := fixtures.ByTag("commit-graph-chain-2").One()
+
+	storer := unpackRepository(f)
+
+	index, err := commitgraph.OpenChainOrFileIndex(storer.Filesystem())
+	c.Assert(err, IsNil)
+
+	newIndex, err := CreateCommitGraph(storer, index, CreateCommitNodeGraphOptions{})
+	c.Assert(err, IsNil)
+
+	appendIndex, err := CreateCommitGraph(storer, index, CreateCommitNodeGraphOptions{Append: true})
+	c.Assert(err, IsNil)
+
+	appendIndexNoGeneration, err := CreateCommitGraph(storer, &noGenerationDataIndex{index}, CreateCommitNodeGraphOptions{Append: true})
+	c.Assert(err, IsNil)
+
+	chainIndex, err := CreateCommitGraph(storer, index, CreateCommitNodeGraphOptions{Chain: true})
+	c.Assert(err, IsNil)
+
+	chainIndexNoGeneration, err := CreateCommitGraph(storer, &noGenerationDataIndex{index}, CreateCommitNodeGraphOptions{Chain: true})
+	c.Assert(err, IsNil)
+
+	fullIndex, err := CreateCommitGraph(storer, nil, CreateCommitNodeGraphOptions{})
+	c.Assert(err, IsNil)
+
+	c.Assert(len(newIndex.Hashes()), Equals, len(index.Hashes()))
+
+	hashesInNewIndex := make([]string, newIndex.MaximumNumberOfHashes())
+	for _, hash := range newIndex.Hashes() {
+		nidx, err := newIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		hashesInNewIndex[nidx] = hash.String()
+		_, err = appendIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		_, err = appendIndexNoGeneration.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		_, err = chainIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		_, err = chainIndexNoGeneration.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+	}
+
+	hashesInIndex := make([]string, index.MaximumNumberOfHashes())
+	for _, hash := range index.Hashes() {
+		oidx, err := index.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		hashesInIndex[oidx] = hash.String()
+		_, err = appendIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		chainIdx, err := chainIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		c.Assert(chainIdx, Equals, oidx)
+	}
+
+	hashesInFullIndex := make([]string, fullIndex.MaximumNumberOfHashes())
+	for _, hash := range fullIndex.Hashes() {
+		fidx, err := fullIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		hashesInFullIndex[fidx] = hash.String()
+	}
+
+	c.Assert(hashesInNewIndex, DeepEquals, hashesInFullIndex)
+	c.Assert(hashesInNewIndex, DeepEquals, hashesInFullIndex)
+
+	for _, hash := range newIndex.Hashes() {
+		fidx, err := fullIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		nidx, err := newIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		newData, err := newIndex.GetCommitDataByIndex(nidx)
+		c.Assert(err, IsNil)
+		fullData, err := fullIndex.GetCommitDataByIndex(fidx)
+		c.Assert(err, IsNil)
+		c.Assert(newData, CommitDataChecker, fullData)
+		chainIdx, err := chainIndexNoGeneration.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		dataChained, err := chainIndexNoGeneration.GetCommitDataByIndex(chainIdx)
+		c.Assert(err, IsNil)
+		c.Assert(newData, CommitDataChecker, dataChained)
+	}
+	for _, hash := range appendIndex.Hashes() {
+		idx, err := appendIndex.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		data, err := appendIndex.GetCommitDataByIndex(idx)
+		c.Assert(err, IsNil)
+		noGenIdx, err := appendIndexNoGeneration.GetIndexByHash(hash)
+		c.Assert(err, IsNil)
+		dataNoGen, err := appendIndexNoGeneration.GetCommitDataByIndex(noGenIdx)
+		c.Assert(err, IsNil)
+		c.Assert(data, CommitDataChecker, dataNoGen)
+	}
+}
+
+type commitDataChecker struct {
+	*CheckerInfo
+}
+
+var CommitDataChecker = &commitDataChecker{
+	&CheckerInfo{Name: "CommitDataChecker", Params: []string{"obtained", "expected"}},
+}
+
+func (checker *commitDataChecker) Check(params []interface{}, names []string) (result bool, error string) {
+	if params[0] == params[1] {
+		return true, ""
+	}
+
+	left, right := params[0].(*commitgraph.CommitData), params[1].(*commitgraph.CommitData)
+	if left == nil ||
+		right == nil ||
+		left.TreeHash != right.TreeHash ||
+		!reflect.DeepEqual(left.ParentIndexes, right.ParentIndexes) ||
+		!reflect.DeepEqual(left.ParentHashes, right.ParentHashes) ||
+		left.Generation != right.Generation ||
+		left.GenerationV2 != right.GenerationV2 ||
+		left.When.Unix() != right.When.Unix() {
+		return DeepEquals.Check(params, names)
+	}
+
+	return true, ""
+}

--- a/plumbing/object/commitgraph/commitnode_object.go
+++ b/plumbing/object/commitgraph/commitnode_object.go
@@ -95,3 +95,7 @@ func (c *objectCommitNode) GenerationV2() uint64 {
 func (c *objectCommitNode) Commit() (*object.Commit, error) {
 	return c.commit, nil
 }
+
+func (c *objectCommitNode) TreeHash() plumbing.Hash {
+	return c.commit.TreeHash
+}

--- a/plumbing/object/commitgraph/commitnode_test.go
+++ b/plumbing/object/commitgraph/commitnode_test.go
@@ -95,6 +95,7 @@ func testCommitAndTree(c *C, nodeIndex CommitNodeIndex) {
 	tree, err := merge3node.Tree()
 	c.Assert(err, IsNil)
 	c.Assert(tree.ID().String(), Equals, merge3commit.TreeHash.String())
+	c.Assert(merge3commit.Committer.When.Unix(), Equals, merge3node.CommitTime().Unix())
 }
 
 func (s *CommitNodeSuite) TestObjectGraph(c *C) {


### PR DESCRIPTION
Make builder function for creating commitgraphs which could be written with the functionality in encoder.go.