### PR TITLE
git: worktree_commit, Modify checking empty commit. Fixes #723

### DIFF
--- a/repository_test.go
+++ b/repository_test.go
@@ -103,9 +103,10 @@ func createCommit(c *C, r *Repository) plumbing.Hash {
 	}
 
 	h, err := wt.Commit("test commit message", &CommitOptions{
-		All:       true,
-		Author:    &author,
-		Committer: &author,
+		All:               true,
+		Author:            &author,
+		Committer:         &author,
+		AllowEmptyCommits: true,
 	})
 	c.Assert(err, IsNil)
 	return h


### PR DESCRIPTION
Changed condition of checking empty commit from `count of entries == 0` to `createdHash == parentHash`.

There was an edge case where the given commit is initial commit and worktree has no entries. So I made another control branch to check it.

I'm not aware of other edge cases it might have. If there is one, please let me know.

Connected to #723 