### PR TITLE
Optimize object tree decode

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -224,9 +224,6 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 		return nil
 	}
 
-	t.Entries = nil
-	t.m = nil
-
 	reader, err := o.Reader()
 	if err != nil {
 		return err
@@ -241,6 +238,11 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	if err != nil {
 		return fmt.Errorf("decoding tree object, expected to read %d bytes, got %d: %w", o.Size(), readSize, err)
 	}
+
+	// estimate the amount of tree entries by counting the number of null bytes
+	entryEstimate := bytes.Count(buf[:readSize], []byte{0x00})
+	t.Entries = make([]TreeEntry, 0, entryEstimate)
+	t.m = nil
 
 	myBuf := buf
 	for {

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -1648,6 +1648,7 @@ func (s *TreeSuite) TestTreeDecodeReadBug(c *C) {
 	var obtained Tree
 	err := obtained.Decode(obj)
 	c.Assert(err, IsNil)
+	c.Assert(len(obtained.Entries), Equals, len(expected.Entries))
 	c.Assert(entriesEquals(obtained.Entries, expected.Entries), Equals, true)
 }
 


### PR DESCRIPTION
I expected bufio reader pools to not allocate any memory. But it actually [allocates a bunch of small buffers](https://github.com/golang/go/blob/master/src/bufio/bufio.go#L499-L501). Let's just allocate one big buffer since we know the exact size of the object we're reading ahead of time.

Doing this reduces the runtime of my `object.DiffTree` [heavy tool](https://github.com/gartnera/git-restore-mtime) by ~30% while only increasing memory usage by ~7%. In this example, I `object.DiffTree` on every commit and it's parent in the [mpv](https://github.com/mpv-player/mpv) repo:

## before

![image](https://github.com/go-git/go-git/assets/2747955/91a687ae-0dad-42ab-a4d6-48ac9237d30f)

![image](https://github.com/go-git/go-git/assets/2747955/d5c0628d-b3cf-4a8c-9d63-0bcecaecc41e)

## after

![image](https://github.com/go-git/go-git/assets/2747955/c50e42d9-b430-4ff8-a616-44b1aa974b0a)

![image](https://github.com/go-git/go-git/assets/2747955/4c31098a-e77e-4e10-9724-d2b149bba76b)
