### PR TITLE
Force git daemon to listen on IPv4 in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ profile.out
 .tmp/
 .git-dist/
 .vscode
+.idea

--- a/plumbing/transport/git/common_test.go
+++ b/plumbing/transport/git/common_test.go
@@ -44,6 +44,7 @@ func startDaemon(t testing.TB, base string, port int) *exec.Cmd {
 		// Unless max-connections is limited to 1, a git-receive-pack
 		// might not be seen by a subsequent operation.
 		"--max-connections=1",
+		"--listen=127.0.0.1",
 	)
 
 	// Environment must be inherited in order to acknowledge GIT_EXEC_PATH if set.
@@ -84,7 +85,7 @@ func waitForPort(ctx context.Context, port int) error {
 		case <-ctx.Done():
 			return errors.New("context canceled before the port is connectable")
 		case <-time.After(10 * time.Millisecond):
-			conn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+			conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 			if err == nil {
 				return conn.Close()
 			}


### PR DESCRIPTION
Fixes #1669 for me on MacOS 26.

I guess `git daemon <...>` prefers IPv6, even if IPv6 is not configured properly (or is blocked by corporate IT rules). Changing the command here to specifically listen on the IPv4 address `127.0.0.1` gets all tests passing for me.