### PR TITLE
fix: allow discovery of non bare repos in fsLoader

### DIFF
--- a/plumbing/transport/server/loader.go
+++ b/plumbing/transport/server/loader.go
@@ -40,8 +40,16 @@ func (l *fsLoader) Load(ep *transport.Endpoint) (storer.Storer, error) {
 		return nil, err
 	}
 
-	if _, err := fs.Stat("config"); err != nil {
-		return nil, transport.ErrRepositoryNotFound
+	var bare bool
+	if _, err := fs.Stat("config"); err == nil {
+		bare = true
+	}
+
+	if !bare {
+		// do not use git.GitDirName due to import cycle
+		if _, err := fs.Stat(".git"); err != nil {
+			return nil, transport.ErrRepositoryNotFound
+		}
 	}
 
 	return filesystem.NewStorage(fs, cache.NewObjectLRUDefault()), nil


### PR DESCRIPTION
This is a simple fix to the fs loader that allows loading of non-bare repositories on the filesystem. Previously only bare repositories could be found due to the config check, now it also checks for the default .git directory.

Also kills the TestLoadIgnoreHost case since it was duplicated with TestLoad.
Doesn't use the git dir constant due to an import conflict