### PR TITLE
plumbing: transport, fix not advertising no-thin capability

### DIFF
--- a/plumbing/protocol/packp/capability/capability.go
+++ b/plumbing/protocol/packp/capability/capability.go
@@ -88,7 +88,7 @@ const (
 	// historically the reference implementation of receive-pack always
 	// understood thin packs. Adding 'no-thin' later allowed receive-pack
 	// to disable the feature in a backwards-compatible manner.
-	ThinPack Capability = "thin-pack"
+	ThinPack, NoThin Capability = "thin-pack", "no-thin"
 	// Sideband means that server can send, and client understand multiplexed
 	// progress reports and error info interleaved with the packfile itself.
 	//

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -28,6 +28,7 @@ func AdvertiseReferences(ctx context.Context, st storage.Storer, w io.Writer, se
 	ar.Capabilities.Set(capability.Sideband64k)                      //nolint:errcheck
 	if forPush {
 		// TODO: support thin-pack
+		ar.Capabilities.Set(capability.NoThin) //nolint:errcheck
 		// TODO: support atomic
 		ar.Capabilities.Set(capability.DeleteRefs)   //nolint:errcheck
 		ar.Capabilities.Set(capability.ReportStatus) //nolint:errcheck


### PR DESCRIPTION
We need to advertise the no-thin capability when the server does not support thin packs. This is important so that clients do not attempt to use thin packs when the server does not support them.