### PR TITLE
plumbing: optimize Tree.Decode with ReadSlice and io.ReadFull

### DIFF
--- a/plumbing/filemode/filemode.go
+++ b/plumbing/filemode/filemode.go
@@ -65,6 +65,26 @@ func New(s string) (FileMode, error) {
 	return FileMode(n), nil
 }
 
+// NewFromBytes parses a FileMode from a byte slice containing an octal
+// number. This avoids allocating a string when parsing from binary data.
+//
+// Please note this function does not check if the returned FileMode
+// is valid in git or if it is malformed.
+func NewFromBytes(b []byte) (FileMode, error) {
+	if len(b) == 0 || len(b) > 7 {
+		return Empty, fmt.Errorf("invalid mode length: %d", len(b))
+	}
+
+	var mode uint32
+	for _, c := range b {
+		if c < '0' || c > '7' {
+			return Empty, fmt.Errorf("invalid octal character: %c", c)
+		}
+		mode = mode*8 + uint32(c-'0')
+	}
+	return FileMode(mode), nil
+}
+
 // NewFromOSFileMode returns the FileMode used by git to represent
 // the provided file system modes and a nil error on success.  If the
 // file system mode cannot be mapped to any valid git mode (as with

--- a/plumbing/filemode/filemode.go
+++ b/plumbing/filemode/filemode.go
@@ -65,12 +65,12 @@ func New(s string) (FileMode, error) {
 	return FileMode(n), nil
 }
 
-// NewFromBytes parses a FileMode from a byte slice containing an octal
+// FromBytes parses a FileMode from a byte slice containing an octal
 // number. This avoids allocating a string when parsing from binary data.
 //
 // Please note this function does not check if the returned FileMode
 // is valid in git or if it is malformed.
