### PR TITLE
[v6] plumbing: transport, fix upload pack service for clients requesting version 2

### DIFF
--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -48,9 +48,9 @@ func ReceivePack(
 			if _, err := pktline.Writef(w, "version %d\n", version); err != nil {
 				return err
 			}
-		case protocol.V0:
+		// TODO: support version 2
+		case protocol.V0, protocol.V2:
 		default:
-			// TODO: support version 2
 			return fmt.Errorf("%w: %q", ErrUnsupportedVersion, version)
 		}
 

--- a/plumbing/transport/receive_pack_test.go
+++ b/plumbing/transport/receive_pack_test.go
@@ -18,6 +18,11 @@ func (s *ReceivePackSuite) TestReceivePackAdvertiseV0() {
 	testAdvertise(s.T(), ReceivePack, "", false)
 }
 
+func (s *ReceivePackSuite) TestReceivePackAdvertiseV2() {
+	// TODO: support version 2
+	testAdvertise(s.T(), UploadPack, "version=2", false)
+}
+
 func (s *ReceivePackSuite) TestReceivePackAdvertiseV1() {
 	buf := testAdvertise(s.T(), ReceivePack, "version=1", false)
 	s.Containsf(buf.String(), "version 1", "advertisement should contain version 1")

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -48,9 +48,9 @@ func UploadPack(
 			if _, err := pktline.Writef(w, "version %d\n", version); err != nil {
 				return err
 			}
-		case protocol.V0:
+		// TODO: support version 2
+		case protocol.V0, protocol.V2:
 		default:
-			// TODO: support version 2
 			return fmt.Errorf("%w: %q", ErrUnsupportedVersion, version)
 		}
 

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -18,6 +18,11 @@ func (s *UploadPackSuite) TestUploadPackAdvertiseV0() {
 	testAdvertise(s.T(), UploadPack, "", false)
 }
 
+func (s *UploadPackSuite) TestUploadPackAdvertiseV2() {
+	// TODO: support version 2
+	testAdvertise(s.T(), UploadPack, "version=2", false)
+}
+
 func (s *UploadPackSuite) TestUploadPackAdvertiseV1() {
 	buf := testAdvertise(s.T(), UploadPack, "version=1", false)
 	s.Containsf(buf.String(), "version 1", "advertisement should contain version 1")


### PR DESCRIPTION
Fixes a mistake made in #1488. Basis for the logic of this commit is [this implementation commit](https//github.com/git/git/commit/8f6982b4e16c60bba713a3b6592b2ff5c7476974#diff-8981f89ee862f086213310d567ec04fde00eb9fb3e23773aabb57be1dc46db53R55)