### PR TITLE
Don't delete untracked files when resetting worktree.

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -469,8 +469,11 @@ func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
 			}
 		}
 
-		if err := w.checkoutChange(ch, t, b); err != nil {
-			return err
+		status, err := w.Status()
+		if err == nil && status.File(nameFromAction(&ch)).Worktree != Untracked {
+			if err := w.checkoutChange(ch, t, b); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/worktree.go
+++ b/worktree.go
@@ -446,6 +446,11 @@ func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
 	}
 	b := newIndexBuilder(idx)
 
+	status, err := w.Status()
+	if err != nil {
+		return err
+	}
+
 	for _, ch := range changes {
 		if err := w.validChange(ch); err != nil {
 			return err
@@ -469,8 +474,7 @@ func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
 			}
 		}
 
-		status, err := w.Status()
-		if err == nil && status.File(nameFromAction(&ch)).Worktree != Untracked {
+		if status.File(nameFromAction(&ch)).Worktree != Untracked {
 			if err := w.checkoutChange(ch, t, b); err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR is just a direct copy of https://github.com/BillXiang/go-git/commit/8d52a2a431befbeede79854202fd8337d48518be 

I recently ran into this issue: https://github.com/go-git/go-git/issues/53 where running the following code would remove any untracked files from my repo, even if they were in the `.gitignore`

```
worktree.Reset(&git.ResetOptions{
    Mode: git.HardReset,
})
```

This commit fixed the issue for me. 
