### PR TITLE
[backport] build: test, Fix build on Windows.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         go-version: ${{ matrix.go-version }}   
   
     - name: Configure known hosts
+      continue-on-error: true
       if: matrix.platform != 'ubuntu-latest'
       run: |
         mkdir -p  ~/.ssh


### PR DESCRIPTION
Ignore adding github.com keys to known_hosts.

Win32-OpenSSH does not support the key exchange method sntrup761x25519-sha512@openssh.com.

This method was recently added to github.com - see https://github.blog/engineering/platform-security/post-quantum-security-for-ssh-access-on-github/

For more information about the KEX method support see https://github.com/PowerShell/Win32-OpenSSH/issues/2140

x-ref: #1663