### PR TITLE
plumbing: Fix NewKnownHostsCallback panic

### DIFF
--- a/plumbing/transport/ssh/auth_method.go
+++ b/plumbing/transport/ssh/auth_method.go
@@ -242,6 +242,9 @@ func (a *PublicKeysCallback) ClientConfig() (*ssh.ClientConfig, error) {
 //	/etc/ssh/ssh_known_hosts
 func NewKnownHostsCallback(files ...string) (ssh.HostKeyCallback, error) {
 	db, err := newKnownHostsDb(files...)
+	if db == nil {
+		return nil, err
+	}
 	return db.HostKeyCallback(), err
 }
 


### PR DESCRIPTION
NewKnownHostsCallback attempts to return db.HostKeyCallback() without checking if db is nil, leading to a panic when there is an error initializing the database.