### PR TITLE
fix: canonicalize pathnames when calling Worktree.Add()

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -370,7 +370,11 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 		}
 	}
 
+	// Relative paths only; see: https://github.com/go-git/go-git/issues/1460
 	path = filepath.Clean(path)
+	if filepath.IsAbs(path) {
+		path, _ = filepath.Rel(w.Filesystem.Root(), path)
+	}
 
 	if err != nil || !fi.IsDir() {
 		added, h, err = w.doAddFile(idx, s, path, ignorePattern)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1529,7 +1529,7 @@ func (s *WorktreeSuite) TestAddUntracked() {
 	err = util.WriteFile(w.Filesystem, "foo", []byte("FOO"), 0755)
 	s.NoError(err)
 
-	hash, err := w.Add("foo")
+	hash, err := w.Add("/foo")
 	s.Equal("d96c7efbfec2814ae0301ad054dc8d9fc416c9b5", hash.String())
 	s.NoError(err)
 


### PR DESCRIPTION
Ensure that adding files off the filesystem root gets the filenames right.

Fixes: Issue #1460