### PR TITLE
plumbing: object, Optimize logging with file.

### DIFF
--- a/plumbing/object/commit_walker_path.go
+++ b/plumbing/object/commit_walker_path.go
@@ -57,6 +57,8 @@ func (c *commitPathIter) Next() (*Commit, error) {
 }
 
 func (c *commitPathIter) getNextFileCommit() (*Commit, error) {
+	var parentTree, currentTree *Tree
+
 	for {
 		// Parent-commit can be nil if the current-commit is the initial commit
 		parentCommit, parentCommitErr := c.sourceIter.Next()
@@ -68,13 +70,17 @@ func (c *commitPathIter) getNextFileCommit() (*Commit, error) {
 			parentCommit = nil
 		}
 
-		// Fetch the trees of the current and parent commits
-		currentTree, currTreeErr := c.currentCommit.Tree()
-		if currTreeErr != nil {
-			return nil, currTreeErr
+		if parentTree == nil {
+			var currTreeErr error
+			currentTree, currTreeErr = c.currentCommit.Tree()
+			if currTreeErr != nil {
+				return nil, currTreeErr
+			}
+		} else {
+			currentTree = parentTree
+			parentTree = nil
 		}
 
-		var parentTree *Tree
 		if parentCommit != nil {
 			var parentTreeErr error
 			parentTree, parentTreeErr = parentCommit.Tree()

--- a/plumbing/object/treenoder.go
+++ b/plumbing/object/treenoder.go
@@ -88,7 +88,9 @@ func (t *treeNoder) Children() ([]noder.Noder, error) {
 		}
 	}
 
-	return transformChildren(parent)
+	var err error
+	t.children, err = transformChildren(parent)
+	return t.children, err
 }
 
 // Returns the children of a tree as treenoders.


### PR DESCRIPTION
Connected to: #811

So, I've been digging this issue. Then I found that `object.(*treeNoder).NumChildren` was the one that is consuming most of cpu time.

After some investigtion, I figured out that treeNoder.children field is documented as "memoized", but none of the code actually saves its result.

```go
type treeNoder struct {
	parent   *Tree  // the root node is its own parent
	name     string // empty string for the root node
	mode     filemode.FileMode
	hash     plumbing.Hash
	children []noder.Noder // memoized <- here!!
}
```

So I modified the code to save the result of `transformChildren()`. And here's how it is changed.

> Ran on Apple M2 processor

## Before

<img width="1665" alt="image1" src="https://github.com/go-git/go-git/assets/103808587/9359d896-0bb9-4192-9674-0dbf5cb51ee6">

Output:

```
$ go run main.go
2024/03/10 13:53:55 cloning repository
2024/03/10 13:54:01 git log start
2024/03/10 13:54:33 time elapsed: 31.432235916s
```

## After

<img width="1673" alt="image" src="https://github.com/go-git/go-git/assets/103808587/0c39d434-20d4-4e9d-bd96-876598fa84ff">

Output:

```
$ go run main.go
2024/03/10 13:49:51 cloning repository
2024/03/10 13:49:58 git log start
2024/03/10 13:50:10 time elapsed: 12.343892125s
```

I'm guessing there could be more optimization like making `object.(*Tree).Decode` faster, but I have no idea what to do with it.

Also, I added little optimization in `(*commitPathIter).getNextFileCommit()` which reuses parent's tree in iteration.

code used to test it:

```go
package main

import (
	"log"
	"time"

	"net/http"
	_ "net/http/pprof"

	"github.com/go-git/go-billy/v5/memfs"
	git "github.com/go-git/go-git/v5"
	"github.com/go-git/go-git/v5/plumbing/object"
	"github.com/go-git/go-git/v5/storage/memory"
)

func main() {
	go func() {
		log.Println(http.ListenAndServe("localhost:6060", nil))
	}()

	fs := memfs.New()

	log.Println("cloning repository")
	rep, _ := git.Clone(memory.NewStorage(), fs, &git.CloneOptions{
		URL: "https://www.github.com/sigmahq/sigma",
	})

	f := "README.md"

	log.Println("git log start")
	start := time.Now()

	cIter, _ := rep.Log(&git.LogOptions{FileName: &f})
	_ = cIter.ForEach(func(c *object.Commit) error { return nil })

	log.Printf("time elapsed: %s\n", time.Since(start))
}

```
