### PR TITLE
plumbing: transport, fix ssh connection leak when start return err EOF

### DIFF
--- a/plumbing/transport/pack.go
+++ b/plumbing/transport/pack.go
@@ -95,6 +95,7 @@ func (p *PackSession) Handshake(ctx context.Context, service Service, params ...
 	defer func() { checkError(c.stderr(), &err) }()
 
 	if err := cmd.Start(); err != nil {
+		_ = cmd.Close()
 		return nil, err
 	}
 

--- a/plumbing/transport/pack_test.go
+++ b/plumbing/transport/pack_test.go
@@ -1,0 +1,71 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/go-git/go-git/v6/utils/ioutil"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestCmdStartEOFSuite(t *testing.T) {
+	suite.Run(t, new(CmdStartEOFSuite))
+}
+
+type CmdStartEOFSuite struct {
+	suite.Suite
+}
+
+type mockStartEOFCommand struct {
+	stdin         bytes.Buffer
+	stdout        bytes.Buffer
+	stderr        bytes.Buffer
+	sessionOpened bool
+}
+
+func (c *mockStartEOFCommand) StderrPipe() (io.Reader, error) {
+	return &c.stderr, nil
+}
+
+func (c *mockStartEOFCommand) StdinPipe() (io.WriteCloser, error) {
+	return ioutil.WriteNopCloser(&c.stdin), nil
+}
+
+func (c *mockStartEOFCommand) StdoutPipe() (io.Reader, error) {
+	return &c.stdout, nil
+}
+
+func (c *mockStartEOFCommand) Start() error {
+	c.sessionOpened = true
+	return io.EOF
+}
+
+func (c *mockStartEOFCommand) Close() error {
+	c.sessionOpened = false
+	return nil
+}
+
+type mockStartEOFCommander struct {
+	mockCmd *mockStartEOFCommand
+}
+
+func (c *mockStartEOFCommander) Command(_ context.Context, cmd string, ep *Endpoint, auth AuthMethod, _ ...string) (Command, error) {
+	c.mockCmd = &mockStartEOFCommand{}
+	return c.mockCmd, nil
+}
+
+func (s *CmdStartEOFSuite) TestCmdStartEOFConnectionLeakError() {
+	client := NewPackTransport(&mockStartEOFCommander{})
+	sess, err := client.NewSession(nil, nil, nil)
+	if err != nil {
+		s.T().Fatalf("unexpected error: %s", err)
+	}
+
+	_, err = sess.Handshake(context.TODO(), UploadPackService)
+	s.ErrorIs(err, io.EOF)
+	cmdrInterface := sess.(*PackSession).cmdr
+	cmdr := cmdrInterface.(*mockStartEOFCommander)
+	s.False(cmdr.mockCmd.sessionOpened)
+}


### PR DESCRIPTION
when err is `EOF`, the ssh connection not closed
```
$ lsof -p 4883 | grep ":ssh" | awk -F '->' '{print $2}' | sort | uniq -c
     21 127.0.1.100:ssh (ESTABLISHED)
    151 127.0.1.101:ssh (ESTABLISHED)
```