### PR TITLE
plumbing: pktline, quote packet data in trace

### DIFF
--- a/utils/trace/trace.go
+++ b/utils/trace/trace.go
@@ -69,14 +69,19 @@ func SetLogger(l *log.Logger) {
 
 // Print prints the given message only if the target is enabled.
 func (t Target) Print(args ...interface{}) {
-	if int32(t)&current.Load() != 0 {
+	if t.Enabled() {
 		logger.Output(2, fmt.Sprint(args...)) // nolint: errcheck
 	}
 }
 
 // Printf prints the given message only if the target is enabled.
 func (t Target) Printf(format string, args ...interface{}) {
-	if int32(t)&current.Load() != 0 {
+	if t.Enabled() {
 		logger.Output(2, fmt.Sprintf(format, args...)) // nolint: errcheck
 	}
+}
+
+// Enabled returns true if the target is enabled.
+func (t Target) Enabled() bool {
+	return int32(t)&current.Load() != 0
 }


### PR DESCRIPTION
When tracing packet data, quote the data to make it easier to distinguish between the data and the length field and avoid escape sequences in the output that might be misinterpreted.

Before:
```
15:19:00.195792 pktline.go:20: packet: > 006e want f5c9cd905f3a9eeba77fdd1a522b1aa4cb79fa49 multi_ack_detailed side-band-64k ofs-delta agent=go-git/5.x
15:19:00.217529 pktline.go:224: packet: < 00f5 VLdLUFGiGDT
bj4~F43i
9^qe?.D`\r*r1y{zQr9{?=HHe
                         㶷K2=EL-Ԯu@{
```

After:
```
15:08:08.668554 pktline.go:20: packet: > 006e "want f5c9cd905f3a9eeba77fdd1a522b1aa4cb79fa49 multi_ack_detailed side-band-64k ofs-delta agent=go-git/5.x\n"
15:20:16.778797 pktline.go:224: packet: < 00f5 "[ PACKDATA ]"
```

Sideband:

upstream
```
15:33:17.289680 pkt-line.c:86           packet:     sideband< \2Compressing objects: 100% (75/75), done.
```

go-git
```
15:35:14.800579 pktline.go:228: packet: < 002e "\x02Compressing objects: 100% (75/75), done.\n"
```