### PR TITLE
fix: use "errors" package for comparaison

### DIFF
--- a/_examples/ls/main.go
+++ b/_examples/ls/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -131,7 +132,7 @@ func getFullPath(treePath, path string) string {
 
 func getFileHashes(c commitgraph.CommitNode, treePath string, paths []string) (map[string]plumbing.Hash, error) {
 	tree, err := getCommitTree(c, treePath)
-	if err == object.ErrDirectoryNotFound {
+	if errors.Is(err, object.ErrDirectoryNotFound) {
 		// The whole tree didn't exist, so return empty map
 		return make(map[string]plumbing.Hash), nil
 	}

--- a/_examples/tag-create-push/main.go
+++ b/_examples/tag-create-push/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -136,7 +137,7 @@ func pushTags(r *git.Repository, publicKeyPath string) error {
 	err := r.Push(po)
 
 	if err != nil {
-		if err == git.NoErrAlreadyUpToDate {
+		if errors.Is(err, git.NoErrAlreadyUpToDate) {
 			log.Print("origin remote was up to date, no push done")
 			return nil
 		}

--- a/cli/go-git/main.go
+++ b/cli/go-git/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -28,7 +29,8 @@ func main() {
 
 	_, err := parser.Parse()
 	if err != nil {
-		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrCommandRequired {
+		var e *flags.Error
+		if errors.As(err, &e) && e.Type == flags.ErrCommandRequired {
 			parser.WriteHelp(os.Stdout)
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -361,7 +361,7 @@ func unmarshalSubmodules(fc *format.Config, submodules map[string]*Submodule) {
 		m := &Submodule{}
 		m.unmarshal(sub)
 
-		if m.Validate() == ErrModuleBadPath {
+		if errors.Is(m.Validate(), ErrModuleBadPath) {
 			continue
 		}
 

--- a/options.go
+++ b/options.go
@@ -491,7 +491,7 @@ func (o *CommitOptions) Validate(r *Repository) error {
 
 	if len(o.Parents) == 0 {
 		head, err := r.Head()
-		if err != nil && err != plumbing.ErrReferenceNotFound {
+		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return err
 		}
 

--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -232,7 +232,7 @@ func (d *Decoder) readExtensions(idx *Index) error {
 		}
 	}
 
-	if err != errUnknownExtension {
+	if !errors.Is(err, errUnknownExtension) {
 		return err
 	}
 

--- a/plumbing/format/pktline/scanner.go
+++ b/plumbing/format/pktline/scanner.go
@@ -80,7 +80,7 @@ func (s *Scanner) Bytes() []byte {
 // pkt-len and subtracting the pkt-len size.
 func (s *Scanner) readPayloadLen() (int, error) {
 	if _, err := io.ReadFull(s.r, s.len[:]); err != nil {
-		if err == io.ErrUnexpectedEOF {
+		if errors.Is(err, io.ErrUnexpectedEOF) {
 			return 0, ErrInvalidPktLen
 		}
 

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"container/list"
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -103,7 +104,7 @@ func (w *commitPreIterator) ForEach(cb func(*Commit) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {
@@ -171,7 +172,7 @@ func (w *commitPostIterator) ForEach(cb func(*Commit) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {
@@ -201,7 +202,7 @@ func NewCommitAllIter(repoStorer storage.Storer, commitIterFunc func(*Commit) Co
 		err = addReference(repoStorer, commitIterFunc, head, commitsPath, commitsLookup)
 	}
 
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return nil, err
 	}
 
@@ -218,7 +219,7 @@ func NewCommitAllIter(repoStorer storage.Storer, commitIterFunc func(*Commit) Co
 			break
 		}
 
-		if err == plumbing.ErrReferenceNotFound {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
 			continue
 		}
 
@@ -311,7 +312,7 @@ func (it *commitAllIterator) ForEach(cb func(*Commit) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {

--- a/plumbing/object/commit_walker_bfs.go
+++ b/plumbing/object/commit_walker_bfs.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -86,7 +87,7 @@ func (w *bfsCommitIterator) ForEach(cb func(*Commit) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {

--- a/plumbing/object/commit_walker_bfs_filtered.go
+++ b/plumbing/object/commit_walker_bfs_filtered.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -99,7 +100,7 @@ func (w *filterCommitIter) ForEach(cb func(*Commit) error) error {
 			return err
 		}
 
-		if err := cb(commit); err == storer.ErrStop {
+		if err := cb(commit); errors.Is(err, storer.ErrStop) {
 			break
 		} else if err != nil {
 			return err

--- a/plumbing/object/commit_walker_ctime.go
+++ b/plumbing/object/commit_walker_ctime.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 
 	"github.com/emirpasic/gods/trees/binaryheap"
@@ -89,7 +90,7 @@ func (w *commitIteratorByCTime) ForEach(cb func(*Commit) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {

--- a/plumbing/object/commit_walker_limit.go
+++ b/plumbing/object/commit_walker_limit.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -51,7 +52,7 @@ func (c *commitLimitIter) ForEach(cb func(*Commit) error) error {
 			return nextErr
 		}
 		err := cb(commit)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			return nil
 		} else if err != nil {
 			return err

--- a/plumbing/object/commit_walker_path.go
+++ b/plumbing/object/commit_walker_path.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -146,7 +147,7 @@ func (c *commitPathIter) ForEach(cb func(*Commit) error) error {
 			return nextErr
 		}
 		err := cb(commit)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			return nil
 		} else if err != nil {
 			return err

--- a/plumbing/object/commitgraph/commitnode_walker_ctime.go
+++ b/plumbing/object/commitgraph/commitnode_walker_ctime.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -83,7 +84,7 @@ func (w *commitNodeIteratorByCTime) Next() (CommitNode, error) {
 func (w *commitNodeIteratorByCTime) ForEach(cb func(CommitNode) error) error {
 	for {
 		c, err := w.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -91,7 +92,7 @@ func (w *commitNodeIteratorByCTime) ForEach(cb func(CommitNode) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {

--- a/plumbing/object/difftree.go
+++ b/plumbing/object/difftree.go
@@ -3,6 +3,8 @@ package object
 import (
 	"bytes"
 	"context"
+	"errors"
+
 
 	"github.com/go-git/go-git/v5/utils/merkletrie"
 	"github.com/go-git/go-git/v5/utils/merkletrie/noder"
@@ -75,7 +77,7 @@ func DiffTreeWithOptions(
 
 	merkletrieChanges, err := merkletrie.DiffTreeContext(ctx, from, to, hashEqual)
 	if err != nil {
-		if err == merkletrie.ErrCanceled {
+		if errors.Is(err, merkletrie.ErrCanceled) {
 			return nil, ErrCanceled
 		}
 		return nil, err

--- a/plumbing/object/file.go
+++ b/plumbing/object/file.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"strings"
 
@@ -123,7 +124,7 @@ func (iter *FileIter) ForEach(cb func(*File) error) error {
 		}
 
 		if err := cb(f); err != nil {
-			if err == storer.ErrStop {
+			if errors.Is(err, storer.ErrStop) {
 				return nil
 			}
 

--- a/plumbing/object/merge_base.go
+++ b/plumbing/object/merge_base.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -21,7 +22,7 @@ func (c *Commit) MergeBase(other *Commit) ([]*Commit, error) {
 	older := sorted[1]
 
 	newerHistory, err := ancestorsIndex(older, newer)
-	if err == errIsReachable {
+	if errors.Is(err, errIsReachable) {
 		return []*Commit{older}, nil
 	}
 

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -189,7 +189,7 @@ func (iter *ObjectIter) Next() (Object, error) {
 		}
 
 		o, err := iter.toObject(obj)
-		if err == plumbing.ErrInvalidType {
+		if errors.Is(err, plumbing.ErrInvalidType) {
 			continue
 		}
 
@@ -207,7 +207,7 @@ func (iter *ObjectIter) Next() (Object, error) {
 func (iter *ObjectIter) ForEach(cb func(Object) error) error {
 	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
 		o, err := iter.toObject(obj)
-		if err == plumbing.ErrInvalidType {
+		if errors.Is(err, plumbing.ErrInvalidType) {
 			return nil
 		}
 

--- a/plumbing/object/rename.go
+++ b/plumbing/object/rename.go
@@ -478,7 +478,7 @@ outerLoop:
 			if s == nil {
 				s, err = fileSimilarityIndex(from)
 				if err != nil {
-					if err == errIndexFull {
+					if errors.Is(err, errIndexFull) {
 						continue outerLoop
 					}
 					return nil, err
@@ -494,7 +494,7 @@ outerLoop:
 
 			di, err := fileSimilarityIndex(to)
 			if err != nil {
-				if err == errIndexFull {
+				if errors.Is(err, errIndexFull) {
 					dstTooLarge[dstIdx] = true
 				}
 
@@ -605,7 +605,7 @@ func (i *similarityIndex) hashContent(r io.Reader, size int64, isBin bool) error
 				ptr = 0
 				var err error
 				cnt, err = io.ReadFull(r, buf)
-				if err != nil && err != io.ErrUnexpectedEOF {
+				if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 					return err
 				}
 

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -78,7 +78,7 @@ func (t *Tree) File(path string) (*File, error) {
 
 	blob, err := GetBlob(t.s, e.Hash)
 	if err != nil {
-		if err == plumbing.ErrObjectNotFound {
+		if errors.Is(err, plumbing.ErrObjectNotFound) {
 			return nil, ErrFileNotFound
 		}
 		return nil, err
@@ -107,7 +107,7 @@ func (t *Tree) Tree(path string) (*Tree, error) {
 	}
 
 	tree, err := GetTree(t.s, e.Hash)
-	if err == plumbing.ErrObjectNotFound {
+	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		return nil, ErrDirectoryNotFound
 	}
 

--- a/plumbing/protocol/packp/advrefs.go
+++ b/plumbing/protocol/packp/advrefs.go
@@ -1,6 +1,7 @@
 package packp
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -97,7 +98,7 @@ func (a *AdvRefs) addRefs(s storer.ReferenceStorer) error {
 // Git versions prior to 1.8.4.3 has an special procedure to get
 // the reference where is pointing to HEAD:
 // - Check if a reference called master exists. If exists and it
-//	 has the same hash as HEAD hash, we can say that HEAD is pointing to master
+//   has the same hash as HEAD hash, we can say that HEAD is pointing to master
 // - If master does not exists or does not have the same hash as HEAD,
 //   order references and check in that order if that reference has the same
 //   hash than HEAD. If yes, set HEAD pointing to that branch hash
@@ -121,7 +122,7 @@ func (a *AdvRefs) resolveHead(s storer.ReferenceStorer) error {
 		}
 	}
 
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 

--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -3,6 +3,7 @@
 package revlist
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -61,7 +62,7 @@ func objects(
 
 	for _, h := range objects {
 		if err := processObject(s, h, seen, visited, ignore, walkerFunc); err != nil {
-			if allowMissingObjects && err == plumbing.ErrObjectNotFound {
+			if allowMissingObjects && errors.Is(err, plumbing.ErrObjectNotFound) {
 				continue
 			}
 

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -278,7 +278,7 @@ func ForEachIterator(iter bareIterator, cb func(plumbing.EncodedObject) error) e
 		}
 
 		if err := cb(obj); err != nil {
-			if err == ErrStop {
+			if errors.Is(err, ErrStop) {
 				return nil
 			}
 

--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -80,7 +80,7 @@ func (iter *referenceFilteredIter) ForEach(cb func(*plumbing.Reference) error) e
 		}
 
 		if err := cb(r); err != nil {
-			if err == ErrStop {
+			if errors.Is(err, ErrStop) {
 				break
 			}
 
@@ -152,7 +152,7 @@ func forEachReferenceIter(iter bareReferenceIterator, cb func(*plumbing.Referenc
 		}
 
 		if err := cb(obj); err != nil {
-			if err == ErrStop {
+			if errors.Is(err, ErrStop) {
 				return nil
 			}
 

--- a/plumbing/transport/file/client.go
+++ b/plumbing/transport/file/client.go
@@ -86,13 +86,12 @@ func (r *runner) Command(cmd string, ep *transport.Endpoint, auth transport.Auth
 
 	_, err := execabs.LookPath(cmd)
 	if err != nil {
-		if e, ok := err.(*execabs.Error); ok && e.Err == execabs.ErrNotFound {
+		var e *execabs.Error
+		if errors.As(err, &e) && errors.Is(e.Err, execabs.ErrNotFound) {
 			cmd, err = prefixExecPath(cmd)
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			return nil, err
 		}
 	}
 

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -4,6 +4,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -60,7 +61,7 @@ func advertisedReferences(ctx context.Context, s *session, serviceName string) (
 
 	ar := packp.NewAdvRefs()
 	if err = ar.Decode(res.Body); err != nil {
-		if err == packp.ErrEmptyAdvRefs {
+		if errors.Is(err, packp.ErrEmptyAdvRefs) {
 			err = transport.ErrEmptyRemoteRepository
 		}
 

--- a/plumbing/transport/http/receive_pack.go
+++ b/plumbing/transport/http/receive_pack.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -50,7 +51,7 @@ func (s *rpSession) ReceivePack(ctx context.Context, req *packp.ReferenceUpdateR
 	}
 
 	r, err := ioutil.NonEmptyReader(res.Body)
-	if err == ioutil.ErrEmptyReader {
+	if errors.Is(err, ioutil.ErrEmptyReader) {
 		return nil, nil
 	}
 

--- a/plumbing/transport/http/upload_pack.go
+++ b/plumbing/transport/http/upload_pack.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -61,7 +62,7 @@ func (s *upSession) UploadPack(
 
 	r, err := ioutil.NonEmptyReader(res.Body)
 	if err != nil {
-		if err == ioutil.ErrEmptyReader || err == io.ErrUnexpectedEOF {
+		if errors.Is(err, ioutil.ErrEmptyReader) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return nil, transport.ErrEmptyUploadPackRequest
 		}
 

--- a/plumbing/transport/server/server.go
+++ b/plumbing/transport/server/server.go
@@ -372,7 +372,7 @@ func (*rpSession) setSupportedCapabilities(c *capability.List) error {
 
 func setHEAD(s storer.Storer, ar *packp.AdvRefs) error {
 	ref, err := s.Reference(plumbing.HEAD)
-	if err == plumbing.ErrReferenceNotFound {
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return nil
 	}
 
@@ -386,7 +386,7 @@ func setHEAD(s storer.Storer, ar *packp.AdvRefs) error {
 		}
 
 		ref, err = storer.ResolveReference(s, ref.Target())
-		if err == plumbing.ErrReferenceNotFound {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return nil
 		}
 
@@ -424,7 +424,7 @@ func setReferences(s storer.Storer, ar *packp.AdvRefs) error {
 
 func referenceExists(s storer.ReferenceStorer, n plumbing.ReferenceName) (bool, error) {
 	_, err := s.Reference(n)
-	if err == plumbing.ErrReferenceNotFound {
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return false, nil
 	}
 

--- a/remote.go
+++ b/remote.go
@@ -692,7 +692,7 @@ func (r *Remote) addCommit(rs config.RefSpec,
 		}
 
 		cmd.Old = remoteRef.Hash()
-	} else if err != plumbing.ErrReferenceNotFound {
+	} else if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 	if cmd.Old == cmd.New {
@@ -734,7 +734,7 @@ func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
 		}
 
 		cmd.Old = remoteRef.Hash()
-	} else if err != plumbing.ErrReferenceNotFound {
+	} else if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 
@@ -1011,7 +1011,7 @@ func getWants(localStorer storage.Storer, refs memory.ReferenceStorage) ([]plumb
 
 func objectExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
 	_, err := s.EncodedObject(plumbing.AnyObject, h)
-	if err == plumbing.ErrObjectNotFound {
+	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		return false, nil
 	}
 
@@ -1021,7 +1021,7 @@ func objectExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
 func checkFastForwardUpdate(s storer.EncodedObjectStorer, remoteRefs storer.ReferenceStorer, cmd *packp.Command) error {
 	if cmd.Old == plumbing.ZeroHash {
 		_, err := remoteRefs.Reference(cmd.Name)
-		if err == plumbing.ErrReferenceNotFound {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return nil
 		}
 
@@ -1219,7 +1219,7 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 		}
 
 		_, err := r.s.EncodedObject(plumbing.AnyObject, ref.Hash())
-		if err == plumbing.ErrObjectNotFound {
+		if errors.Is(err, plumbing.ErrObjectNotFound) {
 			continue
 		}
 

--- a/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
+++ b/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
@@ -1,6 +1,7 @@
 package dotgit
 
 import (
+	"errors"
 	"io"
 	"os"
 	"runtime"
@@ -29,7 +30,7 @@ func (d *DotGit) rewritePackedRefsWhileLocked(
 
 	// If we are in a filesystem that does not support rename (e.g. sivafs)
 	// a full copy is done.
-	if err == billy.ErrNotSupported {
+	if errors.Is(err, billy.ErrNotSupported) {
 		return d.copyNewFile(tmp, pr)
 	}
 

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -1,6 +1,7 @@
 package dotgit
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync/atomic"
@@ -79,7 +80,7 @@ func (w *PackWriter) buildIndex() {
 // ignore the error
 func (w *PackWriter) waitBuildIndex() error {
 	err := <-w.result
-	if err == packfile.ErrEmptyPackfile {
+	if errors.Is(err, packfile.ErrEmptyPackfile) {
 		return nil
 	}
 

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -2,6 +2,7 @@
 package memory
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -177,7 +178,7 @@ func (o *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 	for h := range o.Objects {
 		err := fun(h)
 		if err != nil {
-			if err == storer.ErrStop {
+			if errors.Is(err, storer.ErrStop) {
 				return nil
 			}
 			return err

--- a/storage/transactional/object.go
+++ b/storage/transactional/object.go
@@ -1,6 +1,8 @@
 package transactional
 
 import (
+	"errors"
+
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 )
@@ -25,7 +27,7 @@ func (o *ObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.H
 // HasEncodedObject honors the storer.EncodedObjectStorer interface.
 func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) error {
 	err := o.EncodedObjectStorer.HasEncodedObject(h)
-	if err == plumbing.ErrObjectNotFound {
+	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		return o.temporal.HasEncodedObject(h)
 	}
 
@@ -35,7 +37,7 @@ func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) error {
 // EncodedObjectSize honors the storer.EncodedObjectStorer interface.
 func (o *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (int64, error) {
 	sz, err := o.EncodedObjectStorer.EncodedObjectSize(h)
-	if err == plumbing.ErrObjectNotFound {
+	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		return o.temporal.EncodedObjectSize(h)
 	}
 
@@ -45,7 +47,7 @@ func (o *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (int64, error) {
 // EncodedObject honors the storer.EncodedObjectStorer interface.
 func (o *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, err := o.EncodedObjectStorer.EncodedObject(t, h)
-	if err == plumbing.ErrObjectNotFound {
+	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		return o.temporal.EncodedObject(t, h)
 	}
 

--- a/storage/transactional/reference.go
+++ b/storage/transactional/reference.go
@@ -1,6 +1,8 @@
 package transactional
 
 import (
+	"errors"
+
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/storage"
@@ -41,7 +43,7 @@ func (r *ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) er
 	}
 
 	tmp, err := r.temporal.Reference(old.Name())
-	if err == plumbing.ErrReferenceNotFound {
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
 		tmp, err = r.ReferenceStorer.Reference(old.Name())
 	}
 
@@ -63,7 +65,7 @@ func (r ReferenceStorage) Reference(n plumbing.ReferenceName) (*plumbing.Referen
 	}
 
 	ref, err := r.temporal.Reference(n)
-	if err == plumbing.ErrReferenceNotFound {
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return r.ReferenceStorer.Reference(n)
 	}
 

--- a/submodule.go
+++ b/submodule.go
@@ -69,7 +69,7 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 	}
 
 	e, err := idx.Entry(s.c.Path)
-	if err != nil && err != index.ErrEntryNotFound {
+	if err != nil && !errors.Is(err, index.ErrEntryNotFound) {
 		return nil, err
 	}
 
@@ -91,7 +91,7 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 		status.Current = head.Hash()
 	}
 
-	if err != nil && err == plumbing.ErrReferenceNotFound {
+	if err != nil && errors.Is(err, plumbing.ErrReferenceNotFound) {
 		err = nil
 	}
 
@@ -110,7 +110,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 	}
 
 	_, err = storer.Reference(plumbing.HEAD)
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return nil, err
 	}
 
@@ -244,7 +244,7 @@ func (s *Submodule) fetchAndCheckout(
 ) error {
 	if !o.NoFetch {
 		err := r.FetchContext(ctx, &FetchOptions{Auth: o.Auth})
-		if err != nil && err != NoErrAlreadyUpToDate {
+		if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) {
 			return err
 		}
 	}
@@ -266,7 +266,7 @@ func (s *Submodule) fetchAndCheckout(
 				Auth:     o.Auth,
 				RefSpecs: []config.RefSpec{refSpec},
 			})
-			if err != nil && err != NoErrAlreadyUpToDate && err != ErrExactSHA1NotSupported {
+			if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) && !errors.Is(err, ErrExactSHA1NotSupported) {
 				return err
 			}
 		}

--- a/worktree.go
+++ b/worktree.go
@@ -82,7 +82,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 	})
 
 	updated := true
-	if err == NoErrAlreadyUpToDate {
+	if errors.Is(err, NoErrAlreadyUpToDate) {
 		updated = false
 	} else if err != nil {
 		return err
@@ -114,7 +114,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		}
 	}
 
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 
@@ -194,7 +194,7 @@ func (w *Worktree) createBranch(opts *CheckoutOptions) error {
 		return fmt.Errorf("a branch named %q already exists", opts.Branch)
 	}
 
-	if err != plumbing.ErrReferenceNotFound {
+	if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -36,7 +36,7 @@ func (w *Worktree) Status() (Status, error) {
 	var hash plumbing.Hash
 
 	ref, err := w.r.Head()
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return nil, err
 	}
 
@@ -519,11 +519,11 @@ func (w *Worktree) fillEncodedObjectFromSymlink(dst io.Writer, path string, fi o
 
 func (w *Worktree) addOrUpdateFileToIndex(idx *index.Index, filename string, h plumbing.Hash) error {
 	e, err := idx.Entry(filename)
-	if err != nil && err != index.ErrEntryNotFound {
+	if err != nil && !errors.Is(err, index.ErrEntryNotFound) {
 		return err
 	}
 
-	if err == index.ErrEntryNotFound {
+	if errors.Is(err, index.ErrEntryNotFound) {
 		return w.doAddFileToIndex(idx, filename, h)
 	}
 
@@ -592,7 +592,7 @@ func (w *Worktree) doRemoveDirectory(idx *index.Index, directory string) (remove
 			r, err = w.doRemoveDirectory(idx, name)
 		} else {
 			_, err = w.doRemoveFile(idx, name)
-			if err == index.ErrEntryNotFound {
+			if errors.Is(err, index.ErrEntryNotFound) {
 				err = nil
 			}
 		}


### PR DESCRIPTION
Comparison with errors using equality operators fails on wrapped errors

use the golang 1.13 best practices: https://tip.golang.org/doc/go1.13#error_wrapping