### PR TITLE
plumbing: add cert auth support to `releases/v5.x`

### DIFF
--- a/plumbing/transport/ssh/auth_method.go
+++ b/plumbing/transport/ssh/auth_method.go
@@ -54,7 +54,7 @@ func (a *KeyboardInteractive) String() string {
 }
 
 func (a *KeyboardInteractive) ClientConfig() (*ssh.ClientConfig, error) {
-	return a.SetHostKeyCallback(&ssh.ClientConfig{
+	return a.SetHostKeyCallbackAndAlgorithms(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{
 			a.Challenge,
@@ -78,7 +78,7 @@ func (a *Password) String() string {
 }
 
 func (a *Password) ClientConfig() (*ssh.ClientConfig, error) {
-	return a.SetHostKeyCallback(&ssh.ClientConfig{
+	return a.SetHostKeyCallbackAndAlgorithms(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.Password(a.Password)},
 	})
@@ -101,7 +101,7 @@ func (a *PasswordCallback) String() string {
 }
 
 func (a *PasswordCallback) ClientConfig() (*ssh.ClientConfig, error) {
-	return a.SetHostKeyCallback(&ssh.ClientConfig{
+	return a.SetHostKeyCallbackAndAlgorithms(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.PasswordCallback(a.Callback)},
 	})
@@ -150,7 +150,7 @@ func (a *PublicKeys) String() string {
 }
 
 func (a *PublicKeys) ClientConfig() (*ssh.ClientConfig, error) {
-	return a.SetHostKeyCallback(&ssh.ClientConfig{
+	return a.SetHostKeyCallbackAndAlgorithms(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.PublicKeys(a.Signer)},
 	})
@@ -211,7 +211,7 @@ func (a *PublicKeysCallback) String() string {
 }
 
 func (a *PublicKeysCallback) ClientConfig() (*ssh.ClientConfig, error) {
-	return a.SetHostKeyCallback(&ssh.ClientConfig{
+	return a.SetHostKeyCallbackAndAlgorithms(&ssh.ClientConfig{
 		User: a.User,
 		Auth: []ssh.AuthMethod{ssh.PublicKeysCallback(a.Callback)},
 	})
@@ -301,20 +301,23 @@ func filterKnownHostsFiles(files ...string) ([]string, error) {
 }
 
 // HostKeyCallbackHelper is a helper that provides common functionality to
-// configure HostKeyCallback into a ssh.ClientConfig.
+// configure HostKeyCallback and HostKeyAlgorithms into a ssh.ClientConfig.
 type HostKeyCallbackHelper struct {
 	// HostKeyCallback is the function type used for verifying server keys.
 	// If nil, a default callback will be created using NewKnownHostsDb
 	// without argument.
 	HostKeyCallback ssh.HostKeyCallback
 
+	// HostKeyAlgorithms is a list of supported host key algorithms that will
+	// be used for host key verification.
+	HostKeyAlgorithms []string
 }
 
-// SetHostKeyCallback sets the field HostKeyCallback in the given cfg.
-// If the host key callback is empty it is left empty. It will be handled
-// by the dial method by falling back to knownhosts.
-func (m *HostKeyCallbackHelper) SetHostKeyCallback(cfg *ssh.ClientConfig) (*ssh.ClientConfig, error) {
-
+// SetHostKeyCallbackAndAlgorithms sets the field HostKeyCallback and HostKeyAlgorithms in the given cfg.
+// If the host key callback or algorithms is empty it is left empty. It will be handled by the dial method,
+// falling back to knownhosts.
+func (m *HostKeyCallbackHelper) SetHostKeyCallbackAndAlgorithms(cfg *ssh.ClientConfig) (*ssh.ClientConfig, error) {
 	cfg.HostKeyCallback = m.HostKeyCallback
+	cfg.HostKeyAlgorithms = m.HostKeyAlgorithms
 	return cfg, nil
 }

--- a/plumbing/transport/ssh/auth_method_test.go
+++ b/plumbing/transport/ssh/auth_method_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/go-git/go-billy/v5/osfs"
@@ -18,7 +19,8 @@ import (
 type (
 	SuiteCommon struct{}
 
-	mockKnownHosts struct{}
+	mockKnownHosts         struct{}
+	mockKnownHostsWithCert struct{}
 )
 
 func (mockKnownHosts) host() string { return "github.com" }
@@ -27,6 +29,19 @@ func (mockKnownHosts) knownHosts() []byte {
 }
 func (mockKnownHosts) Network() string { return "tcp" }
 func (mockKnownHosts) String() string  { return "github.com:22" }
+func (mockKnownHosts) Algorithms() []string {
+	return []string{ssh.KeyAlgoRSA, ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSASHA512}
+}
+
+func (mockKnownHostsWithCert) host() string { return "github.com" }
+func (mockKnownHostsWithCert) knownHosts() []byte {
+	return []byte(`@cert-authority github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==`)
+}
+func (mockKnownHostsWithCert) Network() string { return "tcp" }
+func (mockKnownHostsWithCert) String() string  { return "github.com:22" }
+func (mockKnownHostsWithCert) Algorithms() []string {
+	return []string{ssh.CertAlgoRSASHA512v01, ssh.CertAlgoRSASHA256v01, ssh.CertAlgoRSAv01}
+}
 
 var _ = Suite(&SuiteCommon{})
 
@@ -229,4 +244,76 @@ func (*SuiteCommon) TestNewKnownHostsCallback(c *C) {
 
 	err = clb(mock.String(), mock, hostKey)
 	c.Assert(err, IsNil)
+}
+
+func (*SuiteCommon) TestNewKnownHostsDbWithoutCert(c *C) {
+	if runtime.GOOS == "js" {
+		c.Skip("not available in wasm")
+	}
+
+	var mock = mockKnownHosts{}
+
+	f, err := util.TempFile(osfs.Default, "", "known-hosts")
+	c.Assert(err, IsNil)
+
+	_, err = f.Write(mock.knownHosts())
+	c.Assert(err, IsNil)
+
+	err = f.Close()
+	c.Assert(err, IsNil)
+
+	defer util.RemoveAll(osfs.Default, f.Name())
+
+	f, err = osfs.Default.Open(f.Name())
+	c.Assert(err, IsNil)
+
+	defer f.Close()
+
+	db, err := NewKnownHostsDb(f.Name())
+	c.Assert(err, IsNil)
+
+	algos := db.HostKeyAlgorithms(mock.String())
+	c.Assert(algos, HasLen, len(mock.Algorithms()))
+
+	for _, algorithm := range mock.Algorithms() {
+		if !slices.Contains(algos, algorithm) {
+			c.Error("algos does not contain ", algorithm)
+		}
+	}
+}
+
+func (*SuiteCommon) TestNewKnownHostsDbWithCert(c *C) {
+	if runtime.GOOS == "js" {
+		c.Skip("not available in wasm")
+	}
+
+	var mock = mockKnownHostsWithCert{}
+
+	f, err := util.TempFile(osfs.Default, "", "known-hosts")
+	c.Assert(err, IsNil)
+
+	_, err = f.Write(mock.knownHosts())
+	c.Assert(err, IsNil)
+
+	err = f.Close()
+	c.Assert(err, IsNil)
+
+	defer util.RemoveAll(osfs.Default, f.Name())
+
+	f, err = osfs.Default.Open(f.Name())
+	c.Assert(err, IsNil)
+
+	defer f.Close()
+
+	db, err := NewKnownHostsDb(f.Name())
+	c.Assert(err, IsNil)
+
+	algos := db.HostKeyAlgorithms(mock.String())
+	c.Assert(algos, HasLen, len(mock.Algorithms()))
+
+	for _, algorithm := range mock.Algorithms() {
+		if !slices.Contains(algos, algorithm) {
+			c.Error("algos does not contain ", algorithm)
+		}
+	}
 }

--- a/plumbing/transport/ssh/common_test.go
+++ b/plumbing/transport/ssh/common_test.go
@@ -129,10 +129,33 @@ func (s *SuiteCommon) TestFixedHostKeyCallback(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(auth, NotNil)
 	auth.HostKeyCallback = stdssh.FixedHostKey(hostKey.PublicKey())
+	auth.HostKeyAlgorithms = []string{"ssh-ed25519"}
 	ep := uploadPack.newEndpoint(c, "bar.git")
 	ps, err := uploadPack.Client.NewUploadPackSession(ep, auth)
 	c.Assert(err, IsNil)
 	c.Assert(ps, NotNil)
+}
+
+func (s *SuiteCommon) TestFixedHostKeyCallbackUnexpectedAlgorithm(c *C) {
+	hostKey, err := stdssh.ParsePrivateKey(testdata.PEMBytes["ed25519"])
+	c.Assert(err, IsNil)
+	uploadPack := &UploadPackSuite{
+		opts: []ssh.Option{
+			ssh.HostKeyPEM(testdata.PEMBytes["rsa"]),
+		},
+	}
+	uploadPack.SetUpSuite(c)
+	// Use the default client, which does not have a host key callback
+	uploadPack.Client = DefaultClient
+	auth, err := NewPublicKeys("foo", testdata.PEMBytes["rsa"], "")
+	c.Assert(err, IsNil)
+	c.Assert(auth, NotNil)
+	auth.HostKeyCallback = stdssh.FixedHostKey(hostKey.PublicKey())
+	auth.HostKeyAlgorithms = []string{"ssh-ed25519"}
+	ep := uploadPack.newEndpoint(c, "bar.git")
+	ps, err := uploadPack.Client.NewUploadPackSession(ep, auth)
+	c.Assert(err, NotNil)
+	c.Assert(ps, IsNil)
 }
 
 func (s *SuiteCommon) TestFailHostKeyCallback(c *C) {


### PR DESCRIPTION
Re-adds support for cert authorities using skeema/knownhosts. 
It performs two separate changes: 
- Simplify the `AuthMethod`s provided by go-git so that they populate HostKeyCallback and HostKeyAlgorithms, while still allowing the user to inject a custom HostKeyCallback. If the HostKeyCallback is empty, then the `HostKeyCallback` and the `HostKeyAlgorithms` are set using the knownhosts DB functionality, which now supports cert authorities.
- Add an option so that a user of the default `AuthMethod`s provided by go-git can set a custom `HostKeyAlgorithms` when they use a custom `HostKeyCallback`. This is needed for usages of `ssh.FixedHostKey`.

fixes 1417