### PR TITLE
internal: trace, read trace target from env

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -1,0 +1,29 @@
+package trace
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/go-git/go-git/v6/utils/trace"
+)
+
+// envToTarget maps what environment variables can be used
+// to enable specific trace targets.
+var envToTarget = map[string]trace.Target{
+	"GIT_TRACE":             trace.General,
+	"GIT_TRACE_PACKET":      trace.Packet,
+	"GIT_TRACE_SSH":         trace.SSH,
+	"GIT_TRACE_PERFORMANCE": trace.Performance,
+}
+
+// ReadEnv reads the environment variables and sets the trace targets.
+// This is used to enable tracing in the go-git library.
+func ReadEnv() {
+	var target trace.Target
+	for k, v := range envToTarget {
+		if val, _ := strconv.ParseBool(os.Getenv(k)); val {
+			target |= v
+		}
+	}
+	trace.SetTarget(target)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,14 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v6/internal/trace"
+)
+
+func TestMain(t *testing.M) {
+	// Set the trace targets based on the environment variables.
+	trace.ReadEnv()
+	// Run the tests.
+	t.Run()
+}

--- a/utils/trace/trace.go
+++ b/utils/trace/trace.go
@@ -4,19 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"sync/atomic"
 )
-
-func init() {
-	var target Target
-	for k, v := range envToTarget {
-		if strings.EqualFold(os.Getenv(k), "true") {
-			target |= v
-		}
-	}
-	SetTarget(target)
-}
 
 var (
 	// logger is the logger to use for tracing.
@@ -24,15 +13,6 @@ var (
 
 	// current is the targets that are enabled for tracing.
 	current atomic.Int32
-
-	// envToTarget maps what environment variables can be used
-	// to enable specific trace targets.
-	envToTarget = map[string]Target{
-		"GIT_TRACE":             General,
-		"GIT_TRACE_PACKET":      Packet,
-		"GIT_TRACE_SSH":         SSH,
-		"GIT_TRACE_PERFORMANCE": Performance,
-	}
 )
 
 func newLogger() *log.Logger {


### PR DESCRIPTION
This moves the trace initialization to the internal package and makes it opt-in instead of automatic. It also enables tracing on test runs by default.