### PR TITLE
fix: Concurrent map read/write in Tree methods

### DIFF
--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -264,6 +264,7 @@ func (s *TreeSuite) TestTreeDecodeEncodeIdempotent(c *C) {
 		err = newTree.Decode(obj)
 		c.Assert(err, IsNil)
 		tree.Hash = obj.Hash()
+		tree.buildMap()
 		c.Assert(newTree, DeepEquals, tree)
 	}
 }


### PR DESCRIPTION
The "tree path cache" internal field in Tree struct is preventing Tree methods to be called from multiple goroutines concurrently - producing "concurrent map read/write" panics.
This PR disables this internal cache and allows the same Tree object methods to be called concurrently.

IMHO, this type of cache is a bad practice in Go and it is better to utilize multiple goroutines to make processing things faster.
Of course, unless the performance gain by this cache was measured thoroughly and this cache definitely improves performance, but I don't think this is the case.

Thanks!