### PR TITLE
v6: Consume push URLs when they are provided

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -275,6 +275,7 @@ const (
 	protocolSection            = "protocol"
 	fetchKey                   = "fetch"
 	urlKey                     = "url"
+	pushurlKey                 = "pushurl"
 	bareKey                    = "bare"
 	worktreeKey                = "worktree"
 	commentCharKey             = "commentChar"
@@ -688,6 +689,7 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 
 	c.Name = c.raw.Name
 	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
+	c.URLs = append([]string(nil), c.raw.Options.GetAll(pushurlKey)...)
 	c.Fetch = fetch
 	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
 

--- a/config/config.go
+++ b/config/config.go
@@ -689,7 +689,7 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 
 	c.Name = c.raw.Name
 	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
-	c.URLs = append([]string(nil), c.raw.Options.GetAll(pushurlKey)...)
+	c.URLs = append(c.URLs, c.raw.Options.GetAll(pushurlKey)...)
 	c.Fetch = fetch
 	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -392,3 +392,26 @@ func (s *ConfigSuite) TestProtocol(c *C) {
 	}
 	c.Assert(err, IsNil)
 }
+
+func (s *ConfigSuite) TestUnmarshalRemotes(c *C) {
+	input := []byte(`[core]
+	bare = true
+	worktree = foo
+	custom = ignored
+[user]
+	name = John Doe
+	email = john@example.com
+[remote "origin"]
+	url = https://git.sr.ht/~mcepl/go-git
+	pushurl = git@git.sr.ht:~mcepl/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	mirror = true
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	c.Assert(err, IsNil)
+
+	c.Assert(cfg.Remotes["origin"].URLs[0], Equals, "https://git.sr.ht/~mcepl/go-git")
+	c.Assert(cfg.Remotes["origin"].URLs[1], Equals, "git@git.sr.ht:~mcepl/go-git.git")
+}

--- a/remote.go
+++ b/remote.go
@@ -82,7 +82,7 @@ func (r *Remote) String() string {
 	var fetch, push string
 	if len(r.c.URLs) > 0 {
 		fetch = r.c.URLs[0]
-		push = r.c.URLs[len(r.c.URLs) - 1]
+		push = r.c.URLs[len(r.c.URLs)-1]
 	}
 
 	return fmt.Sprintf("%s\t%s (fetch)\n%[1]s\t%[3]s (push)", r.c.Name, fetch, push)
@@ -109,8 +109,8 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		return fmt.Errorf("remote names don't match: %s != %s", o.RemoteName, r.c.Name)
 	}
 
-	if o.RemoteURL == "" {
-		o.RemoteURL = r.c.URLs[len(r.c.URLs) - 1]
+	if o.RemoteURL == "" && len(r.c.URLs) > 0 {
+		o.RemoteURL = r.c.URLs[len(r.c.URLs)-1]
 	}
 
 	s, err := newSendPackSession(o.RemoteURL, o.Auth, o.InsecureSkipTLS, o.CABundle, o.ProxyOptions)

--- a/remote.go
+++ b/remote.go
@@ -82,7 +82,7 @@ func (r *Remote) String() string {
 	var fetch, push string
 	if len(r.c.URLs) > 0 {
 		fetch = r.c.URLs[0]
-		push = r.c.URLs[0]
+		push = r.c.URLs[len(r.c.URLs) - 1]
 	}
 
 	return fmt.Sprintf("%s\t%s (fetch)\n%[1]s\t%[3]s (push)", r.c.Name, fetch, push)
@@ -110,7 +110,7 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 	}
 
 	if o.RemoteURL == "" {
-		o.RemoteURL = r.c.URLs[0]
+		o.RemoteURL = r.c.URLs[len(r.c.URLs) - 1]
 	}
 
 	s, err := newSendPackSession(o.RemoteURL, o.Auth, o.InsecureSkipTLS, o.CABundle, o.ProxyOptions)


### PR DESCRIPTION
Rebase of https://github.com/go-git/go-git/pull/1191 for the [v6-exp](https://github.com/go-git/go-git/tree/v6-exp) branch.