### PR TITLE
*: Use ephemeral dir creation for tests

### DIFF
--- a/plumbing/transport/ssh/upload_pack_test.go
+++ b/plumbing/transport/ssh/upload_pack_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -71,8 +70,7 @@ func setupTest(t testing.TB, opts ...ssh.Option) (base string, port int, client 
 
 	addr := startServer(t, opts...)
 
-	base, err := os.MkdirTemp(t.TempDir(), fmt.Sprintf("go-git-ssh-%d", addr.Port))
-	require.NoError(t, err)
+	base = t.TempDir()
 
 	return base, addr.Port, client
 }

--- a/remote_test.go
+++ b/remote_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -569,9 +568,7 @@ func (s *RemoteSuite) TestString() {
 }
 
 func (s *RemoteSuite) TestPushToEmptyRepository() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
 
@@ -671,10 +668,8 @@ func eventually(s *RemoteSuite, condition func() bool) {
 }
 
 func (s *RemoteSuite) TestPushContextCanceled() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
-	_, err = PlainInit(url, true)
+	url := s.T().TempDir()
+	_, err := PlainInit(url, true)
 	s.NoError(err)
 
 	fs := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
@@ -701,9 +696,7 @@ func (s *RemoteSuite) TestPushContextCanceled() {
 }
 
 func (s *RemoteSuite) TestPushTags() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
 
@@ -819,9 +812,7 @@ func (s *RemoteSuite) TestPushTreeByOID() {
 }
 
 func (s *RemoteSuite) TestPushFollowTags() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
 
@@ -1484,10 +1475,8 @@ func (s *RemoteSuite) TestUpdateShallows() {
 */
 
 func (s *RemoteSuite) TestUseRefDeltas() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
-	_, err = PlainInit(url, true)
+	url := s.T().TempDir()
+	_, err := PlainInit(url, true)
 	s.NoError(err)
 
 	fs := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
@@ -1561,18 +1550,14 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 }
 
 func (s *RemoteSuite) TestFetchPrune() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
