### PR TITLE
plumbing: format/config, remove empty config subsection name test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -379,6 +379,21 @@ func (c *Config) unmarshalRemotes() error {
 		c.Remotes[r.Name] = r
 	}
 
+	// Check if the main remote section still has options
+	// after unmarshaling named subsections - this indicates an empty subsection name
+	if len(s.Options) > 0 {
+		emptySubsection := &format.Subsection{
+			Name:    "",
+			Options: s.Options,
+		}
+
+		r := &RemoteConfig{}
+		if err := r.unmarshal(emptySubsection); err != nil {
+			return err
+		}
+
+		c.Remotes[r.Name] = r
+	}
 	// Apply insteadOf url rules
 	for _, r := range c.Remotes {
 		r.applyURLRules(c.URLs)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.7
 
 // Use the v6-exp branch across go-git dependencies.
 replace (
+	github.com/go-git/gcfg/v2 v2.0.1 => github.com/CLBRITTON2/gcfg/v2 v2.0.2
 	github.com/go-git/go-billy/v5 => github.com/go-git/go-billy/v5 v5.5.1-0.20250112183528-18f878617b0e
 	github.com/go-git/go-git-fixtures/v5 => github.com/go-git/go-git-fixtures/v5 v5.0.0-20241203230421-0753e18f8f03
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.23.7
 
 // Use the v6-exp branch across go-git dependencies.
 replace (
-	github.com/go-git/gcfg/v2 v2.0.1 => github.com/CLBRITTON2/gcfg/v2 v2.0.2
 	github.com/go-git/go-billy/v5 => github.com/go-git/go-billy/v5 v5.5.1-0.20250112183528-18f878617b0e
 	github.com/go-git/go-git-fixtures/v5 => github.com/go-git/go-git-fixtures/v5 v5.0.0-20241203230421-0753e18f8f03
 )
@@ -20,7 +19,7 @@ require (
 	github.com/elazarl/goproxy v1.7.2
 	github.com/emirpasic/gods v1.18.1
 	github.com/gliderlabs/ssh v0.3.8
-	github.com/go-git/gcfg/v2 v2.0.1
+	github.com/go-git/gcfg/v2 v2.0.2
 	github.com/go-git/go-billy/v5 v5.6.2
 	github.com/go-git/go-git-fixtures/v5 v5.0.0-20241203230421-0753e18f8f03
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/CLBRITTON2/gcfg/v2 v2.0.2 h1:rs43yG+OH5tsSTO1GeXgf1HT/vxMBxSOQxaxWy/PyJc=
+github.com/CLBRITTON2/gcfg/v2 v2.0.2/go.mod h1:/lv2NsxvhepuMrldsFilrgct6pxzpGdSRC13ydTLSLs=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
@@ -22,8 +24,6 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
-github.com/go-git/gcfg/v2 v2.0.1 h1:vIDPEdcmkwmbMCHs/0Fv/HFA9SH9ZVVI/gglNeLztF0=
-github.com/go-git/gcfg/v2 v2.0.1/go.mod h1:/lv2NsxvhepuMrldsFilrgct6pxzpGdSRC13ydTLSLs=
 github.com/go-git/go-billy/v5 v5.5.1-0.20250112183528-18f878617b0e h1:3AG0UOghlvUIcy9IuH9WXL+/AFz59bu/HCjycG78yl8=
 github.com/go-git/go-billy/v5 v5.5.1-0.20250112183528-18f878617b0e/go.mod h1:1B6rEdNBj35pFhqC8nx/d+Kg6ENsneqc/aIhZaTtAAk=
 github.com/go-git/go-git-fixtures/v5 v5.0.0-20241203230421-0753e18f8f03 h1:LumE+tQdnYW24a9RoO08w64LHTzkNkdUqBD/0QPtlEY=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/CLBRITTON2/gcfg/v2 v2.0.2 h1:rs43yG+OH5tsSTO1GeXgf1HT/vxMBxSOQxaxWy/PyJc=
-github.com/CLBRITTON2/gcfg/v2 v2.0.2/go.mod h1:/lv2NsxvhepuMrldsFilrgct6pxzpGdSRC13ydTLSLs=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBiRGFrw=
@@ -24,6 +22,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
+github.com/go-git/gcfg/v2 v2.0.2 h1:MY5SIIfTGGEMhdA7d7JePuVVxtKL7Hp+ApGDJAJ7dpo=
+github.com/go-git/gcfg/v2 v2.0.2/go.mod h1:/lv2NsxvhepuMrldsFilrgct6pxzpGdSRC13ydTLSLs=
 github.com/go-git/go-billy/v5 v5.5.1-0.20250112183528-18f878617b0e h1:3AG0UOghlvUIcy9IuH9WXL+/AFz59bu/HCjycG78yl8=
 github.com/go-git/go-billy/v5 v5.5.1-0.20250112183528-18f878617b0e/go.mod h1:1B6rEdNBj35pFhqC8nx/d+Kg6ENsneqc/aIhZaTtAAk=
 github.com/go-git/go-git-fixtures/v5 v5.0.0-20241203230421-0753e18f8f03 h1:LumE+tQdnYW24a9RoO08w64LHTzkNkdUqBD/0QPtlEY=

--- a/plumbing/format/config/decoder_test.go
+++ b/plumbing/format/config/decoder_test.go
@@ -47,12 +47,12 @@ func (s *DecoderSuite) TestDecodeFailsWithEmptySectionName() {
 	decodeFails(s, t)
 }
 
-func (s *DecoderSuite) TestDecodeFailsWithEmptySubsectionName() {
+func (s *DecoderSuite) TestDecodeSucceedsWithEmptySubsectionName() {
 	t := `
 	[remote ""]
 	key=value
 	`
-	decodeFails(s, t)
+	decodeSucceeds(s, t)
 }
 
 func (s *DecoderSuite) TestDecodeFailsWithBadSubsectionName() {
@@ -98,10 +98,21 @@ func decodeFails(s *DecoderSuite, text string) {
 	s.NotNil(err)
 }
 
+func decodeSucceeds(s *DecoderSuite, text string) {
+	r := bytes.NewReader([]byte(text))
+	d := NewDecoder(r)
+	cfg := &Config{}
+	err := d.Decode(cfg)
+	s.NoError(err)
+
+	s.True(cfg.HasSection("remote"))
+	remote := cfg.Section("remote")
+	s.True(remote.HasOption("key"))
+	s.Equal("value", remote.Option("key"))
+}
+
 func FuzzDecoder(f *testing.F) {
-
 	f.Fuzz(func(t *testing.T, input []byte) {
-
 		d := NewDecoder(bytes.NewReader(input))
 		cfg := &Config{}
 		d.Decode(cfg)


### PR DESCRIPTION
step 1 in fix for issue #1197
point go.mod to fork of gcfg that removes empty subsection name check and error
This will stop go-git from throwing an error when parsing a config file with an empty subsection name.
To match git we'll have to account for options that fall under empty subsection names like URLs for example during config marshal/unmarshal.
