### PR TITLE
git: Added an example for Repository.Branches

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -137,6 +137,21 @@ func ExampleRepository_References() {
 
 }
 
+func ExampleRepository_Branches() {
+	r, _ := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+		URL: "https://github.com/git-fixtures/basic.git",
+	})
+
+	branches, _ := r.Branches()
+	branches.ForEach(func(branch *plumbing.Reference) error {
+		fmt.Println(branch.Hash().String(), branch.Name())
+		return nil
+	})
+
+	// Example Output:
+	// 6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/master
+}
+
 func ExampleRepository_CreateRemote() {
 	r, _ := git.Init(memory.NewStorage(), nil)
 


### PR DESCRIPTION
Hi, 

Just wanted to say I think this library is super cool and I really appreciate the hard work you guys do.
I saw that some methods are missing examples so I wanted to give back and write an example for the Branches() function.

I read the [contributing guidelines](https://github.com/go-git/go-git/blob/bdb35e1950b5829c88df134810a0aa9a7da9bc22/CONTRIBUTING.md) to see how I should format my commit message and I ended up going with using `git` as the prefix for the commit message because the example is tied to that package. Let me know if this is right :)