### PR TITLE
plumbing: use errors package for comparaison

### DIFF
--- a/_examples/checkout-branch/main.go
+++ b/_examples/checkout-branch/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -74,7 +75,7 @@ func fetchOrigin(repo *git.Repository, refSpecStr string) error {
 	if err = remote.Fetch(&git.FetchOptions{
 		RefSpecs: refSpecs,
 	}); err != nil {
-		if err == git.NoErrAlreadyUpToDate {
+		if errors.Is(err, git.NoErrAlreadyUpToDate) {
 			fmt.Print("refs already up to date")
 		} else {
 			return fmt.Errorf("fetch origin failed: %v", err)

--- a/_examples/ls/main.go
+++ b/_examples/ls/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -131,7 +132,7 @@ func getFullPath(treePath, path string) string {
 
 func getFileHashes(c commitgraph.CommitNode, treePath string, paths []string) (map[string]plumbing.Hash, error) {
 	tree, err := getCommitTree(c, treePath)
-	if err == object.ErrDirectoryNotFound {
+	if errors.Is(err, object.ErrDirectoryNotFound) {
 		// The whole tree didn't exist, so return empty map
 		return make(map[string]plumbing.Hash), nil
 	}

--- a/_examples/tag-create-push/main.go
+++ b/_examples/tag-create-push/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -135,7 +136,7 @@ func pushTags(r *git.Repository, publicKeyPath string) error {
 	err := r.Push(po)
 
 	if err != nil {
-		if err == git.NoErrAlreadyUpToDate {
+		if errors.Is(err, git.NoErrAlreadyUpToDate) {
 			log.Print("origin remote was up to date, no push done")
 			return nil
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -495,7 +495,7 @@ func unmarshalSubmodules(fc *format.Config, submodules map[string]*Submodule) {
 		m := &Submodule{}
 		m.unmarshal(sub)
 
-		if m.Validate() == ErrModuleBadPath {
+		if errors.Is(m.Validate(), ErrModuleBadPath) {
 			continue
 		}
 

--- a/options.go
+++ b/options.go
@@ -603,7 +603,7 @@ func (o *CommitOptions) Validate(r *Repository) error {
 
 	if len(o.Parents) == 0 {
 		head, err := r.Head()
-		if err != nil && err != plumbing.ErrReferenceNotFound {
+		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return err
 		}
 

--- a/plumbing/object/commit_walker_bfs.go
+++ b/plumbing/object/commit_walker_bfs.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -86,7 +87,7 @@ func (w *bfsCommitIterator) ForEach(cb func(*Commit) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {

--- a/plumbing/object/commit_walker_bfs_filtered.go
+++ b/plumbing/object/commit_walker_bfs_filtered.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -99,7 +100,7 @@ func (w *filterCommitIter) ForEach(cb func(*Commit) error) error {
 			return err
 		}
 
-		if err := cb(commit); err == storer.ErrStop {
+		if err := cb(commit); errors.Is(err, storer.ErrStop) {
 			break
 		} else if err != nil {
 			return err

--- a/plumbing/object/commit_walker_ctime.go
+++ b/plumbing/object/commit_walker_ctime.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 
 	"github.com/emirpasic/gods/trees/binaryheap"
@@ -89,7 +90,7 @@ func (w *commitIteratorByCTime) ForEach(cb func(*Commit) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {

--- a/plumbing/object/commit_walker_limit.go
+++ b/plumbing/object/commit_walker_limit.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -52,11 +53,11 @@ func (c *commitLimitIter) ForEach(cb func(*Commit) error) error {
 		if nextErr == io.EOF {
 			break
 		}
-		if nextErr != nil && nextErr != storer.ErrStop {
+		if nextErr != nil && !errors.Is(nextErr, storer.ErrStop) {
 			return nextErr
 		}
 		err := cb(commit)
-		if err == storer.ErrStop || nextErr == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) || errors.Is(nextErr, storer.ErrStop) {
 			return nil
 		} else if err != nil {
 			return err

--- a/plumbing/object/commit_walker_path.go
+++ b/plumbing/object/commit_walker_path.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -153,7 +154,7 @@ func (c *commitPathIter) ForEach(cb func(*Commit) error) error {
 			return nextErr
 		}
 		err := cb(commit)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			return nil
 		} else if err != nil {
 			return err

--- a/plumbing/object/commitgraph/commitnode.go
+++ b/plumbing/object/commitgraph/commitnode.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -64,7 +65,7 @@ func newParentgraphCommitNodeIter(node CommitNode) CommitNodeIter {
 // there are no more commits, it returns io.EOF.
 func (iter *parentCommitNodeIter) Next() (CommitNode, error) {
 	obj, err := iter.node.ParentNode(iter.i)
-	if err == object.ErrParentNotFound {
+	if errors.Is(err, object.ErrParentNotFound) {
 		return nil, io.EOF
 	}
 	if err == nil {
@@ -89,7 +90,7 @@ func (iter *parentCommitNodeIter) ForEach(cb func(CommitNode) error) error {
 		}
 
 		if err := cb(obj); err != nil {
-			if err == storer.ErrStop {
+			if errors.Is(err, storer.ErrStop) {
 				return nil
 			}
 

--- a/plumbing/object/commitgraph/commitnode_walker_ctime.go
+++ b/plumbing/object/commitgraph/commitnode_walker_ctime.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -92,7 +93,7 @@ func (w *commitNodeIteratorByCTime) ForEach(cb func(CommitNode) error) error {
 		}
 
 		err = cb(c)
-		if err == storer.ErrStop {
+		if errors.Is(err, storer.ErrStop) {
 			break
 		}
 		if err != nil {

--- a/plumbing/object/commitgraph/commitnode_walker_topo_order.go
+++ b/plumbing/object/commitgraph/commitnode_walker_topo_order.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"errors"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -148,7 +149,7 @@ func (iter *commitNodeIteratorTopological) ForEach(cb func(CommitNode) error) er
 		}
 
 		if err := cb(obj); err != nil {
-			if err == storer.ErrStop {
+			if errors.Is(err, storer.ErrStop) {
 				return nil
 			}
 

--- a/plumbing/object/difftree.go
+++ b/plumbing/object/difftree.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"context"
+	"errors"
 
 	"github.com/go-git/go-git/v6/utils/merkletrie"
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
@@ -75,7 +76,7 @@ func DiffTreeWithOptions(
 
 	merkletrieChanges, err := merkletrie.DiffTreeContext(ctx, from, to, hashEqual)
 	if err != nil {
-		if err == merkletrie.ErrCanceled {
+		if errors.Is(err, merkletrie.ErrCanceled) {
 			return nil, ErrCanceled
 		}
 		return nil, err

--- a/plumbing/object/file.go
+++ b/plumbing/object/file.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"strings"
 
@@ -123,7 +124,7 @@ func (iter *FileIter) ForEach(cb func(*File) error) error {
 		}
 
 		if err := cb(f); err != nil {
-			if err == storer.ErrStop {
+			if errors.Is(err, storer.ErrStop) {
 				return nil
 			}
 

--- a/plumbing/object/merge_base.go
+++ b/plumbing/object/merge_base.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -21,7 +22,7 @@ func (c *Commit) MergeBase(other *Commit) ([]*Commit, error) {
 	older := sorted[1]
 
 	newerHistory, err := ancestorsIndex(older, newer)
-	if err == errIsReachable {
+	if errors.Is(err, errIsReachable) {
 		return []*Commit{older}, nil
 	}
 

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -189,7 +189,7 @@ func (iter *ObjectIter) Next() (Object, error) {
 		}
 
 		o, err := iter.toObject(obj)
-		if err == plumbing.ErrInvalidType {
+		if errors.Is(err, plumbing.ErrInvalidType) {
 			continue
 		}
 
@@ -207,7 +207,7 @@ func (iter *ObjectIter) Next() (Object, error) {
 func (iter *ObjectIter) ForEach(cb func(Object) error) error {
 	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
 		o, err := iter.toObject(obj)
-		if err == plumbing.ErrInvalidType {
+		if errors.Is(err, plumbing.ErrInvalidType) {
 			return nil
 		}
 

--- a/plumbing/object/rename.go
+++ b/plumbing/object/rename.go
@@ -478,7 +478,7 @@ outerLoop:
 			if s == nil {
 				s, err = fileSimilarityIndex(from)
 				if err != nil {
-					if err == errIndexFull {
+					if errors.Is(err, errIndexFull) {
 						continue outerLoop
 					}
 					return nil, err
@@ -494,7 +494,7 @@ outerLoop:
 
 			di, err := fileSimilarityIndex(to)
 			if err != nil {
-				if err == errIndexFull {
+				if errors.Is(err, errIndexFull) {
 					dstTooLarge[dstIdx] = true
 				}
 
@@ -605,7 +605,7 @@ func (i *similarityIndex) hashContent(r io.Reader, size int64, isBin bool) error
 				ptr = 0
 				var err error
 				cnt, err = io.ReadFull(r, buf)
-				if err != nil && err != io.ErrUnexpectedEOF {
+				if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 					return err
 				}
 

--- a/plumbing/protocol/packp/advrefs.go
+++ b/plumbing/protocol/packp/advrefs.go
@@ -1,6 +1,7 @@
 package packp
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -110,7 +111,7 @@ func (a *AdvRefs) resolveHead(s storer.ReferenceStorer) error {
 		}
 	}
 
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -282,7 +282,7 @@ func ForEachIterator(iter bareIterator, cb func(plumbing.EncodedObject) error) e
 		}
 
 		if err := cb(obj); err != nil {
-			if err == ErrStop {
+			if errors.Is(err, ErrStop) {
 				return nil
 			}
 

--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -80,7 +80,7 @@ func (iter *referenceFilteredIter) ForEach(cb func(*plumbing.Reference) error) e
 		}
 
 		if err := cb(r); err != nil {
-			if err == ErrStop {
+			if errors.Is(err, ErrStop) {
 				break
 			}
 
@@ -152,7 +152,7 @@ func forEachReferenceIter(iter bareReferenceIterator, cb func(*plumbing.Referenc
 		}
 
 		if err := cb(obj); err != nil {
-			if err == ErrStop {
+			if errors.Is(err, ErrStop) {
 				return nil
 			}
 

--- a/remote.go
+++ b/remote.go
@@ -685,7 +685,7 @@ func (r *Remote) addObject(rs config.RefSpec,
 		}
 
 		cmd.Old = remoteRef.Hash()
-	} else if err != plumbing.ErrReferenceNotFound {
+	} else if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 	if cmd.Old == cmd.New {
@@ -727,7 +727,7 @@ func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
 		}
 
 		cmd.Old = remoteRef.Hash()
-	} else if err != plumbing.ErrReferenceNotFound {
+	} else if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 
@@ -1014,7 +1014,7 @@ func objectExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
 func checkFastForwardUpdate(s storer.EncodedObjectStorer, remoteRefs storer.ReferenceStorer, cmd *packp.Command) error {
 	if cmd.Old == plumbing.ZeroHash {
 		_, err := remoteRefs.Reference(cmd.Name)
-		if err == plumbing.ErrReferenceNotFound {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return nil
 		}
 

--- a/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
+++ b/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
@@ -1,6 +1,7 @@
 package dotgit
 
 import (
+	"errors"
 	"io"
 	"os"
 	"runtime"
@@ -29,7 +30,7 @@ func (d *DotGit) rewritePackedRefsWhileLocked(
 
 	// If we are in a filesystem that does not support rename (e.g. sivafs)
 	// a full copy is done.
-	if err == billy.ErrNotSupported {
+	if errors.Is(err, billy.ErrNotSupported) {
 		return d.copyNewFile(tmp, pr)
 	}
 

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -1,6 +1,7 @@
 package dotgit
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync/atomic"
@@ -75,7 +76,7 @@ func (w *PackWriter) buildIndex() {
 // ignore the error
 func (w *PackWriter) waitBuildIndex() error {
 	err := <-w.result
-	if err == packfile.ErrEmptyPackfile {
+	if errors.Is(err, packfile.ErrEmptyPackfile) {
 		return nil
 	}
 

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -2,6 +2,7 @@
 package memory
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -230,7 +231,7 @@ func (o *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 	for h := range o.Objects {
 		err := fun(h)
 		if err != nil {
-			if err == storer.ErrStop {
+			if errors.Is(err, storer.ErrStop) {
 				return nil
 			}
 			return err

--- a/submodule.go
+++ b/submodule.go
@@ -69,7 +69,7 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 	}
 
 	e, err := idx.Entry(s.c.Path)
-	if err != nil && err != index.ErrEntryNotFound {
+	if err != nil && !errors.Is(err, index.ErrEntryNotFound) {
 		return nil, err
 	}
 
@@ -91,7 +91,7 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 		status.Current = head.Hash()
 	}
 
-	if err != nil && err == plumbing.ErrReferenceNotFound {
+	if err != nil && errors.Is(err, plumbing.ErrReferenceNotFound) {
 		err = nil
 	}
 
@@ -110,7 +110,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 	}
 
 	_, err = storer.Reference(plumbing.HEAD)
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return nil, err
 	}
 
@@ -244,7 +244,7 @@ func (s *Submodule) fetchAndCheckout(
 ) error {
 	if !o.NoFetch {
 		err := r.FetchContext(ctx, &FetchOptions{Auth: o.Auth, Depth: o.Depth})
-		if err != nil && err != NoErrAlreadyUpToDate {
+		if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) {
 			return err
 		}
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -92,7 +92,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 	})
 
 	updated := true
-	if err == NoErrAlreadyUpToDate {
+	if errors.Is(err, NoErrAlreadyUpToDate) {
 		updated = false
 	} else if err != nil {
 		return err
@@ -132,7 +132,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		}
 	}
 
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 
@@ -217,7 +217,7 @@ func (w *Worktree) createBranch(opts *CheckoutOptions) error {
 		return fmt.Errorf("a branch named %q already exists", opts.Branch)
 	}
 
-	if err != plumbing.ErrReferenceNotFound {
+	if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return err
 	}
 

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -51,7 +51,7 @@ func (w *Worktree) StatusWithOptions(o StatusOptions) (Status, error) {
 	var hash plumbing.Hash
 
 	ref, err := w.r.Head()
-	if err != nil && err != plumbing.ErrReferenceNotFound {
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return nil, err
 	}
 
@@ -564,11 +564,11 @@ func (w *Worktree) fillEncodedObjectFromSymlink(dst io.Writer, path string, _ os
 
 func (w *Worktree) addOrUpdateFileToIndex(idx *index.Index, filename string, h plumbing.Hash) error {
 	e, err := idx.Entry(filename)
-	if err != nil && err != index.ErrEntryNotFound {
+	if err != nil && !errors.Is(err, index.ErrEntryNotFound) {
 		return err
 	}
 
-	if err == index.ErrEntryNotFound {
+	if errors.Is(err, index.ErrEntryNotFound) {
 		return w.doAddFileToIndex(idx, filename, h)
 	}
 
@@ -639,7 +639,7 @@ func (w *Worktree) doRemoveDirectory(idx *index.Index, directory string) (remove
 			r, err = w.doRemoveDirectory(idx, name)
 		} else {
 			_, err = w.doRemoveFile(idx, name)
-			if err == index.ErrEntryNotFound {
+			if errors.Is(err, index.ErrEntryNotFound) {
 				err = nil
 			}
 		}


### PR DESCRIPTION
Comparison with errors using equality operators fails on wrapped errors

use the golang 1.13 best practices: https://tip.golang.org/doc/go1.13#error_wrapping