### PR TITLE
_example: fix 404 link and added ssh-agent clone link

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -10,7 +10,8 @@ Here you can find a list of annotated _go-git_ examples:
       using a username and password.
     - [personal access token](clone/auth/basic/access_token/main.go) - Cloning
       a repository using a GitHub personal access token.
-    - [ssh private key](clone/auth/ssh/main.go) - Cloning a repository using a ssh private key.
+    - [ssh private key](clone/auth/ssh/private_key/main.go) - Cloning a repository using a ssh private key.
+    - [ssh agent](clone/auth/ssh/ssh_agent/main.go) - Cloning a repository using ssh-agent.
 - [commit](commit/main.go) - Commit changes to the current branch to an existent repository.
 - [push](push/main.go) - Push repository to default remote (origin).
 - [pull](pull/main.go) - Pull changes from a remote repository.


### PR DESCRIPTION
- Fixing dead links on readme and added link for the missing example