### PR TITLE
plumbing: transport, Expose test suites in transport/file.

### DIFF
--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -211,9 +211,6 @@ func (s *ReceivePackSuite) TestSendPackOnNonEmptyWithReportStatusWithError() {
 	req.Commands = []*packp.Command{
 		{Name: "refs/heads/master", Old: plumbing.ZeroHash, New: plumbing.NewHash(fixture.Head)},
 	}
-	// req.Capabilities.Set(capability.ReportStatus)
-
-	// report, err := s.receivePackNoCheck(endpoint, req, fixture, full)
 	err := s.receivePackNoCheck(endpoint, req, fixture, full)
 	// XXX: Recent git versions return "failed to update ref", while older
 	//     (>=1.9) return "failed to lock".

--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -267,11 +267,21 @@ func (s *ReceivePackSuite) receivePackNoCheck(ep *transport.Endpoint,
 		s.Require().NotNil(info, comment)
 	}
 
-	if fixture != nil {
-		s.Require().NotNil(fixture.Packfile())
-		req.Packfile = fixture.Packfile()
-	} else {
-		req.Packfile = s.emptyPackfile()
+	var needPackfile bool
+	for _, cmd := range req.Commands {
+		if cmd.Action() != packp.Delete {
+			needPackfile = true
+			break
+		}
+	}
+
+	if needPackfile {
+		if fixture != nil {
+			s.Require().NotNil(fixture.Packfile())
+			req.Packfile = fixture.Packfile()
+		} else {
+			req.Packfile = s.emptyPackfile()
+		}
 	}
 
 	return conn.Push(ctx, req)
@@ -363,9 +373,6 @@ func (s *ReceivePackSuite) testSendPackAddReference() {
 			{Name: "refs/heads/newbranch", Old: plumbing.ZeroHash, New: plumbing.NewHash(fixture.Head)},
 		},
 	}
-	// if refs.Capabilities.Supports(capability.ReportStatus) {
-	// 	req.Capabilities.Set(capability.ReportStatus)
-	// }
 
 	s.receivePack(s.Endpoint, req, fixture, false)
 	s.checkRemoteReference(s.Endpoint, "refs/heads/newbranch", plumbing.NewHash(fixture.Head))
@@ -393,9 +400,6 @@ func (s *ReceivePackSuite) testSendPackDeleteReference() {
 			{Name: "refs/heads/newbranch", Old: plumbing.NewHash(fixture.Head), New: plumbing.ZeroHash},
 		},
 	}
-	// if refs.Capabilities.Supports(capability.ReportStatus) {
-	// 	req.Capabilities.Set(capability.ReportStatus)
-	// }
 
 	if !caps.Supports(capability.DeleteRefs) {
 		s.Fail("capability delete-refs not supported")

--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -367,7 +367,7 @@ func (s *ReceivePackSuite) testSendPackAddReference() {
 	// 	req.Capabilities.Set(capability.ReportStatus)
 	// }
 
-	s.receivePack(s.Endpoint, req, nil, false)
+	s.receivePack(s.Endpoint, req, fixture, false)
 	s.checkRemoteReference(s.Endpoint, "refs/heads/newbranch", plumbing.NewHash(fixture.Head))
 }
 
@@ -401,7 +401,7 @@ func (s *ReceivePackSuite) testSendPackDeleteReference() {
 		s.Fail("capability delete-refs not supported")
 	}
 
-	s.receivePack(s.Endpoint, req, nil, false)
+	s.receivePack(s.Endpoint, req, fixture, false)
 	s.checkRemoteReference(s.Endpoint, "refs/heads/newbranch", plumbing.ZeroHash)
 }
 