-	_, err = PlainClone(url, &CloneOptions{
+	url := s.T().TempDir()
+	_, err := PlainClone(url, &CloneOptions{
 		URL:  s.GetBasicLocalRepositoryURL(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
 
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainClone(dir, &CloneOptions{
 		URL:  url,
 		Bare: true,
@@ -1590,9 +1575,7 @@ func (s *RemoteSuite) TestFetchPrune() {
 	}})
 	s.NoError(err)
 
-	dirSave, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dirSave := s.T().TempDir()
 	rSave, err := PlainClone(dirSave, &CloneOptions{
 		URL:  url,
 		Bare: true,
@@ -1620,18 +1603,14 @@ func (s *RemoteSuite) TestFetchPrune() {
 }
 
 func (s *RemoteSuite) TestFetchPruneTags() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
-	_, err = PlainClone(url, &CloneOptions{
+	url := s.T().TempDir()
+	_, err := PlainClone(url, &CloneOptions{
 		URL:  s.GetBasicLocalRepositoryURL(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
 
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainClone(dir, &CloneOptions{
 		URL:  url,
 		Bare: true,
@@ -1649,9 +1628,7 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 	}})
 	s.NoError(err)
 
-	dirSave, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dirSave := s.T().TempDir()
 	rSave, err := PlainClone(dirSave, &CloneOptions{
 		URL:  url,
 		Bare: true,
@@ -1724,8 +1701,7 @@ func (s *RemoteSuite) TestCanPushShasToReference() {
 }
 
 func (s *RemoteSuite) TestFetchAfterShallowClone() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	tempDir := s.T().TempDir()
 	remoteUrl := filepath.Join(tempDir, "remote")
 	repoDir := filepath.Join(tempDir, "repo")
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -90,10 +90,12 @@ func createCommit(s *RepositorySuite, r *Repository) plumbing.Hash {
 	wt, err := r.Worktree()
 	s.NoError(err)
 
-	rm, err := wt.Filesystem.Create("foo.txt")
+	f, err := wt.Filesystem.Create("foo.txt")
 	s.NoError(err)
 
-	_, err = rm.Write([]byte("foo text"))
+	defer f.Close()
+
+	_, err = f.Write([]byte("foo text"))
 	s.NoError(err)
 
 	_, err = wt.Add("foo.txt")
@@ -116,9 +118,7 @@ func createCommit(s *RepositorySuite, r *Repository) plumbing.Hash {
 }
 
 func (s *RepositorySuite) TestInitNonStandardDotGit() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	fs := osfs.New(dir)
 	dot, _ := fs.Chroot("storage")
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
@@ -142,9 +142,7 @@ func (s *RepositorySuite) TestInitNonStandardDotGit() {
 }
 
 func (s *RepositorySuite) TestInitStandardDotGit() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	fs := osfs.New(dir)
 	dot, _ := fs.Chroot(".git")
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
@@ -641,9 +639,7 @@ func (s *RepositorySuite) TestDeleteBranch() {
 }
 
 func (s *RepositorySuite) TestPlainInit() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainInit(dir, true)
 	s.NoError(err)
 	s.NotNil(r)
@@ -654,9 +650,7 @@ func (s *RepositorySuite) TestPlainInit() {
 }
 
 func (s *RepositorySuite) TestPlainInitWithOptions() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainInit(dir,
 		false,
 		WithDefaultBranch("refs/heads/foo"),
@@ -676,9 +670,7 @@ func (s *RepositorySuite) TestPlainInitWithOptions() {
 }
 
 func (s *RepositorySuite) TestPlainInitAlreadyExists() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainInit(dir, true)
 	s.NoError(err)
 	s.NotNil(r)
@@ -689,9 +681,7 @@ func (s *RepositorySuite) TestPlainInitAlreadyExists() {
 }
 
 func (s *RepositorySuite) TestPlainOpen() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
 	s.NotNil(r)
@@ -725,9 +715,7 @@ func (s *RepositorySuite) TestPlainOpenTildePath() {
 }
 
 func (s *RepositorySuite) TestPlainOpenBare() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainInit(dir, true)
 	s.NoError(err)
 	s.NotNil(r)
@@ -738,9 +726,7 @@ func (s *RepositorySuite) TestPlainOpenBare() {
 }
 
 func (s *RepositorySuite) TestPlainOpenNotBare() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
 	s.NotNil(r)
@@ -892,9 +878,7 @@ func (s *RepositorySuite) TestPlainOpenDetectDotGit() {
 }
 
 func (s *RepositorySuite) TestPlainOpenNotExistsDetectDotGit() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	opt := &PlainOpenOptions{DetectDotGit: true}
 	r, err := PlainOpenWithOptions(dir, opt)
 	s.ErrorIs(err, ErrRepositoryNotExists)
@@ -921,9 +905,7 @@ func (s *RepositorySuite) TestPlainClone() {
 }
 
 func (s *RepositorySuite) TestPlainCloneBareAndShared() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	remote := s.GetBasicLocalRepositoryURL()
 
 	r, err := PlainClone(dir, &CloneOptions{
@@ -950,9 +932,7 @@ func (s *RepositorySuite) TestPlainCloneBareAndShared() {
 }
 
 func (s *RepositorySuite) TestPlainCloneShared() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	remote := s.GetBasicLocalRepositoryURL()
 
 	r, err := PlainClone(dir, &CloneOptions{
@@ -978,12 +958,10 @@ func (s *RepositorySuite) TestPlainCloneShared() {
 }
 
 func (s *RepositorySuite) TestPlainCloneSharedHttpShouldReturnError() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	remote := "http://somerepo"
 
-	_, err = PlainClone(dir, &CloneOptions{
+	_, err := PlainClone(dir, &CloneOptions{
 		URL:    remote,
 		Shared: true,
 	})
@@ -991,12 +969,10 @@ func (s *RepositorySuite) TestPlainCloneSharedHttpShouldReturnError() {
 }
 
 func (s *RepositorySuite) TestPlainCloneSharedHttpsShouldReturnError() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	remote := "https://somerepo"
 
-	_, err = PlainClone(dir, &CloneOptions{
+	_, err := PlainClone(dir, &CloneOptions{
 		URL:    remote,
 		Shared: true,
 	})
@@ -1004,12 +980,10 @@ func (s *RepositorySuite) TestPlainCloneSharedHttpsShouldReturnError() {
 }
 
 func (s *RepositorySuite) TestPlainCloneSharedSSHShouldReturnError() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	remote := "ssh://somerepo"
 
-	_, err = PlainClone(dir, &CloneOptions{
+	_, err := PlainClone(dir, &CloneOptions{
 		URL:    remote,
 		Shared: true,
 	})
@@ -1017,9 +991,7 @@ func (s *RepositorySuite) TestPlainCloneSharedSSHShouldReturnError() {
 }
 
 func (s *RepositorySuite) TestPlainCloneWithRemoteName() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainClone(dir, &CloneOptions{
 		URL:        s.GetBasicLocalRepositoryURL(),
 		RemoteName: "test",
@@ -1033,9 +1005,7 @@ func (s *RepositorySuite) TestPlainCloneWithRemoteName() {
 }
 
 func (s *RepositorySuite) TestPlainCloneOverExistingGitDirectory() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainInit(dir, false)
 	s.NotNil(r)
 	s.NoError(err)
@@ -1051,9 +1021,7 @@ func (s *RepositorySuite) TestPlainCloneContextCancel() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainCloneContext(ctx, dir, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
@@ -1163,9 +1131,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistingOverExistingGitDirecto
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	dir := s.T().TempDir()
 	r, err := PlainInit(dir, false)
 	s.NotNil(r)
 	s.NoError(err)
@@ -1678,9 +1644,7 @@ func (s *RepositorySuite) TestCloneWithFilter() {
 }
 
 func (s *RepositorySuite) TestPush() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
+	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
 
@@ -1707,10 +1671,8 @@ func (s *RepositorySuite) TestPush() {
 }
 
 func (s *RepositorySuite) TestPushContext() {
-	url, err := os.MkdirTemp("", "")
-	s.NoError(err)
-
-	_, err = PlainInit(url, true)
+	url := s.T().TempDir()
+	_, err := PlainInit(url, true)
 	s.NoError(err)
 
 	_, err = s.Repository.CreateRemote(&config.RemoteConfig{

--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -207,8 +207,7 @@ func (s *NoderSuite) TestSocket() {
 		s.T().Skip("socket files do not exist on windows")
 	}
 
-	td, err := os.MkdirTemp("", "socket-test")
-	s.NoError(err)
+	td := s.T().TempDir()
 
 	sock, err := net.ListenUnix("unix", &net.UnixAddr{Name: fmt.Sprintf("%s/socket", td), Net: "unix"})
 	s.NoError(err)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -308,8 +308,7 @@ func (s *WorktreeSuite) TestPullDepth() {
 }
 
 func (s *WorktreeSuite) TestPullAfterShallowClone() {
-	tempDir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	tempDir := s.T().TempDir()
 	remoteURL := filepath.Join(tempDir, "remote")
 	repoDir := filepath.Join(tempDir, "repo")
 
@@ -437,8 +436,7 @@ func (s *WorktreeSuite) TestCheckoutSymlink() {
 		s.T().Skip("git doesn't support symlinks by default in windows")
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	dir := s.T().TempDir()
 
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
@@ -2081,8 +2079,7 @@ func (s *WorktreeSuite) TestAddRemovedInDirectoryDot() {
 }
 
 func (s *WorktreeSuite) TestAddSymlink() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	dir := s.T().TempDir()
 
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
@@ -3143,8 +3140,7 @@ func (s *WorktreeSuite) TestGrepBare() {
 }
 
 func (s *WorktreeSuite) TestResetLingeringDirectories() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	dir := s.T().TempDir()
 
 	commitOpts := &CommitOptions{Author: &object.Signature{
 		Name:  "foo",
@@ -3195,8 +3191,7 @@ func (s *WorktreeSuite) TestResetLingeringDirectories() {
 func (s *WorktreeSuite) TestAddAndCommit() {
 	expectedFiles := 2
 
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	dir := s.T().TempDir()
 
 	repo, err := PlainInit(dir, false)
 	s.NoError(err)
@@ -3238,8 +3233,7 @@ func (s *WorktreeSuite) TestAddAndCommit() {
 }
 
 func (s *WorktreeSuite) TestAddAndCommitEmpty() {
-	dir, err := os.MkdirTemp("", "")
-	s.NoError(err)
+	dir := s.T().TempDir()
 
 	repo, err := PlainInit(dir, false)
 	s.NoError(err)


### PR DESCRIPTION
Some of the tests need new directories created, some of them are not deleting those long-lasting dirs, resulting in leftover temporary directories after the test execution. This PR leans on the use of dir creation for tests, which are automatically removed after the test execution.