### PR TITLE
plumbing: correct matching of file vs. dir globs in `.gitignore`, Fixes #154

### DIFF
--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -146,6 +146,10 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 			}
 			matched = true
 			path = path[1:]
+			// files matching dir globs, don't match
+			if len(path) == 0 && i < len(p.pattern)-1 {
+				matched = false
+			}
 		}
 	}
 	if matched && p.dirOnly && !isDir && len(path) == 0 {

--- a/plumbing/format/gitignore/pattern_test.go
+++ b/plumbing/format/gitignore/pattern_test.go
@@ -221,7 +221,7 @@ func (s *PatternSuite) TestGlobMatch_tailingAsterisks() {
 func (s *PatternSuite) TestGlobMatch_tailingAsterisks_exactMatch() {
 	p := ParsePattern("/*lue/vol?ano/**", nil)
 	r := p.Match([]string{"value", "volcano"}, false)
-	s.Equal(Exclude, r)
+	s.Equal(NoMatch, r)
 }
 
 func (s *PatternSuite) TestGlobMatch_middleAsterisks_emptyMatch() {
@@ -288,4 +288,16 @@ func (s *PatternSuite) TestGlobMatch_issue_923() {
 	p := ParsePattern("**/android/**/GeneratedPluginRegistrant.java", nil)
 	r := p.Match([]string{"packages", "flutter_tools", "lib", "src", "android", "gradle.dart"}, false)
 	s.Equal(NoMatch, r)
+}
+
+func (s *PatternSuite) TestGlobMatch_folderVersusFile() {
+	p := ParsePattern("/a*/**", nil)
+	r := p.Match([]string{"ab"}, false)
+	s.Equal(NoMatch, r)
+}
+
+func (s *PatternSuite) TestGlobMatch_folderVersusFileAgain() {
+	p := ParsePattern("/a*/**/a*", nil)
+	r := p.Match([]string{"ab", "ab"}, false)
+	s.Equal(Exclude, r)
 }


### PR DESCRIPTION
e.g., the pattern `/a*/**` in `.gitignore` should not match a file `ab` in the project root.

Fix a broken test that was enforcing the incorrect behavior.

Fixes: Issue #154