### PR TITLE
Fix tests TestFetchOfMissingObjects and TestFetchWildcardTags

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -821,13 +821,6 @@ func getHavesFromRef(
 		return nil
 	}
 
-	// No need to load the commit if we know the remote already
-	// has this hash.
-	if remoteRefs[h] {
-		haves[h] = true
-		return nil
-	}
-
 	commit, err := object.GetCommit(s, h)
 	if err != nil {
 		if !errors.Is(err, plumbing.ErrObjectNotFound) {

--- a/remote_test.go
+++ b/remote_test.go
@@ -125,6 +125,7 @@ func (s *RemoteSuite) TestFetchWildcardTags() {
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
+		Tags: AllTags,
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f"),
 		plumbing.NewReferenceFromStrings("refs/tags/annotated-tag", "b742a2a9fa0afcfa9a6fad080980fbc26b007c69"),
@@ -356,7 +357,7 @@ func (s *RemoteSuite) testFetch(r *Remote, o *FetchOptions, expected []*plumbing
 	for _, exp := range expected {
 		r, err := r.s.Reference(exp.Name())
 		s.Require().NoError(err)
-		s.Equal(r.String(), exp.String())
+		s.Equal(exp.String(), r.String())
 	}
 }
 


### PR DESCRIPTION
#### TestFetchWildcardTags
When comparing the expected behaviour versus upstream git cli, it became clear that the tests expected all tags to be pulled - without actually setting that. This is a change in behaviour which will be introduced in v6, whereby Fetch is not expected to return all tags by default.

The git commands used for testing were:
```
git clone --no-checkout --bare  https://github.com/git-fixtures/tags.git /tmp/tags
cd /tmp/tags
git fetch origin '+refs/heads/*:refs/remotes/origin/*'
```

Based on the above, the test was amended to actively request for all tags to be returned.
This change has been tagged as breaking to reflect the previously made change that required it.

#### TestFetchOfMissingObjects
The test was failing due to a recently introduced optimisation, which skipped getting a commit if the reference was already known. The challenge with this approach is that it removes go-git's ability to self-heal when the underlying objects are no longer available.