### PR TITLE
doc: Fix dead commit-graph-format links

### DIFF
--- a/plumbing/format/commitgraph/doc.go
+++ b/plumbing/format/commitgraph/doc.go
@@ -102,5 +102,5 @@
 //	H-byte HASH-checksum of all of the above.
 //
 // Source:
-// https://raw.githubusercontent.com/git/git/master/Documentation/technical/commit-graph-format.txt
+// https://raw.githubusercontent.com/git/git/master/Documentation/technical/commit-graph.adoc
 package commitgraph

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -53,7 +53,7 @@ type fileIndex struct {
 }
 
 // OpenFileIndex opens a serialized commit graph file in the format described at
-// https://github.com/git/git/blob/master/Documentation/technical/commit-graph-format.txt
+// https://github.com/git/git/blob/master/Documentation/technical/commit-graph.adoc
 //
 // Deprecated: This package uses the wrong types for Generation and Index in CommitData.
 // Use the v2 package instead.

--- a/plumbing/format/commitgraph/v2/doc.go
+++ b/plumbing/format/commitgraph/v2/doc.go
@@ -102,5 +102,5 @@
 //	H-byte HASH-checksum of all of the above.
 //
 // Source:
-// https://raw.githubusercontent.com/git/git/master/Documentation/technical/commit-graph-format.txt
+// https://raw.githubusercontent.com/git/git/master/Documentation/technical/commit-graph.adoc
 package v2

--- a/plumbing/format/commitgraph/v2/file.go
+++ b/plumbing/format/commitgraph/v2/file.go
@@ -60,13 +60,13 @@ type ReaderAtCloser interface {
 }
 
 // OpenFileIndex opens a serialized commit graph file in the format described at
-// https://github.com/git/git/blob/master/Documentation/technical/commit-graph-format.txt
+// https://github.com/git/git/blob/master/Documentation/technical/commit-graph.adoc
 func OpenFileIndex(reader ReaderAtCloser) (Index, error) {
 	return OpenFileIndexWithParent(reader, nil)
 }
 
 // OpenFileIndexWithParent opens a serialized commit graph file in the format described at
-// https://github.com/git/git/blob/master/Documentation/technical/commit-graph-format.txt
+// https://github.com/git/git/blob/master/Documentation/technical/commit-graph.adoc
 func OpenFileIndexWithParent(reader ReaderAtCloser, parent Index) (Index, error) {
 	if reader == nil {
 		return nil, io.ErrUnexpectedEOF


### PR DESCRIPTION
Not 100% sure, but I'm guessing this new file is what was originally targeted