### PR TITLE
storage: dotgit, head reference usually comes first

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -249,7 +249,7 @@ func (d *DotGit) objectPacks() ([]plumbing.Hash, error) {
 			continue
 		}
 
-		h := plumbing.NewHash(n[5 : len(n)-5]) //pack-(hash).pack
+		h := plumbing.NewHash(n[5 : len(n)-5]) // pack-(hash).pack
 		if h.IsZero() {
 			// Ignore files with badly-formatted names.
 			continue
@@ -701,16 +701,16 @@ func (d *DotGit) SetRef(r, old *plumbing.Reference) error {
 // Symbolic references are resolved and included in the output.
 func (d *DotGit) Refs() ([]*plumbing.Reference, error) {
 	var refs []*plumbing.Reference
-	var seen = make(map[plumbing.ReferenceName]bool)
+	seen := make(map[plumbing.ReferenceName]bool)
+	if err := d.addRefFromHEAD(&refs); err != nil {
+		return nil, err
+	}
+
 	if err := d.addRefsFromRefDir(&refs, seen); err != nil {
 		return nil, err
 	}
 
 	if err := d.addRefsFromPackedRefs(&refs, seen); err != nil {
-		return nil, err
-	}
-
-	if err := d.addRefFromHEAD(&refs); err != nil {
 		return nil, err
 	}
 
@@ -815,7 +815,8 @@ func (d *DotGit) addRefsFromPackedRefsFile(refs *[]*plumbing.Reference, f billy.
 }
 
 func (d *DotGit) openAndLockPackedRefs(doCreate bool) (
-	pr billy.File, err error) {
+	pr billy.File, err error,
+) {
 	var f billy.File
 	defer func() {
 		if err != nil && f != nil {
@@ -1020,7 +1021,7 @@ func (d *DotGit) readReferenceFile(path, name string) (ref *plumbing.Reference, 
 
 func (d *DotGit) CountLooseRefs() (int, error) {
 	var refs []*plumbing.Reference
-	var seen = make(map[plumbing.ReferenceName]bool)
+	seen := make(map[plumbing.ReferenceName]bool)
 	if err := d.addRefsFromRefDir(&refs, seen); err != nil {
 		return 0, err
 	}

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -85,6 +85,15 @@ func (s *SuiteDotGit) TestSetRefsNorwfs(c *C) {
 	testSetRefs(c, dir)
 }
 
+func (s *SuiteDotGit) TestRefsHeadFirst(c *C) {
+	fs := fixtures.Basic().ByTag(".git").One().DotGit()
+	dir := New(fs)
+	refs, err := dir.Refs()
+	c.Assert(err, IsNil)
+	c.Assert(len(refs), Not(Equals), 0)
+	c.Assert(refs[0].Name().String(), Equals, "HEAD")
+}
+
 func testSetRefs(c *C, dir *DotGit) {
 	firstFoo := plumbing.NewReferenceFromStrings(
 		"refs/heads/foo",
@@ -175,7 +184,6 @@ func (s *SuiteDotGit) TestRefsFromPackedRefs(c *C) {
 	ref := findReference(refs, "refs/remotes/origin/branch")
 	c.Assert(ref, NotNil)
 	c.Assert(ref.Hash().String(), Equals, "e8d3ffab552895c19b9fcf7aa264d277cde33881")
-
 }
 
 func (s *SuiteDotGit) TestRefsFromReferenceFile(c *C) {
@@ -189,7 +197,6 @@ func (s *SuiteDotGit) TestRefsFromReferenceFile(c *C) {
 	c.Assert(ref, NotNil)
 	c.Assert(ref.Type(), Equals, plumbing.SymbolicReference)
 	c.Assert(string(ref.Target()), Equals, "refs/remotes/origin/master")
-
 }
 
 func BenchmarkRefMultipleTimes(b *testing.B) {
@@ -538,7 +545,6 @@ func (s *SuiteDotGit) TestObjectPackWithKeepDescriptors(c *C) {
 
 	err = dir.Close()
 	c.Assert(err, NotNil)
-
 }
 
 func (s *SuiteDotGit) TestObjectPackIdx(c *C) {
@@ -649,7 +655,7 @@ func (s *SuiteDotGit) TestObject(c *C) {
 		file.Name(), fs.Join("objects", "03", "db8e1fbe133a480f2867aac478fd866686d69e")),
 		Equals, true,
 	)
-	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
+	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "tmp_objdir-incoming-123456")
 	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
 	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
@@ -670,7 +676,7 @@ func (s *SuiteDotGit) TestPreGit235Object(c *C) {
 		file.Name(), fs.Join("objects", "03", "db8e1fbe133a480f2867aac478fd866686d69e")),
 		Equals, true,
 	)
-	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
+	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "incoming-123456")
 	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
 	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
@@ -687,7 +693,7 @@ func (s *SuiteDotGit) TestObjectStat(c *C) {
 	hash := plumbing.NewHash("03db8e1fbe133a480f2867aac478fd866686d69e")
 	_, err := dir.ObjectStat(hash)
 	c.Assert(err, IsNil)
-	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
+	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "tmp_objdir-incoming-123456")
 	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
 	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
@@ -705,7 +711,7 @@ func (s *SuiteDotGit) TestObjectDelete(c *C) {
 	err := dir.ObjectDelete(hash)
 	c.Assert(err, IsNil)
 
-	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
+	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "tmp_objdir-incoming-123456")
 	incomingSubDirPath := fs.Join(incomingDirPath, incomingHash[0:2])
 	incomingFilePath := fs.Join(incomingSubDirPath, incomingHash[2:40])


### PR DESCRIPTION
When reading the repository references from DotGit, the HEAD reference should always come first.

This mimics the behavior of `git show-ref --head`