### PR TITLE
config: add GetOption and GetAllOptions to Sections and Subsections

### DIFF
--- a/plumbing/format/config/common.go
+++ b/plumbing/format/config/common.go
@@ -87,7 +87,7 @@ func (c *Config) RemoveSubsection(section string, subsection string) *Config {
 // AddOption adds an option to a given section and subsection. Use the
 // NoSubsection constant for the subsection argument if no subsection is wanted.
 func (c *Config) AddOption(section string, subsection string, key string, value string) *Config {
-	if subsection == "" {
+	if subsection == NoSubsection {
 		c.Section(section).AddOption(key, value)
 	} else {
 		c.Section(section).Subsection(subsection).AddOption(key, value)
@@ -99,11 +99,37 @@ func (c *Config) AddOption(section string, subsection string, key string, value 
 // SetOption sets an option to a given section and subsection. Use the
 // NoSubsection constant for the subsection argument if no subsection is wanted.
 func (c *Config) SetOption(section string, subsection string, key string, value string) *Config {
-	if subsection == "" {
+	if subsection == NoSubsection {
 		c.Section(section).SetOption(key, value)
 	} else {
 		c.Section(section).Subsection(subsection).SetOption(key, value)
 	}
 
 	return c
+}
+
+// GetOption gets the value of a named Option from the Section and Subsection. Use the
+// NoSubsection constant for the subsection argument if no subsection is wanted. If the
+// option does not exist or is not set, it returns the empty string. Note that there
+// is no difference. This matches git behaviour since git v1.8.1-rc1, if there are
+// multiple definitions of a key, the last one wins.
+func (c *Config) GetOption(section string, subsection string, key string) string {
+	if subsection == NoSubsection {
+		return c.Section(section).GetOption(key)
+	} else {
+		return c.Section(section).Subsection(subsection).GetOption(key)
+	}
+}
+
+// GetAllOptions gets an option from a given section and subsection. Use the
+// GetAllOptions gets all the values of a named Option from the Section. Use the
+// NoSubsection constant for the subsection argument if no subsection is wanted.
+// If the option does not exist or is not set, it returns an empty slice.
+// This matches git behaviour since git v1.8.1-rc1.
+func (c *Config) GetAllOptions(section string, subsection string, key string) []string {
+	if subsection == NoSubsection {
+		return c.Section(section).GetAllOptions(key)
+	} else {
+		return c.Section(section).Subsection(subsection).GetAllOptions(key)
+	}
 }

--- a/plumbing/format/config/common.go
+++ b/plumbing/format/config/common.go
@@ -98,11 +98,11 @@ func (c *Config) AddOption(section string, subsection string, key string, value 
 
 // SetOption sets an option to a given section and subsection. Use the
 // NoSubsection constant for the subsection argument if no subsection is wanted.
-func (c *Config) SetOption(section string, subsection string, key string, value string) *Config {
+func (c *Config) SetOption(section string, subsection string, key string, value ...string) *Config {
 	if subsection == NoSubsection {
-		c.Section(section).SetOption(key, value)
+		c.Section(section).SetOption(key, value...)
 	} else {
-		c.Section(section).Subsection(subsection).SetOption(key, value)
+		c.Section(section).Subsection(subsection).SetOption(key, value...)
 	}
 
 	return c

--- a/plumbing/format/config/common_test.go
+++ b/plumbing/format/config/common_test.go
@@ -51,6 +51,172 @@ func (s *CommonSuite) TestConfig_SetOption() {
 	s.Equal(expected, obtained)
 }
 
+func (s *CommonSuite) TestConfig_GetOption() {
+	var cfg *Config
+	var obtained string
+
+	// when option does not exist, return empty string
+	cfg = New()
+	obtained = cfg.GetOption("section", NoSubsection, "key1")
+	s.Equal("", obtained)
+
+	// when single value exists, return value
+	cfg = &Config{
+		Sections: []*Section{
+			{
+				Name: "section",
+				Options: []*Option{
+					{Key: "key1", Value: "value1"},
+				},
+			},
+		},
+	}
+	obtained = cfg.GetOption("section", NoSubsection, "key1")
+	s.Equal("value1", obtained)
+
+	// when multiple values exist, return last value
+	cfg = &Config{
+		Sections: []*Section{
+			{
+				Name: "section",
+				Options: []*Option{
+					{Key: "key1", Value: "value1"},
+					{Key: "key1", Value: "value2"},
+				},
+			},
+		},
+	}
+	obtained = cfg.GetOption("section", NoSubsection, "key1")
+	s.Equal("value2", obtained)
+
+	// when subsection option does not exist, return empty string
+	cfg = New()
+	obtained = cfg.GetOption("section", "subsection", "key1")
+	s.Equal("", obtained)
+
+	// when subsection single value exists, return value
+	cfg = &Config{
+		Sections: []*Section{
+			{
+				Name: "section",
+				Subsections: []*Subsection{
+					{
+						Name: "subsection",
+						Options: []*Option{
+							{Key: "key1", Value: "value1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	obtained = cfg.GetOption("section", "subsection", "key1")
+	s.Equal("value1", obtained)
+
+	// when multiple values exist, return last value
+	cfg = &Config{
+		Sections: []*Section{
+			{
+				Name: "section",
+				Subsections: []*Subsection{
+					{
+						Name: "subsection",
+						Options: []*Option{
+							{Key: "key1", Value: "value1"},
+							{Key: "key1", Value: "value2"},
+						},
+					},
+				},
+			},
+		},
+	}
+	obtained = cfg.GetOption("section", "subsection", "key1")
+	s.Equal("value2", obtained)
+}
+
+func (s *CommonSuite) TestConfig_GetAllOptions() {
+	var cfg *Config
+	var obtained []string
+
+	// when option does not exist, return empty string
+	cfg = New()
+	obtained = cfg.GetAllOptions("section", NoSubsection, "key1")
+	s.Equal([]string{}, obtained)
+
+	// when single value exists, return value
+	cfg = &Config{
+		Sections: []*Section{
+			{
+				Name: "section",
+				Options: []*Option{
+					{Key: "key1", Value: "value1"},
+				},
+			},
+		},
+	}
+	obtained = cfg.GetAllOptions("section", NoSubsection, "key1")
+	s.Equal([]string{"value1"}, obtained)
+
+	// when multiple values exist, return last value
+	cfg = &Config{
+		Sections: []*Section{
+			{
+				Name: "section",
+				Options: []*Option{
+					{Key: "key1", Value: "value1"},
+					{Key: "key1", Value: "value2"},
+				},
+			},
+		},
+	}
+	obtained = cfg.GetAllOptions("section", NoSubsection, "key1")
+	s.Equal([]string{"value1", "value2"}, obtained)
+
+	// when subsection option does not exist, return empty string
+	cfg = New()
+	obtained = cfg.GetAllOptions("section", "subsection", "key1")
+	s.Equal([]string{}, obtained)
+
+	// when subsection single value exists, return value
+	cfg = &Config{
+		Sections: []*Section{
+			{
+				Name: "section",
+				Subsections: []*Subsection{
+					{
+						Name: "subsection",
+						Options: []*Option{
+							{Key: "key1", Value: "value1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	obtained = cfg.GetAllOptions("section", "subsection", "key1")
+	s.Equal([]string{"value1"}, obtained)
+
+	// when multiple values exist, return last value
+	cfg = &Config{
+		Sections: []*Section{
+			{
+				Name: "section",
+				Subsections: []*Subsection{
+					{
+						Name: "subsection",
+						Options: []*Option{
+							{Key: "key1", Value: "value1"},
+							{Key: "key1", Value: "value2"},
+						},
+					},
+				},
+			},
+		},
+	}
+	obtained = cfg.GetAllOptions("section", "subsection", "key1")
+	s.Equal([]string{"value1", "value2"}, obtained)
+}
+
 func (s *CommonSuite) TestConfig_AddOption() {
 	obtained := New().AddOption("section", NoSubsection, "key1", "value1")
 	expected := &Config{

--- a/plumbing/format/config/section.go
+++ b/plumbing/format/config/section.go
@@ -12,7 +12,7 @@ import (
 // put its name in double quotes, separated by space from the section name,
 // in the section header, like in the example below:
 //
-//     [section "subsection"]
+//	[section "subsection"]
 //
 // All the other lines (and the remainder of the line after the section header)
 // are recognized as option variables, in the form "name = value" (or just name,
@@ -20,12 +20,11 @@ import (
 // The variable names are case-insensitive, allow only alphanumeric characters
 // and -, and must start with an alphabetic character:
 //
-//     [section "subsection1"]
-//         option1 = value1
-//         option2
-//     [section "subsection2"]
-//         option3 = value2
-//
+//	[section "subsection1"]
+//	    option1 = value1
+//	    option2
+//	[section "subsection2"]
+//	    option3 = value2
 type Section struct {
 	Name        string
 	Options     Options
@@ -133,7 +132,20 @@ func (s *Section) SetOption(key string, value string) *Section {
 	return s
 }
 
-// Remove an option with the specified key. The updated Section is returned.
+// GetOption gets the value of a named Option from the Section. If the option does not exist or is
+// not set, it returns the empty string. Note that there is no difference. This matches git behaviour
+// since git v1.8.1-rc1, if there are multiple definitions of a key, the last one wins.
+func (s *Section) GetOption(key string) string {
+	return s.Options.Get(key)
+}
+
+// GetAllOptions gets all the values of a named Option from the Section. If the option does not
+// exist or is not set, it returns an empty slice. This matches git behaviour since git v1.8.1-rc1.
+func (s *Section) GetAllOptions(key string) []string {
+	return s.Options.GetAll(key)
+}
+
+// RemoveOption removes an option with the specified key. The updated Section is returned.
 func (s *Section) RemoveOption(key string) *Section {
 	s.Options = s.Options.withoutOption(key)
 	return s
@@ -172,6 +184,19 @@ func (s *Subsection) AddOption(key string, value string) *Subsection {
 func (s *Subsection) SetOption(key string, value ...string) *Subsection {
 	s.Options = s.Options.withSettedOption(key, value...)
 	return s
+}
+
+// GetOption gets the value of a named Option from the Subsection. If the option does not exist or is
+// not set, it returns the empty string. Note that there is no difference. This matches git behaviour
+// since git v1.8.1-rc1, if there are multiple definitions of a key, the last one wins.
+func (s *Subsection) GetOption(key string) string {
+	return s.Options.Get(key)
+}
+
+// GetAllOptions gets all the values of a named Option from the Subsection. If the option does not
+// exist or is not set, it returns an empty slice. This matches git behaviour since git v1.8.1-rc1.
+func (s *Subsection) GetAllOptions(key string) []string {
+	return s.Options.GetAll(key)
 }
 
 // RemoveOption removes the option with the specified key. The updated Subsection is returned.

--- a/plumbing/format/config/section.go
+++ b/plumbing/format/config/section.go
@@ -127,8 +127,8 @@ func (s *Section) AddOption(key string, value string) *Section {
 
 // SetOption adds a new Option to the Section. If the option already exists, is replaced.
 // The updated Section is returned.
-func (s *Section) SetOption(key string, value string) *Section {
-	s.Options = s.Options.withSettedOption(key, value)
+func (s *Section) SetOption(key string, value ...string) *Section {
+	s.Options = s.Options.withSettedOption(key, value...)
 	return s
 }
 


### PR DESCRIPTION
These config structures had HasOption, SetOption, and AddOption
but were missing GetOption and GetAllOptions even though the
underlying Option struct exposed Get and GetAll methods.

Echoing these up on the Sections and Subsections structs will
facilitate higher-level operations when reading config values.

Relates to: GH #395