### PR TITLE
*: use gocheck's MkDir instead of TempDir for tests. Fixes #807

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -136,21 +136,6 @@ func (s *BaseSuite) GetLocalRepositoryURL(f *fixtures.Fixture) string {
 	return f.DotGit().Root()
 }
 
-func (s *BaseSuite) TemporalDir() (path string, clean func()) {
-	fs := osfs.New(os.TempDir())
-	relPath, err := util.TempDir(fs, "", "")
-	if err != nil {
-		panic(err)
-	}
-
-	path = fs.Join(fs.Root(), relPath)
-	clean = func() {
-		_ = util.RemoveAll(fs, relPath)
-	}
-
-	return
-}
-
 func (s *BaseSuite) TemporalHomeDir() (path string, clean func()) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -171,8 +156,8 @@ func (s *BaseSuite) TemporalHomeDir() (path string, clean func()) {
 	return
 }
 
-func (s *BaseSuite) TemporalFilesystem() (fs billy.Filesystem, clean func()) {
-	fs = osfs.New(os.TempDir())
+func (s *BaseSuite) TemporalFilesystem(c *C) (fs billy.Filesystem) {
+	fs = osfs.New(c.MkDir())
 	path, err := util.TempDir(fs, "", "")
 	if err != nil {
 		panic(err)
@@ -181,10 +166,6 @@ func (s *BaseSuite) TemporalFilesystem() (fs billy.Filesystem, clean func()) {
 	fs, err = fs.Chroot(path)
 	if err != nil {
 		panic(err)
-	}
-
-	clean = func() {
-		_ = util.RemoveAll(fs, path)
 	}
 
 	return

--- a/options_test.go
+++ b/options_test.go
@@ -97,7 +97,7 @@ func (s *OptionsSuite) TestCreateTagOptionsLoadGlobal(c *C) {
 }
 
 func (s *OptionsSuite) writeGlobalConfig(c *C, cfg *config.Config) func() {
-	fs, clean := s.TemporalFilesystem()
+	fs := s.TemporalFilesystem(c)
 
 	tmp, err := util.TempDir(fs, "", "test-options")
 	c.Assert(err, IsNil)
@@ -115,7 +115,6 @@ func (s *OptionsSuite) writeGlobalConfig(c *C, cfg *config.Config) func() {
 	c.Assert(err, IsNil)
 
 	return func() {
-		clean()
 		os.Setenv("XDG_CONFIG_HOME", "")
 
 	}

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -82,7 +82,7 @@ func (s *ParserSuite) TestParserHashes(c *C) {
 }
 
 func (s *ParserSuite) TestThinPack(c *C) {
-	fs := osfs.New(os.TempDir())
+	fs := osfs.New(c.MkDir())
 	path, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
 

--- a/plumbing/transport/file/common_test.go
+++ b/plumbing/transport/file/common_test.go
@@ -24,7 +24,7 @@ func (s *CommonSuite) SetUpSuite(c *C) {
 	}
 
 	var err error
-	s.tmpDir, err = os.MkdirTemp("", "")
+	s.tmpDir, err = os.MkdirTemp(c.MkDir(), "")
 	c.Assert(err, IsNil)
 	s.ReceivePackBin = filepath.Join(s.tmpDir, "git-receive-pack")
 	s.UploadPackBin = filepath.Join(s.tmpDir, "git-upload-pack")
@@ -38,5 +38,4 @@ func (s *CommonSuite) SetUpSuite(c *C) {
 
 func (s *CommonSuite) TearDownSuite(c *C) {
 	defer s.Suite.TearDownSuite(c)
-	c.Assert(os.RemoveAll(s.tmpDir), IsNil)
 }

--- a/plumbing/transport/git/common_test.go
+++ b/plumbing/transport/git/common_test.go
@@ -42,7 +42,7 @@ func (s *BaseSuite) SetUpTest(c *C) {
 	s.port, err = freePort()
 	c.Assert(err, IsNil)
 
-	s.base, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-protocol-%d", s.port))
+	s.base, err = os.MkdirTemp(c.MkDir(), fmt.Sprintf("go-git-protocol-%d", s.port))
 	c.Assert(err, IsNil)
 }
 
@@ -94,11 +94,6 @@ func (s *BaseSuite) TearDownTest(c *C) {
 	if s.daemon != nil {
 		_ = s.daemon.Process.Signal(os.Kill)
 		_ = s.daemon.Wait()
-	}
-
-	if s.base != "" {
-		err := os.RemoveAll(s.base)
-		c.Assert(err, IsNil)
 	}
 }
 

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -240,7 +240,7 @@ func (s *BaseSuite) SetUpTest(c *C) {
 	l, err := net.Listen("tcp", "localhost:0")
 	c.Assert(err, IsNil)
 
-	base, err := os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-http-%d", s.port))
+	base, err := os.MkdirTemp(c.MkDir(), fmt.Sprintf("go-git-http-%d", s.port))
 	c.Assert(err, IsNil)
 
 	s.port = l.Addr().(*net.TCPAddr).Port
@@ -282,9 +282,4 @@ func (s *BaseSuite) newEndpoint(c *C, name string) *transport.Endpoint {
 	c.Assert(err, IsNil)
 
 	return ep
-}
-
-func (s *BaseSuite) TearDownTest(c *C) {
-	err := os.RemoveAll(s.base)
-	c.Assert(err, IsNil)
 }

--- a/plumbing/transport/ssh/internal/test/proxy_test.go
+++ b/plumbing/transport/ssh/internal/test/proxy_test.go
@@ -58,7 +58,7 @@ func (s *ProxyEnvSuite) TestCommand(c *C) {
 	}()
 
 	s.port = sshListener.Addr().(*net.TCPAddr).Port
-	s.base, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.port))
+	s.base, err = os.MkdirTemp(c.MkDir(), fmt.Sprintf("go-git-ssh-%d", s.port))
 	c.Assert(err, IsNil)
 
 	ggssh.DefaultAuthBuilder = func(user string) (ggssh.AuthMethod, error) {

--- a/plumbing/transport/ssh/proxy_test.go
+++ b/plumbing/transport/ssh/proxy_test.go
@@ -53,7 +53,7 @@ func (s *ProxySuite) TestCommand(c *C) {
 	}()
 
 	s.u.port = sshListener.Addr().(*net.TCPAddr).Port
-	s.u.base, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.u.port))
+	s.u.base, err = os.MkdirTemp(c.MkDir(), fmt.Sprintf("go-git-ssh-%d", s.u.port))
 	c.Assert(err, IsNil)
 
 	DefaultAuthBuilder = func(user string) (AuthMethod, error) {

--- a/plumbing/transport/ssh/upload_pack_test.go
+++ b/plumbing/transport/ssh/upload_pack_test.go
@@ -42,7 +42,7 @@ func (s *UploadPackSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 
 	s.port = l.Addr().(*net.TCPAddr).Port
-	s.base, err = os.MkdirTemp(os.TempDir(), fmt.Sprintf("go-git-ssh-%d", s.port))
+	s.base, err = os.MkdirTemp(c.MkDir(), fmt.Sprintf("go-git-ssh-%d", s.port))
 	c.Assert(err, IsNil)
 
 	DefaultAuthBuilder = func(user string) (AuthMethod, error) {

--- a/remote_test.go
+++ b/remote_test.go
@@ -350,8 +350,7 @@ func (s *RemoteSuite) testFetch(c *C, r *Remote, o *FetchOptions, expected []*pl
 }
 
 func (s *RemoteSuite) TestFetchOfMissingObjects(c *C) {
-	tmp, clean := s.TemporalDir()
-	defer clean()
+	tmp := c.MkDir()
 
 	// clone to a local temp folder
 	_, err := PlainClone(tmp, true, &CloneOptions{
@@ -411,8 +410,7 @@ func (m *mockPackfileWriter) PackfileWriter() (io.WriteCloser, error) {
 }
 
 func (s *RemoteSuite) TestFetchWithPackfileWriter(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	mock := &mockPackfileWriter{Storer: fss}
@@ -544,8 +542,7 @@ func (s *RemoteSuite) TestFetchFastForwardMem(c *C) {
 }
 
 func (s *RemoteSuite) TestFetchFastForwardFS(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
@@ -566,8 +563,7 @@ func (s *RemoteSuite) TestString(c *C) {
 }
 
 func (s *RemoteSuite) TestPushToEmptyRepository(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	server, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -605,8 +601,7 @@ func (s *RemoteSuite) TestPushToEmptyRepository(c *C) {
 }
 
 func (s *RemoteSuite) TestPushContext(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	_, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -648,8 +643,7 @@ func eventually(c *C, condition func() bool) {
 }
 
 func (s *RemoteSuite) TestPushContextCanceled(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	_, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -678,8 +672,7 @@ func (s *RemoteSuite) TestPushContextCanceled(c *C) {
 }
 
 func (s *RemoteSuite) TestPushTags(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	server, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -707,8 +700,7 @@ func (s *RemoteSuite) TestPushTags(c *C) {
 }
 
 func (s *RemoteSuite) TestPushFollowTags(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	server, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -785,8 +777,7 @@ func (s *RemoteSuite) TestPushDeleteReference(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	r, err := PlainClone(url, true, &CloneOptions{
 		URL: fs.Root(),
@@ -812,8 +803,7 @@ func (s *RemoteSuite) TestForcePushDeleteReference(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	r, err := PlainClone(url, true, &CloneOptions{
 		URL: fs.Root(),
@@ -840,8 +830,7 @@ func (s *RemoteSuite) TestPushRejectNonFastForward(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 	server := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	r, err := PlainClone(url, true, &CloneOptions{
 		URL: fs.Root(),
@@ -1052,16 +1041,14 @@ func (s *RemoteSuite) TestPushForceWithLease_failure(c *C) {
 func (s *RemoteSuite) TestPushPrune(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	server, err := PlainClone(url, true, &CloneOptions{
 		URL: fs.Root(),
 	})
 	c.Assert(err, IsNil)
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, true, &CloneOptions{
 		URL: url,
@@ -1115,16 +1102,14 @@ func (s *RemoteSuite) TestPushPrune(c *C) {
 func (s *RemoteSuite) TestPushNewReference(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	server, err := PlainClone(url, true, &CloneOptions{
 		URL: fs.Root(),
 	})
 	c.Assert(err, IsNil)
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, true, &CloneOptions{
 		URL: url,
@@ -1154,16 +1139,14 @@ func (s *RemoteSuite) TestPushNewReference(c *C) {
 func (s *RemoteSuite) TestPushNewReferenceAndDeleteInBatch(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	server, err := PlainClone(url, true, &CloneOptions{
 		URL: fs.Root(),
 	})
 	c.Assert(err, IsNil)
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, true, &CloneOptions{
 		URL: url,
@@ -1406,8 +1389,7 @@ func (s *RemoteSuite) TestUpdateShallows(c *C) {
 }
 
 func (s *RemoteSuite) TestUseRefDeltas(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	_, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -1485,16 +1467,14 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs(c *C) {
 func (s *RemoteSuite) TestFetchPrune(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	_, err := PlainClone(url, true, &CloneOptions{
 		URL: fs.Root(),
 	})
 	c.Assert(err, IsNil)
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, true, &CloneOptions{
 		URL: url,
@@ -1512,8 +1492,7 @@ func (s *RemoteSuite) TestFetchPrune(c *C) {
 	}})
 	c.Assert(err, IsNil)
 
-	dirSave, clean := s.TemporalDir()
-	defer clean()
+	dirSave := c.MkDir()
 
 	rSave, err := PlainClone(dirSave, true, &CloneOptions{
 		URL: url,
@@ -1543,16 +1522,14 @@ func (s *RemoteSuite) TestFetchPrune(c *C) {
 func (s *RemoteSuite) TestFetchPruneTags(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	_, err := PlainClone(url, true, &CloneOptions{
 		URL: fs.Root(),
 	})
 	c.Assert(err, IsNil)
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, true, &CloneOptions{
 		URL: url,
@@ -1570,8 +1547,7 @@ func (s *RemoteSuite) TestFetchPruneTags(c *C) {
 	}})
 	c.Assert(err, IsNil)
 
-	dirSave, clean := s.TemporalDir()
-	defer clean()
+	dirSave := c.MkDir()
 
 	rSave, err := PlainClone(dirSave, true, &CloneOptions{
 		URL: url,
@@ -1599,12 +1575,12 @@ func (s *RemoteSuite) TestFetchPruneTags(c *C) {
 }
 
 func (s *RemoteSuite) TestCanPushShasToReference(c *C) {
-	d, err := os.MkdirTemp("", "TestCanPushShasToReference")
+	d := c.MkDir()
+	d, err := os.MkdirTemp(d, "TestCanPushShasToReference")
 	c.Assert(err, IsNil)
 	if err != nil {
 		return
 	}
-	defer os.RemoveAll(d)
 
 	// remote currently forces a plain path for path based remotes inside the PushContext function.
 	// This makes it impossible, in the current state to use memfs.
@@ -1649,8 +1625,7 @@ func (s *RemoteSuite) TestCanPushShasToReference(c *C) {
 }
 
 func (s *RemoteSuite) TestFetchAfterShallowClone(c *C) {
-	tempDir, clean := s.TemporalDir()
-	defer clean()
+	tempDir := c.MkDir()
 	remoteUrl := filepath.Join(tempDir, "remote")
 	repoDir := filepath.Join(tempDir, "repo")
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -113,8 +113,7 @@ func createCommit(c *C, r *Repository) plumbing.Hash {
 }
 
 func (s *RepositorySuite) TestInitNonStandardDotGit(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	fs := osfs.New(dir)
 	dot, _ := fs.Chroot("storage")
@@ -139,8 +138,7 @@ func (s *RepositorySuite) TestInitNonStandardDotGit(c *C) {
 }
 
 func (s *RepositorySuite) TestInitStandardDotGit(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	fs := osfs.New(dir)
 	dot, _ := fs.Chroot(".git")
@@ -638,8 +636,7 @@ func (s *RepositorySuite) TestDeleteBranch(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainInit(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, true)
 	c.Assert(err, IsNil)
@@ -651,8 +648,7 @@ func (s *RepositorySuite) TestPlainInit(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainInitWithOptions(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInitWithOptions(dir, &PlainInitOptions{
 		InitOptions: InitOptions{
@@ -675,8 +671,7 @@ func (s *RepositorySuite) TestPlainInitWithOptions(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainInitAlreadyExists(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, true)
 	c.Assert(err, IsNil)
@@ -688,8 +683,7 @@ func (s *RepositorySuite) TestPlainInitAlreadyExists(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainOpen(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, false)
 	c.Assert(err, IsNil)
@@ -724,8 +718,7 @@ func (s *RepositorySuite) TestPlainOpenTildePath(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainOpenBare(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, true)
 	c.Assert(err, IsNil)
@@ -737,8 +730,7 @@ func (s *RepositorySuite) TestPlainOpenBare(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainOpenNotBare(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, false)
 	c.Assert(err, IsNil)
@@ -750,8 +742,7 @@ func (s *RepositorySuite) TestPlainOpenNotBare(c *C) {
 }
 
 func (s *RepositorySuite) testPlainOpenGitFile(c *C, f func(string, string) string) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir, err := util.TempDir(fs, "", "plain-open")
 	c.Assert(err, IsNil)
@@ -804,8 +795,7 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileNoEOL(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
@@ -829,8 +819,7 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage(c *
 }
 
 func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileBadPrefix(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
@@ -860,8 +849,7 @@ func (s *RepositorySuite) TestPlainOpenNotExists(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainOpenDetectDotGit(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
@@ -895,8 +883,7 @@ func (s *RepositorySuite) TestPlainOpenDetectDotGit(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainOpenNotExistsDetectDotGit(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	opt := &PlainOpenOptions{DetectDotGit: true}
 	r, err := PlainOpenWithOptions(dir, opt)
@@ -905,8 +892,7 @@ func (s *RepositorySuite) TestPlainOpenNotExistsDetectDotGit(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainClone(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, false, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -924,8 +910,7 @@ func (s *RepositorySuite) TestPlainClone(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneBareAndShared(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	remote := s.GetBasicLocalRepositoryURL()
 
@@ -952,8 +937,7 @@ func (s *RepositorySuite) TestPlainCloneBareAndShared(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneShared(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	remote := s.GetBasicLocalRepositoryURL()
 
@@ -980,8 +964,7 @@ func (s *RepositorySuite) TestPlainCloneShared(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneSharedHttpShouldReturnError(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	remote := "http://somerepo"
 
@@ -993,8 +976,7 @@ func (s *RepositorySuite) TestPlainCloneSharedHttpShouldReturnError(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneSharedHttpsShouldReturnError(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	remote := "https://somerepo"
 
@@ -1006,8 +988,7 @@ func (s *RepositorySuite) TestPlainCloneSharedHttpsShouldReturnError(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneSharedSSHShouldReturnError(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	remote := "ssh://somerepo"
 
@@ -1019,8 +1000,7 @@ func (s *RepositorySuite) TestPlainCloneSharedSSHShouldReturnError(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneWithRemoteName(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, false, &CloneOptions{
 		URL:        s.GetBasicLocalRepositoryURL(),
@@ -1035,8 +1015,7 @@ func (s *RepositorySuite) TestPlainCloneWithRemoteName(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneOverExistingGitDirectory(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, false)
 	c.Assert(r, NotNil)
@@ -1053,8 +1032,7 @@ func (s *RepositorySuite) TestPlainCloneContextCancel(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainCloneContext(ctx, dir, false, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -1068,8 +1046,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithExistentDir(c *C) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
@@ -1092,8 +1069,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNonExistentDir(c *
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	tmpDir, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
@@ -1114,8 +1090,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNotDir(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	tmpDir, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
@@ -1141,8 +1116,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNotEmptyDir(c *C) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	tmpDir, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
@@ -1170,8 +1144,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistingOverExistingGitDirecto
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, false)
 	c.Assert(r, NotNil)
@@ -1189,8 +1162,7 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules(c *C) {
 		c.Skip("skipping test in short mode.")
 	}
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	path := fixtures.ByTag("submodule").One().Worktree().Root()
 	r, err := PlainClone(dir, false, &CloneOptions{
@@ -1212,8 +1184,7 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules(c *C) {
 		c.Skip("skipping test in short mode.")
 	}
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	path := fixtures.ByTag("submodule").One().Worktree().Root()
 	mainRepo, err := PlainClone(dir, false, &CloneOptions{
@@ -1245,8 +1216,7 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneNoCheckout(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	path := fixtures.ByTag("submodule").One().Worktree().Root()
 	r, err := PlainClone(dir, false, &CloneOptions{
@@ -1641,8 +1611,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAnnotatedTag(c *C) {
 }
 
 func (s *RepositorySuite) TestPush(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	server, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -1670,8 +1639,7 @@ func (s *RepositorySuite) TestPush(c *C) {
 }
 
 func (s *RepositorySuite) TestPushContext(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	_, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -1704,8 +1672,7 @@ func installPreReceiveHook(c *C, fs billy.Filesystem, path, m string) {
 }
 
 func (s *RepositorySuite) TestPushWithProgress(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	path, err := util.TempDir(fs, "", "")
 	c.Assert(err, IsNil)
@@ -1740,8 +1707,7 @@ func (s *RepositorySuite) TestPushWithProgress(c *C) {
 }
 
 func (s *RepositorySuite) TestPushDepth(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	server, err := PlainClone(url, true, &CloneOptions{
 		URL: fixtures.Basic().One().DotGit().Root(),
@@ -2832,8 +2798,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotated(c *C) {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
@@ -2880,8 +2845,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotatedUnpacked(c *C) {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 

--- a/repository_windows_test.go
+++ b/repository_windows_test.go
@@ -16,8 +16,7 @@ func preReceiveHook(m string) []byte {
 }
 
 func (s *RepositorySuite) TestCloneFileUrlWindows(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, false)
 	c.Assert(err, IsNil)

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -29,8 +29,8 @@ type SuiteDotGit struct {
 
 var _ = Suite(&SuiteDotGit{})
 
-func (s *SuiteDotGit) TemporalFilesystem() (fs billy.Filesystem, clean func()) {
-	fs = osfs.New(os.TempDir())
+func (s *SuiteDotGit) TemporalFilesystem(c *C) (fs billy.Filesystem) {
+	fs = osfs.New(c.MkDir())
 	path, err := util.TempDir(fs, "", "")
 	if err != nil {
 		panic(err)
@@ -41,14 +41,11 @@ func (s *SuiteDotGit) TemporalFilesystem() (fs billy.Filesystem, clean func()) {
 		panic(err)
 	}
 
-	return fs, func() {
-		util.RemoveAll(fs, path)
-	}
+	return fs
 }
 
 func (s *SuiteDotGit) TestInitialize(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 
@@ -69,8 +66,7 @@ func (s *SuiteDotGit) TestInitialize(c *C) {
 }
 
 func (s *SuiteDotGit) TestSetRefs(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 
@@ -78,8 +74,7 @@ func (s *SuiteDotGit) TestSetRefs(c *C) {
 }
 
 func (s *SuiteDotGit) TestSetRefsNorwfs(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(&norwfs{fs})
 
@@ -369,8 +364,7 @@ func (s *SuiteDotGit) TestConfig(c *C) {
 }
 
 func (s *SuiteDotGit) TestConfigWriteAndConfig(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 
@@ -399,8 +393,7 @@ func (s *SuiteDotGit) TestIndex(c *C) {
 }
 
 func (s *SuiteDotGit) TestIndexWriteAndIndex(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 
@@ -429,8 +422,7 @@ func (s *SuiteDotGit) TestShallow(c *C) {
 }
 
 func (s *SuiteDotGit) TestShallowWriteAndShallow(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 
@@ -573,8 +565,7 @@ func (s *SuiteDotGit) TestObjectPackNotFound(c *C) {
 }
 
 func (s *SuiteDotGit) TestNewObject(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 	w, err := dir.NewObject()
@@ -636,8 +627,7 @@ func testObjectsWithPrefix(c *C, _ billy.Filesystem, dir *DotGit) {
 }
 
 func (s *SuiteDotGit) TestObjectsNoFolder(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 	hash, err := dir.Objects()
@@ -750,8 +740,7 @@ func (s *SuiteDotGit) TestSubmodules(c *C) {
 }
 
 func (s *SuiteDotGit) TestPackRefs(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 
@@ -1015,8 +1004,7 @@ func (f *notExistsFS) ReadDir(path string) ([]os.FileInfo, error) {
 }
 
 func (s *SuiteDotGit) TestDeletedRefs(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(&notExistsFS{
 		Filesystem: fs,
@@ -1050,8 +1038,7 @@ func (s *SuiteDotGit) TestDeletedRefs(c *C) {
 
 // Checks that seting a reference that has been packed and checking its old value is successful
 func (s *SuiteDotGit) TestSetPackedRef(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dir := New(fs)
 

--- a/storage/filesystem/dotgit/repository_filesystem_test.go
+++ b/storage/filesystem/dotgit/repository_filesystem_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func (s *SuiteDotGit) TestRepositoryFilesystem(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	err := fs.MkdirAll("dotGit", 0777)
 	c.Assert(err, IsNil)

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -19,8 +19,7 @@ import (
 func (s *SuiteDotGit) TestNewObjectPack(c *C) {
 	f := fixtures.Basic().One()
 
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dot := New(fs)
 
@@ -59,8 +58,7 @@ func (s *SuiteDotGit) TestNewObjectPack(c *C) {
 }
 
 func (s *SuiteDotGit) TestNewObjectPackUnused(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	dot := New(fs)
 
@@ -126,8 +124,7 @@ func (s *SuiteDotGit) TestSyncedReader(c *C) {
 }
 
 func (s *SuiteDotGit) TestPackWriterUnusedNotify(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	w, err := newPackWrite(fs)
 	c.Assert(err, IsNil)

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -17,7 +17,6 @@ import (
 type SubmoduleSuite struct {
 	BaseSuite
 	Worktree *Worktree
-	clean    func()
 }
 
 var _ = Suite(&SubmoduleSuite{})
@@ -25,8 +24,7 @@ var _ = Suite(&SubmoduleSuite{})
 func (s *SubmoduleSuite) SetUpTest(c *C) {
 	path := fixtures.ByTag("submodule").One().Worktree().Root()
 
-	var dir string
-	dir, s.clean = s.TemporalDir()
+	dir := c.MkDir()
 
 	r, err := PlainClone(filepath.Join(dir, "worktree"), false, &CloneOptions{
 		URL: path,
@@ -37,10 +35,6 @@ func (s *SubmoduleSuite) SetUpTest(c *C) {
 	s.Repository = r
 	s.Worktree, err = r.Worktree()
 	c.Assert(err, IsNil)
-}
-
-func (s *SubmoduleSuite) TearDownTest(_ *C) {
-	s.clean()
 }
 
 func (s *SubmoduleSuite) TestInit(c *C) {

--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -205,8 +205,7 @@ func (s *NoderSuite) TestSocket(c *C) {
 		c.Skip("socket files do not exist on windows")
 	}
 
-	td, err := os.MkdirTemp("", "socket-test")
-	defer os.RemoveAll(td)
+	td, err := os.MkdirTemp(c.MkDir(), "socket-test")
 	c.Assert(err, IsNil)
 
 	sock, err := net.ListenUnix("unix", &net.UnixAddr{Name: fmt.Sprintf("%s/socket", td), Net: "unix"})

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -514,8 +514,7 @@ func (s *WorktreeSuite) TestCommitSignBadKey(c *C) {
 }
 
 func (s *WorktreeSuite) TestCommitTreeSort(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	_, err := Init(st, nil)
@@ -562,8 +561,7 @@ func (s *WorktreeSuite) TestCommitTreeSort(c *C) {
 
 // https://github.com/go-git/go-git/pull/224
 func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	fsDotgit, err := fs.Chroot(".git") // real fs to get modified timestamps
 	c.Assert(err, IsNil)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -70,8 +70,7 @@ func (s *WorktreeSuite) TestPullCheckout(c *C) {
 }
 
 func (s *WorktreeSuite) TestPullFastForward(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 
@@ -80,8 +79,7 @@ func (s *WorktreeSuite) TestPullFastForward(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, false, &CloneOptions{
 		URL: url,
@@ -108,8 +106,7 @@ func (s *WorktreeSuite) TestPullFastForward(c *C) {
 }
 
 func (s *WorktreeSuite) TestPullNonFastForward(c *C) {
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 
@@ -118,8 +115,7 @@ func (s *WorktreeSuite) TestPullNonFastForward(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, false, &CloneOptions{
 		URL: url,
@@ -230,8 +226,7 @@ func (s *WorktreeSuite) TestPullProgressWithRecursion(c *C) {
 
 	path := fixtures.ByTag("submodule").One().Worktree().Root()
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, _ := PlainInit(dir, false)
 	r.CreateRemote(&config.RemoteConfig{
@@ -325,8 +320,7 @@ func (s *WorktreeSuite) TestPullDepth(c *C) {
 }
 
 func (s *WorktreeSuite) TestPullAfterShallowClone(c *C) {
-	tempDir, clean := s.TemporalDir()
-	defer clean()
+	tempDir := c.MkDir()
 	remoteURL := filepath.Join(tempDir, "remote")
 	repoDir := filepath.Join(tempDir, "repo")
 
@@ -454,8 +448,7 @@ func (s *WorktreeSuite) TestCheckoutSymlink(c *C) {
 		c.Skip("git doesn't support symlinks by default in windows")
 	}
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, false)
 	c.Assert(err, IsNil)
@@ -518,8 +511,7 @@ func (s *WorktreeSuite) TestFilenameNormalization(c *C) {
 		c.Skip("windows paths may contain non utf-8 sequences")
 	}
 
-	url, clean := s.TemporalDir()
-	defer clean()
+	url := c.MkDir()
 
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 
@@ -711,8 +703,7 @@ func (s *WorktreeSuite) TestCheckoutIndexMem(c *C) {
 }
 
 func (s *WorktreeSuite) TestCheckoutIndexOS(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	w := &Worktree{
 		r:          s.Repository,
@@ -1310,8 +1301,7 @@ func (s *WorktreeSuite) TestStatusAfterCheckout(c *C) {
 }
 
 func (s *WorktreeSuite) TestStatusModified(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	w := &Worktree{
 		r:          s.Repository,
@@ -1402,8 +1392,7 @@ func (s *WorktreeSuite) TestStatusUntracked(c *C) {
 }
 
 func (s *WorktreeSuite) TestStatusDeleted(c *C) {
-	fs, clean := s.TemporalFilesystem()
-	defer clean()
+	fs := s.TemporalFilesystem(c)
 
 	w := &Worktree{
 		r:          s.Repository,
@@ -1775,8 +1764,7 @@ func (s *WorktreeSuite) TestAddRemovedInDirectoryDot(c *C) {
 }
 
 func (s *WorktreeSuite) TestAddSymlink(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainInit(dir, false)
 	c.Assert(err, IsNil)
@@ -2656,8 +2644,7 @@ func (s *WorktreeSuite) TestGrep(c *C) {
 
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	server, err := PlainClone(dir, false, &CloneOptions{
 		URL: path,
@@ -2740,8 +2727,7 @@ func (s *WorktreeSuite) TestGrepBare(c *C) {
 
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Root()
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	r, err := PlainClone(dir, true, &CloneOptions{
 		URL: path,
@@ -2789,8 +2775,7 @@ func (s *WorktreeSuite) TestGrepBare(c *C) {
 }
 
 func (s *WorktreeSuite) TestResetLingeringDirectories(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	commitOpts := &CommitOptions{Author: &object.Signature{
 		Name:  "foo",
@@ -2841,8 +2826,7 @@ func (s *WorktreeSuite) TestResetLingeringDirectories(c *C) {
 func (s *WorktreeSuite) TestAddAndCommit(c *C) {
 	expectedFiles := 2
 
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	repo, err := PlainInit(dir, false)
 	c.Assert(err, IsNil)
@@ -2884,8 +2868,7 @@ func (s *WorktreeSuite) TestAddAndCommit(c *C) {
 }
 
 func (s *WorktreeSuite) TestAddAndCommitEmpty(c *C) {
-	dir, clean := s.TemporalDir()
-	defer clean()
+	dir := c.MkDir()
 
 	repo, err := PlainInit(dir, false)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This PR removes all the usage of `TempDir` and replaces it with gocheck's `MkDir`. It removes the requirement of cleanup functions. 

Note that I haven't removed them from examples directory as they are not tests. 

Fixes: #807 