### PR TITLE
refactor transport: plumbing: transport/http, support http dumb protocol (4/5)

### DIFF
--- a/plumbing/protocol/packp/advrefs_encode.go
+++ b/plumbing/protocol/packp/advrefs_encode.go
@@ -47,16 +47,21 @@ func (e *advRefsEncoder) Encode(v *AdvRefs) error {
 	return e.err
 }
 
-func (e *advRefsEncoder) sortRefs() {
-	if len(e.data.References) > 0 {
-		refs := make([]string, 0, len(e.data.References))
-		for refName := range e.data.References {
-			refs = append(refs, refName)
+func sortRefs(refs map[string]plumbing.Hash) []string {
+	if len(refs) > 0 {
+		sortedRefs := make([]string, 0, len(refs))
+		for refName := range refs {
+			sortedRefs = append(sortedRefs, refName)
 		}
 
-		sort.Strings(refs)
-		e.sortedRefs = refs
+		sort.Strings(sortedRefs)
+		return sortedRefs
 	}
+	return nil
+}
+
+func (e *advRefsEncoder) sortRefs() {
+	e.sortedRefs = sortRefs(e.data.References)
 }
 
 func (e *advRefsEncoder) setFirstRef() {

--- a/plumbing/protocol/packp/advrefs_encode.go
+++ b/plumbing/protocol/packp/advrefs_encode.go
@@ -47,6 +47,7 @@ func (e *advRefsEncoder) Encode(v *AdvRefs) error {
 	return e.err
 }
 
+// sortRefs returns a sorted slice of reference names by name.
 func sortRefs(refs map[string]plumbing.Hash) []string {
 	if len(refs) > 0 {
 		sortedRefs := make([]string, 0, len(refs))

--- a/plumbing/protocol/packp/inforefs.go
+++ b/plumbing/protocol/packp/inforefs.go
@@ -1,0 +1,67 @@
+package packp
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// InfoRefs represents the information of the references advertised by an
+// HTTP dumb server.
+type InfoRefs struct {
+	// References are the hash references.
+	References map[string]plumbing.Hash
+	// Peeled are the peeled hash references.
+	Peeled map[string]plumbing.Hash
+}
+
+func (i *InfoRefs) init() {
+	if i.References == nil {
+		i.References = make(map[string]plumbing.Hash)
+	}
+	if i.Peeled == nil {
+		i.Peeled = make(map[string]plumbing.Hash)
+	}
+}
+
+// Decode decodes an InfoRefs from reader.
+func (i *InfoRefs) Decode(r io.Reader) error {
+	i.init()
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		parts := strings.SplitN(s.Text(), "\t", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		hash := plumbing.NewHash(parts[0])
+		refname := parts[1]
+		if strings.HasSuffix(refname, string(peeled)) {
+			i.Peeled[strings.TrimSuffix(refname, string(peeled))] = hash
+		} else {
+			i.References[refname] = hash
+		}
+	}
+
+	return s.Err()
+}
+
+// Encode encodes an InfoRefs to writer.
+func (i *InfoRefs) Encode(w io.Writer) error {
+	sortedRefs := sortRefs(i.References)
+	for _, ref := range sortedRefs {
+		hash := i.References[ref]
+		if _, err := fmt.Fprintf(w, "%s\t%s\n", hash.String(), ref); err != nil {
+			return err
+		}
+		if peeled, ok := i.Peeled[ref]; ok {
+			if _, err := fmt.Fprintf(w, "%s\t%s%s\n", peeled.String(), ref, peeled); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/plumbing/transport/http/dumb.go
+++ b/plumbing/transport/http/dumb.go
@@ -1,0 +1,432 @@
+package http
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
+	"github.com/go-git/go-git/v5/plumbing/format/objfile"
+	"github.com/go-git/go-git/v5/plumbing/format/packfile"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/utils/ioutil"
+)
+
+func (s *HTTPSession) fetchDumb(ctx context.Context, req *transport.FetchRequest) error {
+	if req.Depth != 0 {
+		return fmt.Errorf("dumb http protocol does not support shallow capabilities")
+	}
+
+	fsi, ok := s.st.(interface {
+		Filesystem() billy.Filesystem
+	})
+	if !ok {
+		return fmt.Errorf("dumb http protocol requires a filesystem")
+	}
+
+	repoFs := fsi.Filesystem()
+	r := newFetchWalker(s, ctx, repoFs)
+	if err := r.process(); err != nil {
+		return err
+	}
+
+	if err := r.fetch(); err != nil {
+		return fmt.Errorf("error fetching objects: %w", err)
+	}
+
+	return nil
+}
+
+// fetchWalker implements the Dumb protocol for fetching objects.
+type fetchWalker struct {
+	*HTTPSession
+	ctx     context.Context
+	fs      billy.Filesystem
+	queue   []plumbing.Hash
+	packIdx map[plumbing.Hash]string
+}
+
+func newFetchWalker(s *HTTPSession, ctx context.Context, fs billy.Filesystem) *fetchWalker {
+	walker := new(fetchWalker)
+	walker.HTTPSession = s
+	walker.ctx = ctx
+	walker.fs = fs
+	walker.queue = make([]plumbing.Hash, 0)
+	walker.packIdx = make(map[plumbing.Hash]string)
+	return walker
+}
+
+func (r *fetchWalker) getInfoPacks() ([]string, error) {
+	url := fmt.Sprintf("%s/objects/info/packs", r.ep.String())
+	req, err := http.NewRequestWithContext(r.ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	applyHeaders(req, "", r.ep, r.auth, "", false)
+	res, err := doRequest(r.client, req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	switch res.StatusCode {
+	case http.StatusOK:
+		// continue
+	case http.StatusNotFound:
+		return nil, transport.ErrRepositoryNotFound
+	default:
+		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	var packs []string
+	s := bufio.NewScanner(res.Body)
+	for s.Scan() {
+		line := s.Text()
+		hash := strings.TrimPrefix(line, "P pack-")
+		hash = strings.TrimSuffix(hash, ".pack")
+		packs = append(packs, hash)
+	}
+
+	return packs, s.Err()
+}
+
+// downloadFile downloads a file from the server and saves it to the filesystem.
+func (r *fetchWalker) downloadFile(path string) error {
+	url := fmt.Sprintf("%s/%s", r.ep.String(), path)
+	req, err := http.NewRequestWithContext(r.ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	applyHeaders(req, "", r.ep, r.auth, "", false)
+	res, err := doRequest(r.client, req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	f, err := r.fs.TempFile(filepath.Dir(path), filepath.Base(path)+".temp")
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(f, res.Body); err != nil {
+		_ = f.Close()
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	// TODO: support hardlinks and "core.createobject" configuration
+	return r.fs.Rename(f.Name(), path)
+}
+
+// getHead returns the HEAD reference from the server.
+func (r *fetchWalker) getHead() (*plumbing.Reference, error) {
+	url := fmt.Sprintf("%s/HEAD", r.ep.String())
+	req, err := http.NewRequestWithContext(r.ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	applyHeaders(req, "", r.ep, r.auth, "", false)
+	res, err := doRequest(r.client, req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	switch res.StatusCode {
+	case http.StatusOK:
+		// continue
+	case http.StatusNotFound:
+		return nil, transport.ErrRepositoryNotFound
+	default:
+		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	s := bufio.NewScanner(res.Body)
+	if !s.Scan() {
+		return nil, s.Err()
+	}
+
+	line := s.Text()
+	if strings.HasPrefix(line, "ref: ") {
+		target := strings.TrimPrefix(line, "ref: ")
+		return plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.ReferenceName(target)), nil
+	}
+
+	return plumbing.NewHashReference(plumbing.HEAD, plumbing.NewHash(line)), nil
+}
+
+// process calculates the objects to fetch and downloads them.
+func (r *fetchWalker) process() error {
+	var head plumbing.Hash
+	if r.refs.Head == nil {
+		hash, err := r.getHead()
+		if err != nil {
+			return err
+		}
+
+		switch hash.Type() {
+		case plumbing.HashReference:
+			head = hash.Hash()
+			r.refs.Head = &head
+		case plumbing.SymbolicReference:
+			for name, h := range r.refs.References {
+				if name == hash.Target().String() {
+					head = h
+					break
+				}
+			}
+		}
+	} else {
+		head = *r.refs.Head
+	}
+
+	if head.IsZero() {
+		// TODO: better error message?
+		return transport.ErrRepositoryNotFound
+	}
+
+	infoPacks, err := r.getInfoPacks()
+	if err != nil {
+		return err
+	}
+
+	for _, hash := range infoPacks {
+		h := plumbing.NewHash(hash)
+		if h.IsZero() {
+			continue
+		}
+
+		// XXX: we need to check if the index file exists. Currently, there is
+		// no way to do so using the storer interfaces except useing
+		// HasEncodedObject which might be an expensive operation.
+		packIdx := fmt.Sprintf("objects/pack/pack-%s.idx", hash)
+		if _, err := r.fs.Stat(packIdx); errors.Is(err, fs.ErrExist) {
+			r.packIdx[h] = packIdx
+		} else {
+			if err := r.downloadFile(packIdx); err != nil {
+				return err
+			}
+
+			// TODO: parse and checksum the index file
+			r.packIdx[h] = packIdx
+		}
+	}
+
+	r.queue = append(r.queue, head)
+	for name, hash := range r.refs.References {
+		peeled, hasPeeled := r.refs.Peeled[name]
+		if r.st.HasEncodedObject(hash) != nil {
+			r.queue = append(r.queue, hash)
+		}
+		if hasPeeled && r.st.HasEncodedObject(peeled) != nil {
+			r.queue = append(r.queue, peeled)
+		}
+	}
+
+	r.queue = append(r.queue, head)
+
+	return nil
+}
+
+func (r *fetchWalker) fetchObject(hash plumbing.Hash, obj plumbing.EncodedObject) (err error) {
+	if r.st.HasEncodedObject(hash) == nil {
+		return nil
+	}
+
+	h := hash.String()
+	url := fmt.Sprintf("%s/objects/%s/%s", r.ep.String(), h[:2], h[2:])
+	req, err := http.NewRequestWithContext(r.ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	applyHeaders(req, "", r.ep, r.auth, "", false)
+	res, err := doRequest(r.client, req)
+	if errors.Is(err, transport.ErrRepositoryNotFound) {
+		// TODO: better error handling
+		return io.EOF
+	}
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	switch res.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return io.EOF
+	default:
+		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	rd, err := objfile.NewReader(res.Body)
+	if err != nil {
+		return err
+	}
+
+	ioutil.CheckClose(rd, &err)
+
+	t, size, err := rd.Header()
+	if err != nil {
+		return err
+	}
+
+	obj.SetType(t)
+	obj.SetSize(size)
+
+	w, err := obj.Writer()
+	if err != nil {
+		return err
+	}
+
+	ioutil.CheckClose(w, &err)
+
+	if _, err := io.Copy(w, rd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *fetchWalker) fetch() error {
+	packs := map[string]struct{}{}
+	processed := map[string]struct{}{}
+	indicies := []*idxfile.MemoryIndex{}
+
+LOOP:
+	for len(r.queue) > 0 {
+		objHash := r.queue[0]
+		r.queue = r.queue[1:]
+		if _, ok := processed[objHash.String()]; ok {
+			continue
+		}
+
+		for _, idx := range indicies {
+			if ok, err := idx.Contains(objHash); err == nil && ok {
+				continue LOOP
+			}
+		}
+
+		obj := r.st.NewEncodedObject()
+		err := r.fetchObject(objHash, obj)
+		if err == io.EOF {
+			// TODO: support http-alternates
+			for packHash, packIdxPath := range r.packIdx {
+				idxFile, err := r.fs.Open(packIdxPath)
+				if err != nil {
+					return fmt.Errorf("error opening index file: %w", err)
+				}
+
+				idx := idxfile.NewMemoryIndex()
+				d := idxfile.NewDecoder(idxFile)
+				if err := d.Decode(idx); err != nil {
+					_ = idxFile.Close()
+					return fmt.Errorf("error decoding index file: %w", err)
+				}
+
+				indicies = append(indicies, idx)
+				packPath := fmt.Sprintf("objects/pack/pack-%s.pack", packHash.String())
+				if ok, err := idx.Contains(objHash); err == nil && ok {
+					processed[objHash.String()] = struct{}{}
+					if _, ok := packs[packPath]; ok {
+						continue LOOP
+					}
+
+					if _, err := r.fs.Stat(packPath); errors.Is(err, fs.ErrExist) {
+						packs[packPath] = struct{}{}
+						continue LOOP
+					}
+
+					if err := r.downloadFile(packPath); err != nil {
+						return fmt.Errorf("error downloading pack file: %w", err)
+					}
+
+					packs[packPath] = struct{}{}
+					continue LOOP
+				}
+			}
+		} else if err != nil {
+			return err
+		}
+
+		switch obj.Type() {
+		case plumbing.CommitObject:
+			commit, err := object.DecodeCommit(r.st, obj)
+			if err != nil {
+				return err
+			}
+
+			r.queue = append(r.queue, commit.ParentHashes...)
+			r.queue = append(r.queue, commit.TreeHash)
+		case plumbing.TreeObject:
+			tree, err := object.DecodeTree(r.st, obj)
+			if err != nil {
+				return err
+			}
+
+			r.queue = append(r.queue, tree.Hash)
+			for _, e := range tree.Entries {
+				r.queue = append(r.queue, e.Hash)
+			}
+		case plumbing.TagObject:
+			tag, err := object.DecodeTag(r.st, obj)
+			if err != nil {
+				return err
+			}
+
+			r.queue = append(r.queue, tag.Hash)
+			r.queue = append(r.queue, tag.Target)
+		case plumbing.BlobObject:
+			blob, err := object.DecodeBlob(obj)
+			if err != nil {
+				return err
+			}
+
+			r.queue = append(r.queue, blob.Hash)
+		default:
+			return plumbing.ErrInvalidType
+		}
+
+		if _, err := r.st.SetEncodedObject(obj); err != nil {
+			return err
+		}
+		processed[objHash.String()] = struct{}{}
+	}
+
+	for packPath := range packs {
+		f, err := r.fs.Open(packPath)
+		if err != nil {
+			return err
+		}
+
+		if err := packfile.UpdateObjectStorage(r.st, f); err != nil {
+			_ = f.Close()
+			return err
+		}
+
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -200,8 +200,7 @@ func (s *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
 	return nil
 }
 
-func (s *ObjectStorage) encodedObjectSizeFromUnpacked(h plumbing.Hash) (
-	size int64, err error) {
+func (s *ObjectStorage) encodedObjectSizeFromUnpacked(h plumbing.Hash) (size int64, err error) {
 	f, err := s.dir.Object(h)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -292,8 +291,7 @@ func (s *ObjectStorage) storePackfileInCache(hash plumbing.Hash, p *packfile.Pac
 	return nil
 }
 
-func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (
-	size int64, err error) {
+func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (size int64, err error) {
 	if err := s.requireIndex(); err != nil {
 		return 0, err
 	}
@@ -328,8 +326,7 @@ func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (
 
 // EncodedObjectSize returns the plaintext size of the given object,
 // without actually reading the full object data from storage.
-func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (
-	size int64, err error) {
+func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (size int64, err error) {
 	size, err = s.encodedObjectSizeFromUnpacked(h)
 	if err != nil && err != plumbing.ErrObjectNotFound {
 		return 0, err
@@ -389,8 +386,7 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 
 // DeltaObject returns the object with the given hash, by searching for
 // it in the packfile and the git object directories.
-func (s *ObjectStorage) DeltaObject(t plumbing.ObjectType,
-	h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (s *ObjectStorage) DeltaObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, err := s.getFromUnpacked(h)
 	if err == plumbing.ErrObjectNotFound {
 		obj, err = s.getFromPackfile(h, true)
@@ -469,9 +465,7 @@ var copyBufferPool = sync.Pool{
 
 // Get returns the object with the given hash, by searching for it in
 // the packfile.
-func (s *ObjectStorage) getFromPackfile(h plumbing.Hash, canBeDelta bool) (
-	plumbing.EncodedObject, error) {
-
+func (s *ObjectStorage) getFromPackfile(h plumbing.Hash, canBeDelta bool) (plumbing.EncodedObject, error) {
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
@@ -522,9 +516,7 @@ func (s *ObjectStorage) decodeDeltaObjectAt(
 
 	header := scan.Data().Value().(packfile.ObjectHeader)
 
-	var (
-		base plumbing.Hash
-	)
+	var base plumbing.Hash
 
 	switch header.Type {
 	case plumbing.REFDeltaObject:


### PR DESCRIPTION
This adds support to the HTTP dumb protocol described in
https://git-scm.com/book/en/v2/Git-Internals-Transfer-Protocols

Fixes: https://github.com/go-git/go-git/issues/492

Based on: https://github.com/go-git/go-git/pull/1303 and https://github.com/go-git/go-git/pull/1337