### PR TITLE
git: Implement Merge function with initial `FastForwardMerge` support

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -27,14 +27,14 @@ compatibility status with go-git.
 
 ## Branching and merging
 
-| Feature     | Sub-feature | Status | Notes                                   | Examples                                                                                        |
-| ----------- | ----------- | ------ | --------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `branch`    |             | ✅     |                                         | - [branch](_examples/branch/main.go)                                                            |
-| `checkout`  |             | ✅     | Basic usages of checkout are supported. | - [checkout](_examples/checkout/main.go)                                                        |
-| `merge`     |             | ❌     |                                         |                                                                                                 |
-| `mergetool` |             | ❌     |                                         |                                                                                                 |
-| `stash`     |             | ❌     |                                         |                                                                                                 |
-| `tag`       |             | ✅     |                                         | - [tag](_examples/tag/main.go) <br/> - [tag create and push](_examples/tag-create-push/main.go) |
+| Feature     | Sub-feature | Status       | Notes                                   | Examples                                                                                        |
+| ----------- | ----------- | ------------ | --------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `branch`    |             | ✅           |                                         | - [branch](_examples/branch/main.go)                                                            |
+| `checkout`  |             | ✅           | Basic usages of checkout are supported. | - [checkout](_examples/checkout/main.go)                                                        |
+| `merge`     |             | ⚠️ (partial) | Fast-forward only                       |                                                                                                 |
+| `mergetool` |             | ❌           |                                         |                                                                                                 |
+| `stash`     |             | ❌           |                                         |                                                                                                 |
+| `tag`       |             | ✅           |                                         | - [tag](_examples/tag/main.go) <br/> - [tag create and push](_examples/tag-create-push/main.go) |
 
 ## Sharing and updating projects
 

--- a/options.go
+++ b/options.go
@@ -89,6 +89,13 @@ type CloneOptions struct {
 	Shared bool
 }
 
