### PR TITLE
git: checkout.validate should set to branch only if both branch and hash are empty

### DIFF
--- a/options.go
+++ b/options.go
@@ -349,6 +349,7 @@ type SubmoduleUpdateOptions struct {
 var (
 	ErrBranchHashExclusive  = errors.New("Branch and Hash are mutually exclusive")
 	ErrCreateRequiresBranch = errors.New("Branch is mandatory when Create is used")
+	ErrForceKeepExclusive   = errors.New("Force and branch are mutually exclusive")
 )
 
 // CheckoutOptions describes how a checkout operation should be performed.
@@ -375,16 +376,23 @@ type CheckoutOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *CheckoutOptions) Validate() error {
+	// if not create, both hash and branch cannot be provided
 	if !o.Create && !o.Hash.IsZero() && o.Branch != "" {
 		return ErrBranchHashExclusive
 	}
 
-	if o.Create && o.Branch == "" {
+	// if create with branch not provided but hash is provided, ask for branch name?
+	if o.Create && o.Branch == "" && !o.Hash.IsZero() {
 		return ErrCreateRequiresBranch
 	}
 
-	if o.Branch == "" {
+	// if create with both branch and hash are not provided, set branch to master
+	if o.Create && o.Branch == "" && o.Hash.IsZero() {
 		o.Branch = plumbing.Master
+	}
+
+	if o.Force && o.Keep {
+		return ErrForceKeepExclusive
 	}
 
 	return nil

--- a/options_test.go
+++ b/options_test.go
@@ -120,6 +120,31 @@ func (s *OptionsSuite) writeGlobalConfig(cfg *config.Config) func() {
 
 	return func() {
 		os.Setenv("XDG_CONFIG_HOME", "")
-
 	}
+}
+
+func (s *OptionsSuite) TestCheckoutOptionsValidate() {
+	checkoutOpts := CheckoutOptions{}
+	err := checkoutOpts.Validate()
+	s.NotNil(err)
+	s.Equal(ErrBranchHashExclusive, err)
+
+	checkoutOpts.Create = true
+	err = checkoutOpts.Validate()
+	s.Nil(err)
+	s.Equal(plumbing.Master, checkoutOpts.Branch)
+
+	checkoutOpts.Branch = ""
+	checkoutOpts.Hash = plumbing.NewHash("ab1b15c6f6487b4db16f10d8ec69bb8bf91dcabd")
+	err = checkoutOpts.Validate()
+	s.NotNil(err)
+	s.Equal(ErrCreateRequiresBranch, err)
+
+	checkoutOpts.Branch = "test"
+	checkoutOpts.Force = true
+	checkoutOpts.Keep = true
+
+	err = checkoutOpts.Validate()
+	s.NotNil(err)
+	s.Equal(ErrForceKeepExclusive, err)
 }


### PR DESCRIPTION
add validation usecase for Force and keep.

This would avoid the error condition where if Hash is provided on CheckoutOptions but NOT branch and validate is called since per documentation:

// Branch to be checked out, if Branch and Hash are empty is set to master.
Branch plumbing.ReferenceName