### PR TITLE
build: Bump Go test versions to 1.23-1.25 (v5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
+        go-version: [1.23.x, 1.24.x, 1.25.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Ensure that the versions used to test the v5 release are align with the project policy.