### PR TITLE
fix: OnInflatedObjectContent doesn't include object contents

### DIFF
--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -330,7 +330,7 @@ func (p *Parser) resolveDeltas() error {
 			return err
 		}
 
-		if err := p.onInflatedObjectContent(obj.SHA1, obj.Offset, obj.Crc32, nil); err != nil {
+		if err := p.onInflatedObjectContent(obj.SHA1, obj.Offset, obj.Crc32, buf.Bytes()); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
In #799 [packfile.Parser](https://pkg.go.dev/github.com/go-git/go-git/v5@v5.16.2/plumbing/format/packfile#Parser) was refactored to reduce memory usage and no longer properly invokes the [packfile.Observer](https://pkg.go.dev/github.com/go-git/go-git/v5@v5.16.2/plumbing/format/packfile#Observer) interface. Specifically, `OnInflatedObjectContent` is invoked but `content` will always be `nil`.

This PR restores the `content` bytes for callers that are directly using [packfile.Parser](https://pkg.go.dev/github.com/go-git/go-git/v5@v5.16.2/plumbing/format/packfile#Parser) outside of the more standard workflow where the values are stored in a storer.