### PR TITLE
Support relative paths in PlainInit/PlainClone. fixes #1610

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -295,6 +295,13 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 			return Init(s, options...)
 		}
 	} else {
+		// Allow users to use relative paths. Convert them
+		// to absolute paths to avoid osfs pre-pending
+		// its baseDir and wreaking havoc by doubling
+		// up the baseDir prefix.
+		if !filepath.IsAbs(path) {
+			path, _ = filepath.Abs(path)
+		}
 		wt = osfs.New(path, osfs.WithBoundOS())
 		dot, _ = wt.Chroot(GitDirName)
 		initFn = func(s *filesystem.Storage) (*Repository, error) {

--- a/repository.go
+++ b/repository.go
@@ -300,7 +300,11 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 		// its baseDir and wreaking havoc by doubling
 		// up the baseDir prefix.
 		if !filepath.IsAbs(path) {
-			path, _ = filepath.Abs(path)
+			var err error
+			path, err = filepath.Abs(path)
+			if err != nil {
+				return nil, fmt.Errorf("PlainInit path error: filepath.Abs('%v') error: '%v'", path, err)
+			}
 		}
 		wt = osfs.New(path, osfs.WithBoundOS())
 		dot, _ = wt.Chroot(GitDirName)


### PR DESCRIPTION
This is the simplest fix for #1610, as it emulates what 
is mostly tested in the test suite: absolute paths
generated by os.MkdirTemp.

We simply convert relative paths to absolute path and proceed.

Fixes #1610