### PR TITLE
repository: adopt variadic options pattern for Init and PlainInit

### DIFF
--- a/options.go
+++ b/options.go
@@ -791,15 +791,54 @@ type PlainOpenOptions struct {
 // Validate validates the fields and sets the default values.
 func (o *PlainOpenOptions) Validate() error { return nil }
 
-type PlainInitOptions struct {
-	InitOptions
-	// Determines if the repository will have a worktree (non-bare) or not (bare).
-	Bare         bool
-	ObjectFormat formatcfg.ObjectFormat
+type plainInitOptions struct {
+	initOptions []InitOption
+
+	bare         bool
+	objectFormat formatcfg.ObjectFormat
+}
+
+type PlainInitOption func(*plainInitOptions)
+
+// newPlainInitOptions creates a new instance of plainInitOptions with default settings.
+func newPlainInitOptions() plainInitOptions {
+	return plainInitOptions{
+		initOptions:  make([]InitOption, 0),
+		bare:         false,
+		objectFormat: "",
+	}
+}
+
+// WithInitOptions passes a set of general InitOption functions through to the shared initOptions.
+func WithInitOptions(opts ...InitOption) PlainInitOption {
+	return func(o *plainInitOptions) {
+		o.initOptions = opts
+	}
+}
+
+// WithWorkTree determines if the repository will have a worktree (non-bare) or not (bare).
+func WithWorkTree(hasWorkTree bool) PlainInitOption {
+	return func(o *plainInitOptions) {
+		o.bare = !hasWorkTree
+	}
+}
+
+// WithBare is for backwards compatibility and is the opposite of WithWorkTree; a bare repo has no worktree.
+func WithBare(isBare bool) PlainInitOption {
+	return func(o *plainInitOptions) {
+		o.bare = isBare
+	}
+}
+
+// WithObjectFormat sets the object format when invoking PlainInitWithOptions.
+func WithObjectFormat(of formatcfg.ObjectFormat) PlainInitOption {
+	return func(o *plainInitOptions) {
+		o.objectFormat = of
+	}
 }
 
 // Validate validates the fields and sets the default values.
-func (o *PlainInitOptions) Validate() error { return nil }
+func (o *plainInitOptions) Validate() error { return nil }
 
 var ErrNoRestorePaths = errors.New("you must specify path(s) to restore")
 

--- a/repository.go
+++ b/repository.go
@@ -77,31 +77,45 @@ type Repository struct {
 	wt billy.Filesystem
 }
 
-type InitOptions struct {
-	// The default branch (e.g. "refs/heads/master")
-	DefaultBranch plumbing.ReferenceName
+type initOptions struct {
+	defaultBranch plumbing.ReferenceName
+}
+
+func newInitOptions() initOptions {
+	return initOptions{
+		defaultBranch: plumbing.Master,
+	}
+}
+
+type InitOption func(*initOptions)
+
+// WithDefaultBranch sets the  default branch for the new repo (e.g. "refs/heads/master").
+func WithDefaultBranch(b plumbing.ReferenceName) InitOption {
+	return func(o *initOptions) {
+		o.defaultBranch = b
+	}
 }
 
 // Init creates an empty git repository, based on the given Storer and worktree.
 // The worktree Filesystem is optional, if nil a bare repository is created. If
 // the given storer is not empty ErrRepositoryAlreadyExists is returned
 func Init(s storage.Storer, worktree billy.Filesystem) (*Repository, error) {
-	options := InitOptions{
-		DefaultBranch: plumbing.Master,
-	}
-	return InitWithOptions(s, worktree, options)
+	return InitWithOptions(s, worktree,
+		WithDefaultBranch(plumbing.Master),
+	)
 }
 
-func InitWithOptions(s storage.Storer, worktree billy.Filesystem, options InitOptions) (*Repository, error) {
+func InitWithOptions(s storage.Storer, worktree billy.Filesystem, opts ...InitOption) (*Repository, error) {
+	options := newInitOptions()
+	for _, oFn := range opts {
+		oFn(&options)
+	}
+
 	if err := initStorer(s); err != nil {
 		return nil, err
 	}
 
-	if options.DefaultBranch == "" {
-		options.DefaultBranch = plumbing.Master
-	}
-
-	if err := options.DefaultBranch.Validate(); err != nil {
+	if err := options.defaultBranch.Validate(); err != nil {
 		return nil, err
 	}
 
@@ -115,7 +129,7 @@ func InitWithOptions(s storage.Storer, worktree billy.Filesystem, options InitOp
 		return nil, err
 	}
 
-	h := plumbing.NewSymbolicReference(plumbing.HEAD, options.DefaultBranch)
+	h := plumbing.NewSymbolicReference(plumbing.HEAD, options.defaultBranch)
 	if err := s.SetReference(h); err != nil {
 		return nil, err
 	}
@@ -253,19 +267,20 @@ func CloneContext(
 // if the repository will have worktree (non-bare) or not (bare), if the path
 // is not empty ErrRepositoryAlreadyExists is returned.
 func PlainInit(path string, isBare bool) (*Repository, error) {
-	return PlainInitWithOptions(path, &PlainInitOptions{
-		Bare: isBare,
-	})
+	return PlainInitWithOptions(path,
+		WithWorkTree(!isBare),
+	)
 }
 
-func PlainInitWithOptions(path string, opts *PlainInitOptions) (*Repository, error) {
-	if opts == nil {
-		opts = &PlainInitOptions{}
+func PlainInitWithOptions(path string, opts ...PlainInitOption) (*Repository, error) {
+	options := newPlainInitOptions()
+	for _, oFn := range opts {
+		oFn(&options)
 	}
 
 	var wt, dot billy.Filesystem
 
-	if opts.Bare {
+	if options.bare {
 		dot = osfs.New(path, osfs.WithBoundOS())
 	} else {
 		wt = osfs.New(path, osfs.WithBoundOS())
@@ -274,7 +289,7 @@ func PlainInitWithOptions(path string, opts *PlainInitOptions) (*Repository, err
 
 	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 
-	r, err := InitWithOptions(s, wt, opts.InitOptions)
+	r, err := InitWithOptions(s, wt, options.initOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -284,13 +299,13 @@ func PlainInitWithOptions(path string, opts *PlainInitOptions) (*Repository, err
 		return nil, err
 	}
 
-	if opts.ObjectFormat != "" {
-		if opts.ObjectFormat == formatcfg.SHA256 && hash.CryptoType != crypto.SHA256 {
+	if options.objectFormat != "" {
+		if options.objectFormat == formatcfg.SHA256 && hash.CryptoType != crypto.SHA256 {
 			return nil, ErrSHA256NotSupported
 		}
 
 		cfg.Core.RepositoryFormatVersion = formatcfg.Version_1
-		cfg.Extensions.ObjectFormat = opts.ObjectFormat
+		cfg.Extensions.ObjectFormat = options.objectFormat
 	}
 
 	err = r.Storer.SetConfig(cfg)

--- a/repository_test.go
+++ b/repository_test.go
@@ -67,9 +67,9 @@ func (s *RepositorySuite) TestInit() {
 }
 
 func (s *RepositorySuite) TestInitWithOptions() {
-	r, err := InitWithOptions(memory.NewStorage(), memfs.New(), InitOptions{
-		DefaultBranch: "refs/heads/foo",
-	})
+	r, err := InitWithOptions(memory.NewStorage(), memfs.New(),
+		WithDefaultBranch("refs/heads/foo"),
+	)
 	s.NoError(err)
 	s.NotNil(r)
 	createCommit(s, r)
@@ -81,9 +81,9 @@ func (s *RepositorySuite) TestInitWithOptions() {
 }
 
 func (s *RepositorySuite) TestInitWithInvalidDefaultBranch() {
-	_, err := InitWithOptions(memory.NewStorage(), memfs.New(), InitOptions{
-		DefaultBranch: "foo",
-	})
+	_, err := InitWithOptions(memory.NewStorage(), memfs.New(),
+		WithDefaultBranch("foo"),
+	)
 	s.NotNil(err)
 }
 
@@ -659,12 +659,12 @@ func (s *RepositorySuite) TestPlainInitWithOptions() {
 	dir, err := os.MkdirTemp("", "")
 	s.NoError(err)
 
-	r, err := PlainInitWithOptions(dir, &PlainInitOptions{
-		InitOptions: InitOptions{
-			DefaultBranch: "refs/heads/foo",
-		},
-		Bare: false,
-	})
+	r, err := PlainInitWithOptions(dir,
+		WithInitOptions(
+			WithDefaultBranch("refs/heads/foo"),
+		),
+		WithWorkTree(true),
+	)
 	s.NoError(err)
 	s.NotNil(r)
 


### PR DESCRIPTION
This PR refactors the options for the Repository `Init` and `PlainInit` methods to accept some variadic style options in the same style as the recently refactored [packfile.Parser](https://github.com/go-git/go-git/blob/main/plumbing/format/packfile/parser.go#L45).

This refactoring for the repository factory functions paves the way for additional options to opt-in to legacy v5 configuration handlings (see #395 and the initial work in #1019)

I am looking for feedback to confirm that this syntax and semantics are going in an aligned direction. Specifically I ran into the similarity between `Init` and `PlainInit` args and the fact that Golang does not support two functions named the same of different types (e.g. `WithDefaultBranch` might become `WithPlainInitDefaultBranch` but that seems to add no value) so I compromised and introduced a `WithInitOptions` helper that allows passing `initOption` helpers into the `plainInitOption`'s inner `initOptions`

A different approach would be to collapse all the init options into a single struct and remove `PlainInit`, replacing it with `Init` and the options that configure a bare repo.

@pjbgf I am looking for some confirmation or direction on this set of changes before I push forward to address the rest of #395 