### PR TITLE
git: worktree, Don't panic on empty or root path when checking if it is valid

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -428,6 +428,10 @@ var worktreeDeny = map[string]struct{}{
 func validPath(paths ...string) error {
 	for _, p := range paths {
 		parts := strings.FieldsFunc(p, func(r rune) bool { return (r == '\\' || r == '/') })
+		if len(parts) == 0 {
+			return fmt.Errorf("invalid path: %q", p)
+		}
+
 		if _, denied := worktreeDeny[strings.ToLower(parts[0])]; denied {
 			return fmt.Errorf("invalid path prefix: %q", p)
 		}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2957,6 +2957,8 @@ func TestValidPath(t *testing.T) {
 		{"git~1", true},
 		{"a/../b", true},
 		{"a\\..\\b", true},
+		{"/", true},
+		{"", true},
 		{".gitmodules", false},
 		{".gitignore", false},
 		{"a..b", false},


### PR DESCRIPTION
I didn't dig into the specific case that was triggering this, but we did have a panic in our production system.