### PR TITLE
Properly support skipping of non-mandatory extensions 

### DIFF
--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -273,6 +273,8 @@ func (d *Decoder) readExtension(idx *Index) error {
 			return err
 		}
 	default:
+		// See https://git-scm.com/docs/index-format, which says:
+		// If the first byte is 'A'..'Z' the extension is optional and can be ignored.
 		if header[0] < 'A' || header[0] > 'Z' {
 			return ErrUnknownExtension
 		}

--- a/storage/filesystem/index.go
+++ b/storage/filesystem/index.go
@@ -48,7 +48,7 @@ func (s *IndexStorage) Index() (i *index.Index, err error) {
 
 	defer ioutil.CheckClose(f, &err)
 
-	d := index.NewDecoder(bufio.NewReader(f))
+	d := index.NewDecoder(f)
 	err = d.Decode(idx)
 	return idx, err
 }


### PR DESCRIPTION
See the 2 individual commits.

This fix might cause some existing repos to fail now, because go-git did not properly fail on `link` extensions (split index). I assume it's fine to fail, as this extension is mandatory anyway and behaviour is actually undefined/buggy when handling of it is skipped.

Fixes: #299
