### PR TITLE
refactor transport: plumbing: transport, support multi-ack and multi-ack-detailed capabilities (3/5)

### DIFF
--- a/internal/reference/refs.go
+++ b/internal/reference/refs.go
@@ -1,0 +1,33 @@
+package reference
+
+import (
+	"io"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage"
+)
+
+// References returns all references from the storage.
+func References(st storage.Storer) ([]*plumbing.Reference, error) {
+	var localRefs []*plumbing.Reference
+
+	iter, err := st.IterReferences()
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		ref, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		localRefs = append(localRefs, ref)
+	}
+
+	return localRefs, nil
+}

--- a/plumbing/protocol/packp/packp.go
+++ b/plumbing/protocol/packp/packp.go
@@ -1,0 +1,15 @@
+package packp
+
+import "io"
+
+// Encoder is the interface implemented by an object that can encode itself
+// into a [io.Writer].
+type Encoder interface {
+	Encode(w io.Writer) error
+}
+
+// Decoder is the interface implemented by an object that can decode itself
+// from a [io.Reader].
+type Decoder interface {
+	Decode(r io.Reader) error
+}

--- a/plumbing/protocol/packp/uphav.go
+++ b/plumbing/protocol/packp/uphav.go
@@ -4,15 +4,19 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/pktline"
 )
 
 // UploadHaves is a message to signal the references that a client has in a
-// upload-pack. Do not use this directly. Use UploadPackRequest request instead.
+// upload-pack. Done is true when the client has sent a "done" message.
+// Otherwise, it means that the client has more haves to send and this request
+// was completed with a flush.
 type UploadHaves struct {
 	Haves []plumbing.Hash
+	Done  bool
 }
 
 // Encode encodes the UploadHaves into the Writer.
@@ -30,6 +34,49 @@ func (u *UploadHaves) Encode(w io.Writer) error {
 		}
 
 		last = have
+	}
+
+	if u.Done {
+		if _, err := pktline.Writeln(w, "done"); err != nil {
+			return fmt.Errorf("sending done: %s", err)
+		}
+	} else {
+		if err := pktline.WriteFlush(w); err != nil {
+			return fmt.Errorf("sending flush-pkt: %s", err)
+		}
+	}
+	return nil
+}
+
+// Decode decodes the UploadHaves from the Reader.
+func (u *UploadHaves) Decode(r io.Reader) error {
+	u.Haves = make([]plumbing.Hash, 0)
+
+	for {
+		l, line, err := pktline.ReadLine(r)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+
+			return fmt.Errorf("decoding haves: %s", err)
+		}
+
+		if l == pktline.Flush {
+			break
+		}
+
+		if bytes.Equal(line, []byte("done\n")) {
+			u.Done = true
+			break
+		}
+
+		if !bytes.HasPrefix(line, []byte("have ")) {
+			return fmt.Errorf("invalid have line: %q", line)
+		}
+
+		have := plumbing.NewHash(strings.TrimSpace(string(line[5:])))
+		u.Haves = append(u.Haves, have)
 	}
 
 	return nil

