### PR TITLE
plumbing: support commits extra headers, support jujutsu signed commit [5.x]

### DIFF
--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -553,6 +553,114 @@ func (s *SuiteCommit) TestEncodeWithoutSignature(c *C) {
 		"Merge branch 'master' of github.com:tyba/git-fixture\n")
 }
 
+func (s *SuiteCommit) TestEncodeWithoutSignatureJujutsu(c *C) {
+	object := &plumbing.MemoryObject{}
+	object.SetType(plumbing.CommitObject)
+	object.Write([]byte(`tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+gpgsig -----BEGIN PGP SIGNATURE-----
+ 
+ iHUEABMIAB0WIQSZpnSpGKbQbDaLe5iiNQl48cTY5gUCaJ91XQAKCRCiNQl48cTY
+ 5vCYAP9Sf1yV9oUviRIxEA+4rsGIx0hI6kqFajJ/3TtBjyCTggD+PFnKOxdXeFL2
+ GLwcCzFIsmQmkLxuLypsg+vueDSLpsM=
+ =VucY
+ -----END PGP SIGNATURE-----
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`))
+
+	commit, err := DecodeCommit(s.Storer, object)
+	c.Assert(err, IsNil)
+
+	// Similar to TestString since no signature
+	encoded := &plumbing.MemoryObject{}
+	err = commit.EncodeWithoutSignature(encoded)
+	er, err := encoded.Reader()
+	c.Assert(err, IsNil)
+	payload, err := io.ReadAll(er)
+	c.Assert(err, IsNil)
+
+	c.Assert(string(payload), Equals, `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`)
+}
+
+func (s *SuiteCommit) TestEncodeExtraHeaders(c *C) {
+	object := &plumbing.MemoryObject{}
+	object.SetType(plumbing.CommitObject)
+	object.Write([]byte(`tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+continuedheader to be
+ continued
+continuedheader to be
+ continued
+ on
+ more than
+ a single line
+simpleflag
+ value no key
+
+initial commit
+`))
+
+	commit, err := DecodeCommit(s.Storer, object)
+	c.Assert(err, IsNil)
+
+	c.Assert(commit.ExtraHeaders, DeepEquals, []ExtraHeader{
+		ExtraHeader {
+			Key: "continuedheader",
+			Value: "to be\ncontinued",
+		},
+		ExtraHeader {
+			Key: "continuedheader",
+			Value: "to be\ncontinued\non\nmore than\na single line",
+		},
+		ExtraHeader {
+			Key: "simpleflag",
+			Value: "",
+		},
+		ExtraHeader {
+			Key: "",
+			Value: "value no key",
+		},
+	})
+
+	// Similar to TestString since no signature
+	encoded := &plumbing.MemoryObject{}
+	err = commit.EncodeWithoutSignature(encoded)
+	er, err := encoded.Reader()
+	c.Assert(err, IsNil)
+	payload, err := io.ReadAll(er)
+	c.Assert(err, IsNil)
+
+	c.Assert(string(payload), Equals, `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+continuedheader to be
+ continued
+continuedheader to be
+ continued
+ on
+ more than
+ a single line
+simpleflag
+ value no key
+
+initial commit
+`)
+}
+
 func (s *SuiteCommit) TestLess(c *C) {
 	when1 := time.Now()
 	when2 := when1.Add(time.Hour)


### PR DESCRIPTION
This adds support for extra headers. While git has a set of  ["standard headers"] (`tree`, `parent`, `author`, `committer`, and `encoding`), it will also support [extra headers] when serializing.

The extra headers must come after the standard ones, but they are otherwise freetyped.

[Jujutsu] takes advantage of that to store its own identifier (`change-id`) as an extra header.

Because signatures will cover the hash of the whole commit (standard headers, extra headers and the message. Everything but the signature itself), if we deserialize a commit and then `EncodeWithoutSignature` to get back the "canonical" representation of a commit, if we don't serialize back the extra headers, the hash will no longer match and the signature will fail to verify.

This adds support for parsing and reencoding the extra headers from the original commit and it's expected to fix support for Jujutsu signed commits.

Fixes #1626

["standard headers"]: https://github.com/git/git/blob/724518f3884d8707c5f51428ba98c115818229b8/commit.c#L1450
[extra headers]: https://github.com/git/git/blob/724518f3884d8707c5f51428ba98c115818229b8/commit.c#L1690
[Jujutsu]: https://github.com/jj-vcs/jj

This is a backport of https://github.com/go-git/go-git/pull/1627 targeting `release-5.x`