### PR TITLE
plumbing: protocol/packp/sideband, Expose Flush() to make muxer usable.

### DIFF
--- a/plumbing/protocol/packp/sideband/muxer.go
+++ b/plumbing/protocol/packp/sideband/muxer.go
@@ -37,6 +37,11 @@ func (m *Muxer) Write(p []byte) (int, error) {
 	return m.WriteChannel(PackData, p)
 }
 
+// Flush encodes a flush-pkt to the output stream
+func (m *Muxer) Flush() error {
+	return m.e.Flush()
+}
+
 // WriteChannel writes p in the given channel. This method can be used with any
 // channel, but is recommend use it only for the ProgressMessage and
 // ErrorMessage channels and use Write for the PackData channel

--- a/plumbing/protocol/packp/sideband/muxer_test.go
+++ b/plumbing/protocol/packp/sideband/muxer_test.go
@@ -15,6 +15,10 @@ func (s *SidebandSuite) TestMuxerWrite(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 1998)
 	c.Assert(buf.Len(), Equals, 2008)
+
+	err = m.Flush()
+	c.Assert(err, IsNil)
+	c.Assert(buf.Len(), Equals, 2012)
 }
 
 func (s *SidebandSuite) TestMuxerWriteChannelMultipleChannels(c *C) {
@@ -34,6 +38,9 @@ func (s *SidebandSuite) TestMuxerWriteChannelMultipleChannels(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 4)
 
-	c.Assert(buf.Len(), Equals, 27)
-	c.Assert(buf.String(), Equals, "0009\x01DDDD0009\x02PPPP0009\x01DDDD")
+	err = m.Flush()
+	c.Assert(err, IsNil)
+
+	c.Assert(buf.Len(), Equals, 31)
+	c.Assert(buf.String(), Equals, "0009\x01DDDD0009\x02PPPP0009\x01DDDD0000")
 }


### PR DESCRIPTION
Without printing the Flush command, the muxer cannot be used to communicate with a git client. Exposed Flush() method from the pkt-line encoder to be able to call it through the Muxer.