### PR TITLE
internal: use clear built-in

### DIFF
--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -293,7 +293,7 @@ func (tx *TxObjectStorage) Commit() error {
 }
 
 func (tx *TxObjectStorage) Rollback() error {
-	tx.Objects = make(map[plumbing.Hash]plumbing.EncodedObject)
+	clear(tx.Objects)
 	return nil
 }
 

--- a/utils/sync/bytes.go
+++ b/utils/sync/bytes.go
@@ -33,11 +33,7 @@ func GetByteSlice() *[]byte {
 		b = b[:cap(b)]
 	}
 
-	// zero out the array contents.
-	for i := 0; i < len(b); i++ {
-		b[i] = 0
-	}
-
+	clear(b)
 	return &b
 }
 


### PR DESCRIPTION
similar to #1725, clear was added in go1.21.
https://pkg.go.dev/builtin#clear