### PR TITLE
plumbing: format/objfile, gocheck to testify migration. Fixes #1292

### DIFF
--- a/plumbing/format/objfile/common_test.go
+++ b/plumbing/format/objfile/common_test.go
@@ -2,11 +2,8 @@ package objfile
 
 import (
 	"encoding/base64"
-	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
-
-	. "gopkg.in/check.v1"
 )
 
 type objfileFixture struct {
@@ -66,5 +63,3 @@ var objfileFixtures = []objfileFixture{
 		"eAGtjksOgjAUAF33FO8CktZ+aBNjTNy51Qs8Xl8FAjSh5f4SvILLmcVkKM/zUOEi3amuzMDBxE6mkBKhMZHaDiM71DaoZI1RXutgsSWBW+3zCs9c+g3hNeY4LB+4jgc35cf3QiNO04ALcUN5voEy1lmtrNdwll5Ksdt9oPIfUuLNpcLjCIov3ApFmQ==",
 	},
 }
-
-func Test(t *testing.T) { TestingT(t) }

--- a/plumbing/format/objfile/writer_test.go
+++ b/plumbing/format/objfile/writer_test.go
@@ -5,17 +5,22 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
-
-	. "gopkg.in/check.v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-type SuiteWriter struct{}
+type SuiteWriter struct {
+	suite.Suite
+}
 
-var _ = Suite(&SuiteWriter{})
+func TestSuiteWriter(t *testing.T) {
+	suite.Run(t, new(SuiteWriter))
+}
 
-func (s *SuiteWriter) TestWriteObjfile(c *C) {
+func (s *SuiteWriter) TestWriteObjfile() {
 	for k, fixture := range objfileFixtures {
 		buffer := bytes.NewBuffer(nil)
 
@@ -24,58 +29,58 @@ func (s *SuiteWriter) TestWriteObjfile(c *C) {
 		content, _ := base64.StdEncoding.DecodeString(fixture.content)
 
 		// Write the data out to the buffer
-		testWriter(c, buffer, hash, fixture.t, content)
+		testWriter(s.T(), buffer, hash, fixture.t, content)
 
 		// Read the data back in from the buffer to be sure it matches
-		testReader(c, buffer, hash, fixture.t, content, com)
+		testReader(s.T(), buffer, hash, fixture.t, content, com)
 	}
 }
 
-func testWriter(c *C, dest io.Writer, hash plumbing.Hash, t plumbing.ObjectType, content []byte) {
+func testWriter(t *testing.T, dest io.Writer, hash plumbing.Hash, o plumbing.ObjectType, content []byte) {
 	size := int64(len(content))
 	w := NewWriter(dest)
 
-	err := w.WriteHeader(t, size)
-	c.Assert(err, IsNil)
+	err := w.WriteHeader(o, size)
+	assert.NoError(t, err)
 
 	written, err := io.Copy(w, bytes.NewReader(content))
-	c.Assert(err, IsNil)
-	c.Assert(written, Equals, size)
+	assert.NoError(t, err)
+	assert.Equal(t, size, written)
 
-	c.Assert(w.Hash(), Equals, hash)
-	c.Assert(w.Close(), IsNil)
+	assert.Equal(t, hash, w.Hash())
+	assert.NoError(t, w.Close())
 }
 
-func (s *SuiteWriter) TestWriteOverflow(c *C) {
+func (s *SuiteWriter) TestWriteOverflow() {
 	buf := bytes.NewBuffer(nil)
 	w := NewWriter(buf)
 
 	err := w.WriteHeader(plumbing.BlobObject, 8)
-	c.Assert(err, IsNil)
+	s.NoError(err)
 
 	n, err := w.Write([]byte("1234"))
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, 4)
+	s.NoError(err)
+	s.Equal(4, n)
 
 	n, err = w.Write([]byte("56789"))
-	c.Assert(err, Equals, ErrOverflow)
-	c.Assert(n, Equals, 4)
+	s.ErrorIs(err, ErrOverflow)
+	s.Equal(4, n)
 }
 
-func (s *SuiteWriter) TestNewWriterInvalidType(c *C) {
+func (s *SuiteWriter) TestNewWriterInvalidType() {
 	buf := bytes.NewBuffer(nil)
 	w := NewWriter(buf)
 
 	err := w.WriteHeader(plumbing.InvalidObject, 8)
-	c.Assert(err, Equals, plumbing.ErrInvalidType)
+	s.ErrorIs(err, plumbing.ErrInvalidType)
 }
 
-func (s *SuiteWriter) TestNewWriterInvalidSize(c *C) {
+func (s *SuiteWriter) TestNewWriterInvalidSize() {
 	buf := bytes.NewBuffer(nil)
 	w := NewWriter(buf)
 
 	err := w.WriteHeader(plumbing.BlobObject, -1)
-	c.Assert(err, Equals, ErrNegativeSize)
+	s.ErrorIs(err, ErrNegativeSize)
 	err = w.WriteHeader(plumbing.BlobObject, -1651860)
-	c.Assert(err, Equals, ErrNegativeSize)
+	s.ErrorIs(err, ErrNegativeSize)
 }


### PR DESCRIPTION
Fixes #1292