### PR TITLE
Fix problem with when using Reset with ResetOptions.Files that are in sub directories

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -452,9 +452,9 @@ func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
 		if len(files) > 0 {
 			file := ""
 			if ch.From != nil {
-				file = ch.From.Name()
+				file = ch.From.String()
 			} else if ch.To != nil {
-				file = ch.To.Name()
+				file = ch.To.String()
 			}
 
 			if file == "" {


### PR DESCRIPTION
resetWorktree was using the name instead of the full path when pulling path out of the change. This resulted with everything working for file that exist in to root, but not anything in sub directories