### PR TITLE
utils: add ioutil.ContextReader and ioutil.ContextWriter and drop ctx…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399
 	github.com/go-git/go-git-fixtures/v5 v5.0.0-20241203230421-0753e18f8f03
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
-	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/pjbgf/sha1cd v0.3.0
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/go-git/go-git-fixtures/v5 v5.0.0-20241203230421-0753e18f8f03 h1:LumE+
 github.com/go-git/go-git-fixtures/v5 v5.0.0-20241203230421-0753e18f8f03/go.mod h1:hMKrMnUE4W0SJ7bFyM00dyz/HoknZoptGWzrj6M+dEM=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
-github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
-github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/utils/ioutil/context.go
+++ b/utils/ioutil/context.go
@@ -1,0 +1,117 @@
+package ioutil
+
+import (
+	"context"
+	"io"
+	"slices"
+)
+
+type ioret struct {
+	err error
+	n   int
+}
+
+type Writer interface {
+	io.Writer
+}
+
+type ctxWriter struct {
+	w   io.Writer
+	ctx context.Context
+}
+
+// NewContextWriter wraps a writer to make it respect the given Context.
+// If there is a blocking write, the returned Writer will return
+// whenever the context is cancelled (the return values are n=0
+// and err=ctx.Err().)
+//
+// Note that this wrapper DOES NOT ACTUALLY cancel the underlying
+// write, as there is no way to do that with the standard Go io
+// interface. So the read and write _will_ happen or hang. Use
+// this sparingly, make sure to cancel the read or write as necessary
+// (e.g. closing a connection whose context is up, etc.)
+//
+// Furthermore, in order to protect your memory from being read
+// _after_ you've cancelled the context, this io.Writer will
+// first make a **copy** of the buffer.
+func NewContextWriter(ctx context.Context, w io.Writer) *ctxWriter {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return &ctxWriter{ctx: ctx, w: w}
+}
+
+func (w *ctxWriter) Write(buf []byte) (int, error) {
+	buf2 := slices.Clone(buf)
+
+	c := make(chan ioret, 1)
+
+	go func() {
+		n, err := w.w.Write(buf2)
+		c <- ioret{err, n}
+		close(c)
+	}()
+
+	select {
+	case r := <-c:
+		return r.n, r.err
+	case <-w.ctx.Done():
+		return 0, w.ctx.Err()
+	}
+}
+
+type Reader interface {
+	io.Reader
+}
+
+type ctxReader struct {
+	r      io.Reader
+	ctx    context.Context
+	closer io.Closer
+}
+
+// NewContextReader wraps a reader to make it respect given Context.
+// If there is a blocking read, the returned Reader will return
+// whenever the context is cancelled (the return values are n=0
+// and err=ctx.Err().)
+//
+// Note well: this wrapper DOES NOT ACTUALLY cancel the underlying
+// write-- there is no way to do that with the standard go io
+// interface. So the read and write _will_ happen or hang. So, use
+// this sparingly, make sure to cancel the read or write as necesary
+// (e.g. closing a connection whose context is up, etc.)
+//
+// Furthermore, in order to protect your memory from being read
+// _before_ you've cancelled the context, this io.Reader will
+// allocate a buffer of the same size, and **copy** into the client's
+// if the read succeeds in time.
+func NewContextReader(ctx context.Context, r io.Reader) *ctxReader {
+	return &ctxReader{ctx: ctx, r: r}
+}
+
+func (r *ctxReader) Read(buf []byte) (int, error) {
+	buf2 := make([]byte, len(buf))
+
+	c := make(chan ioret, 1)
+
+	go func() {
+		n, err := r.r.Read(buf2)
+		c <- ioret{err, n}
+		close(c)
+	}()
+
+	select {
+	case ret := <-c:
+		copy(buf, buf2)
+		return ret.n, ret.err
+	case <-r.ctx.Done():
+		if r.closer != nil {
+			r.closer.Close()
+		}
+		return 0, r.ctx.Err()
+	}
+}
+
+func NewContextReaderWithCloser(ctx context.Context, r io.Reader, closer io.Closer) *ctxReader {
+	return &ctxReader{ctx: ctx, r: r, closer: closer}
+}

