### PR TITLE
Add Filter to FetchOptions

### DIFF
--- a/options.go
+++ b/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	formatcfg "github.com/go-git/go-git/v5/plumbing/format/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 )
@@ -199,6 +200,8 @@ type FetchOptions struct {
 	// Depth limit fetching to the specified number of commits from the tip of
 	// each remote branch history.
 	Depth int
+	// Filter asks the server for a filter as described in git-rev-list.
+	Filter packp.Filter
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 	// Progress is where the human readable information sent by the server is

--- a/plumbing/protocol/packp/ulreq.go
+++ b/plumbing/protocol/packp/ulreq.go
@@ -99,6 +99,10 @@ func NewUploadRequestFromCapabilities(adv *capability.List) *UploadRequest {
 		r.Capabilities.Set(capability.Agent, capability.DefaultAgent())
 	}
 
+	if adv.Supports(capability.Filter) {
+		r.Capabilities.Set(capability.Filter)
+	}
+
 	return r
 }
 
@@ -131,6 +135,10 @@ func (req *UploadRequest) validateRequiredCapabilities() error {
 
 	if len(req.Shallows) != 0 && !req.Capabilities.Supports(capability.Shallow) {
 		return fmt.Errorf(msg, capability.Shallow)
+	}
+
+	if req.Filter != "" && !req.Capabilities.Supports(capability.Filter) {
+		return fmt.Errorf(msg, capability.Filter)
 	}
 
 	switch req.Depth.(type) {

--- a/plumbing/protocol/packp/ulreq_test.go
+++ b/plumbing/protocol/packp/ulreq_test.go
@@ -107,3 +107,16 @@ func (s *UlReqSuite) TestValidateConflictMultiACK(c *C) {
 	err := r.Validate()
 	c.Assert(err, NotNil)
 }
+
+func (s *UlReqSuite) TestValidateFilter(c *C) {
+	r := NewUploadRequest()
+	r.Wants = append(r.Wants, plumbing.NewHash("1111111111111111111111111111111111111111"))
+	r.Filter = "blob:none"
+
+	err := r.Validate()
+	c.Assert(err, NotNil)
+
+	r.Capabilities.Set(capability.Filter)
+	err = r.Validate()
+	c.Assert(err, IsNil)
+}

--- a/remote.go
+++ b/remote.go
@@ -1156,6 +1156,10 @@ func (r *Remote) newUploadPackRequest(o *FetchOptions,
 		}
 	}
 
+	if o.Filter != "" {
+		req.Filter = o.Filter
+	}
+
 	if o.Progress == nil && ar.Capabilities.Supports(capability.NoProgress) {
 		if err := req.Capabilities.Set(capability.NoProgress); err != nil {
 			return nil, err


### PR DESCRIPTION
Allow a Filter to be specified in FetchOptions.

Positively set the Filter capability when constructing an UploadRequest, and include the Filter when constructing an UploadPackRequest.