### PR TITLE
storage, dotgit: translate error code in *DotGit.Object

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -608,6 +608,9 @@ func (d *DotGit) hasIncomingObjects() bool {
 func (d *DotGit) Object(h plumbing.Hash) (billy.File, error) {
 	err := d.hasObject(h)
 	if err != nil {
+		if err == plumbing.ErrObjectNotFound {
+			return nil, os.ErrNotExist
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Callers of *DotGit.Object expect an os.ErrNotExist error when an object file is not found, but the internal hasObject function might return a plumbing.ErrObjectNotFound error, which needs to be translated.