### PR TITLE
plumbing: format/packfile, remove duplicate checks in findMatch()

### DIFF
--- a/plumbing/format/packfile/delta_index.go
+++ b/plumbing/format/packfile/delta_index.go
@@ -35,11 +35,11 @@ func (idx *deltaIndex) findMatch(src, tgt []byte, tgtOffset int) (srcOffset, l i
 	h := hashBlock(tgt, tgtOffset)
 	tIdx := h & idx.mask
 	eIdx := idx.table[tIdx]
-	if eIdx != 0 {
-		srcOffset = idx.entries[eIdx]
-	} else {
+	if eIdx == 0 {
 		return
 	}
+
+	srcOffset = idx.entries[eIdx]
 
 	l = matchLength(src, tgt, tgtOffset, srcOffset)
 

--- a/plumbing/format/packfile/delta_index.go
+++ b/plumbing/format/packfile/delta_index.go
@@ -32,18 +32,16 @@ func (idx *deltaIndex) findMatch(src, tgt []byte, tgtOffset int) (srcOffset, l i
 		return 0, -1
 	}
 
-	if len(tgt) >= tgtOffset+s && len(src) >= blksz {
-		h := hashBlock(tgt, tgtOffset)
-		tIdx := h & idx.mask
-		eIdx := idx.table[tIdx]
-		if eIdx != 0 {
-			srcOffset = idx.entries[eIdx]
-		} else {
-			return
-		}
-
-		l = matchLength(src, tgt, tgtOffset, srcOffset)
+	h := hashBlock(tgt, tgtOffset)
+	tIdx := h & idx.mask
+	eIdx := idx.table[tIdx]
+	if eIdx != 0 {
+		srcOffset = idx.entries[eIdx]
+	} else {
+		return
 	}
+
+	l = matchLength(src, tgt, tgtOffset, srcOffset)
 
 	return
 }


### PR DESCRIPTION
At the beginning of `findMatch()`, there exist two checks for `len(tgt) < tgtOffset+s` and `len(src) < blksz`.

Simplify the code by removing the inverse checks `len(tgt) >= tgtOffset+s` and `len(src) >= blksz` down below.