### PR TITLE
plumbing: transport, refactor transport Endpoint to use url.URL

### DIFF
--- a/plumbing/transport/git/common.go
+++ b/plumbing/transport/git/common.go
@@ -49,12 +49,7 @@ func (c *command) Start() error {
 		ExtraParams:    c.params,
 	}
 
-	host := c.endpoint.Host
-	if c.endpoint.Port != DefaultPort {
-		host = net.JoinHostPort(c.endpoint.Host, strconv.Itoa(c.endpoint.Port))
-	}
-
-	req.Host = host
+	req.Host = c.getHostWithPort()
 
 	return req.Encode(c.conn)
 }
@@ -76,12 +71,12 @@ func (c *command) connect() error {
 
 func (c *command) getHostWithPort() string {
 	host := c.endpoint.Host
-	port := c.endpoint.Port
-	if port <= 0 {
-		port = DefaultPort
+	port := c.endpoint.Port()
+	if port == "" {
+		return net.JoinHostPort(host, strconv.Itoa(DefaultPort))
 	}
 
-	return net.JoinHostPort(host, strconv.Itoa(port))
+	return host
 }
 
 // StderrPipe git protocol doesn't have any dedicated error channel

--- a/plumbing/transport/registry_test.go
+++ b/plumbing/transport/registry_test.go
@@ -22,7 +22,7 @@ func (s *RegistrySuite) TestNewClientSSH() {
 	e, err := NewEndpoint("ssh://github.com/src-d/go-git")
 	s.NoError(err)
 
-	output, err := Get(e.Protocol)
+	output, err := Get(e.Scheme)
 	s.NoError(err)
 	s.NotNil(output)
 }
@@ -31,7 +31,7 @@ func (s *RegistrySuite) TestNewClientUnknown() {
 	e, err := NewEndpoint("unknown://github.com/src-d/go-git")
 	s.NoError(err)
 
-	_, err = Get(e.Protocol)
+	_, err = Get(e.Scheme)
 	s.Error(err)
 }
 
@@ -40,7 +40,7 @@ func (s *RegistrySuite) TestNewClientNil() {
 	e, err := NewEndpoint("newscheme://github.com/src-d/go-git")
 	s.NoError(err)
 
-	_, err = Get(e.Protocol)
+	_, err = Get(e.Scheme)
 	s.Error(err)
 }
 

--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -227,13 +227,7 @@ func (c *command) getHostWithPort() string {
 		return addr
 	}
 
-	host := c.endpoint.Host
-	port := c.endpoint.Port
-	if port <= 0 {
-		port = DefaultPort
-	}
-
-	return net.JoinHostPort(host, strconv.Itoa(port))
+	return c.endpoint.Host
 }
 
 func (c *command) doGetHostWithPortFromSSHConfig() (addr string, found bool) {
@@ -241,12 +235,12 @@ func (c *command) doGetHostWithPortFromSSHConfig() (addr string, found bool) {
 		return
 	}
 
-	host := c.endpoint.Host
-	port := c.endpoint.Port
+	hostname := c.endpoint.Hostname()
+	port := c.endpoint.Port()
 
-	configHost := DefaultSSHConfig.Get(c.endpoint.Host, "Hostname")
+	configHost := DefaultSSHConfig.Get(c.endpoint.Hostname(), "Hostname")
 	if configHost != "" {
-		host = configHost
+		hostname = configHost
 		found = true
 	}
 
@@ -254,20 +248,24 @@ func (c *command) doGetHostWithPortFromSSHConfig() (addr string, found bool) {
 		return
 	}
 
-	configPort := DefaultSSHConfig.Get(c.endpoint.Host, "Port")
+	configPort := DefaultSSHConfig.Get(c.endpoint.Hostname(), "Port")
 	if configPort != "" {
-		if i, err := strconv.Atoi(configPort); err == nil {
-			port = i
+		if _, err := strconv.Atoi(configPort); err == nil {
+			port = configPort
 		}
 	}
 
-	addr = net.JoinHostPort(host, strconv.Itoa(port))
+	addr = net.JoinHostPort(hostname, port)
 	return
 }
 
 func (c *command) setAuthFromEndpoint() error {
 	var err error
-	c.auth, err = DefaultAuthBuilder(c.endpoint.User)
+	var username string
+	if c.endpoint.User != nil {
+		username = c.endpoint.User.Username()
+	}
+	c.auth, err = DefaultAuthBuilder(username)
 	return err
 }
 

--- a/plumbing/transport/ssh/common_test.go
+++ b/plumbing/transport/ssh/common_test.go
@@ -74,7 +74,7 @@ func (s *SuiteCommon) TestDefaultSSHConfigNil() {
 	s.NoError(err)
 
 	cmd := &command{endpoint: ep}
-	s.Equal("github.com:22", cmd.getHostWithPort())
+	s.Equal("github.com", cmd.getHostWithPort())
 }
 
 func (s *SuiteCommon) TestDefaultSSHConfigWildcard() {
@@ -92,7 +92,7 @@ func (s *SuiteCommon) TestDefaultSSHConfigWildcard() {
 	s.NoError(err)
 
 	cmd := &command{endpoint: ep}
-	s.Equal("github.com:22", cmd.getHostWithPort())
+	s.Equal("github.com", cmd.getHostWithPort())
 }
 
 func TestIgnoreHostKeyCallback(t *testing.T) {

--- a/plumbing/transport/transport.go
+++ b/plumbing/transport/transport.go
@@ -13,13 +13,12 @@
 package transport
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 
 	giturl "github.com/go-git/go-git/v6/internal/url"
@@ -58,19 +57,8 @@ type AuthMethod interface {
 
 // Endpoint represents a Git URL in any supported protocol.
 type Endpoint struct {
-	// Protocol is the protocol of the endpoint (e.g. git, https, file).
-	Protocol string
-	// User is the user.
-	User string
-	// Password is the password.
-	Password string
-	// Host is the host.
-	Host string
-	// Port is the port to connect, if 0 the default port for the given protocol
-	// will be used.
-	Port int
-	// Path is the repository path.
-	Path string
+	url.URL
+
 	// InsecureSkipTLS skips ssl verify if protocol is https
 	InsecureSkipTLS bool
 	// CaBundle specify additional ca bundle with system cert pool
@@ -108,55 +96,7 @@ func (o *ProxyOptions) FullURL() (*url.URL, error) {
 	return proxyURL, nil
 }
 
-var defaultPorts = map[string]int{
-	"http":  80,
-	"https": 443,
-	"git":   9418,
-	"ssh":   22,
-}
-
 var fileIssueWindows = regexp.MustCompile(`^/[A-Za-z]:(/|\\)`)
-
-// String returns a string representation of the Git URL.
-func (u *Endpoint) String() string {
-	var buf bytes.Buffer
-	if u.Protocol != "" {
-		buf.WriteString(u.Protocol)
-		buf.WriteByte(':')
-	}
-
-	if u.Protocol != "" || u.Host != "" || u.User != "" || u.Password != "" {
-		buf.WriteString("//")
-
-		if u.User != "" || u.Password != "" {
-			buf.WriteString(url.PathEscape(u.User))
-			if u.Password != "" {
-				buf.WriteByte(':')
-				buf.WriteString(url.PathEscape(u.Password))
-			}
-
-			buf.WriteByte('@')
-		}
-
-		if u.Host != "" {
-			buf.WriteString(u.Host)
-
-			if u.Port != 0 {
-				port, ok := defaultPorts[strings.ToLower(u.Protocol)]
-				if !ok || ok && port != u.Port {
-					fmt.Fprintf(&buf, ":%d", u.Port)
-				}
-			}
-		}
-	}
-
-	if u.Path != "" && u.Path[0] != '/' && u.Host != "" {
-		buf.WriteByte('/')
-	}
-
-	buf.WriteString(u.Path)
-	return buf.String()
-}
 
 func NewEndpoint(endpoint string) (*Endpoint, error) {
 	if e, ok := parseSCPLike(endpoint); ok {
@@ -171,8 +111,8 @@ func NewEndpoint(endpoint string) (*Endpoint, error) {
 }
 
 func parseURL(endpoint string) (*Endpoint, error) {
-	if strings.HasPrefix(endpoint, "file://") {
-		endpoint = strings.TrimPrefix(endpoint, "file://")
+	if after, ok := strings.CutPrefix(endpoint, "file://"); ok {
+		endpoint = after
 
 		// When triple / is used, the path in Windows may end up having an
 		// additional / resulting in "/C:/Dir".
@@ -181,8 +121,10 @@ func parseURL(endpoint string) (*Endpoint, error) {
 			endpoint = endpoint[1:]
 		}
 		return &Endpoint{
-			Protocol: "file",
-			Path:     endpoint,
+			URL: url.URL{
+				Scheme: "file",
+				Path:   endpoint,
+			},
 		}, nil
 	}
 
@@ -197,53 +139,9 @@ func parseURL(endpoint string) (*Endpoint, error) {
 		))
 	}
 
-	var user, pass string
-	if u.User != nil {
-		user = u.User.Username()
-		pass, _ = u.User.Password()
-	}
-
-	host := u.Hostname()
-	if strings.Contains(host, ":") {
-		// IPv6 address
-		host = "[" + host + "]"
-	}
-
 	return &Endpoint{
-		Protocol: u.Scheme,
-		User:     user,
-		Password: pass,
-		Host:     host,
-		Port:     getPort(u),
-		Path:     getPath(u),
+		URL: *u,
 	}, nil
-}
-
-func getPort(u *url.URL) int {
-	p := u.Port()
-	if p == "" {
-		return 0
-	}
-
-	i, err := strconv.Atoi(p)
-	if err != nil {
-		return 0
-	}
-
-	return i
-}
-
-func getPath(u *url.URL) string {
-	var res string = u.Path
-	if u.RawQuery != "" {
-		res += "?" + u.RawQuery
-	}
-
-	if u.Fragment != "" {
-		res += "#" + u.Fragment
-	}
-
-	return res
 }
 
 func parseSCPLike(endpoint string) (*Endpoint, bool) {
@@ -251,18 +149,18 @@ func parseSCPLike(endpoint string) (*Endpoint, bool) {
 		return nil, false
 	}
 
-	user, host, portStr, path := giturl.FindScpLikeComponents(endpoint)
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		port = 22
+	user, host, port, path := giturl.FindScpLikeComponents(endpoint)
+	if port != "" {
+		host = net.JoinHostPort(host, port)
 	}
 
 	return &Endpoint{
-		Protocol: "ssh",
-		User:     user,
-		Host:     host,
-		Port:     port,
-		Path:     path,
+		URL: url.URL{
+			Scheme: "ssh",
+			User:   url.User(user),
+			Host:   host,
+			Path:   path,
+		},
 	}, true
 }
 
@@ -273,7 +171,9 @@ func parseFile(endpoint string) (*Endpoint, bool) {
 
 	path := endpoint
 	return &Endpoint{
-		Protocol: "file",
-		Path:     path,
+		URL: url.URL{
+			Scheme: "file",
+			Path:   path,
+		},
 	}, true
 }

--- a/plumbing/transport/transport_test.go
+++ b/plumbing/transport/transport_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
@@ -24,7 +25,7 @@ func TestNewEndpoint(t *testing.T) {
 			want:  "http://git:pass@github.com:8080/user/repository.git?foo#bar",
 		},
 		{
-			input: "https://git:pass@github.com:443/user/repository.git?foo#bar",
+			input: "https://git:pass@github.com/user/repository.git?foo#bar",
 			want:  "https://git:pass@github.com/user/repository.git?foo#bar",
 		},
 		{
@@ -36,14 +37,14 @@ func TestNewEndpoint(t *testing.T) {
 				url.PathEscape("person@mail.com"),
 				url.PathEscape(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"),
 			),
-			want: "http://person@mail.com:%20%21%22%23$%25&%27%28%29%2A+%2C-.%2F:%3B%3C=%3E%3F@%5B%5C%5D%5E_%60%7B%7C%7D~@github.com/user/repository.git",
+			want: "http://person%40mail.com:%20%21%22%23$%25&%27%28%29%2A+,-.%2F%3A;%3C=%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~@github.com/user/repository.git",
 		},
 		{
 			input: "http://[::1]:8080/foo.git",
 			want:  "http://[::1]:8080/foo.git",
 		},
 		{
-			input: "ssh://git:pass@github.com:22/user/repository.git?foo#bar",
+			input: "ssh://git:pass@github.com/user/repository.git?foo#bar",
 			want:  "ssh://git:pass@github.com/user/repository.git?foo#bar",
 		},
 		{
@@ -71,9 +72,34 @@ func TestNewEndpoint(t *testing.T) {
 			want:  "ssh://git@github.com:8080/9999/user/repository.git",
 		},
 		{
-			input: "git://github.com:9418/user/repository.git?foo#bar",
+			input: "git://github.com/user/repository.git?foo#bar",
 			want:  "git://github.com/user/repository.git?foo#bar",
 		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			ep, err := NewEndpoint(tc.input)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, ep.String())
+			}
+		})
+	}
+}
+
+func TestNewEndpointFile(t *testing.T) {
+	type tt struct {
+		input   string
+		want    string
+		wantErr string
+	}
+
+	tests := []tt{
 		{
 			input: "/foo.git",
 			want:  "file:///foo.git",
@@ -93,7 +119,8 @@ func TestNewEndpoint(t *testing.T) {
 		{
 			input: "file:///foo.git",
 			want:  "file:///foo.git",
-		}, {
+		},
+		{
 			input: "file:///path/to/repo",
 			want:  "file:///path/to/repo",
 		},
@@ -130,7 +157,7 @@ func TestNewEndpoint(t *testing.T) {
 				require.ErrorContains(t, err, tc.wantErr)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tc.want, ep.String())
+				assert.Equal(t, strings.TrimPrefix(tc.want, "file://"), ep.Path)
 			}
 		})
 	}

--- a/remote.go
+++ b/remote.go
@@ -527,7 +527,7 @@ func newClient(url string, insecure bool, cabundle []byte, proxyOpts transport.P
 	ep.CaBundle = cabundle
 	ep.Proxy = proxyOpts
 
-	c, err := transport.Get(ep.Protocol)
+	c, err := transport.Get(ep.Scheme)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/submodule.go
+++ b/submodule.go
@@ -138,7 +138,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 		return nil, err
 	}
 
-	if !path.IsAbs(moduleEndpoint.Path) && moduleEndpoint.Protocol == "file" {
+	if !path.IsAbs(moduleEndpoint.Path) && moduleEndpoint.Scheme == "file" {
 		remotes, err := s.w.r.Remotes()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
There's no need to duplicate the logic already present in url.URL and the standard library to parse and handle URLs. This refactor simplifies the codebase by removing redundant fields and methods, and leverages the existing functionality of url.URL.

This also remove unused code in transport/http ModifyEndpointIfRedirect and its related tests.