### PR TITLE
server: uploadpack, implement multi_ack capability

### DIFF
--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -86,7 +86,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported(c *C) {
 
 	info, err := r.AdvertisedReferences()
 	c.Assert(err, IsNil)
-	c.Assert(info.Capabilities.Supports(capability.MultiACK), Equals, false)
+	c.Assert(info.Capabilities.Supports(capability.MultiACK), Equals, true)
 }
 
 func (s *UploadPackSuite) TestCapabilities(c *C) {

--- a/plumbing/protocol/packp/common.go
+++ b/plumbing/protocol/packp/common.go
@@ -32,6 +32,8 @@ var (
 	deepenCommits   = []byte("deepen ")
 	deepenSince     = []byte("deepen-since ")
 	deepenReference = []byte("deepen-not ")
+	have            = []byte("have ")
+	done            = []byte("done")
 
 	// shallow-update
 	unshallow = []byte("unshallow ")

--- a/plumbing/protocol/packp/srvresp_test.go
+++ b/plumbing/protocol/packp/srvresp_test.go
@@ -99,10 +99,6 @@ func (s *ServerResponseSuite) TestDecodeMalformed(c *C) {
 	c.Assert(err, NotNil)
 }
 
-// multi_ack isn't fully implemented, this ensures that Decode ignores that fact,
-// as in some circumstances that's OK to assume so.
-//
-// TODO: Review as part of multi_ack implementation.
 func (s *ServerResponseSuite) TestDecodeMultiACK(c *C) {
 	raw := "" +
 		"0031ACK 1111111111111111111111111111111111111111\n" +

--- a/plumbing/protocol/packp/srvresp_test.go
+++ b/plumbing/protocol/packp/srvresp_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 
 	. "gopkg.in/check.v1"
 )
@@ -112,4 +113,85 @@ func (s *ServerResponseSuite) TestDecodeMultiACK(c *C) {
 	c.Assert(sr.ACKs, HasLen, 2)
 	c.Assert(sr.ACKs[0], Equals, plumbing.NewHash("1111111111111111111111111111111111111111"))
 	c.Assert(sr.ACKs[1], Equals, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+}
+
+func (s *ServerResponseSuite) TestEncodeEmpty(c *C) {
+	haves := make(chan UploadPackCommand)
+	go func() {
+		close(haves)
+	}()
+	sr := &ServerResponse{req: &UploadPackRequest{UploadPackCommands: haves, UploadRequest: UploadRequest{Capabilities: capability.NewList()}}}
+	b := bytes.NewBuffer(nil)
+	err := sr.Encode(b)
+	c.Assert(err, IsNil)
+
+	c.Assert(b.String(), Equals, "0008NAK\n")
+}
+
+func (s *ServerResponseSuite) TestEncodeSingleAck(c *C) {
+	haves := make(chan UploadPackCommand)
+	go func() {
+		haves <- UploadPackCommand{
+			Acks: []UploadPackRequestAck{
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e1")},
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e2")},
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e3"), IsCommon: true},
+			}}
+		close(haves)
+	}()
+	sr := &ServerResponse{req: &UploadPackRequest{UploadPackCommands: haves, UploadRequest: UploadRequest{Capabilities: capability.NewList()}}}
+	b := bytes.NewBuffer(nil)
+	err := sr.Encode(b)
+	c.Assert(err, IsNil)
+
+	c.Assert(b.String(), Equals, "0031ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e3\n")
+}
+
+func (s *ServerResponseSuite) TestEncodeSingleAckDone(c *C) {
+	haves := make(chan UploadPackCommand)
+	go func() {
+		haves <- UploadPackCommand{
+			Acks: []UploadPackRequestAck{
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e1")},
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e2")},
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e3"), IsCommon: true},
+			},
+			Done: true,
+		}
+		close(haves)
+	}()
+	sr := &ServerResponse{req: &UploadPackRequest{UploadPackCommands: haves, UploadRequest: UploadRequest{Capabilities: capability.NewList()}}}
+	b := bytes.NewBuffer(nil)
+	err := sr.Encode(b)
+	c.Assert(err, IsNil)
+
+	c.Assert(b.String(), Equals, "0031ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e3\n")
+}
+
+func (s *ServerResponseSuite) TestEncodeMutiAck(c *C) {
+	haves := make(chan UploadPackCommand)
+	go func() {
+		haves <- UploadPackCommand{
+			Acks: []UploadPackRequestAck{
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e1")},
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e2"), IsCommon: true},
+				{Hash: plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e3")},
+			}}
+		close(haves)
+	}()
+	capabilities := capability.NewList()
+	capabilities.Add(capability.MultiACK)
+	sr := &ServerResponse{req: &UploadPackRequest{UploadPackCommands: haves, UploadRequest: UploadRequest{Capabilities: capabilities}}}
+	b := bytes.NewBuffer(nil)
+	err := sr.Encode(b)
+	c.Assert(err, IsNil)
+
+	lines := strings.Split(b.String(), "\n")
+	c.Assert(len(lines), Equals, 6)
+	c.Assert(lines[0], Equals, "003aACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e1 continue")
+	c.Assert(lines[1], Equals, "003aACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e2 continue")
+	c.Assert(lines[2], Equals, "003aACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e3 continue")
+	c.Assert(lines[3], Equals, "0008NAK")
+	c.Assert(lines[4], Equals, "0031ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e2")
+	c.Assert(lines[5], Equals, "")
 }

--- a/plumbing/protocol/packp/ulreq.go
+++ b/plumbing/protocol/packp/ulreq.go
@@ -71,7 +71,7 @@ func NewUploadRequest() *UploadRequest {
 		Wants:        []plumbing.Hash{},
 		Shallows:     []plumbing.Hash{},
 		Depth:        DepthCommits(0),
-		HavesUR:      make(chan UploadRequestHave),
+		HavesUR:      make(chan UploadRequestHave, 1),
 	}
 }
 

--- a/plumbing/protocol/packp/ulreq.go
+++ b/plumbing/protocol/packp/ulreq.go
@@ -18,6 +18,7 @@ type UploadRequest struct {
 	Shallows     []plumbing.Hash
 	Depth        Depth
 	Filter       Filter
+	HavesUR      []plumbing.Hash
 }
 
 // Depth values stores the desired depth of the requested packfile: see
@@ -65,6 +66,7 @@ func NewUploadRequest() *UploadRequest {
 		Wants:        []plumbing.Hash{},
 		Shallows:     []plumbing.Hash{},
 		Depth:        DepthCommits(0),
+		HavesUR:      []plumbing.Hash{},
 	}
 }
 

--- a/plumbing/protocol/packp/ulreq.go
+++ b/plumbing/protocol/packp/ulreq.go
@@ -18,7 +18,12 @@ type UploadRequest struct {
 	Shallows     []plumbing.Hash
 	Depth        Depth
 	Filter       Filter
-	HavesUR      []plumbing.Hash
+	HavesUR      chan UploadRequestHave
+}
+
+type UploadRequestHave struct {
+	Done  bool
+	Haves []plumbing.Hash
 }
 
 // Depth values stores the desired depth of the requested packfile: see
@@ -66,7 +71,7 @@ func NewUploadRequest() *UploadRequest {
 		Wants:        []plumbing.Hash{},
 		Shallows:     []plumbing.Hash{},
 		Depth:        DepthCommits(0),
-		HavesUR:      []plumbing.Hash{},
+		HavesUR:      make(chan UploadRequestHave),
 	}
 }
 

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -495,6 +495,8 @@ func (s *UlReqDecodeSuite) TestAll(c *C) {
 		"shallow dddddddddddddddddddddddddddddddddddddddd",
 		"deepen 1234",
 		"",
+		"have 5555555555555555555555555555555555555555",
+		"",
 	}
 	ur := s.testDecodeOK(c, payloads)
 
@@ -504,11 +506,17 @@ func (s *UlReqDecodeSuite) TestAll(c *C) {
 		plumbing.NewHash("3333333333333333333333333333333333333333"),
 		plumbing.NewHash("4444444444444444444444444444444444444444"),
 	}
+	expectedHave := []plumbing.Hash{
+		plumbing.NewHash("5555555555555555555555555555555555555555"),
+	}
+	sort.Sort(byHash(expectedHave))
+	sort.Sort(byHash(ur.HavesUR))
+	c.Assert(ur.HavesUR, DeepEquals, expectedHave)
+	c.Assert(ur.Capabilities.Supports(capability.OFSDelta), Equals, true)
+	c.Assert(ur.Capabilities.Supports(capability.MultiACK), Equals, true)
 	sort.Sort(byHash(expectedWants))
 	sort.Sort(byHash(ur.Wants))
 	c.Assert(ur.Wants, DeepEquals, expectedWants)
-	c.Assert(ur.Capabilities.Supports(capability.OFSDelta), Equals, true)
-	c.Assert(ur.Capabilities.Supports(capability.MultiACK), Equals, true)
 
 	expectedShallows := []plumbing.Hash{
 		plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -58,14 +58,14 @@ func (s *UlReqDecodeSuite) TestWantOK(c *C) {
 		"want 1111111111111111111111111111111111111111",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	c.Assert(ur.Wants, DeepEquals, []plumbing.Hash{
 		plumbing.NewHash("1111111111111111111111111111111111111111"),
 	})
 }
 
-func (s *UlReqDecodeSuite) testDecodeOK(c *C, payloads []string) *UploadRequest {
+func (s *UlReqDecodeSuite) testDecodeOK(c *C, payloads []string, expectedHaveCalls int) (*UploadRequest, []plumbing.Hash) {
 	var buf bytes.Buffer
 	for _, p := range payloads {
 		if p == "" {
@@ -81,7 +81,16 @@ func (s *UlReqDecodeSuite) testDecodeOK(c *C, payloads []string) *UploadRequest 
 
 	c.Assert(d.Decode(ur), IsNil)
 
-	return ur
+	haves := []plumbing.Hash{}
+	nbCall := 0
+	for h := range ur.HavesUR {
+		nbCall++
+		haves = append(haves, h.Haves...)
+	}
+
+	c.Assert(nbCall, Equals, expectedHaveCalls)
+
+	return ur, haves
 }
 
 func (s *UlReqDecodeSuite) TestWantWithCapabilities(c *C) {
@@ -89,7 +98,7 @@ func (s *UlReqDecodeSuite) TestWantWithCapabilities(c *C) {
 		"want 1111111111111111111111111111111111111111 ofs-delta multi_ack",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 	c.Assert(ur.Wants, DeepEquals, []plumbing.Hash{
 		plumbing.NewHash("1111111111111111111111111111111111111111"),
 	})
@@ -106,7 +115,7 @@ func (s *UlReqDecodeSuite) TestManyWantsNoCapabilities(c *C) {
 		"want 2222222222222222222222222222222222222222",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	expected := []plumbing.Hash{
 		plumbing.NewHash("1111111111111111111111111111111111111111"),
@@ -162,7 +171,7 @@ func (s *UlReqDecodeSuite) TestManyWantsWithCapabilities(c *C) {
 		"want 2222222222222222222222222222222222222222",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	expected := []plumbing.Hash{
 		plumbing.NewHash("1111111111111111111111111111111111111111"),
@@ -185,7 +194,7 @@ func (s *UlReqDecodeSuite) TestSingleShallowSingleWant(c *C) {
 		"shallow aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	expectedWants := []plumbing.Hash{
 		plumbing.NewHash("3333333333333333333333333333333333333333"),
@@ -211,7 +220,7 @@ func (s *UlReqDecodeSuite) TestSingleShallowManyWants(c *C) {
 		"shallow aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	expectedWants := []plumbing.Hash{
 		plumbing.NewHash("1111111111111111111111111111111111111111"),
@@ -242,7 +251,7 @@ func (s *UlReqDecodeSuite) TestManyShallowSingleWant(c *C) {
 		"shallow dddddddddddddddddddddddddddddddddddddddd",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	expectedWants := []plumbing.Hash{
 		plumbing.NewHash("3333333333333333333333333333333333333333"),
@@ -276,7 +285,7 @@ func (s *UlReqDecodeSuite) TestManyShallowManyWants(c *C) {
 		"shallow dddddddddddddddddddddddddddddddddddddddd",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	expectedWants := []plumbing.Hash{
 		plumbing.NewHash("1111111111111111111111111111111111111111"),
@@ -395,7 +404,7 @@ func (s *UlReqDecodeSuite) TestDeepenCommits(c *C) {
 		"deepen 1234",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	c.Assert(ur.Depth, FitsTypeOf, DepthCommits(0))
 	commits, ok := ur.Depth.(DepthCommits)
@@ -409,7 +418,7 @@ func (s *UlReqDecodeSuite) TestDeepenCommitsInfiniteImplicit(c *C) {
 		"deepen 0",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	c.Assert(ur.Depth, FitsTypeOf, DepthCommits(0))
 	commits, ok := ur.Depth.(DepthCommits)
@@ -422,7 +431,7 @@ func (s *UlReqDecodeSuite) TestDeepenCommitsInfiniteExplicit(c *C) {
 		"want 3333333333333333333333333333333333333333 ofs-delta multi_ack",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	c.Assert(ur.Depth, FitsTypeOf, DepthCommits(0))
 	commits, ok := ur.Depth.(DepthCommits)
@@ -456,7 +465,7 @@ func (s *UlReqDecodeSuite) TestDeepenSince(c *C) {
 		"deepen-since 1420167845", // 2015-01-02T03:04:05+00:00
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	expected := time.Date(2015, time.January, 2, 3, 4, 5, 0, time.UTC)
 
@@ -473,7 +482,7 @@ func (s *UlReqDecodeSuite) TestDeepenReference(c *C) {
 		"deepen-not refs/heads/master",
 		"",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, _ := s.testDecodeOK(c, payloads, 0)
 
 	expected := "refs/heads/master"
 
@@ -497,8 +506,11 @@ func (s *UlReqDecodeSuite) TestAll(c *C) {
 		"",
 		"have 5555555555555555555555555555555555555555",
 		"",
+		"have 6666666666666666666666666666666666666666",
+		"",
+		"done",
 	}
-	ur := s.testDecodeOK(c, payloads)
+	ur, haves := s.testDecodeOK(c, payloads, 2)
 
 	expectedWants := []plumbing.Hash{
 		plumbing.NewHash("1111111111111111111111111111111111111111"),
@@ -508,10 +520,11 @@ func (s *UlReqDecodeSuite) TestAll(c *C) {
 	}
 	expectedHave := []plumbing.Hash{
 		plumbing.NewHash("5555555555555555555555555555555555555555"),
+		plumbing.NewHash("6666666666666666666666666666666666666666"),
 	}
 	sort.Sort(byHash(expectedHave))
-	sort.Sort(byHash(ur.HavesUR))
-	c.Assert(ur.HavesUR, DeepEquals, expectedHave)
+	sort.Sort(byHash(haves))
+	c.Assert(haves, DeepEquals, expectedHave)
 	c.Assert(ur.Capabilities.Supports(capability.OFSDelta), Equals, true)
 	c.Assert(ur.Capabilities.Supports(capability.MultiACK), Equals, true)
 	sort.Sort(byHash(expectedWants))

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -507,7 +507,6 @@ func (s *UlReqDecodeSuite) TestAll(c *C) {
 		"have 5555555555555555555555555555555555555555",
 		"",
 		"have 6666666666666666666666666666666666666666",
-		"",
 		"done",
 	}
 	ur, haves := s.testDecodeOK(c, payloads, 2)

--- a/plumbing/protocol/packp/uppackreq.go
+++ b/plumbing/protocol/packp/uppackreq.go
@@ -26,6 +26,7 @@ type UploadPackCommand struct {
 type UploadPackRequestAck struct {
 	Hash     plumbing.Hash
 	IsCommon bool
+	IsReady  bool
 }
 
 // NewUploadPackRequest creates a new UploadPackRequest and returns a pointer.
@@ -34,7 +35,7 @@ func NewUploadPackRequest() *UploadPackRequest {
 	return &UploadPackRequest{
 		UploadHaves:        UploadHaves{},
 		UploadRequest:      *ur,
-		UploadPackCommands: make(chan UploadPackCommand),
+		UploadPackCommands: make(chan UploadPackCommand, 1),
 	}
 }
 
@@ -47,7 +48,7 @@ func NewUploadPackRequestFromCapabilities(adv *capability.List) *UploadPackReque
 	return &UploadPackRequest{
 		UploadHaves:        UploadHaves{},
 		UploadRequest:      *ur,
-		UploadPackCommands: make(chan UploadPackCommand),
+		UploadPackCommands: make(chan UploadPackCommand, 1),
 	}
 }
 

--- a/plumbing/protocol/packp/uppackreq.go
+++ b/plumbing/protocol/packp/uppackreq.go
@@ -15,14 +15,26 @@ import (
 type UploadPackRequest struct {
 	UploadRequest
 	UploadHaves
+	UploadPackCommands chan UploadPackCommand
+}
+
+type UploadPackCommand struct {
+	Acks []UploadPackRequestAck
+	Done bool
+}
+
+type UploadPackRequestAck struct {
+	Hash     plumbing.Hash
+	IsCommon bool
 }
 
 // NewUploadPackRequest creates a new UploadPackRequest and returns a pointer.
 func NewUploadPackRequest() *UploadPackRequest {
 	ur := NewUploadRequest()
 	return &UploadPackRequest{
-		UploadHaves:   UploadHaves{},
-		UploadRequest: *ur,
+		UploadHaves:        UploadHaves{},
+		UploadRequest:      *ur,
+		UploadPackCommands: make(chan UploadPackCommand),
 	}
 }
 
@@ -33,8 +45,9 @@ func NewUploadPackRequest() *UploadPackRequest {
 func NewUploadPackRequestFromCapabilities(adv *capability.List) *UploadPackRequest {
 	ur := NewUploadRequestFromCapabilities(adv)
 	return &UploadPackRequest{
-		UploadHaves:   UploadHaves{},
-		UploadRequest: *ur,
+		UploadHaves:        UploadHaves{},
+		UploadRequest:      *ur,
+		UploadPackCommands: make(chan UploadPackCommand),
 	}
 }
 

--- a/plumbing/protocol/packp/uppackresp.go
+++ b/plumbing/protocol/packp/uppackresp.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/utils/ioutil"
 )
@@ -33,21 +32,11 @@ func NewUploadPackResponse(req *UploadPackRequest) *UploadPackResponse {
 	isShallow := !req.Depth.IsZero()
 	isMultiACK := req.Capabilities.Supports(capability.MultiACK) ||
 		req.Capabilities.Supports(capability.MultiACKDetailed)
-	acks := []plumbing.Hash{}
-	if isMultiACK {
-		for _, ch := range req.HavesUR {
-			for _, h := range req.Haves {
-				if h == ch {
-					acks = append(acks, h)
-					break
-				}
-			}
-		}
-	}
+
 	return &UploadPackResponse{
 		isShallow:      isShallow,
 		isMultiACK:     isMultiACK,
-		ServerResponse: ServerResponse{ACKs: acks},
+		ServerResponse: ServerResponse{req: req},
 	}
 }
 

--- a/plumbing/protocol/packp/uppackresp_test.go
+++ b/plumbing/protocol/packp/uppackresp_test.go
@@ -90,6 +90,10 @@ func (s *UploadPackResponseSuite) TestEncodeNAK(c *C) {
 	defer func() { c.Assert(res.Close(), IsNil) }()
 
 	go func() {
+		req.UploadPackCommands <- UploadPackCommand{
+			Acks: []UploadPackRequestAck{},
+			Done: true,
+		}
 		close(req.UploadPackCommands)
 	}()
 	b := bytes.NewBuffer(nil)
@@ -108,6 +112,10 @@ func (s *UploadPackResponseSuite) TestEncodeDepth(c *C) {
 	defer func() { c.Assert(res.Close(), IsNil) }()
 
 	go func() {
+		req.UploadPackCommands <- UploadPackCommand{
+			Acks: []UploadPackRequestAck{},
+			Done: true,
+		}
 		close(req.UploadPackCommands)
 	}()
 	b := bytes.NewBuffer(nil)
@@ -129,14 +137,18 @@ func (s *UploadPackResponseSuite) TestEncodeMultiACK(c *C) {
 			Acks: []UploadPackRequestAck{
 				{Hash: plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f81")},
 				{Hash: plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f82"), IsCommon: true},
-			}}
+			},
+		}
+		req.UploadPackCommands <- UploadPackCommand{
+			Acks: []UploadPackRequestAck{},
+			Done: true,
+		}
 		close(req.UploadPackCommands)
 	}()
 	b := bytes.NewBuffer(nil)
 	c.Assert(res.Encode(b), IsNil)
 
-	expected := "003aACK 5dc01c595e6c6ec9ccda4f6f69c131c0dd945f81 continue\n" +
-		"003aACK 5dc01c595e6c6ec9ccda4f6f69c131c0dd945f82 continue\n" +
+	expected := "003aACK 5dc01c595e6c6ec9ccda4f6f69c131c0dd945f82 continue\n" +
 		"0008NAK\n" +
 		"0031ACK 5dc01c595e6c6ec9ccda4f6f69c131c0dd945f82\n" +
 		"[PACK]"

--- a/plumbing/protocol/packp/uppackresp_test.go
+++ b/plumbing/protocol/packp/uppackresp_test.go
@@ -60,10 +60,6 @@ func (s *UploadPackResponseSuite) TestDecodeMalformed(c *C) {
 	c.Assert(err, NotNil)
 }
 
-// multi_ack isn't fully implemented, this ensures that Decode ignores that fact,
-// as in some circumstances that's OK to assume so.
-//
-// TODO: Review as part of multi_ack implementation.
 func (s *UploadPackResponseSuite) TestDecodeMultiACK(c *C) {
 	req := NewUploadPackRequest()
 	req.Capabilities.Set(capability.MultiACK)
@@ -118,6 +114,7 @@ func (s *UploadPackResponseSuite) TestEncodeDepth(c *C) {
 func (s *UploadPackResponseSuite) TestEncodeMultiACK(c *C) {
 	pf := io.NopCloser(bytes.NewBuffer([]byte("[PACK]")))
 	req := NewUploadPackRequest()
+	req.Capabilities.Set(capability.MultiACK)
 
 	res := NewUploadPackResponseWithPackfile(req, pf)
 	defer func() { c.Assert(res.Close(), IsNil) }()
@@ -127,7 +124,7 @@ func (s *UploadPackResponseSuite) TestEncodeMultiACK(c *C) {
 	}
 
 	b := bytes.NewBuffer(nil)
-	c.Assert(res.Encode(b), NotNil)
+	c.Assert(res.Encode(b), IsNil)
 }
 
 func FuzzDecoder(f *testing.F) {

--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -24,6 +24,19 @@ func Objects(
 	return ObjectsWithStorageForIgnores(s, s, objs, ignore)
 }
 
+func ObjectsMissing(
+	s storer.EncodedObjectStorer,
+	objs,
+	ignore []plumbing.Hash,
+) ([]plumbing.Hash, error) {
+	ignore, err := objects(s, ignore, nil, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return objects(s, objs, ignore, true)
+}
+
 // ObjectsWithStorageForIgnores is the same as Objects, but a
 // secondary storage layer can be provided, to be used to finding the
 // full set of objects to be ignored while finding the reachable

--- a/plumbing/server/server.go
+++ b/plumbing/server/server.go
@@ -187,10 +187,12 @@ func (s *upSession) UploadPack(ctx context.Context, req *packp.UploadPackRequest
 }
 
 func (s *upSession) objectsToUpload(req *packp.UploadPackRequest) ([]plumbing.Hash, error) {
-	haves, err := revlist.Objects(s.storer, req.Haves, nil)
+	haves, err := revlist.ObjectsMissing(s.storer, req.Haves, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Haves = haves
 
 	return revlist.Objects(s.storer, req.Wants, haves)
 }

--- a/plumbing/server/server.go
+++ b/plumbing/server/server.go
@@ -168,7 +168,7 @@ func (s *upSession) UploadPack(ctx context.Context, req *packp.UploadPackRequest
 		return nil, fmt.Errorf("shallow not supported")
 	}
 
-	objs, err := s.objectsToUpload(req)
+	havesWithRef, err := revlist.ObjectsWithRef(s.storer, req.Wants, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -176,8 +176,24 @@ func (s *upSession) UploadPack(ctx context.Context, req *packp.UploadPackRequest
 	pr, pw := io.Pipe()
 	e := packfile.NewEncoder(pw, s.storer, false)
 	go func() {
-		// TODO: plumb through a pack window.
-		_, err := e.Encode(objs, 10)
+		allHaves := []plumbing.Hash{}
+		for haves := range req.HavesUR {
+			acks := []packp.UploadPackRequestAck{}
+			for _, hu := range haves.Haves {
+				if refs, ok := havesWithRef[hu]; ok {
+					acks = append(acks, packp.UploadPackRequestAck{Hash: hu, IsCommon: len(refs) >= len(req.Wants)})
+					allHaves = append(allHaves, hu)
+				}
+			}
+			req.UploadPackCommands <- packp.UploadPackCommand{Acks: acks, Done: haves.Done}
+		}
+		close(req.UploadPackCommands)
+		objs, err := s.objectsToUpload(req.Wants, allHaves)
+		if err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		_, err = e.Encode(objs, 10)
 		pw.CloseWithError(err)
 	}()
 
@@ -186,15 +202,8 @@ func (s *upSession) UploadPack(ctx context.Context, req *packp.UploadPackRequest
 	), nil
 }
 
-func (s *upSession) objectsToUpload(req *packp.UploadPackRequest) ([]plumbing.Hash, error) {
-	haves, err := revlist.ObjectsMissing(s.storer, req.Haves, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Haves = haves
-
-	return revlist.Objects(s.storer, req.Wants, haves)
+func (s *upSession) objectsToUpload(wants, haves []plumbing.Hash) ([]plumbing.Hash, error) {
+	return revlist.Objects(s.storer, wants, haves)
 }
 
 func (*upSession) setSupportedCapabilities(c *capability.List) error {

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -457,7 +457,6 @@ func isRepoNotFoundError(s string) bool {
 
 // uploadPack implements the git-upload-pack protocol.
 func uploadPack(w io.WriteCloser, _ io.Reader, req *packp.UploadPackRequest) error {
-	// TODO support multi_ack mode
 	// TODO support multi_ack_detailed mode
 	// TODO support acks for common objects
 	// TODO build a proper state machine for all these processing options

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -457,7 +457,6 @@ func isRepoNotFoundError(s string) bool {
 
 // uploadPack implements the git-upload-pack protocol.
 func uploadPack(w io.WriteCloser, _ io.Reader, req *packp.UploadPackRequest) error {
-	// TODO support multi_ack_detailed mode
 	// TODO support acks for common objects
 	// TODO build a proper state machine for all these processing options
 

--- a/plumbing/transport/transport.go
+++ b/plumbing/transport/transport.go
@@ -309,7 +309,6 @@ func parseFile(endpoint string) (*Endpoint, bool) {
 // UnsupportedCapabilities are the capabilities not supported by any client
 // implementation
 var UnsupportedCapabilities = []capability.Capability{
-	capability.MultiACK,
 	capability.MultiACKDetailed,
 	capability.ThinPack,
 }

--- a/plumbing/transport/transport.go
+++ b/plumbing/transport/transport.go
@@ -309,7 +309,6 @@ func parseFile(endpoint string) (*Endpoint, bool) {
 // UnsupportedCapabilities are the capabilities not supported by any client
 // implementation
 var UnsupportedCapabilities = []capability.Capability{
-	capability.MultiACKDetailed,
 	capability.ThinPack,
 }
 

--- a/plumbing/transport/transport_test.go
+++ b/plumbing/transport/transport_test.go
@@ -219,7 +219,7 @@ func (s *SuiteCommon) TestFilterUnsupportedCapabilities(c *C) {
 	l.Set(capability.MultiACK)
 
 	FilterUnsupportedCapabilities(l)
-	c.Assert(l.Supports(capability.MultiACK), Equals, false)
+	c.Assert(l.Supports(capability.MultiACKDetailed), Equals, false)
 }
 
 func (s *SuiteCommon) TestNewEndpointIPv6(c *C) {

--- a/plumbing/transport/transport_test.go
+++ b/plumbing/transport/transport_test.go
@@ -217,9 +217,10 @@ func (s *SuiteCommon) TestNewEndpointInvalidURL(c *C) {
 func (s *SuiteCommon) TestFilterUnsupportedCapabilities(c *C) {
 	l := capability.NewList()
 	l.Set(capability.MultiACK)
+	l.Set(capability.MultiACKDetailed)
 
 	FilterUnsupportedCapabilities(l)
-	c.Assert(l.Supports(capability.MultiACKDetailed), Equals, false)
+	c.Assert(l.Supports(capability.ThinPack), Equals, false)
 }
 
 func (s *SuiteCommon) TestNewEndpointIPv6(c *C) {


### PR DESCRIPTION
I push to v6 (because I use it on my project) but I think it should work on v5.

Should close https://github.com/go-git/go-git/issues/647 (at least on my project).

I'm not sure why, but when I add `ar.Capabilities.Add("multi_ack")` in my project I can delete the `Capabilities.Add("no-thin")` capability.