### PR TITLE
[V6] Add some report-status and send-pack tests

### DIFF
--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -218,13 +218,6 @@ func (s *ReceivePackSuite) TestSendPackOnNonEmptyWithReportStatusWithError() {
 	// XXX: Recent git versions return "failed to update ref", while older
 	//     (>=1.9) return "failed to lock".
 	s.Regexp(regexp.MustCompile(".*(failed to update ref|failed to lock).*"), err)
-	// TODO: We no longer return a [packp.ReportStatus] when we receive a
-	// pack using [transport.SendPack].
-	// We should move this test to [transport.SendPack] tests.
-	// s.Require().Equal("ok", report.UnpackStatus)
-	// s.Require().Len(report.CommandStatuses, 1)
-	// s.Require().Equal(plumbing.ReferenceName("refs/heads/master"), report.CommandStatuses[0].ReferenceName)
-	// s.Regexp(regexp.MustCompile("(failed to update ref|failed to lock)"), report.CommandStatuses[0].Status)
 	s.checkRemoteHead(endpoint, plumbing.NewHash(fixture.Head))
 }
 

--- a/plumbing/format/pktline/common.go
+++ b/plumbing/format/pktline/common.go
@@ -1,6 +1,8 @@
 package pktline
 
-import "errors"
+import (
+	"errors"
+)
 
 const (
 	// Err is returned when the pktline has encountered an error.

--- a/plumbing/format/pktline/length.go
+++ b/plumbing/format/pktline/length.go
@@ -1,11 +1,13 @@
 package pktline
 
+import "fmt"
+
 // ParseLength parses a four digit hexadecimal number from the given byte slice
 // into its integer representation. If the byte slice contains non-hexadecimal,
 // it will return an error.
 func ParseLength(b []byte) (int, error) {
 	if b == nil {
-		return Err, ErrInvalidPktLen
+		return Err, fmt.Errorf("%w: pkt-line does not exist", ErrInvalidPktLen)
 	}
 
 	n, err := hexDecode(b)
@@ -14,14 +16,14 @@ func ParseLength(b []byte) (int, error) {
 	}
 
 	if n == 3 {
-		return Err, ErrInvalidPktLen
+		return Err, fmt.Errorf("%w: %04x", ErrInvalidPktLen, n)
 	}
 
 	// Limit the maximum size of a pkt-line to 65520 bytes.
 	// Fixes: b4177b89c08b (plumbing: format: pktline, Accept oversized pkt-lines up to 65524 bytes)
 	// See https://github.com/git/git/commit/7841c4801ce51f1f62d376d164372e8677c6bc94
 	if n > MaxSize {
-		return Err, ErrInvalidPktLen
+		return Err, fmt.Errorf("%w: %04x is too big", ErrInvalidPktLen, n)
 	}
 
 	return n, nil
@@ -33,14 +35,14 @@ func ParseLength(b []byte) (int, error) {
 // GC.
 func hexDecode(buf []byte) (int, error) {
 	if len(buf) < 4 {
-		return 0, ErrInvalidPktLen
+		return 0, fmt.Errorf("%w: small pkt-line buffer", ErrInvalidPktLen)
 	}
 
 	var ret int
 	for i := 0; i < LenSize; i++ {
 		n, err := asciiHexToByte(buf[i])
 		if err != nil {
-			return 0, ErrInvalidPktLen
+			return 0, fmt.Errorf("%w: %w", ErrInvalidPktLen, err)
 		}
 		ret = 16*ret + int(n)
 	}
@@ -58,7 +60,7 @@ func asciiHexToByte(b byte) (byte, error) {
 	case b >= 'A' && b <= 'F':
 		return b - 'A' + 10, nil
 	default:
-		return 0, ErrInvalidPktLen
+		return 0, fmt.Errorf("not a hexadecimal byte %q", b)
 	}
 }
 

--- a/plumbing/format/pktline/pktline.go
+++ b/plumbing/format/pktline/pktline.go
@@ -2,6 +2,7 @@ package pktline
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -45,7 +46,7 @@ func Writef(w io.Writer, format string, a ...interface{}) (n int, err error) {
 	if len(a) == 0 {
 		return Write(w, []byte(format))
 	}
-	return Write(w, []byte(fmt.Sprintf(format, a...)))
+	return Write(w, fmt.Appendf(nil, format, a...))
 }
 
 // Writeln writes a pktline packet from a string and appends a newline.
@@ -115,8 +116,8 @@ func WriteResponseEnd(w io.Writer) (err error) {
 func Read(r io.Reader, p []byte) (l int, err error) {
 	_, err = io.ReadFull(r, p[:LenSize])
 	if err != nil {
-		if err == io.ErrUnexpectedEOF {
-			return Err, ErrInvalidPktLen
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			return Err, fmt.Errorf("%w: short pkt-line %q", ErrInvalidPktLen, len(p[:LenSize]))
 		}
 		return Err, err
 	}

--- a/plumbing/protocol/packp/sideband/demux.go
+++ b/plumbing/protocol/packp/sideband/demux.go
@@ -115,6 +115,10 @@ func (d *Demuxer) nextPackData() ([]byte, error) {
 		return nil, ErrMaxPackedExceeded
 	}
 
+	if len(content) < 1 {
+		return nil, fmt.Errorf("invalid sideband pktline %04x %q", l, content)
+	}
+
 	switch Channel(content[0]) {
 	case PackData:
 		return content[1:], nil

--- a/plumbing/transport/build_update_requests_test.go
+++ b/plumbing/transport/build_update_requests_test.go
@@ -1,0 +1,221 @@
+package transport
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildUpdateRequestsWithReportStatus(t *testing.T) {
+	// Create capabilities with ReportStatus
+	caps := capability.NewList()
+	caps.Add(capability.ReportStatus)
+
+	// Create a push request
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+	}
+
+	// Build update requests
+	upreq := buildUpdateRequests(caps, req)
+
+	// Verify ReportStatus capability is set
+	assert.True(t, upreq.Capabilities.Supports(capability.ReportStatus))
+
+	// Verify commands are properly set
+	require.Len(t, upreq.Commands, 1)
+	assert.Equal(t, plumbing.ReferenceName("refs/heads/master"), upreq.Commands[0].Name)
+	assert.Equal(t, plumbing.ZeroHash, upreq.Commands[0].Old)
+	assert.Equal(t, plumbing.NewHash("0123456789012345678901234567890123456789"), upreq.Commands[0].New)
+}
+
+func TestBuildUpdateRequestsWithoutReportStatus(t *testing.T) {
+	// Create capabilities without ReportStatus
+	caps := capability.NewList()
+
+	// Create a push request
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+	}
+
+	// Build update requests
+	upreq := buildUpdateRequests(caps, req)
+
+	// Verify ReportStatus capability is not set
+	assert.False(t, upreq.Capabilities.Supports(capability.ReportStatus))
+}
+
+func TestBuildUpdateRequestsWithProgress(t *testing.T) {
+	// Create capabilities with Sideband64k
+	caps := capability.NewList()
+	caps.Add(capability.Sideband64k)
+
+	// Create a push request with progress
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+		Progress: &mockWriter{},
+	}
+
+	// Build update requests
+	upreq := buildUpdateRequests(caps, req)
+
+	// Verify Sideband64k capability is set
+	assert.True(t, upreq.Capabilities.Supports(capability.Sideband64k))
+	assert.False(t, upreq.Capabilities.Supports(capability.Sideband))
+	assert.False(t, upreq.Capabilities.Supports(capability.NoProgress))
+}
+
+func TestBuildUpdateRequestsWithProgressFallback(t *testing.T) {
+	// Create capabilities with Sideband but not Sideband64k
+	caps := capability.NewList()
+	caps.Add(capability.Sideband)
+
+	// Create a push request with progress
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+		Progress: &mockWriter{},
+	}
+
+	// Build update requests
+	upreq := buildUpdateRequests(caps, req)
+
+	// Verify Sideband capability is set but not Sideband64k
+	assert.False(t, upreq.Capabilities.Supports(capability.Sideband64k))
+	assert.True(t, upreq.Capabilities.Supports(capability.Sideband))
+	assert.False(t, upreq.Capabilities.Supports(capability.NoProgress))
+}
+
+func TestBuildUpdateRequestsWithNoProgress(t *testing.T) {
+	// Create capabilities with NoProgress
+	caps := capability.NewList()
+	caps.Add(capability.NoProgress)
+
+	// Create a push request without progress
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+	}
+
+	// Build update requests
+	upreq := buildUpdateRequests(caps, req)
+
+	// Verify NoProgress capability is set
+	assert.True(t, upreq.Capabilities.Supports(capability.NoProgress))
+}
+
+func TestBuildUpdateRequestsWithAtomic(t *testing.T) {
+	// Create capabilities with Atomic
+	caps := capability.NewList()
+	caps.Add(capability.Atomic)
+
+	// Create a push request with Atomic
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+		Atomic: true,
+	}
+
+	// Build update requests
+	upreq := buildUpdateRequests(caps, req)
+
+	// Verify Atomic capability is set
+	assert.True(t, upreq.Capabilities.Supports(capability.Atomic))
+}
+
+func TestBuildUpdateRequestsWithAtomicNotSupported(t *testing.T) {
+	// Create capabilities without Atomic
+	caps := capability.NewList()
+
+	// Create a push request with Atomic
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+		Atomic: true,
+	}
+
+	// Build update requests
+	upreq := buildUpdateRequests(caps, req)
+
+	// Verify Atomic capability is not set
+	assert.False(t, upreq.Capabilities.Supports(capability.Atomic))
+}
+
+func TestBuildUpdateRequestsWithAgent(t *testing.T) {
+	// Create capabilities with Agent
+	caps := capability.NewList()
+	caps.Set(capability.Agent, capability.DefaultAgent())
+
+	// Create a push request
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+	}
+
+	// Build update requests
+	upreq := buildUpdateRequests(caps, req)
+
+	// Verify Agent capability is set
+	assert.True(t, upreq.Capabilities.Supports(capability.Agent))
+
+	// Verify agent value is set to default agent
+	val := upreq.Capabilities.Get(capability.Agent)
+	assert.Equal(t, []string{capability.DefaultAgent()}, val)
+}
+
+// mockWriter is a simple io.Writer implementation for testing
+type mockWriter struct {
+	data []byte
+}
+
+func (w *mockWriter) Write(p []byte) (int, error) {
+	w.data = append(w.data, p...)
+	return len(p), nil
+}

