### PR TITLE
prevent concurrent map read and write panic

### DIFF
--- a/plumbing/format/idxfile/idxfile_test.go
+++ b/plumbing/format/idxfile/idxfile_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -166,4 +167,35 @@ func fixtureIndex() (*idxfile.MemoryIndex, error) {
 	}
 
 	return idx, nil
+}
+
+func TestOffsetHashConcurrentPopulation(t *testing.T) {
+	idx, err := fixtureIndex()
+	if err != nil {
+		t.Fatalf("failed to build fixture index: %v", err)
+	}
+
+	var wg sync.WaitGroup
+
+	for _, h := range fixtureHashes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 5000; i++ {
+				_, _ = idx.FindOffset(h)
+			}
+		}()
+	}
+
+	for _, off := range fixtureOffsets {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 3000; i++ {
+				_, _ = idx.FindHash(off)
+			}
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
Got a panic on concurrent read/write of this map calling Repository.PushContext(). It's difficult to reproduce but the panic is pretty clear. This should fix it. Was using v5.16.2 at the time. Patch is for main but can back port if preferred.