### PR TITLE
fix(transport): correctly parse Windows drive-letter paths as file en…

### DIFF
--- a/plumbing/transport/transport.go
+++ b/plumbing/transport/transport.go
@@ -116,6 +116,7 @@ var defaultPorts = map[string]int{
 }
 
 var fileIssueWindows = regexp.MustCompile(`^/[A-Za-z]:(/|\\)`)
+var windowsDrive = regexp.MustCompile(`^[A-Za-z]:(/|\\)`)
 
 // String returns a string representation of the Git URL.
 func (u *Endpoint) String() string {
@@ -247,6 +248,12 @@ func getPath(u *url.URL) string {
 }
 
 func parseSCPLike(endpoint string) (*Endpoint, bool) {
+	// On Windows, a path like "C:/..." or "C:\\..." should be treated
+	// as a local file path, not an SCP-like SSH URL. Avoid matching those
+	// as SCP-like endpoints.
+	if runtime.GOOS == "windows" && windowsDrive.MatchString(endpoint) {
+		return nil, false
+	}
 	if giturl.MatchesScheme(endpoint) || !giturl.MatchesScpLike(endpoint) {
 		return nil, false
 	}

--- a/plumbing/transport/transport_windows_test.go
+++ b/plumbing/transport/transport_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+// +build windows
+
+package transport
+
+import (
+	"testing"
+)
+
+func TestNewEndpoint_WindowsDrivePath_IsFile(t *testing.T) {
+	// Paths like "C:/path/to/repo" or "C:\\path\\to\\repo" should
+	// be treated as local file endpoints on Windows, not SCP/SSH.
+	eps := []string{
+		"C:/Users/Administrator/Downloads/workdir/repository",
+		"C:\\Users\\Administrator\\Downloads\\workdir\\repository",
+	}
+
+	for _, ep := range eps {
+		e, err := NewEndpoint(ep)
+		if err != nil {
+			t.Fatalf("NewEndpoint(%q) returned error: %v", ep, err)
+		}
+		if e.Protocol != "file" {
+			t.Fatalf("expected protocol=file for %q, got %q", ep, e.Protocol)
+		}
+		if e.Path != ep {
+			t.Fatalf("expected path=%q for %q, got %q", ep, ep, e.Path)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes issue #1621 where local Windows paths (e.g., C:/... or C:\...) were incorrectly parsed as SCP/SSH endpoints, causing go-git to attempt SSH connections for local repositories.

Changes
Added a platform-specific guard  to prevent Windows drive-letter paths from being treated as SCP-like.
Ensured that such paths are parsed as file endpoints.
Added a Windows-only regression test (transport_windows_test.go) to verify that [NewEndpoint("C:/...")] and [NewEndpoint("C:\\...")] return protocol "file".