### PR TITLE
git: worktree, Fix sparse reset. Fixes #90

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -34,6 +34,7 @@ compatibility status with go-git.
 | `merge`     |             | ⚠️ (partial) | Fast-forward only                       |                                                                                                 |
 | `mergetool` |             | ❌           |                                         |                                                                                                 |
 | `stash`     |             | ❌           |                                         |                                                                                                 |
+| `sparse-checkout`     |             | ✅           |                                         | - [sparse-checkout](_examples/sparse-checkout/main.go)                                                                                               |
 | `tag`       |             | ✅           |                                         | - [tag](_examples/tag/main.go) <br/> - [tag create and push](_examples/tag-create-push/main.go) |
 
 ## Sharing and updating projects

--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -33,6 +33,7 @@ var args = map[string][]string{
 	"revision":                   {cloneRepository(defaultURL, tempFolder()), "master~2^"},
 	"sha256":                     {tempFolder()},
 	"showcase":                   {defaultURL, tempFolder()},
+	"sparse-checkout":            {defaultURL, "vendor", tempFolder()},
 	"tag":                        {cloneRepository(defaultURL, tempFolder())},
 }
 

--- a/_examples/sparse-checkout/main.go
+++ b/_examples/sparse-checkout/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"os"
+
+	"github.com/go-git/go-git/v5"
+	. "github.com/go-git/go-git/v5/_examples"
+)
+
+func main() {
+	CheckArgs("<url>", "<sparse_path>", "<directory>")
+	url := os.Args[1]
+	path := os.Args[2]
+	directory := os.Args[3]
+
+	Info("git clone %s %s", url, directory)
+
+	r, err := git.PlainClone(directory, false, &git.CloneOptions{
+		URL:        url,
+		NoCheckout: true,
+	})
+	CheckIfError(err)
+
+	w, err := r.Worktree()
+	CheckIfError(err)
+
+	err = w.Checkout(&git.CheckoutOptions{
+		SparseCheckoutDirectories: []string{path},
+	})
+	CheckIfError(err)
+}

--- a/repository_test.go
+++ b/repository_test.go
@@ -301,7 +301,8 @@ func (s *RepositorySuite) TestCloneWithTags(c *C) {
 func (s *RepositorySuite) TestCloneSparse(c *C) {
 	fs := memfs.New()
 	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
-		URL: s.GetBasicLocalRepositoryURL(),
+		URL:        s.GetBasicLocalRepositoryURL(),
+		NoCheckout: true,
 	})
 	c.Assert(err, IsNil)
 

--- a/worktree.go
+++ b/worktree.go
@@ -328,13 +328,10 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 
 func (w *Worktree) resetIndex(t *object.Tree, dirs []string) error {
 	idx, err := w.r.Storer.Index()
-	if len(dirs) > 0 {
-		idx.SkipUnless(dirs)
-	}
-
 	if err != nil {
 		return err
 	}
+
 	b := newIndexBuilder(idx)
 
 	changes, err := w.diffTreeWithStaging(t, true)
@@ -376,6 +373,11 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs []string) error {
 	}
 
 	b.Write(idx)
+
+	if len(dirs) > 0 {
+		idx.SkipUnless(dirs)
+	}
+
 	return w.r.Storer.SetIndex(idx)
 }
 
@@ -1058,7 +1060,7 @@ func rmFileAndDirsIfEmpty(fs billy.Filesystem, name string) error {
 	dir := filepath.Dir(name)
 	for {
 		removed, err := removeDirIfEmpty(fs, dir)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -484,7 +484,8 @@ func (s *WorktreeSuite) TestCheckoutSymlink(c *C) {
 func (s *WorktreeSuite) TestCheckoutSparse(c *C) {
 	fs := memfs.New()
 	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
-		URL: s.GetBasicLocalRepositoryURL(),
+		URL:        s.GetBasicLocalRepositoryURL(),
+		NoCheckout: true,
 	})
 	c.Assert(err, IsNil)
 
@@ -1263,6 +1264,29 @@ func (s *WorktreeSuite) TestResetHardWithGitIgnore(c *C) {
 	status, err = w.Status()
 	c.Assert(err, IsNil)
 	c.Assert(status.IsClean(), Equals, true)
+}
+
+func (s *WorktreeSuite) TestResetSparsely(c *C) {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	sparseResetDirs := []string{"php"}
+
+	err := w.ResetSparsely(&ResetOptions{Mode: HardReset}, sparseResetDirs)
+	c.Assert(err, IsNil)
+
+	files, err := fs.ReadDir("/")
+	c.Assert(err, IsNil)
+	c.Assert(files, HasLen, 1)
+	c.Assert(files[0].Name(), Equals, "php")
+
+	files, err = fs.ReadDir("/php")
+	c.Assert(err, IsNil)
+	c.Assert(files, HasLen, 1)
+	c.Assert(files[0].Name(), Equals, "crappy.php")
 }
 
 func (s *WorktreeSuite) TestStatusAfterCheckout(c *C) {


### PR DESCRIPTION
The operation applying sparse reset directories was performed before modifying indexes.
Therefore, It was overwritten by index modification.

So I moved the logic to perform after index modification.

This should fix #90.

