### PR TITLE
storage: Fix external documentation link

### DIFF
--- a/storage/filesystem/dotgit/repository_filesystem.go
+++ b/storage/filesystem/dotgit/repository_filesystem.go
@@ -10,7 +10,7 @@ import (
 
 // RepositoryFilesystem is a billy.Filesystem compatible object wrapper
 // which handles dot-git filesystem operations and supports commondir according to git scm layout:
-// https://github.com/git/git/blob/master/Documentation/gitrepository-layout.txt
+// https://github.com/git/git/blob/master/Documentation/gitrepository-layout.adoc
 type RepositoryFilesystem struct {
 	dotGitFs       billy.Filesystem
 	commonDotGitFs billy.Filesystem


### PR DESCRIPTION
The `gitrepository-layout.txt` was renamed in https://github.com/git/git/commit/1f010d6bdf756129db13d1367c888aa4153f6d87