### PR TITLE
Introduce a no-merges traversal option

### DIFF
--- a/options.go
+++ b/options.go
@@ -455,7 +455,7 @@ const (
 	LogOrderDFSPost
 	LogOrderBSF
 	LogOrderCommitterTime
-	LogOrderDFSPostNoMerge
+	LogOrderDFSPostFirstParent
 )
 
 // LogOptions describes how a log action should be performed.

--- a/options.go
+++ b/options.go
@@ -455,6 +455,7 @@ const (
 	LogOrderDFSPost
 	LogOrderBSF
 	LogOrderCommitterTime
+	LogOrderDFSPostNoMerge
 )
 
 // LogOptions describes how a log action should be performed.

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -184,7 +184,7 @@ func (w *commitPostIterator) ForEach(cb func(*Commit) error) error {
 
 func (w *commitPostIterator) Close() {}
 
-type commitPostIteratorNM struct {
+type commitPostIteratorFirstParent struct {
 	stack []*Commit
 	seen  map[plumbing.Hash]bool
 }
@@ -194,19 +194,19 @@ type commitPostIteratorNM struct {
 // walking a merge commit, the merged commit will be walked before the base
 // it was merged on. This can be useful if you wish to see the history in
 // chronological order. Ignore allows to skip some commits from being iterated.
-func NewCommitPostorderIterNoMerge(c *Commit, ignore []plumbing.Hash) CommitIter {
+func NewCommitPostorderIterFirstParent(c *Commit, ignore []plumbing.Hash) CommitIter {
 	seen := make(map[plumbing.Hash]bool)
 	for _, h := range ignore {
 		seen[h] = true
 	}
 
-	return &commitPostIteratorNM{
+	return &commitPostIteratorFirstParent{
 		stack: []*Commit{c},
 		seen:  seen,
 	}
 }
 
-func (w *commitPostIteratorNM) Next() (*Commit, error) {
+func (w *commitPostIteratorFirstParent) Next() (*Commit, error) {
 	for {
 		if len(w.stack) == 0 {
 			return nil, io.EOF
@@ -230,7 +230,7 @@ func (w *commitPostIteratorNM) Next() (*Commit, error) {
 	}
 }
 
-func (w *commitPostIteratorNM) ForEach(cb func(*Commit) error) error {
+func (w *commitPostIteratorFirstParent) ForEach(cb func(*Commit) error) error {
 	for {
 		c, err := w.Next()
 		if err == io.EOF {
@@ -252,7 +252,7 @@ func (w *commitPostIteratorNM) ForEach(cb func(*Commit) error) error {
 	return nil
 }
 
-func (w *commitPostIteratorNM) Close() {}
+func (w *commitPostIteratorFirstParent) Close() {}
 
 // commitAllIterator stands for commit iterator for all refs.
 type commitAllIterator struct {

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -220,9 +220,11 @@ func (w *commitPostIteratorNM) Next() (*Commit, error) {
 		}
 
 		w.seen[c.Hash] = true
-		// TODO: change this
+
 		return c, c.Parents().ForEach(func(p *Commit) error {
-			w.stack = append(w.stack, p)
+			if p.Hash == c.ParentHashes[0] {
+				w.stack = append(w.stack, p)
+			}
 			return nil
 		})
 	}

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -193,7 +193,7 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnore() {
 }
 
 func (s *CommitWalkerSuite) TestCommitPostIteratorNoMerge(c *C) {
-	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
+	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
 	NewCommitPostorderIterNoMerge(commit, nil).ForEach(func(c *Commit) error {
@@ -201,7 +201,7 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorNoMerge(c *C) {
 		return nil
 	})
 
-	c.Assert(commits, HasLen, 6)
+	s.Len(commits, 6)
 
 	expected := []string{
 		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
@@ -213,12 +213,12 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorNoMerge(c *C) {
 	}
 
 	for i, commit := range commits {
-		c.Assert(commit.Hash.String(), Equals, expected[i])
+		s.Equal(expected[i], commit.Hash.String())
 	}
 }
 
 func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnoreNoMerge(c *C) {
-	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
+	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
 	NewCommitPostorderIterNoMerge(commit, []plumbing.Hash{
@@ -228,14 +228,14 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnoreNoMerge(c *C) {
 		return nil
 	})
 
-	c.Assert(commits, HasLen, 2)
+	s.Len(commits, 2)
 
 	expected := []string{
 		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
 		"918c48b83bd081e863dbe1b80f8998f058cd8294",
 	}
 	for i, commit := range commits {
-		c.Assert(commit.Hash.String(), Equals, expected[i])
+		s.Equal(expected[i], commit.Hash.String())
 	}
 }
 

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -192,6 +192,53 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnore() {
 	}
 }
 
+func (s *CommitWalkerSuite) TestCommitPostIteratorNoMerge(c *C) {
+	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
+
+	var commits []*Commit
+	NewCommitPostorderIterNoMerge(commit, nil).ForEach(func(c *Commit) error {
+		commits = append(commits, c)
+		return nil
+	})
+
+	c.Assert(commits, HasLen, 6)
+
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+		"1669dce138d9b841a518c64b10914d88f5e488ea",
+		"35e85108805c84807bc66a02d91535e1e24b38b9",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+	}
+
+	for i, commit := range commits {
+		c.Assert(commit.Hash.String(), Equals, expected[i])
+	}
+}
+
+func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnoreNoMerge(c *C) {
+	commit := s.commit(c, plumbing.NewHash(s.Fixture.Head))
+
+	var commits []*Commit
+	NewCommitPostorderIterNoMerge(commit, []plumbing.Hash{
+		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
+	}).ForEach(func(c *Commit) error {
+		commits = append(commits, c)
+		return nil
+	})
+
+	c.Assert(commits, HasLen, 2)
+
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+	}
+	for i, commit := range commits {
+		c.Assert(commit.Hash.String(), Equals, expected[i])
+	}
+}
+
 func (s *CommitWalkerSuite) TestCommitCTimeIterator() {
 	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -192,11 +192,11 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnore() {
 	}
 }
 
-func (s *CommitWalkerSuite) TestCommitPostIteratorNoMerge(c *C) {
+func (s *CommitWalkerSuite) TestCommitPostIteratorFirstParent(c *C) {
 	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
-	NewCommitPostorderIterNoMerge(commit, nil).ForEach(func(c *Commit) error {
+	NewCommitPostorderIterFirstParent(commit, nil).ForEach(func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -217,11 +217,11 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorNoMerge(c *C) {
 	}
 }
 
-func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnoreNoMerge(c *C) {
+func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnoreFirstParent(c *C) {
 	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
-	NewCommitPostorderIterNoMerge(commit, []plumbing.Hash{
+	NewCommitPostorderIterFirstParent(commit, []plumbing.Hash{
 		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
 	}).ForEach(func(c *Commit) error {
 		commits = append(commits, c)

--- a/repository.go
+++ b/repository.go
@@ -1358,9 +1358,9 @@ func commitIterFunc(order LogOrder) func(c *object.Commit) object.CommitIter {
 		return func(c *object.Commit) object.CommitIter {
 			return object.NewCommitIterCTime(c, nil, nil)
 		}
-	case LogOrderDFSPostNoMerge:
+	case LogOrderDFSPostFirstParent:
 		return func(c *object.Commit) object.CommitIter {
-			return object.NewCommitPostorderIterNoMerge(c, nil)
+			return object.NewCommitPostorderIterFirstParent(c, nil)
 		}
 	}
 	return nil

--- a/repository.go
+++ b/repository.go
@@ -1358,6 +1358,10 @@ func commitIterFunc(order LogOrder) func(c *object.Commit) object.CommitIter {
 		return func(c *object.Commit) object.CommitIter {
 			return object.NewCommitIterCTime(c, nil, nil)
 		}
+	case LogOrderDFSPostNoMerge:
+		return func(c *object.Commit) object.CommitIter {
+			return object.NewCommitPostorderIterNoMerge(c, nil)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR is the result of a fix I made to solve a personal usecase in which i needed to be able to view the git log without seeing the contents of merged commits (since they seem to intersperse themselves into the order of commits).

I eventually found that the `--first-parent` option to `git log` from https://stackoverflow.com/a/39586986 was the perfect solution, however I did not see an existing option in the library that enables me to traverse the log this way. With search results leading me to a few mentions of this flag, none of which proposed an alternative way to achieve this, I decided to build my own.

This PR represents a cleaned-up version of my hacked-together changes.

Since I did not see any existing options objects passed into the existing iterators, I decided to copy paste the one that was closest to my usecase and modify it. I realize that this now introduces the issue where the other traversal methods probably also need their own first-parent versions as well, however that seemed like it was both quite out of scope for my personal usecase and also would likely require discussion to determine if theres a better way to handle this in the first place.  