### PR TITLE
[v6] plumbing: format/packfile, Optimise packfile delta processing

### DIFF
--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -245,7 +245,7 @@ func sendFile(w http.ResponseWriter, r *http.Request, contentType string) {
 	w.Header().Set("Last-Modified", stat.ModTime().Format(http.TimeFormat))
 
 	frw := &flushResponseWriter{ResponseWriter: w, log: errorLog, chunkSize: defaultChunkSize}
-	if _, err := ioutil.Copy(frw, f); err != nil {
+	if _, err := ioutil.CopyBufferPool(frw, f); err != nil {
 		logf(errorLog, "error writing response: %v", err)
 		renderStatusError(w, http.StatusInternalServerError)
 		return

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -245,7 +245,7 @@ func sendFile(w http.ResponseWriter, r *http.Request, contentType string) {
 	w.Header().Set("Last-Modified", stat.ModTime().Format(http.TimeFormat))
 
 	frw := &flushResponseWriter{ResponseWriter: w, log: errorLog, chunkSize: defaultChunkSize}
-	if _, err := io.Copy(frw, f); err != nil {
+	if _, err := ioutil.Copy(frw, f); err != nil {
 		logf(errorLog, "error writing response: %v", err)
 		renderStatusError(w, http.StatusInternalServerError)
 		return

--- a/blame_test.go
+++ b/blame_test.go
@@ -56,10 +56,10 @@ func (s *BlameSuite) TestBlame() {
 
 		exp := s.mockBlame(t, r)
 		commit, err := r.CommitObject(plumbing.NewHash(t.rev))
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		obt, err := Blame(commit, t.path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equal(exp, obt)
 
 		for i, l := range obt.Lines {
@@ -70,19 +70,19 @@ func (s *BlameSuite) TestBlame() {
 
 func (s *BlameSuite) mockBlame(t blameTest, r *Repository) (blame *BlameResult) {
 	commit, err := r.CommitObject(plumbing.NewHash(t.rev))
-	s.NoError(err, fmt.Sprintf("%v: repo=%s, rev=%s", err, t.repo, t.rev))
+	s.Require().NoError(err, fmt.Sprintf("%v: repo=%s, rev=%s", err, t.repo, t.rev))
 
 	f, err := commit.File(t.path)
-	s.NoError(err)
+	s.Require().NoError(err)
 	lines, err := f.Lines()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(t.blames, len(lines), fmt.Sprintf(
 		"repo=%s, path=%s, rev=%s: the number of lines in the file and the number of expected blames differ (len(blames)=%d, len(lines)=%d)\nblames=%#q\nlines=%#q", t.repo, t.path, t.rev, len(t.blames), len(lines), t.blames, lines))
 
 	blamedLines := make([]*Line, 0, len(t.blames))
 	for i := range t.blames {
 		commit, err := r.CommitObject(plumbing.NewHash(t.blames[i]))
-		s.NoError(err)
+		s.Require().NoError(err)
 		l := &Line{
 			Author:     commit.Author.Email,
 			AuthorName: commit.Author.Name,

--- a/plumbing/format/objfile/reader.go
+++ b/plumbing/format/objfile/reader.go
@@ -25,6 +25,7 @@ type Reader struct {
 	zlib    io.Reader
 	zlibref sync.ZLibReader
 	hasher  plumbing.Hasher
+	closed  bool
 }
 
 // NewReader returns a new Reader reading from r.
@@ -113,6 +114,10 @@ func (r *Reader) Hash() plumbing.Hash {
 // Close releases any resources consumed by the Reader. Calling Close does not
 // close the wrapped io.Reader originally passed to NewReader.
 func (r *Reader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
 	sync.PutZlibReader(r.zlibref)
 	return nil
 }

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -54,7 +54,7 @@ func WritePackfileToObjectStorage(
 
 	defer ioutil.CheckClose(w, &err)
 
-	n, err := ioutil.Copy(w, packfile)
+	n, err := ioutil.CopyBufferPool(w, packfile)
 	if err == nil && n == 0 {
 		return ErrEmptyPackfile
 	}

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/utils/ioutil"
-	"github.com/go-git/go-git/v6/utils/sync"
 	"github.com/go-git/go-git/v6/utils/trace"
 )
 
@@ -54,12 +53,8 @@ func WritePackfileToObjectStorage(
 	}
 
 	defer ioutil.CheckClose(w, &err)
-	var n int64
 
-	buf := sync.GetByteSlice()
-	n, err = io.CopyBuffer(w, packfile, *buf)
-	sync.PutByteSlice(buf, int(n))
-
+	n, err := ioutil.Copy(w, packfile)
 	if err == nil && n == 0 {
 		return ErrEmptyPackfile
 	}

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -58,7 +58,7 @@ func WritePackfileToObjectStorage(
 
 	buf := sync.GetByteSlice()
 	n, err = io.CopyBuffer(w, packfile, *buf)
-	sync.PutByteSlice(buf)
+	sync.PutByteSlice(buf, int(n))
 
 	if err == nil && n == 0 {
 		return ErrEmptyPackfile

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -132,7 +132,7 @@ func (e *Encoder) entry(o *ObjectToPack) (err error) {
 
 	defer ioutil.CheckClose(or, &err)
 
-	_, err = ioutil.Copy(e.zw, or)
+	_, err = ioutil.CopyBufferPool(e.zw, or)
 	return err
 }
 

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -132,7 +132,7 @@ func (e *Encoder) entry(o *ObjectToPack) (err error) {
 
 	defer ioutil.CheckClose(or, &err)
 
-	_, err = io.Copy(e.zw, or)
+	_, err = ioutil.Copy(e.zw, or)
 	return err
 }
 

--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -100,7 +100,7 @@ func (r *zlibReadCloser) Read(p []byte) (int, error) {
 }
 
 func (r *zlibReadCloser) Close() error {
-	sync.PutByteSlice(r.dict)
+	sync.PutByteSlice(r.dict, 0)
 	sync.PutZlibReader(r.r)
 	if r.f != nil {
 		r.f.Close()

--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -85,13 +85,14 @@ func (o *FSObject) Reader() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &zlibReadCloser{zr, dict, closer}, nil
+	return &zlibReadCloser{zr, dict, closer, false}, nil
 }
 
 type zlibReadCloser struct {
-	r    sync.ZLibReader
-	dict *[]byte
-	f    io.Closer
+	r      sync.ZLibReader
+	dict   *[]byte
+	f      io.Closer
+	closed bool
 }
 
 // Read reads up to len(p) bytes into p from the data.
@@ -100,7 +101,10 @@ func (r *zlibReadCloser) Read(p []byte) (int, error) {
 }
 
 func (r *zlibReadCloser) Close() error {
-	sync.PutByteSlice(r.dict, 0)
+	if r.closed {
+		return nil
+	}
+	r.closed = true
 	sync.PutZlibReader(r.r)
 	if r.f != nil {
 		r.f.Close()

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -345,19 +345,6 @@ func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, er
 	return obj, nil
 }
 
-// isInvalid checks whether an error is an os.PathError with an os.ErrInvalid
-// error inside. It also checks for the windows error, which is different from
-// os.ErrInvalid.
-func isInvalid(err error) bool {
-	pe, ok := err.(*os.PathError)
-	if !ok {
-		return false
-	}
-
-	errstr := pe.Err.Error()
-	return errstr == errInvalidUnix || errstr == errInvalidWindows
-}
-
 // errInvalidWindows is the Windows equivalent to os.ErrInvalid
 const errInvalidWindows = "The parameter is incorrect."
 

--- a/plumbing/format/packfile/packfile_test.go
+++ b/plumbing/format/packfile/packfile_test.go
@@ -28,8 +28,8 @@ func TestGet(t *testing.T) {
 	for h := range expectedEntries {
 		obj, err := p.Get(h)
 
-		assert.NoError(t, err)
-		assert.NotNil(t, obj)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
 		assert.Equal(t, h.String(), obj.Hash().String())
 	}
 
@@ -37,7 +37,7 @@ func TestGet(t *testing.T) {
 	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 
 	id, err := p.ID()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, f.PackfileHash, id.String())
 }
 
@@ -53,8 +53,8 @@ func TestGetByOffset(t *testing.T) {
 
 	for h, o := range expectedEntries {
 		obj, err := p.GetByOffset(o)
-		assert.NoError(t, err)
-		assert.NotNil(t, obj)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
 		assert.Equal(t, h.String(), obj.Hash().String())
 	}
 
@@ -73,7 +73,7 @@ func TestGetAll(t *testing.T) {
 		packfile.WithFs(fixtures.Filesystem))
 
 	iter, err := p.GetAll()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var objects int
 	for {
@@ -81,7 +81,7 @@ func TestGetAll(t *testing.T) {
 		if err == io.EOF {
 			break
 		}
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		objects++
 		h := o.Hash()
@@ -92,7 +92,7 @@ func TestGetAll(t *testing.T) {
 	assert.Len(t, expectedEntries, objects)
 
 	iter.Close()
-	assert.NoError(t, p.Close())
+	require.NoError(t, p.Close())
 }
 
 func TestDecode(t *testing.T) {
@@ -112,12 +112,12 @@ func TestDecode(t *testing.T) {
 		for _, h := range expectedHashes {
 			h := h
 			obj, err := p.Get(plumbing.NewHash(h))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, obj.Hash().String(), h)
 		}
 
 		err := p.Close()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -132,7 +132,7 @@ func TestDecodeByTypeRefDelta(t *testing.T) {
 		packfile.WithIdx(index), packfile.WithFs(fixtures.Filesystem))
 
 	iter, err := packfile.GetByType(plumbing.CommitObject)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var count int
 	for {
@@ -142,13 +142,13 @@ func TestDecodeByTypeRefDelta(t *testing.T) {
 		}
 
 		count++
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, obj.Type(), plumbing.CommitObject)
 	}
 
 	err = packfile.Close()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Greater(t, count, 0)
 }
 
@@ -174,13 +174,13 @@ func TestDecodeByType(t *testing.T) {
 			defer packfile.Close()
 
 			iter, err := packfile.GetByType(typ)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = iter.ForEach(func(obj plumbing.EncodedObject) error {
 				assert.Equal(t, typ, obj.Type())
 				return nil
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		}
 	}
 }
@@ -232,17 +232,17 @@ func TestSize(t *testing.T) {
 
 	// Get the size of binary.jpg, which is not delta-encoded.
 	offset, err := packfile.FindOffset(plumbing.NewHash("d5c0f4ab811897cadf03aec358ae60d21f91c50d"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	size, err := packfile.GetSizeByOffset(offset)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(76110), size)
 
 	// Get the size of the root commit, which is delta-encoded.
 	offset, err = packfile.FindOffset(plumbing.NewHash(f.Head))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	size, err = packfile.GetSizeByOffset(offset)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(245), size)
 }
 

--- a/plumbing/format/packfile/packfile_test.go
+++ b/plumbing/format/packfile/packfile_test.go
@@ -20,10 +20,13 @@ func TestGet(t *testing.T) {
 	t.Parallel()
 
 	f := fixtures.Basic().One()
-	idx := getIndexFromIdxFile(f.Idx())
+	index := getIndexFromIdxFile(f.Idx())
+	n, err := index.Count()
+	require.NoError(t, err)
+	require.Equal(t, int64(31), n)
 
 	p := packfile.NewPackfile(f.Packfile(),
-		packfile.WithIdx(idx), packfile.WithFs(osfs.New(t.TempDir())),
+		packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())),
 	)
 
 	for h := range expectedEntries {
@@ -34,7 +37,7 @@ func TestGet(t *testing.T) {
 		assert.Equal(t, h.String(), obj.Hash().String())
 	}
 
-	_, err := p.Get(plumbing.ZeroHash)
+	_, err = p.Get(plumbing.ZeroHash)
 	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 
 	id, err := p.ID()
@@ -46,10 +49,13 @@ func TestGetByOffset(t *testing.T) {
 	t.Parallel()
 
 	f := fixtures.Basic().One()
-	idx := getIndexFromIdxFile(f.Idx())
+	index := getIndexFromIdxFile(f.Idx())
+	n, err := index.Count()
+	require.NoError(t, err)
+	require.Equal(t, int64(31), n)
 
 	p := packfile.NewPackfile(f.Packfile(),
-		packfile.WithIdx(idx), packfile.WithFs(osfs.New(t.TempDir())),
+		packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())),
 	)
 
 	for h, o := range expectedEntries {
@@ -59,7 +65,7 @@ func TestGetByOffset(t *testing.T) {
 		assert.Equal(t, h.String(), obj.Hash().String())
 	}
 
-	_, err := p.GetByOffset(math.MaxInt64)
+	_, err = p.GetByOffset(math.MaxInt64)
 	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 }
 
@@ -67,10 +73,13 @@ func TestGetAll(t *testing.T) {
 	t.Parallel()
 
 	f := fixtures.Basic().One()
-	idx := getIndexFromIdxFile(f.Idx())
+	index := getIndexFromIdxFile(f.Idx())
+	n, err := index.Count()
+	require.NoError(t, err)
+	require.Equal(t, int64(31), n)
 
 	p := packfile.NewPackfile(f.Packfile(),
-		packfile.WithIdx(idx),
+		packfile.WithIdx(index),
 		packfile.WithFs(osfs.New(t.TempDir())))
 
 	iter, err := p.GetAll()
@@ -106,6 +115,9 @@ func TestDecode(t *testing.T) {
 	for _, f := range packfiles {
 		f := f
 		index := getIndexFromIdxFile(f.Idx())
+		n, err := index.Count()
+		require.NoError(t, err)
+		require.Equal(t, int64(31), n)
 
 		p := packfile.NewPackfile(f.Packfile(),
 			packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())),
@@ -118,7 +130,7 @@ func TestDecode(t *testing.T) {
 			assert.Equal(t, obj.Hash().String(), h)
 		}
 
-		err := p.Close()
+		err = p.Close()
 		require.NoError(t, err)
 	}
 }
@@ -129,6 +141,9 @@ func TestDecodeByTypeRefDelta(t *testing.T) {
 	f := fixtures.Basic().ByTag("ref-delta").One()
 
 	index := getIndexFromIdxFile(f.Idx())
+	n, err := index.Count()
+	require.NoError(t, err)
+	require.Equal(t, int64(31), n)
 
 	packfile := packfile.NewPackfile(f.Packfile(),
 		packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())))
@@ -169,6 +184,9 @@ func TestDecodeByType(t *testing.T) {
 		for _, typ := range types {
 			typ := typ
 			index := getIndexFromIdxFile(f.Idx())
+			n, err := index.Count()
+			require.NoError(t, err)
+			require.Equal(t, int64(31), n)
 
 			packfile := packfile.NewPackfile(f.Packfile(),
 				packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())),
@@ -192,13 +210,16 @@ func TestDecodeByTypeConstructor(t *testing.T) {
 
 	f := fixtures.Basic().ByTag("packfile").One()
 	index := getIndexFromIdxFile(f.Idx())
+	n, err := index.Count()
+	require.NoError(t, err)
+	require.Equal(t, int64(31), n)
 
 	packfile := packfile.NewPackfile(f.Packfile(),
 		packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())),
 	)
 	defer packfile.Close()
 
-	_, err := packfile.GetByType(plumbing.OFSDeltaObject)
+	_, err = packfile.GetByType(plumbing.OFSDeltaObject)
 	assert.ErrorIs(t, err, plumbing.ErrInvalidType)
 
 	_, err = packfile.GetByType(plumbing.REFDeltaObject)
@@ -225,6 +246,9 @@ func TestSize(t *testing.T) {
 	f := fixtures.Basic().ByTag("ref-delta").One()
 
 	index := getIndexFromIdxFile(f.Idx())
+	n, err := index.Count()
+	require.NoError(t, err)
+	require.Equal(t, int64(31), n)
 
 	packfile := packfile.NewPackfile(f.Packfile(),
 		packfile.WithIdx(index),

--- a/plumbing/format/packfile/packfile_test.go
+++ b/plumbing/format/packfile/packfile_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/go-git/go-billy/v6/osfs"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
@@ -22,7 +23,7 @@ func TestGet(t *testing.T) {
 	idx := getIndexFromIdxFile(f.Idx())
 
 	p := packfile.NewPackfile(f.Packfile(),
-		packfile.WithIdx(idx), packfile.WithFs(fixtures.Filesystem),
+		packfile.WithIdx(idx), packfile.WithFs(osfs.New(t.TempDir())),
 	)
 
 	for h := range expectedEntries {
@@ -48,7 +49,7 @@ func TestGetByOffset(t *testing.T) {
 	idx := getIndexFromIdxFile(f.Idx())
 
 	p := packfile.NewPackfile(f.Packfile(),
-		packfile.WithIdx(idx), packfile.WithFs(fixtures.Filesystem),
+		packfile.WithIdx(idx), packfile.WithFs(osfs.New(t.TempDir())),
 	)
 
 	for h, o := range expectedEntries {
@@ -70,7 +71,7 @@ func TestGetAll(t *testing.T) {
 
 	p := packfile.NewPackfile(f.Packfile(),
 		packfile.WithIdx(idx),
-		packfile.WithFs(fixtures.Filesystem))
+		packfile.WithFs(osfs.New(t.TempDir())))
 
 	iter, err := p.GetAll()
 	require.NoError(t, err)
@@ -82,6 +83,7 @@ func TestGetAll(t *testing.T) {
 			break
 		}
 		require.NoError(t, err)
+		require.NotNil(t, o)
 
 		objects++
 		h := o.Hash()
@@ -106,7 +108,7 @@ func TestDecode(t *testing.T) {
 		index := getIndexFromIdxFile(f.Idx())
 
 		p := packfile.NewPackfile(f.Packfile(),
-			packfile.WithIdx(index), packfile.WithFs(fixtures.Filesystem),
+			packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())),
 		)
 
 		for _, h := range expectedHashes {
@@ -129,7 +131,7 @@ func TestDecodeByTypeRefDelta(t *testing.T) {
 	index := getIndexFromIdxFile(f.Idx())
 
 	packfile := packfile.NewPackfile(f.Packfile(),
-		packfile.WithIdx(index), packfile.WithFs(fixtures.Filesystem))
+		packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())))
 
 	iter, err := packfile.GetByType(plumbing.CommitObject)
 	require.NoError(t, err)
@@ -169,7 +171,7 @@ func TestDecodeByType(t *testing.T) {
 			index := getIndexFromIdxFile(f.Idx())
 
 			packfile := packfile.NewPackfile(f.Packfile(),
-				packfile.WithIdx(index), packfile.WithFs(fixtures.Filesystem),
+				packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())),
 			)
 			defer packfile.Close()
 
@@ -192,7 +194,7 @@ func TestDecodeByTypeConstructor(t *testing.T) {
 	index := getIndexFromIdxFile(f.Idx())
 
 	packfile := packfile.NewPackfile(f.Packfile(),
-		packfile.WithIdx(index), packfile.WithFs(fixtures.Filesystem),
+		packfile.WithIdx(index), packfile.WithFs(osfs.New(t.TempDir())),
 	)
 	defer packfile.Close()
 
@@ -226,7 +228,7 @@ func TestSize(t *testing.T) {
 
 	packfile := packfile.NewPackfile(f.Packfile(),
 		packfile.WithIdx(index),
-		packfile.WithFs(fixtures.Filesystem),
+		packfile.WithFs(osfs.New(t.TempDir())),
 	)
 	defer packfile.Close()
 
@@ -256,7 +258,7 @@ func BenchmarkGetByOffset(b *testing.B) {
 
 	b.Run("with storage",
 		benchmarkGetByOffset(packfile.NewPackfile(f.Packfile(),
-			packfile.WithIdx(idx), packfile.WithFs(fixtures.Filesystem),
+			packfile.WithIdx(idx), packfile.WithFs(osfs.New(b.TempDir())),
 			packfile.WithCache(cache),
 		)))
 	b.Run("without storage",

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -293,6 +293,8 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 			parent.Size = obj.Size()
 			r, err := obj.Reader()
 			if err == nil {
+				defer r.Close()
+
 				if parent.content == nil {
 					parent.content = sync.GetBytesBuffer()
 				}
@@ -302,10 +304,6 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 				if err == nil {
 					return bytes.NewReader(parent.content.Bytes()), nil
 				}
-			}
-
-			if err = r.Close(); err != nil {
-				return nil, fmt.Errorf("close parent obj reader: %w", err)
 			}
 		}
 	}

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -92,7 +92,7 @@ func (p *Parser) storeOrCache(oh *ObjectHeader) error {
 
 		defer w.Close()
 
-		_, err = ioutil.Copy(w, oh.content)
+		_, err = ioutil.CopyBufferPool(w, oh.content)
 		if err != nil {
 			return err
 		}
@@ -300,7 +300,7 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 				}
 				parent.content.Grow(int(parent.Size))
 
-				_, err = ioutil.Copy(parent.content, r)
+				_, err = ioutil.CopyBufferPool(parent.content, r)
 				if err == nil {
 					return bytes.NewReader(parent.content.Bytes()), nil
 				}

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -70,10 +70,10 @@ func NewParser(data io.Reader, opts ...ParserOption) *Parser {
 
 		lm, ok := p.storage.(LowMemoryCapable)
 		p.lowMemoryMode = ok && lm.LowMemoryMode()
+	}
 
-		if p.scanner.seeker == nil {
-			p.lowMemoryMode = false
-		}
+	if p.scanner.seeker == nil {
+		p.lowMemoryMode = false
 	}
 	p.scanner.lowMemoryMode = p.lowMemoryMode
 	p.cache = newParserCache()

--- a/plumbing/format/packfile/parser_options.go
+++ b/plumbing/format/packfile/parser_options.go
@@ -25,3 +25,14 @@ func WithScannerObservers(ob ...Observer) ParserOption {
 		p.observers = ob
 	}
 }
+
+// WithHighMemoryUsage makes the parser optimise for speed rather than
+// for memory consumption. This is disabled by default.
+//
+// When enabled the inflated content of all delta objects (ofs and ref)
+// will be loaded into cache, making it faster to navigate through them.
+func WithHighMemoryUsage() ParserOption {
+	return func(p *Parser) {
+		p.lowMemory = false
+	}
+}

--- a/plumbing/format/packfile/parser_options.go
+++ b/plumbing/format/packfile/parser_options.go
@@ -26,13 +26,22 @@ func WithScannerObservers(ob ...Observer) ParserOption {
 	}
 }
 
-// WithHighMemoryUsage makes the parser optimise for speed rather than
-// for memory consumption. This is disabled by default.
+// WithHighMemoryMode optimises the parser for speed rather than
+// for memory consumption, making the Parser faster from an execution
+// time perspective, but yielding much more allocations, which in the
+// long run could make the application slower due to GC pressure.
+//
+// When the parser is being used without a storage, this is enabled
+// automatically, as it can't operate without it. Some storage types
+// may no support low memory mode (i.e. memory storage), for storage
+// types that do support it, this becomes an opt-in feature.
 //
 // When enabled the inflated content of all delta objects (ofs and ref)
 // will be loaded into cache, making it faster to navigate through them.
-func WithHighMemoryUsage() ParserOption {
+// If the reader provided to the parser does not implement io.Seeker,
+// full objects may also be loaded into memory.
+func WithHighMemoryMode() ParserOption {
 	return func(p *Parser) {
-		p.lowMemory = false
+		p.lowMemoryMode = false
 	}
 }

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParserHashes(t *testing.T) {
@@ -24,20 +25,25 @@ func TestParserHashes(t *testing.T) {
 		option  packfile.ParserOption
 	}{
 		{
-			name: "without storage",
+			name: "without storage (implicit high memory mode)",
 		},
 		{
-			name:    "with storage",
+			name:    "with filesystem storage",
 			storage: filesystem.NewStorage(osfs.New(t.TempDir()), cache.NewObjectLRUDefault()),
 		},
 		{
-			name:   "without storage and high memory usage",
-			option: packfile.WithHighMemoryUsage(),
+			name:    "with storage and high memory mode",
+			storage: filesystem.NewStorage(osfs.New(t.TempDir()), cache.NewObjectLRUDefault()),
+			option:  packfile.WithHighMemoryMode(),
 		},
 		{
-			name:    "with storage and high memory usage",
-			storage: filesystem.NewStorage(osfs.New(t.TempDir()), cache.NewObjectLRUDefault()),
-			option:  packfile.WithHighMemoryUsage(),
+			name:    "with memory storage (implicit high memory)",
+			storage: memory.NewStorage(),
+		},
+		{
+			name:    "with memory storage and high memory mode (no-op)",
+			storage: memory.NewStorage(),
+			option:  packfile.WithHighMemoryMode(),
 		},
 	}
 
@@ -88,7 +94,7 @@ func TestParserHashes(t *testing.T) {
 			}
 
 			_, err := parser.Parse()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, "a3fed42da1e8189a077c0e6846c040dcf73fc9dd", obs.checksum)
 			assert.Equal(t, objs, obs.objects)

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -87,7 +87,7 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta *bytes.Buffer) (err e
 
 	target.SetSize(int64(dst.Len()))
 
-	_, err = ioutil.Copy(w, dst)
+	_, err = ioutil.CopyBufferPool(w, dst)
 	return err
 }
 
@@ -200,7 +200,7 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 					basePos += uint(n)
 					discard -= uint(n)
 				}
-				if _, err := ioutil.Copy(dstWr, io.LimitReader(baseBuf, int64(sz))); err != nil {
+				if _, err := ioutil.CopyBufferPool(dstWr, io.LimitReader(baseBuf, int64(sz))); err != nil {
 					_ = dstWr.CloseWithError(err)
 					return
 				}
@@ -213,7 +213,7 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 					_ = dstWr.CloseWithError(ErrInvalidDelta)
 					return
 				}
-				if _, err := ioutil.Copy(dstWr, io.LimitReader(deltaBuf, int64(sz))); err != nil {
+				if _, err := ioutil.CopyBufferPool(dstWr, io.LimitReader(deltaBuf, int64(sz))); err != nil {
 					_ = dstWr.CloseWithError(err)
 					return
 				}

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -87,9 +87,7 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta *bytes.Buffer) (err e
 
 	target.SetSize(int64(dst.Len()))
 
-	b := sync.GetByteSlice()
-	n, err := io.CopyBuffer(w, dst, *b)
-	sync.PutByteSlice(b, int(n))
+	_, err = ioutil.Copy(w, dst)
 	return err
 }
 
@@ -202,7 +200,7 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 					basePos += uint(n)
 					discard -= uint(n)
 				}
-				if _, err := io.Copy(dstWr, io.LimitReader(baseBuf, int64(sz))); err != nil {
+				if _, err := ioutil.Copy(dstWr, io.LimitReader(baseBuf, int64(sz))); err != nil {
 					_ = dstWr.CloseWithError(err)
 					return
 				}
@@ -215,7 +213,7 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 					_ = dstWr.CloseWithError(ErrInvalidDelta)
 					return
 				}
-				if _, err := io.Copy(dstWr, io.LimitReader(deltaBuf, int64(sz))); err != nil {
+				if _, err := ioutil.Copy(dstWr, io.LimitReader(deltaBuf, int64(sz))); err != nil {
 					_ = dstWr.CloseWithError(err)
 					return
 				}
@@ -354,7 +352,7 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 	mw := io.MultiWriter(dst, hasher)
 
 	bufp := sync.GetByteSlice()
-	defer sync.PutByteSlice(bufp, 0)
+	defer sync.PutByteSlice(bufp)
 
 	sr := io.NewSectionReader(base, int64(0), int64(srcSz))
 	// Keep both the io.LimitedReader types, so we can reset N.

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -55,7 +55,7 @@ var sizes = []offset{
 }
 
 // ApplyDelta writes to target the result of applying the modification deltas in delta to base.
-func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) (err error) {
+func ApplyDelta(target, base plumbing.EncodedObject, delta *bytes.Buffer) (err error) {
 	r, err := base.Reader()
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) (err error) {
 
 	dst := sync.GetBytesBuffer()
 	defer sync.PutBytesBuffer(dst)
-	err = patchDelta(dst, src, delta)
+	err = patchDelta(dst, src, delta.Bytes())
 	if err != nil {
 		return err
 	}

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -88,8 +88,8 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) (err error) {
 	target.SetSize(int64(dst.Len()))
 
 	b := sync.GetByteSlice()
-	_, err = io.CopyBuffer(w, dst, *b)
-	sync.PutByteSlice(b)
+	n, err := io.CopyBuffer(w, dst, *b)
+	sync.PutByteSlice(b, int(n))
 	return err
 }
 
@@ -349,7 +349,7 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 	mw := io.MultiWriter(dst, hasher)
 
 	bufp := sync.GetByteSlice()
-	defer sync.PutByteSlice(bufp)
+	defer sync.PutByteSlice(bufp, 0)
 
 	sr := io.NewSectionReader(base, int64(0), int64(srcSz))
 	// Keep both the io.LimitedReader types, so we can reset N.

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -234,7 +234,7 @@ func (s *Scanner) inflateContent(contentOffset int64, writer io.Writer) error {
 		return fmt.Errorf("zlib reset error: %s", err)
 	}
 
-	_, err = io.Copy(writer, s.zr.Reader)
+	_, err = ioutil.Copy(writer, s.zr.Reader)
 	if err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func objectEntry(r *Scanner) (stateFn, error) {
 		}
 
 		// For non delta objects, simply calculate the hash of each object.
-		_, err = io.CopyBuffer(mw, r.zr.Reader, r.buf.Bytes())
+		_, err = ioutil.Copy(mw, r.zr.Reader)
 		if err != nil {
 			return nil, err
 		}
@@ -436,7 +436,7 @@ func objectEntry(r *Scanner) (stateFn, error) {
 		} else {
 			// We don't know the compressed length, so we can't seek to
 			// the next object, we must discard the data instead.
-			_, err = io.Copy(io.Discard, r.zr.Reader)
+			_, err = ioutil.Copy(io.Discard, r.zr.Reader)
 			if err != nil {
 				return nil, err
 			}

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -199,7 +199,7 @@ func (r *Scanner) SeekFromStart(offset int64) error {
 
 func (s *Scanner) WriteObject(oh *ObjectHeader, writer io.Writer) error {
 	if oh.content != nil && oh.content.Len() > 0 {
-		_, err := ioutil.Copy(writer, oh.content)
+		_, err := ioutil.CopyBufferPool(writer, oh.content)
 		return err
 	}
 
@@ -234,7 +234,7 @@ func (s *Scanner) inflateContent(contentOffset int64, writer io.Writer) error {
 		return fmt.Errorf("zlib reset error: %s", err)
 	}
 
-	_, err = ioutil.Copy(writer, s.zr.Reader)
+	_, err = ioutil.CopyBufferPool(writer, s.zr.Reader)
 	if err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func objectEntry(r *Scanner) (stateFn, error) {
 		}
 
 		// For non delta objects, simply calculate the hash of each object.
-		_, err = ioutil.Copy(mw, r.zr.Reader)
+		_, err = ioutil.CopyBufferPool(mw, r.zr.Reader)
 		if err != nil {
 			return nil, err
 		}
@@ -436,7 +436,7 @@ func objectEntry(r *Scanner) (stateFn, error) {
 		} else {
 			// We don't know the compressed length, so we can't seek to
 			// the next object, we must discard the data instead.
-			_, err = ioutil.Copy(io.Discard, r.zr.Reader)
+			_, err = ioutil.CopyBufferPool(io.Discard, r.zr.Reader)
 			if err != nil {
 				return nil, err
 			}

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -16,6 +16,7 @@ import (
 	gogithash "github.com/go-git/go-git/v6/plumbing/hash"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/utils/binary"
+	"github.com/go-git/go-git/v6/utils/ioutil"
 	gogitsync "github.com/go-git/go-git/v6/utils/sync"
 )
 
@@ -197,8 +198,8 @@ func (r *Scanner) SeekFromStart(offset int64) error {
 }
 
 func (s *Scanner) WriteObject(oh *ObjectHeader, writer io.Writer) error {
-	if oh.content.Len() > 0 {
-		_, err := io.Copy(writer, bytes.NewReader(oh.content.Bytes()))
+	if oh.content != nil && oh.content.Len() > 0 {
+		_, err := ioutil.Copy(writer, oh.content)
 		return err
 	}
 

--- a/plumbing/format/packfile/scanner_reader.go
+++ b/plumbing/format/packfile/scanner_reader.go
@@ -50,7 +50,7 @@ func (r *scannerReader) Reset(reader io.Reader) {
 	r.seeker = seeker
 
 	if ok {
-		r.offset, _ = seeker.Seek(0, io.SeekCurrent)
+		r.offset, _ = seeker.Seek(0, io.SeekStart)
 	}
 }
 

--- a/plumbing/format/packfile/types.go
+++ b/plumbing/format/packfile/types.go
@@ -34,7 +34,7 @@ type ObjectHeader struct {
 	Hash            plumbing.Hash
 	Hash256         *plumbing.Hash
 
-	content     bytes.Buffer
+	content     *bytes.Buffer
 	parent      *ObjectHeader
 	diskType    plumbing.ObjectType
 	externalRef bool

--- a/plumbing/object/blob.go
+++ b/plumbing/object/blob.go
@@ -84,7 +84,7 @@ func (b *Blob) Encode(o plumbing.EncodedObject) (err error) {
 
 	defer ioutil.CheckClose(r, &err)
 
-	_, err = io.Copy(w, r)
+	_, err = ioutil.Copy(w, r)
 	return err
 }
 

--- a/plumbing/object/blob.go
+++ b/plumbing/object/blob.go
@@ -84,7 +84,7 @@ func (b *Blob) Encode(o plumbing.EncodedObject) (err error) {
 
 	defer ioutil.CheckClose(r, &err)
 
-	_, err = ioutil.Copy(w, r)
+	_, err = ioutil.CopyBufferPool(w, r)
 	return err
 }
 

--- a/plumbing/transport/http/dumb.go
+++ b/plumbing/transport/http/dumb.go
@@ -127,7 +127,7 @@ func (r *fetchWalker) downloadFile(fp string) (rErr error) {
 	}
 
 	copy := func(w io.Writer) error {
-		if _, err := io.Copy(w, res.Body); err != nil {
+		if _, err := ioutil.Copy(w, res.Body); err != nil {
 			return err
 		}
 
@@ -344,7 +344,7 @@ func (r *fetchWalker) fetchObject(hash plumbing.Hash, obj plumbing.EncodedObject
 
 	ioutil.CheckClose(w, &err)
 
-	if _, err := io.Copy(w, rd); err != nil {
+	if _, err := ioutil.Copy(w, rd); err != nil {
 		return err
 	}
 

--- a/plumbing/transport/http/dumb.go
+++ b/plumbing/transport/http/dumb.go
@@ -127,7 +127,7 @@ func (r *fetchWalker) downloadFile(fp string) (rErr error) {
 	}
 
 	copy := func(w io.Writer) error {
-		if _, err := ioutil.Copy(w, res.Body); err != nil {
+		if _, err := ioutil.CopyBufferPool(w, res.Body); err != nil {
 			return err
 		}
 
@@ -344,7 +344,7 @@ func (r *fetchWalker) fetchObject(hash plumbing.Hash, obj plumbing.EncodedObject
 
 	ioutil.CheckClose(w, &err)
 
-	if _, err := ioutil.Copy(w, rd); err != nil {
+	if _, err := ioutil.CopyBufferPool(w, rd); err != nil {
 		return err
 	}
 

--- a/plumbing/transport/loader.go
+++ b/plumbing/transport/loader.go
@@ -62,7 +62,7 @@ func (l *FilesystemLoader) load(ep *Endpoint, tried bool) (storage.Storer, error
 		return nil, ErrRepositoryNotFound
 	}
 
-	return filesystem.NewStorage(fs, cache.NewObjectLRUDefault()), nil
+	return filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{}), nil
 }
 
 // MapLoader is a Loader that uses a lookup map of storer.Storer by

--- a/plumbing/transport/pack.go
+++ b/plumbing/transport/pack.go
@@ -88,7 +88,7 @@ func (p *PackSession) Handshake(ctx context.Context, service Service, params ...
 	// Some transports like Git doesn't support stderr, so we need to check if
 	// it's not nil before starting to read it.
 	if stderr != nil {
-		go ioutil.Copy(&c.stderrBuf, stderr) // nolint: errcheck
+		go ioutil.CopyBufferPool(&c.stderrBuf, stderr) // nolint: errcheck
 	}
 
 	// Check if stderr is not empty before returning.

--- a/plumbing/transport/pack.go
+++ b/plumbing/transport/pack.go
@@ -88,7 +88,7 @@ func (p *PackSession) Handshake(ctx context.Context, service Service, params ...
 	// Some transports like Git doesn't support stderr, so we need to check if
 	// it's not nil before starting to read it.
 	if stderr != nil {
-		go io.Copy(&c.stderrBuf, stderr) // nolint: errcheck
+		go ioutil.Copy(&c.stderrBuf, stderr) // nolint: errcheck
 	}
 
 	// Check if stderr is not empty before returning.

--- a/plumbing/transport/push.go
+++ b/plumbing/transport/push.go
@@ -95,7 +95,7 @@ func SendPack(
 
 	// Send the packfile.
 	if req.Packfile != nil {
-		if _, err := ioutil.Copy(writer, req.Packfile); err != nil {
+		if _, err := ioutil.CopyBufferPool(writer, req.Packfile); err != nil {
 			return err
 		}
 

--- a/plumbing/transport/push.go
+++ b/plumbing/transport/push.go
@@ -95,7 +95,7 @@ func SendPack(
 
 	// Send the packfile.
 	if req.Packfile != nil {
-		if _, err := io.Copy(writer, req.Packfile); err != nil {
+		if _, err := ioutil.Copy(writer, req.Packfile); err != nil {
 			return err
 		}
 

--- a/storage/filesystem/config_test.go
+++ b/storage/filesystem/config_test.go
@@ -25,7 +25,7 @@ func TestConfigSuite(t *testing.T) {
 
 func (s *ConfigSuite) SetupTest() {
 	tmp, err := util.TempDir(osfs.Default, "", "go-git-filestystem-config")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.dir = dotgit.New(osfs.New(tmp))
 	s.path = tmp
@@ -36,7 +36,7 @@ func (s *ConfigSuite) TestRemotes() {
 	storer := &ConfigStorage{dir}
 
 	cfg, err := storer.Config()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	remotes := cfg.Remotes
 	s.Len(remotes, 1)

--- a/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
+++ b/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
@@ -57,7 +57,7 @@ func (d *DotGit) copyToExistingFile(tmp, pr billy.File) error {
 	if err != nil {
 		return err
 	}
-	_, err = ioutil.Copy(pr, tmp)
+	_, err = ioutil.CopyBufferPool(pr, tmp)
 
 	return err
 }
@@ -75,7 +75,7 @@ func (d *DotGit) copyNewFile(tmp billy.File, pr billy.File) (err error) {
 		return err
 	}
 
-	_, err = ioutil.Copy(prWrite, tmp)
+	_, err = ioutil.CopyBufferPool(prWrite, tmp)
 
 	return err
 }

--- a/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
+++ b/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
@@ -57,7 +57,7 @@ func (d *DotGit) copyToExistingFile(tmp, pr billy.File) error {
 	if err != nil {
 		return err
 	}
-	_, err = io.Copy(pr, tmp)
+	_, err = ioutil.Copy(pr, tmp)
 
 	return err
 }
@@ -75,7 +75,7 @@ func (d *DotGit) copyNewFile(tmp billy.File, pr billy.File) (err error) {
 		return err
 	}
 
-	_, err = io.Copy(prWrite, tmp)
+	_, err = ioutil.Copy(prWrite, tmp)
 
 	return err
 }

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -38,19 +38,19 @@ func (s *SuiteDotGit) TestInitialize() {
 	dir := New(fs)
 
 	err := dir.Initialize()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = fs.Stat(fs.Join("objects", "info"))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = fs.Stat(fs.Join("objects", "pack"))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = fs.Stat(fs.Join("refs", "heads"))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = fs.Stat(fs.Join("refs", "tags"))
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *SuiteDotGit) TestSetRefs() {
@@ -73,7 +73,7 @@ func (s *SuiteDotGit) TestRefsHeadFirst() {
 	fs := fixtures.Basic().ByTag(".git").One().DotGit()
 	dir := New(fs)
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotEqual(0, len(refs))
 	s.Equal("HEAD", refs[0].Name().String())
 }
@@ -85,29 +85,29 @@ func testSetRefs(s *SuiteDotGit, dir *DotGit) {
 	)
 	err := dir.SetRef(firstFoo, nil)
 
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"refs/heads/symbolic",
 		"ref: refs/heads/foo",
 	), nil)
 
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"bar",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"refs/heads/feature/baz",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(refs, 3)
 
 	ref := findReference(refs, "refs/heads/foo")
@@ -122,23 +122,23 @@ func testSetRefs(s *SuiteDotGit, dir *DotGit) {
 	s.Nil(ref)
 
 	_, err = dir.readReferenceFile(".", "refs/heads/feature/baz")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = dir.readReferenceFile(".", "refs/heads/feature")
 	s.ErrorIs(err, ErrIsDir)
 
 	ref, err = dir.Ref("refs/heads/foo")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ref)
 	s.Equal("e8d3ffab552895c19b9fcf7aa264d277cde33881", ref.Hash().String())
 
 	ref, err = dir.Ref("refs/heads/symbolic")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ref)
 	s.Equal("refs/heads/foo", ref.Target().String())
 
 	ref, err = dir.Ref("bar")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ref)
 	s.Equal("e8d3ffab552895c19b9fcf7aa264d277cde33881", ref.Hash().String())
 
@@ -147,7 +147,7 @@ func testSetRefs(s *SuiteDotGit, dir *DotGit) {
 		"refs/heads/foo",
 		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
 	), firstFoo)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// `firstFoo` is no longer the right `old` reference, so this
 	// should fail.
@@ -163,7 +163,7 @@ func (s *SuiteDotGit) TestRefsFromPackedRefs() {
 	dir := New(fs)
 
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ref := findReference(refs, "refs/remotes/origin/branch")
 	s.NotNil(ref)
@@ -175,7 +175,7 @@ func (s *SuiteDotGit) TestRefsFromReferenceFile() {
 	dir := New(fs)
 
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ref := findReference(refs, "refs/remotes/origin/HEAD")
 	s.NotNil(ref)
@@ -207,10 +207,10 @@ func (s *SuiteDotGit) TestRemoveRefFromReferenceFile() {
 
 	name := plumbing.ReferenceName("refs/remotes/origin/HEAD")
 	err := dir.RemoveRef(name)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ref := findReference(refs, string(name))
 	s.Nil(ref)
@@ -222,10 +222,10 @@ func (s *SuiteDotGit) TestRemoveRefFromPackedRefs() {
 
 	name := plumbing.ReferenceName("refs/remotes/origin/master")
 	err := dir.RemoveRef(name)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	b, err := util.ReadFile(fs, packedRefsPath)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(""+
 		"# pack-refs with: peeled fully-peeled \n"+
@@ -243,11 +243,11 @@ func (s *SuiteDotGit) TestRemoveRefFromReferenceFileAndPackedRefs() {
 		"refs/remotes/origin/branch",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// Make sure it only appears once in the refs list.
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	found := false
 	for _, ref := range refs {
 		if ref.Name() == "refs/remotes/origin/branch" {
@@ -258,10 +258,10 @@ func (s *SuiteDotGit) TestRemoveRefFromReferenceFileAndPackedRefs() {
 
 	name := plumbing.ReferenceName("refs/remotes/origin/branch")
 	err = dir.RemoveRef(name)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	b, err := util.ReadFile(fs, packedRefsPath)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(""+
 		"# pack-refs with: peeled fully-peeled \n"+
@@ -270,7 +270,7 @@ func (s *SuiteDotGit) TestRemoveRefFromReferenceFileAndPackedRefs() {
 		string(b))
 
 	refs, err = dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ref := findReference(refs, string(name))
 	s.Nil(ref)
@@ -281,14 +281,14 @@ func (s *SuiteDotGit) TestRemoveRefNonExistent() {
 	dir := New(fs)
 
 	before, err := util.ReadFile(fs, packedRefsPath)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	name := plumbing.ReferenceName("refs/heads/nonexistent")
 	err = dir.RemoveRef(name)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	after, err := util.ReadFile(fs, packedRefsPath)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(string(after), string(before))
 }
@@ -300,14 +300,14 @@ func (s *SuiteDotGit) TestRemoveRefInvalidPackedRefs() {
 	brokenContent := "BROKEN STUFF REALLY BROKEN"
 
 	err := util.WriteFile(fs, packedRefsPath, []byte(brokenContent), os.FileMode(0755))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	name := plumbing.ReferenceName("refs/heads/nonexistent")
 	err = dir.RemoveRef(name)
 	s.NotNil(err)
 
 	after, err := util.ReadFile(fs, packedRefsPath)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(string(after), brokenContent)
 }
@@ -319,14 +319,14 @@ func (s *SuiteDotGit) TestRemoveRefInvalidPackedRefs2() {
 	brokenContent := strings.Repeat("a", bufio.MaxScanTokenSize*2)
 
 	err := util.WriteFile(fs, packedRefsPath, []byte(brokenContent), os.FileMode(0755))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	name := plumbing.ReferenceName("refs/heads/nonexistent")
 	err = dir.RemoveRef(name)
 	s.NotNil(err)
 
 	after, err := util.ReadFile(fs, packedRefsPath)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(string(after), brokenContent)
 }
@@ -336,7 +336,7 @@ func (s *SuiteDotGit) TestRefsFromHEADFile() {
 	dir := New(fs)
 
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ref := findReference(refs, "HEAD")
 	s.NotNil(ref)
@@ -349,7 +349,7 @@ func (s *SuiteDotGit) TestConfig() {
 	dir := New(fs)
 
 	file, err := dir.Config()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("config", filepath.Base(file.Name()))
 }
 
@@ -359,16 +359,16 @@ func (s *SuiteDotGit) TestConfigWriteAndConfig() {
 	dir := New(fs)
 
 	f, err := dir.ConfigWriter()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = f.Write([]byte("foo"))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	f, err = dir.Config()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cnt, err := io.ReadAll(f)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("foo", string(cnt))
 }
@@ -378,7 +378,7 @@ func (s *SuiteDotGit) TestIndex() {
 	dir := New(fs)
 
 	idx, err := dir.Index()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(idx)
 }
 
@@ -388,16 +388,16 @@ func (s *SuiteDotGit) TestIndexWriteAndIndex() {
 	dir := New(fs)
 
 	f, err := dir.IndexWriter()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = f.Write([]byte("foo"))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	f, err = dir.Index()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cnt, err := io.ReadAll(f)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("foo", string(cnt))
 }
@@ -407,7 +407,7 @@ func (s *SuiteDotGit) TestShallow() {
 	dir := New(fs)
 
 	file, err := dir.Shallow()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Nil(file)
 }
 
@@ -417,16 +417,16 @@ func (s *SuiteDotGit) TestShallowWriteAndShallow() {
 	dir := New(fs)
 
 	f, err := dir.ShallowWriter()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = f.Write([]byte("foo"))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	f, err = dir.Shallow()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cnt, err := io.ReadAll(f)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal("foo", string(cnt))
 }
@@ -460,24 +460,24 @@ func (s *SuiteDotGit) TestObjectPacksExclusive() {
 
 func testObjectPacks(s *SuiteDotGit, fs billy.Filesystem, dir *DotGit, f *fixtures.Fixture) {
 	hashes, err := dir.ObjectPacks()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(hashes, 1)
 	s.Equal(plumbing.NewHash(f.PackfileHash), hashes[0])
 
 	// Make sure that a random file in the pack directory doesn't
 	// break everything.
 	badFile, err := fs.Create("objects/pack/OOPS_THIS_IS_NOT_RIGHT.pack")
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = badFile.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 	// temporary file generated by git gc
 	tmpFile, err := fs.Create("objects/pack/.tmp-11111-pack-58rf8y4wm1b1k52bpe0kdlx6lpreg6ahso8n3ylc.pack")
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = tmpFile.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	hashes2, err := dir.ObjectPacks()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(hashes2, 1)
 	s.Equal(hashes2[0], hashes[0])
 }
@@ -488,7 +488,7 @@ func (s *SuiteDotGit) TestObjectPack() {
 	dir := New(fs)
 
 	pack, err := dir.ObjectPack(plumbing.NewHash(f.PackfileHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(".pack", filepath.Ext(pack.Name()))
 }
 
@@ -498,33 +498,33 @@ func (s *SuiteDotGit) TestObjectPackWithKeepDescriptors() {
 	dir := NewWithOptions(fs, Options{KeepDescriptors: true})
 
 	pack, err := dir.ObjectPack(plumbing.NewHash(f.PackfileHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(".pack", filepath.Ext(pack.Name()))
 
 	// Move to an specific offset
 	pack.Seek(42, io.SeekStart)
 
 	pack2, err := dir.ObjectPack(plumbing.NewHash(f.PackfileHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// If the file is the same the offset should be the same
 	offset, err := pack2.Seek(0, io.SeekCurrent)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(int64(42), offset)
 
 	err = dir.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	pack2, err = dir.ObjectPack(plumbing.NewHash(f.PackfileHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// If the file is opened again its offset should be 0
 	offset, err = pack2.Seek(0, io.SeekCurrent)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(int64(0), offset)
 
 	err = pack2.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = dir.Close()
 	s.NotNil(err)
@@ -536,7 +536,7 @@ func (s *SuiteDotGit) TestObjectPackIdx() {
 	dir := New(fs)
 
 	idx, err := dir.ObjectPackIdx(plumbing.NewHash(f.PackfileHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(".idx", filepath.Ext(idx.Name()))
 	s.Nil(idx.Close())
 }
@@ -559,21 +559,21 @@ func (s *SuiteDotGit) TestNewObject() {
 
 	dir := New(fs)
 	w, err := dir.NewObject()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = w.WriteHeader(plumbing.BlobObject, 14)
-	s.NoError(err)
+	s.Require().NoError(err)
 	n, err := w.Write([]byte("this is a test"))
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(14, n)
 
 	s.Equal("a8a940627d132695a9769df883f85992f0ff4a43", w.Hash().String())
 
 	err = w.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	i, err := fs.Stat("objects/a8/a940627d132695a9769df883f85992f0ff4a43")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(int64(34), i.Size())
 }
 
@@ -595,7 +595,7 @@ func (s *SuiteDotGit) TestObjectsExclusive() {
 
 func testObjects(s *SuiteDotGit, _ billy.Filesystem, dir *DotGit) {
 	hashes, err := dir.Objects()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(hashes, 187)
 	s.Equal("0097821d427a3c3385898eb13b50dcbc8702b8a3", hashes[0].String())
 	s.Equal("01d5fa556c33743006de7e76e67a2dfcd994ca04", hashes[1].String())
@@ -605,14 +605,14 @@ func testObjects(s *SuiteDotGit, _ billy.Filesystem, dir *DotGit) {
 func testObjectsWithPrefix(s *SuiteDotGit, _ billy.Filesystem, dir *DotGit) {
 	prefix, _ := hex.DecodeString("01d5")
 	hashes, err := dir.ObjectsWithPrefix(prefix)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(hashes, 1)
 	s.Equal("01d5fa556c33743006de7e76e67a2dfcd994ca04", hashes[0].String())
 
 	// Empty prefix should yield all objects.
 	// (subset of testObjects)
 	hashes, err = dir.ObjectsWithPrefix(nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(hashes, 187)
 }
 
@@ -621,7 +621,7 @@ func (s *SuiteDotGit) TestObjectsNoFolder() {
 
 	dir := New(fs)
 	hash, err := dir.Objects()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(hash, 0)
 }
 
@@ -631,7 +631,7 @@ func (s *SuiteDotGit) TestObject() {
 
 	hash := plumbing.NewHash("03db8e1fbe133a480f2867aac478fd866686d69e")
 	file, err := dir.Object(hash)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.True(strings.HasSuffix(
 		file.Name(), fs.Join("objects", "03", "db8e1fbe133a480f2867aac478fd866686d69e")),
 	)
@@ -642,7 +642,7 @@ func (s *SuiteDotGit) TestObject() {
 	fs.Create(incomingFilePath)
 
 	_, err = dir.Object(plumbing.NewHash(incomingHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *SuiteDotGit) TestPreGit235Object() {
@@ -651,7 +651,7 @@ func (s *SuiteDotGit) TestPreGit235Object() {
 
 	hash := plumbing.NewHash("03db8e1fbe133a480f2867aac478fd866686d69e")
 	file, err := dir.Object(hash)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.True(strings.HasSuffix(
 		file.Name(), fs.Join("objects", "03", "db8e1fbe133a480f2867aac478fd866686d69e")),
 	)
@@ -662,7 +662,7 @@ func (s *SuiteDotGit) TestPreGit235Object() {
 	fs.Create(incomingFilePath)
 
 	_, err = dir.Object(plumbing.NewHash(incomingHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *SuiteDotGit) TestObjectStat() {
@@ -671,7 +671,7 @@ func (s *SuiteDotGit) TestObjectStat() {
 
 	hash := plumbing.NewHash("03db8e1fbe133a480f2867aac478fd866686d69e")
 	_, err := dir.ObjectStat(hash)
-	s.NoError(err)
+	s.Require().NoError(err)
 	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "tmp_objdir-incoming-123456")
 	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
@@ -679,7 +679,7 @@ func (s *SuiteDotGit) TestObjectStat() {
 	fs.Create(incomingFilePath)
 
 	_, err = dir.ObjectStat(plumbing.NewHash(incomingHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *SuiteDotGit) TestObjectDelete() {
@@ -688,7 +688,7 @@ func (s *SuiteDotGit) TestObjectDelete() {
 
 	hash := plumbing.NewHash("03db8e1fbe133a480f2867aac478fd866686d69e")
 	err := dir.ObjectDelete(hash)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "tmp_objdir-incoming-123456")
@@ -696,16 +696,16 @@ func (s *SuiteDotGit) TestObjectDelete() {
 	incomingFilePath := fs.Join(incomingSubDirPath, incomingHash[2:40])
 
 	err = fs.MkdirAll(incomingSubDirPath, os.FileMode(0755))
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	f, err := fs.Create(incomingFilePath)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = f.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = dir.ObjectDelete(plumbing.NewHash(incomingHash))
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *SuiteDotGit) TestObjectNotFound() {
@@ -723,7 +723,7 @@ func (s *SuiteDotGit) TestSubmodules() {
 	dir := New(fs)
 
 	m, err := dir.Module("basic")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.True(strings.HasSuffix(m.Root(), m.Join(".git", "modules", "basic")))
 }
 
@@ -736,37 +736,37 @@ func (s *SuiteDotGit) TestPackRefs() {
 		"refs/heads/foo",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"refs/heads/bar",
 		"a8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(refs, 2)
 	looseCount, err := dir.CountLooseRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(2, looseCount)
 
 	err = dir.PackRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// Make sure the refs are still there, but no longer loose.
 	refs, err = dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(refs, 2)
 	looseCount, err = dir.CountLooseRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(0, looseCount)
 
 	ref, err := dir.Ref("refs/heads/foo")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ref)
 	s.Equal("e8d3ffab552895c19b9fcf7aa264d277cde33881", ref.Hash().String())
 	ref, err = dir.Ref("refs/heads/bar")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ref)
 	s.Equal("a8d3ffab552895c19b9fcf7aa264d277cde33881", ref.Hash().String())
 
@@ -775,23 +775,23 @@ func (s *SuiteDotGit) TestPackRefs() {
 		"refs/heads/foo",
 		"b8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 	looseCount, err = dir.CountLooseRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(1, looseCount)
 	err = dir.PackRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// Make sure the refs are still there, but no longer loose.
 	refs, err = dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(refs, 2)
 	looseCount, err = dir.CountLooseRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(0, looseCount)
 
 	ref, err = dir.Ref("refs/heads/foo")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ref)
 	s.Equal("b8d3ffab552895c19b9fcf7aa264d277cde33881", ref.Hash().String())
 }
@@ -1006,20 +1006,20 @@ func (s *SuiteDotGit) TestDeletedRefs() {
 		"refs/heads/foo",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"refs/heads/bar",
 		"a8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"refs/heads/baz/baz",
 		"a8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(refs, 1)
 	s.Equal(plumbing.ReferenceName("refs/heads/foo"), refs[0].Name())
 }
@@ -1034,28 +1034,28 @@ func (s *SuiteDotGit) TestSetPackedRef() {
 		"refs/heads/foo",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	refs, err := dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(refs, 1)
 	looseCount, err := dir.CountLooseRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(1, looseCount)
 
 	err = dir.PackRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	// Make sure the refs are still there, but no longer loose.
 	refs, err = dir.Refs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(refs, 1)
 	looseCount, err = dir.CountLooseRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(0, looseCount)
 
 	ref, err := dir.Ref("refs/heads/foo")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotNil(ref)
 	s.Equal("e8d3ffab552895c19b9fcf7aa264d277cde33881", ref.Hash().String())
 
@@ -1077,8 +1077,8 @@ func (s *SuiteDotGit) TestSetPackedRef() {
 		"refs/heads/foo",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	))
-	s.NoError(err)
+	s.Require().NoError(err)
 	looseCount, err = dir.CountLooseRefs()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(1, looseCount)
 }

--- a/storage/filesystem/dotgit/repository_filesystem_test.go
+++ b/storage/filesystem/dotgit/repository_filesystem_test.go
@@ -8,63 +8,63 @@ func (s *SuiteDotGit) TestRepositoryFilesystem() {
 	fs := s.EmptyFS()
 
 	err := fs.MkdirAll("dotGit", 0777)
-	s.NoError(err)
+	s.Require().NoError(err)
 	dotGitFs, err := fs.Chroot("dotGit")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = fs.MkdirAll("commonDotGit", 0777)
-	s.NoError(err)
+	s.Require().NoError(err)
 	commonDotGitFs, err := fs.Chroot("commonDotGit")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	repositoryFs := NewRepositoryFilesystem(dotGitFs, commonDotGitFs)
 	s.Equal(dotGitFs.Root(), repositoryFs.Root())
 
 	somedir, err := repositoryFs.Chroot("somedir")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(repositoryFs.Join(dotGitFs.Root(), "somedir"), somedir.Root())
 
 	_, err = repositoryFs.Create("somefile")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = repositoryFs.Stat("somefile")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	file, err := repositoryFs.Open("somefile")
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = file.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	file, err = repositoryFs.OpenFile("somefile", os.O_RDONLY, 0666)
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = file.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	file, err = repositoryFs.Create("somefile2")
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = file.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 	_, err = repositoryFs.Stat("somefile2")
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = repositoryFs.Rename("somefile2", "newfile")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	tempDir, err := repositoryFs.TempFile("tmp", "myprefix")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(repositoryFs.Join(dotGitFs.Root(), "tmp", tempDir.Name()), repositoryFs.Join(repositoryFs.Root(), "tmp", tempDir.Name()))
 
 	err = repositoryFs.Symlink("newfile", "somelink")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = repositoryFs.Lstat("somelink")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	link, err := repositoryFs.Readlink("somelink")
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("newfile", link)
 
 	err = repositoryFs.Remove("somelink")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = repositoryFs.Stat("somelink")
 	s.True(os.IsNotExist(err))
@@ -72,9 +72,9 @@ func (s *SuiteDotGit) TestRepositoryFilesystem() {
 	dirs := []string{objectsPath, refsPath, packedRefsPath, configPath, branchesPath, hooksPath, infoPath, remotesPath, logsPath, shallowPath, worktreesPath}
 	for _, dir := range dirs {
 		err := repositoryFs.MkdirAll(dir, 0777)
-		s.NoError(err)
+		s.Require().NoError(err)
 		_, err = commonDotGitFs.Stat(dir)
-		s.NoError(err)
+		s.Require().NoError(err)
 		_, err = dotGitFs.Stat(dir)
 		s.True(os.IsNotExist(err))
 	}
@@ -82,31 +82,31 @@ func (s *SuiteDotGit) TestRepositoryFilesystem() {
 	exceptionsPaths := []string{repositoryFs.Join(logsPath, "HEAD"), repositoryFs.Join(refsPath, "bisect"), repositoryFs.Join(refsPath, "rewritten"), repositoryFs.Join(refsPath, "worktree")}
 	for _, path := range exceptionsPaths {
 		_, err := repositoryFs.Create(path)
-		s.NoError(err)
+		s.Require().NoError(err)
 		_, err = commonDotGitFs.Stat(path)
 		s.True(os.IsNotExist(err))
 		_, err = dotGitFs.Stat(path)
-		s.NoError(err)
+		s.Require().NoError(err)
 	}
 
 	err = repositoryFs.MkdirAll("refs/heads", 0777)
-	s.NoError(err)
+	s.Require().NoError(err)
 	_, err = commonDotGitFs.Stat("refs/heads")
-	s.NoError(err)
+	s.Require().NoError(err)
 	_, err = dotGitFs.Stat("refs/heads")
 	s.True(os.IsNotExist(err))
 
 	err = repositoryFs.MkdirAll("objects/pack", 0777)
-	s.NoError(err)
+	s.Require().NoError(err)
 	_, err = commonDotGitFs.Stat("objects/pack")
-	s.NoError(err)
+	s.Require().NoError(err)
 	_, err = dotGitFs.Stat("objects/pack")
 	s.True(os.IsNotExist(err))
 
 	err = repositoryFs.MkdirAll("a/b/c", 0777)
-	s.NoError(err)
+	s.Require().NoError(err)
 	_, err = commonDotGitFs.Stat("a/b/c")
 	s.True(os.IsNotExist(err))
 	_, err = dotGitFs.Stat("a/b/c")
-	s.NoError(err)
+	s.Require().NoError(err)
 }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -161,7 +161,7 @@ func (s *ObjectStorage) SetEncodedObject(o plumbing.EncodedObject) (h plumbing.H
 		return plumbing.ZeroHash, err
 	}
 
-	if _, err = io.Copy(ow, or); err != nil {
+	if _, err = ioutil.Copy(ow, or); err != nil {
 		return plumbing.ZeroHash, err
 	}
 

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -161,7 +161,7 @@ func (s *ObjectStorage) SetEncodedObject(o plumbing.EncodedObject) (h plumbing.H
 		return plumbing.ZeroHash, err
 	}
 
-	if _, err = ioutil.Copy(ow, or); err != nil {
+	if _, err = ioutil.CopyBufferPool(ow, or); err != nil {
 		return plumbing.ZeroHash, err
 	}
 
@@ -454,7 +454,7 @@ func (s *ObjectStorage) getFromUnpacked(h plumbing.Hash) (obj plumbing.EncodedOb
 
 	defer ioutil.CheckClose(w, &err)
 
-	_, err = ioutil.Copy(w, r)
+	_, err = ioutil.CopyBufferPool(w, r)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -342,8 +342,6 @@ func (s *FsSuite) TestPackfileReindex() {
 }
 
 func (s *FsSuite) TestPackfileIterKeepDescriptors() {
-	s.T().Skip("packfileIter with keep descriptors is currently broken")
-
 	for _, f := range fixtures.ByTag(".git") {
 		fs := f.DotGit()
 		ops := dotgit.Options{KeepDescriptors: true}

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -39,7 +39,7 @@ func (s *FsSuite) TestGetFromObjectFile() {
 
 	expected := plumbing.NewHash("f3dfe29d268303fc6e1bbce268605fc99573406e")
 	obj, err := o.EncodedObject(plumbing.AnyObject, expected)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 }
 
@@ -50,7 +50,7 @@ func (s *FsSuite) TestGetFromPackfile() {
 
 		expected := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 		obj, err := o.EncodedObject(plumbing.AnyObject, expected)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equal(expected, obj.Hash())
 	}
 }
@@ -63,29 +63,29 @@ func (s *FsSuite) TestGetFromPackfileKeepDescriptors() {
 
 		expected := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 		obj, err := o.EncodedObject(plumbing.AnyObject, expected)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equal(expected, obj.Hash())
 
 		packfiles, err := dg.ObjectPacks()
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		pack1, err := dg.ObjectPack(packfiles[0])
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		pack1.Seek(42, io.SeekStart)
 
 		err = o.Close()
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		pack2, err := dg.ObjectPack(packfiles[0])
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		offset, err := pack2.Seek(0, io.SeekCurrent)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equal(int64(0), offset)
 
 		err = o.Close()
-		s.NoError(err)
+		s.Require().NoError(err)
 
 	}
 }
@@ -96,16 +96,16 @@ func (s *FsSuite) TestGetFromPackfileMaxOpenDescriptors() {
 
 	expected := plumbing.NewHash("8d45a34641d73851e01d3754320b33bb5be3c4d3")
 	obj, err := o.getFromPackfile(expected, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
 	expected = plumbing.NewHash("e9cfa4c9ca160546efd7e8582ec77952a27b17db")
 	obj, err = o.getFromPackfile(expected, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
 	err = o.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *FsSuite) TestGetFromPackfileMaxOpenDescriptorsLargeObjectThreshold() {
@@ -117,16 +117,16 @@ func (s *FsSuite) TestGetFromPackfileMaxOpenDescriptorsLargeObjectThreshold() {
 
 	expected := plumbing.NewHash("8d45a34641d73851e01d3754320b33bb5be3c4d3")
 	obj, err := o.getFromPackfile(expected, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
 	expected = plumbing.NewHash("e9cfa4c9ca160546efd7e8582ec77952a27b17db")
 	obj, err = o.getFromPackfile(expected, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
 	err = o.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *FsSuite) TestGetSizeOfObjectFile() {
@@ -136,7 +136,7 @@ func (s *FsSuite) TestGetSizeOfObjectFile() {
 	// Get the size of `tree_walker.go`.
 	expected := plumbing.NewHash("cbd81c47be12341eb1185b379d1c82675aeded6a")
 	size, err := o.EncodedObjectSize(expected)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(int64(2412), size)
 }
 
@@ -148,7 +148,7 @@ func (s *FsSuite) TestGetSizeFromPackfile() {
 		// Get the size of `binary.jpg`.
 		expected := plumbing.NewHash("d5c0f4ab811897cadf03aec358ae60d21f91c50d")
 		size, err := o.EncodedObjectSize(expected)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equal(int64(76110), size)
 	}
 }
@@ -160,11 +160,11 @@ func (s *FsSuite) TestGetSizeOfAllObjectFiles() {
 	// Get the size of `tree_walker.go`.
 	err := o.ForEachObjectHash(func(h plumbing.Hash) error {
 		size, err := o.EncodedObjectSize(h)
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.NotEqual(int64(0), size)
 		return nil
 	})
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *FsSuite) TestGetFromPackfileMultiplePackfiles() {
@@ -173,12 +173,12 @@ func (s *FsSuite) TestGetFromPackfileMultiplePackfiles() {
 
 	expected := plumbing.NewHash("8d45a34641d73851e01d3754320b33bb5be3c4d3")
 	obj, err := o.getFromPackfile(expected, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
 	expected = plumbing.NewHash("e9cfa4c9ca160546efd7e8582ec77952a27b17db")
 	obj, err = o.getFromPackfile(expected, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 }
 
@@ -188,12 +188,12 @@ func (s *FsSuite) TestGetFromPackfileMultiplePackfilesLargeObjectThreshold() {
 
 	expected := plumbing.NewHash("8d45a34641d73851e01d3754320b33bb5be3c4d3")
 	obj, err := o.getFromPackfile(expected, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
 	expected = plumbing.NewHash("e9cfa4c9ca160546efd7e8582ec77952a27b17db")
 	obj, err = o.getFromPackfile(expected, false)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 }
 
@@ -203,7 +203,7 @@ func (s *FsSuite) TestIter() {
 		o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 
 		iter, err := o.IterEncodedObjects(plumbing.AnyObject)
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		var count int32
 		err = iter.ForEach(func(o plumbing.EncodedObject) error {
@@ -211,7 +211,7 @@ func (s *FsSuite) TestIter() {
 			return nil
 		})
 
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equal(f.ObjectsCount, count)
 	}
 }
@@ -222,7 +222,7 @@ func (s *FsSuite) TestIterLargeObjectThreshold() {
 		o := NewObjectStorageWithOptions(dotgit.New(fs), cache.NewObjectLRUDefault(), Options{LargeObjectThreshold: 1})
 
 		iter, err := o.IterEncodedObjects(plumbing.AnyObject)
-		s.NoError(err)
+		s.Require().NoError(err)
 
 		var count int32
 		err = iter.ForEach(func(o plumbing.EncodedObject) error {
@@ -230,7 +230,7 @@ func (s *FsSuite) TestIterLargeObjectThreshold() {
 			return nil
 		})
 
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Equal(f.ObjectsCount, count)
 	}
 }
@@ -242,14 +242,14 @@ func (s *FsSuite) TestIterWithType() {
 			o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 
 			iter, err := o.IterEncodedObjects(t)
-			s.NoError(err)
+			s.Require().NoError(err)
 
 			err = iter.ForEach(func(o plumbing.EncodedObject) error {
 				s.Equal(t, o.Type())
 				return nil
 			})
 
-			s.NoError(err)
+			s.Require().NoError(err)
 		}
 
 	}
@@ -262,23 +262,23 @@ func (s *FsSuite) TestPackfileIter() {
 
 		for _, t := range objectTypes {
 			ph, err := dg.ObjectPacks()
-			s.NoError(err)
+			s.Require().NoError(err)
 
 			for _, h := range ph {
 				f, err := dg.ObjectPack(h)
-				s.NoError(err)
+				s.Require().NoError(err)
 
 				idxf, err := dg.ObjectPackIdx(h)
-				s.NoError(err)
+				s.Require().NoError(err)
 
 				iter, err := NewPackfileIter(fs, f, idxf, t, false, 0, crypto.SHA1.Size())
-				s.NoError(err)
+				s.Require().NoError(err)
 
 				err = iter.ForEach(func(o plumbing.EncodedObject) error {
 					s.Equal(t, o.Type())
 					return nil
 				})
-				s.NoError(err)
+				s.Require().NoError(err)
 			}
 		}
 	}
@@ -336,7 +336,7 @@ func (s *FsSuite) TestPackfileReindex() {
 
 		// Now check that the test object can be retrieved
 		_, err = storer.EncodedObject(plumbing.CommitObject, testObjectHash)
-		s.NoError(err)
+		s.Require().NoError(err)
 
 	}
 }
@@ -349,17 +349,17 @@ func (s *FsSuite) TestPackfileIterKeepDescriptors() {
 
 		for _, t := range objectTypes {
 			ph, err := dg.ObjectPacks()
-			s.NoError(err)
+			s.Require().NoError(err)
 
 			for _, h := range ph {
 				f, err := dg.ObjectPack(h)
-				s.NoError(err)
+				s.Require().NoError(err)
 
 				idxf, err := dg.ObjectPackIdx(h)
-				s.NoError(err)
+				s.Require().NoError(err)
 
 				iter, err := NewPackfileIter(fs, f, idxf, t, true, 0, crypto.SHA1.Size())
-				s.NoError(err)
+				s.Require().NoError(err)
 
 				if err != nil {
 					continue
@@ -369,14 +369,14 @@ func (s *FsSuite) TestPackfileIterKeepDescriptors() {
 					s.Equal(t, o.Type())
 					return nil
 				})
-				s.NoError(err)
+				s.Require().NoError(err)
 
 				// test twice to check that packfiles are not closed
 				err = iter.ForEach(func(o plumbing.EncodedObject) error {
 					s.Equal(t, o.Type())
 					return nil
 				})
-				s.NoError(err)
+				s.Require().NoError(err)
 			}
 		}
 	}
@@ -392,7 +392,7 @@ func (s *FsSuite) TestGetFromObjectFileSharedCache() {
 
 	expected := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
 	obj, err := o1.EncodedObject(plumbing.CommitObject, expected)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
 	_, err = o2.EncodedObject(plumbing.CommitObject, expected)
@@ -405,12 +405,12 @@ func (s *FsSuite) TestHashesWithPrefix() {
 	o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 	expected := plumbing.NewHash("f3dfe29d268303fc6e1bbce268605fc99573406e")
 	obj, err := o.EncodedObject(plumbing.AnyObject, expected)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
 	prefix, _ := hex.DecodeString("f3dfe2")
 	hashes, err := o.HashesWithPrefix(prefix)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(hashes, 1)
 	s.Equal("f3dfe29d268303fc6e1bbce268605fc99573406e", hashes[0].String())
 }
@@ -424,7 +424,7 @@ func (s *FsSuite) TestHashesWithPrefixFromPackfile() {
 		expected := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 		// Only pass the first 8 bytes
 		hashes, err := o.HashesWithPrefix(expected.Bytes()[:8])
-		s.NoError(err)
+		s.Require().NoError(err)
 		s.Len(hashes, 1)
 		s.Equal(expected, hashes[0])
 	}
@@ -564,7 +564,7 @@ func (s *FsSuite) TestGetFromUnpackedCachesObjects() {
 
 	// Load the object
 	obj, err := objectStorage.EncodedObject(plumbing.AnyObject, hash)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(hash, obj.Hash())
 
 	// The object should've been cached during the load
@@ -575,20 +575,20 @@ func (s *FsSuite) TestGetFromUnpackedCachesObjects() {
 	// Assert that both objects can be read and that they both produce the same bytes
 
 	objReader, err := obj.Reader()
-	s.NoError(err)
+	s.Require().NoError(err)
 	objBytes, err := io.ReadAll(objReader)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.NotEqual(0, len(objBytes))
 	err = objReader.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	cachedObjReader, err := cachedObj.Reader()
-	s.NoError(err)
+	s.Require().NoError(err)
 	cachedObjBytes, err := io.ReadAll(cachedObjReader)
 	s.NotEqual(0, len(cachedObjBytes))
-	s.NoError(err)
+	s.Require().NoError(err)
 	err = cachedObjReader.Close()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(objBytes, cachedObjBytes)
 }
@@ -605,7 +605,7 @@ func (s *FsSuite) TestGetFromUnpackedDoesNotCacheLargeObjects() {
 
 	// Load the object
 	obj, err := objectStorage.EncodedObject(plumbing.AnyObject, hash)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal(hash, obj.Hash())
 
 	// The object should not have been cached during the load

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -58,6 +58,7 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 	dirOps := dotgit.Options{
 		ExclusiveAccess: ops.ExclusiveAccess,
 		AlternatesFS:    ops.AlternatesFS,
+		KeepDescriptors: ops.KeepDescriptors,
 	}
 	dir := dotgit.NewWithOptions(fs, dirOps)
 

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -41,6 +41,10 @@ type Options struct {
 	// If none is provided, it falls back to using the underlying instance used for
 	// DotGit.
 	AlternatesFS billy.Filesystem
+	// HighMemoryMode defines whether the storage will operate in high-memory
+	// mode. This defaults to false. For more information refer to packfile's Parser
+	// WithHighMemoryMode option.
+	HighMemoryMode bool
 }
 
 // NewStorage returns a new Storage backed by a given `fs.Filesystem` and cache.
@@ -86,4 +90,8 @@ func (s *Storage) Init() error {
 
 func (s *Storage) AddAlternate(remote string) error {
 	return s.dir.AddAlternate(remote)
+}
+
+func (s *Storage) LowMemoryMode() bool {
+	return !s.options.HighMemoryMode
 }

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -2,8 +2,6 @@ package git
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
@@ -27,13 +25,7 @@ func TestSubmoduleSuite(t *testing.T) {
 func (s *SubmoduleSuite) SetupTest() {
 	url := s.GetLocalRepositoryURL(fixtures.ByTag("submodule").One())
 
-	dir, err := os.MkdirTemp("", "")
-	s.Require().NoError(err)
-
-	r, err := PlainClone(filepath.Join(dir, "worktree"), &CloneOptions{
-		URL: url,
-	})
-
+	r, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
 
 	s.Repository = r

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
@@ -25,7 +27,13 @@ func TestSubmoduleSuite(t *testing.T) {
 func (s *SubmoduleSuite) SetupTest() {
 	url := s.GetLocalRepositoryURL(fixtures.ByTag("submodule").One())
 
-	r, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
+	dir, err := os.MkdirTemp("", "")
+	s.Require().NoError(err)
+
+	r, err := PlainClone(filepath.Join(dir, "worktree"), &CloneOptions{
+		URL: url,
+	})
+
 	s.Require().NoError(err)
 
 	s.Repository = r
@@ -35,22 +43,22 @@ func (s *SubmoduleSuite) SetupTest() {
 
 func (s *SubmoduleSuite) TestInit() {
 	sm, err := s.Worktree.Submodule("basic")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.False(sm.initialized)
 	err = sm.Init()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.True(sm.initialized)
 
 	cfg, err := s.Repository.Config()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Len(cfg.Submodules, 1)
 	s.NotNil(cfg.Submodules["basic"])
 
 	status, err := sm.Status()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.False(status.IsClean())
 }
 
@@ -60,29 +68,29 @@ func (s *SubmoduleSuite) TestUpdate() {
 	}
 
 	sm, err := s.Worktree.Submodule("basic")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = sm.Update(&SubmoduleUpdateOptions{
 		Init: true,
 	})
 
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	r, err := sm.Repository()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ref, err := r.Reference(plumbing.HEAD, true)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", ref.Hash().String())
 
 	status, err := sm.Status()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.True(status.IsClean())
 }
 
 func (s *SubmoduleSuite) TestRepositoryWithoutInit() {
 	sm, err := s.Worktree.Submodule("basic")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	r, err := sm.Repository()
 	s.ErrorIs(err, ErrSubmoduleNotInitialized)
@@ -91,7 +99,7 @@ func (s *SubmoduleSuite) TestRepositoryWithoutInit() {
 
 func (s *SubmoduleSuite) TestUpdateWithoutInit() {
 	sm, err := s.Worktree.Submodule("basic")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = sm.Update(&SubmoduleUpdateOptions{})
 	s.ErrorIs(err, ErrSubmoduleNotInitialized)
@@ -99,7 +107,7 @@ func (s *SubmoduleSuite) TestUpdateWithoutInit() {
 
 func (s *SubmoduleSuite) TestUpdateWithNotFetch() {
 	sm, err := s.Worktree.Submodule("basic")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = sm.Update(&SubmoduleUpdateOptions{
 		Init:    true,
@@ -116,18 +124,18 @@ func (s *SubmoduleSuite) TestUpdateWithRecursion() {
 	}
 
 	sm, err := s.Worktree.Submodule("itself")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = sm.Update(&SubmoduleUpdateOptions{
 		Init:              true,
 		RecurseSubmodules: 2,
 	})
 
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	fs := s.Worktree.Filesystem
 	_, err = fs.Stat(fs.Join("itself", "basic", "LICENSE"))
-	s.NoError(err)
+	s.Require().NoError(err)
 }
 
 func (s *SubmoduleSuite) TestUpdateWithInitAndUpdate() {
@@ -136,15 +144,15 @@ func (s *SubmoduleSuite) TestUpdateWithInitAndUpdate() {
 	}
 
 	sm, err := s.Worktree.Submodule("basic")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = sm.Update(&SubmoduleUpdateOptions{
 		Init: true,
 	})
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	idx, err := s.Repository.Storer.Index()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	for i, e := range idx.Entries {
 		if e.Name == "basic" {
@@ -155,29 +163,28 @@ func (s *SubmoduleSuite) TestUpdateWithInitAndUpdate() {
 	}
 
 	err = s.Repository.Storer.SetIndex(idx)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = sm.Update(&SubmoduleUpdateOptions{})
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	r, err := sm.Repository()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ref, err := r.Reference(plumbing.HEAD, true)
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Equal("b029517f6300c2da0f4b651b8642506cd6aaf45d", ref.Hash().String())
-
 }
 
 func (s *SubmoduleSuite) TestSubmodulesInit() {
 	sm, err := s.Worktree.Submodules()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = sm.Init()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	sm, err = s.Worktree.Submodules()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	for _, m := range sm {
 		s.True(m.initialized)
@@ -186,14 +193,14 @@ func (s *SubmoduleSuite) TestSubmodulesInit() {
 
 func (s *SubmoduleSuite) TestGitSubmodulesSymlink() {
 	f, err := s.Worktree.Filesystem.Create("badfile")
-	s.NoError(err)
-	defer func() { _ = f.Close() }()
+	s.Require().NoError(err)
+	s.Require().NoError(f.Close())
 
 	err = s.Worktree.Filesystem.Remove(gitmodulesFile)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = s.Worktree.Filesystem.Symlink("badfile", gitmodulesFile)
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	_, err = s.Worktree.Submodules()
 	s.ErrorIs(err, ErrGitModulesSymlink)
@@ -201,10 +208,10 @@ func (s *SubmoduleSuite) TestGitSubmodulesSymlink() {
 
 func (s *SubmoduleSuite) TestSubmodulesStatus() {
 	sm, err := s.Worktree.Submodules()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	status, err := sm.Status()
-	s.NoError(err)
+	s.Require().NoError(err)
 	s.Len(status, 2)
 }
 
@@ -214,7 +221,7 @@ func (s *SubmoduleSuite) TestSubmodulesUpdateContext() {
 	}
 
 	sm, err := s.Worktree.Submodules()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -229,25 +236,25 @@ func (s *SubmoduleSuite) TestSubmodulesFetchDepth() {
 	}
 
 	sm, err := s.Worktree.Submodule("basic")
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	err = sm.Update(&SubmoduleUpdateOptions{
 		Init:  true,
 		Depth: 1,
 	})
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	r, err := sm.Repository()
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	lr, err := r.Log(&LogOptions{})
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	commitCount := 0
 	for _, err := lr.Next(); err == nil; _, err = lr.Next() {
 		commitCount++
 	}
-	s.NoError(err)
+	s.Require().NoError(err)
 
 	s.Equal(1, commitCount)
 }
@@ -272,5 +279,5 @@ func (s *SubmoduleSuite) TestSubmoduleParseScp() {
 	}
 
 	_, err := submodule.Repository()
-	s.NoError(err)
+	s.Require().NoError(err)
 }

--- a/utils/ioutil/sync.go
+++ b/utils/ioutil/sync.go
@@ -11,9 +11,8 @@ import (
 // of a new buffer per call.
 func Copy(dst io.Writer, src io.Reader) (n int64, err error) {
 	buf := sync.GetByteSlice()
-	defer sync.PutByteSlice(buf)
-
 	n, err = io.CopyBuffer(dst, src, *buf)
+	sync.PutByteSlice(buf)
 
 	return
 }

--- a/utils/ioutil/sync.go
+++ b/utils/ioutil/sync.go
@@ -11,8 +11,9 @@ import (
 // of a new buffer per call.
 func Copy(dst io.Writer, src io.Reader) (n int64, err error) {
 	buf := sync.GetByteSlice()
+	defer sync.PutByteSlice(buf)
+
 	n, err = io.CopyBuffer(dst, src, *buf)
-	sync.PutByteSlice(buf, int(n))
 
 	return
 }

--- a/utils/ioutil/sync.go
+++ b/utils/ioutil/sync.go
@@ -1,0 +1,18 @@
+package ioutil
+
+import (
+	"io"
+
+	"github.com/go-git/go-git/v6/utils/sync"
+)
+
+// Copy calls io.CopyBuffer and uses a buffer from sync.GetByteSlice,
+// to reduce the complexity when using it while avoiding the allocation
+// of a new buffer per call.
+func Copy(dst io.Writer, src io.Reader) (n int64, err error) {
+	buf := sync.GetByteSlice()
+	n, err = io.CopyBuffer(dst, src, *buf)
+	sync.PutByteSlice(buf, int(n))
+
+	return
+}

--- a/utils/ioutil/sync.go
+++ b/utils/ioutil/sync.go
@@ -6,10 +6,10 @@ import (
 	"github.com/go-git/go-git/v6/utils/sync"
 )
 
-// Copy calls io.CopyBuffer and uses a buffer from sync.GetByteSlice,
+// CopyBufferPool calls io.CopyBuffer and uses a buffer from sync.GetByteSlice,
 // to reduce the complexity when using it while avoiding the allocation
 // of a new buffer per call.
-func Copy(dst io.Writer, src io.Reader) (n int64, err error) {
+func CopyBufferPool(dst io.Writer, src io.Reader) (n int64, err error) {
 	buf := sync.GetByteSlice()
 	n, err = io.CopyBuffer(dst, src, *buf)
 	sync.PutByteSlice(buf)

--- a/utils/sync/bytes.go
+++ b/utils/sync/bytes.go
@@ -6,9 +6,11 @@ import (
 )
 
 var (
+	size = 32 * 1024
+
 	byteSlice = sync.Pool{
 		New: func() interface{} {
-			b := make([]byte, 16*1024)
+			b := make([]byte, size)
 			return &b
 		},
 	}
@@ -20,32 +22,32 @@ var (
 )
 
 // GetByteSlice returns a *[]byte that is managed by a sync.Pool.
-// The initial slice length will be 16384 (16kb).
+// The initial slice length will be 32768 (32kb).
 //
 // After use, the *[]byte should be put back into the sync.Pool
 // by calling PutByteSlice.
 func GetByteSlice() *[]byte {
 	buf := byteSlice.Get().(*[]byte)
-	return buf
+	b := *buf
+	if len(b) < size {
+		b = append(b[:cap(b)])
+	}
+
+	// zero out the array contents.
+	for i := 0; i < len(b); i++ {
+		b[i] = 0
+	}
+
+	return &b
 }
 
 // PutByteSlice puts buf back into its sync.Pool.
-func PutByteSlice(buf *[]byte, used int) {
+func PutByteSlice(buf *[]byte) {
 	if buf == nil {
 		return
 	}
 
-	b := *buf
-	if used <= 0 {
-		used = cap(b)
-	}
-
-	n := min(int(used), cap(b))
-	for i := 0; i < n; i++ {
-		b[i] = 0
-	}
-
-	byteSlice.Put(&b)
+	byteSlice.Put(buf)
 }
 
 // GetBytesBuffer returns a *bytes.Buffer that is managed by a sync.Pool.

--- a/utils/sync/bytes.go
+++ b/utils/sync/bytes.go
@@ -30,8 +30,22 @@ func GetByteSlice() *[]byte {
 }
 
 // PutByteSlice puts buf back into its sync.Pool.
-func PutByteSlice(buf *[]byte) {
-	byteSlice.Put(buf)
+func PutByteSlice(buf *[]byte, used int) {
+	if buf == nil {
+		return
+	}
+
+	b := *buf
+	if used <= 0 {
+		used = cap(b)
+	}
+
+	n := min(int(used), cap(b))
+	for i := 0; i < n; i++ {
+		b[i] = 0
+	}
+
+	byteSlice.Put(&b)
 }
 
 // GetBytesBuffer returns a *bytes.Buffer that is managed by a sync.Pool.
@@ -47,5 +61,8 @@ func GetBytesBuffer() *bytes.Buffer {
 
 // PutBytesBuffer puts buf back into its sync.Pool.
 func PutBytesBuffer(buf *bytes.Buffer) {
+	if buf == nil {
+		return
+	}
 	bytesBuffer.Put(buf)
 }

--- a/utils/sync/bytes.go
+++ b/utils/sync/bytes.go
@@ -30,7 +30,7 @@ func GetByteSlice() *[]byte {
 	buf := byteSlice.Get().(*[]byte)
 	b := *buf
 	if len(b) < size {
-		b = append(b[:cap(b)])
+		b = b[:cap(b)]
 	}
 
 	// zero out the array contents.

--- a/utils/sync/bytes_test.go
+++ b/utils/sync/bytes_test.go
@@ -40,7 +40,7 @@ func TestGetAndPutByteSlice(t *testing.T) {
 	}
 
 	newByteSlice := make([]byte, wanted*2)
-	PutByteSlice(&newByteSlice)
+	PutByteSlice(&newByteSlice, 0)
 
 	newSlice := GetByteSlice()
 	if len(*newSlice) != len(newByteSlice) {

--- a/utils/sync/zlib.go
+++ b/utils/sync/zlib.go
@@ -66,7 +66,7 @@ func GetZlibReader(r io.Reader) (ZLibReader, error) {
 // The Byte slice dictionary is also put back into its sync.Pool.
 func PutZlibReader(z ZLibReader) {
 	z.Reader.Close()
-	PutByteSlice(z.dict, 0)
+	PutByteSlice(z.dict)
 	zlibReader.Put(z)
 }
 

--- a/utils/sync/zlib.go
+++ b/utils/sync/zlib.go
@@ -66,7 +66,7 @@ func GetZlibReader(r io.Reader) (ZLibReader, error) {
 // The Byte slice dictionary is also put back into its sync.Pool.
 func PutZlibReader(z ZLibReader) {
 	z.Reader.Close()
-	PutByteSlice(z.dict)
+	PutByteSlice(z.dict, 0)
 	zlibReader.Put(z)
 }
 

--- a/utils/sync/zlib_test.go
+++ b/utils/sync/zlib_test.go
@@ -26,10 +26,6 @@ func TestGetAndPutZlibReader(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if dict != z2.dict {
-		t.Errorf("zlib dictionary was not reused")
-	}
-
 	if &reader != z2.Reader {
 		t.Errorf("zlib reader was not reused")
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -787,7 +787,7 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 	}
 
 	defer ioutil.CheckClose(to, &err)
-	_, err = ioutil.Copy(to, from)
+	_, err = ioutil.CopyBufferPool(to, from)
 	return
 }
 

--- a/worktree.go
+++ b/worktree.go
@@ -789,8 +789,8 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 
 	defer ioutil.CheckClose(to, &err)
 	buf := sync.GetByteSlice()
-	_, err = io.CopyBuffer(to, from, *buf)
-	sync.PutByteSlice(buf)
+	n, err := io.CopyBuffer(to, from, *buf)
+	sync.PutByteSlice(buf, int(n))
 	return
 }
 

--- a/worktree.go
+++ b/worktree.go
@@ -786,6 +786,7 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 		return
 	}
 
+	defer ioutil.CheckClose(to, &err)
 	_, err = ioutil.Copy(to, from)
 	return
 }

--- a/worktree.go
+++ b/worktree.go
@@ -789,8 +789,8 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 
 	defer ioutil.CheckClose(to, &err)
 	buf := sync.GetByteSlice()
-	n, err := io.CopyBuffer(to, from, *buf)
-	sync.PutByteSlice(buf, int(n))
+	_, err = io.CopyBuffer(to, from, *buf)
+	sync.PutByteSlice(buf)
 	return
 }
 

--- a/worktree.go
+++ b/worktree.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 	"github.com/go-git/go-git/v6/utils/merkletrie"
-	"github.com/go-git/go-git/v6/utils/sync"
 	"github.com/go-git/go-git/v6/utils/trace"
 )
 
@@ -787,10 +786,7 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 		return
 	}
 
-	defer ioutil.CheckClose(to, &err)
-	buf := sync.GetByteSlice()
-	_, err = io.CopyBuffer(to, from, *buf)
-	sync.PutByteSlice(buf)
+	_, err = ioutil.Copy(to, from)
 	return
 }
 

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -514,7 +514,7 @@ func (w *Worktree) fillEncodedObjectFromFile(dst io.Writer, path string, _ os.Fi
 
 	defer ioutil.CheckClose(src, &err)
 
-	if _, err := ioutil.Copy(dst, src); err != nil {
+	if _, err := ioutil.CopyBufferPool(dst, src); err != nil {
 		return err
 	}
 

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -514,7 +514,7 @@ func (w *Worktree) fillEncodedObjectFromFile(dst io.Writer, path string, _ os.Fi
 
 	defer ioutil.CheckClose(src, &err)
 
-	if _, err := io.Copy(dst, src); err != nil {
+	if _, err := ioutil.Copy(dst, src); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The memory churn for processing delta objects was quite high, due to the performance optimisation which kept in memory all the inflated contents for each object.

The changes introduced allows for supporting storage implementations (i.e. `storage/filesystem`) to only keep in memory the contents of the parents needed to resolve the contents of the delta being processed. The buffers used for all the contents are reused to avoid unnecessary churn.

Users can opt-out by using `WithHighMemoryUsage()` when creating the Parser, or `HighMemoryMode` in the storage option. 

A new `ioutil.Copy` was introduced to simplify the process of reusing buffers during Copy operations.

Fixes https://github.com/go-git/go-git/issues/1188 https://github.com/go-git/go-git/issues/1331.

---
Benchmarks comparing this PR against the [current](https://github.com/go-git/go-git/commit/5d6af409877bf81b28775aef461d5d2738c9c309) `main` branch using BenchmarkPlainClone against the `kubernetes/kubernetes` repository.

#### Filesystem storage (1.4GB less memory churn)
![image](https://github.com/user-attachments/assets/6dbe52d4-2b65-4702-88bf-8955de2d624e)
![image](https://github.com/user-attachments/assets/335b5051-223b-49c5-a2f7-a4d43c8fd595)


#### Memory storage (1GB less memory churn)
![image](https://github.com/user-attachments/assets/01cc400f-5c10-46a9-801b-33ac2d7d48ae)
![image](https://github.com/user-attachments/assets/74ab2645-9619-48a3-94ab-b297d522c078)

#### Reduced GC pressure
The decreased memory churn results in reduced GC pressure:
![image](https://github.com/user-attachments/assets/1930ce7a-97ff-4b26-ab47-647cd2eb1975)

---
Running the benchmark against `torvalds/linux` with `high` or `low` memory usage, compared with the [current version](https://github.com/go-git/go-git/commit/5d6af409877bf81b28775aef461d5d2738c9c309) in `main`:
```
BenchmarkPlainClone/high-memory-16                 1	21255659542 ns/op	1418664608 B/op	 2227027 allocs/op
BenchmarkPlainClone/low-memory-16          	   1	22576359873 ns/op	1402975104 B/op	 2167243 allocs/op
BenchmarkPlainClone/main-16    	                   1	22154340340 ns/op	4962471016 B/op	 2483031 allocs/op
```

Note that even the version with High memory usage yield over 250k less allocations than the previous version. The difference in memory churn aligns with what the pprof information above (although this is for a different repo). 