### PR TITLE
[v6] plumbing: transport, fix advertise protocol version

### DIFF
--- a/plumbing/transport/receive_pack_test.go
+++ b/plumbing/transport/receive_pack_test.go
@@ -1,0 +1,24 @@
+package transport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ReceivePackSuite struct {
+	suite.Suite
+}
+
+func TestReceivePackSuite(t *testing.T) {
+	suite.Run(t, new(ReceivePackSuite))
+}
+
+func (s *ReceivePackSuite) TestReceivePackAdvertiseV0() {
+	testAdvertise(s.T(), ReceivePack, "", false)
+}
+
+func (s *ReceivePackSuite) TestReceivePackAdvertiseV1() {
+	buf := testAdvertise(s.T(), ReceivePack, "version=1", false)
+	s.Containsf(buf.String(), "version 1", "advertisement should contain version 1")
+}

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -18,7 +18,19 @@ var ErrUpdateReference = errors.New("failed to update ref")
 
 // AdvertiseReferences is a server command that implements the reference
 // discovery phase of the Git transfer protocol.
-func AdvertiseReferences(ctx context.Context, st storage.Storer, w io.Writer, service Service, stateless bool) error {
+func AdvertiseReferences(
+	ctx context.Context,
+	st storage.Storer,
+	w io.Writer,
+	service Service,
+	smart bool,
+) error {
+	switch service {
+	case UploadPackService, ReceivePackService:
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedService, service)
+	}
+
 	forPush := service == ReceivePackService
 	ar := packp.NewAdvRefs()
 
@@ -49,7 +61,7 @@ func AdvertiseReferences(ctx context.Context, st storage.Storer, w io.Writer, se
 		return err
 	}
 
-	if stateless {
+	if smart {
 		smartReply := packp.SmartReply{
 			Service: service.String(),
 		}

--- a/plumbing/transport/serve_test.go
+++ b/plumbing/transport/serve_test.go
@@ -1,0 +1,46 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+	"github.com/stretchr/testify/require"
+)
+
+func testAdvertise[T UploadPackOptions | ReceivePackOptions](
+	t testing.TB,
+	fun func(
+		ctx context.Context,
+		st storage.Storer,
+		r io.ReadCloser,
+		w io.WriteCloser,
+		opts *T,
+	) error,
+	proto string,
+	stateless bool,
+) *bytes.Buffer {
+	var out bytes.Buffer
+	dot := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(t.TempDir))
+	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	err := fun(
+		context.TODO(),
+		st,
+		io.NopCloser(bytes.NewBuffer(nil)),
+		ioutil.WriteNopCloser(&out),
+		&T{
+			GitProtocol:   proto,
+			AdvertiseRefs: true,
+			StatelessRPC:  stateless,
+		},
+	)
+	require.NoError(t, err)
+	require.Greater(t, out.Len(), 0)
+	return &out
+}

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -42,223 +42,224 @@ func UploadPack(
 		opts = &UploadPackOptions{}
 	}
 
-	switch version := ProtocolVersion(opts.GitProtocol); version {
-	case protocol.V2:
-		// TODO: support version 2
-	case protocol.V1:
-		if _, err := pktline.Writef(w, "version=%s\n", version.String()); err != nil {
-			return err
-		}
-		fallthrough
-	case protocol.V0:
-	default:
-		return fmt.Errorf("unknown protocol version %q", version)
-	}
-
 	if opts.AdvertiseRefs || !opts.StatelessRPC {
+		switch version := ProtocolVersion(opts.GitProtocol); version {
+		case protocol.V1:
+			if _, err := pktline.Writef(w, "version %d\n", version); err != nil {
+				return err
+			}
+		case protocol.V0:
+		default:
+			// TODO: support version 2
+			return fmt.Errorf("%w: %q", ErrUnsupportedVersion, version)
+		}
+
 		if err := AdvertiseReferences(ctx, st, w, UploadPackService, opts.StatelessRPC); err != nil {
 			return fmt.Errorf("advertising references: %w", err)
 		}
 	}
 
+	if opts.AdvertiseRefs {
+		// Done, there's nothing else to do
+		return nil
+	}
+
 	rd := bufio.NewReader(r)
-	if !opts.AdvertiseRefs {
-		l, _, err := pktline.PeekLine(rd)
-		if err != nil {
-			return fmt.Errorf("peeking line: %w", err)
-		}
+	l, _, err := pktline.PeekLine(rd)
+	if err != nil {
+		return fmt.Errorf("peeking line: %w", err)
+	}
 
-		// In case the client has nothing to send, it sends a flush packet to
-		// indicate that it is done sending data. In that case, we're done
-		// here.
-		if l == pktline.Flush {
-			return nil
-		}
+	// In case the client has nothing to send, it sends a flush packet to
+	// indicate that it is done sending data. In that case, we're done
+	// here.
+	if l == pktline.Flush {
+		return nil
+	}
 
-		var done bool
-		var haves []plumbing.Hash
-		var upreq *packp.UploadRequest
-		var havesWithRef map[plumbing.Hash][]plumbing.Hash
-		var multiAck, multiAckDetailed bool
-		var caps *capability.List
-		var wants []plumbing.Hash
-		firstRound := true
-		for !done {
-			writec := make(chan error)
-			if firstRound || opts.StatelessRPC {
-				upreq = packp.NewUploadRequest()
-				if err := upreq.Decode(rd); err != nil {
-					return fmt.Errorf("decoding upload-request: %w", err)
-				}
-
-				wants = upreq.Wants
-				caps = upreq.Capabilities
-
-				if err := r.Close(); err != nil {
-					return fmt.Errorf("closing reader: %w", err)
-				}
-
-				// Find common commits/objects
-				havesWithRef, err = revlist.ObjectsWithRef(st, wants, nil)
-				if err != nil {
-					return fmt.Errorf("getting objects with ref: %w", err)
-				}
-
-				// Encode objects to packfile and write to client
-				multiAck = caps.Supports(capability.MultiACK)
-				multiAckDetailed = caps.Supports(capability.MultiACKDetailed)
-
-				go func() {
-					// TODO: support deepen-since, and deepen-not
-					var shupd packp.ShallowUpdate
-					if !upreq.Depth.IsZero() {
-						switch depth := upreq.Depth.(type) {
-						case packp.DepthCommits:
-							if err := getShallowCommits(st, wants, int(depth), &shupd); err != nil {
-								writec <- fmt.Errorf("getting shallow commits: %w", err)
-								return
-							}
-						default:
-							writec <- fmt.Errorf("unsupported depth type %T", upreq.Depth)
-							return
-						}
-
-						if err := shupd.Encode(w); err != nil {
-							writec <- fmt.Errorf("sending shallow-update: %w", err)
-							return
-						}
-					}
-
-					writec <- nil
-				}()
+	var done bool
+	var haves []plumbing.Hash
+	var upreq *packp.UploadRequest
+	var havesWithRef map[plumbing.Hash][]plumbing.Hash
+	var multiAck, multiAckDetailed bool
+	var caps *capability.List
+	var wants []plumbing.Hash
+	firstRound := true
+	for !done {
+		writec := make(chan error)
+		if firstRound || opts.StatelessRPC {
+			upreq = packp.NewUploadRequest()
+			if err := upreq.Decode(rd); err != nil {
+				return fmt.Errorf("decoding upload-request: %w", err)
 			}
 
-			if err := <-writec; err != nil {
-				return err
-			}
-
-			var uphav packp.UploadHaves
-			if err := uphav.Decode(rd); err != nil {
-				return fmt.Errorf("decoding upload-haves: %w", err)
-			}
+			wants = upreq.Wants
+			caps = upreq.Capabilities
 
 			if err := r.Close(); err != nil {
 				return fmt.Errorf("closing reader: %w", err)
 			}
 
-			haves = append(haves, uphav.Haves...)
-			done = uphav.Done
-
-			common := map[plumbing.Hash]struct{}{}
-			var ack packp.ACK
-			var acks []packp.ACK
-			for _, hu := range uphav.Haves {
-				refs, ok := havesWithRef[hu]
-				if ok {
-					for _, ref := range refs {
-						common[ref] = struct{}{}
-					}
-				}
-
-				var status packp.ACKStatus
-				if multiAckDetailed {
-					status = packp.ACKCommon
-					if !ok {
-						status = packp.ACKReady
-					}
-				} else if multiAck {
-					status = packp.ACKContinue
-				}
-
-				if ok || multiAck || multiAckDetailed {
-					ack = packp.ACK{Hash: hu, Status: status}
-					acks = append(acks, ack)
-					if !multiAck && !multiAckDetailed {
-						break
-					}
-				}
+			// Find common commits/objects
+			havesWithRef, err = revlist.ObjectsWithRef(st, wants, nil)
+			if err != nil {
+				return fmt.Errorf("getting objects with ref: %w", err)
 			}
 
+			// Encode objects to packfile and write to client
+			multiAck = caps.Supports(capability.MultiACK)
+			multiAckDetailed = caps.Supports(capability.MultiACKDetailed)
+
 			go func() {
-				defer close(writec)
-
-				if len(haves) > 0 {
-					// Encode ACKs to client when we have haves
-					srvrsp := packp.ServerResponse{ACKs: acks}
-					if err := srvrsp.Encode(w); err != nil {
-						writec <- fmt.Errorf("sending acks server-response: %w", err)
-						return
-					}
-				}
-
-				if !done {
-					if multiAck || multiAckDetailed {
-						// Encode a NAK for multi-ack
-						srvrsp := packp.ServerResponse{}
-						if err := srvrsp.Encode(w); err != nil {
-							writec <- fmt.Errorf("sending nak server-response: %w", err)
+				// TODO: support deepen-since, and deepen-not
+				var shupd packp.ShallowUpdate
+				if !upreq.Depth.IsZero() {
+					switch depth := upreq.Depth.(type) {
+					case packp.DepthCommits:
+						if err := getShallowCommits(st, wants, int(depth), &shupd); err != nil {
+							writec <- fmt.Errorf("getting shallow commits: %w", err)
 							return
 						}
-					}
-				} else if !ack.Hash.IsZero() && (multiAck || multiAckDetailed) {
-					// We're done, send the final ACK
-					ack.Status = 0
-					srvrsp := packp.ServerResponse{ACKs: []packp.ACK{ack}}
-					if err := srvrsp.Encode(w); err != nil {
-						writec <- fmt.Errorf("sending final ack server-response: %w", err)
+					default:
+						writec <- fmt.Errorf("unsupported depth type %T", upreq.Depth)
 						return
 					}
-				} else if ack.Hash.IsZero() {
-					// We don't have multi-ack and there are no haves. Encode a NAK.
-					srvrsp := packp.ServerResponse{}
-					if err := srvrsp.Encode(w); err != nil {
-						writec <- fmt.Errorf("sending final nak server-response: %w", err)
+
+					if err := shupd.Encode(w); err != nil {
+						writec <- fmt.Errorf("sending shallow-update: %w", err)
 						return
 					}
 				}
 
 				writec <- nil
 			}()
-
-			if err := <-writec; err != nil {
-				return err
-			}
-
-			firstRound = false
 		}
 
-		// Done with the request, now close the reader
-		// to indicate that we are done reading from it.
+		if err := <-writec; err != nil {
+			return err
+		}
+
+		var uphav packp.UploadHaves
+		if err := uphav.Decode(rd); err != nil {
+			return fmt.Errorf("decoding upload-haves: %w", err)
+		}
+
 		if err := r.Close(); err != nil {
 			return fmt.Errorf("closing reader: %w", err)
 		}
 
-		objs, err := objectsToUpload(st, wants, haves)
-		if err != nil {
-			w.Close() //nolint:errcheck
-			return fmt.Errorf("getting objects to upload: %w", err)
-		}
+		haves = append(haves, uphav.Haves...)
+		done = uphav.Done
 
-		var writer io.Writer = w
-		if !caps.Supports(capability.NoProgress) {
-			if caps.Supports(capability.Sideband64k) {
-				writer = sideband.NewMuxer(sideband.Sideband64k, w)
-			} else if caps.Supports(capability.Sideband) {
-				writer = sideband.NewMuxer(sideband.Sideband, w)
+		common := map[plumbing.Hash]struct{}{}
+		var ack packp.ACK
+		var acks []packp.ACK
+		for _, hu := range uphav.Haves {
+			refs, ok := havesWithRef[hu]
+			if ok {
+				for _, ref := range refs {
+					common[ref] = struct{}{}
+				}
+			}
+
+			var status packp.ACKStatus
+			if multiAckDetailed {
+				status = packp.ACKCommon
+				if !ok {
+					status = packp.ACKReady
+				}
+			} else if multiAck {
+				status = packp.ACKContinue
+			}
+
+			if ok || multiAck || multiAckDetailed {
+				ack = packp.ACK{Hash: hu, Status: status}
+				acks = append(acks, ack)
+				if !multiAck && !multiAckDetailed {
+					break
+				}
 			}
 		}
 
-		// TODO: Support shallow-file
-		// TODO: Support thin-pack
-		e := packfile.NewEncoder(writer, st, false)
-		_, err = e.Encode(objs, 10)
-		if err != nil {
-			return fmt.Errorf("encoding packfile: %w", err)
+		go func() {
+			defer close(writec)
+
+			if len(haves) > 0 {
+				// Encode ACKs to client when we have haves
+				srvrsp := packp.ServerResponse{ACKs: acks}
+				if err := srvrsp.Encode(w); err != nil {
+					writec <- fmt.Errorf("sending acks server-response: %w", err)
+					return
+				}
+			}
+
+			if !done {
+				if multiAck || multiAckDetailed {
+					// Encode a NAK for multi-ack
+					srvrsp := packp.ServerResponse{}
+					if err := srvrsp.Encode(w); err != nil {
+						writec <- fmt.Errorf("sending nak server-response: %w", err)
+						return
+					}
+				}
+			} else if !ack.Hash.IsZero() && (multiAck || multiAckDetailed) {
+				// We're done, send the final ACK
+				ack.Status = 0
+				srvrsp := packp.ServerResponse{ACKs: []packp.ACK{ack}}
+				if err := srvrsp.Encode(w); err != nil {
+					writec <- fmt.Errorf("sending final ack server-response: %w", err)
+					return
+				}
+			} else if ack.Hash.IsZero() {
+				// We don't have multi-ack and there are no haves. Encode a NAK.
+				srvrsp := packp.ServerResponse{}
+				if err := srvrsp.Encode(w); err != nil {
+					writec <- fmt.Errorf("sending final nak server-response: %w", err)
+					return
+				}
+			}
+
+			writec <- nil
+		}()
+
+		if err := <-writec; err != nil {
+			return err
 		}
 
-		if err := w.Close(); err != nil {
-			return fmt.Errorf("closing writer: %w", err)
+		firstRound = false
+	}
+
+	// Done with the request, now close the reader
+	// to indicate that we are done reading from it.
+	if err := r.Close(); err != nil {
+		return fmt.Errorf("closing reader: %w", err)
+	}
+
+	objs, err := objectsToUpload(st, wants, haves)
+	if err != nil {
+		w.Close() //nolint:errcheck
+		return fmt.Errorf("getting objects to upload: %w", err)
+	}
+
+	var writer io.Writer = w
+	if !caps.Supports(capability.NoProgress) {
+		if caps.Supports(capability.Sideband64k) {
+			writer = sideband.NewMuxer(sideband.Sideband64k, w)
+		} else if caps.Supports(capability.Sideband) {
+			writer = sideband.NewMuxer(sideband.Sideband, w)
 		}
+	}
+
+	// TODO: Support shallow-file
+	// TODO: Support thin-pack
+	e := packfile.NewEncoder(writer, st, false)
+	_, err = e.Encode(objs, 10)
+	if err != nil {
+		return fmt.Errorf("encoding packfile: %w", err)
+	}
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("closing writer: %w", err)
 	}
 
 	return nil

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -1,0 +1,24 @@
+package transport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type UploadPackSuite struct {
+	suite.Suite
+}
+
+func TestUploadPackSuite(t *testing.T) {
+	suite.Run(t, new(UploadPackSuite))
+}
+
+func (s *UploadPackSuite) TestUploadPackAdvertiseV0() {
+	testAdvertise(s.T(), UploadPack, "", false)
+}
+
+func (s *UploadPackSuite) TestUploadPackAdvertiseV1() {
+	buf := testAdvertise(s.T(), UploadPack, "version=1", false)
+	s.Containsf(buf.String(), "version 1", "advertisement should contain version 1")
+}


### PR DESCRIPTION
This commit fixes the protocol version advertisement for the ReceivePack and UploadPack services. The version should be advertised during the advertisement phase if and only if we're advertising references during the ReceivePack or UploadPack routines.

This will also change the behavior of the AdvertiseReferences function to only accept UploadPackService and ReceivePackService as valid services.

It will also error out if the protocol version is not supported.