### PR TITLE
git: repository, Ignore ErrEmptyRemoteRepositry when cloning an empty repo. Fixes #986

### DIFF
--- a/plumbing/transport/http/receive_pack_test.go
+++ b/plumbing/transport/http/receive_pack_test.go
@@ -22,3 +22,12 @@ func (s *ReceivePackSuite) SetUpTest(c *C) {
 	s.ReceivePackSuite.EmptyEndpoint = s.prepareRepository(c, fixtures.ByTag("empty").One(), "empty.git")
 	s.ReceivePackSuite.NonExistentEndpoint = s.newEndpoint(c, "non-existent.git")
 }
+
+func (s *ReceivePackSuite) TestAdvertisedReferencesEmptyRepo(c *C) {
+	client, err := s.Client.NewReceivePackSession(s.EmptyEndpoint, basicAuthFromEndpoint(s.EmptyEndpoint))
+	c.Assert(err, IsNil)
+
+	ref, err := client.AdvertisedReferences()
+	c.Assert(err, IsNil)
+	c.Assert(ref.IsEmpty(), Equals, true)
+}

--- a/repository_test.go
+++ b/repository_test.go
@@ -276,6 +276,19 @@ func (s *RepositorySuite) TestCloneMirror(c *C) {
 	c.Assert(cfg.Remotes[DefaultRemoteName].Mirror, Equals, true)
 }
 
+func (s *RepositorySuite) TestCloneEmptyRemote(c *C) {
+	fs := memfs.New()
+	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
+		URL: fixtures.ByTag("empty").One().URL,
+	})
+
+	c.Assert(err, IsNil)
+
+	remotes, err := r.Remotes()
+	c.Assert(err, IsNil)
+	c.Assert(remotes, HasLen, 1)
+}
+
 func (s *RepositorySuite) TestCloneWithTags(c *C) {
 	url := s.GetLocalRepositoryURL(
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),


### PR DESCRIPTION
Connected to: #986 

Modified (*Repository).clone() to not occur an error when remote repository is empty.
I also added a test for receive pack with empty repo.