### PR TITLE
Revert "Add option approximating `git clean -x` flag."

### DIFF
--- a/options.go
+++ b/options.go
@@ -721,10 +721,7 @@ const (
 
 // CleanOptions describes how a clean should be performed.
 type CleanOptions struct {
-	// Dir recurses into nested directories.
 	Dir bool
-	// All removes all changes, even those excluded by gitignore.
-	All bool
 }
 
 // GrepOptions describes how a grep should be performed.

--- a/worktree.go
+++ b/worktree.go
@@ -865,11 +865,10 @@ func (w *Worktree) Clean(opts *CleanOptions) error {
 	if err != nil {
 		return err
 	}
-	m := gitignore.NewMatcher([]gitignore.Pattern{})
 	return w.doClean(s, opts, root, files)
 }
 
-func (w *Worktree) doClean(status Status, matcher gitignore.Matcher, opts *CleanOptions, dir string, files []os.FileInfo) error {
+func (w *Worktree) doClean(status Status, opts *CleanOptions, dir string, files []os.FileInfo) error {
 	for _, fi := range files {
 		if fi.Name() == GitDirName {
 			continue
@@ -886,12 +885,12 @@ func (w *Worktree) doClean(status Status, matcher gitignore.Matcher, opts *Clean
 			if err != nil {
 				return err
 			}
-			err = w.doClean(status, matcher, opts, path, subfiles)
+			err = w.doClean(status, opts, path, subfiles)
 			if err != nil {
 				return err
 			}
 		} else {
-			if status.IsUntracked(path) || (opts.All && matcher.Match(strings.Split(path, string(os.PathSeparator)), false)) {
+			if status.IsUntracked(path) {
 				if err := w.Filesystem.Remove(path); err != nil {
 					return err
 				}

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -144,20 +144,20 @@ func (w *Worktree) diffStagingWithWorktree(reverse, excludeIgnoredChanges bool) 
 	return c, nil
 }
 
-func (w *Worktree) gitignoreMatcher() (gitignore.Matcher, error) {
-	patterns, err := gitignore.ReadPatterns(w.Filesystem, nil)
-	if err != nil {
-		return nil, err
-	}
-	patterns = append(patterns, w.Excludes...)
-	return gitignore.NewMatcher(patterns), nil
-}
-	
 func (w *Worktree) excludeIgnoredChanges(changes merkletrie.Changes) merkletrie.Changes {
-	m, err := w.gitignoreMatcher()
+	patterns, err := gitignore.ReadPatterns(w.Filesystem, nil)
 	if err != nil {
 		return changes
 	}
+
+	patterns = append(patterns, w.Excludes...)
+
+	if len(patterns) == 0 {
+		return changes
+	}
+
+	m := gitignore.NewMatcher(patterns)
+
 	var res merkletrie.Changes
 	for _, ch := range changes {
 		var path []string

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2371,45 +2371,6 @@ func (s *WorktreeSuite) TestClean(c *C) {
 	c.Assert(err, ErrorMatches, ".*(no such file or directory.*|.*file does not exist)*.")
 }
 
-func (s *WorktreeSuite) TestCleanAll(c *C) {
-	fs := fixtures.Basic().ByTag("worktree").One().Worktree()
-	r, err := PlainOpen(fs.Root())
-	c.Assert(err, IsNil)
-	w, err := r.Worktree()
-	c.Assert(err, IsNil)
-
-	err = util.WriteFile(w.Filesystem, ".gitignore", []byte("foo\n"), 0755)
-	c.Assert(err, IsNil)
-
-	_, err = w.Add(".")
-	c.Assert(err, IsNil)
-
-	commitOpts := &CommitOptions{Author: &object.Signature{Name: "foo", Email: "foo@foo.foo", When: time.Now()}}
-	_, err = w.Commit("Add gitignore", commitOpts)
-	c.Assert(err, IsNil)
-
-	status, err := w.Status()
-	c.Assert(err, IsNil)
-	c.Assert(len(status), Equals, 0)
-
-	err = util.WriteFile(w.Filesystem, "foo", []byte("foo\n"), 0755)
-	c.Assert(err, IsNil)
-
-	status, err = w.Status()
-	c.Assert(err, IsNil)
-	c.Assert(len(status), Equals, 0)
-
-	err = w.Clean(&CleanOptions{All: true, Dir: true})
-	c.Assert(err, IsNil)
-
-	status, err = w.Status()
-	c.Assert(err, IsNil)
-	c.Assert(len(status), Equals, 0)
-
-	_, err = fs.Lstat("foo")
-	c.Assert(err, ErrorMatches, ".*(no such file or directory.*|.*file does not exist)*.")
-}
-
 func (s *WorktreeSuite) TestCleanBare(c *C) {
 	storer := memory.NewStorage()
 


### PR DESCRIPTION
Reverts go-git/go-git#995 as it broke the master branch.