### PR TITLE
fix: open repo in worktree

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -358,13 +358,13 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 		return nil, err
 	}
 
-	var repositoryFs billy.Filesystem
+	dotGitCommon, err := dotGitCommonDirectory(dot)
+	if err != nil {
+		return nil, err
+	}
 
-	if o.EnableDotGitCommonDir {
-		dotGitCommon, err := dotGitCommonDirectory(dot)
-		if err != nil {
-			return nil, err
-		}
+	var repositoryFs billy.Filesystem
+	if o.EnableDotGitCommonDir || dotGitCommon != nil {
 		repositoryFs = dotgit.NewRepositoryFilesystem(dot, dotGitCommon)
 	} else {
 		repositoryFs = dot


### PR DESCRIPTION
This PR aims to fix the `git.PlainOpenWithOptions` when opening a worktree. Previously the err "no reference found" were returned.