### PR TITLE
Fix for "Brown Out" when trying to connect to Microsoft DevOps Repos

### DIFF
--- a/plumbing/transport/ssh/auth_method.go
+++ b/plumbing/transport/ssh/auth_method.go
@@ -81,6 +81,10 @@ func (a *Password) ClientConfig() (*ssh.ClientConfig, error) {
 	return a.SetHostKeyCallback(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.Password(a.Password)},
+		HostKeyAlgorithms: []string{
+			ssh.KeyAlgoRSASHA256,
+			ssh.KeyAlgoRSASHA512,
+		},
 	})
 }
 


### PR DESCRIPTION
Microsoft introduced a "brownout" for SSH-RSA based authenticaction. In the future, only RSA-SHA2-256 and RSA-SHA2-512 are accepted. This does make a lot of sense, as the SHA-1 algorithm used for SSH-RSA authentication is not considered state of the art any more.

Details on SSH-RSA deprecaction:
https://devblogs.microsoft.com/devops/ssh-rsa-deprecation/

This patch changes the configuration of the SSH client to use RSA-SHA2-256 and RSA-SHA2-512 only. It's not advised to keep using SSH-RSA.

The fix caused by go-git based program to work again.

I'm very sorry for not providing a unit-test and detailled bug reports with this fix. It does work - I'm using it in production. It's also very tiny, so you might be able to accept it from a simple review. 

Otherwise, please feed back to me and I'll try to provide more material, as soon as I find the time. 



