### PR TITLE
storage: filesystem, Fix object cache not working due to uninitialised objects being put into cache

### DIFF
--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -431,12 +431,12 @@ func (s *ObjectStorage) getFromUnpacked(h plumbing.Hash) (obj plumbing.EncodedOb
 
 	defer ioutil.CheckClose(w, &err)
 
-	s.objectCache.Put(obj)
-
 	bufp := copyBufferPool.Get().(*[]byte)
 	buf := *bufp
 	_, err = io.CopyBuffer(w, r, buf)
 	copyBufferPool.Put(bufp)
+
+	s.objectCache.Put(obj)
 
 	return obj, err
 }


### PR DESCRIPTION
I noticed the `ObjectStorage.getFromUnpacked` function has an object cache, but it is never actually used to resolve any objects. I found that when a new object is being put into cache its hash (which is used as the cache key) is always zero, which makes future loads of that same object always miss when trying the cache. See the debugger screenshots in the expandable sections.

<details>
  <summary>Hash of the queried object at the check cache point</summary>

![image](https://github.com/user-attachments/assets/41c9172b-ce70-4673-ba4c-c8418a55be7d)

</details>

<details>
  <summary>Hash of the loaded object when it's being put into cache (it's zero)</summary>

![image](https://github.com/user-attachments/assets/66e818a3-6de5-4504-8f08-0a8531f70c6d)

The hash is later used as cache key:
```Go
func (c *ObjectLRU) Put(obj plumbing.EncodedObject) {
	...
	objSize := FileSize(obj.Size())
	key := obj.Hash()
	...
```

</details>

<details>
  <summary>Hash of the loaded object when it's being returned from the function (now it matches the queried hash)</summary>

![image](https://github.com/user-attachments/assets/c729ff85-74d9-4c05-a388-c030b6c68981)

</details>

It seems to me this is a bug, so I opened this PR with the fix. However, this is my first contribution to this project, so I would appreciate a thorough review.