### PR TITLE
Add support for storage options to PlainOpenWithOptions

### DIFF
--- a/options.go
+++ b/options.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
 // SubmoduleRecursivity defines how depth will affect any submodule recursive
@@ -792,6 +793,9 @@ type PlainOpenOptions struct {
 	// Enable .git/commondir support (see https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt).
 	// NOTE: This option will only work with the filesystem storage.
 	EnableDotGitCommonDir bool
+
+	// Options to pass into the filesystem storage object.
+	StorageOptions filesystem.Options
 }
 
 // Validate validates the fields and sets the default values.

--- a/repository.go
+++ b/repository.go
@@ -370,7 +370,7 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 		repositoryFs = dot
 	}
 
-	s := filesystem.NewStorage(repositoryFs, cache.NewObjectLRUDefault())
+	s := filesystem.NewStorageWithOptions(repositoryFs, cache.NewObjectLRUDefault(), o.StorageOptions)
 
 	return Open(s, wt)
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -877,6 +877,34 @@ func (s *RepositorySuite) TestPlainOpenDetectDotGit() {
 	s.Nil(r)
 }
 
+func (s *RepositorySuite) TestPlainOpenWithStorageOptions() {
+	fs := s.TemporalFilesystem()
+
+	dir, err := util.TempDir(fs, "", "")
+	s.NoError(err)
+
+	subdir := filepath.Join(dir, "a", "b")
+	err = fs.MkdirAll(subdir, 0o755)
+	s.NoError(err)
+
+	file := fs.Join(subdir, "file.txt")
+	f, err := fs.Create(file)
+	s.NoError(err)
+	f.Close()
+
+	r, err := PlainInit(fs.Join(fs.Root(), dir), false)
+	s.NoError(err)
+	s.NotNil(r)
+
+	opt := &PlainOpenOptions{
+		DetectDotGit:   true,
+		StorageOptions: filesystem.Options{KeepDescriptors: true}}
+
+	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), subdir), opt)
+	s.NoError(err)
+	s.NotNil(r)
+}
+
 func (s *RepositorySuite) TestPlainOpenNotExistsDetectDotGit() {
 	dir := s.T().TempDir()
 	opt := &PlainOpenOptions{DetectDotGit: true}


### PR DESCRIPTION
Quick PR to support custom storage options when opening repo using `git.PlainOpenWithOptions()`

Would alleviate idiosyncracies like this one - having to replicate `git.PlainOpen()` logic just to pass `KeepDescriptors: true`:

https://github.com/sourcegraph/zoekt/blob/e1cef6f2b4dc40a2075839273a729c26f9a61c27/gitindex/index.go#L588-L591