### PR TITLE
git: worktree, Fix file reported as `Untracked` while it is committed

### DIFF
--- a/status.go
+++ b/status.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+
+	mindex "github.com/go-git/go-git/v5/utils/merkletrie/index"
+	"github.com/go-git/go-git/v5/utils/merkletrie/noder"
 )
 
 // Status represents the current status of a Worktree.
@@ -77,3 +80,69 @@ const (
 	Copied             StatusCode = 'C'
 	UpdatedButUnmerged StatusCode = 'U'
 )
+
+// StatusStrategy defines the different types of strategies when processing
+// the worktree status.
+type StatusStrategy int
+
+const (
+	// TODO: (V6) Review the default status strategy.
+	// TODO: (V6) Review the type used to represent Status, to enable lazy
+	// processing of statuses going direct to the backing filesystem.
+	defaultStatusStrategy = Empty
+
+	// Empty starts its status map from empty. Missing entries for a given
+	// path means that the file is untracked. This causes a known issue (#119)
+	// whereby unmodified files can be incorrectly reported as untracked.
+	//
+	// This can be used when returning the changed state within a modified Worktree.
+	// For example, to check whether the current worktree is clean.
+	Empty StatusStrategy = 0
+	// Preload goes through all existing nodes from the index and add them to the
+	// status map as unmodified. This is currently the most reliable strategy
+	// although it comes at a performance cost in large repositories.
+	//
+	// This method is recommended when fetching the status of unmodified files.
+	// For example, to confirm the status of a specific file that is either
+	// untracked or unmodified.
+	Preload StatusStrategy = 1
+)
+
+func (s StatusStrategy) new(w *Worktree) (Status, error) {
+	switch s {
+	case Preload:
+		return preloadStatus(w)
+	case Empty:
+		return make(Status), nil
+	}
+	return nil, fmt.Errorf("%w: %+v", ErrUnsupportedStatusStrategy, s)
+}
+
+func preloadStatus(w *Worktree) (Status, error) {
+	idx, err := w.r.Storer.Index()
+	if err != nil {
+		return nil, err
+	}
+
+	idxRoot := mindex.NewRootNode(idx)
+	nodes := []noder.Noder{idxRoot}
+
+	status := make(Status)
+	for len(nodes) > 0 {
+		var node noder.Noder
+		node, nodes = nodes[0], nodes[1:]
+		if node.IsDir() {
+			children, err := node.Children()
+			if err != nil {
+				return nil, err
+			}
+			nodes = append(nodes, children...)
+			continue
+		}
+		fs := status.File(node.Name())
+		fs.Worktree = Unmodified
+		fs.Staging = Unmodified
+	}
+
+	return status, nil
+}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1052,6 +1052,25 @@ func (s *WorktreeSuite) TestStatusEmptyDirty(c *C) {
 	c.Assert(status, HasLen, 1)
 }
 
+func (s *WorktreeSuite) TestStatusUnmodified(c *C) {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	err := w.Checkout(&CheckoutOptions{Force: true})
+	c.Assert(err, IsNil)
+
+	status, err := w.Status()
+	c.Assert(err, IsNil)
+	c.Assert(status.IsClean(), Equals, true)
+	c.Assert(status.IsUntracked("LICENSE"), Equals, false)
+
+	c.Assert(status.File("LICENSE").Staging, Equals, Unmodified)
+	c.Assert(status.File("LICENSE").Worktree, Equals, Unmodified)
+}
+
 func (s *WorktreeSuite) TestReset(c *C) {
 	fs := memfs.New()
 	w := &Worktree{

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1062,13 +1062,21 @@ func (s *WorktreeSuite) TestStatusUnmodified(c *C) {
 	err := w.Checkout(&CheckoutOptions{Force: true})
 	c.Assert(err, IsNil)
 
-	status, err := w.Status()
+	status, err := w.StatusWithOptions(StatusOptions{Strategy: Preload})
 	c.Assert(err, IsNil)
 	c.Assert(status.IsClean(), Equals, true)
 	c.Assert(status.IsUntracked("LICENSE"), Equals, false)
 
 	c.Assert(status.File("LICENSE").Staging, Equals, Unmodified)
 	c.Assert(status.File("LICENSE").Worktree, Equals, Unmodified)
+
+	status, err = w.StatusWithOptions(StatusOptions{Strategy: Empty})
+	c.Assert(err, IsNil)
+	c.Assert(status.IsClean(), Equals, true)
+	c.Assert(status.IsUntracked("LICENSE"), Equals, false)
+
+	c.Assert(status.File("LICENSE").Staging, Equals, Untracked)
+	c.Assert(status.File("LICENSE").Worktree, Equals, Untracked)
 }
 
 func (s *WorktreeSuite) TestReset(c *C) {


### PR DESCRIPTION
## Overview

When using the lib I have also faced this problem #119. After looking into the code my understanding is that we were initializing the `status` empty before making the diff operations. This causes an empty status object when no diff is encountered. Which lead us to get `Untracked` status for committed files.

I manage to solve this by adding an initialization method for our `status` that iterates over the `storer` index building an initial status with all the unmodified files included. This way, when we use `status.File` it will find it on the map and will return correctly the `Unmodified` status.

Fix #119 