### PR TITLE
plumbing: object, Make first commit visible on logs filtered with filename. Fixes #191

### DIFF
--- a/plumbing/object/commit_walker_path.go
+++ b/plumbing/object/commit_walker_path.go
@@ -115,7 +115,8 @@ func (c *commitPathIter) hasFileChange(changes Changes, parent *Commit) bool {
 
 		// filename matches, now check if source iterator contains all commits (from all refs)
 		if c.checkParent {
-			if parent != nil && isParentHash(parent.Hash, c.currentCommit) {
+			// Check if parent is beyond the initial commit
+			if parent == nil || isParentHash(parent.Hash, c.currentCommit) {
 				return true
 			}
 			continue

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -228,3 +228,29 @@ func (s *CommitWalkerSuite) TestCommitBSFIteratorWithIgnore(c *C) {
 		c.Assert(commit.Hash.String(), Equals, expected[i])
 	}
 }
+
+func (s *CommitWalkerSuite) TestCommitPathIteratorInitialCommit(c *C) {
+	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
+
+	fileName := "LICENSE"
+
+	var commits []*Commit
+	NewCommitPathIterFromIter(
+		func(path string) bool { return path == fileName },
+		NewCommitIterCTime(commit, nil, nil),
+		true,
+	).ForEach(func(c *Commit) error {
+		commits = append(commits, c)
+		return nil
+	})
+
+	expected := []string{
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+	}
+
+	c.Assert(commits, HasLen, len(expected))
+
+	for i, commit := range commits {
+		c.Assert(commit.Hash.String(), Equals, expected[i])
+	}
+}


### PR DESCRIPTION
This PR fixes #191.

Because the `parentCommit` in `(*commitPathIter).getNextFileCommit()` is nil if `currentCommit` is initial commit, 
I modified the condition to pass when parent == nil.


