### PR TITLE
Implement autocrlf

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,10 @@ type Config struct {
 		CommentChar string
 		// RepositoryFormatVersion identifies the repository format and layout version.
 		RepositoryFormatVersion format.RepositoryFormatVersion
+		// AutoCRLF if "true", all the CRLF line endings in the worktree will be
+		// converted to LF when added to the repository, and vice versa on checkout.
+		// If set to "input", only worktree-to-repository conversion is performed.
+		AutoCRLF string
 	}
 
 	User struct {
@@ -290,6 +294,7 @@ const (
 	objectFormat               = "objectformat"
 	mirrorKey                  = "mirror"
 	versionKey                 = "version"
+	autoCRLFKey                = "autocrlf"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.
@@ -337,6 +342,7 @@ func (c *Config) unmarshalCore() {
 
 	c.Core.Worktree = s.Options.Get(worktreeKey)
 	c.Core.CommentChar = s.Options.Get(commentCharKey)
+	c.Core.AutoCRLF = s.Options.Get(autoCRLFKey)
 }
 
 func (c *Config) unmarshalUser() {
@@ -497,6 +503,10 @@ func (c *Config) marshalCore() {
 
 	if c.Core.Worktree != "" {
 		s.SetOption(worktreeKey, c.Core.Worktree)
+	}
+
+	if c.Core.AutoCRLF != "" {
+		s.SetOption(autoCRLFKey, c.Core.AutoCRLF)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,7 @@ func (s *ConfigSuite) TestUnmarshal() {
 		bare = true
 		worktree = foo
 		commentchar = bar
+		autocrlf = true
 [user]
 		name = John Doe
 		email = john@example.com
@@ -70,6 +71,7 @@ func (s *ConfigSuite) TestUnmarshal() {
 	s.True(cfg.Core.IsBare)
 	s.Equal("foo", cfg.Core.Worktree)
 	s.Equal("bar", cfg.Core.CommentChar)
+	s.Equal("true", cfg.Core.AutoCRLF)
 	s.Equal("John Doe", cfg.User.Name)
 	s.Equal("john@example.com", cfg.User.Email)
 	s.Equal("Jane Roe", cfg.Author.Name)
@@ -101,6 +103,7 @@ func (s *ConfigSuite) TestMarshal() {
 	output := []byte(`[core]
 	bare = true
 	worktree = bar
+	autocrlf = true
 [pack]
 	window = 20
 [remote "alt"]
@@ -129,6 +132,7 @@ func (s *ConfigSuite) TestMarshal() {
 	cfg := NewConfig()
 	cfg.Core.IsBare = true
 	cfg.Core.Worktree = "bar"
+	cfg.Core.AutoCRLF = "true"
 	cfg.Pack.Window = 20
 	cfg.Init.DefaultBranch = "main"
 	cfg.Remotes["origin"] = &RemoteConfig{
@@ -180,6 +184,7 @@ func (s *ConfigSuite) TestUnmarshalMarshal() {
 	bare = true
 	worktree = foo
 	custom = ignored
+	autocrlf = true
 [user]
 	name = John Doe
 	email = john@example.com

--- a/utils/convert/eol.go
+++ b/utils/convert/eol.go
@@ -1,0 +1,108 @@
+package convert
+
+import (
+	"bytes"
+	"io"
+)
+
+type crlfToLFWriter struct {
+	w io.Writer
+}
+
+// NewLFWriter wraps a writer to convert CRLF line endings into LF line endings.
+// It assumes that data is text; not binary. See [Stat.IsBinary].
+func NewLFWriter(w io.Writer) io.Writer {
+	return &crlfToLFWriter{w: w}
+}
+
+func (conv *crlfToLFWriter) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+
+	var n int
+	for {
+		window := data[n:]
+
+		idx := bytes.Index(window, []byte{'\r', '\n'})
+		if idx == -1 {
+			break
+		}
+
+		w, err := conv.w.Write(window[:idx])
+		if err != nil {
+			return n + w, err
+		}
+		_, err = conv.w.Write([]byte{'\n'})
+		if err != nil {
+			return n + w, err
+		}
+
+		n += idx + 2
+	}
+
+	if data[len(data)-1] == '\r' {
+		// Lone CR woudn't exist. So it's CRLF.
+		rest, err := conv.w.Write(data[n : len(data)-1])
+		if err != nil {
+			return n + rest, err
+		}
+		return n + rest + 1, nil
+	}
+
+	rest, err := conv.w.Write(data[n:])
+	return n + rest, err
+}
+
+type lfToCRLFWriter struct {
+	w     io.Writer
+	hadCR bool
+}
+
+// NewCRLFWriter wraps a writer to convert LF line endings into CRLF line endings.
+// It assumes that data is text; not binary. See [Stat.IsBinary].
+func NewCRLFWriter(w io.Writer) io.Writer {
+	return &lfToCRLFWriter{w: w}
+}
+
+func (conv *lfToCRLFWriter) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+
+	var n int
+	for {
+		window := data[n:]
+
+		idx := bytes.IndexByte(window, '\n')
+		if idx == -1 {
+			break
+		}
+
+		switch {
+		case idx == 0 && conv.hadCR:
+			fallthrough
+		case idx > 0 && window[idx-1] == '\r':
+			w, err := conv.w.Write(window[:idx+1])
+			if err != nil {
+				return n + w, err
+			}
+		default:
+			w, err := conv.w.Write(window[:idx])
+			if err != nil {
+				return n + w, err
+			}
+			_, err = conv.w.Write([]byte{'\r', '\n'})
+			if err != nil {
+				return n + w, err
+			}
+		}
+
+		n += idx + 1
+	}
+
+	conv.hadCR = data[len(data)-1] == '\r'
+
+	rest, err := conv.w.Write(data[n:])
+	return n + rest, err
+}

--- a/utils/convert/eol_test.go
+++ b/utils/convert/eol_test.go
@@ -1,0 +1,67 @@
+package convert
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCRLFToLFConverter(t *testing.T) {
+	tests := []struct {
+		input  []byte
+		output []byte
+	}{
+		{
+			input:  []byte("CRLF\r\nto\r\nLF"),
+			output: []byte("CRLF\nto\nLF"),
+		},
+		{
+			input:  []byte("\r\n\r\n\r\n\r\n\r\n"),
+			output: []byte("\n\n\n\n\n"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.input), func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			conv := NewLFWriter(buf)
+
+			n, err := conv.Write(test.input)
+			require.NoError(t, err)
+
+			assert.Equal(t, len(test.input), n)
+			assert.Equal(t, test.output, buf.Bytes())
+		})
+	}
+}
+
+func TestLFToCRLFConverter(t *testing.T) {
+	tests := []struct {
+		input  []byte
+		output []byte
+	}{
+		{
+			input:  []byte("LF\nto\nCRLF"),
+			output: []byte("LF\r\nto\r\nCRLF"),
+		},
+		{
+			input:  []byte("\n\n\n\n\n"),
+			output: []byte("\r\n\r\n\r\n\r\n\r\n"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.input), func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			conv := NewCRLFWriter(buf)
+
+			n, err := conv.Write(test.input)
+			require.NoError(t, err)
+
+			assert.Equal(t, len(test.input), n)
+			assert.Equal(t, test.output, buf.Bytes())
+		})
+	}
+}

--- a/utils/convert/stat.go
+++ b/utils/convert/stat.go
@@ -1,0 +1,85 @@
+package convert
+
+import "io"
+
+type Stat struct {
+	NUL, LoneCR, LoneLF, CRLF uint
+	Printable, NonPrintable   uint
+}
+
+// IsBinary detects if data is binary based on:
+// https://git.kernel.org/pub/scm/git/git.git/tree/convert.c?id=HEAD#n94
+func (s Stat) IsBinary() bool {
+	if s.NUL > 0 {
+		return true
+	}
+	if s.LoneCR > 0 {
+		return true
+	}
+
+	mostlyPrintable := (s.Printable >> 7) >= s.NonPrintable
+
+	return !mostlyPrintable
+}
+
+// GetStat returns [Stat] of the reader based on:
+// https://git.kernel.org/pub/scm/git/git.git/tree/convert.c?id=HEAD#n45
+func GetStat(r io.Reader) (stat Stat, err error) {
+	var hadCR bool
+
+	buf := make([]byte, 1)
+
+	for {
+		if _, err := r.Read(buf); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return Stat{}, err
+		}
+
+		b := buf[0]
+
+		if b != '\n' && hadCR {
+			// CR not followed by LF. Lone CR is considered binary.
+			stat.LoneCR++
+			hadCR = false
+		}
+
+		switch {
+		case b == '\n':
+			if hadCR {
+				stat.CRLF++
+				hadCR = false
+			} else {
+				stat.LoneLF++
+			}
+		case b == '\r':
+			hadCR = true
+		case b == 127: // DEL
+			stat.NonPrintable++
+		case b < 32:
+			switch b {
+			case '\b', '\t', '\033', '\014': // BS, HT, ESC and FF
+				stat.Printable++
+			case 0:
+				stat.NUL++
+			default:
+				stat.NonPrintable++
+			}
+		default:
+			stat.Printable++
+		}
+	}
+
+	if hadCR {
+		// Last byte is lone CR.
+		stat.LoneCR++
+	}
+
+	// If file ends with EOF then don't count this EOF as non-printable.
+	if buf[0] == '\032' {
+		stat.NonPrintable--
+	}
+
+	return stat, nil
+}

--- a/utils/convert/stat_test.go
+++ b/utils/convert/stat_test.go
@@ -1,0 +1,92 @@
+package convert
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStat(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		expected Stat
+	}{
+		{
+			input: []byte("ABCDEFG"),
+			expected: Stat{
+				Printable: 7,
+			},
+		},
+		{
+			input: []byte("\r\n\r\n\r\n"),
+			expected: Stat{
+				CRLF: 3,
+			},
+		},
+		{
+			input: []byte("\r\r\n"),
+			expected: Stat{
+				LoneCR: 1,
+				CRLF:   1,
+			},
+		},
+		{
+			input: []byte("\r\n\r"),
+			expected: Stat{
+				LoneCR: 1,
+				CRLF:   1,
+			},
+		},
+		{
+			input: []byte("NUL\x00"),
+			expected: Stat{
+				Printable: 3,
+				NUL:       1,
+			},
+		},
+		{
+			input: []byte{127}, // DEL
+			expected: Stat{
+				NonPrintable: 1,
+			},
+		},
+		{
+			input: []byte{'\n', '\032'}, // LF, EOF
+			expected: Stat{
+				LoneLF:       1,
+				NonPrintable: 0,
+			},
+		},
+	}
+
+	for idx, test := range tests {
+		t.Run(fmt.Sprintf("#%d %s", idx, test.input), func(t *testing.T) {
+			r := bytes.NewReader(test.input)
+
+			stat, err := GetStat(r)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, stat)
+		})
+	}
+}
+
+func TestIsBinary(t *testing.T) {
+	stat := Stat{}
+	assert.False(t, stat.IsBinary())
+
+	stat = Stat{NUL: 1}
+	assert.True(t, stat.IsBinary())
+
+	stat = Stat{LoneCR: 1}
+	assert.True(t, stat.IsBinary())
+
+	stat = Stat{Printable: 1, NonPrintable: 1}
+	assert.True(t, stat.IsBinary())
+
+	stat = Stat{Printable: 1 << 7, NonPrintable: 1}
+	assert.False(t, stat.IsBinary())
+}

--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -51,6 +51,29 @@ func (s *NoderSuite) TestDiff() {
 	s.Len(ch, 0)
 }
 
+func (s *NoderSuite) TestDiffCRLF() {
+	fsA := memfs.New()
+	WriteFile(fsA, "foo", []byte("foo\n"), 0644)
+	WriteFile(fsA, "qux/bar", []byte("foo\n"), 0644)
+	WriteFile(fsA, "qux/qux", []byte("foo\n"), 0644)
+	fsA.Symlink("foo", "bar")
+
+	fsB := memfs.New()
+	WriteFile(fsB, "foo", []byte("foo\r\n"), 0644)
+	WriteFile(fsB, "qux/bar", []byte("foo\r\n"), 0644)
+	WriteFile(fsB, "qux/qux", []byte("foo\r\n"), 0644)
+	fsB.Symlink("foo", "bar")
+
+	ch, err := merkletrie.DiffTree(
+		NewRootNode(fsA, nil),
+		NewRootNodeWithOptions(fsB, nil, Options{AutoCRLF: true}),
+		IsEquals,
+	)
+
+	s.NoError(err)
+	s.Len(ch, 0)
+}
+
 func (s *NoderSuite) TestDiffChangeLink() {
 	fsA := memfs.New()
 	fsA.Symlink("qux", "foo")

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -143,7 +143,16 @@ func (w *Worktree) diffStagingWithWorktree(reverse, excludeIgnoredChanges bool) 
 		return nil, err
 	}
 
-	to := filesystem.NewRootNode(w.Filesystem, submodules)
+	cfg, err := w.r.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	fsOpts := filesystem.Options{
+		AutoCRLF: cfg.Core.AutoCRLF == "true" || cfg.Core.AutoCRLF == "input",
+	}
+
+	to := filesystem.NewRootNodeWithOptions(w.Filesystem, submodules, fsOpts)
 
 	var c merkletrie.Changes
 	if reverse {

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -509,6 +509,10 @@ func (s *WorktreeSuite) TestCheckoutCRLF() {
 
 		require.NoError(t, wt.Checkout(&CheckoutOptions{}))
 
+		status, err := wt.Status()
+		require.NoError(t, err)
+		require.True(t, status.IsClean(), status)
+
 		file, err := wt.Filesystem.Open("CHANGELOG")
 		require.NoError(t, err)
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -495,6 +495,40 @@ func (s *WorktreeSuite) TestCheckoutSparse() {
 	}
 }
 
+func (s *WorktreeSuite) TestCheckoutCRLF() {
+	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
+		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())
+
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		cfg.Core.AutoCRLF = autoCRLF
+		require.NoError(t, r.SetConfig(cfg))
+
+		wt, err := r.Worktree()
+		require.NoError(t, err)
+
+		require.NoError(t, wt.Checkout(&CheckoutOptions{}))
+
+		file, err := wt.Filesystem.Open("CHANGELOG")
+		require.NoError(t, err)
+
+		content, err := io.ReadAll(file)
+		require.NoError(t, err)
+
+		return content
+	}
+
+	s.Run("autocrlf=true", func() {
+		result := runTest(s.T(), "true")
+		s.Equal("Initial changelog\r\n", string(result))
+	})
+
+	s.Run("autocrlf=input", func() {
+		result := runTest(s.T(), "input")
+		s.Equal("Initial changelog\n", string(result))
+	})
+}
+
 func (s *WorktreeSuite) TestFilenameNormalization() {
 	if runtime.GOOS == "windows" {
 		s.T().Skip("windows paths may contain non utf-8 sequences")
@@ -1796,6 +1830,49 @@ func (s *WorktreeSuite) TestAddUntracked() {
 	s.NoError(err)
 	s.NotNil(obj)
 	s.Equal(int64(3), obj.Size())
+}
+
+func (s *WorktreeSuite) TestAddCRLF() {
+	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
+		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())
+
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		cfg.Core.AutoCRLF = autoCRLF
+		require.NoError(t, r.SetConfig(cfg))
+
+		wt, err := r.Worktree()
+		require.NoError(t, err)
+
+		err = util.WriteFile(wt.Filesystem, "foo", []byte("FOO\r\n"), 0o755)
+		require.NoError(t, err)
+
+		h, err := wt.Add("foo")
+		require.NoError(t, err)
+
+		obj, err := r.Storer.EncodedObject(plumbing.BlobObject, h)
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+
+		reader, err := obj.Reader()
+		require.NoError(t, err)
+		defer reader.Close()
+
+		content, err := io.ReadAll(reader)
+		s.Require().NoError(err)
+
+		return content
+	}
+
+	s.Run("autocrlf=true", func() {
+		result := runTest(s.T(), "true")
+		s.Equal("FOO\n", string(result))
+	})
+
+	s.Run("autocrlf=input", func() {
+		result := runTest(s.T(), "input")
+		s.Equal("FOO\n", string(result))
+	})
 }
 
 func (s *WorktreeSuite) TestIgnored() {


### PR DESCRIPTION
This PR introduces autocrlf configuration support.

Fixes https://github.com/go-git/go-git/issues/594, https://github.com/go-git/go-git/issues/691, https://github.com/go-git/go-git/issues/436, https://github.com/go-git/go-git/issues/1615

Summary of the changes:
- Added `core.autocrlf` configuration option.
- Created `util/convert` packageq with CRLF converters and `Stat` object referenced from upstream.
- Added `AutoCRLF bool` option on `filesystem.node` for CRLF conversion on diff.
- Applied CRLF conversion on add, checkout, diff.

