### PR TITLE
Consume push URLs when they are provided

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,7 @@ const (
 	extensionsSection          = "extensions"
 	fetchKey                   = "fetch"
 	urlKey                     = "url"
+	pushurlKey                 = "pushurl"
 	bareKey                    = "bare"
 	worktreeKey                = "worktree"
 	commentCharKey             = "commentChar"
@@ -633,6 +634,7 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 
 	c.Name = c.raw.Name
 	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
+	c.URLs = append([]string(nil), c.raw.Options.GetAll(pushurlKey)...)
 	c.Fetch = fetch
 	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
 

--- a/config/config.go
+++ b/config/config.go
@@ -634,7 +634,7 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 
 	c.Name = c.raw.Name
 	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
-	c.URLs = append([]string(nil), c.raw.Options.GetAll(pushurlKey)...)
+	c.URLs = append(c.URLs, c.raw.Options.GetAll(pushurlKey)...)
 	c.Fetch = fetch
 	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -371,3 +371,27 @@ func (s *ConfigSuite) TestRemoveUrlOptions(c *C) {
 	}
 	c.Assert(err, IsNil)
 }
+
+func (s *ConfigSuite) TestUnmarshalRemotes(c *C) {
+	input := []byte(`[core]
+	bare = true
+	worktree = foo
+	custom = ignored
+[user]
+	name = John Doe
+	email = john@example.com
+[remote "origin"]
+	url = https://git.sr.ht/~mcepl/go-git
+	pushurl = git@git.sr.ht:~mcepl/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	mirror = true
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	c.Assert(err, IsNil)
+
+	c.Assert(cfg.Remotes["origin"].URLs[0], Equals, "https://git.sr.ht/~mcepl/go-git")
+	c.Assert(cfg.Remotes["origin"].URLs[1], Equals, "git@git.sr.ht:~mcepl/go-git.git")
+}
+

--- a/remote.go
+++ b/remote.go
@@ -83,7 +83,7 @@ func (r *Remote) String() string {
 	var fetch, push string
 	if len(r.c.URLs) > 0 {
 		fetch = r.c.URLs[0]
-		push = r.c.URLs[len(r.c.URLs) - 1]
+		push = r.c.URLs[len(r.c.URLs)-1]
 	}
 
 	return fmt.Sprintf("%s\t%s (fetch)\n%[1]s\t%[3]s (push)", r.c.Name, fetch, push)
@@ -110,8 +110,8 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		return fmt.Errorf("remote names don't match: %s != %s", o.RemoteName, r.c.Name)
 	}
 
-	if o.RemoteURL == "" {
-		o.RemoteURL = r.c.URLs[len(r.c.URLs) - 1]
+	if o.RemoteURL == "" && len(r.c.URLs) > 0 {
+		o.RemoteURL = r.c.URLs[len(r.c.URLs)-1]
 	}
 
 	s, err := newSendPackSession(o.RemoteURL, o.Auth, o.InsecureSkipTLS, o.CABundle, o.ProxyOptions)

--- a/remote.go
+++ b/remote.go
@@ -83,7 +83,7 @@ func (r *Remote) String() string {
 	var fetch, push string
 	if len(r.c.URLs) > 0 {
 		fetch = r.c.URLs[0]
-		push = r.c.URLs[0]
+		push = r.c.URLs[len(r.c.URLs) - 1]
 	}
 
 	return fmt.Sprintf("%s\t%s (fetch)\n%[1]s\t%[3]s (push)", r.c.Name, fetch, push)
@@ -111,7 +111,7 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 	}
 
 	if o.RemoteURL == "" {
-		o.RemoteURL = r.c.URLs[0]
+		o.RemoteURL = r.c.URLs[len(r.c.URLs) - 1]
 	}
 
 	s, err := newSendPackSession(o.RemoteURL, o.Auth, o.InsecureSkipTLS, o.CABundle, o.ProxyOptions)


### PR DESCRIPTION
I am not sure how far this goes with finally fixing #489, but it certainly shouldn’t make things worse.

We now consider also `pushurl` values in the repository config