### PR TITLE
plumbing: allow discovery of non bare repos in fsLoader

### DIFF
--- a/plumbing/server/loader.go
+++ b/plumbing/server/loader.go
@@ -40,8 +40,16 @@ func (l *fsLoader) Load(ep *transport.Endpoint) (storer.Storer, error) {
 		return nil, err
 	}
 
-	if _, err := fs.Stat("config"); err != nil {
-		return nil, transport.ErrRepositoryNotFound
+	var bare bool
+	if _, err := fs.Stat("config"); err == nil {
+		bare = true
+	}
+
+	if !bare {
+		// do not use git.GitDirName due to import cycle
+		if _, err := fs.Stat(".git"); err != nil {
+			return nil, transport.ErrRepositoryNotFound
+		}
 	}
 
 	return filesystem.NewStorage(fs, cache.NewObjectLRUDefault()), nil


### PR DESCRIPTION
(cherry picked from commit 36756c91730bb3ccd0982703c90760a3621caf28)

cherry-picked based on https://github.com/go-git/go-git/pull/1170