### PR TITLE
plumbing/object: pre-allocate Tree.Entries slice in Decode

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -290,6 +290,13 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 		return nil
 	}
 
+	// Estimate number of entries based on object size and hash type.
+	// Entry format: mode(~6) + space(1) + name(~12 avg) + null(1) + hash.
+	hashSize := o.Hash().Size() // 20 for SHA1, 32 for SHA256
+	avgBytesPerEntry := 20 + hashSize
+	estimatedEntries := int(o.Size())*105/(avgBytesPerEntry*100) + 4
+	t.Entries = make([]TreeEntry, 0, estimatedEntries)
+
 	reader, err := o.Reader()
 	if err != nil {
 		return err

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	maxTreeDepth      = 1024
-	startingStackSize = 8
+	maxTreeDepth           = 1024
+	startingStackSize      = 8
+	maxTreeEntriesPrealloc = 1 << 16 // 65536 entries ≈ 4.7 MiB worst case
 )
 
 // New errors defined by this package.
@@ -292,9 +293,10 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 
 	// Estimate number of entries based on object size and hash type.
 	// Entry format: mode(~6) + space(1) + name(~12 avg) + null(1) + hash.
-	hashSize := o.Hash().Size() // 20 for SHA1, 32 for SHA256
+	hashSize := t.Hash.Size() // 20 for SHA1, 32 for SHA256
 	avgBytesPerEntry := 20 + hashSize
 	estimatedEntries := int(o.Size())*105/(avgBytesPerEntry*100) + 4
+	estimatedEntries = min(estimatedEntries, maxTreeEntriesPrealloc)
 	t.Entries = make([]TreeEntry, 0, estimatedEntries)
 
 	reader, err := o.Reader()


### PR DESCRIPTION
Optimize Tree.Decode by estimating and pre-allocating the Entries slice capacity based on the encoded object size and hash type. This eliminates multiple reallocations during the decode loop.

Each tree entry requires approximately 40 bytes on average for SHA1 repositories (mode + space + name + null + 20-byte hash) and 52 bytes for SHA256 repositories (with 32-byte hash). By calculating an estimated capacity with a 5% buffer and adding a minimum of 4 entries, we avoid O(log n) reallocations and memory copies during slice growth.

The implementation uses integer arithmetic for efficiency and adapts to the repository's hash type (SHA1 or SHA256) by querying the object's hash size.

Performance improvements (benchstat results, n=10):
- TreeDecode: -10.0% time, -14.5% memory, -10.3% allocations
- TreeDecodeLarge (100 entries): -2.5% memory, -1.9% allocations
- Overall: 3 fewer allocations per decode (29 → 26)

The optimization provides the best results for typical and large trees while maintaining acceptable performance for small trees. The hash-aware estimation ensures optimal capacity allocation for both SHA1 and SHA256 repositories.