### PR TITLE
pktline : accept upercase hexadecimal value as pktline length information

### DIFF
--- a/plumbing/format/pktline/scanner.go
+++ b/plumbing/format/pktline/scanner.go
@@ -140,6 +140,8 @@ func asciiHexToByte(b byte) (byte, error) {
 		return b - '0', nil
 	case b >= 'a' && b <= 'f':
 		return b - 'a' + 10, nil
+	case b >= 'A' && b <= 'F':
+		return b - 'A' + 10, nil
 	default:
 		return 0, ErrInvalidPktLen
 	}


### PR DESCRIPTION
Hello,
At work, I use a homemade git client implemented using Go-Git v5.12.
This client tries to clone repos hosted on a gitolite instance through http protocol.
A gitweb server handle the communication between my client and the gitolite server.

When the gitolite server grants access to the repository, it returns such pktlines in its answer:
001e# service=git-upload-pack
000000b5ab0ed9bd726e63e0679491160be72aaae876838b HEADmulti_ack thin-pack side-band side-band-64k ofs-delta shallow no-progress include-tag multi_ack_detailed no-done agent=git/[1.8.3.1](http://1.8.3.1/)

The length of first pktline (0x001e) is correctly parsed by Go-Git and the clone is done as expected.

However, when the gitolite server doesn't grant access to the repository, it returns such pktlines in its answer:
001E# service=git-upload-pack
00000064ERR FATAL: R any reponame username DENIED by fallthru
(or you mis-spelled the reponame)

You may have notice that the first pktline length (0x001E) is in uppercase.
Go-Git can't handle an uppercase hexadecimal value and returns "invalid pkt-len found".
I would have expected to receive an ErrorLine error with this Text value :
```shell
FATAL: R any reponame username DENIED by fallthru
(or you mis-spelled the reponame)
```

I saw that the Pack and Http Protocols consider a valid hexadecimal digit as:
```
HEXDIG    =  DIGIT / "a" / "b" / "c" / "d" / "e" / "f"
``` 

Is it possible to accept A, B, C, D, E and F as well ?
