### PR TITLE
plumbing: format/gitattributes, close file in ReadAttributesFile

### DIFF
--- a/plumbing/format/gitattributes/attributes.go
+++ b/plumbing/format/gitattributes/attributes.go
@@ -1,6 +1,7 @@
 package gitattributes
 
 import (
+	"bufio"
 	"errors"
 	"io"
 	"strings"
@@ -88,13 +89,10 @@ func (a attribute) String() string {
 
 // ReadAttributes reads patterns and attributes from the gitattributes format.
 func ReadAttributes(r io.Reader, domain []string, allowMacro bool) (attributes []MatchAttribute, err error) {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
+	scanner := bufio.NewScanner(r)
 
-	for _, line := range strings.Split(string(data), eol) {
-		attribute, err := ParseAttributesLine(line, domain, allowMacro)
+	for scanner.Scan() {
+		attribute, err := ParseAttributesLine(scanner.Text(), domain, allowMacro)
 		if err != nil {
 			return attributes, err
 		}
@@ -103,6 +101,10 @@ func ReadAttributes(r io.Reader, domain []string, allowMacro bool) (attributes [
 		}
 
 		attributes = append(attributes, attribute)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return attributes, err
 	}
 
 	return attributes, nil

--- a/plumbing/format/gitattributes/dir.go
+++ b/plumbing/format/gitattributes/dir.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/go-git/go-billy/v5"
+
 	"github.com/go-git/go-git/v5/plumbing/format/config"
 	gioutil "github.com/go-git/go-git/v5/utils/ioutil"
 )
@@ -25,6 +26,8 @@ func ReadAttributesFile(fs billy.Filesystem, path []string, attributesFile strin
 	if err != nil {
 		return nil, err
 	}
+
+	defer gioutil.CheckClose(f, &err)
 
 	return ReadAttributes(f, path, allowMacro)
 }


### PR DESCRIPTION
`gitattributes.ReadAttributesFile(...)` currently doesn't close the successfully opened file causing troubles especially on Windows systems.

This PR fixes this issue.

Furthermore I added a tiny optimisation to not read the `.gitattributes` file completely to memory before processing it but to use a `bufio.Scanner` to process it line by line.

See issue #1017 