--- a/utils/ioutil/context_test.go
+++ b/utils/ioutil/context_test.go
@@ -1,0 +1,273 @@
+package ioutil
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	context "golang.org/x/net/context"
+)
+
+func TestReader(t *testing.T) {
+	buf := []byte("abcdef")
+	buf2 := make([]byte, 3)
+	r := NewContextReader(context.Background(), bytes.NewReader(buf))
+
+	// read first half
+	n, err := r.Read(buf2)
+	if n != 3 {
+		t.Error("n should be 3")
+	}
+	if err != nil {
+		t.Error("should have no error")
+	}
+	if string(buf2) != string(buf[:3]) {
+		t.Error("incorrect contents")
+	}
+
+	// read second half
+	n, err = r.Read(buf2)
+	if n != 3 {
+		t.Error("n should be 3")
+	}
+	if err != nil {
+		t.Error("should have no error")
+	}
+	if string(buf2) != string(buf[3:6]) {
+		t.Error("incorrect contents")
+	}
+
+	// read more.
+	n, err = r.Read(buf2)
+	if n != 0 {
+		t.Error("n should be 0", n)
+	}
+	if err != io.EOF {
+		t.Error("should be EOF", err)
+	}
+}
+
+func TestWriter(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewContextWriter(context.Background(), &buf)
+
+	// write three
+	n, err := w.Write([]byte("abc"))
+	if n != 3 {
+		t.Error("n should be 3")
+	}
+	if err != nil {
+		t.Error("should have no error")
+	}
+	if string(buf.Bytes()) != string("abc") {
+		t.Error("incorrect contents")
+	}
+
+	// write three more
+	n, err = w.Write([]byte("def"))
+	if n != 3 {
+		t.Error("n should be 3")
+	}
+	if err != nil {
+		t.Error("should have no error")
+	}
+	if string(buf.Bytes()) != string("abcdef") {
+		t.Error("incorrect contents")
+	}
+}
+
+func TestReaderCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	piper, pipew := io.Pipe()
+	r := NewContextReader(ctx, piper)
+
+	buf := make([]byte, 10)
+	done := make(chan ioret)
+
+	go func() {
+		n, err := r.Read(buf)
+		done <- ioret{err, n}
+	}()
+
+	pipew.Write([]byte("abcdefghij"))
+
+	select {
+	case ret := <-done:
+		if ret.n != 10 {
+			t.Error("ret.n should be 10", ret.n)
+		}
+		if ret.err != nil {
+			t.Error("ret.err should be nil", ret.err)
+		}
+		if string(buf) != "abcdefghij" {
+			t.Error("read contents differ")
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("failed to read")
+	}
+
+	go func() {
+		n, err := r.Read(buf)
+		done <- ioret{err, n}
+	}()
+
+	cancel()
+
+	select {
+	case ret := <-done:
+		if ret.n != 0 {
+			t.Error("ret.n should be 0", ret.n)
+		}
+		if ret.err == nil {
+			t.Error("ret.err should be ctx error", ret.err)
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("failed to stop reading after cancel")
+	}
+}
+
+func TestWriterCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	piper, pipew := io.Pipe()
+	w := NewContextWriter(ctx, pipew)
+
+	buf := make([]byte, 10)
+	done := make(chan ioret)
+
+	go func() {
+		n, err := w.Write([]byte("abcdefghij"))
+		done <- ioret{err, n}
+	}()
+
+	piper.Read(buf)
+
+	select {
+	case ret := <-done:
+		if ret.n != 10 {
+			t.Error("ret.n should be 10", ret.n)
+		}
+		if ret.err != nil {
+			t.Error("ret.err should be nil", ret.err)
+		}
+		if string(buf) != "abcdefghij" {
+			t.Error("write contents differ")
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("failed to write")
+	}
+
+	go func() {
+		n, err := w.Write([]byte("abcdefghij"))
+		done <- ioret{err, n}
+	}()
+
+	cancel()
+
+	select {
+	case ret := <-done:
+		if ret.n != 0 {
+			t.Error("ret.n should be 0", ret.n)
+		}
+		if ret.err == nil {
+			t.Error("ret.err should be ctx error", ret.err)
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("failed to stop writing after cancel")
+	}
+}
+
+func TestReadPostCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	piper, pipew := io.Pipe()
+	r := NewContextReader(ctx, piper)
+
+	buf := make([]byte, 10)
+	done := make(chan ioret)
+
+	go func() {
+		n, err := r.Read(buf)
+		done <- ioret{err, n}
+	}()
+
+	cancel()
+
+	select {
+	case ret := <-done:
+		if ret.n != 0 {
+			t.Error("ret.n should be 0", ret.n)
+		}
+		if ret.err == nil {
+			t.Error("ret.err should be ctx error", ret.err)
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("failed to stop reading after cancel")
+	}
+
+	pipew.Write([]byte("abcdefghij"))
+
+	if !bytes.Equal(buf, make([]byte, len(buf))) {
+		t.Fatal("buffer should have not been written to")
+	}
+}
+
+func TestWritePostCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	piper, pipew := io.Pipe()
+	w := NewContextWriter(ctx, pipew)
+
+	buf := []byte("abcdefghij")
+	buf2 := make([]byte, 10)
+	done := make(chan ioret)
+
+	go func() {
+		n, err := w.Write(buf)
+		done <- ioret{err, n}
+	}()
+
+	piper.Read(buf2)
+
+	select {
+	case ret := <-done:
+		if ret.n != 10 {
+			t.Error("ret.n should be 10", ret.n)
+		}
+		if ret.err != nil {
+			t.Error("ret.err should be nil", ret.err)
+		}
+		if string(buf2) != "abcdefghij" {
+			t.Error("write contents differ")
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("failed to write")
+	}
+
+	go func() {
+		n, err := w.Write(buf)
+		done <- ioret{err, n}
+	}()
+
+	cancel()
+
+	select {
+	case ret := <-done:
+		if ret.n != 0 {
+			t.Error("ret.n should be 0", ret.n)
+		}
+		if ret.err == nil {
+			t.Error("ret.err should be ctx error", ret.err)
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("failed to stop writing after cancel")
+	}
+
+	copy(buf, []byte("aaaaaaaaaa"))
+
+	piper.Read(buf2)
+
+	if string(buf2) == "aaaaaaaaaa" {
+		t.Error("buffer was read from after ctx cancel")
+	} else if string(buf2) != "abcdefghij" {
+		t.Error("write contents differ from expected")
+	}
+}


### PR DESCRIPTION
…io package

This adds `ioutil.ContextReader` and `ioutil.ContextWriter` to the `ioutil` package and drops the `ctxio` package. It also introduces a `CloserFunc` type to implement the `io.Closer` interface with a function.

This extracts changes from #1111