--- a/plumbing/protocol/packp/uphav.go
+++ b/plumbing/protocol/packp/uphav.go
@@ -38,11 +38,11 @@ func (u *UploadHaves) Encode(w io.Writer) error {
 
 	if u.Done {
 		if _, err := pktline.Writeln(w, "done"); err != nil {
-			return fmt.Errorf("sending done: %s", err)
+			return fmt.Errorf("sending done: %w", err)
 		}
 	} else {
 		if err := pktline.WriteFlush(w); err != nil {
-			return fmt.Errorf("sending flush-pkt: %s", err)
+			return fmt.Errorf("sending flush-pkt: %w", err)
 		}
 	}
 	return nil
@@ -59,7 +59,7 @@ func (u *UploadHaves) Decode(r io.Reader) error {
 				break
 			}
 
-			return fmt.Errorf("decoding haves: %s", err)
+			return fmt.Errorf("decoding haves: %w", err)
 		}
 
 		if l == pktline.Flush {

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -99,7 +99,7 @@ func NegotiatePack(
 	common := map[plumbing.Hash]struct{}{}
 	localRefs, err := reference.References(st)
 	if err != nil {
-		return nil, fmt.Errorf("getting local references: %s", err)
+		return nil, fmt.Errorf("getting local references: %w", err)
 	}
 
 	var pending []*object.Commit
@@ -122,7 +122,7 @@ func NegotiatePack(
 		if firstRound || conn.StatelessRPC() {
 			firstRound = false
 			if err := upreq.Encode(writer); err != nil {
-				return nil, fmt.Errorf("sending upload-request: %s", err)
+				return nil, fmt.Errorf("sending upload-request: %w", err)
 			}
 		}
 
@@ -138,7 +138,7 @@ func NegotiatePack(
 				pending = append(pending, p)
 				return nil
 			}); err != nil {
-				return nil, fmt.Errorf("getting parents: %s", err)
+				return nil, fmt.Errorf("getting parents: %w", err)
 			}
 
 			uphav.Haves = append(uphav.Haves, c.Hash)
@@ -158,14 +158,14 @@ func NegotiatePack(
 		// Close the writer to signal the end of the request
 		if conn.StatelessRPC() {
 			if err := writer.Close(); err != nil {
-				return nil, fmt.Errorf("closing writer: %s", err)
+				return nil, fmt.Errorf("closing writer: %w", err)
 			}
 		}
 
 		if done || len(uphav.Haves) > 0 {
 			var srvrs packp.ServerResponse
 			if err := srvrs.Decode(reader); err != nil {
-				return nil, fmt.Errorf("decoding server-response: %s", err)
+				return nil, fmt.Errorf("decoding server-response: %w", err)
 			}
 
 			for _, ack := range srvrs.ACKs {
@@ -191,7 +191,7 @@ func NegotiatePack(
 	var shupd packp.ShallowUpdate
 	if req.Depth != 0 {
 		if err := shupd.Decode(reader); err != nil {
-			return nil, fmt.Errorf("decoding shallow-update: %s", err)
+			return nil, fmt.Errorf("decoding shallow-update: %w", err)
 		}
 	}
 

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -1,12 +1,14 @@
 package transport
 
 import (
-	"bytes"
 	"fmt"
 	"io"
+	"sort"
 
+	"github.com/go-git/go-git/v5/internal/reference"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/pktline"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/storage"
@@ -14,7 +16,6 @@ import (
 
 // NegotiatePack returns the result of the pack negotiation phase of the fetch operation.
 // See https://git-scm.com/docs/pack-protocol#_packfile_negotiation
-// TODO: make it return only shallows.
 func NegotiatePack(
 	st storage.Storer,
 	conn Connection,
@@ -30,12 +31,13 @@ func NegotiatePack(
 
 	// Create upload-request
 	upreq := packp.NewUploadRequest()
-	// TODO: support multi_ack and multi_ack_detailed caps
-	// if caps.Supports(capability.MultiACKDetailed) {
-	// 	upreq.Capabilities.Set(capability.MultiACKDetailed) // nolint: errcheck
-	// } else if caps.Supports(capability.MultiACK) {
-	// 	upreq.Capabilities.Set(capability.MultiACK) // nolint: errcheck
-	// }
+	multiAck := caps.Supports(capability.MultiACK)
+	multiAckDetailed := caps.Supports(capability.MultiACKDetailed)
+	if multiAckDetailed {
+		upreq.Capabilities.Set(capability.MultiACKDetailed) // nolint: errcheck
+	} else if multiAck {
+		upreq.Capabilities.Set(capability.MultiACK) // nolint: errcheck
+	}
 
 	if req.Progress != nil {
 		if caps.Supports(capability.Sideband64k) {
@@ -94,72 +96,103 @@ func NegotiatePack(
 	}
 
 	// Create upload-haves
-	var uphav packp.UploadHaves
-	uphav.Haves = req.Haves
+	common := map[plumbing.Hash]struct{}{}
+	localRefs, err := reference.References(st)
+	if err != nil {
+		return nil, fmt.Errorf("getting local references: %s", err)
+	}
 
-	var (
-		done  bool
-		srvrs packp.ServerResponse
-	)
+	var pending []*object.Commit
+	for _, r := range localRefs {
+		c, err := object.GetCommit(st, r.Hash())
+		if err == nil {
+			pending = append(pending, c)
+		}
+	}
 
-	var shupd packp.ShallowUpdate
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].Committer.When.Before(pending[j].Committer.When)
+	})
+
+	var inVein int
+	var done bool
+	var gotContinue bool // whether we got a continue from the server
+	firstRound := true
 	for !done {
-		if err := upreq.Encode(writer); err != nil {
-			return nil, fmt.Errorf("sending upload-request: %w", err)
+		if firstRound || conn.StatelessRPC() {
+			firstRound = false
+			if err := upreq.Encode(writer); err != nil {
+				return nil, fmt.Errorf("sending upload-request: %s", err)
+			}
 		}
 
+		// Pop the last 32 have commits from the pending list and insert their
+		// parents into the pending list.
+		var uphav packp.UploadHaves
+		uphav.Haves = []plumbing.Hash{}
+		for i := 0; i < 32 && len(pending) > 0; i++ {
+			c := pending[len(pending)-1]
+			pending = pending[:len(pending)-1]
+			parents := c.Parents()
+			if err := parents.ForEach(func(p *object.Commit) error {
+				pending = append(pending, p)
+				return nil
+			}); err != nil {
+				return nil, fmt.Errorf("getting parents: %s", err)
+			}
+
+			uphav.Haves = append(uphav.Haves, c.Hash)
+			inVein++
+		}
+
+		// Let the server know we're done
+		const maxInVein = 256
+		done = len(pending) == 0 || (gotContinue && inVein >= maxInVein)
+		uphav.Done = done
+
 		// Encode upload-haves
-		// TODO: support multi_ack and multi_ack_detailed caps
 		if err := uphav.Encode(writer); err != nil {
 			return nil, fmt.Errorf("sending upload-haves: %w", err)
 		}
 
-		// Note: Stateless RPC servers don't expect a flush-pkt after the
-		// haves. Sending one might result in a response without a packfile in
-		// return.
-		if !conn.StatelessRPC() && len(uphav.Haves) > 0 {
-			if err := pktline.WriteFlush(writer); err != nil {
-				return nil, fmt.Errorf("sending flush-pkt after haves: %w", err)
+		// Close the writer to signal the end of the request
+		if conn.StatelessRPC() {
+			if err := writer.Close(); err != nil {
+				return nil, fmt.Errorf("closing writer: %s", err)
 			}
 		}
 
-		// Let the server know we're done
-		if _, err := pktline.Writeln(writer, "done"); err != nil {
-			return nil, fmt.Errorf("sending done: %w", err)
-		}
+		if done || len(uphav.Haves) > 0 {
+			var srvrs packp.ServerResponse
+			if err := srvrs.Decode(reader); err != nil {
+				return nil, fmt.Errorf("decoding server-response: %s", err)
+			}
 
-		// Close the writer to signal the end of the request
+			for _, ack := range srvrs.ACKs {
+				if !gotContinue && ack.Status > 0 {
+					gotContinue = true
+				}
+				if ack.Status == packp.ACKCommon {
+					common[ack.Hash] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if !conn.StatelessRPC() {
 		if err := writer.Close(); err != nil {
 			return nil, fmt.Errorf("closing writer: %w", err)
 		}
+	}
 
-		// TODO: handle server-response to support incremental fetch i.e.
-		// multi_ack and multi_ack_detailed modes.
-
-		done = true
-
-		// Decode shallow-update
-		// If depth is not zero, then we expect a shallow update from the
-		// server.
-		if req.Depth != 0 {
-			if err := shupd.Decode(reader); err != nil {
-				return nil, fmt.Errorf("decoding shallow-update: %w", err)
-			}
+	// Decode shallow-update
+	// If depth is not zero, then we expect a shallow update from the
+	// server.
+	var shupd packp.ShallowUpdate
+	if req.Depth != 0 {
+		if err := shupd.Decode(reader); err != nil {
+			return nil, fmt.Errorf("decoding shallow-update: %s", err)
 		}
-
-		// The server replies with one last NAK/ACK after the client is
-		// done sending the request.
-		var acks bytes.Buffer
-		tee := io.TeeReader(reader, &acks)
-		if l, p, err := pktline.ReadLine(tee); err != nil {
-			return nil, fmt.Errorf("reading server-response, len: %d, pkt: %q: %w", l, p, err)
-		}
-
-		// Decode server-response final ACK/NAK
-		if err := srvrs.Decode(&acks); err != nil {
-			return nil, fmt.Errorf("decoding server-response: %w", err)
-		}
-
 	}
 
 	return shupd.Shallows, nil

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -33,14 +33,15 @@ func AdvertiseReferences(ctx context.Context, st storage.Storer, w io.Writer, se
 		ar.Capabilities.Set(capability.ReportStatus) //nolint:errcheck
 		ar.Capabilities.Set(capability.PushOptions)  //nolint:errcheck
 	} else {
-		// TODO: support multi_ack and multi_ack_detailed caps
 		// TODO: support include-tag
 		// TODO: support deepen
 		// TODO: support deepen-since
-		ar.Capabilities.Set(capability.Sideband)   //nolint:errcheck
-		ar.Capabilities.Set(capability.NoProgress) //nolint:errcheck
-		ar.Capabilities.Set(capability.SymRef)     //nolint:errcheck
-		ar.Capabilities.Set(capability.Shallow)    //nolint:errcheck
+		ar.Capabilities.Set(capability.MultiACK)         //nolint:errcheck
+		ar.Capabilities.Set(capability.MultiACKDetailed) //nolint:errcheck
+		ar.Capabilities.Set(capability.Sideband)         //nolint:errcheck
+		ar.Capabilities.Set(capability.NoProgress)       //nolint:errcheck
+		ar.Capabilities.Set(capability.SymRef)           //nolint:errcheck
+		ar.Capabilities.Set(capability.Shallow)          //nolint:errcheck
 	}
 
 	// Set references

--- a/plumbing/transport/ssh/knownhosts/knownhosts.go
+++ b/plumbing/transport/ssh/knownhosts/knownhosts.go
@@ -460,9 +460,11 @@ type fakePublicKey struct{}
 func (fakePublicKey) Type() string {
 	return "fake-public-key"
 }
+
 func (fakePublicKey) Marshal() []byte {
 	return []byte("fake public key")
 }
+
 func (fakePublicKey) Verify(_ []byte, _ *ssh.Signature) error {
 	return errors.New("Verify called on placeholder key")
 }

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -96,11 +96,10 @@ func UploadPack(
 
 		var writer io.Writer = w
 		if !caps.Supports(capability.NoProgress) {
-			if caps.Supports(capability.Sideband) {
-				writer = sideband.NewMuxer(sideband.Sideband, w)
-			}
 			if caps.Supports(capability.Sideband64k) {
 				writer = sideband.NewMuxer(sideband.Sideband64k, w)
+			} else if caps.Supports(capability.Sideband) {
+				writer = sideband.NewMuxer(sideband.Sideband, w)
 			}
 		}
 

--- a/remote.go
+++ b/remote.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/internal/reference"
 	"github.com/go-git/go-git/v5/internal/repository"
 	"github.com/go-git/go-git/v5/internal/url"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -170,7 +171,7 @@ func (r *Remote) sendPack(ctx context.Context, conn transport.Connection, remote
 		}
 	}
 
-	localRefs, err := r.references()
+	localRefs, err := reference.References(r.s)
 	if err != nil {
 		return err
 	}
@@ -401,7 +402,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	}
 
 	remoteRefs := referenceStorageFromRefs(rRefs, true)
-	localRefs, err := r.references()
+	localRefs, err := reference.References(r.s)
 	if err != nil {
 		return nil, err
 	}
@@ -768,30 +769,6 @@ func (r *Remote) checkForceWithLease(localRef *plumbing.Reference, cmd *packp.Co
 	}
 
 	return nil
-}
-
-func (r *Remote) references() ([]*plumbing.Reference, error) {
-	var localRefs []*plumbing.Reference
-
-	iter, err := r.s.IterReferences()
-	if err != nil {
-		return nil, err
-	}
-
-	for {
-		ref, err := iter.Next()
-		if err == io.EOF {
-			break
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		localRefs = append(localRefs, ref)
-	}
-
-	return localRefs, nil
 }
 
 func getRemoteRefsFromStorer(remoteRefStorer storer.ReferenceStorer) (


### PR DESCRIPTION
This adds support for multi-ack and multi-ack-detailed capabilities in
the transport package. The support includes both the client and server.

This works by properly implementing the negotiation algorithm where the client and server can send/receive multiple upload-haves and server-response requests. The implementation follows canonical git sending 32 have lines per compute step to find the optimal packfile.

Related: https://github.com/go-git/go-git/commit/2ebd65f9d532401606d9ea16657fb6c6c42f3df5
Related: https://github.com/go-git/go-git/pull/1204

Based on: https://github.com/go-git/go-git/pull/1303 and https://github.com/go-git/go-git/pull/1337