### PR TITLE
plumbing: transport, Add support for filters

### DIFF
--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -110,6 +110,10 @@ type FetchRequest struct {
 	// Depth is the depth of the fetch.
 	Depth int
 
+	// Filter holds the filters to be applied when deciding what
+	// objects will be added to the packfile.
+	Filter packp.Filter
+
 	// IncludeTags indicates whether tags should be fetched.
 	IncludeTags bool
 }

--- a/remote.go
+++ b/remote.go
@@ -35,7 +35,6 @@ var (
 	ErrForceNeeded           = errors.New("some refs were not updated")
 	ErrExactSHA1NotSupported = errors.New("server does not support exact SHA1 refspec")
 	ErrEmptyUrls             = errors.New("URLs cannot be empty")
-	ErrFilterNotSupported    = errors.New("server does not support filters")
 )
 
 type NoMatchingRefSpecError struct {
@@ -446,6 +445,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 			Depth:       o.Depth,
 			Progress:    o.Progress,
 			IncludeTags: isWildcard && o.Tags == plumbing.TagFollowing,
+			Filter:      o.Filter,
 		}
 
 		if err := conn.Fetch(ctx, req); err != nil && !errors.Is(err, transport.ErrNoChange) {

--- a/repository_test.go
+++ b/repository_test.go
@@ -1300,9 +1300,6 @@ func (s *RepositorySuite) TestFetchContext() {
 }
 
 func (s *RepositorySuite) TestFetchWithFilters() {
-	// TODO: Re-enable test when filter support is reintroduced
-	s.T().SkipNow()
-
 	r, _ := Init(memory.NewStorage(), nil)
 	_, err := r.CreateRemote(&config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -1313,13 +1310,10 @@ func (s *RepositorySuite) TestFetchWithFilters() {
 	err = r.Fetch(&FetchOptions{
 		Filter: packp.FilterBlobNone(),
 	})
-	s.ErrorIs(err, ErrFilterNotSupported)
+	s.ErrorIs(err, transport.ErrFilterNotSupported)
 
 }
 func (s *RepositorySuite) TestFetchWithFiltersReal() {
-	// TODO: Re-enable test when filter support is reintroduced
-	s.T().SkipNow()
-
 	r, _ := Init(memory.NewStorage(), nil)
 	_, err := r.CreateRemote(&config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -1681,9 +1675,6 @@ func (s *RepositorySuite) TestCloneDetachedHEADAnnotatedTag() {
 }
 
 func (s *RepositorySuite) TestCloneWithFilter() {
-	// TODO: Re-enable test when filter support is reintroduced
-	s.T().SkipNow()
-
 	r, _ := Init(memory.NewStorage(), nil)
 
 	err := r.clone(context.Background(), &CloneOptions{


### PR DESCRIPTION
Add support for filters for `v6-transport` and re-enable tests.