--- a/plumbing/protocol/packp/capability/capability.go
+++ b/plumbing/protocol/packp/capability/capability.go
@@ -195,6 +195,13 @@ const (
 	// successful, it will send back an error message.  See pack-protocol.txt
 	// for example messages.
 	ReportStatus Capability = "report-status"
+	// ReportStatusV2 extends capability report-status by adding new "option"
+	// directives in order to support reference rewritten by the "proc-receive"
+	// hook. The "proc-receive" hook may handle a command for a
+	// pseudo-reference which may create or update a reference with different
+	// name, new-oid, and old-oid. While the capability report-status cannot
+	// report for such case. See gitprotocol-pack[5] for details.
+	ReportStatusV2 Capability = "report-status-v2"
 	// DeleteRefs If the server sends back this capability, it means that
 	// it is capable of accepting a zero-id value as the target
 	// value of a reference update.  It is not sent back by the client, it

--- a/plumbing/transport/build_update_requests_test.go
+++ b/plumbing/transport/build_update_requests_test.go
@@ -75,8 +75,8 @@ func TestBuildUpdateRequestsWithProgress(t *testing.T) {
 
 	upreq := buildUpdateRequests(caps, req)
 
-	// Verify Sideband64k capability is set
-	assert.True(t, upreq.Capabilities.Supports(capability.Sideband64k))
+	// Verify Sideband64k capability is not set
+	assert.False(t, upreq.Capabilities.Supports(capability.Sideband64k))
 	assert.False(t, upreq.Capabilities.Supports(capability.Sideband))
 	assert.False(t, upreq.Capabilities.Supports(capability.NoProgress))
 }
@@ -99,9 +99,9 @@ func TestBuildUpdateRequestsWithProgressFallback(t *testing.T) {
 
 	upreq := buildUpdateRequests(caps, req)
 
-	// Verify Sideband capability is set but not Sideband64k
+	// Verify Sideband capability is not set but not Sideband64k
 	assert.False(t, upreq.Capabilities.Supports(capability.Sideband64k))
-	assert.True(t, upreq.Capabilities.Supports(capability.Sideband))
+	assert.False(t, upreq.Capabilities.Supports(capability.Sideband))
 	assert.False(t, upreq.Capabilities.Supports(capability.NoProgress))
 }
 
@@ -122,8 +122,8 @@ func TestBuildUpdateRequestsWithNoProgress(t *testing.T) {
 
 	upreq := buildUpdateRequests(caps, req)
 
-	// Verify NoProgress capability is set
-	assert.True(t, upreq.Capabilities.Supports(capability.NoProgress))
+	// Verify NoProgress capability is not set
+	assert.False(t, upreq.Capabilities.Supports(capability.NoProgress))
 }
 
 func TestBuildUpdateRequestsWithAtomic(t *testing.T) {
@@ -184,12 +184,8 @@ func TestBuildUpdateRequestsWithAgent(t *testing.T) {
 
 	upreq := buildUpdateRequests(caps, req)
 
-	// Verify Agent capability is set
-	assert.True(t, upreq.Capabilities.Supports(capability.Agent))
-
-	// Verify agent value is set to default agent
-	val := upreq.Capabilities.Get(capability.Agent)
-	assert.Equal(t, []string{capability.DefaultAgent()}, val)
+	// Verify Agent capability is not set
+	assert.False(t, upreq.Capabilities.Supports(capability.Agent))
 }
 
 // mockWriter is a simple io.Writer implementation for testing

--- a/plumbing/transport/file/client_test.go
+++ b/plumbing/transport/file/client_test.go
@@ -2,16 +2,12 @@ package file
 
 import (
 	"context"
-	"io"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -52,28 +48,4 @@ func (s *ClientSuite) TestCommand() {
 	// Make sure we get an error for one that doesn't exist.
 	_, err = runner.Command(context.TODO(), "git-fake-command", ep, emptyAuth)
 	s.NotNil(err)
-}
-
-const bareConfig = `[core]
-repositoryformatversion = 0
-filemode = true
-bare = true`
-
-func prepareRepo(t *testing.T, path string) *transport.Endpoint {
-	ep, err := transport.NewEndpoint(path)
-	assert.Nil(t, err)
-
-	// git-receive-pack refuses to update refs/heads/master on non-bare repo
-	// so we ensure bare repo config.
-	config := filepath.Join(path, "config")
-	if _, err := os.Stat(config); err == nil {
-		f, err := os.OpenFile(config, os.O_TRUNC|os.O_WRONLY, 0)
-		assert.Nil(t, err)
-		content := strings.NewReader(bareConfig)
-		_, err = io.Copy(f, content)
-		assert.Nil(t, err)
-		assert.Nil(t, f.Close())
-	}
-
-	return ep
 }

--- a/plumbing/transport/file/upload_pack_test.go
+++ b/plumbing/transport/file/upload_pack_test.go
@@ -2,10 +2,14 @@ package file
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/stretchr/testify/suite"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
@@ -16,34 +20,34 @@ func TestUploadPackSuite(t *testing.T) {
 }
 
 type UploadPackSuite struct {
-	suite.Suite
-	ups test.UploadPackSuite
+	test.UploadPackSuite
 }
 
 func (s *UploadPackSuite) SetupSuite() {
-	s.ups.SetS(s)
-	s.ups.Client = DefaultTransport
+	s.Client = DefaultTransport
+}
 
-	fixture := fixtures.Basic().One()
-	path := fixture.DotGit().Root()
-	ep, err := transport.NewEndpoint(path)
-	s.Nil(err)
-	s.ups.Endpoint = ep
+func (s *UploadPackSuite) SetupTest() {
+	base := filepath.Join(s.T().TempDir(), "go-git-file")
 
-	fixture = fixtures.ByTag("empty").One()
-	path = fixture.DotGit().Root()
-	ep, err = transport.NewEndpoint(path)
-	s.Nil(err)
-	s.ups.EmptyEndpoint = ep
+	basic := test.PrepareRepository(s.T(), fixtures.Basic().One(), base, "basic.git")
+	empty := test.PrepareRepository(s.T(), fixtures.ByTag("empty").One(), base, "empty.git")
 
-	ep, err = transport.NewEndpoint("non-existent")
-	s.Nil(err)
-	s.ups.NonExistentEndpoint = ep
+	var err error
+	s.Endpoint, err = transport.NewEndpoint(basic.Root())
+	s.Require().NoError(err)
+	s.Storer = filesystem.NewStorage(basic, cache.NewObjectLRUDefault())
+
+	s.EmptyEndpoint, _ = transport.NewEndpoint(empty.Root())
+	s.EmptyStorer = filesystem.NewStorage(empty, cache.NewObjectLRUDefault())
+
+	s.NonExistentEndpoint, _ = transport.NewEndpoint("/non-existent")
+	s.NonExistentStorer = memory.NewStorage()
 }
 
 func (s *UploadPackSuite) TestNonExistentCommand() {
 	client := DefaultTransport
-	session, err := client.NewSession(s.ups.Storer, s.ups.Endpoint, s.ups.EmptyAuth)
+	session, err := client.NewSession(s.Storer, s.Endpoint, s.EmptyAuth)
 	s.NoError(err)
 	conn, err := session.Handshake(context.TODO(), transport.Service("git-fake-command"))
 	s.ErrorContains(err, "unsupported")

--- a/plumbing/transport/push.go
+++ b/plumbing/transport/push.go
@@ -25,15 +25,21 @@ func buildUpdateRequests(caps *capability.List, req *PushRequest) *packp.UpdateR
 	// ofs-delta, atomic and push-options.
 	for _, cap := range []capability.Capability{
 		capability.ReportStatus,
-		capability.ReportStatusV2,
+		// TODO: support report-status-v2
+		// capability.ReportStatusV2,
 		capability.DeleteRefs,
 		capability.OFSDelta,
-		capability.Atomic,
-		// capability.PushOptions, // This is set later if options are present.
+
+		// This is set later if options are present.
+		// capability.PushOptions,
 	} {
 		if caps.Supports(cap) {
 			upreq.Capabilities.Set(cap) //nolint:errcheck
 		}
+	}
+
+	if req.Atomic && caps.Supports(capability.Atomic) {
+		upreq.Capabilities.Set(capability.Atomic) //nolint:errcheck
 	}
 
 	upreq.Commands = req.Commands

--- a/plumbing/transport/push.go
+++ b/plumbing/transport/push.go
@@ -17,24 +17,23 @@ import (
 func buildUpdateRequests(caps *capability.List, req *PushRequest) *packp.UpdateRequests {
 	upreq := packp.NewUpdateRequests()
 
-	// Prepare the request and capabilities
-	if caps.Supports(capability.Agent) {
-		upreq.Capabilities.Set(capability.Agent, capability.DefaultAgent()) // nolint: errcheck
-	}
-	if caps.Supports(capability.ReportStatus) {
-		upreq.Capabilities.Set(capability.ReportStatus) // nolint: errcheck
-	}
-	if req.Progress != nil {
-		if caps.Supports(capability.Sideband64k) {
-			upreq.Capabilities.Set(capability.Sideband64k) // nolint: errcheck
-		} else if caps.Supports(capability.Sideband) {
-			upreq.Capabilities.Set(capability.Sideband) // nolint: errcheck
+	// The reference discovery phase is done nearly the same way as it is in
+	// the fetching protocol. Each reference obj-id and name on the server is
+	// sent in packet-line format to the client, followed by a flush-pkt. The
+	// only real difference is that the capability listing is different - the
+	// only possible values are report-status, report-status-v2, delete-refs,
+	// ofs-delta, atomic and push-options.
+	for _, cap := range []capability.Capability{
+		capability.ReportStatus,
+		capability.ReportStatusV2,
+		capability.DeleteRefs,
+		capability.OFSDelta,
+		capability.Atomic,
+		capability.PushOptions,
+	} {
+		if caps.Supports(cap) {
+			upreq.Capabilities.Set(cap) //nolint:errcheck
 		}
-	} else if caps.Supports(capability.NoProgress) {
-		upreq.Capabilities.Set(capability.NoProgress) // nolint: errcheck
-	}
-	if req.Atomic && caps.Supports(capability.Atomic) {
-		upreq.Capabilities.Set(capability.Atomic) // nolint: errcheck
 	}
 
 	upreq.Commands = req.Commands

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -38,6 +38,8 @@ func ReceivePack(
 		return fmt.Errorf("nil writer")
 	}
 
+	w = ioutil.NewContextWriteCloser(ctx, w)
+
 	if opts == nil {
 		opts = &ReceivePackOptions{}
 	}
@@ -67,6 +69,8 @@ func ReceivePack(
 	if r == nil {
 		return fmt.Errorf("nil reader")
 	}
+
+	r = ioutil.NewContextReadCloser(ctx, r)
 
 	rd := bufio.NewReader(r)
 	l, _, err := pktline.PeekLine(rd)

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -104,7 +104,7 @@ func ReceivePack(
 
 	// Should we expect a packfile?
 	for _, cmd := range updreq.Commands {
-		if cmd.New != plumbing.ZeroHash {
+		if cmd.Action() != packp.Delete {
 			needPackfile = true
 			break
 		}

--- a/plumbing/transport/send_pack_test.go
+++ b/plumbing/transport/send_pack_test.go
@@ -89,7 +89,7 @@ func (rw *mockReadWriteCloser) Close() error {
 // TestSendPackWithReportStatus tests the SendPack function with ReportStatus capability
 func TestSendPackWithReportStatus(t *testing.T) {
 	caps := capability.NewList()
-	caps.Add(capability.ReportStatus)
+	caps.Add(capability.ReportStatus) //nolint:errcheck
 	conn := &mockConnection{caps: caps}
 
 	// Create a mock reader with a valid report status response
@@ -101,6 +101,7 @@ func TestSendPackWithReportStatus(t *testing.T) {
 	reader := newMockRWC([]byte(reportStatusResponse))
 	writer := newMockRWC(nil)
 
+	var buf bytes.Buffer
 	req := &PushRequest{
 		Commands: []*packp.Command{
 			{
@@ -109,6 +110,7 @@ func TestSendPackWithReportStatus(t *testing.T) {
 				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
 			},
 		},
+		Packfile: io.NopCloser(&buf), // Use a buffer to simulate packfile
 	}
 
 	storer := memory.NewStorage()
@@ -135,6 +137,7 @@ func TestSendPackWithReportStatusError(t *testing.T) {
 	reader := newMockRWC([]byte(reportStatusResponse))
 	writer := newMockRWC(nil)
 
+	var buf bytes.Buffer
 	req := &PushRequest{
 		Commands: []*packp.Command{
 			{
@@ -143,6 +146,7 @@ func TestSendPackWithReportStatusError(t *testing.T) {
 				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
 			},
 		},
+		Packfile: io.NopCloser(&buf), // Use a buffer to simulate packfile
 	}
 
 	// Call SendPack
@@ -167,6 +171,7 @@ func TestSendPackWithoutReportStatus(t *testing.T) {
 	reader := newMockRWC(nil)
 	writer := newMockRWC(nil)
 
+	var buf bytes.Buffer
 	req := &PushRequest{
 		Commands: []*packp.Command{
 			{
@@ -175,6 +180,7 @@ func TestSendPackWithoutReportStatus(t *testing.T) {
 				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
 			},
 		},
+		Packfile: io.NopCloser(&buf), // Use a buffer to simulate packfile
 	}
 
 	storer := memory.NewStorage()
@@ -216,6 +222,7 @@ func TestSendPackWithProgress(t *testing.T) {
 	// Create a progress buffer to capture progress messages
 	progressBuf := &bytes.Buffer{}
 
+	var buf bytes.Buffer
 	req := &PushRequest{
 		Commands: []*packp.Command{
 			{
@@ -224,6 +231,7 @@ func TestSendPackWithProgress(t *testing.T) {
 				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
 			},
 		},
+		Packfile: io.NopCloser(&buf), // Use a buffer to simulate packfile
 		Progress: progressBuf,
 	}
 
@@ -289,6 +297,7 @@ func TestSendPackErrors(t *testing.T) {
 		writer.writeErr = errors.New("encode error")
 		reader := newMockRWC(nil)
 
+		var buf bytes.Buffer
 		req := &PushRequest{
 			Commands: []*packp.Command{
 				{
@@ -297,6 +306,7 @@ func TestSendPackErrors(t *testing.T) {
 					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
 				},
 			},
+			Packfile: io.NopCloser(&buf), // Use a buffer to simulate packfile
 		}
 
 		storer := memory.NewStorage()
@@ -336,6 +346,7 @@ func TestSendPackErrors(t *testing.T) {
 		writer.closeErr = errors.New("writer close error")
 		reader := newMockRWC(nil)
 
+		var buf bytes.Buffer
 		req := &PushRequest{
 			Commands: []*packp.Command{
 				{
@@ -344,6 +355,7 @@ func TestSendPackErrors(t *testing.T) {
 					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
 				},
 			},
+			Packfile: io.NopCloser(&buf), // Use a buffer to simulate packfile
 		}
 
 		storer := memory.NewStorage()
@@ -361,6 +373,7 @@ func TestSendPackErrors(t *testing.T) {
 		reader := newMockRWC([]byte(invalidResponse))
 		writer := newMockRWC(nil)
 
+		var buf bytes.Buffer
 		req := &PushRequest{
 			Commands: []*packp.Command{
 				{
@@ -369,6 +382,7 @@ func TestSendPackErrors(t *testing.T) {
 					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
 				},
 			},
+			Packfile: io.NopCloser(&buf), // Use a buffer to simulate packfile
 		}
 
 		storer := memory.NewStorage()
@@ -388,6 +402,7 @@ func TestSendPackErrors(t *testing.T) {
 		reader.closeErr = errors.New("reader close error")
 		writer := newMockRWC(nil)
 
+		var buf bytes.Buffer
 		req := &PushRequest{
 			Commands: []*packp.Command{
 				{
@@ -396,6 +411,7 @@ func TestSendPackErrors(t *testing.T) {
 					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
 				},
 			},
+			Packfile: io.NopCloser(&buf), // Use a buffer to simulate packfile
 		}
 
 		storer := memory.NewStorage()

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/revlist"
 	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
 // UploadPackOptions is a set of options for the UploadPack service.
@@ -37,6 +38,8 @@ func UploadPack(
 	if w == nil {
 		return fmt.Errorf("nil writer")
 	}
+
+	w = ioutil.NewContextWriteCloser(ctx, w)
 
 	if opts == nil {
 		opts = &UploadPackOptions{}
@@ -67,6 +70,8 @@ func UploadPack(
 	if r == nil {
 		return fmt.Errorf("nil reader")
 	}
+
+	r = ioutil.NewContextReadCloser(ctx, r)
 
 	rd := bufio.NewReader(r)
 	l, _, err := pktline.PeekLine(rd)


### PR DESCRIPTION
One of the changes in https://github.com/go-git/go-git/pull/1450.

Partial fix was introduced in https://github.com/go-git/go-git/pull/1496 and this will entirely fix https://github.com/go-git/go-git/issues/1445.