### PR TITLE
[v6] plumbing: fix, prevent double decoding of commands and flush

### DIFF
--- a/options.go
+++ b/options.go
@@ -286,7 +286,7 @@ type PushOptions struct {
 	// ForceWithLease allows a force push as long as the remote ref adheres to a "lease"
 	ForceWithLease *ForceWithLease
 	// PushOptions sets options to be transferred to the server during push.
-	Options map[string]string
+	Options []string
 	// Atomic sets option to be an atomic push
 	Atomic bool
 	// ProxyOptions provides info required for connecting to a proxy.

--- a/plumbing/protocol/packp/pushopts.go
+++ b/plumbing/protocol/packp/pushopts.go
@@ -1,0 +1,50 @@
+package packp
+
+import (
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+// PushOptions represents a list of update request push-options.
+//
+// See https://git-scm.com/docs/gitprotocol-pack#_reference_update_request_and_packfile_transfer
+type PushOptions struct {
+	Options []string
+}
+
+// Encode encodes the push options into the given writer.
+func (opts *PushOptions) Encode(w io.Writer) error {
+	if len(opts.Options) == 0 {
+		return nil
+	}
+
+	for _, opt := range opts.Options {
+		if _, err := pktline.Writef(w, "%s", opt); err != nil {
+			return err
+		}
+	}
+
+	return pktline.WriteFlush(w)
+}
+
+// Decode decodes the push options from the given reader.
+func (opts *PushOptions) Decode(r io.Reader) error {
+	if opts.Options == nil {
+		opts.Options = make([]string, 0)
+	}
+
+	for {
+		l, line, err := pktline.ReadLine(r)
+		if err != nil {
+			return err
+		}
+		if l == pktline.Flush {
+			break
+		}
+
+		opts.Options = append(opts.Options, string(line))
+	}
+
+	return nil
+}

--- a/plumbing/protocol/packp/pushopts_test.go
+++ b/plumbing/protocol/packp/pushopts_test.go
@@ -1,0 +1,54 @@
+package packp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PushOptionsSuite struct {
+	suite.Suite
+}
+
+func TestPushOptionsSuite(t *testing.T) {
+	suite.Run(t, new(PushOptionsSuite))
+}
+
+func (s *PushOptionsSuite) TestPushOptionsEncode() {
+	var r PushOptions
+	r.Options = []string{
+		"SomeKey=SomeValue",
+		"AnotherKey=AnotherValue",
+	}
+
+	expected := pktlines(s.T(),
+		"SomeKey=SomeValue",
+		"AnotherKey=AnotherValue",
+		"",
+	)
+
+	var buf bytes.Buffer
+	s.Require().Nil(r.Encode(&buf))
+	s.Require().Equal(expected, buf.Bytes())
+}
+
+func (s *PushOptionsSuite) TestPushOptionsDecode() {
+	var r PushOptions
+	r.Options = nil
+
+	input := pktlines(s.T(),
+		"SomeKey=SomeValue",
+		"AnotherKey=AnotherValue",
+		"",
+	)
+
+	s.Require().Nil(r.Decode(bytes.NewReader(input)))
+
+	expected := []string{
+		"SomeKey=SomeValue",
+		"AnotherKey=AnotherValue",
+	}
+
+	s.Require().Equal(expected, r.Options)
+}

--- a/plumbing/protocol/packp/updreq.go
+++ b/plumbing/protocol/packp/updreq.go
@@ -17,8 +17,8 @@ var (
 type UpdateRequests struct {
 	Capabilities *capability.List
 	Commands     []*Command
-	Options      []*Option
 	Shallow      *plumbing.Hash
+	// TODO: Support push-cert
 }
 
 // NewUpdateRequests returns a new UpdateRequests.
@@ -80,9 +80,4 @@ func (c *Command) validate() error {
 	}
 
 	return nil
-}
-
-type Option struct {
-	Key   string
-	Value string
 }

--- a/plumbing/protocol/packp/updreq_decode_test.go
+++ b/plumbing/protocol/packp/updreq_decode_test.go
@@ -22,7 +22,7 @@ func TestUpdReqDecodeSuite(t *testing.T) {
 func (s *UpdReqDecodeSuite) TestEmpty() {
 	r := NewUpdateRequests()
 	var buf bytes.Buffer
-	s.Equal(ErrEmpty, r.Decode(&buf))
+	s.ErrorIs(r.Decode(&buf), ErrEmpty)
 	s.Equal(NewUpdateRequests(), r)
 }
 

--- a/plumbing/protocol/packp/updreq_encode.go
+++ b/plumbing/protocol/packp/updreq_encode.go
@@ -23,12 +23,6 @@ func (req *UpdateRequests) Encode(w io.Writer) error {
 		return err
 	}
 
-	if req.Capabilities.Supports(capability.PushOptions) {
-		if err := req.encodeOptions(w, req.Options); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -65,16 +59,4 @@ func formatCommand(cmd *Command) string {
 	o := cmd.Old.String()
 	n := cmd.New.String()
 	return fmt.Sprintf("%s %s %s", o, n, cmd.Name)
-}
-
-func (req *UpdateRequests) encodeOptions(w io.Writer,
-	opts []*Option,
-) error {
-	for _, opt := range opts {
-		if _, err := pktline.Writef(w, "%s=%s", opt.Key, opt.Value); err != nil {
-			return err
-		}
-	}
-
-	return pktline.WriteFlush(w)
 }

--- a/plumbing/protocol/packp/updreq_encode_test.go
+++ b/plumbing/protocol/packp/updreq_encode_test.go
@@ -149,32 +149,6 @@ func (s *UpdReqEncodeSuite) TestWithPackfile() {
 }
 */
 
-func (s *UpdReqEncodeSuite) TestPushOptions() {
-	hash1 := plumbing.NewHash("1ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	hash2 := plumbing.NewHash("2ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	name := plumbing.ReferenceName("myref")
-
-	r := NewUpdateRequests()
-	r.Capabilities.Set(capability.PushOptions)
-	r.Commands = []*Command{
-		{Name: name, Old: hash1, New: hash2},
-	}
-	r.Options = []*Option{
-		{Key: "SomeKey", Value: "SomeValue"},
-		{Key: "AnotherKey", Value: "AnotherValue"},
-	}
-
-	expected := pktlines(s.T(),
-		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00push-options",
-		"",
-		"SomeKey=SomeValue",
-		"AnotherKey=AnotherValue",
-		"",
-	)
-
-	s.testEncode(r, expected)
-}
-
 func (s *UpdReqEncodeSuite) TestPushAtomic() {
 	hash1 := plumbing.NewHash("1ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 	hash2 := plumbing.NewHash("2ecf0ef2c2dffb796033e5a02219af86ec6584e5")

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -131,7 +131,7 @@ type PushRequest struct {
 	Progress sideband.Progress
 
 	// Options is a set of push-options to be sent to the server during push.
-	Options map[string]string
+	Options []string
 
 	// Atomic indicates an atomic push.
 	// If the server supports atomic push, it will update the refs in one

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -85,7 +85,15 @@ func ReceivePack(
 	var (
 		caps         = updreq.Capabilities
 		needPackfile bool
+		pushOpts     packp.PushOptions
 	)
+
+	// TODO: Pass the options to the server-side hooks.
+	if updreq.Capabilities.Supports(capability.PushOptions) {
+		if err := pushOpts.Decode(rd); err != nil {
+			return fmt.Errorf("decoding push-options: %w", err)
+		}
+	}
 
 	// Should we expect a packfile?
 	for _, cmd := range updreq.Commands {

--- a/remote_test.go
+++ b/remote_test.go
@@ -647,6 +647,29 @@ func (s *RemoteSuite) TestPushContext() {
 	})
 }
 
+func (s *RemoteSuite) TestPushPushOptions() {
+	url := s.T().TempDir()
+	_, err := PlainInit(url, true)
+	s.Require().NoError(err)
+
+	fs := fixtures.Basic().One().DotGit()
+	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{url},
+	})
+
+	// TODO: Validate the push options was received by the server and implement
+	// server-side hooks.
+	err = r.Push(&PushOptions{
+		Options: []string{
+			"iam-a-push-option",
+		},
+	})
+	s.Require().NoError(err)
+}
+
 func eventually(s *RemoteSuite, condition func() bool) {
 	select {
 	case <-time.After(5 * time.Second):


### PR DESCRIPTION
This refactors the decoding of commands and capabilities in the update-requests decoder to avoid double decoding the commands and eating the next pktlines in the reader.

The issue was that the decoder doesn't stop once it reaches a flush packet and continues to read the next line. This is incorrect as an update-requests always expects a flush packet after the commands have been sent.