### PR TITLE
Add sparse reset directory validation and remove ResetSparsely.

### DIFF
--- a/options.go
+++ b/options.go
@@ -425,6 +425,13 @@ type ResetOptions struct {
 	// Files, if not empty will constrain the reseting the index to only files
 	// specified in this list.
 	Files []string
+
+	// SparseDirs specifies which directories should be checked out.
+	// Directories not listed here will not appear in the worktree.
+	SparseDirs []string
+
+	// SkipSparseDirValidation will skip the validation for SparseDirs.
+	SkipSparseDirValidation bool
 }
 
 // Validate validates the fields and sets the default values.

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1366,6 +1366,41 @@ func (s *WorktreeSuite) TestResetSparsely() {
 	s.Equal("crappy.php", files[0].Name())
 }
 
+func (s *WorktreeSuite) TestResetSparselyInvalidDir() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	tests := []struct {
+		name    string
+		opts    ResetOptions
+		dirs    []string
+		wantErr bool
+	}{
+		{
+			name:    "non existent directory",
+			opts:    ResetOptions{},
+			dirs:    []string{"non-existent"},
+			wantErr: true,
+		},
+		{
+			name:    "exists but is not directory",
+			opts:    ResetOptions{},
+			dirs:    []string{"php/crappy.php"},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			err := w.ResetSparsely(&test.opts, test.dirs)
+			s.Require().ErrorIs(err, ErrSparseResetDirectoryNotFound)
+		})
+	}
+}
+
 func (s *WorktreeSuite) TestStatusAfterCheckout() {
 	fs := memfs.New()
 	w := &Worktree{

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -3167,6 +3167,50 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 	}
 }
 
+func TestTreeContainsDirs(t *testing.T) {
+	tree := &object.Tree{
+		Entries: []object.TreeEntry{
+			{Name: "foo", Mode: filemode.Dir},
+			{Name: "bar", Mode: filemode.Dir},
+			{Name: "baz", Mode: filemode.Dir},
+			{Name: "this-is-regular", Mode: filemode.Regular},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		dirs     []string
+		expected bool
+	}{
+		{
+			name:     "example",
+			dirs:     []string{"foo", "baz"},
+			expected: true,
+		},
+		{
+			name:     "empty directories",
+			dirs:     []string{},
+			expected: false,
+		},
+		{
+			name:     "non existent directory",
+			dirs:     []string{"foobarbaz"},
+			expected: false,
+		},
+		{
+			name:     "exists but is not directory",
+			dirs:     []string{"this-is-regular"},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, treeContainsDirs(tree, test.dirs))
+		})
+	}
+}
+
 func TestValidPath(t *testing.T) {
 	type testcase struct {
 		path    string


### PR DESCRIPTION
Fixes #1500 

1. Added a validation to check if directory exists in the commit tree.
2. Removed `ResetSparsely` and moved `dirs` into `ResetOptions`.
3. Added a flag to disable validation. See [this comment](https://github.com/go-git/go-git/issues/1500#issuecomment-2817634195).
