### PR TITLE
plumbing: blame simplification

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -107,10 +107,7 @@ func Blame(c *object.Commit, path string) (*BlameResult, error) {
 		b.lineToCommit[i] = needsMap[i].Commit
 	}
 
-	lines, err := newLines(finalLines, b.lineToCommit)
-	if err != nil {
-		return nil, err
-	}
+	lines := newLines(finalLines, b.lineToCommit)
 
 	return &BlameResult{
 		Path:  path,
@@ -143,7 +140,7 @@ func newLine(author, authorName, text string, date time.Time, hash plumbing.Hash
 	}
 }
 
-func newLines(contents []string, commits []*object.Commit) ([]*Line, error) {
+func newLines(contents []string, commits []*object.Commit) []*Line {
 	result := make([]*Line, 0, len(contents))
 	for i := range contents {
 		result = append(result, newLine(
@@ -152,7 +149,7 @@ func newLines(contents []string, commits []*object.Commit) ([]*Line, error) {
 		))
 	}
 
-	return result, nil
+	return result
 }
 
 // this struct is internally used by the blame function to hold its

--- a/blame_test.go
+++ b/blame_test.go
@@ -22,24 +22,22 @@ func TestBlameSuite(t *testing.T) {
 
 func (s *BlameSuite) TestNewLines() {
 	h := plumbing.NewHash("ce9f123d790717599aaeb76bc62510de437761be")
-	lines, err := newLines([]string{"foo"}, []*object.Commit{{
+	lines := newLines([]string{"foo"}, []*object.Commit{{
 		Hash:    h,
 		Message: "foo",
 	}})
 
-	s.NoError(err)
 	s.Len(lines, 1)
 	s.Equal("foo", lines[0].Text)
 	s.Equal(h, lines[0].Hash)
 }
 
 func (s *BlameSuite) TestNewLinesWithNewLine() {
-	lines, err := newLines([]string{"foo", ""}, []*object.Commit{
+	lines := newLines([]string{"foo", ""}, []*object.Commit{
 		{Message: "foo"},
 		{Message: "bar"},
 	})
 
-	s.NoError(err)
 	s.Len(lines, 2)
 	s.Equal("foo", lines[0].Text)
 	s.Equal("", lines[1].Text)


### PR DESCRIPTION
remove unused result parameter and dead code