### PR TITLE
refactor(plumbing): improve revfile encode/decode

### DIFF
--- a/plumbing/format/revfile/decoder_test.go
+++ b/plumbing/format/revfile/decoder_test.go
@@ -1,11 +1,10 @@
 package revfile
 
 import (
-	"bufio"
 	"bytes"
 	"crypto"
+	"errors"
 	"io"
-	"sync"
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
@@ -14,6 +13,31 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// errorAfterReader wraps a reader and returns an error after n bytes have been read.
+type errorAfterReader struct {
+	r         io.Reader
+	bytesLeft int
+	err       error
+}
+
+func (e *errorAfterReader) Read(p []byte) (int, error) {
+	if e.bytesLeft <= 0 {
+		return 0, e.err
+	}
+	if len(p) > e.bytesLeft {
+		p = p[:e.bytesLeft]
+	}
+	n, err := e.r.Read(p)
+	e.bytesLeft -= n
+	if err != nil {
+		return n, err
+	}
+	if e.bytesLeft <= 0 {
+		return n, e.err
+	}
+	return n, nil
+}
 
 func TestDecodeSHA256(t *testing.T) {
 	fixture := fixtures.ByTag("packfile-sha256").One()
@@ -30,22 +54,22 @@ func TestDecodeSHA256(t *testing.T) {
 
 	count, err := idx.Count()
 	require.NoError(t, err)
-	d := NewDecoder(bufio.NewReader(revf), count, idx.PackfileChecksum)
 
 	idxPos := make(chan uint32)
 
 	want := []uint32{2, 0, 3, 4, 5, 1}
 	got := []uint32{}
 
+	errCh := make(chan error, 1)
 	go func() {
-		err = d.Decode(idxPos)
+		errCh <- Decode(revf, count, idx.PackfileChecksum, idxPos)
 	}()
 
 	for pos := range idxPos {
 		got = append(got, pos)
 	}
 
-	require.NoError(t, err)
+	require.NoError(t, <-errCh)
 	assert.Equal(t, want, got)
 }
 
@@ -56,7 +80,7 @@ func TestDecode(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		revFile      *bufio.Reader
+		revFile      io.Reader
 		objCount     int64
 		packChecksum plumbing.ObjectID
 		ch           chan uint32
@@ -68,24 +92,13 @@ func TestDecode(t *testing.T) {
 		},
 		{
 			name:     "nil chan",
-			revFile:  bufio.NewReader(fixture.Rev()),
+			revFile:  fixture.Rev(),
 			objCount: 6,
 			want:     "nil channel",
 		},
 		{
-			name:     "closed chan",
-			revFile:  bufio.NewReader(fixture.Rev()),
-			objCount: 6,
-			ch: func() chan uint32 {
-				ch := make(chan uint32)
-				close(ch)
-				return ch
-			}(),
-			want: "close of closed channel",
-		},
-		{
 			name:         "shorter obj count",
-			revFile:      bufio.NewReader(fixture.Rev()),
+			revFile:      fixture.Rev(),
 			objCount:     5,
 			packChecksum: plumbing.NewHash("00000001407497645643e18a7ba56c6132603f167fe9c51c00361ee0c81d74a8"),
 			ch:           make(chan uint32),
@@ -93,15 +106,15 @@ func TestDecode(t *testing.T) {
 		},
 		{
 			name:         "longer obj count",
-			revFile:      bufio.NewReader(fixture.Rev()),
+			revFile:      fixture.Rev(),
 			objCount:     50,
 			packChecksum: plumbing.NewHash("00"),
 			ch:           make(chan uint32),
-			want:         "EOF",
+			want:         "malformed rev file: unexpected EOF at object 22",
 		},
 		{
 			name:         "wrong pack checksum",
-			revFile:      bufio.NewReader(fixture.Rev()),
+			revFile:      fixture.Rev(),
 			objCount:     6,
 			packChecksum: plumbing.NewHash("aa7497645643e18a7ba56c6132603f167fe9c51c00361ee0c81d74a8f55d0ee2"),
 			ch:           make(chan uint32),
@@ -109,27 +122,35 @@ func TestDecode(t *testing.T) {
 		},
 		{
 			name: "longer rev file",
-			revFile: bufio.NewReader(io.MultiReader(
+			revFile: io.MultiReader(
 				fixture.Rev(),
 				bytes.NewReader([]byte{0xFF}),
-			)),
+			),
 			objCount:     6,
 			packChecksum: plumbing.NewHash("407497645643e18a7ba56c6132603f167fe9c51c00361ee0c81d74a8f55d0ee2"),
 			ch:           make(chan uint32),
 			want:         "malformed rev file: expected EOF",
 		},
+		{
+			name: "read error at EOF check",
+			revFile: &errorAfterReader{
+				r:         fixture.Rev(),
+				bytesLeft: 100, // rev file is 100 bytes (header + entries + checksums)
+				err:       errors.New("network error"),
+			},
+			objCount:     6,
+			packChecksum: plumbing.NewHash("407497645643e18a7ba56c6132603f167fe9c51c00361ee0c81d74a8f55d0ee2"),
+			ch:           make(chan uint32),
+			want:         "network error",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			d := NewDecoder(tc.revFile, tc.objCount, tc.packChecksum)
+			errCh := make(chan error, 1)
 
-			var err error
-			var wg sync.WaitGroup
-			wg.Add(1)
 			go func() {
-				err = d.Decode(tc.ch)
-				wg.Done()
+				errCh <- Decode(tc.revFile, tc.objCount, tc.packChecksum, tc.ch)
 			}()
 
 			if tc.ch != nil {
@@ -137,7 +158,7 @@ func TestDecode(t *testing.T) {
 				}
 			}
 
-			wg.Wait()
+			err := <-errCh
 			if tc.want != "" {
 				assert.EqualError(t, err, tc.want)
 			} else {

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -175,8 +175,7 @@ func (w *PackWriter) encodeRev(writer io.Writer, h hash.Hash) error {
 		return err
 	}
 
-	e := revfile.NewEncoder(writer, h)
-	return e.Encode(idx)
+	return revfile.Encode(writer, h, idx)
 }
 
 type syncedReader struct {


### PR DESCRIPTION
related to #1731

* Make encode and decode a function and unexport encoder/decoder to hide state so that
there is less opportunity to misuse concurrently,
and drop mutex and recover as a result.
* Handle non EOF errors in decode trailing check.
* Add context in object decode for EOF.
* Drop unused stateFn in encoder/decoder.
* Accept io.Reader since it's more idiomatic. For decode, internally, we create buffered reader
if already not buffered but not doing it for
writing since flushing is required and it's
generally controlled by caller (file, buffer, etc).

Keeping explicit check for io.EOF because of
convention https://github.com/golang/go/issues/39155