### PR TITLE
utils: fix diff so subpaths work for sparse checkouts, fixes 1455

### DIFF
--- a/utils/merkletrie/change.go
+++ b/utils/merkletrie/change.go
@@ -148,7 +148,7 @@ func (l *Changes) addRecursive(root noder.Path, ctor noderToChangeFn) error {
 			}
 			return err
 		}
-		if current.IsDir() {
+		if current.IsDir() || current.Skip() {
 			continue
 		}
 		l.Add(ctor(current))

--- a/utils/merkletrie/index/node.go
+++ b/utils/merkletrie/index/node.go
@@ -36,7 +36,15 @@ func NewRootNode(idx *index.Index) noder.Noder {
 			parent := fullpath
 			fullpath = path.Join(fullpath, part)
 
-			if _, ok := m[fullpath]; ok {
+			// It's possible that the first occurrence of subdirectory is skipped.
+			// The parent node can be created with SkipWorktree set to true, but
+			// if any future children do not skip their subtree, the entire lineage
+			// of the tree needs to have this value set to false so that subdirectories
+			// are not ignored.
+			if parentNode, ok := m[fullpath]; ok {
+				if e.SkipWorktree == false {
+					parentNode.skip = false
+				}
 				continue
 			}
 

--- a/utils/merkletrie/index/node_test.go
+++ b/utils/merkletrie/index/node_test.go
@@ -2,7 +2,7 @@ package index
 
 import (
 	"bytes"
-	"path/filepath"
+	"path"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -47,14 +47,14 @@ func (s *NoderSuite) TestDiff() {
 func (s *NoderSuite) TestDiffChange() {
 	indexA := &index.Index{
 		Entries: []*index.Entry{{
-			Name: filepath.Join("bar", "baz", "bar"),
+			Name: path.Join("bar", "baz", "bar"),
 			Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"),
 		}},
 	}
 
 	indexB := &index.Index{
 		Entries: []*index.Entry{{
-			Name: filepath.Join("bar", "baz", "foo"),
+			Name: path.Join("bar", "baz", "foo"),
 			Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"),
 		}},
 	}
@@ -62,6 +62,32 @@ func (s *NoderSuite) TestDiffChange() {
 	ch, err := merkletrie.DiffTree(NewRootNode(indexA), NewRootNode(indexB), isEquals)
 	s.NoError(err)
 	s.Len(ch, 2)
+}
+
+func (s *NoderSuite) TestDiffSkipIssue1455() {
+	indexA := &index.Index{
+		Entries: []*index.Entry{
+			{
+				Name:         path.Join("bar", "baz", "bar"),
+				Hash:         plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"),
+				SkipWorktree: true,
+			},
+			{
+				Name:         path.Join("bar", "biz", "bat"),
+				Hash:         plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"),
+				SkipWorktree: false,
+			},
+		},
+	}
+
+	indexB := &index.Index{}
+
+	ch, err := merkletrie.DiffTree(NewRootNode(indexB), NewRootNode(indexA), isEquals)
+	s.NoError(err)
+	s.Len(ch, 1)
+	a, err := ch[0].Action()
+	s.NoError(err)
+	s.Equal(a, merkletrie.Insert)
 }
 
 func (s *NoderSuite) TestDiffDir() {
@@ -74,7 +100,7 @@ func (s *NoderSuite) TestDiffDir() {
 
 	indexB := &index.Index{
 		Entries: []*index.Entry{{
-			Name: filepath.Join("foo", "bar"),
+			Name: path.Join("foo", "bar"),
 			Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"),
 		}},
 	}


### PR DESCRIPTION
# Summary

Fix for https://github.com/go-git/go-git/issues/1455

When attempting to check out anything that isn't a root directory the Sparse Checkout options do not work correctly. This is reproducible with the examples in the above issue. 

# Problem 
"virtual" nodes are created in the tree that represent directories. The first time a file is added to the tree it's parts are split and any missing nodes (including any directories) are added to the tree. 

For example, if the first added file is `foo/bar/file.yaml` and this file should be skipped, entries are created for `foo`, `foo/bar`, and `foo/bar/file.yaml`, with all three entries setting `SkipWorktree` to `true`. If `foo/baz/file.yaml` is subsequently added, but should _not_ be skipped, this is the current bug. `foo` already exists in the tree, and had `SkipWorktree` set to `true`. Even though `foo/baz` and `foo/baz/file.yaml` will have skip to false, they will never be included in the diff because their parent `foo` was already marked as skipped. 

# Fix
This change makes it so that any existing parents are re-checked and have their `SkipWorktree` boolean reset when _any_ child of that subtree has `SkipWorktree` set to false. 

The final issue is in the `addRecursive()` method. It doesn't take into consideration the `SkipWorktree` flag via the `Skip()` interface. It now checks this condition and does not add any subtrees which were marked as `Skip() == true`

# Testing
I tested the changes with the reproduction case provided as well as through a simple unit test that attempts to highlight the issue and solution. 

Open to any suggestions. 