--- a/plumbing/transport/send_pack_test.go
+++ b/plumbing/transport/send_pack_test.go
@@ -1,0 +1,433 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
+	"github.com/go-git/go-git/v6/storage/memory"
+	"github.com/go-git/go-git/v6/utils/trace"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockConnection implements the Connection interface for testing
+type mockConnection struct {
+	caps *capability.List
+}
+
+func (c *mockConnection) Close() error {
+	return nil
+}
+
+func (c *mockConnection) Capabilities() *capability.List {
+	return c.caps
+}
+
+func (c *mockConnection) Version() protocol.Version {
+	return protocol.V1
+}
+
+func (c *mockConnection) StatelessRPC() bool {
+	return false
+}
+
+func (c *mockConnection) GetRemoteRefs(ctx context.Context) ([]*plumbing.Reference, error) {
+	return nil, nil
+}
+
+func (c *mockConnection) Fetch(ctx context.Context, req *FetchRequest) error {
+	return nil
+}
+
+func (c *mockConnection) Push(ctx context.Context, req *PushRequest) error {
+	return nil
+}
+
+// mockReadWriteCloser implements io.ReadWriteCloser for testing
+type mockReadWriteCloser struct {
+	readBuf  *bytes.Buffer
+	writeBuf *bytes.Buffer
+	closed   bool
+	readErr  error
+	writeErr error
+	closeErr error
+}
+
+func newMockRWC(readData []byte) *mockReadWriteCloser {
+	return &mockReadWriteCloser{
+		readBuf:  bytes.NewBuffer(readData),
+		writeBuf: &bytes.Buffer{},
+	}
+}
+
+func (rw *mockReadWriteCloser) Read(p []byte) (int, error) {
+	if rw.readErr != nil {
+		return 0, rw.readErr
+	}
+	return rw.readBuf.Read(p)
+}
+
+func (rw *mockReadWriteCloser) Write(p []byte) (int, error) {
+	if rw.writeErr != nil {
+		return 0, rw.writeErr
+	}
+	return rw.writeBuf.Write(p)
+}
+
+func (rw *mockReadWriteCloser) Close() error {
+	rw.closed = true
+	return rw.closeErr
+}
+
+// TestSendPackWithReportStatus tests the SendPack function with ReportStatus capability
+func TestSendPackWithReportStatus(t *testing.T) {
+	// Create a mock connection with ReportStatus capability
+	caps := capability.NewList()
+	caps.Add(capability.ReportStatus)
+	conn := &mockConnection{caps: caps}
+
+	// Create a mock reader with a valid report status response
+	reportStatusResponse := strings.Join([]string{
+		"000eunpack ok\n",            // "unpack ok\n"
+		"0019ok refs/heads/master\n", // "ok refs/heads/master\n"
+		"0000",                       // flush-pkt
+	}, "")
+	reader := newMockRWC([]byte(reportStatusResponse))
+	writer := newMockRWC(nil)
+
+	// Create a push request
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+	}
+
+	// Call SendPack
+	storer := memory.NewStorage()
+	err := SendPack(context.TODO(), storer, conn, writer, reader, req)
+
+	// Verify no error was returned
+	assert.NoError(t, err)
+
+	// Verify the reader and writer were closed
+	assert.True(t, reader.closed)
+	assert.True(t, writer.closed)
+}
+
+// TestSendPackWithReportStatusError tests the SendPack function with an error in the report status
+func TestSendPackWithReportStatusError(t *testing.T) {
+	// Create a mock connection with ReportStatus capability
+	caps := capability.NewList()
+	caps.Add(capability.ReportStatus)
+	conn := &mockConnection{caps: caps}
+
+	// Create a mock reader with an error report status response
+	reportStatusResponse := strings.Join([]string{
+		"0012unpack failed\n", // "unpack failed\n"
+		"0000",                // flush-pkt
+	}, "")
+	reader := newMockRWC([]byte(reportStatusResponse))
+	writer := newMockRWC(nil)
+
+	// Create a push request
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+	}
+
+	// Call SendPack
+	storer := memory.NewStorage()
+	err := SendPack(context.Background(), storer, conn, writer, reader, req)
+
+	// Verify an error was returned
+	assert.Error(t, err)
+	t.Logf("error is %q", err)
+	assert.Contains(t, err.Error(), "unpack error: failed")
+
+	// Verify the reader and writer were closed
+	assert.True(t, reader.closed)
+	assert.True(t, writer.closed)
+}
+
+// TestSendPackWithoutReportStatus tests the SendPack function without ReportStatus capability
+func TestSendPackWithoutReportStatus(t *testing.T) {
+	// Create a mock connection without ReportStatus capability
+	caps := capability.NewList()
+	conn := &mockConnection{caps: caps}
+
+	reader := newMockRWC(nil)
+	writer := newMockRWC(nil)
+
+	// Create a push request
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+	}
+
+	// Call SendPack
+	storer := memory.NewStorage()
+	err := SendPack(context.Background(), storer, conn, writer, reader, req)
+
+	// Verify no error was returned
+	assert.NoError(t, err)
+
+	// Verify the writer was closed but not the reader (since we don't read without ReportStatus)
+	assert.False(t, reader.closed)
+	assert.True(t, writer.closed)
+}
+
+func init() {
+	trace.SetTarget(trace.General | trace.Packet)
+}
+
+// TestSendPackWithProgress tests the SendPack function with progress reporting
+func TestSendPackWithProgress(t *testing.T) {
+	// Create a mock connection with ReportStatus and Sideband64k capabilities
+	caps := capability.NewList()
+	caps.Add(capability.ReportStatus)
+	caps.Add(capability.Sideband64k)
+	conn := &mockConnection{caps: caps}
+
+	// Create a mock reader with a sideband-encoded report status response
+	// This simulates a response with progress messages and a report status
+	sidebandResponse := strings.Join([]string{
+		// Sideband progress message (channel 2) fake progress
+		"0013\x02Progress: 50%\n", // "Progress: 50%\n"
+		// Sideband pack data message (channel 1) with report-status
+		"0030\x01" +
+			"000eunpack ok\n" + // "unpack ok\n"
+			"0019ok refs/heads/master\n" + // "ok refs/heads/master\n"
+			"0000", // flush-pkt
+		// Flush-pkt to terminate the sideband message.
+		"0000", // flush-pkt
+	}, "")
+	reader := newMockRWC([]byte(sidebandResponse))
+	writer := newMockRWC(nil)
+
+	// Create a progress buffer to capture progress messages
+	progressBuf := &bytes.Buffer{}
+
+	// Create a push request with progress
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+		Progress: progressBuf,
+	}
+
+	// Call SendPack
+	storer := memory.NewStorage()
+	err := SendPack(context.Background(), storer, conn, writer, reader, req)
+
+	// Verify no error was returned
+	assert.NoError(t, err)
+
+	// Verify progress was captured
+	assert.Contains(t, progressBuf.String(), "Progress: 50%")
+}
+
+// TestSendPackWithPackfile tests the SendPack function with a packfile
+func TestSendPackWithPackfile(t *testing.T) {
+	// Create a mock connection with ReportStatus capability
+	caps := capability.NewList()
+	caps.Add(capability.ReportStatus)
+	conn := &mockConnection{caps: caps}
+
+	// Create a mock reader with a valid report status response
+	reportStatusResponse := strings.Join([]string{
+		"000eunpack ok\n",            // "unpack ok\n"
+		"0019ok refs/heads/master\n", // "ok refs/heads/master\n"
+		"0000",                       // flush-pkt
+	}, "")
+	reader := newMockRWC([]byte(reportStatusResponse))
+	writer := newMockRWC(nil)
+
+	// Create a packfile
+	packfileContent := []byte("mock packfile content")
+	packfile := io.NopCloser(bytes.NewReader(packfileContent))
+
+	// Create a push request with a packfile
+	req := &PushRequest{
+		Commands: []*packp.Command{
+			{
+				Name: plumbing.ReferenceName("refs/heads/master"),
+				Old:  plumbing.ZeroHash,
+				New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+			},
+		},
+		Packfile: packfile,
+	}
+
+	// Call SendPack
+	storer := memory.NewStorage()
+	err := SendPack(context.Background(), storer, conn, writer, reader, req)
+
+	// Verify no error was returned
+	assert.NoError(t, err)
+
+	// Verify the packfile was written
+	assert.Contains(t, writer.writeBuf.String(), "mock packfile content")
+}
+
+// TestSendPackErrors tests various error conditions in SendPack
+func TestSendPackErrors(t *testing.T) {
+	// Create a mock connection with ReportStatus capability
+	caps := capability.NewList()
+	caps.Add(capability.ReportStatus)
+	conn := &mockConnection{caps: caps}
+
+	// Test case: error encoding update requests
+	t.Run("EncodeError", func(t *testing.T) {
+		writer := newMockRWC(nil)
+		writer.writeErr = errors.New("encode error")
+		reader := newMockRWC(nil)
+
+		req := &PushRequest{
+			Commands: []*packp.Command{
+				{
+					Name: plumbing.ReferenceName("refs/heads/master"),
+					Old:  plumbing.ZeroHash,
+					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+				},
+			},
+		}
+
+		storer := memory.NewStorage()
+		err := SendPack(context.Background(), storer, conn, writer, reader, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "encode error")
+	})
+
+	// Test case: error copying packfile
+	t.Run("PackfileCopyError", func(t *testing.T) {
+		writer := newMockRWC(nil)
+		reader := newMockRWC(nil)
+
+		// Create a packfile that returns an error on read
+		errPackfile := &errorReader{err: errors.New("packfile read error")}
+
+		req := &PushRequest{
+			Commands: []*packp.Command{
+				{
+					Name: plumbing.ReferenceName("refs/heads/master"),
+					Old:  plumbing.ZeroHash,
+					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+				},
+			},
+			Packfile: io.NopCloser(errPackfile),
+		}
+
+		storer := memory.NewStorage()
+		err := SendPack(context.Background(), storer, conn, writer, reader, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "packfile read error")
+	})
+
+	// Test case: error closing writer
+	t.Run("WriterCloseError", func(t *testing.T) {
+		writer := newMockRWC(nil)
+		writer.closeErr = errors.New("writer close error")
+		reader := newMockRWC(nil)
+
+		req := &PushRequest{
+			Commands: []*packp.Command{
+				{
+					Name: plumbing.ReferenceName("refs/heads/master"),
+					Old:  plumbing.ZeroHash,
+					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+				},
+			},
+		}
+
+		storer := memory.NewStorage()
+		err := SendPack(context.Background(), storer, conn, writer, reader, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "writer close error")
+	})
+
+	// Test case: error decoding report status
+	t.Run("ReportStatusDecodeError", func(t *testing.T) {
+		// Create invalid report status response (missing flush)
+		invalidResponse := strings.Join([]string{
+			"000eunpack ok\n", // "unpack ok\n"
+		}, "")
+		reader := newMockRWC([]byte(invalidResponse))
+		writer := newMockRWC(nil)
+
+		req := &PushRequest{
+			Commands: []*packp.Command{
+				{
+					Name: plumbing.ReferenceName("refs/heads/master"),
+					Old:  plumbing.ZeroHash,
+					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+				},
+			},
+		}
+
+		storer := memory.NewStorage()
+		err := SendPack(context.Background(), storer, conn, writer, reader, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "decode report-status")
+	})
+
+	// Test case: error closing reader
+	t.Run("ReaderCloseError", func(t *testing.T) {
+		// Create valid report status response
+		validResponse := strings.Join([]string{
+			"000eunpack ok\n", // "unpack ok\n"
+			"0000",            // flush-pkt
+		}, "")
+		reader := newMockRWC([]byte(validResponse))
+		reader.closeErr = errors.New("reader close error")
+		writer := newMockRWC(nil)
+
+		req := &PushRequest{
+			Commands: []*packp.Command{
+				{
+					Name: plumbing.ReferenceName("refs/heads/master"),
+					Old:  plumbing.ZeroHash,
+					New:  plumbing.NewHash("0123456789012345678901234567890123456789"),
+				},
+			},
+		}
+
+		storer := memory.NewStorage()
+		err := SendPack(context.Background(), storer, conn, writer, reader, req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "closing reader: reader close error")
+	})
+}
+
+// errorReader is a simple io.Reader that always returns an error
+type errorReader struct {
+	err error
+}
+
+func (r *errorReader) Read(p []byte) (int, error) {
+	return 0, r.err
+}


### PR DESCRIPTION
This adds a new few tests for `report-status` during the `SendPack` routine. It also adds more informative `pktline` error messages, and typed `report-status` errors.