-func NewFromBytes(b []byte) (FileMode, error) {
+func FromBytes(b []byte) (FileMode, error) {
 	if len(b) == 0 || len(b) > 7 {
 		return Empty, fmt.Errorf("invalid mode length: %d", len(b))
 	}

--- a/plumbing/filemode/filemode_test.go
+++ b/plumbing/filemode/filemode_test.go
@@ -67,6 +67,59 @@ func (s *ModeSuite) TestNewErrors() {
 	}
 }
 
+func (s *ModeSuite) TestFromBytes() {
+	for _, test := range [...]struct {
+		input    string
+		expected FileMode
+	}{
+		{input: "40000", expected: Dir},
+		{input: "100644", expected: Regular},
+		{input: "100664", expected: Deprecated},
+		{input: "100755", expected: Executable},
+		{input: "120000", expected: Symlink},
+		{input: "160000", expected: Submodule},
+		{input: "000000", expected: Empty},
+		{input: "040000", expected: Dir},
+		{input: "0", expected: Empty},
+		{input: "42", expected: FileMode(0o42)},
+	} {
+		comment := fmt.Sprintf("input = %q", test.input)
+		obtained, err := FromBytes([]byte(test.input))
+		s.Equal(test.expected, obtained, comment)
+		s.NoError(err, comment)
+	}
+}
+
+func (s *ModeSuite) TestFromBytesErrors() {
+	for _, input := range [...]string{
+		"",         // empty
+		"9",        // non-octal digit
+		"09",       // non-octal digit
+		"mode",     // letters
+		"12345678", // too long (>7 chars)
+		"0x81a4",   // hex prefix
+		"-100644",  // negative
+	} {
+		comment := fmt.Sprintf("input = %q", input)
+		obtained, err := FromBytes([]byte(input))
+		s.Equal(Empty, obtained, comment)
+		s.NotNil(err, comment)
+	}
+}
+
+func (s *ModeSuite) TestFromBytesEquivalence() {
+	// FromBytes should produce the same results as New for valid git modes
+	for _, m := range [...]string{
+		"40000", "100644", "100664", "100755", "120000", "160000",
+	} {
+		expected, err1 := New(m)
+		s.NoError(err1)
+		got, err2 := FromBytes([]byte(m))
+		s.NoError(err2)
+		s.Equal(expected, got, "mismatch for mode %q", m)
+	}
+}
+
 // fixtures for testing NewModeFromOSFileMode
 type fixture struct {
 	input    os.FileMode

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -300,10 +301,13 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 
 	var prevSortName string
 	for {
-		str, err := r.ReadString(' ')
+		// Use ReadSlice to get a view into bufio's internal buffer,
+		// avoiding a string allocation for the mode (which is parsed
+		// into a uint32 immediately and doesn't need to persist).
+		modeSlice, err := r.ReadSlice(' ')
 		if err != nil {
 			if err == io.EOF {
-				if len(str) != 0 {
+				if len(modeSlice) != 0 {
 					return fmt.Errorf("%w: missing mode terminator", ErrMalformedTree)
 				}
 				break
@@ -311,24 +315,35 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 
 			return err
 		}
-		str = str[:len(str)-1] // strip last byte (' ')
+		modeSlice = modeSlice[:len(modeSlice)-1] // strip delimiter
 
-		mode, err := filemode.New(str)
+		mode, err := filemode.NewFromBytes(modeSlice)
 		if err != nil {
 			return fmt.Errorf("%w: malformed mode", ErrMalformedTree)
 		}
 		mode = canonicalTreeMode(mode)
 
-		name, err := r.ReadString(0)
+		nameSlice, err := r.ReadSlice(0)
+		if err == bufio.ErrBufferFull {
+			// Rare: name exceeds bufio's buffer. Accumulate the rest.
+			buf := append([]byte(nil), nameSlice...)
+			for err == bufio.ErrBufferFull {
+				var more []byte
+				more, err = r.ReadSlice(0)
+				buf = append(buf, more...)
+			}
+			nameSlice = buf
+		}
 		if err != nil {
 			if err == io.EOF {
 				return fmt.Errorf("%w: missing filename terminator", ErrMalformedTree)
 			}
 			return err
 		}
-		if len(name) == 1 {
+		if len(nameSlice) == 1 {
 			return fmt.Errorf("%w: empty filename", ErrMalformedTree)
 		}
+		name := string(nameSlice[:len(nameSlice)-1]) // strip delimiter
 
 		var hash plumbing.Hash
 		hash.ResetBySize(t.Hash.Size())
@@ -339,11 +354,10 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 			return err
 		}
 
-		baseName := name[:len(name)-1]
 		entry := TreeEntry{
 			Hash: hash,
 			Mode: mode,
-			Name: baseName,
+			Name: name,
 		}
 		sortName := treeEntrySortName(&entry)
 		if len(t.Entries) != 0 && prevSortName > sortName {

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -317,7 +317,7 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 		}
 		modeSlice = modeSlice[:len(modeSlice)-1] // strip delimiter
 
-		mode, err := filemode.NewFromBytes(modeSlice)
+		mode, err := filemode.FromBytes(modeSlice)
 		if err != nil {
 			return fmt.Errorf("%w: malformed mode", ErrMalformedTree)
 		}

--- a/plumbing/object/tree_benchmark_test.go
+++ b/plumbing/object/tree_benchmark_test.go
@@ -1,0 +1,80 @@
+package object
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// createTestTreeObject creates a synthetic tree object for benchmarking
+func createTestTreeObject(numEntries int) *plumbing.MemoryObject {
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+
+	w, _ := obj.Writer()
+	for i := range numEntries {
+		// Write mode
+		w.Write([]byte("100644 "))
+		// Write name
+		name := make([]byte, 0, 16)
+		name = fmt.Appendf(name, "file%03d", i)
+		w.Write(name)
+		w.Write([]byte{0})
+		// Write hash (20 bytes)
+		hash := plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")
+		hash.WriteTo(w)
+	}
+	w.Close()
+
+	return obj
+}
+
+// BenchmarkTreeDecode benchmarks the decoding of tree objects with varying sizes
+func BenchmarkTreeDecode(b *testing.B) {
+	tests := []struct {
+		name       string
+		numEntries int
+	}{
+		{"Small/1entry", 1},
+		{"Medium/8entries", 8},
+		{"Large/100entries", 100},
+		{"VeryLarge/1000entries", 1000},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			obj := createTestTreeObject(tt.numEntries)
+			b.ReportAllocs()
+
+			for b.Loop() {
+				tree := &Tree{}
+				err := tree.Decode(obj)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMultipleTreeDecodes simulates a Clone operation pattern
+func BenchmarkMultipleTreeDecodes(b *testing.B) {
+	// Create multiple tree objects
+	objects := []*plumbing.MemoryObject{
+		createTestTreeObject(5),
+		createTestTreeObject(10),
+		createTestTreeObject(20),
+		createTestTreeObject(8),
+		createTestTreeObject(15),
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		for _, obj := range objects {
+			tree := &Tree{}
+			tree.Decode(obj)
+		}
+	}
+}

--- a/plumbing/objectid.go
+++ b/plumbing/objectid.go
@@ -150,5 +150,5 @@ func (s *ObjectID) ResetBySize(idSize int) {
 	} else {
 		s.format = format.UnsetObjectFormat
 	}
-	copy(s.hash[:], s.hash[:0])
+	clear(s.hash[:])
 }

--- a/plumbing/objectid.go
+++ b/plumbing/objectid.go
@@ -122,7 +122,7 @@ func (s *ObjectID) ReadFrom(r io.Reader) (int64, error) {
 	n, err := io.ReadFull(r, s.hash[:s.Size()])
 	if err != nil {
 		// Clear partial read so the hash remains zero on error.
-		clear(s.hash[:s.Size()])
+		s.ResetBySize(s.Size())
 		return 0, err
 	}
 	return int64(n), nil


### PR DESCRIPTION
Replace allocating ReadString calls with zero-allocation ReadSlice in
Tree.Decode, add filemode.NewFromBytes to parse modes directly from
byte slices, and replace binary.Read with io.ReadFull in ObjectID.ReadFrom
to avoid reflection overhead.

Benchmark results (n=6, AMD Ryzen 7 6800U):

  TreeDecode/Small/1entry      -19.76%  (424.7ns → 340.8ns)
  TreeDecode/Medium/8entries   -33.36%  (2.268µs → 1.512µs)
  TreeDecode/Large/100entries  -31.15%  (24.71µs → 17.02µs)
  TreeDecode/VeryLarge/1000    -33.41%  (228.1µs → 151.9µs)

  Allocations reduced 20-33%, B/op increased ~8% due to ReadFull.