### PR TITLE
plumbing: fix err mngt in packfile processDelta

### DIFF
--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -190,7 +190,10 @@ func (p *Parser) processDelta(oh *ObjectHeader) error {
 
 	var deltaData bytes.Buffer
 	if oh.content.Len() > 0 {
-		oh.content.WriteTo(&deltaData)
+		_, err = oh.content.WriteTo(&deltaData)
+		if err != nil {
+			return err
+		}
 	} else {
 		deltaData = *bytes.NewBuffer(make([]byte, 0, oh.Size))
 		err = p.scanner.inflateContent(oh.ContentOffset, &deltaData)


### PR DESCRIPTION
this func could fail silently and couldn't be catch at higher level