### PR TITLE
fix(1212): Fix invalid reference name error while cloning branches containing `/-`

### DIFF
--- a/_examples/clone/auth/basic/access_token/branch/main.go
+++ b/_examples/clone/auth/basic/access_token/branch/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	git "github.com/go-git/go-git/v5"
+	. "github.com/go-git/go-git/v5/_examples"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+func main() {
+	CheckArgs("<url>", "<branch>", "<directory>", "<github_access_token>")
+	url, branch, directory, token := os.Args[1], os.Args[2], os.Args[3], os.Args[4]
+
+	// Clone the given repository to the given directory
+	Info("git clone %s %s %s", url, branch, directory)
+
+	r, err := git.PlainClone(directory, false, &git.CloneOptions{
+		// The intended use of a GitHub personal access token is in replace of your password
+		// because access tokens can easily be revoked.
+		// https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+		Auth: &http.BasicAuth{
+			Username: "abc123", // yes, this can be anything except an empty string
+			Password: token,
+		},
+		URL:           url,
+		Progress:      os.Stdout,
+		ReferenceName: plumbing.ReferenceName(branch),
+	})
+	CheckIfError(err)
+
+	// ... retrieving the branch being pointed by HEAD
+	ref, err := r.Head()
+	CheckIfError(err)
+	// ... retrieving the commit object
+	commit, err := r.CommitObject(ref.Hash())
+	CheckIfError(err)
+
+	fmt.Println(commit)
+}

--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -222,14 +222,9 @@ func (r ReferenceName) Validate() error {
 			return ErrInvalidReferenceName
 		}
 
-	}
-
-	if (isBranch) && strings.HasPrefix(r.BranchName(), "-") { // branches & tags can't start with -
-		return ErrInvalidReferenceName
-	}
-
-	if (isTag) && strings.HasPrefix(r.TagName(), "-") { // branches & tags can't start with -
-		return ErrInvalidReferenceName
+		if (isBranch || isTag) && strings.HasPrefix(part, "-") && i == 2 { // branches & tags can't start with -
+			return ErrInvalidReferenceName
+		}
 	}
 
 	return nil

--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -95,6 +95,14 @@ func (r ReferenceName) IsBranch() bool {
 	return strings.HasPrefix(string(r), refHeadPrefix)
 }
 
+// BranchName returns the branch name if the reference is a branch
+func (r ReferenceName) BranchName() string {
+	if r.IsBranch() {
+		return strings.TrimPrefix(string(r), refHeadPrefix)
+	}
+	return ""
+}
+
 // IsNote check if a reference is a note
 func (r ReferenceName) IsNote() bool {
 	return strings.HasPrefix(string(r), refNotePrefix)
@@ -108,6 +116,15 @@ func (r ReferenceName) IsRemote() bool {
 // IsTag check if a reference is a tag
 func (r ReferenceName) IsTag() bool {
 	return strings.HasPrefix(string(r), refTagPrefix)
+}
+
+// TagName returns the Tag name if the reference is a tag
+func (r ReferenceName) TagName() string {
+	if r.IsTag() {
+		return strings.TrimPrefix(string(r), refTagPrefix)
+	}
+
+	return ""
 }
 
 func (r ReferenceName) String() string {
@@ -205,9 +222,14 @@ func (r ReferenceName) Validate() error {
 			return ErrInvalidReferenceName
 		}
 
-		if (isBranch || isTag) && strings.HasPrefix(part, "-") { // branches & tags can't start with -
-			return ErrInvalidReferenceName
-		}
+	}
+
+	if (isBranch) && strings.HasPrefix(r.BranchName(), "-") { // branches & tags can't start with -
+		return ErrInvalidReferenceName
+	}
+
+	if (isTag) && strings.HasPrefix(r.TagName(), "-") { // branches & tags can't start with -
+		return ErrInvalidReferenceName
 	}
 
 	return nil


### PR DESCRIPTION
Fix(https://github.com/go-git/go-git/issues/1212) 

This pull request includes changes to add a new example for cloning a repository using a GitHub access token and enhancements to the `ReferenceName` type in the `plumbing` package. The most important changes include adding a new example in the `_examples` directory, introducing new methods to `ReferenceName`, and updating the `Validate` method to use these new methods.

### New Example for Cloning with Access Token:

* [`_examples/clone/auth/basic/access_token/branch/main.go`](diffhunk://#diff-d08255be8265002b0053c9eb47a8af4a8565725190aac3e5b69dc7b9c3e3bdbfR1-R42): Added a new example demonstrating how to clone a repository using a GitHub access token.

### Enhancements to `ReferenceName` Type:

* [`plumbing/reference.go`](diffhunk://#diff-b289cf98bc682ff246ede6d0c7c706ccff0fc59700f81e6e1e7ebcf1ebc425e4R98-R105): Added `BranchName` and `TagName` methods to `ReferenceName` to extract the branch and tag names, respectively. [[1]](diffhunk://#diff-b289cf98bc682ff246ede6d0c7c706ccff0fc59700f81e6e1e7ebcf1ebc425e4R98-R105) [[2]](diffhunk://#diff-b289cf98bc682ff246ede6d0c7c706ccff0fc59700f81e6e1e7ebcf1ebc425e4R121-R129)
* [`plumbing/reference.go`](diffhunk://#diff-b289cf98bc682ff246ede6d0c7c706ccff0fc59700f81e6e1e7ebcf1ebc425e4L208-R232): Updated the `Validate` method to use the new `BranchName` and `TagName` methods for improved validation of branch and tag names.