### PR TITLE
plumbing: transport, determine protocol version

### DIFF
--- a/plumbing/protocol/version.go
+++ b/plumbing/protocol/version.go
@@ -11,13 +11,14 @@ var ErrUnknownProtocol = errors.New("unknown Git Wire protocol")
 type Version int
 
 const (
-	Undefined Version = -1
 	// V0 represents the original Wire protocol.
 	V0 Version = iota
 	// V1 represents the version V1 of the Wire protocol.
 	V1
 	// V2 represents the version V2 of the Wire protocol.
 	V2
+
+	Undefined Version = -1
 )
 
 // String converts a Version into string.

--- a/plumbing/transport/version.go
+++ b/plumbing/transport/version.go
@@ -1,0 +1,47 @@
+package transport
+
+import (
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/format/pktline"
+	"github.com/go-git/go-git/v5/plumbing/protocol"
+	"github.com/go-git/go-git/v5/utils/ioutil"
+)
+
+// DiscoverVersion reads the first pktline from the reader to determine the
+// protocol version. This is used by the client to determine the protocol
+// version of the server.
+func DiscoverVersion(r ioutil.ReadPeeker) (protocol.Version, error) {
+	ver := protocol.V0
+	_, pktb, err := pktline.PeekLine(r)
+	if err != nil {
+		return ver, err
+	}
+
+	pkt := strings.TrimSpace(string(pktb))
+	if strings.HasPrefix(pkt, "version ") {
+		// Consume the version packet
+		pktline.ReadLine(r) // nolint:errcheck
+		if v, _ := protocol.Parse(pkt[8:]); v > ver {
+			ver = protocol.Version(v)
+		}
+	}
+
+	return ver, nil
+}
+
+// ProtocolVersion tries to find the version parameter in the protocol string.
+// This expects the protocol string from the GIT_PROTOCOL environment variable.
+// This is used by the server to determine the protocol version requested by
+// the client.
+func ProtocolVersion(p string) protocol.Version {
+	var ver protocol.Version
+	for _, param := range strings.Split(p, ":") {
+		if strings.HasPrefix(param, "version=") {
+			if v, _ := protocol.Parse(param[8:]); v > ver {
+				ver = protocol.Version(v)
+			}
+		}
+	}
+	return ver
+}

--- a/plumbing/transport/version_test.go
+++ b/plumbing/transport/version_test.go
@@ -1,0 +1,117 @@
+package transport
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/format/pktline"
+	"github.com/go-git/go-git/v5/plumbing/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscoverVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected protocol.Version
+		wantErr  bool
+	}{
+		{
+			name:     "version 1",
+			input:    "version 1\n",
+			expected: protocol.V1,
+		},
+		{
+			name:     "version 2",
+			input:    "version 2\n",
+			expected: protocol.V2,
+		},
+		{
+			name:     "no version prefix",
+			input:    "git-upload-pack /project.git\n",
+			expected: protocol.V0,
+		},
+		{
+			name:     "unknown version",
+			input:    "version 999\n",
+			expected: protocol.V0,
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: protocol.V0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if tt.input != "" {
+				pktline.WriteString(&buf, tt.input) //nolint:errcheck
+			}
+
+			r := bufio.NewReader(&buf)
+			version, err := DiscoverVersion(r)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, version)
+		})
+	}
+}
+
+func TestProtocolVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected protocol.Version
+	}{
+		{
+			name:     "version 1",
+			input:    "version=1",
+			expected: protocol.V1,
+		},
+		{
+			name:     "version 2",
+			input:    "version=2",
+			expected: protocol.V2,
+		},
+		{
+			name:     "version with other parameters",
+			input:    "hello:version=2:side-band-64k",
+			expected: protocol.V2,
+		},
+		{
+			name:     "multiple versions takes highest",
+			input:    "version=1:version=2",
+			expected: protocol.V2,
+		},
+		{
+			name:     "no version parameter",
+			input:    "side-band-64k:thin-pack",
+			expected: protocol.V0,
+		},
+		{
+			name:     "unknown version",
+			input:    "version=999",
+			expected: protocol.V0,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: protocol.V0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version := ProtocolVersion(tt.input)
+			assert.Equal(t, tt.expected, version)
+		})
+	}
+}


### PR DESCRIPTION
This adds two functions to the transport package to determine the protocol version for the client and server. The DiscoverVersion function reads the first pktline from the reader to determine the protocol version. This is usually used by the client-side.
The DiscoverProtocolVersion function tries to find the version parameter in the protocol string. This expects the protocol string from the GIT_PROTOCOL environment variable. This is used by the server-side.

This is based on https://github.com/go-git/go-git/pull/1332