### PR TITLE
plumbing: fix err when adding a deleted directory

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -651,10 +651,29 @@ func (w *Worktree) doRemoveFile(idx *index.Index, path string) (plumbing.Hash, e
 func (w *Worktree) deleteFromIndex(idx *index.Index, path string) (plumbing.Hash, error) {
 	e, err := idx.Remove(path)
 	if err != nil {
+		if err == index.ErrEntryNotFound {
+			return plumbing.ZeroHash, w.deleteFilesFromIndex(idx, path)
+		}
 		return plumbing.ZeroHash, err
 	}
 
 	return e.Hash, nil
+}
+
+// when adding a deleted directory, you cannot process it through idx.Remove, need to traverse and process the index entry under the directory
+func (w *Worktree) deleteFilesFromIndex(idx *index.Index, path string) error {
+	path = filepath.ToSlash(path)
+	count := 0
+	for index, e := range idx.Entries {
+		if strings.HasPrefix(e.Name, path) {
+			idx.Entries = append(idx.Entries[:index], idx.Entries[index+1:]...)
+			count++
+		}
+	}
+	if count == 0 {
+		return index.ErrEntryNotFound
+	}
+	return nil
 }
 
 func (w *Worktree) deleteFromFilesystem(path string) error {

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-billy/v5/osfs"
+	"github.com/go-git/go-billy/v5/util"
+	fixtures "github.com/go-git/go-git-fixtures/v4"
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/stretchr/testify/assert"
@@ -86,4 +89,52 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 
 	// Check whether the index was updated with the two new line breaks.
 	assert.Equal(t, uint32(len(content)+2), idx.Entries[0].Size)
+}
+
+func TestAddEmptyDirectory(t *testing.T) {
+	f := fixtures.Basic().One()
+	fs := memfs.New()
+	r := NewRepositoryWithEmptyWorktree(f)
+	w := &Worktree{
+		r:          r,
+		Filesystem: fs,
+	}
+
+	err := w.Checkout(&CheckoutOptions{})
+	require.NoError(t, err)
+
+	// write and add foo file in the dir directory
+	assert.NoError(t, util.WriteFile(fs, "/dir/f1", []byte("foo"), 0644))
+
+	err = w.AddWithOptions(&AddOptions{
+		Path:       "/dir/f1",
+		SkipStatus: true,
+	})
+	require.NoError(t, err)
+
+	_, err = w.Commit("commit foo only\n", &CommitOptions{
+		Author: defaultSignature(),
+	})
+	assert.NoError(t, err)
+
+	// remove dir directory and add it
+	assert.NoError(t, util.RemoveAll(fs, "/dir"))
+
+	err = w.AddWithOptions(&AddOptions{
+		Path:       "/dir",
+		SkipStatus: true,
+	})
+	require.NoError(t, err)
+
+	_, err = w.Commit("commit remove dir\n", &CommitOptions{
+		Author: defaultSignature(),
+	})
+	assert.NoError(t, err)
+
+	// add invalid directory with error
+	err = w.AddWithOptions(&AddOptions{
+		Path:       "/dir2",
+		SkipStatus: true,
+	})
+	require.Error(t, err)
 }


### PR DESCRIPTION
When adding a deleted directory, an "entry not found" error is reported.
This modification can avoid errors and correctly add the files in the directory to the temporary storage.