### PR TITLE
plumbing: use the correct user agent string. Fixes #883

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/utils/ioutil"
 	"github.com/golang/groupcache/lru"
@@ -24,7 +25,7 @@ import (
 
 // it requires a bytes.Buffer, because we need to know the length
 func applyHeadersToRequest(req *http.Request, content *bytes.Buffer, host string, requestType string) {
-	req.Header.Add("User-Agent", "git/1.0")
+	req.Header.Add("User-Agent", capability.DefaultAgent())
 	req.Header.Add("Host", host) // host:port
 
 	if content == nil {


### PR DESCRIPTION
Fixes: #883 

Makes sure the transport uses correct `userAgent` instead of hardcoded `git/1.0`