### PR TITLE
plumbing: Properly encode index version 4

### DIFF
--- a/plumbing/format/index/encoder.go
+++ b/plumbing/format/index/encoder.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5/plumbing/hash"
@@ -14,7 +16,7 @@ import (
 
 var (
 	// EncodeVersionSupported is the range of supported index versions
-	EncodeVersionSupported uint32 = 3
+	EncodeVersionSupported uint32 = 4
 
 	// ErrInvalidTimestamp is returned by Encode if a Index with a Entry with
 	// negative timestamp values
@@ -23,15 +25,16 @@ var (
 
 // An Encoder writes an Index to an output stream.
 type Encoder struct {
-	w    io.Writer
-	hash hash.Hash
+	w         io.Writer
+	hash      hash.Hash
+	lastEntry *Entry
 }
 
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
 	h := hash.New(hash.CryptoType)
 	mw := io.MultiWriter(w, h)
-	return &Encoder{mw, h}
+	return &Encoder{mw, h, nil}
 }
 
 // Encode writes the Index to the stream of the encoder.
@@ -41,7 +44,6 @@ func (e *Encoder) Encode(idx *Index) error {
 
 func (e *Encoder) encode(idx *Index, footer bool) error {
 
-	// TODO: support v4
 	// TODO: support extensions
 	if idx.Version > EncodeVersionSupported {
 		return ErrUnsupportedVersion
@@ -73,7 +75,7 @@ func (e *Encoder) encodeEntries(idx *Index) error {
 	sort.Sort(byName(idx.Entries))
 
 	for _, entry := range idx.Entries {
-		if err := e.encodeEntry(entry); err != nil {
+		if err := e.encodeEntry(idx, entry); err != nil {
 			return err
 		}
 		entryLength := entryHeaderLength
@@ -82,7 +84,7 @@ func (e *Encoder) encodeEntries(idx *Index) error {
 		}
 
 		wrote := entryLength + len(entry.Name)
-		if err := e.padEntry(wrote); err != nil {
+		if err := e.padEntry(idx, wrote); err != nil {
 			return err
 		}
 	}
@@ -90,7 +92,7 @@ func (e *Encoder) encodeEntries(idx *Index) error {
 	return nil
 }
 
-func (e *Encoder) encodeEntry(entry *Entry) error {
+func (e *Encoder) encodeEntry(idx *Index, entry *Entry) error {
 	sec, nsec, err := e.timeToUint32(&entry.CreatedAt)
 	if err != nil {
 		return err
@@ -141,7 +143,44 @@ func (e *Encoder) encodeEntry(entry *Entry) error {
 		return err
 	}
 
+	switch idx.Version {
+	case 2, 3:
+		err = e.encodeEntryName(entry)
+	case 4:
+		err = e.encodeEntryNameV4(entry)
+	default:
+		err = ErrUnsupportedVersion
+	}
+
+	return err
+
+}
+
+func (e *Encoder) encodeEntryName(entry *Entry) error {
 	return binary.Write(e.w, []byte(entry.Name))
+}
+
+func (e *Encoder) encodeEntryNameV4(entry *Entry) error {
+	name := entry.Name
+	l := 0
+	if e.lastEntry != nil {
+		dir := path.Dir(e.lastEntry.Name) + "/"
+		if strings.HasPrefix(entry.Name, dir) {
+			l = len(e.lastEntry.Name) - len(dir)
+			name = strings.TrimPrefix(entry.Name, dir)
+		} else {
+			l = len(e.lastEntry.Name)
+		}
+	}
+
+	e.lastEntry = entry
+
+	err := binary.WriteVariableWidthInt(e.w, int64(l))
+	if err != nil {
+		return err
+	}
+
+	return binary.Write(e.w, []byte(name+string('\x00')))
 }
 
 func (e *Encoder) encodeRawExtension(signature string, data []byte) error {
@@ -179,7 +218,11 @@ func (e *Encoder) timeToUint32(t *time.Time) (uint32, uint32, error) {
 	return uint32(t.Unix()), uint32(t.Nanosecond()), nil
 }
 
-func (e *Encoder) padEntry(wrote int) error {
+func (e *Encoder) padEntry(idx *Index, wrote int) error {
+	if idx.Version == 4 {
+		return nil
+	}
+
 	padLen := 8 - wrote%8
 
 	_, err := e.w.Write(bytes.Repeat([]byte{'\x00'}, padLen))

--- a/plumbing/format/index/encoder.go
+++ b/plumbing/format/index/encoder.go
@@ -153,7 +153,6 @@ func (e *Encoder) encodeEntry(idx *Index, entry *Entry) error {
 	}
 
 	return err
-
 }
 
 func (e *Encoder) encodeEntryName(entry *Entry) error {

--- a/plumbing/format/index/encoder_test.go
+++ b/plumbing/format/index/encoder_test.go
@@ -110,7 +110,6 @@ func (s *IndexSuite) TestEncodeV4(c *C) {
 	c.Assert(output.Entries[2].Name, Equals, "baz/bar")
 	c.Assert(output.Entries[3].Name, Equals, "baz/bar/bar")
 	c.Assert(output.Entries[4].Name, Equals, "foo")
-
 }
 
 func (s *IndexSuite) TestEncodeUnsupportedVersion(c *C) {

--- a/plumbing/format/index/encoder_test.go
+++ b/plumbing/format/index/encoder_test.go
@@ -56,8 +56,65 @@ func (s *IndexSuite) TestEncode(c *C) {
 
 }
 
+func (s *IndexSuite) TestEncodeV4(c *C) {
+	idx := &Index{
+		Version: 4,
+		Entries: []*Entry{{
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Dev:        4242,
+			Inode:      424242,
+			UID:        84,
+			GID:        8484,
+			Size:       42,
+			Stage:      TheirMode,
+			Hash:       plumbing.NewHash("e25b29c8946e0e192fae2edc1dabf7be71e8ecf3"),
+			Name:       "foo",
+		}, {
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       "bar",
+			Size:       82,
+		}, {
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       strings.Repeat(" ", 20),
+			Size:       82,
+		}, {
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       "baz/bar",
+			Size:       82,
+		}, {
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       "baz/bar/bar",
+			Size:       82,
+		}},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	e := NewEncoder(buf)
+	err := e.Encode(idx)
+	c.Assert(err, IsNil)
+
+	output := &Index{}
+	d := NewDecoder(buf)
+	err = d.Decode(output)
+	c.Assert(err, IsNil)
+
+	c.Assert(cmp.Equal(idx, output), Equals, true)
+
+	c.Assert(output.Entries[0].Name, Equals, strings.Repeat(" ", 20))
+	c.Assert(output.Entries[1].Name, Equals, "bar")
+	c.Assert(output.Entries[2].Name, Equals, "baz/bar")
+	c.Assert(output.Entries[3].Name, Equals, "baz/bar/bar")
+	c.Assert(output.Entries[4].Name, Equals, "foo")
+
+}
+
 func (s *IndexSuite) TestEncodeUnsupportedVersion(c *C) {
-	idx := &Index{Version: 4}
+	idx := &Index{Version: 5}
 
 	buf := bytes.NewBuffer(nil)
 	e := NewEncoder(buf)


### PR DESCRIPTION
Hello,
With this pull request, Go-Git no more returns ErrUnsupportedVersion error when updating a version 4 .git/index file.