### PR TITLE
plumbing: transport/ssh, Add support for SSH @cert-authority.

### DIFF
--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/internal/common"
-	"github.com/skeema/knownhosts"
 
 	"github.com/kevinburke/ssh_config"
 	"golang.org/x/crypto/ssh"
@@ -127,17 +126,25 @@ func (c *command) connect() error {
 	}
 	hostWithPort := c.getHostWithPort()
 	if config.HostKeyCallback == nil {
-		kh, err := newKnownHosts()
+		db, err := newKnownHostsDb()
 		if err != nil {
 			return err
 		}
-		config.HostKeyCallback = kh.HostKeyCallback()
-		config.HostKeyAlgorithms = kh.HostKeyAlgorithms(hostWithPort)
+
+		config.HostKeyCallback = db.HostKeyCallback()
+		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 	} else if len(config.HostKeyAlgorithms) == 0 {
 		// Set the HostKeyAlgorithms based on HostKeyCallback.
 		// For background see https://github.com/go-git/go-git/issues/411 as well as
 		// https://github.com/golang/go/issues/29286 for root cause.
-		config.HostKeyAlgorithms = knownhosts.HostKeyAlgorithms(config.HostKeyCallback, hostWithPort)
+		db, err := newKnownHostsDb()
+		if err != nil {
+			return err
+		}
+
+		// Note that the knownhost database is used, as it provides additional functionality
+		// to handle ssh cert-authorities.
+		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 	}
 
 	overrideConfig(c.config, config)


### PR DESCRIPTION
The recently released skeema/knownhosts v1.3.0 introduced a `HostKeyDB` type that extends the `HostKeyCallback` functionality to support @cert-authority algorithms in its key `HostKeyAlgorithms` discovery functionality.

`known_hosts` files may contain lines with @cert-authority markers to represent a certificate instead of a key. If a git remote uses cert authorities as the preferred host identification mechanism, the functionality added in skeema/knownhosts v1.3.0 is needed so that go-git can interact with this remote and verify it.

See https://github.com/skeema/knownhosts/pull/9 for details.