+// MergeOptions describes how a merge should be erformed
+type MergeOptions struct {
+	// Requires a merge to be fast forward only. If this is true, then a merge will
+	// throw an error if ff is not possible.
+	FFOnly bool
+}
+
 // Validate validates the fields and sets the default values.
 func (o *CloneOptions) Validate() error {
 	if o.URL == "" {

--- a/options.go
+++ b/options.go
@@ -89,12 +89,24 @@ type CloneOptions struct {
 	Shared bool
 }
 
-// MergeOptions describes how a merge should be erformed
+// MergeOptions describes how a merge should be performed.
 type MergeOptions struct {
-	// Requires a merge to be fast forward only. If this is true, then a merge will
-	// throw an error if ff is not possible.
-	FFOnly bool
+	// Strategy defines the merge strategy to be used.
+	Strategy MergeStrategy
 }
+
+// MergeStrategy represents the different types of merge strategies.
+type MergeStrategy int8
+
+const (
+	// FastForwardMerge represents a Git merge strategy where the current
+	// branch can be simply updated to point to the HEAD of the branch being
+	// merged. This is only possible if the history of the branch being merged
+	// is a linear descendant of the current branch, with no conflicting commits.
+	//
+	// This is the default option.
+	FastForwardMerge MergeStrategy = iota
+)
 
 // Validate validates the fields and sets the default values.
 func (o *CloneOptions) Validate() error {

--- a/remote.go
+++ b/remote.go
@@ -1128,7 +1128,7 @@ func isFastForward(s storer.EncodedObjectStorer, old, new plumbing.Hash, earlies
 	}
 
 	found := false
-	// stop iterating at the earlist shallow commit, ignoring its parents
+	// stop iterating at the earliest shallow commit, ignoring its parents
 	// note: when pull depth is smaller than the number of new changes on the remote, this fails due to missing parents.
 	//       as far as i can tell, without the commits in-between the shallow pull and the earliest shallow, there's no
 	//       real way of telling whether it will be a fast-forward merge.

--- a/repository.go
+++ b/repository.go
@@ -1769,6 +1769,25 @@ func (r *Repository) RepackObjects(cfg *RepackConfig) (err error) {
 	return nil
 }
 
+// Merge attempts to merge ref onto HEAD. Currently only supports fast-forward merges
+func (r *Repository) Merge(ref plumbing.Reference, opts MergeOptions) error {
+	if !opts.FFOnly {
+		return errors.New("non fast-forward merges are not supported yet")
+	}
+
+	head, err := r.Head()
+	if err != nil {
+		return err
+	}
+
+	ff, err := IsFastForward(r.Storer, head.Hash(), ref.Hash())
+	if !ff {
+		return errors.New("fast forward is not possible")
+	}
+
+	return r.Storer.SetReference(plumbing.NewHashReference(head.Name(), ref.Hash()))
+}
+
 // createNewObjectPack is a helper for RepackObjects taking care
 // of creating a new pack. It is used so the the PackfileWriter
 // deferred close has the right scope.

--- a/repository.go
+++ b/repository.go
@@ -51,19 +51,21 @@ var (
 	// ErrFetching is returned when the packfile could not be downloaded
 	ErrFetching = errors.New("unable to fetch packfile")
 
-	ErrInvalidReference          = errors.New("invalid reference, should be a tag or a branch")
-	ErrRepositoryNotExists       = errors.New("repository does not exist")
-	ErrRepositoryIncomplete      = errors.New("repository's commondir path does not exist")
-	ErrRepositoryAlreadyExists   = errors.New("repository already exists")
-	ErrRemoteNotFound            = errors.New("remote not found")
-	ErrRemoteExists              = errors.New("remote already exists")
-	ErrAnonymousRemoteName       = errors.New("anonymous remote name must be 'anonymous'")
-	ErrWorktreeNotProvided       = errors.New("worktree should be provided")
-	ErrIsBareRepository          = errors.New("worktree not available in a bare repository")
-	ErrUnableToResolveCommit     = errors.New("unable to resolve commit")
-	ErrPackedObjectsNotSupported = errors.New("packed objects not supported")
-	ErrSHA256NotSupported        = errors.New("go-git was not compiled with SHA256 support")
-	ErrAlternatePathNotSupported = errors.New("alternate path must use the file scheme")
+	ErrInvalidReference            = errors.New("invalid reference, should be a tag or a branch")
+	ErrRepositoryNotExists         = errors.New("repository does not exist")
+	ErrRepositoryIncomplete        = errors.New("repository's commondir path does not exist")
+	ErrRepositoryAlreadyExists     = errors.New("repository already exists")
+	ErrRemoteNotFound              = errors.New("remote not found")
+	ErrRemoteExists                = errors.New("remote already exists")
+	ErrAnonymousRemoteName         = errors.New("anonymous remote name must be 'anonymous'")
+	ErrWorktreeNotProvided         = errors.New("worktree should be provided")
+	ErrIsBareRepository            = errors.New("worktree not available in a bare repository")
+	ErrUnableToResolveCommit       = errors.New("unable to resolve commit")
+	ErrPackedObjectsNotSupported   = errors.New("packed objects not supported")
+	ErrSHA256NotSupported          = errors.New("go-git was not compiled with SHA256 support")
+	ErrAlternatePathNotSupported   = errors.New("alternate path must use the file scheme")
+	ErrUnsupportedMergeStrategy    = errors.New("unsupported merge strategy")
+	ErrFastForwardMergeNotPossible = errors.New("not possible to fast-forward merge changes")
 )
 
 // Repository represents a git repository
@@ -1769,10 +1771,22 @@ func (r *Repository) RepackObjects(cfg *RepackConfig) (err error) {
 	return nil
 }
 
-// Merge attempts to merge ref onto HEAD. Currently only supports fast-forward merges
+// Merge merges the reference branch into the current branch.
+//
+// If the merge is not possible (or supported) returns an error without changing
+// the HEAD for the current branch. Possible errors include:
+//   - The merge strategy is not supported.
+//   - The specific strategy cannot be used (e.g. using FastForwardMerge when one is not possible).
 func (r *Repository) Merge(ref plumbing.Reference, opts MergeOptions) error {
-	if !opts.FFOnly {
-		return errors.New("non fast-forward merges are not supported yet")
+	if opts.Strategy != FastForwardMerge {
+		return ErrUnsupportedMergeStrategy
+	}
+
+	// Ignore error as not having a shallow list is optional here.
+	shallowList, _ := r.Storer.Shallow()
+	var earliestShallow *plumbing.Hash
+	if len(shallowList) > 0 {
+		earliestShallow = &shallowList[0]
 	}
 
 	head, err := r.Head()
@@ -1780,9 +1794,13 @@ func (r *Repository) Merge(ref plumbing.Reference, opts MergeOptions) error {
 		return err
 	}
 
-	ff, err := IsFastForward(r.Storer, head.Hash(), ref.Hash())
+	ff, err := isFastForward(r.Storer, head.Hash(), ref.Hash(), earliestShallow)
+	if err != nil {
+		return err
+	}
+
 	if !ff {
-		return errors.New("fast forward is not possible")
+		return ErrFastForwardMergeNotPossible
 	}
 
 	return r.Storer.SetReference(plumbing.NewHashReference(head.Name(), ref.Hash()))


### PR DESCRIPTION
Introduces the `Merge` function for merging branches in the codebase.
Currently, the function only supports `FastForwardMerge` strategy, meaning it can efficiently update the target branch pointer if the source branch history is a linear descendant.

Support for additional merge strategies (e.g., three-way merge) will be added in future commits.

This PR expands and supersedes the work from #442. Thanks @john-cai for the initial contribution.

Fixes https://github.com/go-git/go-git/issues/905. 
Relates to https://github.com/go-git/go-git/issues/942.