### PR TITLE
 utils: merkletrie, Fix diff on sparse-checkout index. Fixes #1406

### DIFF
--- a/utils/merkletrie/change.go
+++ b/utils/merkletrie/change.go
@@ -131,7 +131,9 @@ func (l *Changes) addRecursive(root noder.Path, ctor noderToChangeFn) error {
 	}
 
 	if !root.IsDir() {
-		l.Add(ctor(root))
+		if !root.Skip() {
+			l.Add(ctor(root))
+		}
 		return nil
 	}
 

--- a/utils/merkletrie/difftree.go
+++ b/utils/merkletrie/difftree.go
@@ -321,8 +321,14 @@ func DiffTreeContext(ctx context.Context, fromTree, toTree noder.Noder,
 				if err = ret.AddRecursiveDelete(from); err != nil {
 					return nil, err
 				}
-				if err := ii.nextBoth(); err != nil {
-					return nil, err
+				if from.Name() == to.Name() {
+					if err := ii.nextBoth(); err != nil {
+						return nil, err
+					}
+				} else {
+					if err := ii.nextFrom(); err != nil {
+						return nil, err
+					}
 				}
 				break
 			}
@@ -330,8 +336,14 @@ func DiffTreeContext(ctx context.Context, fromTree, toTree noder.Noder,
 				if err = ret.AddRecursiveDelete(to); err != nil {
 					return nil, err
 				}
-				if err := ii.nextBoth(); err != nil {
-					return nil, err
+				if from.Name() == to.Name() {
+					if err := ii.nextBoth(); err != nil {
+						return nil, err
+					}
+				} else {
+					if err := ii.nextTo(); err != nil {
+						return nil, err
+					}
 				}
 				break
 			}

--- a/utils/merkletrie/difftree.go
+++ b/utils/merkletrie/difftree.go
@@ -297,18 +297,16 @@ func DiffTreeContext(ctx context.Context, fromTree, toTree noder.Noder,
 		case noMoreNoders:
 			return ret, nil
 		case onlyFromRemains:
-			if err = ret.AddRecursiveDelete(from); err != nil {
-				return nil, err
+			if !from.Skip() {
+				if err = ret.AddRecursiveDelete(from); err != nil {
+					return nil, err
+				}
 			}
 			if err = ii.nextFrom(); err != nil {
 				return nil, err
 			}
 		case onlyToRemains:
-			if to.Skip() {
-				if err = ret.AddRecursiveDelete(to); err != nil {
-					return nil, err
-				}
-			} else {
+			if !to.Skip() {
 				if err = ret.AddRecursiveInsert(to); err != nil {
 					return nil, err
 				}
@@ -317,38 +315,25 @@ func DiffTreeContext(ctx context.Context, fromTree, toTree noder.Noder,
 				return nil, err
 			}
 		case bothHaveNodes:
-			if from.Skip() {
-				if err = ret.AddRecursiveDelete(from); err != nil {
-					return nil, err
-				}
+			var err error
+			switch {
+			case from.Skip():
 				if from.Name() == to.Name() {
-					if err := ii.nextBoth(); err != nil {
-						return nil, err
-					}
+					err = ii.nextBoth()
 				} else {
-					if err := ii.nextFrom(); err != nil {
-						return nil, err
-					}
+					err = ii.nextFrom()
 				}
-				break
-			}
-			if to.Skip() {
-				if err = ret.AddRecursiveDelete(to); err != nil {
-					return nil, err
-				}
+			case to.Skip():
 				if from.Name() == to.Name() {
-					if err := ii.nextBoth(); err != nil {
-						return nil, err
-					}
+					err = ii.nextBoth()
 				} else {
-					if err := ii.nextTo(); err != nil {
-						return nil, err
-					}
+					err = ii.nextTo()
 				}
-				break
+			default:
+				err = diffNodes(&ret, ii)
 			}
 
-			if err = diffNodes(&ret, ii); err != nil {
+			if err != nil {
 				return nil, err
 			}
 		default:

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1373,6 +1373,24 @@ func (s *WorktreeSuite) TestStatusAfterCheckout() {
 	s.True(status.IsClean())
 }
 
+func (s *WorktreeSuite) TestStatusAfterSparseCheckout() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	err := w.Checkout(&CheckoutOptions{
+		SparseCheckoutDirectories: []string{"php"},
+		Force:                     true,
+	})
+	s.Require().NoError(err)
+
+	status, err := w.Status()
+	s.Require().NoError(err)
+	s.True(status.IsClean(), status)
+}
+
 func (s *WorktreeSuite) TestStatusModified() {
 	fs := s.TemporalFilesystem()
 


### PR DESCRIPTION
Fixes #1406 

This PR depends on #1484, as it partially fixes a diff issue in the sparse-checkout index.
Building on top of that, I’ve added a small check in the early return of addRecursive() to handle an edge case where the skipped node is a first-level node.
Please let me know if this check should instead be introduced in #1484.  I'm not sure where it belongs.

There's a case where two trees are not the same, and one of them has nodes with skip == true, such as in comparisons between a sparse-checkout index and the worktree.
In this case, we shouldn't call ii.nextBoth(), since we might be comparing different nodes. So I added a check for that as well.

https://github.com/go-git/go-git/blob/4e67bbed91c0e31ce97b9ad5e2b9b51f1cf139de/utils/merkletrie/difftree.go#L319-L341

Since this PR depends on #1484, I'll rebase this after that one is merged.