### PR TITLE
_examples: Add missing update server info example

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -110,10 +110,10 @@ compatibility status with go-git.
 
 ## Server admin
 
-| Feature              | Sub-feature | Status | Notes | Examples                                  |
-| -------------------- | ----------- | ------ | ----- | ----------------------------------------- |
-| `daemon`             |             | ❌     |       |                                           |
-| `update-server-info` |             | ✅     |       | [cli](./cli/go-git/update_server_info.go) |
+| Feature              | Sub-feature | Status | Notes | Examples                                                   |
+| -------------------- | ----------- | ------ | ----- | ---------------------------------------------------------- |
+| `daemon`             |             | ❌     |       |                                                            |
+| `update-server-info` |             | ✅     |       | [update-server-info](_examples/update-server-info/main.go) |
 
 ## Advanced
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -28,6 +28,7 @@ Here you can find a list of annotated _go-git_ examples:
 - [submodule](submodule/main.go) - Submodule update remote.
 - [blame](blame/main.go) - Blame/annotate a commit.
 - [ls-remote](ls-remote/main.go) - List remote tags without cloning a repository.
+- [update-server-info](update-server-info/main.go) - Update server info files in a repository.
 
 ### Advanced
 - [custom_http](custom_http/main.go) - Replacing the HTTP client using a custom one.

--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -39,6 +39,7 @@ var args = map[string][]string{
 	"showcase":                   {defaultURL, tempFolder()},
 	"sparse-checkout":            {defaultURL, "vendor", tempFolder()},
 	"tag":                        {cloneRepository(defaultURL, tempFolder())},
+	"update-server-info":         {cloneRepository(defaultURL, tempFolder())},
 }
 
 // tests not working / set-up

--- a/_examples/update-server-info/main.go
+++ b/_examples/update-server-info/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	. "github.com/go-git/go-git/v6/_examples"
+)
+
+// Updates server info (info/refs & objects/info/packs)
+// files in a repository. Git http transport (dumb) uses them
+// to generate a list of available refs for the repository.
+// https://git-scm.com/docs/git-update-server-info
+// https://git-scm.com/book/id/v2/Git-Internals-Transfer-Protocols#_the_dumb_protocol
+func main() {
+	CheckArgs("<path>")
+	path := os.Args[1]
+
+	// We instantiate a new repository targeting the given path (the .git folder)
+	r, err := git.PlainOpen(path)
+	CheckIfError(err)
+
+	// Update the server info files & save them to the file-system.
+	fs := r.Storer.(*filesystem.Storage).Filesystem()
+	err = transport.UpdateServerInfo(r.Storer, fs)
+	CheckIfError(err)
+}


### PR DESCRIPTION
At some point with the update server info cli example was removed and not reflected within the compatibility document (404 error). Since the update server info still available within the transport package and the fact I was looking for the feature myself. I've included a update server info example to _examples.