### PR TITLE
[v6-exp] plumbing: Improve PACK trace by redacting binary data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
       run: make test-coverage
 
     - name: Test Examples
-      run: go test -timeout 30s -v -run '^TestExamples$' github.com/go-git/go-git/v5/_examples --examples
+      run: go test -timeout 45s -v -run '^TestExamples$' github.com/go-git/go-git/v5/_examples --examples

--- a/plumbing/format/pktline/pktline.go
+++ b/plumbing/format/pktline/pktline.go
@@ -146,7 +146,7 @@ func Read(r io.Reader, p []byte) (l int, err error) {
 		}
 	}
 
-	trace.Packet.Printf("packet: < %04x %s", length, p[LenSize:length])
+	maskPackDataTrace(length, p[LenSize:length])
 
 	return length, err
 }
@@ -211,7 +211,15 @@ func PeekLine(r ioutil.ReadPeeker) (l int, p []byte, err error) {
 		}
 	}
 
-	trace.Packet.Printf("packet: < %04x %s", length, buf)
+	maskPackDataTrace(length, buf)
 
 	return length, buf, err
+}
+
+func maskPackDataTrace(len int, data []byte) {
+	output := []byte("[ PACKDATA ]")
+	if len < 400 {
+		output = data
+	}
+	trace.Packet.Printf("packet: < %04x %s", len, output)
 }


### PR DESCRIPTION
Previously, the trace would output the raw packfile data, which wasn't very useful. This change replaces the binary data with '[ PACKDATA ]' instead of the raw data, resulting in lines such as the following:

```
22:31:38.937878 pktline.go:224: packet: < 6005 [ PACKDATA ]
22:31:38.943047 pktline.go:224: packet: < 4005 [ PACKDATA ]
22:31:38.943865 pktline.go:224: packet: < 2005 [ PACKDATA ]
```