### PR TITLE
fix(up): divide the encoding of UploadPackReponse into two steps

### DIFF
--- a/plumbing/protocol/packp/uppackresp.go
+++ b/plumbing/protocol/packp/uppackresp.go
@@ -72,6 +72,13 @@ func (r *UploadPackResponse) Decode(reader io.ReadCloser) error {
 
 // Encode encodes an UploadPackResponse.
 func (r *UploadPackResponse) Encode(w io.Writer) (err error) {
+	if err := r.EncodePacketLines(w); err != nil {
+		return err
+	}
+	return r.EncodePackfiles(w)
+}
+
+func (r *UploadPackResponse) EncodePacketLines(w io.Writer) error {
 	if r.isShallow {
 		if err := r.ShallowUpdate.Encode(w); err != nil {
 			return err
@@ -82,6 +89,10 @@ func (r *UploadPackResponse) Encode(w io.Writer) (err error) {
 		return err
 	}
 
+	return nil
+}
+
+func (r *UploadPackResponse) EncodePackfiles(w io.Writer) (err error) {
 	defer ioutil.CheckClose(r.r, &err)
 	_, err = io.Copy(w, r.r)
 	return err


### PR DESCRIPTION
This PR is to divide the encoding of UploadPackReponse into two steps. So the user can use two different writers for pkt-lines and packfiles when integrating with `side-band` enabled clients, for example, [isomorphic-git](https://isomorphic-git.org/).

For example, the pseudo-code is like the following:
```
var w io.writer
if err = response.EncodePacketLines(w); err != nil {
	return error
}

muxer := sideband.NewMuxer(sideband.Sideband, w)
if err = response.EncodePackfiles(muxer); err != nil {
	return err
}

return nil
```