### PR TITLE
Update the clone example with no auth required

### DIFF
--- a/_examples/clone/main.go
+++ b/_examples/clone/main.go
@@ -16,8 +16,9 @@ func main() {
 
 	// Clone the given repository to the given directory
 	Info("git clone %s %s --recursive", url, directory)
-
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	
+	// this function takes 3 parameters; One of them is the isBare parameter, and as for the v6(just guessing) is required
+	r, err := git.PlainClone(directory, false, &git.CloneOptions{
 		URL:               url,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})


### PR DESCRIPTION
At the moment writing this  the PlainClone prototype asks for 3 parameters. I am guessing that when the version bump took place the code example wasnt updated.

I also set the isBare parameter to false, because i consider that most of the users will not clone a bare repo.
This might be a bad assumption of mine. 