### PR TITLE
config: url, breaking change to support multiple insteadOf keys in configuration

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -165,8 +165,8 @@ func (s *ConfigSuite) TestMarshal() {
 	}
 
 	cfg.URLs["ssh://git@github.com/"] = &URL{
-		Name:      "ssh://git@github.com/",
-		InsteadOf: "https://github.com/",
+		Name:       "ssh://git@github.com/",
+		InsteadOfs: []string{"https://github.com/"},
 	}
 
 	b, err := cfg.Marshal()

--- a/config/url.go
+++ b/config/url.go
@@ -17,7 +17,7 @@ type URL struct {
 	Name string
 	// Any URL that starts with this value will be rewritten to start, instead, with <base>.
 	// When more than one insteadOf strings match a given URL, the longest match is used.
-	InsteadOf string
+	InsteadOfs []string
 
 	// raw representation of the subsection, filled by marshal or unmarshal are
 	// called.
@@ -26,7 +26,7 @@ type URL struct {
 
 // Validate validates fields of branch
 func (b *URL) Validate() error {
-	if b.InsteadOf == "" {
+	if len(b.InsteadOfs) == 0 {
 		return errURLEmptyInsteadOf
 	}
 
@@ -41,7 +41,7 @@ func (u *URL) unmarshal(s *format.Subsection) error {
 	u.raw = s
 
 	u.Name = s.Name
-	u.InsteadOf = u.raw.Option(insteadOfKey)
+	u.InsteadOfs = u.raw.OptionAll(insteadOfKey)
 	return nil
 }
 
@@ -51,21 +51,28 @@ func (u *URL) marshal() *format.Subsection {
 	}
 
 	u.raw.Name = u.Name
-	u.raw.SetOption(insteadOfKey, u.InsteadOf)
+	u.raw.SetOption(insteadOfKey, u.InsteadOfs...)
 
 	return u.raw
 }
 
 func findLongestInsteadOfMatch(remoteURL string, urls map[string]*URL) *URL {
 	var longestMatch *URL
-	for _, u := range urls {
-		if !strings.HasPrefix(remoteURL, u.InsteadOf) {
-			continue
-		}
+	var longestMatchLength int
 
-		// according to spec if there is more than one match, take the logest
-		if longestMatch == nil || len(longestMatch.InsteadOf) < len(u.InsteadOf) {
-			longestMatch = u
+	for _, u := range urls {
+		for _, currentInsteadOf := range u.InsteadOfs {
+			if !strings.HasPrefix(remoteURL, currentInsteadOf) {
+				continue
+			}
+
+			lengthCurrentInsteadOf := len(currentInsteadOf)
+
+			// according to spec if there is more than one match, take the longest
+			if longestMatch == nil || longestMatchLength < lengthCurrentInsteadOf {
+				longestMatch = u
+				longestMatchLength = lengthCurrentInsteadOf
+			}
 		}
 	}
 
@@ -73,9 +80,11 @@ func findLongestInsteadOfMatch(remoteURL string, urls map[string]*URL) *URL {
 }
 
 func (u *URL) ApplyInsteadOf(url string) string {
-	if !strings.HasPrefix(url, u.InsteadOf) {
-		return url
+	for _, j := range u.InsteadOfs {
+		if strings.HasPrefix(url, j) {
+			return u.Name + url[len(j):]
+		}
 	}
 
-	return u.Name + url[len(u.InsteadOf):]
+	return url
 }

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -16,8 +16,8 @@ func TestURLSuite(t *testing.T) {
 
 func (b *URLSuite) TestValidateInsteadOf() {
 	goodURL := URL{
-		Name:      "ssh://github.com",
-		InsteadOf: "http://github.com",
+		Name:       "ssh://github.com",
+		InsteadOfs: []string{"http://github.com"},
 	}
 	badURL := URL{}
 	b.Nil(goodURL.Validate())
@@ -33,8 +33,27 @@ func (b *URLSuite) TestMarshal() {
 
 	cfg := NewConfig()
 	cfg.URLs["ssh://git@github.com/"] = &URL{
-		Name:      "ssh://git@github.com/",
-		InsteadOf: "https://github.com/",
+		Name:       "ssh://git@github.com/",
+		InsteadOfs: []string{"https://github.com/"},
+	}
+
+	actual, err := cfg.Marshal()
+	b.Nil(err)
+	b.Equal(string(expected), string(actual))
+}
+
+func (b *URLSuite) TestMarshalMultipleInsteadOf() {
+	expected := []byte(`[core]
+	bare = false
+[url "ssh://git@github.com/"]
+	insteadOf = https://github.com/
+	insteadOf = https://google.com/
+`)
+
+	cfg := NewConfig()
+	cfg.URLs["ssh://git@github.com/"] = &URL{
+		Name:       "ssh://git@github.com/",
+		InsteadOfs: []string{"https://github.com/", "https://google.com/"},
 	}
 
 	actual, err := cfg.Marshal()
@@ -54,15 +73,69 @@ func (b *URLSuite) TestUnmarshal() {
 	b.NoError(err)
 	url := cfg.URLs["ssh://git@github.com/"]
 	b.Equal("ssh://git@github.com/", url.Name)
-	b.Equal("https://github.com/", url.InsteadOf)
+	b.Equal("https://github.com/", url.InsteadOfs[0])
+}
+
+func (b *URLSuite) TestUnmarshalMultipleInsteadOf() {
+	input := []byte(`[core]
+	bare = false
+[url "ssh://git@github.com/"]
+	insteadOf = https://github.com/
+	insteadOf = https://google.com/
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	b.Nil(err)
+	url := cfg.URLs["ssh://git@github.com/"]
+	b.Equal("ssh://git@github.com/", url.Name)
+
+	b.Equal("ssh://git@github.com/foobar", url.ApplyInsteadOf("https://github.com/foobar"))
+	b.Equal("ssh://git@github.com/foobar", url.ApplyInsteadOf("https://google.com/foobar"))
+}
+
+func (b *URLSuite) TestUnmarshalDuplicateUrls() {
+	input := []byte(`[core]
+	bare = false
+[url "ssh://git@github.com/"]
+	insteadOf = https://github.com/
+[url "ssh://git@github.com/"]
+	insteadOf = https://google.com/
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	b.Nil(err)
+	url := cfg.URLs["ssh://git@github.com/"]
+	b.Equal("ssh://git@github.com/", url.Name)
+
+	b.Equal("ssh://git@github.com/foobar", url.ApplyInsteadOf("https://github.com/foobar"))
+	b.Equal("ssh://git@github.com/foobar", url.ApplyInsteadOf("https://google.com/foobar"))
 }
 
 func (b *URLSuite) TestApplyInsteadOf() {
 	urlRule := URL{
-		Name:      "ssh://github.com",
-		InsteadOf: "http://github.com",
+		Name:       "ssh://github.com",
+		InsteadOfs: []string{"http://github.com"},
 	}
 
 	b.Equal("http://google.com", urlRule.ApplyInsteadOf("http://google.com"))
 	b.Equal("ssh://github.com/myrepo", urlRule.ApplyInsteadOf("http://github.com/myrepo"))
+}
+
+func (b *URLSuite) TestFindLongestInsteadOfMatch() {
+	urlRules := map[string]*URL{
+		"ssh://github.com": &URL{
+			Name:       "ssh://github.com",
+			InsteadOfs: []string{"http://github.com"},
+		},
+		"ssh://somethingelse.com": &URL{
+			Name:       "ssh://somethingelse.com",
+			InsteadOfs: []string{"http://github.com/foobar"},
+		},
+	}
+
+	longestUrl := findLongestInsteadOfMatch("http://github.com/foobar/bingbash.git", urlRules)
+
+	b.Equal("ssh://somethingelse.com", longestUrl.Name)
 }


### PR DESCRIPTION
breaking change to config.URL to support multiple insteadOf keys in configuration.

this fixes https://github.com/go-git/go-git/issues/862 and https://github.com/go-git/go-git/issues/863


this is a rebase of https://github.com/go-git/go-git/pull/864 -- you can close that PR