### PR TITLE
add stubs to allow compilation under GOOS=tamago

### DIFF
--- a/worktree_tamago.go
+++ b/worktree_tamago.go
@@ -1,0 +1,26 @@
+// +build tamago
+
+package git
+
+import (
+	"syscall"
+	"time"
+
+	"github.com/go-git/go-git/v5/plumbing/format/index"
+)
+
+func init() {
+	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+		if os, ok := sys.(*syscall.Stat_t); ok {
+			e.CreatedAt = time.Unix(int64(os.Ctime), int64(os.CtimeNsec))
+			e.Dev = uint32(os.Dev)
+			e.Inode = uint32(os.Ino)
+			e.GID = os.Gid
+			e.UID = os.Uid
+		}
+	}
+}
+
+func isSymlinkWindowsNonAdmin(err error) bool {
+	return false
+}


### PR DESCRIPTION
The [TamaGo bare metal framework](https://github.com/usbarmory/tamago) would benefit from being able to integrate go-git on bare metal firmware.

This PR, in combination with [this go-billy PR](https://github.com/go-git/go-billy/pull/43) adds the required stubs to allow compilation under GOOS=tamago.

Thanks
