### PR TITLE
Allow all types of objects to be pushed using non-wildcard refspecs

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -618,9 +618,9 @@ func (r *Remote) addOrUpdateReferences(
 	if !rs.IsWildcard() {
 		ref, ok := refsDict[rs.Src()]
 		if !ok {
-			commit, err := object.GetCommit(r.s, plumbing.NewHash(rs.Src()))
+			object, err := object.GetObject(r.s, plumbing.NewHash(rs.Src()))
 			if err == nil {
-				return r.addCommit(rs, remoteRefs, commit.Hash, cmds)
+				return r.addObject(rs, remoteRefs, object.ID(), cmds)
 			}
 			return nil
 		}
@@ -677,8 +677,8 @@ func (r *Remote) deleteReferences(rs config.RefSpec,
 	})
 }
 
-func (r *Remote) addCommit(rs config.RefSpec,
-	remoteRefs storer.ReferenceStorer, localCommit plumbing.Hash,
+func (r *Remote) addObject(rs config.RefSpec,
+	remoteRefs storer.ReferenceStorer, localObject plumbing.Hash,
 	cmds *[]*packp.Command,
 ) error {
 	if rs.IsWildcard() {
@@ -688,7 +688,7 @@ func (r *Remote) addCommit(rs config.RefSpec,
 	cmd := &packp.Command{
 		Name: rs.Dst(""),
 		Old:  plumbing.ZeroHash,
-		New:  localCommit,
+		New:  localObject,
 	}
 	remoteRef, err := remoteRefs.Reference(cmd.Name)
 	if err == nil {

--- a/remote_test.go
+++ b/remote_test.go
@@ -742,6 +742,95 @@ func (s *RemoteSuite) TestPushTags() {
 	})
 }
 
+func (s *RemoteSuite) TestPushTagsByOID() {
+	url := s.T().TempDir()
+
+	server, err := PlainInit(url, true)
+	s.NoError(err)
+
+	fs := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
+	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{url},
+	})
+
+	err = r.Push(&PushOptions{
+		RefSpecs: []config.RefSpec{
+			"f7b877701fbf855b44c0a9e86f3fdce2c298b07f:refs/tags/lightweight-tag-copy",
+			"b742a2a9fa0afcfa9a6fad080980fbc26b007c69:refs/tags/annotated-tag-copy",
+			"ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc:refs/tags/commit-tag-copy",
+			"fe6cb94756faa81e5ed9240f9191b833db5f40ae:refs/tags/blob-tag-copy",
+			"152175bf7e5580299fa1f0ba41ef6474cc043b70:refs/tags/tree-tag-copy",
+		},
+		FollowTags: false,
+	})
+	s.NoError(err)
+
+	AssertReferences(s.T(), server, map[string]string{
+		"refs/tags/lightweight-tag-copy": "f7b877701fbf855b44c0a9e86f3fdce2c298b07f",
+		"refs/tags/annotated-tag-copy":   "b742a2a9fa0afcfa9a6fad080980fbc26b007c69",
+		"refs/tags/commit-tag-copy":      "ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc",
+		"refs/tags/blob-tag-copy":        "fe6cb94756faa81e5ed9240f9191b833db5f40ae",
+		"refs/tags/tree-tag-copy":        "152175bf7e5580299fa1f0ba41ef6474cc043b70",
+	})
+}
+
+func (s *RemoteSuite) TestPushBlobByOID() {
+	url := s.T().TempDir()
+
+	server, err := PlainInit(url, true)
+	s.NoError(err)
+
+	fs := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
+	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{url},
+	})
+
+	err = r.Push(&PushOptions{
+		RefSpecs: []config.RefSpec{
+			"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391:refs/misc/myblob",
+		},
+		FollowTags: false,
+	})
+	s.NoError(err)
+
+	AssertReferences(s.T(), server, map[string]string{
+		"refs/misc/myblob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+	})
+}
+
+func (s *RemoteSuite) TestPushTreeByOID() {
+	url := s.T().TempDir()
+
+	server, err := PlainInit(url, true)
+	s.NoError(err)
+
+	fs := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
+	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{url},
+	})
+
+	err = r.Push(&PushOptions{
+		RefSpecs: []config.RefSpec{
+			"70846e9a10ef7b41064b40f07713d5b8b9a8fc73:refs/misc/mytree",
+		},
+		FollowTags: false,
+	})
+	s.NoError(err)
+
+	AssertReferences(s.T(), server, map[string]string{
+		"refs/misc/mytree": "70846e9a10ef7b41064b40f07713d5b8b9a8fc73",
+	})
+}
+
 func (s *RemoteSuite) TestPushFollowTags() {
 	url, err := os.MkdirTemp("", "")
 	s.NoError(err)


### PR DESCRIPTION
For non-wildcard refspecs, `addOrUpdateReferences()` was trying to resolve the refspec source to a commit. But there's no reason that other objects (tags, trees, blobs) shouldn't be allowed to be pushed by OID. So resolve the refspec source to whatever object type it happens to be.
