### PR TITLE
plumbing: object, limit logs by trailing hash 

### DIFF
--- a/options.go
+++ b/options.go
@@ -457,6 +457,10 @@ type LogOptions struct {
 	// the default From.
 	From plumbing.Hash
 
+	// When To is set the log will go down until it reaches to the commit with the
+	// specified hash. The default value for this field in nil
+	To plumbing.Hash
+
 	// The default traversal algorithm is Depth-first search
 	// set Order=LogOrderCommitterTime for ordering by committer time (more compatible with `git log`)
 	// set Order=LogOrderBSF for Breadth-first search

--- a/plumbing/object/commit_walker_limit.go
+++ b/plumbing/object/commit_walker_limit.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 )
 
@@ -13,8 +14,9 @@ type commitLimitIter struct {
 }
 
 type LogLimitOptions struct {
-	Since *time.Time
-	Until *time.Time
+	Since    *time.Time
+	Until    *time.Time
+	TailHash plumbing.Hash
 }
 
 func NewCommitLimitIterFromIter(commitIter CommitIter, limitOptions LogLimitOptions) CommitIter {
@@ -36,6 +38,9 @@ func (c *commitLimitIter) Next() (*Commit, error) {
 		}
 		if c.limitOptions.Until != nil && commit.Committer.When.After(*c.limitOptions.Until) {
 			continue
+		}
+		if c.limitOptions.TailHash == commit.Hash {
+			return commit, storer.ErrStop
 		}
 		return commit, nil
 	}

--- a/plumbing/object/commit_walker_limit.go
+++ b/plumbing/object/commit_walker_limit.go
@@ -52,11 +52,11 @@ func (c *commitLimitIter) ForEach(cb func(*Commit) error) error {
 		if nextErr == io.EOF {
 			break
 		}
-		if nextErr != nil {
+		if nextErr != nil && nextErr != storer.ErrStop {
 			return nextErr
 		}
 		err := cb(commit)
-		if err == storer.ErrStop {
+		if err == storer.ErrStop || nextErr == storer.ErrStop {
 			return nil
 		} else if err != nil {
 			return err

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -111,8 +111,8 @@ func (s *CommitWalkerSuite) TestCommitLimitIterByTime(c *C) {
 	for i, commit := range commits {
 		c.Assert(commit.Hash.String(), Equals, expected[i])
 	}
-
 }
+
 func (s *CommitWalkerSuite) TestCommitPreIteratorWithSeenExternal(c *C) {
 	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
 

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -1,6 +1,8 @@
 package object
 
 import (
+	"time"
+
 	"github.com/go-git/go-git/v5/plumbing"
 
 	. "gopkg.in/check.v1"
@@ -60,6 +62,57 @@ func (s *CommitWalkerSuite) TestCommitPreIteratorWithIgnore(c *C) {
 	}
 }
 
+func (s *CommitWalkerSuite) TestCommitLimitIterByTrailingHash(c *C) {
+
+	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
+	commitIter := NewCommitPreorderIter(commit, nil, nil)
+	var commits []*Commit
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+		"1669dce138d9b841a518c64b10914d88f5e488ea",
+		"35e85108805c84807bc66a02d91535e1e24b38b9",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+		"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+	}
+	NewCommitLimitIterFromIter(commitIter, LogLimitOptions{
+		TailHash: plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"),
+	}).ForEach(func(c *Commit) error {
+		commits = append(commits, c)
+		return nil
+	})
+
+	for i, commit := range commits {
+		c.Assert(commit.Hash.String(), Equals, expected[i])
+	}
+
+}
+func (s *CommitWalkerSuite) TestCommitLimitIterByTime(c *C) {
+	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
+	commitIter := NewCommitPreorderIter(commit, nil, nil)
+	var commits []*Commit
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+		"1669dce138d9b841a518c64b10914d88f5e488ea",
+	}
+	since, err := time.Parse(time.RFC3339, "2015-03-31T13:48:14+02:00")
+	c.Assert(err, Equals, nil)
+	NewCommitLimitIterFromIter(commitIter, LogLimitOptions{
+		Since:    &since,
+		TailHash: plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"),
+	}).ForEach(func(c *Commit) error {
+		commits = append(commits, c)
+		return nil
+	})
+
+	for i, commit := range commits {
+		c.Assert(commit.Hash.String(), Equals, expected[i])
+	}
+
+}
 func (s *CommitWalkerSuite) TestCommitPreIteratorWithSeenExternal(c *C) {
 	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
 

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -86,8 +86,8 @@ func (s *CommitWalkerSuite) TestCommitLimitIterByTrailingHash(c *C) {
 	for i, commit := range commits {
 		c.Assert(commit.Hash.String(), Equals, expected[i])
 	}
-
 }
+
 func (s *CommitWalkerSuite) TestCommitLimitIterByTime(c *C) {
 	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
 	commitIter := NewCommitPreorderIter(commit, nil, nil)

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -63,7 +63,6 @@ func (s *CommitWalkerSuite) TestCommitPreIteratorWithIgnore(c *C) {
 }
 
 func (s *CommitWalkerSuite) TestCommitLimitIterByTrailingHash(c *C) {
-
 	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
 	commitIter := NewCommitPreorderIter(commit, nil, nil)
 	var commits []*Commit

--- a/repository.go
+++ b/repository.go
@@ -1283,8 +1283,8 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		it = r.logWithPathFilter(o.PathFilter, it, o.All)
 	}
 
-	if o.Since != nil || o.Until != nil {
-		limitOptions := object.LogLimitOptions{Since: o.Since, Until: o.Until}
+	if o.Since != nil || o.Until != nil || !o.To.IsZero() {
+		limitOptions := object.LogLimitOptions{Since: o.Since, Until: o.Until, TailHash: o.To}
 		it = r.logWithLimit(it, limitOptions)
 	}
 


### PR DESCRIPTION
I believe it would be a nice filter parameter if we can limit the logs with the target hash along with time filter. 

what I like to see in this lib is something similar to ancestry path in git cli
```bash
git rev-list --ancestry-path 7b4a07a..ecf5891
```

then we should be able to select a path on the git tree by setting from/to hash 

```

                     __D     
                   /          
         ____B ___E___H
       /          \__F
     A             
      \___ C

```
if I wanna select `HEB` we set `from: H, To: B`
wdyt?