### PR TITLE
*: enable formatters in golangci-lint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+*.go text eol=lf
+go.mod text eol=lf
+go.sum text eol=lf

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,17 +1,29 @@
 version: "2"
 linters:
   default: none
-  enable:
-  - zerologlint
-  exclusions:
-    generated: lax
-    presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
+
 formatters:
-  default: none
   enable:
-  exclusions:
-    generated: lax
+    - gci
+    - gofmt
+    - gofumpt
+  settings:
+    gci:
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/go-git/go-git/) # Custom section: groups all imports with the specified Prefix.
+        - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+        - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+        - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+      no-inline-comments: true
+      no-prefix-comments: true
+      custom-order: true
+      no-lex-order: true
+    gofmt:
+      simplify: true
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'
+    gofumpt:
+      extra-rules: true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ WORKDIR = $(PWD)
 
 # Go parameters
 GOCMD = go
-GOTEST = $(GOCMD) test 
+GOTEST = $(GOCMD) test
 
 # Git config
 GIT_VERSION ?=

--- a/_examples/common.go
+++ b/_examples/common.go
@@ -26,11 +26,11 @@ func CheckIfError(err error) {
 }
 
 // Info should be used to describe the example commands that are about to run.
-func Info(format string, args ...interface{}) {
+func Info(format string, args ...any) {
 	fmt.Printf("\x1b[34;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 }
 
 // Warning should be used to display a warning
-func Warning(format string, args ...interface{}) {
+func Warning(format string, args ...any) {
 	fmt.Printf("\x1b[36;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 }

--- a/_examples/ls/main.go
+++ b/_examples/ls/main.go
@@ -157,7 +157,7 @@ func getFileHashes(c commitgraph.CommitNode, treePath string, paths []string) (m
 
 func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []string) (map[string]*object.Commit, error) {
 	// We do a tree traversal with nodes sorted by commit time
-	heap := binaryheap.NewWith(func(a, b interface{}) int {
+	heap := binaryheap.NewWith(func(a, b any) int {
 		if a.(*commitAndPaths).commit.CommitTime().Before(b.(*commitAndPaths).commit.CommitTime()) {
 			return 1
 		}

--- a/_examples/merge_base/helpers.go
+++ b/_examples/merge_base/helpers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
-func checkIfError(err error, code exitCode, mainReason string, v ...interface{}) {
+func checkIfError(err error, code exitCode, mainReason string, v ...any) {
 	if err == nil {
 		return
 	}
@@ -17,7 +17,7 @@ func checkIfError(err error, code exitCode, mainReason string, v ...interface{})
 	os.Exit(int(code))
 }
 
-func helpAndExit(s string, helpMsg string, code exitCode) {
+func helpAndExit(s, helpMsg string, code exitCode) {
 	if code == exitCodeSuccess {
 		printMsg("%s", s)
 	} else {
@@ -33,7 +33,7 @@ func printErr(err error) {
 	fmt.Printf("\x1b[31;1m%s\x1b[0m\n", fmt.Sprintf("error: %s", err))
 }
 
-func printMsg(format string, args ...interface{}) {
+func printMsg(format string, args ...any) {
 	fmt.Printf("%s\n", fmt.Sprintf(format, args...))
 }
 
@@ -52,7 +52,7 @@ func printCommits(commits []*object.Commit) {
 	}
 }
 
-func wrapErr(err error, s string, v ...interface{}) error {
+func wrapErr(err error, s string, v ...any) error {
 	if err != nil {
 		return fmt.Errorf("%s\n  %s", fmt.Sprintf(s, v...), err)
 	}

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -120,7 +120,7 @@ func (b *Backend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // logf logs the given message to the error log if it is set.
-func logf(logger *log.Logger, format string, v ...interface{}) {
+func logf(logger *log.Logger, format string, v ...any) {
 	if logger != nil {
 		logger.Printf(format, v...)
 	}

--- a/backend/http/http_test.go
+++ b/backend/http/http_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/require"
 )
 
 type fixturesLoader struct {

--- a/backend/http/writer.go
+++ b/backend/http/writer.go
@@ -19,7 +19,7 @@ const defaultChunkSize = 4096
 // Useful when using proxies.
 type flushResponseWriter struct {
 	http.ResponseWriter
-	log *log.Logger
+	log       *log.Logger
 	chunkSize int
 }
 
@@ -54,7 +54,6 @@ func (f *flushResponseWriter) ReadFrom(r io.Reader) (int64, error) {
 
 	return n, nil
 }
-
 
 // Close implements io.Closer interface.
 // It is a no-op.

--- a/blame.go
+++ b/blame.go
@@ -10,10 +10,11 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/sergi/go-diff/diffmatchpatch"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/utils/diff"
-	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 // BlameResult represents the result of a Blame operation.
@@ -504,6 +505,7 @@ func (pq *priorityQueueImp) Pop() any {
 
 	return ret
 }
+
 func (pq *priorityQueueImp) Peek() *object.Commit {
 	if len(*pq) == 0 {
 		return nil
@@ -518,6 +520,7 @@ func (pq *priorityQueue) Len() int { return (*priorityQueueImp)(pq).Len() }
 func (pq *priorityQueue) Push(c *queueItem) {
 	heap.Push((*priorityQueueImp)(pq), c)
 }
+
 func (pq *priorityQueue) Pop() *queueItem {
 	return heap.Pop((*priorityQueueImp)(pq)).(*queueItem)
 }

--- a/blame_test.go
+++ b/blame_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/object"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/suite"
 
-	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
 type BlameSuite struct {

--- a/common_test.go
+++ b/common_test.go
@@ -6,20 +6,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-billy/v6/util"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-
-	"github.com/go-git/go-billy/v6"
-	"github.com/go-git/go-billy/v6/memfs"
-	"github.com/go-git/go-billy/v6/osfs"
-	"github.com/go-git/go-billy/v6/util"
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type BaseSuite struct {
@@ -127,7 +127,7 @@ func (s *BaseSuite) TemporalHomeDir() (path string, clean func()) {
 		_ = util.RemoveAll(fs, relPath)
 	}
 
-	return
+	return path, clean
 }
 
 func (s *BaseSuite) TemporalFilesystem() (fs billy.Filesystem) {

--- a/config/branch_test.go
+++ b/config/branch_test.go
@@ -3,8 +3,9 @@ package config
 import (
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type BranchSuite struct {

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 
 	"github.com/go-git/go-billy/v6/osfs"
+
 	"github.com/go-git/go-git/v6/internal/url"
 	"github.com/go-git/go-git/v6/plumbing"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/format/config"
-	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 )
 
 type ConfigSuite struct {
@@ -270,7 +271,7 @@ func (s *ConfigSuite) TestLoadConfigXDG() {
 	s.NoError(err)
 	defer util.RemoveAll(osfs.Default, tmp)
 
-	err = osfs.Default.MkdirAll(filepath.Join(tmp, "git"), 0777)
+	err = osfs.Default.MkdirAll(filepath.Join(tmp, "git"), 0o777)
 	s.NoError(err)
 
 	os.Setenv("XDG_CONFIG_HOME", tmp)
@@ -282,7 +283,7 @@ func (s *ConfigSuite) TestLoadConfigXDG() {
 	s.NoError(err)
 
 	cfgFile := filepath.Join(tmp, "git/config")
-	err = util.WriteFile(osfs.Default, cfgFile, content, 0777)
+	err = util.WriteFile(osfs.Default, cfgFile, content, 0o777)
 	s.NoError(err)
 
 	cfg, err = LoadConfig(GlobalScope)

--- a/config/modules.go
+++ b/config/modules.go
@@ -14,10 +14,8 @@ var (
 	ErrModuleBadPath   = errors.New("submodule has an invalid path")
 )
 
-var (
-	// Matches module paths with dotdot ".." components.
-	dotdotPath = regexp.MustCompile(`(^|[/\\])\.\.([/\\]|$)`)
-)
+// Matches module paths with dotdot ".." components.
+var dotdotPath = regexp.MustCompile(`(^|[/\\])\.\.([/\\]|$)`)
 
 // Modules defines the submodules properties, represents a .gitmodules file
 // https://www.kernel.org/pub/software/scm/git/docs/gitmodules.html

--- a/config/refspec_test.go
+++ b/config/refspec_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type RefSpecSuite struct {

--- a/config/url.go
+++ b/config/url.go
@@ -7,9 +7,7 @@ import (
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
-var (
-	errURLEmptyInsteadOf = errors.New("url config: empty insteadOf")
-)
+var errURLEmptyInsteadOf = errors.New("url config: empty insteadOf")
 
 // Url defines Url rewrite rules
 type URL struct {

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -127,11 +127,11 @@ func (b *URLSuite) TestApplyInsteadOf() {
 
 func (b *URLSuite) TestFindLongestInsteadOfMatch() {
 	urlRules := map[string]*URL{
-		"ssh://github.com": &URL{
+		"ssh://github.com": {
 			Name:       "ssh://github.com",
 			InsteadOfs: []string{"http://github.com"},
 		},
-		"ssh://somethingelse.com": &URL{
+		"ssh://somethingelse.com": {
 			Name:       "ssh://somethingelse.com",
 			InsteadOfs: []string{"http://github.com/foobar"},
 		},

--- a/crypto.go
+++ b/crypto.go
@@ -1,7 +1,8 @@
 package git
 
 import (
-	_ "crypto/sha256" // Register Go's SHA256 implementation.
-
-	_ "github.com/pjbgf/sha1cd" // Register sha1cd implementation.
+	// Register Go's SHA256 implementation.
+	_ "crypto/sha256"
+	// Register sha1cd implementation.
+	_ "github.com/pjbgf/sha1cd"
 )

--- a/example_test.go
+++ b/example_test.go
@@ -7,13 +7,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-git/go-billy/v6/memfs"
+
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/transport/http"
 	"github.com/go-git/go-git/v6/storage/memory"
-
-	"github.com/go-git/go-billy/v6/memfs"
 )
 
 func ExampleClone() {
@@ -54,7 +54,6 @@ func ExamplePlainClone() {
 	_, err = git.PlainClone(dir, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 	})
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -86,7 +85,6 @@ func ExamplePlainClone_usernamePassword() {
 			Password: "password",
 		},
 	})
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -109,7 +107,6 @@ func ExamplePlainClone_accessToken() {
 			Password: "github_access_token",
 		},
 	})
-
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -134,7 +131,6 @@ func ExampleRepository_References() {
 	// 6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/remotes/origin/master
 	// e8d3ffab552895c19b9fcf7aa264d277cde33881 refs/remotes/origin/branch
 	// 6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/master
-
 }
 
 func ExampleRepository_Branches() {
@@ -160,7 +156,6 @@ func ExampleRepository_CreateRemote() {
 		Name: "example",
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})
-
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/repository/refs.go
+++ b/internal/repository/refs.go
@@ -63,7 +63,7 @@ func WriteInfoRefs(w io.Writer, s storage.Storer) error {
 			hash = ref.Hash()
 			fallthrough
 		case plumbing.HashReference:
-			if _, err :=fmt.Fprintf(w, "%s\t%s\n", hash, name); err != nil {
+			if _, err := fmt.Fprintf(w, "%s\t%s\n", hash, name); err != nil {
 				return fmt.Errorf("writing info reference: %w", err)
 			}
 			if name.IsTag() {

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -25,8 +25,7 @@ func (e *ErrInvalidRevision) Error() string {
 // obtained after parsing a revision string,
 // for instance revision "master~" will be converted in
 // two revision components Ref and TildePath
-type Revisioner interface {
-}
+type Revisioner any
 
 // Ref represents a reference name : HEAD, master, <hash>
 type Ref string
@@ -143,7 +142,6 @@ func (p *Parser) Parse() ([]Revisioner, error) {
 
 	for {
 		tok, _, err = p.scan()
-
 		if err != nil {
 			return nil, err
 		}
@@ -159,7 +157,6 @@ func (p *Parser) Parse() ([]Revisioner, error) {
 			rev, err = p.parseColon()
 		case eof:
 			err = p.validateFullRevision(&revs)
-
 			if err != nil {
 				return []Revisioner{}, err
 			}
@@ -255,7 +252,6 @@ func (p *Parser) parseAt() (Revisioner, error) {
 	var err error
 
 	tok, _, err = p.scan()
-
 	if err != nil {
 		return nil, err
 	}
@@ -267,13 +263,11 @@ func (p *Parser) parseAt() (Revisioner, error) {
 	}
 
 	tok, lit, err = p.scan()
-
 	if err != nil {
 		return nil, err
 	}
 
 	nextTok, nextLit, err = p.scan()
-
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +285,6 @@ func (p *Parser) parseAt() (Revisioner, error) {
 		n, _ := strconv.Atoi(nextLit)
 
 		t, _, err := p.scan()
-
 		if err != nil {
 			return nil, err
 		}
@@ -308,7 +301,6 @@ func (p *Parser) parseAt() (Revisioner, error) {
 
 		for {
 			tok, lit, err = p.scan()
-
 			if err != nil {
 				return nil, err
 			}
@@ -316,7 +308,6 @@ func (p *Parser) parseAt() (Revisioner, error) {
 			switch {
 			case tok == cbrace:
 				t, err := time.Parse("2006-01-02T15:04:05Z", date)
-
 				if err != nil {
 					return nil, &ErrInvalidRevision{fmt.Sprintf(`wrong date "%s" must fit ISO-8601 format : 2006-01-02T15:04:05Z`, date)}
 				}
@@ -338,7 +329,6 @@ func (p *Parser) parseTilde() (Revisioner, error) {
 	var err error
 
 	tok, lit, err = p.scan()
-
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +351,6 @@ func (p *Parser) parseCaret() (Revisioner, error) {
 	var err error
 
 	tok, lit, err = p.scan()
-
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +358,6 @@ func (p *Parser) parseCaret() (Revisioner, error) {
 	switch {
 	case tok == obrace:
 		r, err := p.parseCaretBraces()
-
 		if err != nil {
 			return nil, err
 		}
@@ -400,13 +388,11 @@ func (p *Parser) parseCaretBraces() (Revisioner, error) {
 
 	for {
 		tok, lit, err = p.scan()
-
 		if err != nil {
 			return nil, err
 		}
 
 		nextTok, _, err = p.scan()
-
 		if err != nil {
 			return nil, err
 		}
@@ -435,7 +421,6 @@ func (p *Parser) parseCaretBraces() (Revisioner, error) {
 			p.unscan()
 
 			reg, err := regexp.Compile(re)
-
 			if err != nil {
 				return CaretReg{}, &ErrInvalidRevision{fmt.Sprintf(`revision suffix brace component, %s`, err.Error())}
 			}
@@ -453,7 +438,6 @@ func (p *Parser) parseColon() (Revisioner, error) {
 	var err error
 
 	tok, _, err = p.scan()
-
 	if err != nil {
 		return nil, err
 	}
@@ -477,13 +461,11 @@ func (p *Parser) parseColonSlash() (Revisioner, error) {
 
 	for {
 		tok, lit, err = p.scan()
-
 		if err != nil {
 			return nil, err
 		}
 
 		nextTok, _, err = p.scan()
-
 		if err != nil {
 			return nil, err
 		}
@@ -498,7 +480,6 @@ func (p *Parser) parseColonSlash() (Revisioner, error) {
 		case tok == eof:
 			p.unscan()
 			reg, err := regexp.Compile(re)
-
 			if err != nil {
 				return ColonReg{}, &ErrInvalidRevision{fmt.Sprintf(`revision suffix brace component, %s`, err.Error())}
 			}
@@ -518,16 +499,14 @@ func (p *Parser) parseColonDefault() (Revisioner, error) {
 	var path string
 	var stage int
 	var err error
-	var n = -1
+	n := -1
 
 	tok, lit, err = p.scan()
-
 	if err != nil {
 		return nil, err
 	}
 
 	nextTok, _, err := p.scan()
-
 	if err != nil {
 		return nil, err
 	}
@@ -546,7 +525,6 @@ func (p *Parser) parseColonDefault() (Revisioner, error) {
 
 	for {
 		tok, lit, err = p.scan()
-
 		if err != nil {
 			return nil, err
 		}
@@ -571,7 +549,6 @@ func (p *Parser) parseRef() (Revisioner, error) {
 
 	for {
 		tok, lit, err = p.scan()
-
 		if err != nil {
 			return nil, err
 		}
@@ -582,7 +559,6 @@ func (p *Parser) parseRef() (Revisioner, error) {
 		}
 
 		err := p.checkRefFormat(tok, lit, prevTok, buf, endOfRef)
-
 		if err != nil {
 			return "", err
 		}

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -31,7 +31,6 @@ func tokenizeExpression(ch rune, tokenType token, check runeCategoryValidator, r
 			data = append(data, c)
 		} else {
 			err := r.UnreadRune()
-
 			if err != nil {
 				return tokenError, "", err
 			}

--- a/internal/transport/test/common.go
+++ b/internal/transport/test/common.go
@@ -16,7 +16,7 @@ func FixturesFactory(base, name string) func() string {
 	}
 }
 
-func PrepareRepository(t testing.TB, f *fixtures.Fixture, base string, name string) billy.Filesystem {
+func PrepareRepository(t testing.TB, f *fixtures.Fixture, base, name string) billy.Filesystem {
 	fs := f.DotGit(fixtures.WithTargetDir(FixturesFactory(base, name)))
 	err := fixtures.EnsureIsBare(fs)
 	require.NoError(t, err)

--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -11,6 +11,9 @@ import (
 	"path/filepath"
 	"regexp"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
@@ -18,9 +21,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type ReceivePackSuite struct {

--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
-	"github.com/stretchr/testify/suite"
 )
 
 type UploadPackSuite struct {

--- a/object_walker.go
+++ b/object_walker.go
@@ -84,7 +84,7 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 			// to handle plain files with different modes.
 			// Other non-tree objects are somewhat rare, so they
 			// are not special-cased.
-			if obj.Entries[i].Mode|0755 == filemode.Executable {
+			if obj.Entries[i].Mode|0o755 == filemode.Executable {
 				p.add(obj.Entries[i].Hash)
 				continue
 			}

--- a/options.go
+++ b/options.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"

--- a/options_test.go
+++ b/options_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6/util"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
-	"github.com/stretchr/testify/suite"
 )
 
 type OptionsSuite struct {
@@ -105,7 +106,7 @@ func (s *OptionsSuite) writeGlobalConfig(cfg *config.Config) func() {
 	tmp, err := util.TempDir(fs, "", "test-options")
 	s.NoError(err)
 
-	err = fs.MkdirAll(fs.Join(tmp, "git"), 0777)
+	err = fs.MkdirAll(fs.Join(tmp, "git"), 0o777)
 	s.NoError(err)
 
 	os.Setenv("XDG_CONFIG_HOME", fs.Join(fs.Root(), tmp))
@@ -114,11 +115,10 @@ func (s *OptionsSuite) writeGlobalConfig(cfg *config.Config) func() {
 	s.NoError(err)
 
 	cfgFile := fs.Join(tmp, "git/config")
-	err = util.WriteFile(fs, cfgFile, content, 0777)
+	err = util.WriteFile(fs, cfgFile, content, 0o777)
 	s.NoError(err)
 
 	return func() {
 		os.Setenv("XDG_CONFIG_HOME", "")
-
 	}
 }

--- a/plumbing/cache/buffer_test.go
+++ b/plumbing/cache/buffer_test.go
@@ -127,7 +127,7 @@ func (s *BufferSuite) TestConcurrentAccess() {
 		for i := 0; i < 1000; i++ {
 			wg.Add(3)
 			go func(i int) {
-				o.Put(int64(i), []byte{00})
+				o.Put(int64(i), []byte{0o0})
 				wg.Done()
 			}(i)
 

--- a/plumbing/cache/object_lru.go
+++ b/plumbing/cache/object_lru.go
@@ -14,7 +14,7 @@ type ObjectLRU struct {
 
 	actualSize FileSize
 	ll         *list.List
-	cache      map[interface{}]*list.Element
+	cache      map[any]*list.Element
 	mut        sync.Mutex
 }
 
@@ -38,7 +38,7 @@ func (c *ObjectLRU) Put(obj plumbing.EncodedObject) {
 
 	if c.cache == nil {
 		c.actualSize = 0
-		c.cache = make(map[interface{}]*list.Element, 1000)
+		c.cache = make(map[any]*list.Element, 1000)
 		c.ll = list.New()
 	}
 

--- a/plumbing/cache/object_test.go
+++ b/plumbing/cache/object_test.go
@@ -6,8 +6,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type ObjectSuite struct {

--- a/plumbing/error.go
+++ b/plumbing/error.go
@@ -17,4 +17,3 @@ func NewPermanentError(err error) *PermanentError {
 func (e *PermanentError) Error() string {
 	return fmt.Sprintf("permanent client error: %s", e.Err.Error())
 }
-

--- a/plumbing/filemode/filemode.go
+++ b/plumbing/filemode/filemode.go
@@ -26,24 +26,24 @@ const (
 	// NewFromOsNewFromOSFileMode along with an error, when they fail.
 	Empty FileMode = 0
 	// Dir represent a Directory.
-	Dir FileMode = 0040000
+	Dir FileMode = 0o040000
 	// Regular represent non-executable files.  Please note this is not
 	// the same as golang regular files, which include executable files.
-	Regular FileMode = 0100644
+	Regular FileMode = 0o100644
 	// Deprecated represent non-executable files with the group writable
 	// bit set.  This mode was supported by the first versions of git,
 	// but it has been deprecated nowadays.  This library uses them
 	// internally, so you can read old packfiles, but will treat them as
 	// Regulars when interfacing with the outside world.  This is the
 	// standard git behaviour.
-	Deprecated FileMode = 0100664
+	Deprecated FileMode = 0o100664
 	// Executable represents executable files.
-	Executable FileMode = 0100755
+	Executable FileMode = 0o100755
 	// Symlink represents symbolic links to files.
-	Symlink FileMode = 0120000
+	Symlink FileMode = 0o120000
 	// Submodule represents git submodules.  This mode has no file system
 	// equivalent.
-	Submodule FileMode = 0160000
+	Submodule FileMode = 0o160000
 )
 
 // New takes the octal string representation of a FileMode and returns
@@ -106,7 +106,7 @@ func isSetTemporary(m os.FileMode) bool {
 }
 
 func isSetUserExecutable(m os.FileMode) bool {
-	return m&0100 != 0
+	return m&0o100 != 0
 }
 
 func isSetSymLink(m os.FileMode) bool {
@@ -174,12 +174,12 @@ func (m FileMode) ToOSFileMode() (os.FileMode, error) {
 	case Submodule:
 		return os.ModePerm | os.ModeDir, nil
 	case Regular:
-		return os.FileMode(0644), nil
+		return os.FileMode(0o644), nil
 	// Deprecated is no longer allowed: treated as a Regular instead
 	case Deprecated:
-		return os.FileMode(0644), nil
+		return os.FileMode(0o644), nil
 	case Executable:
-		return os.FileMode(0755), nil
+		return os.FileMode(0o755), nil
 	case Symlink:
 		return os.ModePerm | os.ModeSymlink, nil
 	}

--- a/plumbing/filemode/filemode_test.go
+++ b/plumbing/filemode/filemode_test.go
@@ -37,7 +37,7 @@ func (s *ModeSuite) TestNew() {
 		// these are valid inputs, but probably means there is a bug
 		// somewhere.
 		{input: "0", expected: Empty},
-		{input: "42", expected: FileMode(042)},
+		{input: "42", expected: FileMode(0o42)},
 		{input: "00000000000100644", expected: Regular},
 	} {
 		comment := fmt.Sprintf("input = %q", test.input)
@@ -86,22 +86,22 @@ func (f fixture) test(s *ModeSuite) {
 
 func (s *ModeSuite) TestNewFromOsFileModeSimplePerms() {
 	for _, f := range [...]fixture{
-		{os.FileMode(0755) | os.ModeDir, Dir, ""},         // drwxr-xr-x
-		{os.FileMode(0700) | os.ModeDir, Dir, ""},         // drwx------
-		{os.FileMode(0500) | os.ModeDir, Dir, ""},         // dr-x------
-		{os.FileMode(0644), Regular, ""},                  // -rw-r--r--
-		{os.FileMode(0660), Regular, ""},                  // -rw-rw----
-		{os.FileMode(0640), Regular, ""},                  // -rw-r-----
-		{os.FileMode(0600), Regular, ""},                  // -rw-------
-		{os.FileMode(0400), Regular, ""},                  // -r--------
-		{os.FileMode(0000), Regular, ""},                  // ----------
-		{os.FileMode(0755), Executable, ""},               // -rwxr-xr-x
-		{os.FileMode(0700), Executable, ""},               // -rwx------
-		{os.FileMode(0500), Executable, ""},               // -r-x------
-		{os.FileMode(0744), Executable, ""},               // -rwxr--r--
-		{os.FileMode(0540), Executable, ""},               // -r-xr-----
-		{os.FileMode(0550), Executable, ""},               // -r-xr-x---
-		{os.FileMode(0777) | os.ModeSymlink, Symlink, ""}, // Lrwxrwxrwx
+		{os.FileMode(0o755) | os.ModeDir, Dir, ""},         // drwxr-xr-x
+		{os.FileMode(0o700) | os.ModeDir, Dir, ""},         // drwx------
+		{os.FileMode(0o500) | os.ModeDir, Dir, ""},         // dr-x------
+		{os.FileMode(0o644), Regular, ""},                  // -rw-r--r--
+		{os.FileMode(0o660), Regular, ""},                  // -rw-rw----
+		{os.FileMode(0o640), Regular, ""},                  // -rw-r-----
+		{os.FileMode(0o600), Regular, ""},                  // -rw-------
+		{os.FileMode(0o400), Regular, ""},                  // -r--------
+		{os.FileMode(0o000), Regular, ""},                  // ----------
+		{os.FileMode(0o755), Executable, ""},               // -rwxr-xr-x
+		{os.FileMode(0o700), Executable, ""},               // -rwx------
+		{os.FileMode(0o500), Executable, ""},               // -r-x------
+		{os.FileMode(0o744), Executable, ""},               // -rwxr--r--
+		{os.FileMode(0o540), Executable, ""},               // -r-xr-----
+		{os.FileMode(0o550), Executable, ""},               // -r-xr-x---
+		{os.FileMode(0o777) | os.ModeSymlink, Symlink, ""}, // Lrwxrwxrwx
 	} {
 		f.test(s)
 	}
@@ -110,7 +110,7 @@ func (s *ModeSuite) TestNewFromOsFileModeSimplePerms() {
 func (s *ModeSuite) TestNewFromOsFileModeAppend() {
 	// append files are just regular files
 	fixture{
-		input:    os.FileMode(0644) | os.ModeAppend, // arw-r--r--
+		input:    os.FileMode(0o644) | os.ModeAppend, // arw-r--r--
 		expected: Regular, err: "",
 	}.test(s)
 }
@@ -118,12 +118,12 @@ func (s *ModeSuite) TestNewFromOsFileModeAppend() {
 func (s *ModeSuite) TestNewFromOsFileModeExclusive() {
 	// exclusive files are just regular or executable files
 	fixture{
-		input:    os.FileMode(0644) | os.ModeExclusive, // lrw-r--r--
+		input:    os.FileMode(0o644) | os.ModeExclusive, // lrw-r--r--
 		expected: Regular, err: "",
 	}.test(s)
 
 	fixture{
-		input:    os.FileMode(0755) | os.ModeExclusive, // lrwxr-xr-x
+		input:    os.FileMode(0o755) | os.ModeExclusive, // lrwxr-xr-x
 		expected: Executable, err: "",
 	}.test(s)
 }
@@ -131,12 +131,12 @@ func (s *ModeSuite) TestNewFromOsFileModeExclusive() {
 func (s *ModeSuite) TestNewFromOsFileModeTemporary() {
 	// temporary files are ignored
 	fixture{
-		input:    os.FileMode(0644) | os.ModeTemporary, // Trw-r--r--
+		input:    os.FileMode(0o644) | os.ModeTemporary, // Trw-r--r--
 		expected: Empty, err: "no equivalent",
 	}.test(s)
 
 	fixture{
-		input:    os.FileMode(0755) | os.ModeTemporary, // Trwxr-xr-x
+		input:    os.FileMode(0o755) | os.ModeTemporary, // Trwxr-xr-x
 		expected: Empty, err: "no equivalent",
 	}.test(s)
 }
@@ -144,7 +144,7 @@ func (s *ModeSuite) TestNewFromOsFileModeTemporary() {
 func (s *ModeSuite) TestNewFromOsFileModeDevice() {
 	// device files has no git equivalent
 	fixture{
-		input:    os.FileMode(0644) | os.ModeDevice, // Drw-r--r--
+		input:    os.FileMode(0o644) | os.ModeDevice, // Drw-r--r--
 		expected: Empty, err: "no equivalent",
 	}.test(s)
 }
@@ -152,7 +152,7 @@ func (s *ModeSuite) TestNewFromOsFileModeDevice() {
 func (s *ModeSuite) TestNewFromOsFileNamedPipe() {
 	// named pipes files has not git equivalent
 	fixture{
-		input:    os.FileMode(0644) | os.ModeNamedPipe, // prw-r--r--
+		input:    os.FileMode(0o644) | os.ModeNamedPipe, // prw-r--r--
 		expected: Empty, err: "no equivalent",
 	}.test(s)
 }
@@ -160,7 +160,7 @@ func (s *ModeSuite) TestNewFromOsFileNamedPipe() {
 func (s *ModeSuite) TestNewFromOsFileModeSocket() {
 	// sockets has no git equivalent
 	fixture{
-		input:    os.FileMode(0644) | os.ModeSocket, // Srw-r--r--
+		input:    os.FileMode(0o644) | os.ModeSocket, // Srw-r--r--
 		expected: Empty, err: "no equivalent",
 	}.test(s)
 }
@@ -168,7 +168,7 @@ func (s *ModeSuite) TestNewFromOsFileModeSocket() {
 func (s *ModeSuite) TestNewFromOsFileModeSetuid() {
 	// Setuid are just executables
 	fixture{
-		input:    os.FileMode(0755) | os.ModeSetuid, // urwxr-xr-x
+		input:    os.FileMode(0o755) | os.ModeSetuid, // urwxr-xr-x
 		expected: Executable, err: "",
 	}.test(s)
 }
@@ -176,12 +176,12 @@ func (s *ModeSuite) TestNewFromOsFileModeSetuid() {
 func (s *ModeSuite) TestNewFromOsFileModeSetgid() {
 	// Setguid are regular or executables, depending on the owner perms
 	fixture{
-		input:    os.FileMode(0644) | os.ModeSetgid, // grw-r--r--
+		input:    os.FileMode(0o644) | os.ModeSetgid, // grw-r--r--
 		expected: Regular, err: "",
 	}.test(s)
 
 	fixture{
-		input:    os.FileMode(0755) | os.ModeSetgid, // grwxr-xr-x
+		input:    os.FileMode(0o755) | os.ModeSetgid, // grwxr-xr-x
 		expected: Executable, err: "",
 	}.test(s)
 }
@@ -189,7 +189,7 @@ func (s *ModeSuite) TestNewFromOsFileModeSetgid() {
 func (s *ModeSuite) TestNewFromOsFileModeCharDevice() {
 	// char devices has no git equivalent
 	fixture{
-		input:    os.FileMode(0644) | os.ModeCharDevice, // crw-r--r--
+		input:    os.FileMode(0o644) | os.ModeCharDevice, // crw-r--r--
 		expected: Empty, err: "no equivalent",
 	}.test(s)
 }
@@ -197,7 +197,7 @@ func (s *ModeSuite) TestNewFromOsFileModeCharDevice() {
 func (s *ModeSuite) TestNewFromOsFileModeSticky() {
 	// dirs with the sticky bit are just dirs
 	fixture{
-		input:    os.FileMode(0755) | os.ModeDir | os.ModeSticky, // dtrwxr-xr-x
+		input:    os.FileMode(0o755) | os.ModeDir | os.ModeSticky, // dtrwxr-xr-x
 		expected: Dir, err: "",
 	}.test(s)
 }
@@ -238,12 +238,12 @@ func (s *ModeSuite) TestIsMalformed() {
 		{Executable, false},
 		{Symlink, false},
 		{Submodule, false},
-		{FileMode(01), true},
-		{FileMode(010), true},
-		{FileMode(0100), true},
-		{FileMode(01000), true},
-		{FileMode(010000), true},
-		{FileMode(0100000), true},
+		{FileMode(0o1), true},
+		{FileMode(0o10), true},
+		{FileMode(0o100), true},
+		{FileMode(0o1000), true},
+		{FileMode(0o10000), true},
+		{FileMode(0o100000), true},
 	} {
 		s.Equal(test.expected, test.mode.IsMalformed())
 	}
@@ -261,12 +261,12 @@ func (s *ModeSuite) TestString() {
 		{Executable, "0100755"},
 		{Symlink, "0120000"},
 		{Submodule, "0160000"},
-		{FileMode(01), "0000001"},
-		{FileMode(010), "0000010"},
-		{FileMode(0100), "0000100"},
-		{FileMode(01000), "0001000"},
-		{FileMode(010000), "0010000"},
-		{FileMode(0100000), "0100000"},
+		{FileMode(0o1), "0000001"},
+		{FileMode(0o10), "0000010"},
+		{FileMode(0o100), "0000100"},
+		{FileMode(0o1000), "0001000"},
+		{FileMode(0o10000), "0010000"},
+		{FileMode(0o100000), "0100000"},
 	} {
 		s.Equal(test.expected, test.mode.String())
 	}
@@ -284,12 +284,12 @@ func (s *ModeSuite) TestIsRegular() {
 		{Executable, false},
 		{Symlink, false},
 		{Submodule, false},
-		{FileMode(01), false},
-		{FileMode(010), false},
-		{FileMode(0100), false},
-		{FileMode(01000), false},
-		{FileMode(010000), false},
-		{FileMode(0100000), false},
+		{FileMode(0o1), false},
+		{FileMode(0o10), false},
+		{FileMode(0o100), false},
+		{FileMode(0o1000), false},
+		{FileMode(0o10000), false},
+		{FileMode(0o100000), false},
 	} {
 		s.Equal(test.expected, test.mode.IsRegular())
 	}
@@ -307,12 +307,12 @@ func (s *ModeSuite) TestIsFile() {
 		{Executable, true},
 		{Symlink, true},
 		{Submodule, false},
-		{FileMode(01), false},
-		{FileMode(010), false},
-		{FileMode(0100), false},
-		{FileMode(01000), false},
-		{FileMode(010000), false},
-		{FileMode(0100000), false},
+		{FileMode(0o1), false},
+		{FileMode(0o10), false},
+		{FileMode(0o100), false},
+		{FileMode(0o1000), false},
+		{FileMode(0o10000), false},
+		{FileMode(0o100000), false},
 	} {
 		s.Equal(test.expected, test.mode.IsFile())
 	}
@@ -326,17 +326,17 @@ func (s *ModeSuite) TestToOSFileMode() {
 	}{
 		{Empty, os.FileMode(0), "malformed"},
 		{Dir, os.ModePerm | os.ModeDir, ""},
-		{Regular, os.FileMode(0644), ""},
-		{Deprecated, os.FileMode(0644), ""},
-		{Executable, os.FileMode(0755), ""},
+		{Regular, os.FileMode(0o644), ""},
+		{Deprecated, os.FileMode(0o644), ""},
+		{Executable, os.FileMode(0o755), ""},
 		{Symlink, os.ModePerm | os.ModeSymlink, ""},
 		{Submodule, os.ModePerm | os.ModeDir, ""},
-		{FileMode(01), os.FileMode(0), "malformed"},
-		{FileMode(010), os.FileMode(0), "malformed"},
-		{FileMode(0100), os.FileMode(0), "malformed"},
-		{FileMode(01000), os.FileMode(0), "malformed"},
-		{FileMode(010000), os.FileMode(0), "malformed"},
-		{FileMode(0100000), os.FileMode(0), "malformed"},
+		{FileMode(0o1), os.FileMode(0), "malformed"},
+		{FileMode(0o10), os.FileMode(0), "malformed"},
+		{FileMode(0o100), os.FileMode(0), "malformed"},
+		{FileMode(0o1000), os.FileMode(0), "malformed"},
+		{FileMode(0o10000), os.FileMode(0), "malformed"},
+		{FileMode(0o100000), os.FileMode(0), "malformed"},
 	} {
 		obtained, err := test.input.ToOSFileMode()
 		comment := fmt.Sprintf("input = %s", test.input)

--- a/plumbing/format/commitgraph/chain.go
+++ b/plumbing/format/commitgraph/chain.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 )
 

--- a/plumbing/format/commitgraph/chain_test.go
+++ b/plumbing/format/commitgraph/chain_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/format/commitgraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/format/commitgraph"
 )
 
 func TestOpenChainFile(t *testing.T) {

--- a/plumbing/format/commitgraph/commitgraph_test.go
+++ b/plumbing/format/commitgraph/commitgraph_test.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/util"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	commitgraph "github.com/go-git/go-git/v6/plumbing/format/commitgraph"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type CommitgraphSuite struct {

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -108,7 +108,7 @@ func (fi *fileIndex) Close() (err error) {
 		}()
 	}
 	err = fi.reader.Close()
-	return
+	return err
 }
 
 func (fi *fileIndex) verifyFileHeader() error {

--- a/plumbing/format/config/common.go
+++ b/plumbing/format/config/common.go
@@ -68,7 +68,7 @@ func (c *Config) RemoveSection(name string) *Config {
 }
 
 // RemoveSubsection remove a subsection from a config file.
-func (c *Config) RemoveSubsection(section string, subsection string) *Config {
+func (c *Config) RemoveSubsection(section, subsection string) *Config {
 	for _, s := range c.Sections {
 		if s.IsName(section) {
 			result := Subsections{}
@@ -86,7 +86,7 @@ func (c *Config) RemoveSubsection(section string, subsection string) *Config {
 
 // AddOption adds an option to a given section and subsection. Use the
 // NoSubsection constant for the subsection argument if no subsection is wanted.
-func (c *Config) AddOption(section string, subsection string, key string, value string) *Config {
+func (c *Config) AddOption(section, subsection, key, value string) *Config {
 	if subsection == "" {
 		c.Section(section).AddOption(key, value)
 	} else {
@@ -98,7 +98,7 @@ func (c *Config) AddOption(section string, subsection string, key string, value 
 
 // SetOption sets an option to a given section and subsection. Use the
 // NoSubsection constant for the subsection argument if no subsection is wanted.
-func (c *Config) SetOption(section string, subsection string, key string, value string) *Config {
+func (c *Config) SetOption(section, subsection, key, value string) *Config {
 	if subsection == "" {
 		c.Section(section).SetOption(key, value)
 	} else {

--- a/plumbing/format/config/decoder.go
+++ b/plumbing/format/config/decoder.go
@@ -19,7 +19,7 @@ func NewDecoder(r io.Reader) *Decoder {
 // Decode reads the whole config from its input and stores it in the
 // value pointed to by config.
 func (d *Decoder) Decode(config *Config) error {
-	cb := func(s string, ss string, k string, v string, bv bool) error {
+	cb := func(s, ss, k, v string, bv bool) error {
 		if ss == "" && k == "" {
 			config.Section(s)
 			return nil

--- a/plumbing/format/config/doc.go
+++ b/plumbing/format/config/doc.go
@@ -1,122 +1,121 @@
 // Package config implements encoding and decoding of git config files.
 //
-// 	Configuration File
-// 	------------------
+//	Configuration File
+//	------------------
 //
-// 	The Git configuration file contains a number of variables that affect
-// 	the Git commands' behavior. The `.git/config` file in each repository
-// 	is used to store the configuration for that repository, and
-// 	`$HOME/.gitconfig` is used to store a per-user configuration as
-// 	fallback values for the `.git/config` file. The file `/etc/gitconfig`
-// 	can be used to store a system-wide default configuration.
+//	The Git configuration file contains a number of variables that affect
+//	the Git commands' behavior. The `.git/config` file in each repository
+//	is used to store the configuration for that repository, and
+//	`$HOME/.gitconfig` is used to store a per-user configuration as
+//	fallback values for the `.git/config` file. The file `/etc/gitconfig`
+//	can be used to store a system-wide default configuration.
 //
-// 	The configuration variables are used by both the Git plumbing
-// 	and the porcelains. The variables are divided into sections, wherein
-// 	the fully qualified variable name of the variable itself is the last
-// 	dot-separated segment and the section name is everything before the last
-// 	dot. The variable names are case-insensitive, allow only alphanumeric
-// 	characters and `-`, and must start with an alphabetic character.  Some
-// 	variables may appear multiple times; we say then that the variable is
-// 	multivalued.
+//	The configuration variables are used by both the Git plumbing
+//	and the porcelains. The variables are divided into sections, wherein
+//	the fully qualified variable name of the variable itself is the last
+//	dot-separated segment and the section name is everything before the last
+//	dot. The variable names are case-insensitive, allow only alphanumeric
+//	characters and `-`, and must start with an alphabetic character.  Some
+//	variables may appear multiple times; we say then that the variable is
+//	multivalued.
 //
-// 	Syntax
-// 	~~~~~~
+//	Syntax
+//	~~~~~~
 //
-// 	The syntax is fairly flexible and permissive; whitespaces are mostly
-// 	ignored.  The '#' and ';' characters begin comments to the end of line,
-// 	blank lines are ignored.
+//	The syntax is fairly flexible and permissive; whitespaces are mostly
+//	ignored.  The '#' and ';' characters begin comments to the end of line,
+//	blank lines are ignored.
 //
-// 	The file consists of sections and variables.  A section begins with
-// 	the name of the section in square brackets and continues until the next
-// 	section begins.  Section names are case-insensitive.  Only alphanumeric
-// 	characters, `-` and `.` are allowed in section names.  Each variable
-// 	must belong to some section, which means that there must be a section
-// 	header before the first setting of a variable.
+//	The file consists of sections and variables.  A section begins with
+//	the name of the section in square brackets and continues until the next
+//	section begins.  Section names are case-insensitive.  Only alphanumeric
+//	characters, `-` and `.` are allowed in section names.  Each variable
+//	must belong to some section, which means that there must be a section
+//	header before the first setting of a variable.
 //
-// 	Sections can be further divided into subsections.  To begin a subsection
-// 	put its name in double quotes, separated by space from the section name,
-// 	in the section header, like in the example below:
+//	Sections can be further divided into subsections.  To begin a subsection
+//	put its name in double quotes, separated by space from the section name,
+//	in the section header, like in the example below:
 //
-// 	--------
-// 		[section "subsection"]
+//	--------
+//		[section "subsection"]
 //
-// 	--------
+//	--------
 //
-// 	Subsection names are case sensitive and can contain any characters except
-// 	newline (doublequote `"` and backslash can be included by escaping them
-// 	as `\"` and `\\`, respectively).  Section headers cannot span multiple
-// 	lines.  Variables may belong directly to a section or to a given subsection.
-// 	You can have `[section]` if you have `[section "subsection"]`, but you
-// 	don't need to.
+//	Subsection names are case sensitive and can contain any characters except
+//	newline (doublequote `"` and backslash can be included by escaping them
+//	as `\"` and `\\`, respectively).  Section headers cannot span multiple
+//	lines.  Variables may belong directly to a section or to a given subsection.
+//	You can have `[section]` if you have `[section "subsection"]`, but you
+//	don't need to.
 //
-// 	There is also a deprecated `[section.subsection]` syntax. With this
-// 	syntax, the subsection name is converted to lower-case and is also
-// 	compared case sensitively. These subsection names follow the same
-// 	restrictions as section names.
+//	There is also a deprecated `[section.subsection]` syntax. With this
+//	syntax, the subsection name is converted to lower-case and is also
+//	compared case sensitively. These subsection names follow the same
+//	restrictions as section names.
 //
-// 	All the other lines (and the remainder of the line after the section
-// 	header) are recognized as setting variables, in the form
-// 	'name = value' (or just 'name', which is a short-hand to say that
-// 	the variable is the boolean "true").
-// 	The variable names are case-insensitive, allow only alphanumeric characters
-// 	and `-`, and must start with an alphabetic character.
+//	All the other lines (and the remainder of the line after the section
+//	header) are recognized as setting variables, in the form
+//	'name = value' (or just 'name', which is a short-hand to say that
+//	the variable is the boolean "true").
+//	The variable names are case-insensitive, allow only alphanumeric characters
+//	and `-`, and must start with an alphabetic character.
 //
-// 	A line that defines a value can be continued to the next line by
-// 	ending it with a `\`; the backquote and the end-of-line are
-// 	stripped.  Leading whitespaces after 'name =', the remainder of the
-// 	line after the first comment character '#' or ';', and trailing
-// 	whitespaces of the line are discarded unless they are enclosed in
-// 	double quotes.  Internal whitespaces within the value are retained
-// 	verbatim.
+//	A line that defines a value can be continued to the next line by
+//	ending it with a `\`; the backquote and the end-of-line are
+//	stripped.  Leading whitespaces after 'name =', the remainder of the
+//	line after the first comment character '#' or ';', and trailing
+//	whitespaces of the line are discarded unless they are enclosed in
+//	double quotes.  Internal whitespaces within the value are retained
+//	verbatim.
 //
-// 	Inside double quotes, double quote `"` and backslash `\` characters
-// 	must be escaped: use `\"` for `"` and `\\` for `\`.
+//	Inside double quotes, double quote `"` and backslash `\` characters
+//	must be escaped: use `\"` for `"` and `\\` for `\`.
 //
-// 	The following escape sequences (beside `\"` and `\\`) are recognized:
-// 	`\n` for newline character (NL), `\t` for horizontal tabulation (HT, TAB)
-// 	and `\b` for backspace (BS).  Other char escape sequences (including octal
-// 	escape sequences) are invalid.
+//	The following escape sequences (beside `\"` and `\\`) are recognized:
+//	`\n` for newline character (NL), `\t` for horizontal tabulation (HT, TAB)
+//	and `\b` for backspace (BS).  Other char escape sequences (including octal
+//	escape sequences) are invalid.
 //
-// 	Includes
-// 	~~~~~~~~
+//	Includes
+//	~~~~~~~~
 //
-// 	You can include one config file from another by setting the special
-// 	`include.path` variable to the name of the file to be included. The
-// 	variable takes a pathname as its value, and is subject to tilde
-// 	expansion.
+//	You can include one config file from another by setting the special
+//	`include.path` variable to the name of the file to be included. The
+//	variable takes a pathname as its value, and is subject to tilde
+//	expansion.
 //
-// 	The included file is expanded immediately, as if its contents had been
-// 	found at the location of the include directive. If the value of the
-// 	`include.path` variable is a relative path, the path is considered to be
-// 	relative to the configuration file in which the include directive was
-// 	found.  See below for examples.
+//	The included file is expanded immediately, as if its contents had been
+//	found at the location of the include directive. If the value of the
+//	`include.path` variable is a relative path, the path is considered to be
+//	relative to the configuration file in which the include directive was
+//	found.  See below for examples.
 //
 //
-// 	Example
-// 	~~~~~~~
+//	Example
+//	~~~~~~~
 //
-// 		# Core variables
-// 		[core]
-// 			; Don't trust file modes
-// 			filemode = false
+//		# Core variables
+//		[core]
+//			; Don't trust file modes
+//			filemode = false
 //
-// 		# Our diff algorithm
-// 		[diff]
-// 			external = /usr/local/bin/diff-wrapper
-// 			renames = true
+//		# Our diff algorithm
+//		[diff]
+//			external = /usr/local/bin/diff-wrapper
+//			renames = true
 //
-// 		[branch "devel"]
-// 			remote = origin
-// 			merge = refs/heads/devel
+//		[branch "devel"]
+//			remote = origin
+//			merge = refs/heads/devel
 //
-// 		# Proxy settings
-// 		[core]
-// 			gitProxy="ssh" for "kernel.org"
-// 			gitProxy=default-proxy ; for the rest
+//		# Proxy settings
+//		[core]
+//			gitProxy="ssh" for "kernel.org"
+//			gitProxy=default-proxy ; for the rest
 //
-// 		[include]
-// 			path = /path/to/foo.inc ; include by absolute path
-// 			path = foo ; expand "foo" relative to the current file
-// 			path = ~/foo ; expand "foo" in your `$HOME` directory
-//
+//		[include]
+//			path = /path/to/foo.inc ; include by absolute path
+//			path = foo ; expand "foo" relative to the current file
+//			path = ~/foo ; expand "foo" in your `$HOME` directory
 package config

--- a/plumbing/format/config/encoder.go
+++ b/plumbing/format/config/encoder.go
@@ -13,8 +13,9 @@ type Encoder struct {
 
 var (
 	subsectionReplacer = strings.NewReplacer(`"`, `\"`, `\`, `\\`)
-	valueReplacer = strings.NewReplacer(`"`, `\"`, `\`, `\\`, "\n", `\n`, "\t", `\t`, "\b", `\b`)
+	valueReplacer      = strings.NewReplacer(`"`, `\"`, `\`, `\\`, "\n", `\n`, "\t", `\t`, "\b", `\b`)
 )
+
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{w}
@@ -63,7 +64,7 @@ func (e *Encoder) encodeOptions(opts Options) error {
 	for _, o := range opts {
 		var value string
 		if strings.ContainsAny(o.Value, "#;\"\t\n\\") || strings.HasPrefix(o.Value, " ") || strings.HasSuffix(o.Value, " ") {
-			value = `"`+valueReplacer.Replace(o.Value)+`"`
+			value = `"` + valueReplacer.Replace(o.Value) + `"`
 		} else {
 			value = o.Value
 		}
@@ -76,7 +77,7 @@ func (e *Encoder) encodeOptions(opts Options) error {
 	return nil
 }
 
-func (e *Encoder) printf(msg string, args ...interface{}) error {
+func (e *Encoder) printf(msg string, args ...any) error {
 	_, err := fmt.Fprintf(e.w, msg, args...)
 	return err
 }

--- a/plumbing/format/config/option.go
+++ b/plumbing/format/config/option.go
@@ -34,7 +34,7 @@ func (opts Options) GoString() string {
 // Get gets the value for the given key if set,
 // otherwise it returns the empty string.
 //
-// Note that there is no difference
+// # Note that there is no difference
 //
 // This matches git behaviour since git v1.8.1-rc1,
 // if there are multiple definitions of a key, the
@@ -85,7 +85,7 @@ func (opts Options) withoutOption(key string) Options {
 	return result
 }
 
-func (opts Options) withAddedOption(key string, value string) Options {
+func (opts Options) withAddedOption(key, value string) Options {
 	return append(opts, &Option{key, value})
 }
 

--- a/plumbing/format/config/section.go
+++ b/plumbing/format/config/section.go
@@ -12,7 +12,7 @@ import (
 // put its name in double quotes, separated by space from the section name,
 // in the section header, like in the example below:
 //
-//     [section "subsection"]
+//	[section "subsection"]
 //
 // All the other lines (and the remainder of the line after the section header)
 // are recognized as option variables, in the form "name = value" (or just name,
@@ -20,12 +20,11 @@ import (
 // The variable names are case-insensitive, allow only alphanumeric characters
 // and -, and must start with an alphabetic character:
 //
-//     [section "subsection1"]
-//         option1 = value1
-//         option2
-//     [section "subsection2"]
-//         option3 = value2
-//
+//	[section "subsection1"]
+//	    option1 = value1
+//	    option2
+//	[section "subsection2"]
+//	    option3 = value2
 type Section struct {
 	Name        string
 	Options     Options
@@ -121,14 +120,14 @@ func (s *Section) HasOption(key string) bool {
 }
 
 // AddOption adds a new Option to the Section. The updated Section is returned.
-func (s *Section) AddOption(key string, value string) *Section {
+func (s *Section) AddOption(key, value string) *Section {
 	s.Options = s.Options.withAddedOption(key, value)
 	return s
 }
 
 // SetOption adds a new Option to the Section. If the option already exists, is replaced.
 // The updated Section is returned.
-func (s *Section) SetOption(key string, value string) *Section {
+func (s *Section) SetOption(key, value string) *Section {
 	s.Options = s.Options.withSettedOption(key, value)
 	return s
 }
@@ -162,7 +161,7 @@ func (s *Subsection) HasOption(key string) bool {
 }
 
 // AddOption adds a new Option to the Subsection. The updated Subsection is returned.
-func (s *Subsection) AddOption(key string, value string) *Subsection {
+func (s *Subsection) AddOption(key, value string) *Subsection {
 	s.Options = s.Options.withAddedOption(key, value)
 	return s
 }

--- a/plumbing/format/diff/unified_encoder.go
+++ b/plumbing/format/diff/unified_encoder.go
@@ -243,18 +243,16 @@ func (g *hunksGenerator) processHunk(i int, op Operation) {
 
 	switch op {
 	case Delete:
-		g.current.fromLine, g.current.toLine =
-			g.addLineNumbers(g.fromLine, g.toLine, linesBefore, i, Add)
+		g.current.fromLine, g.current.toLine = g.addLineNumbers(g.fromLine, g.toLine, linesBefore, i, Add)
 	case Add:
-		g.current.toLine, g.current.fromLine =
-			g.addLineNumbers(g.toLine, g.fromLine, linesBefore, i, Delete)
+		g.current.toLine, g.current.fromLine = g.addLineNumbers(g.toLine, g.fromLine, linesBefore, i, Delete)
 	}
 
 	g.beforeContext = nil
 }
 
 // addLineNumbers obtains the line numbers in a new chunk.
-func (g *hunksGenerator) addLineNumbers(la, lb int, linesBefore int, i int, op Operation) (cla, clb int) {
+func (g *hunksGenerator) addLineNumbers(la, lb, linesBefore, i int, op Operation) (cla, clb int) {
 	cla = la - linesBefore
 	// we need to search for a reference for the next diff
 	switch {
@@ -274,7 +272,7 @@ func (g *hunksGenerator) addLineNumbers(la, lb int, linesBefore int, i int, op O
 		}
 	}
 
-	return
+	return cla, clb
 }
 
 func (g *hunksGenerator) processEqualsLines(ls []string, i int) {

--- a/plumbing/format/diff/unified_encoder_test.go
+++ b/plumbing/format/diff/unified_encoder_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/color"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
-	"github.com/stretchr/testify/suite"
 )
 
 type UnifiedEncoderTestSuite struct {
@@ -1023,6 +1024,7 @@ type testFilePatch struct {
 func (t testFilePatch) IsBinary() bool {
 	return len(t.chunks) == 0
 }
+
 func (t testFilePatch) Files() (File, File) {
 	// Go is amazing
 	switch {

--- a/plumbing/format/gitattributes/attributes.go
+++ b/plumbing/format/gitattributes/attributes.go
@@ -116,7 +116,7 @@ func ParseAttributesLine(line string, domain []string, allowMacro bool) (m Match
 	line = strings.TrimSpace(line)
 
 	if strings.HasPrefix(line, commentPrefix) || len(line) == 0 {
-		return
+		return m, err
 	}
 
 	name, unquoted := unquote(line)
@@ -129,7 +129,7 @@ func ParseAttributesLine(line string, domain []string, allowMacro bool) (m Match
 	var macro bool
 	macro, name, err = checkMacro(name, allowMacro)
 	if err != nil {
-		return
+		return m, err
 	}
 
 	m.Name = name
@@ -164,7 +164,7 @@ func ParseAttributesLine(line string, domain []string, allowMacro bool) (m Match
 	if !macro {
 		m.Pattern = ParsePattern(name, domain)
 	}
-	return
+	return m, err
 }
 
 func checkMacro(name string, allowMacro bool) (macro bool, macroName string, err error) {

--- a/plumbing/format/gitattributes/dir.go
+++ b/plumbing/format/gitattributes/dir.go
@@ -43,7 +43,7 @@ func ReadAttributesFile(fs billy.Filesystem, path []string, attributesFile strin
 func ReadPatterns(fs billy.Filesystem, path []string) (attributes []MatchAttribute, err error) {
 	attributes, err = ReadAttributesFile(fs, path, gitattributesFile, true)
 	if err != nil {
-		return
+		return attributes, err
 	}
 
 	attrs, err := walkDirectory(fs, path)
@@ -83,7 +83,7 @@ func walkDirectory(fs billy.Filesystem, root []string) (attributes []MatchAttrib
 		attributes = append(attributes, append(dirAttributes, subAttributes...)...)
 	}
 
-	return
+	return attributes, err
 }
 
 func loadPatterns(fs billy.Filesystem, path string) ([]MatchAttribute, error) {
@@ -119,7 +119,7 @@ func loadPatterns(fs billy.Filesystem, path string) ([]MatchAttribute, error) {
 func LoadGlobalPatterns(fs billy.Filesystem) (attributes []MatchAttribute, err error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return
+		return attributes, err
 	}
 
 	return loadPatterns(fs, fs.Join(home, gitconfigFile))

--- a/plumbing/format/gitattributes/matcher.go
+++ b/plumbing/format/gitattributes/matcher.go
@@ -3,7 +3,7 @@ package gitattributes
 // Matcher defines a global multi-pattern matcher for gitattributes patterns
 type Matcher interface {
 	// Match matches patterns in the order of priorities.
-	Match(path []string, attributes []string) (map[string]Attribute, bool)
+	Match(path, attributes []string) (map[string]Attribute, bool)
 }
 
 type MatcherOptions struct{}
@@ -41,13 +41,13 @@ func (m *matcher) init() {
 //
 // Matched is true if any path was matched to a rule, even if the results map
 // is empty.
-func (m *matcher) Match(path []string, attributes []string) (results map[string]Attribute, matched bool) {
+func (m *matcher) Match(path, attributes []string) (results map[string]Attribute, matched bool) {
 	results = make(map[string]Attribute, len(attributes))
 
 	n := len(m.stack)
 	for i := n - 1; i >= 0; i-- {
 		if len(attributes) > 0 && len(attributes) == len(results) {
-			return
+			return results, matched
 		}
 
 		pattern := m.stack[i].Pattern
@@ -65,7 +65,7 @@ func (m *matcher) Match(path []string, attributes []string) (results map[string]
 			}
 		}
 	}
-	return
+	return results, matched
 }
 
 func (m *matcher) expandMacro(name string, results map[string]Attribute) bool {

--- a/plumbing/format/gitignore/doc.go
+++ b/plumbing/format/gitignore/doc.go
@@ -3,68 +3,68 @@
 // priorities. It support all pattern formats as specified in the original gitignore
 // documentation, copied below:
 //
-//   Pattern format
-//   ==============
+//	  Pattern format
+//	  ==============
 //
-//		- A blank line matches no files, so it can serve as a separator for readability.
+//			- A blank line matches no files, so it can serve as a separator for readability.
 //
-//		- A line starting with # serves as a comment. Put a backslash ("\") in front of
-//		  the first hash for patterns that begin with a hash.
+//			- A line starting with # serves as a comment. Put a backslash ("\") in front of
+//			  the first hash for patterns that begin with a hash.
 //
-//		- Trailing spaces are ignored unless they are quoted with backslash ("\").
+//			- Trailing spaces are ignored unless they are quoted with backslash ("\").
 //
-//		- An optional prefix "!" which negates the pattern; any matching file excluded
-//		  by a previous pattern will become included again. It is not possible to
-//		  re-include a file if a parent directory of that file is excluded.
-//		  Git doesn’t list excluded directories for performance reasons, so
-//		  any patterns on contained files have no effect, no matter where they are
-//		  defined. Put a backslash ("\") in front of the first "!" for patterns
-//		  that begin with a literal "!", for example, "\!important!.txt".
+//			- An optional prefix "!" which negates the pattern; any matching file excluded
+//			  by a previous pattern will become included again. It is not possible to
+//			  re-include a file if a parent directory of that file is excluded.
+//			  Git doesn’t list excluded directories for performance reasons, so
+//			  any patterns on contained files have no effect, no matter where they are
+//			  defined. Put a backslash ("\") in front of the first "!" for patterns
+//			  that begin with a literal "!", for example, "\!important!.txt".
 //
-//		- If the pattern ends with a slash, it is removed for the purpose of the
-//		  following description, but it would only find a match with a directory.
-//		  In other words, foo/ will match a directory foo and paths underneath it,
-//		  but will not match a regular file or a symbolic link foo (this is consistent
-//		  with the way how pathspec works in general in Git).
+//			- If the pattern ends with a slash, it is removed for the purpose of the
+//			  following description, but it would only find a match with a directory.
+//			  In other words, foo/ will match a directory foo and paths underneath it,
+//			  but will not match a regular file or a symbolic link foo (this is consistent
+//			  with the way how pathspec works in general in Git).
 //
-//		- If the pattern does not contain a slash /, Git treats it as a shell glob
-//		  pattern and checks for a match against the pathname relative to the location
-//		  of the .gitignore file (relative to the toplevel of the work tree if not
-//		  from a .gitignore file).
+//			- If the pattern does not contain a slash /, Git treats it as a shell glob
+//			  pattern and checks for a match against the pathname relative to the location
+//			  of the .gitignore file (relative to the toplevel of the work tree if not
+//			  from a .gitignore file).
 //
-//		- Otherwise, Git treats the pattern as a shell glob suitable for consumption
-//		  by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the pattern will
-//		  not match a / in the pathname. For example, "Documentation/*.html" matches
-//		  "Documentation/git.html" but not "Documentation/ppc/ppc.html" or
-//		  "tools/perf/Documentation/perf.html".
+//			- Otherwise, Git treats the pattern as a shell glob suitable for consumption
+//			  by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the pattern will
+//			  not match a / in the pathname. For example, "Documentation/*.html" matches
+//			  "Documentation/git.html" but not "Documentation/ppc/ppc.html" or
+//			  "tools/perf/Documentation/perf.html".
 //
-//		- A leading slash matches the beginning of the pathname. For example,
-//		  "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
+//			- A leading slash matches the beginning of the pathname. For example,
+//			  "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
 //
-//		Two consecutive asterisks ("**") in patterns matched against full pathname
-//		may have special meaning:
+//			Two consecutive asterisks ("**") in patterns matched against full pathname
+//			may have special meaning:
 //
-//		- A leading "**" followed by a slash means match in all directories.
-//		  For example, "**/foo" matches file or directory "foo" anywhere, the same as
-//		  pattern "foo". "**/foo/bar" matches file or directory "bar"
-//		  anywhere that is directly under directory "foo".
+//			- A leading "**" followed by a slash means match in all directories.
+//			  For example, "**/foo" matches file or directory "foo" anywhere, the same as
+//			  pattern "foo". "**/foo/bar" matches file or directory "bar"
+//			  anywhere that is directly under directory "foo".
 //
-//		- A trailing "/**" matches everything inside. For example, "abc/**" matches
-//		  all files inside directory "abc", relative to the location of the
-//		  .gitignore file, with infinite depth.
+//			- A trailing "/**" matches everything inside. For example, "abc/**" matches
+//			  all files inside directory "abc", relative to the location of the
+//			  .gitignore file, with infinite depth.
 //
-//		- A slash followed by two consecutive asterisks then a slash matches
-//		  zero or more directories. For example, "a/**/b" matches "a/b", "a/x/b",
-//		  "a/x/y/b" and so on.
+//			- A slash followed by two consecutive asterisks then a slash matches
+//			  zero or more directories. For example, "a/**/b" matches "a/b", "a/x/b",
+//			  "a/x/y/b" and so on.
 //
-//		- Other consecutive asterisks are considered invalid.
+//			- Other consecutive asterisks are considered invalid.
 //
-//   Copyright and license
-//   =====================
+//	  Copyright and license
+//	  =====================
 //
-//		Copyright (c) Oleg Sklyar, Silvertern and source{d}
+//			Copyright (c) Oleg Sklyar, Silvertern and source{d}
 //
-//		The package code was donated to source{d} to include, modify and develop
-//		further as a part of the `go-git` project, release it on the license of
-//		the whole project or delete it from the project.
+//			The package code was donated to source{d} to include, modify and develop
+//			further as a part of the `go-git` project, release it on the license of
+//			the whole project or delete it from the project.
 package gitignore

--- a/plumbing/format/idxfile/decoder.go
+++ b/plumbing/format/idxfile/decoder.go
@@ -56,7 +56,7 @@ func (d *Decoder) Decode(idx *MemoryIndex) error {
 }
 
 func validateHeader(r io.Reader) error {
-	var h = make([]byte, 4)
+	h := make([]byte, 4)
 	if _, err := io.ReadFull(r, h); err != nil {
 		return err
 	}

--- a/plumbing/format/idxfile/decoder_test.go
+++ b/plumbing/format/idxfile/decoder_test.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
-	. "github.com/go-git/go-git/v6/plumbing/format/idxfile"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/suite"
 
-	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/go-git/go-git/v6/plumbing"
+	. "github.com/go-git/go-git/v6/plumbing/format/idxfile"
 )
 
 type IdxfileSuite struct {

--- a/plumbing/format/idxfile/doc.go
+++ b/plumbing/format/idxfile/doc.go
@@ -1,127 +1,127 @@
 // Package idxfile implements encoding and decoding of packfile idx files.
 //
-//  == Original (version 1) pack-*.idx files have the following format:
+//	== Original (version 1) pack-*.idx files have the following format:
 //
-//    - The header consists of 256 4-byte network byte order
-//      integers.  N-th entry of this table records the number of
-//      objects in the corresponding pack, the first byte of whose
-//      object name is less than or equal to N.  This is called the
-//      'first-level fan-out' table.
+//	  - The header consists of 256 4-byte network byte order
+//	    integers.  N-th entry of this table records the number of
+//	    objects in the corresponding pack, the first byte of whose
+//	    object name is less than or equal to N.  This is called the
+//	    'first-level fan-out' table.
 //
-//    - The header is followed by sorted 24-byte entries, one entry
-//      per object in the pack.  Each entry is:
+//	  - The header is followed by sorted 24-byte entries, one entry
+//	    per object in the pack.  Each entry is:
 //
-//     4-byte network byte order integer, recording where the
-//     object is stored in the packfile as the offset from the
-//     beginning.
+//	   4-byte network byte order integer, recording where the
+//	   object is stored in the packfile as the offset from the
+//	   beginning.
 //
-//     20-byte object name.
+//	   20-byte object name.
 //
-//   - The file is concluded with a trailer:
+//	 - The file is concluded with a trailer:
 //
-//     A copy of the 20-byte SHA1 checksum at the end of
-//     corresponding packfile.
+//	   A copy of the 20-byte SHA1 checksum at the end of
+//	   corresponding packfile.
 //
-//     20-byte SHA1-checksum of all of the above.
+//	   20-byte SHA1-checksum of all of the above.
 //
-//   Pack Idx file:
+//	 Pack Idx file:
 //
-//        --  +--------------------------------+
-//   fanout   | fanout[0] = 2 (for example)    |-.
-//   table    +--------------------------------+ |
-//            | fanout[1]                      | |
-//            +--------------------------------+ |
-//            | fanout[2]                      | |
-//            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ |
-//            | fanout[255] = total objects    |---.
-//        --  +--------------------------------+ | |
-//   main     | offset                         | | |
-//   index    | object name 00XXXXXXXXXXXXXXXX | | |
-//   tab      +--------------------------------+ | |
-//            | offset                         | | |
-//            | object name 00XXXXXXXXXXXXXXXX | | |
-//            +--------------------------------+<+ |
-//          .-| offset                         |   |
-//          | | object name 01XXXXXXXXXXXXXXXX |   |
-//          | +--------------------------------+   |
-//          | | offset                         |   |
-//          | | object name 01XXXXXXXXXXXXXXXX |   |
-//          | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   |
-//          | | offset                         |   |
-//          | | object name FFXXXXXXXXXXXXXXXX |   |
-//        --| +--------------------------------+<--+
-//  trailer | | packfile checksum              |
-//          | +--------------------------------+
-//          | | idxfile checksum               |
-//          | +--------------------------------+
-//          .---------.
-//                    |
-//  Pack file entry: <+
+//	      --  +--------------------------------+
+//	 fanout   | fanout[0] = 2 (for example)    |-.
+//	 table    +--------------------------------+ |
+//	          | fanout[1]                      | |
+//	          +--------------------------------+ |
+//	          | fanout[2]                      | |
+//	          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ |
+//	          | fanout[255] = total objects    |---.
+//	      --  +--------------------------------+ | |
+//	 main     | offset                         | | |
+//	 index    | object name 00XXXXXXXXXXXXXXXX | | |
+//	 tab      +--------------------------------+ | |
+//	          | offset                         | | |
+//	          | object name 00XXXXXXXXXXXXXXXX | | |
+//	          +--------------------------------+<+ |
+//	        .-| offset                         |   |
+//	        | | object name 01XXXXXXXXXXXXXXXX |   |
+//	        | +--------------------------------+   |
+//	        | | offset                         |   |
+//	        | | object name 01XXXXXXXXXXXXXXXX |   |
+//	        | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   |
+//	        | | offset                         |   |
+//	        | | object name FFXXXXXXXXXXXXXXXX |   |
+//	      --| +--------------------------------+<--+
+//	trailer | | packfile checksum              |
+//	        | +--------------------------------+
+//	        | | idxfile checksum               |
+//	        | +--------------------------------+
+//	        .---------.
+//	                  |
+//	Pack file entry: <+
 //
-//     packed object header:
-//     1-byte size extension bit (MSB)
-//           type (next 3 bit)
-//           size0 (lower 4-bit)
-//         n-byte sizeN (as long as MSB is set, each 7-bit)
-//         size0..sizeN form 4+7+7+..+7 bit integer, size0
-//         is the least significant part, and sizeN is the
-//         most significant part.
-//     packed object data:
-//         If it is not DELTA, then deflated bytes (the size above
-//         is the size before compression).
-//     If it is REF_DELTA, then
-//       20-byte base object name SHA1 (the size above is the
-//         size of the delta data that follows).
-//           delta data, deflated.
-//     If it is OFS_DELTA, then
-//       n-byte offset (see below) interpreted as a negative
-//         offset from the type-byte of the header of the
-//         ofs-delta entry (the size above is the size of
-//         the delta data that follows).
-//       delta data, deflated.
+//	   packed object header:
+//	   1-byte size extension bit (MSB)
+//	         type (next 3 bit)
+//	         size0 (lower 4-bit)
+//	       n-byte sizeN (as long as MSB is set, each 7-bit)
+//	       size0..sizeN form 4+7+7+..+7 bit integer, size0
+//	       is the least significant part, and sizeN is the
+//	       most significant part.
+//	   packed object data:
+//	       If it is not DELTA, then deflated bytes (the size above
+//	       is the size before compression).
+//	   If it is REF_DELTA, then
+//	     20-byte base object name SHA1 (the size above is the
+//	       size of the delta data that follows).
+//	         delta data, deflated.
+//	   If it is OFS_DELTA, then
+//	     n-byte offset (see below) interpreted as a negative
+//	       offset from the type-byte of the header of the
+//	       ofs-delta entry (the size above is the size of
+//	       the delta data that follows).
+//	     delta data, deflated.
 //
-//     offset encoding:
-//       n bytes with MSB set in all but the last one.
-//       The offset is then the number constructed by
-//       concatenating the lower 7 bit of each byte, and
-//       for n >= 2 adding 2^7 + 2^14 + ... + 2^(7*(n-1))
-//       to the result.
+//	   offset encoding:
+//	     n bytes with MSB set in all but the last one.
+//	     The offset is then the number constructed by
+//	     concatenating the lower 7 bit of each byte, and
+//	     for n >= 2 adding 2^7 + 2^14 + ... + 2^(7*(n-1))
+//	     to the result.
 //
-//   == Version 2 pack-*.idx files support packs larger than 4 GiB, and
-//      have some other reorganizations.  They have the format:
+//	 == Version 2 pack-*.idx files support packs larger than 4 GiB, and
+//	    have some other reorganizations.  They have the format:
 //
-//     - A 4-byte magic number '\377tOc' which is an unreasonable
-//       fanout[0] value.
+//	   - A 4-byte magic number '\377tOc' which is an unreasonable
+//	     fanout[0] value.
 //
-//     - A 4-byte version number (= 2)
+//	   - A 4-byte version number (= 2)
 //
-//     - A 256-entry fan-out table just like v1.
+//	   - A 256-entry fan-out table just like v1.
 //
-//     - A table of sorted 20-byte SHA1 object names.  These are
-//       packed together without offset values to reduce the cache
-//       footprint of the binary search for a specific object name.
+//	   - A table of sorted 20-byte SHA1 object names.  These are
+//	     packed together without offset values to reduce the cache
+//	     footprint of the binary search for a specific object name.
 //
-//     - A table of 4-byte CRC32 values of the packed object data.
-//       This is new in v2 so compressed data can be copied directly
-//       from pack to pack during repacking without undetected
-//       data corruption.
+//	   - A table of 4-byte CRC32 values of the packed object data.
+//	     This is new in v2 so compressed data can be copied directly
+//	     from pack to pack during repacking without undetected
+//	     data corruption.
 //
-//     - A table of 4-byte offset values (in network byte order).
-//       These are usually 31-bit pack file offsets, but large
-//       offsets are encoded as an index into the next table with
-//       the msbit set.
+//	   - A table of 4-byte offset values (in network byte order).
+//	     These are usually 31-bit pack file offsets, but large
+//	     offsets are encoded as an index into the next table with
+//	     the msbit set.
 //
-//     - A table of 8-byte offset entries (empty for pack files less
-//       than 2 GiB).  Pack files are organized with heavily used
-//       objects toward the front, so most object references should
-//       not need to refer to this table.
+//	   - A table of 8-byte offset entries (empty for pack files less
+//	     than 2 GiB).  Pack files are organized with heavily used
+//	     objects toward the front, so most object references should
+//	     not need to refer to this table.
 //
-//     - The same trailer as a v1 pack file:
+//	   - The same trailer as a v1 pack file:
 //
-//       A copy of the 20-byte SHA1 checksum at the end of
-//       corresponding packfile.
+//	     A copy of the 20-byte SHA1 checksum at the end of
+//	     corresponding packfile.
 //
-//       20-byte SHA1-checksum of all of the above.
+//	     20-byte SHA1-checksum of all of the above.
 //
 // Source:
 // https://www.kernel.org/pub/software/scm/git/docs/v1.7.5/technical/pack-format.txt

--- a/plumbing/format/idxfile/encoder_test.go
+++ b/plumbing/format/idxfile/encoder_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"io"
 
-	. "github.com/go-git/go-git/v6/plumbing/format/idxfile"
-
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+
+	. "github.com/go-git/go-git/v6/plumbing/format/idxfile"
 )
 
 func (s *IdxfileSuite) TestDecodeEncode() {

--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -2,11 +2,10 @@ package idxfile
 
 import (
 	"crypto"
+	encbin "encoding/binary"
 	"io"
 	"sort"
 	"sync"
-
-	encbin "encoding/binary"
 
 	"github.com/go-git/go-git/v6/plumbing"
 )
@@ -18,9 +17,7 @@ const (
 	noMapping = -1
 )
 
-var (
-	idxHeader = []byte{255, 't', 'O', 'c'}
-)
+var idxHeader = []byte{255, 't', 'O', 'c'}
 
 // Index represents an index of a packfile.
 type Index interface {
@@ -360,10 +357,10 @@ func (o entriesByOffset) Len() int {
 	return len(o)
 }
 
-func (o entriesByOffset) Less(i int, j int) bool {
+func (o entriesByOffset) Less(i, j int) bool {
 	return o[i].Offset < o[j].Offset
 }
 
-func (o entriesByOffset) Swap(i int, j int) {
+func (o entriesByOffset) Swap(i, j int) {
 	o[i], o[j] = o[j], o[i]
 }

--- a/plumbing/format/idxfile/idxfile_test.go
+++ b/plumbing/format/idxfile/idxfile_test.go
@@ -8,9 +8,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
-	"github.com/stretchr/testify/suite"
 )
 
 func BenchmarkFindOffset(b *testing.B) {

--- a/plumbing/format/idxfile/writer.go
+++ b/plumbing/format/idxfile/writer.go
@@ -54,7 +54,6 @@ func (w *Writer) Add(h plumbing.Hash, pos uint64, crc uint32) {
 		w.added[h] = struct{}{}
 		w.objects = append(w.objects, Entry{h, crc, pos})
 	}
-
 }
 
 func (w *Writer) Finished() bool {
@@ -69,7 +68,7 @@ func (w *Writer) OnHeader(count uint32) error {
 }
 
 // OnInflatedObjectHeader implements packfile.Observer interface.
-func (w *Writer) OnInflatedObjectHeader(t plumbing.ObjectType, objSize int64, pos int64) error {
+func (w *Writer) OnInflatedObjectHeader(t plumbing.ObjectType, objSize, pos int64) error {
 	return nil
 }
 
@@ -183,11 +182,11 @@ func (o objects) Len() int {
 	return len(o)
 }
 
-func (o objects) Less(i int, j int) bool {
+func (o objects) Less(i, j int) bool {
 	cmp := o[i].Hash.Compare(o[j].Hash.Bytes())
 	return cmp < 0
 }
 
-func (o objects) Swap(i int, j int) {
+func (o objects) Swap(i, j int) {
 	o[i], o[j] = o[j], o[i]
 }

--- a/plumbing/format/idxfile/writer_test.go
+++ b/plumbing/format/idxfile/writer_test.go
@@ -6,12 +6,12 @@ import (
 	"io"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type WriterSuite struct {

--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-
 	"strconv"
 	"time"
 
@@ -100,7 +99,7 @@ func (d *Decoder) readEntry(idx *Index) (*Entry, error) {
 	var msec, mnsec, sec, nsec uint32
 	var flags uint16
 
-	flow := []interface{}{
+	flow := []any{
 		&sec, &nsec,
 		&msec, &mnsec,
 		&e.Dev,
@@ -320,7 +319,7 @@ func (d *Decoder) readChecksum(expected []byte) error {
 }
 
 func validateHeader(r io.Reader) (version uint32, err error) {
-	var s = make([]byte, 4)
+	s := make([]byte, 4)
 	if _, err := io.ReadFull(r, s); err != nil {
 		return 0, err
 	}
@@ -338,7 +337,7 @@ func validateHeader(r io.Reader) (version uint32, err error) {
 		return 0, ErrUnsupportedVersion
 	}
 
-	return
+	return version, err
 }
 
 type treeExtensionDecoder struct {

--- a/plumbing/format/index/decoder_test.go
+++ b/plumbing/format/index/decoder_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,8 +15,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/hash"
 	"github.com/go-git/go-git/v6/utils/binary"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 func TestDecodeEntries(t *testing.T) {
@@ -162,140 +161,129 @@ func TestDecodeEntries(t *testing.T) {
 	}
 }
 
-var (
-	// basicIndex represents fixtures.Basic().One().DotGit().Open("index")
-	basicIndex = Index{
-		Version: 2,
-		Entries: []*Entry{
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140626),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(189),
-				Hash:       plumbing.NewHash("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88"),
-				Name:       ".gitignore",
-				Mode:       filemode.Regular,
-			},
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140627),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(18),
-				Hash:       plumbing.NewHash("d3ff53e0564a9f87d8e84b6e28e5060e517008aa"),
-				Name:       "CHANGELOG",
-				Mode:       filemode.Regular,
-			},
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140628),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(1072),
-				Hash:       plumbing.NewHash("c192bd6a24ea1ab01d78686e417c8bdc7c3d197f"),
-				Name:       "LICENSE",
-				Mode:       filemode.Regular,
-			},
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140629),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(76110),
-				Hash:       plumbing.NewHash("d5c0f4ab811897cadf03aec358ae60d21f91c50d"),
-				Name:       "binary.jpg",
-				Mode:       filemode.Regular,
-			},
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140631),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(2780),
-				Hash:       plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"),
-				Name:       "go/example.go",
-				Mode:       filemode.Regular,
-			},
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140633),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(217848),
-				Hash:       plumbing.NewHash("49c6bb89b17060d7b4deacb7b338fcc6ea2352a9"),
-				Name:       "json/long.json",
-				Mode:       filemode.Regular,
-			},
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140634),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(706),
-				Hash:       plumbing.NewHash("c8f1d8c61f9da76f4cb49fd86322b6e685dba956"),
-				Name:       "json/short.json",
-				Mode:       filemode.Regular,
-			},
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140636),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(11488),
-				Hash:       plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"),
-				Name:       "php/crappy.php",
-				Mode:       filemode.Regular,
-			},
-			{
-
-				CreatedAt:  time.Unix(int64(1480626693), 498593596),
-				ModifiedAt: time.Unix(int64(1480626693), 498593596),
-				Dev:        uint32(39),
-				Inode:      uint32(140638),
-				UID:        uint32(1000),
-				GID:        uint32(100),
-				Size:       uint32(78),
-				Hash:       plumbing.NewHash("9dea2395f5403188298c1dabe8bdafe562c491e3"),
-				Name:       "vendor/foo.go",
-				Mode:       filemode.Regular,
-			},
+// basicIndex represents fixtures.Basic().One().DotGit().Open("index")
+var basicIndex = Index{
+	Version: 2,
+	Entries: []*Entry{
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140626),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(189),
+			Hash:       plumbing.NewHash("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88"),
+			Name:       ".gitignore",
+			Mode:       filemode.Regular,
 		},
-		Cache: &Tree{
-			[]TreeEntry{
-				{Path: "", Entries: 9, Trees: 4, Hash: plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")},
-				{Path: "go", Entries: 1, Trees: 0, Hash: plumbing.NewHash("a39771a7651f97faf5c72e08224d857fc35133db")},
-				{Path: "php", Entries: 1, Trees: 0, Hash: plumbing.NewHash("586af567d0bb5e771e49bdd9434f5e0fb76d25fa")},
-				{Path: "json", Entries: 2, Trees: 0, Hash: plumbing.NewHash("5a877e6a906a2743ad6e45d99c1793642aaf8eda")},
-				{Path: "vendor", Entries: 1, Trees: 0, Hash: plumbing.NewHash("cf4aa3b38974fb7d81f367c0830f7d78d65ab86b")},
-			},
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140627),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(18),
+			Hash:       plumbing.NewHash("d3ff53e0564a9f87d8e84b6e28e5060e517008aa"),
+			Name:       "CHANGELOG",
+			Mode:       filemode.Regular,
 		},
-	}
-)
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140628),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(1072),
+			Hash:       plumbing.NewHash("c192bd6a24ea1ab01d78686e417c8bdc7c3d197f"),
+			Name:       "LICENSE",
+			Mode:       filemode.Regular,
+		},
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140629),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(76110),
+			Hash:       plumbing.NewHash("d5c0f4ab811897cadf03aec358ae60d21f91c50d"),
+			Name:       "binary.jpg",
+			Mode:       filemode.Regular,
+		},
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140631),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(2780),
+			Hash:       plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"),
+			Name:       "go/example.go",
+			Mode:       filemode.Regular,
+		},
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140633),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(217848),
+			Hash:       plumbing.NewHash("49c6bb89b17060d7b4deacb7b338fcc6ea2352a9"),
+			Name:       "json/long.json",
+			Mode:       filemode.Regular,
+		},
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140634),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(706),
+			Hash:       plumbing.NewHash("c8f1d8c61f9da76f4cb49fd86322b6e685dba956"),
+			Name:       "json/short.json",
+			Mode:       filemode.Regular,
+		},
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140636),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(11488),
+			Hash:       plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"),
+			Name:       "php/crappy.php",
+			Mode:       filemode.Regular,
+		},
+		{
+			CreatedAt:  time.Unix(int64(1480626693), 498593596),
+			ModifiedAt: time.Unix(int64(1480626693), 498593596),
+			Dev:        uint32(39),
+			Inode:      uint32(140638),
+			UID:        uint32(1000),
+			GID:        uint32(100),
+			Size:       uint32(78),
+			Hash:       plumbing.NewHash("9dea2395f5403188298c1dabe8bdafe562c491e3"),
+			Name:       "vendor/foo.go",
+			Mode:       filemode.Regular,
+		},
+	},
+	Cache: &Tree{
+		[]TreeEntry{
+			{Path: "", Entries: 9, Trees: 4, Hash: plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")},
+			{Path: "go", Entries: 1, Trees: 0, Hash: plumbing.NewHash("a39771a7651f97faf5c72e08224d857fc35133db")},
+			{Path: "php", Entries: 1, Trees: 0, Hash: plumbing.NewHash("586af567d0bb5e771e49bdd9434f5e0fb76d25fa")},
+			{Path: "json", Entries: 2, Trees: 0, Hash: plumbing.NewHash("5a877e6a906a2743ad6e45d99c1793642aaf8eda")},
+			{Path: "vendor", Entries: 1, Trees: 0, Hash: plumbing.NewHash("cf4aa3b38974fb7d81f367c0830f7d78d65ab86b")},
+		},
+	},
+}
 
 func TestDecodeMergeConflict(t *testing.T) {
 	f, err := fixtures.Basic().ByTag("merge-conflict").One().DotGit().Open("index")
@@ -347,7 +335,7 @@ func (s *IndexSuite) readSimpleIndex() *Index {
 	return idx
 }
 
-func (s *IndexSuite) buildIndexWithExtension(signature string, data string) []byte {
+func (s *IndexSuite) buildIndexWithExtension(signature, data string) []byte {
 	idx := s.readSimpleIndex()
 
 	buf := bytes.NewBuffer(nil)

--- a/plumbing/format/index/encoder.go
+++ b/plumbing/format/index/encoder.go
@@ -109,7 +109,7 @@ func (e *Encoder) encodeEntry(idx *Index, entry *Entry) error {
 		flags |= nameMask
 	}
 
-	flow := []interface{}{
+	flow := []any{
 		sec, nsec,
 		msec, mnsec,
 		entry.Dev,
@@ -121,7 +121,7 @@ func (e *Encoder) encodeEntry(idx *Index, entry *Entry) error {
 		entry.Hash.Bytes(),
 	}
 
-	flagsFlow := []interface{}{flags}
+	flagsFlow := []any{flags}
 
 	if entry.IntentToAdd || entry.SkipWorktree {
 		var extendedFlags uint16
@@ -133,7 +133,7 @@ func (e *Encoder) encodeEntry(idx *Index, entry *Entry) error {
 			extendedFlags |= skipWorkTreeMask
 		}
 
-		flagsFlow = []interface{}{flags | entryExtended, extendedFlags}
+		flagsFlow = []any{flags | entryExtended, extendedFlags}
 	}
 
 	flow = append(flow, flagsFlow...)

--- a/plumbing/format/index/encoder_test.go
+++ b/plumbing/format/index/encoder_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 func TestEncode(t *testing.T) {

--- a/plumbing/format/index/index.go
+++ b/plumbing/format/index/index.go
@@ -107,7 +107,7 @@ func (i *Index) Glob(pattern string) (matches []*Entry, err error) {
 		}
 	}
 
-	return
+	return matches, err
 }
 
 // String is equivalent to `git ls-files --stage --debug`

--- a/plumbing/format/index/match.go
+++ b/plumbing/format/index/match.go
@@ -89,7 +89,7 @@ Scan:
 func matchChunk(chunk, s string) (rest string, ok bool, err error) {
 	for len(chunk) > 0 {
 		if len(s) == 0 {
-			return
+			return rest, ok, err
 		}
 		switch chunk[0] {
 		case '[':
@@ -101,7 +101,7 @@ func matchChunk(chunk, s string) (rest string, ok bool, err error) {
 			// a closing bracket and possibly a caret.
 			if len(chunk) == 0 {
 				err = filepath.ErrBadPattern
-				return
+				return rest, ok, err
 			}
 			// possibly negated
 			negated := chunk[0] == '^'
@@ -118,12 +118,12 @@ func matchChunk(chunk, s string) (rest string, ok bool, err error) {
 				}
 				var lo, hi rune
 				if lo, chunk, err = getEsc(chunk); err != nil {
-					return
+					return rest, ok, err
 				}
 				hi = lo
 				if chunk[0] == '-' {
 					if hi, chunk, err = getEsc(chunk[1:]); err != nil {
-						return
+						return rest, ok, err
 					}
 				}
 				if lo <= r && r <= hi {
@@ -132,7 +132,7 @@ func matchChunk(chunk, s string) (rest string, ok bool, err error) {
 				nrange++
 			}
 			if match == negated {
-				return
+				return rest, ok, err
 			}
 
 		case '?':
@@ -145,14 +145,14 @@ func matchChunk(chunk, s string) (rest string, ok bool, err error) {
 				chunk = chunk[1:]
 				if len(chunk) == 0 {
 					err = filepath.ErrBadPattern
-					return
+					return rest, ok, err
 				}
 			}
 			fallthrough
 
 		default:
 			if chunk[0] != s[0] {
-				return
+				return rest, ok, err
 			}
 			s = s[1:]
 			chunk = chunk[1:]
@@ -165,13 +165,13 @@ func matchChunk(chunk, s string) (rest string, ok bool, err error) {
 func getEsc(chunk string) (r rune, nchunk string, err error) {
 	if len(chunk) == 0 || chunk[0] == '-' || chunk[0] == ']' {
 		err = filepath.ErrBadPattern
-		return
+		return r, nchunk, err
 	}
 	if chunk[0] == '\\' && runtime.GOOS != "windows" {
 		chunk = chunk[1:]
 		if len(chunk) == 0 {
 			err = filepath.ErrBadPattern
-			return
+			return r, nchunk, err
 		}
 	}
 	r, n := utf8.DecodeRuneInString(chunk)
@@ -182,5 +182,5 @@ func getEsc(chunk string) (r rune, nchunk string, err error) {
 	if len(nchunk) == 0 {
 		err = filepath.ErrBadPattern
 	}
-	return
+	return r, nchunk, err
 }

--- a/plumbing/format/objfile/reader.go
+++ b/plumbing/format/objfile/reader.go
@@ -42,27 +42,27 @@ func (r *Reader) Header() (t plumbing.ObjectType, size int64, err error) {
 	var raw []byte
 	raw, err = r.readUntil(' ')
 	if err != nil {
-		return
+		return t, size, err
 	}
 
 	t, err = plumbing.ParseObjectType(string(raw))
 	if err != nil {
-		return
+		return t, size, err
 	}
 
 	raw, err = r.readUntil(0)
 	if err != nil {
-		return
+		return t, size, err
 	}
 
 	size, err = strconv.ParseInt(string(raw), 10, 64)
 	if err != nil {
 		err = ErrHeader
-		return
+		return t, size, err
 	}
 
 	defer r.prepareForRead(t, size)
-	return
+	return t, size, err
 }
 
 // readSlice reads one byte at a time from r until it encounters delim or an

--- a/plumbing/format/objfile/reader_test.go
+++ b/plumbing/format/objfile/reader_test.go
@@ -7,9 +7,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type SuiteReader struct {
@@ -46,7 +47,6 @@ func testReader(t *testing.T, source io.Reader, hash plumbing.Hash, o plumbing.O
 
 	assert.Equal(t, hash, r.Hash()) // Test Hash() before close
 	assert.NoError(t, r.Close())
-
 }
 
 func (s *SuiteReader) TestReadEmptyObjfile() {

--- a/plumbing/format/objfile/writer.go
+++ b/plumbing/format/objfile/writer.go
@@ -86,10 +86,10 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 	w.pending -= int64(n)
 	if err == nil && overwrite {
 		err = ErrOverflow
-		return
+		return n, err
 	}
 
-	return
+	return n, err
 }
 
 // Hash returns the hash of the object data stream that has been written so far.

--- a/plumbing/format/objfile/writer_test.go
+++ b/plumbing/format/objfile/writer_test.go
@@ -7,9 +7,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type SuiteWriter struct {

--- a/plumbing/format/packfile/common_test.go
+++ b/plumbing/format/packfile/common_test.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEmptyUpdateObjectStorage(t *testing.T) {

--- a/plumbing/format/packfile/delta_index.go
+++ b/plumbing/format/packfile/delta_index.go
@@ -1,7 +1,9 @@
 package packfile
 
-const blksz = 16
-const maxChainLength = 64
+const (
+	blksz          = 16
+	maxChainLength = 64
+)
 
 // deltaIndex is a modified version of JGit's DeltaIndex adapted to our current
 // design.
@@ -36,14 +38,14 @@ func (idx *deltaIndex) findMatch(src, tgt []byte, tgtOffset int) (srcOffset, l i
 	tIdx := h & idx.mask
 	eIdx := idx.table[tIdx]
 	if eIdx == 0 {
-		return
+		return srcOffset, l
 	}
 
 	srcOffset = idx.entries[eIdx]
 
 	l = matchLength(src, tgt, tgtOffset, srcOffset)
 
-	return
+	return srcOffset, l
 }
 
 func matchLength(src, tgt []byte, otgt, osrc int) (l int) {
@@ -54,7 +56,7 @@ func matchLength(src, tgt []byte, otgt, osrc int) (l int) {
 		osrc++
 		otgt++
 	}
-	return
+	return l
 }
 
 func countEntries(scan *deltaIndexScanner) (cnt int) {
@@ -84,7 +86,7 @@ func countEntries(scan *deltaIndexScanner) (cnt int) {
 		cnt += size
 	}
 
-	return
+	return cnt
 }
 
 func (idx *deltaIndex) copyEntries(scanner *deltaIndexScanner) {
@@ -240,7 +242,8 @@ func hashBlock(raw []byte, ptr int) int {
 	return int(hash)
 }
 
-var T = []uint32{0x00000000, 0xd4c6b32d, 0x7d4bd577,
+var T = []uint32{
+	0x00000000, 0xd4c6b32d, 0x7d4bd577,
 	0xa98d665a, 0x2e5119c3, 0xfa97aaee, 0x531accb4, 0x87dc7f99,
 	0x5ca23386, 0x886480ab, 0x21e9e6f1, 0xf52f55dc, 0x72f32a45,
 	0xa6359968, 0x0fb8ff32, 0xdb7e4c1f, 0x6d82d421, 0xb944670c,

--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -320,7 +320,8 @@ func (dw *deltaSelector) tryToDeltify(indexMap map[plumbing.Hash]*deltaIndex, ba
 }
 
 func (dw *deltaSelector) deltaSizeLimit(targetSize int64, baseDepth int,
-	targetDepth int, targetDelta bool) int64 {
+	targetDepth int, targetDelta bool,
+) int64 {
 	if !targetDelta {
 		// Any delta should be no more than 50% of the original size
 		// (for text files deflate of whole form should shrink 50%).

--- a/plumbing/format/packfile/delta_selector_test.go
+++ b/plumbing/format/packfile/delta_selector_test.go
@@ -3,9 +3,10 @@ package packfile
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 type DeltaSelectorSuite struct {
@@ -26,15 +27,15 @@ func (s *DeltaSelectorSuite) SetupTest() {
 }
 
 func (s *DeltaSelectorSuite) TestSort() {
-	var o1 = newObjectToPack(newObject(plumbing.BlobObject, []byte("00000")))
-	var o4 = newObjectToPack(newObject(plumbing.BlobObject, []byte("0000")))
-	var o6 = newObjectToPack(newObject(plumbing.BlobObject, []byte("00")))
-	var o9 = newObjectToPack(newObject(plumbing.BlobObject, []byte("0")))
-	var o8 = newObjectToPack(newObject(plumbing.TreeObject, []byte("000")))
-	var o2 = newObjectToPack(newObject(plumbing.TreeObject, []byte("00")))
-	var o3 = newObjectToPack(newObject(plumbing.TreeObject, []byte("0")))
-	var o5 = newObjectToPack(newObject(plumbing.CommitObject, []byte("0000")))
-	var o7 = newObjectToPack(newObject(plumbing.CommitObject, []byte("00")))
+	o1 := newObjectToPack(newObject(plumbing.BlobObject, []byte("00000")))
+	o4 := newObjectToPack(newObject(plumbing.BlobObject, []byte("0000")))
+	o6 := newObjectToPack(newObject(plumbing.BlobObject, []byte("00")))
+	o9 := newObjectToPack(newObject(plumbing.BlobObject, []byte("0")))
+	o8 := newObjectToPack(newObject(plumbing.TreeObject, []byte("000")))
+	o2 := newObjectToPack(newObject(plumbing.TreeObject, []byte("00")))
+	o3 := newObjectToPack(newObject(plumbing.TreeObject, []byte("0")))
+	o5 := newObjectToPack(newObject(plumbing.CommitObject, []byte("0000")))
+	o7 := newObjectToPack(newObject(plumbing.CommitObject, []byte("00")))
 
 	toSort := []*ObjectToPack{o1, o2, o3, o4, o5, o6, o7, o8, o9}
 	s.ds.sort(toSort)

--- a/plumbing/format/packfile/delta_test.go
+++ b/plumbing/format/packfile/delta_test.go
@@ -6,8 +6,9 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type DeltaSuite struct {
@@ -64,10 +65,21 @@ func (s *DeltaSuite) SetupSuite() {
 		target:      []piece{{"0", 100}},
 	}, {
 		description: "complex modification",
-		base: []piece{{"0", 3}, {"1", 40}, {"2", 30}, {"3", 2},
-			{"4", 400}, {"5", 23}},
-		target: []piece{{"1", 30}, {"2", 20}, {"7", 40}, {"4", 400},
-			{"5", 10}},
+		base: []piece{
+			{"0", 3},
+			{"1", 40},
+			{"2", 30},
+			{"3", 2},
+			{"4", 400},
+			{"5", 23},
+		},
+		target: []piece{
+			{"1", 30},
+			{"2", 20},
+			{"7", 40},
+			{"4", 400},
+			{"5", 10},
+		},
 	}, {
 		description: "A copy operation bigger than 64kb",
 		base:        []piece{{bigRandStr, 1}, {"1", 200}},

--- a/plumbing/format/packfile/diff_delta.go
+++ b/plumbing/format/packfile/diff_delta.go
@@ -81,7 +81,7 @@ func DiffDelta(src, tgt []byte) []byte {
 	return diffDelta(new(deltaIndex), src, tgt)
 }
 
-func diffDelta(index *deltaIndex, src []byte, tgt []byte) []byte {
+func diffDelta(index *deltaIndex, src, tgt []byte) []byte {
 	buf := sync.GetBytesBuffer()
 	defer sync.PutBytesBuffer(buf)
 	buf.Write(deltaEncodeSize(len(src)))

--- a/plumbing/format/packfile/doc.go
+++ b/plumbing/format/packfile/doc.go
@@ -1,38 +1,37 @@
 // Package packfile implements encoding and decoding of packfile format.
 //
-//  == pack-*.pack files have the following format:
+//	== pack-*.pack files have the following format:
 //
-//    - A header appears at the beginning and consists of the following:
+//	  - A header appears at the beginning and consists of the following:
 //
-//      4-byte signature:
-//          The signature is: {'P', 'A', 'C', 'K'}
+//	    4-byte signature:
+//	        The signature is: {'P', 'A', 'C', 'K'}
 //
-//      4-byte version number (network byte order):
-//          GIT currently accepts version number 2 or 3 but
-//          generates version 2 only.
+//	    4-byte version number (network byte order):
+//	        GIT currently accepts version number 2 or 3 but
+//	        generates version 2 only.
 //
-//      4-byte number of objects contained in the pack (network byte order)
+//	    4-byte number of objects contained in the pack (network byte order)
 //
-//      Observation: we cannot have more than 4G versions ;-) and
-//      more than 4G objects in a pack.
+//	    Observation: we cannot have more than 4G versions ;-) and
+//	    more than 4G objects in a pack.
 //
-//    - The header is followed by number of object entries, each of
-//      which looks like this:
+//	  - The header is followed by number of object entries, each of
+//	    which looks like this:
 //
-//      (undeltified representation)
-//      n-byte type and length (3-bit type, (n-1)*7+4-bit length)
-//      compressed data
+//	    (undeltified representation)
+//	    n-byte type and length (3-bit type, (n-1)*7+4-bit length)
+//	    compressed data
 //
-//      (deltified representation)
-//      n-byte type and length (3-bit type, (n-1)*7+4-bit length)
-//      20-byte base object name
-//      compressed delta data
+//	    (deltified representation)
+//	    n-byte type and length (3-bit type, (n-1)*7+4-bit length)
+//	    20-byte base object name
+//	    compressed delta data
 //
-//      Observation: length of each object is encoded in a variable
-//      length format and is not constrained to 32-bit or anything.
+//	    Observation: length of each object is encoded in a variable
+//	    length format and is not constrained to 32-bit or anything.
 //
-//   - The trailer records 20-byte SHA1 checksum of all of the above.
-//
+//	 - The trailer records 20-byte SHA1 checksum of all of the above.
 //
 // Source:
 // https://www.kernel.org/pub/software/scm/git/docs/v1.7.5/technical/pack-protocol.txt

--- a/plumbing/format/packfile/encoder_advanced_test.go
+++ b/plumbing/format/packfile/encoder_advanced_test.go
@@ -6,16 +6,16 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/go-git/go-billy/v6/memfs"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	. "github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
-
-	"github.com/go-git/go-billy/v6/memfs"
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type EncoderAdvancedSuite struct {
@@ -69,7 +69,6 @@ func (s *EncoderAdvancedSuite) testEncodeDecode(
 		expectedObjects[o.Hash()] = true
 		hashes = append(hashes, o.Hash())
 		return err
-
 	})
 	s.NoError(err)
 

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -5,12 +5,12 @@ import (
 	"io"
 	"testing"
 
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
-
-	"github.com/go-git/go-billy/v6/memfs"
 )
 
 type EncoderSuite struct {

--- a/plumbing/format/packfile/error.go
+++ b/plumbing/format/packfile/error.go
@@ -22,7 +22,7 @@ func (e *Error) Error() string {
 }
 
 // AddDetails adds details to an error, with additional text.
-func (e *Error) AddDetails(format string, args ...interface{}) *Error {
+func (e *Error) AddDetails(format string, args ...any) *Error {
 	return &Error{
 		reason:  e.reason,
 		details: fmt.Sprintf(format, args...),

--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	billy "github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"

--- a/plumbing/format/packfile/object_pack_test.go
+++ b/plumbing/format/packfile/object_pack_test.go
@@ -4,8 +4,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type ObjectToPackSuite struct {

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	billy "github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
@@ -209,7 +210,7 @@ func (p *Packfile) init() error {
 
 		p.rbuf = gogitsync.GetBufioReader(nil)
 
-		var opts = []ScannerOption{WithBufioReader(p.rbuf)}
+		opts := []ScannerOption{WithBufioReader(p.rbuf)}
 
 		if p.objectIdSize == format.SHA256Size {
 			opts = append(opts, WithSHA256())
@@ -299,7 +300,7 @@ func (p *Packfile) objectFromHeader(oh *ObjectHeader) (plumbing.EncodedObject, e
 }
 
 func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, error) {
-	var obj = new(plumbing.MemoryObject)
+	obj := new(plumbing.MemoryObject)
 	obj.SetSize(oh.Size)
 	obj.SetType(oh.Type)
 

--- a/plumbing/format/packfile/packfile_options.go
+++ b/plumbing/format/packfile/packfile_options.go
@@ -2,6 +2,7 @@ package packfile
 
 import (
 	billy "github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 )

--- a/plumbing/format/packfile/packfile_test.go
+++ b/plumbing/format/packfile/packfile_test.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/go-git/go-billy/v6/osfs"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGet(t *testing.T) {

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -8,6 +8,9 @@ import (
 	billy "github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/osfs"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
@@ -15,8 +18,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParserHashes(t *testing.T) {
@@ -198,7 +199,8 @@ func BenchmarkParseBasic(b *testing.B) {
 
 func benchmarkParseBasic(b *testing.B,
 	f billy.File, scanner *packfile.Scanner,
-	opts ...packfile.ParserOption) {
+	opts ...packfile.ParserOption,
+) {
 	for i := 0; i < b.N; i++ {
 		f.Seek(0, io.SeekStart)
 		scanner.Reset()
@@ -246,7 +248,7 @@ func (t *testObserver) OnHeader(count uint32) error {
 	return nil
 }
 
-func (t *testObserver) OnInflatedObjectHeader(otype plumbing.ObjectType, objSize int64, pos int64) error {
+func (t *testObserver) OnInflatedObjectHeader(otype plumbing.ObjectType, objSize, pos int64) error {
 	o := t.get(pos)
 	o.otype = otype
 	o.size = objSize

--- a/plumbing/format/packfile/parser_types.go
+++ b/plumbing/format/packfile/parser_types.go
@@ -9,7 +9,7 @@ type Observer interface {
 	// OnHeader is called when a new packfile is opened.
 	OnHeader(count uint32) error
 	// OnInflatedObjectHeader is called for each object header read.
-	OnInflatedObjectHeader(t plumbing.ObjectType, objSize int64, pos int64) error
+	OnInflatedObjectHeader(t plumbing.ObjectType, objSize, pos int64) error
 	// OnInflatedObjectContent is called for each decoded object.
 	OnInflatedObjectContent(h plumbing.Hash, pos int64, crc uint32, content []byte) error
 	// OnFooter is called when decoding is done.

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -308,7 +308,8 @@ func patchDelta(dst *bytes.Buffer, src, delta []byte) error {
 }
 
 func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
-	typ plumbing.ObjectType, writeHeader objectHeaderWriter) (uint, plumbing.Hash, error) {
+	typ plumbing.ObjectType, writeHeader objectHeaderWriter,
+) (uint, plumbing.Hash, error) {
 	deltaBuf := bufio.NewReader(delta)
 	srcSz, err := decodeLEB128ByteReader(deltaBuf)
 	if err != nil {

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -6,7 +6,6 @@ import (
 	"crypto"
 	"encoding/hex"
 	"fmt"
-
 	"hash"
 	"hash/crc32"
 	"io"

--- a/plumbing/format/packfile/scanner_reader.go
+++ b/plumbing/format/packfile/scanner_reader.go
@@ -65,7 +65,7 @@ func (r *scannerReader) Read(p []byte) (n int, err error) {
 	if _, err := r.wbuf.Write(p[:n]); err != nil {
 		return n, err
 	}
-	return
+	return n, err
 }
 
 func (r *scannerReader) ReadByte() (b byte, err error) {
@@ -74,7 +74,7 @@ func (r *scannerReader) ReadByte() (b byte, err error) {
 		r.offset++
 		return b, r.wbuf.WriteByte(b)
 	}
-	return
+	return b, err
 }
 
 func (r *scannerReader) Flush() error {

--- a/plumbing/format/packfile/scanner_test.go
+++ b/plumbing/format/packfile/scanner_test.go
@@ -10,8 +10,9 @@ import (
 
 	"github.com/go-git/go-billy/v6"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 func TestScan(t *testing.T) {
@@ -321,77 +322,123 @@ func ptr[T any](value T) *T {
 }
 
 var expectedHeadersOFS256 = []ObjectHeader{
-	{Type: plumbing.CommitObject, Offset: 12, Size: 254,
+	{
+		Type: plumbing.CommitObject, Offset: 12, Size: 254,
 		Hash:    plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
-		Hash256: ptr(plumbing.NewHash("751ee7d8e2736460ea9b6f1b88aeb050dad7d7641b0313d27f0bb9bedd1b3726"))},
+		Hash256: ptr(plumbing.NewHash("751ee7d8e2736460ea9b6f1b88aeb050dad7d7641b0313d27f0bb9bedd1b3726")),
+	},
 	{Type: plumbing.OFSDeltaObject, Offset: 186, Size: 93, OffsetReference: 12},
-	{Type: plumbing.CommitObject, Offset: 286, Size: 242,
+	{
+		Type: plumbing.CommitObject, Offset: 286, Size: 242,
 		Hash:    plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"),
-		Hash256: ptr(plumbing.NewHash("a279e860c7074462629fefb6a96e77eecb240eba291791c163581f6afeaa7f12"))},
-	{Type: plumbing.CommitObject, Offset: 449, Size: 242,
+		Hash256: ptr(plumbing.NewHash("a279e860c7074462629fefb6a96e77eecb240eba291791c163581f6afeaa7f12")),
+	},
+	{
+		Type: plumbing.CommitObject, Offset: 449, Size: 242,
 		Hash:    plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
-		Hash256: ptr(plumbing.NewHash("aa68eba21ad1796f88c16e470e0374bf6ed1376495ab3a367cd85698c3df766f"))},
-	{Type: plumbing.CommitObject, Offset: 615, Size: 333,
+		Hash256: ptr(plumbing.NewHash("aa68eba21ad1796f88c16e470e0374bf6ed1376495ab3a367cd85698c3df766f")),
+	},
+	{
+		Type: plumbing.CommitObject, Offset: 615, Size: 333,
 		Hash:    plumbing.NewHash("1669dce138d9b841a518c64b10914d88f5e488ea"),
-		Hash256: ptr(plumbing.NewHash("4d00acb62a3ecb5f3f6871aa29c8ea670fc3d27042842277280c6b3e48a206f1"))},
-	{Type: plumbing.CommitObject, Offset: 838, Size: 332,
+		Hash256: ptr(plumbing.NewHash("4d00acb62a3ecb5f3f6871aa29c8ea670fc3d27042842277280c6b3e48a206f1")),
+	},
+	{
+		Type: plumbing.CommitObject, Offset: 838, Size: 332,
 		Hash:    plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"),
-		Hash256: ptr(plumbing.NewHash("627852504dc677ba7ac2ec7717d69b42f787c8d79bac9fe1370b8775d2312e94"))},
-	{Type: plumbing.CommitObject, Offset: 1063, Size: 244,
+		Hash256: ptr(plumbing.NewHash("627852504dc677ba7ac2ec7717d69b42f787c8d79bac9fe1370b8775d2312e94")),
+	},
+	{
+		Type: plumbing.CommitObject, Offset: 1063, Size: 244,
 		Hash:    plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
-		Hash256: ptr(plumbing.NewHash("00f0a27f127cffbb2a1089b772edd3ba7c82a6b69d666048b75d4bdcee24515d"))},
-	{Type: plumbing.CommitObject, Offset: 1230, Size: 243,
+		Hash256: ptr(plumbing.NewHash("00f0a27f127cffbb2a1089b772edd3ba7c82a6b69d666048b75d4bdcee24515d")),
+	},
+	{
+		Type: plumbing.CommitObject, Offset: 1230, Size: 243,
 		Hash:    plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"),
-		Hash256: ptr(plumbing.NewHash("ef5441299e83e8707722706fefd89e77290a2a6e84be5202b980128eaa6decc2"))},
-	{Type: plumbing.CommitObject, Offset: 1392, Size: 187,
+		Hash256: ptr(plumbing.NewHash("ef5441299e83e8707722706fefd89e77290a2a6e84be5202b980128eaa6decc2")),
+	},
+	{
+		Type: plumbing.CommitObject, Offset: 1392, Size: 187,
 		Hash:    plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
-		Hash256: ptr(plumbing.NewHash("809c0681b603794597ef162c71184b38dda79364a423c6c61d2e514a1d46efff"))},
-	{Type: plumbing.BlobObject, Offset: 1524, Size: 189,
+		Hash256: ptr(plumbing.NewHash("809c0681b603794597ef162c71184b38dda79364a423c6c61d2e514a1d46efff")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 1524, Size: 189,
 		Hash:    plumbing.NewHash("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88"),
-		Hash256: ptr(plumbing.NewHash("40b7c05726c9da78c3d5a705c2a48a120261b36f521302ce06bad41916d000f7"))},
-	{Type: plumbing.BlobObject, Offset: 1685, Size: 18,
+		Hash256: ptr(plumbing.NewHash("40b7c05726c9da78c3d5a705c2a48a120261b36f521302ce06bad41916d000f7")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 1685, Size: 18,
 		Hash:    plumbing.NewHash("d3ff53e0564a9f87d8e84b6e28e5060e517008aa"),
-		Hash256: ptr(plumbing.NewHash("e6ee53c7eb0e33417ee04110b84b304ff2da5c1b856f320b61ad9f2ef56c6e4e"))},
-	{Type: plumbing.BlobObject, Offset: 1713, Size: 1072,
+		Hash256: ptr(plumbing.NewHash("e6ee53c7eb0e33417ee04110b84b304ff2da5c1b856f320b61ad9f2ef56c6e4e")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 1713, Size: 1072,
 		Hash:    plumbing.NewHash("c192bd6a24ea1ab01d78686e417c8bdc7c3d197f"),
-		Hash256: ptr(plumbing.NewHash("789c9f4220d167b66020b46bacddcad0ab5bb12f0f469576aa60bb59d98293dc"))},
-	{Type: plumbing.BlobObject, Offset: 2351, Size: 76110,
+		Hash256: ptr(plumbing.NewHash("789c9f4220d167b66020b46bacddcad0ab5bb12f0f469576aa60bb59d98293dc")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 2351, Size: 76110,
 		Hash:    plumbing.NewHash("d5c0f4ab811897cadf03aec358ae60d21f91c50d"),
-		Hash256: ptr(plumbing.NewHash("665e33431d9b88280d7c1837680fdb66664c4cb4b394c9057cdbd07f3b4acff8"))},
-	{Type: plumbing.BlobObject, Offset: 78050, Size: 2780,
+		Hash256: ptr(plumbing.NewHash("665e33431d9b88280d7c1837680fdb66664c4cb4b394c9057cdbd07f3b4acff8")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 78050, Size: 2780,
 		Hash:    plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"),
-		Hash256: ptr(plumbing.NewHash("33a5013ed4af64b6e54076c986a4733c2c11ce8ab27ede79f21366e8722ac5ed"))},
-	{Type: plumbing.BlobObject, Offset: 78882, Size: 217848,
+		Hash256: ptr(plumbing.NewHash("33a5013ed4af64b6e54076c986a4733c2c11ce8ab27ede79f21366e8722ac5ed")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 78882, Size: 217848,
 		Hash:    plumbing.NewHash("49c6bb89b17060d7b4deacb7b338fcc6ea2352a9"),
-		Hash256: ptr(plumbing.NewHash("4c61794e77ff8c7ab7f07404cdb1bc0e989b27530e37a6be6d2ef73639aaff6d"))},
-	{Type: plumbing.BlobObject, Offset: 80725, Size: 706,
+		Hash256: ptr(plumbing.NewHash("4c61794e77ff8c7ab7f07404cdb1bc0e989b27530e37a6be6d2ef73639aaff6d")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 80725, Size: 706,
 		Hash:    plumbing.NewHash("c8f1d8c61f9da76f4cb49fd86322b6e685dba956"),
-		Hash256: ptr(plumbing.NewHash("2a246d3eaea67b7c4ac36d96d1dc9dad2a4dc24486c4d67eb7cb73963f522481"))},
-	{Type: plumbing.BlobObject, Offset: 80998, Size: 11488,
+		Hash256: ptr(plumbing.NewHash("2a246d3eaea67b7c4ac36d96d1dc9dad2a4dc24486c4d67eb7cb73963f522481")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 80998, Size: 11488,
 		Hash:    plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"),
-		Hash256: ptr(plumbing.NewHash("73660d98a4c6c8951f86bb8c4744a0b4837a6dd5f796c314064c1615781c400c"))},
-	{Type: plumbing.BlobObject, Offset: 84032, Size: 78,
+		Hash256: ptr(plumbing.NewHash("73660d98a4c6c8951f86bb8c4744a0b4837a6dd5f796c314064c1615781c400c")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 84032, Size: 78,
 		Hash:    plumbing.NewHash("9dea2395f5403188298c1dabe8bdafe562c491e3"),
-		Hash256: ptr(plumbing.NewHash("2a7543a59f760f7ca41784bc898057799ae960323733cab1175c21960a750f72"))},
-	{Type: plumbing.TreeObject, Offset: 84115, Size: 272,
+		Hash256: ptr(plumbing.NewHash("2a7543a59f760f7ca41784bc898057799ae960323733cab1175c21960a750f72")),
+	},
+	{
+		Type: plumbing.TreeObject, Offset: 84115, Size: 272,
 		Hash:    plumbing.NewHash("dbd3641b371024f44d0e469a9c8f5457b0660de1"),
-		Hash256: ptr(plumbing.NewHash("773b6c73238a74067c97f193c06c1bf38a982e39ded04fdf9c833ebc34cedd3d"))},
+		Hash256: ptr(plumbing.NewHash("773b6c73238a74067c97f193c06c1bf38a982e39ded04fdf9c833ebc34cedd3d")),
+	},
 	{Type: plumbing.OFSDeltaObject, Offset: 84375, Size: 43, OffsetReference: 84115},
-	{Type: plumbing.TreeObject, Offset: 84430, Size: 38,
+	{
+		Type: plumbing.TreeObject, Offset: 84430, Size: 38,
 		Hash:    plumbing.NewHash("a39771a7651f97faf5c72e08224d857fc35133db"),
-		Hash256: ptr(plumbing.NewHash("166e4d7c5b5771422259dda0819ea54e06a6e4f07cf927d9fc95f5c370fff28a"))},
-	{Type: plumbing.TreeObject, Offset: 84479, Size: 75,
+		Hash256: ptr(plumbing.NewHash("166e4d7c5b5771422259dda0819ea54e06a6e4f07cf927d9fc95f5c370fff28a")),
+	},
+	{
+		Type: plumbing.TreeObject, Offset: 84479, Size: 75,
 		Hash:    plumbing.NewHash("5a877e6a906a2743ad6e45d99c1793642aaf8eda"),
-		Hash256: ptr(plumbing.NewHash("393e771684c98451b904457acffac4ca5bd5a736a1b9127cedf7b8fa1b6a9901"))},
-	{Type: plumbing.TreeObject, Offset: 84559, Size: 38,
+		Hash256: ptr(plumbing.NewHash("393e771684c98451b904457acffac4ca5bd5a736a1b9127cedf7b8fa1b6a9901")),
+	},
+	{
+		Type: plumbing.TreeObject, Offset: 84559, Size: 38,
 		Hash:    plumbing.NewHash("586af567d0bb5e771e49bdd9434f5e0fb76d25fa"),
-		Hash256: ptr(plumbing.NewHash("3db5b7f8353ebe6e4d4bff0bd2953952e08d73e72040abe4a46d08e7c3593dcc"))},
-	{Type: plumbing.TreeObject, Offset: 84608, Size: 34,
+		Hash256: ptr(plumbing.NewHash("3db5b7f8353ebe6e4d4bff0bd2953952e08d73e72040abe4a46d08e7c3593dcc")),
+	},
+	{
+		Type: plumbing.TreeObject, Offset: 84608, Size: 34,
 		Hash:    plumbing.NewHash("cf4aa3b38974fb7d81f367c0830f7d78d65ab86b"),
-		Hash256: ptr(plumbing.NewHash("e39c8c3d47aa310861634c6cf44e54e847c02f99c34c8cb25246e16f40502a7e"))},
-	{Type: plumbing.BlobObject, Offset: 84653, Size: 9,
+		Hash256: ptr(plumbing.NewHash("e39c8c3d47aa310861634c6cf44e54e847c02f99c34c8cb25246e16f40502a7e")),
+	},
+	{
+		Type: plumbing.BlobObject, Offset: 84653, Size: 9,
 		Hash:    plumbing.NewHash("7e59600739c96546163833214c36459e324bad0a"),
-		Hash256: ptr(plumbing.NewHash("1f307724f91af43be1570b77aeef69c5010e8136e50bef83c28de2918a08f494"))},
+		Hash256: ptr(plumbing.NewHash("1f307724f91af43be1570b77aeef69c5010e8136e50bef83c28de2918a08f494")),
+	},
 	{Type: plumbing.OFSDeltaObject, Offset: 84671, Size: 6, OffsetReference: 84375},
 	{Type: plumbing.OFSDeltaObject, Offset: 84688, Size: 9, OffsetReference: 84375},
 	{Type: plumbing.OFSDeltaObject, Offset: 84708, Size: 6, OffsetReference: 84375},
@@ -436,8 +483,10 @@ var expectedCRCOFS = []uint32{
 
 var expectedHeadersREF = []ObjectHeader{
 	{Type: plumbing.CommitObject, Offset: 12, Size: 254, Hash: plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")},
-	{Type: plumbing.REFDeltaObject, Offset: 186, Size: 93,
-		Reference: plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")},
+	{
+		Type: plumbing.REFDeltaObject, Offset: 186, Size: 93,
+		Reference: plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
+	},
 	{Type: plumbing.CommitObject, Offset: 304, Size: 242, Hash: plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294")},
 	{Type: plumbing.CommitObject, Offset: 467, Size: 242, Hash: plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")},
 	{Type: plumbing.CommitObject, Offset: 633, Size: 333, Hash: plumbing.NewHash("1669dce138d9b841a518c64b10914d88f5e488ea")},
@@ -459,18 +508,28 @@ var expectedHeadersREF = []ObjectHeader{
 	{Type: plumbing.TreeObject, Offset: 84752, Size: 34, Hash: plumbing.NewHash("cf4aa3b38974fb7d81f367c0830f7d78d65ab86b")},
 	{Type: plumbing.BlobObject, Offset: 84797, Size: 78, Hash: plumbing.NewHash("9dea2395f5403188298c1dabe8bdafe562c491e3")},
 	{Type: plumbing.TreeObject, Offset: 84880, Size: 271, Hash: plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")},
-	{Type: plumbing.REFDeltaObject, Offset: 85141, Size: 6,
-		Reference: plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")},
-	{Type: plumbing.REFDeltaObject, Offset: 85176, Size: 37,
-		Reference: plumbing.NewHash("fb72698cab7617ac416264415f13224dfd7a165e")},
+	{
+		Type: plumbing.REFDeltaObject, Offset: 85141, Size: 6,
+		Reference: plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c"),
+	},
+	{
+		Type: plumbing.REFDeltaObject, Offset: 85176, Size: 37,
+		Reference: plumbing.NewHash("fb72698cab7617ac416264415f13224dfd7a165e"),
+	},
 	{Type: plumbing.BlobObject, Offset: 85244, Size: 9, Hash: plumbing.NewHash("7e59600739c96546163833214c36459e324bad0a")},
-	{Type: plumbing.REFDeltaObject, Offset: 85262, Size: 9,
-		Reference: plumbing.NewHash("fb72698cab7617ac416264415f13224dfd7a165e")},
-	{Type: plumbing.REFDeltaObject, Offset: 85300, Size: 6,
-		Reference: plumbing.NewHash("fb72698cab7617ac416264415f13224dfd7a165e")},
+	{
+		Type: plumbing.REFDeltaObject, Offset: 85262, Size: 9,
+		Reference: plumbing.NewHash("fb72698cab7617ac416264415f13224dfd7a165e"),
+	},
+	{
+		Type: plumbing.REFDeltaObject, Offset: 85300, Size: 6,
+		Reference: plumbing.NewHash("fb72698cab7617ac416264415f13224dfd7a165e"),
+	},
 	{Type: plumbing.TreeObject, Offset: 85335, Size: 110, Hash: plumbing.NewHash("c2d30fa8ef288618f65f6eed6e168e0d514886f4")},
-	{Type: plumbing.REFDeltaObject, Offset: 85448, Size: 8,
-		Reference: plumbing.NewHash("eba74343e2f15d62adedfd8c883ee0262b5c8021")},
+	{
+		Type: plumbing.REFDeltaObject, Offset: 85448, Size: 8,
+		Reference: plumbing.NewHash("eba74343e2f15d62adedfd8c883ee0262b5c8021"),
+	},
 	{Type: plumbing.TreeObject, Offset: 85485, Size: 73, Hash: plumbing.NewHash("aa9b383c260e1d05fbbf6b30a02914555e20c725")},
 }
 

--- a/plumbing/format/packfile/types.go
+++ b/plumbing/format/packfile/types.go
@@ -68,7 +68,7 @@ type PackData struct {
 	checksum     plumbing.Hash
 }
 
-func (p PackData) Value() interface{} {
+func (p PackData) Value() any {
 	switch p.Section {
 	case HeaderSection:
 		return p.header

--- a/plumbing/format/pktline/pktline.go
+++ b/plumbing/format/pktline/pktline.go
@@ -33,16 +33,16 @@ func Write(w io.Writer, p []byte) (n int, err error) {
 	pktlen := len(p) + LenSize
 	n, err = w.Write(asciiHex16(pktlen))
 	if err != nil {
-		return
+		return n, err
 	}
 
 	n2, err := w.Write(p)
 	n += n2
-	return
+	return n, err
 }
 
 // Writef writes a pktline packet from a format string.
-func Writef(w io.Writer, format string, a ...interface{}) (n int, err error) {
+func Writef(w io.Writer, format string, a ...any) (n int, err error) {
 	if len(a) == 0 {
 		return Write(w, []byte(format))
 	}

--- a/plumbing/format/pktline/pktline_read_test.go
+++ b/plumbing/format/pktline/pktline_read_test.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
 type SuiteReader struct {

--- a/plumbing/format/pktline/pktline_write_test.go
+++ b/plumbing/format/pktline/pktline_write_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
 type SuiteWriter struct {

--- a/plumbing/format/pktline/scanner_test.go
+++ b/plumbing/format/pktline/scanner_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
 type SuiteScanner struct {

--- a/plumbing/format/pktline/sync.go
+++ b/plumbing/format/pktline/sync.go
@@ -3,7 +3,7 @@ package pktline
 import "sync"
 
 var pktBuffer = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		var b [MaxSize]byte
 		return &b
 	},

--- a/plumbing/format/revfile/decoder_test.go
+++ b/plumbing/format/revfile/decoder_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 )
 
 // errorAfterReader wraps a reader and returns an error after n bytes have been read.

--- a/plumbing/format/revfile/encoder_test.go
+++ b/plumbing/format/revfile/encoder_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
-	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
-	plumbinghash "github.com/go-git/go-git/v6/plumbing/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
+	plumbinghash "github.com/go-git/go-git/v6/plumbing/hash"
 )
 
 func TestEncode(t *testing.T) {

--- a/plumbing/hash.go
+++ b/plumbing/hash.go
@@ -55,7 +55,7 @@ func (h Hasher) Reset(t ObjectType, size int64) {
 func (h Hasher) Sum() (hash Hash) {
 	hash.format = h.format
 	hash.Write(h.Hash.Sum(nil))
-	return
+	return hash
 }
 
 // HashesSort sorts a slice of Hashes in increasing order.

--- a/plumbing/hash/hash.go
+++ b/plumbing/hash/hash.go
@@ -8,13 +8,12 @@ import (
 	"fmt"
 	"hash"
 
-	format "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/pjbgf/sha1cd"
+
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
-var (
-	ErrUnsupportedHashFunction = errors.New("unsupported hash function")
-)
+var ErrUnsupportedHashFunction = errors.New("unsupported hash function")
 
 // algos is a map of hash algorithms.
 var algos = map[crypto.Hash]func() hash.Hash{}

--- a/plumbing/object.go
+++ b/plumbing/object.go
@@ -107,5 +107,5 @@ func ParseObjectType(value string) (typ ObjectType, err error) {
 	default:
 		err = ErrInvalidType
 	}
-	return
+	return typ, err
 }

--- a/plumbing/object/blob_test.go
+++ b/plumbing/object/blob_test.go
@@ -5,8 +5,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type BlobsSuite struct {

--- a/plumbing/object/change.go
+++ b/plumbing/object/change.go
@@ -44,7 +44,7 @@ func (c *Change) Action() (merkletrie.Action, error) {
 func (c *Change) Files() (from, to *File, err error) {
 	action, err := c.Action()
 	if err != nil {
-		return
+		return from, to, err
 	}
 
 	if action == merkletrie.Insert || action == merkletrie.Modify {
@@ -54,7 +54,7 @@ func (c *Change) Files() (from, to *File, err error) {
 		}
 
 		if err != nil {
-			return
+			return from, to, err
 		}
 	}
 
@@ -65,11 +65,11 @@ func (c *Change) Files() (from, to *File, err error) {
 		}
 
 		if err != nil {
-			return
+			return from, to, err
 		}
 	}
 
-	return
+	return from, to, err
 }
 
 func (c *Change) String() string {

--- a/plumbing/object/change_adaptor_test.go
+++ b/plumbing/object/change_adaptor_test.go
@@ -4,6 +4,9 @@ import (
 	"sort"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -11,9 +14,6 @@ import (
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/utils/merkletrie"
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type ChangeAdaptorSuite struct {

--- a/plumbing/object/change_test.go
+++ b/plumbing/object/change_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -13,7 +15,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/utils/merkletrie"
-	"github.com/stretchr/testify/suite"
 )
 
 type ChangeSuite struct {

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -98,8 +98,8 @@ func (h ExtraHeader) Format(f fmt.State, verb rune) {
 func parseExtraHeader(line []byte) (ExtraHeader, bool) {
 	split := bytes.SplitN(line, []byte{' '}, 2)
 
-	out := ExtraHeader {
-		Key: string(bytes.TrimRight(split[0], "\n")),
+	out := ExtraHeader{
+		Key:   string(bytes.TrimRight(split[0], "\n")),
 		Value: "",
 	}
 
@@ -407,7 +407,6 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	}
 
 	for _, header := range c.ExtraHeaders {
-		
 		if _, err = fmt.Fprintf(w, "\n%s", header); err != nil {
 			return err
 		}

--- a/plumbing/object/commit_stats_test.go
+++ b/plumbing/object/commit_stats_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
-
-	"github.com/go-git/go-billy/v6/memfs"
-	"github.com/go-git/go-billy/v6/util"
 )
 
 type CommitStatsSuite struct {
@@ -83,7 +83,7 @@ func (s *CommitStatsSuite) writeHistory(files ...[]byte) (*git.Repository, plumb
 
 	var hash plumbing.Hash
 	for _, content := range files {
-		util.WriteFile(fs, "foo", content, 0644)
+		util.WriteFile(fs, "foo", content, 0o644)
 
 		_, err = w.Add("foo")
 		s.NoError(err)

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
@@ -522,7 +522,6 @@ func (s *SuiteCommit) TestPatchCancel() {
 	patch, err := from.PatchContext(ctx, to)
 	s.Nil(patch)
 	s.ErrorContains(err, "operation canceled")
-
 }
 
 func (s *SuiteCommit) TestMalformedHeader() {
@@ -629,20 +628,20 @@ initial commit
 	s.NoError(err)
 
 	s.Equal(commit.ExtraHeaders, []ExtraHeader{
-		ExtraHeader {
-			Key: "continuedheader",
+		{
+			Key:   "continuedheader",
 			Value: "to be\ncontinued",
 		},
-		ExtraHeader {
-			Key: "continuedheader",
+		{
+			Key:   "continuedheader",
 			Value: "to be\ncontinued\non\nmore than\na single line",
 		},
-		ExtraHeader {
-			Key: "simpleflag",
+		{
+			Key:   "simpleflag",
 			Value: "",
 		},
-		ExtraHeader {
-			Key: "",
+		{
+			Key:   "",
 			Value: "value no key",
 		},
 	})

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -17,7 +17,6 @@ type commitPreIterator struct {
 	start        *Commit
 }
 
-
 func forEachCommit(next func() (*Commit, error), cb func(*Commit) error) error {
 	for {
 		c, err := next()
@@ -279,8 +278,8 @@ func addReference(
 	commitIterFunc func(*Commit) CommitIter,
 	ref *plumbing.Reference,
 	commitsPath *list.List,
-	commitsLookup map[plumbing.Hash]*list.Element) error {
-
+	commitsLookup map[plumbing.Hash]*list.Element,
+) error {
 	_, exists := commitsLookup[ref.Hash()]
 	if exists {
 		// we already have it - skip the reference.

--- a/plumbing/object/commit_walker_bfs_filtered_test.go
+++ b/plumbing/object/commit_walker_bfs_filtered_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestFilterCommitIterSuite(t *testing.T) {
@@ -214,7 +215,6 @@ func (s *filterCommitIterSuite) TestFilterCommitIterWithInvalidAndStopAt() {
 //   - b029517f6300c2da0f4b651b8642506cd6aaf45d
 //   - b8e471f58bcbca63b07bda20e428190409c2db47
 func (s *filterCommitIterSuite) TestIteratorForEachCallbackReturn() {
-
 	var visited []*Commit
 	errUnexpected := fmt.Errorf("Could not continue")
 	cb := func(c *Commit) error {

--- a/plumbing/object/commit_walker_ctime.go
+++ b/plumbing/object/commit_walker_ctime.go
@@ -34,7 +34,7 @@ func NewCommitIterCTime(
 		seen[h] = true
 	}
 
-	heap := binaryheap.NewWith(func(a, b interface{}) int {
+	heap := binaryheap.NewWith(func(a, b any) int {
 		if a.(*Commit).Committer.When.Before(b.(*Commit).Committer.When) {
 			return 1
 		}

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type CommitWalkerSuite struct {

--- a/plumbing/object/commitgraph/commitnode_test.go
+++ b/plumbing/object/commitgraph/commitnode_test.go
@@ -4,14 +4,14 @@ import (
 	"path"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	commitgraph "github.com/go-git/go-git/v6/plumbing/format/commitgraph"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type CommitNodeSuite struct {

--- a/plumbing/object/commitgraph/commitnode_walker_author_order.go
+++ b/plumbing/object/commitgraph/commitnode_walker_author_order.go
@@ -1,9 +1,9 @@
 package commitgraph
 
 import (
-	"github.com/go-git/go-git/v6/plumbing"
-
 	"github.com/emirpasic/gods/trees/binaryheap"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 // NewCommitNodeIterAuthorDateOrder returns a CommitNodeIter that walks the commit history,
@@ -32,7 +32,7 @@ func NewCommitNodeIterAuthorDateOrder(c CommitNode,
 	exploreHeap := &commitNodeHeap{binaryheap.NewWith(generationAndDateOrderComparator)}
 	exploreHeap.Push(c)
 
-	visitHeap := &commitNodeHeap{binaryheap.NewWith(func(left, right interface{}) int {
+	visitHeap := &commitNodeHeap{binaryheap.NewWith(func(left, right any) int {
 		leftCommit, err := left.(CommitNode).Commit()
 		if err != nil {
 			return -1

--- a/plumbing/object/commitgraph/commitnode_walker_ctime.go
+++ b/plumbing/object/commitgraph/commitnode_walker_ctime.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"io"
 
+	"github.com/emirpasic/gods/trees/binaryheap"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
-
-	"github.com/emirpasic/gods/trees/binaryheap"
 )
 
 type commitNodeIteratorByCTime struct {
@@ -35,7 +35,7 @@ func NewCommitNodeIterCTime(
 		seen[h] = true
 	}
 
-	heap := binaryheap.NewWith(func(a, b interface{}) int {
+	heap := binaryheap.NewWith(func(a, b any) int {
 		if a.(CommitNode).CommitTime().Before(b.(CommitNode).CommitTime()) {
 			return 1
 		}

--- a/plumbing/object/commitgraph/commitnode_walker_date_order.go
+++ b/plumbing/object/commitgraph/commitnode_walker_date_order.go
@@ -1,9 +1,9 @@
 package commitgraph
 
 import (
-	"github.com/go-git/go-git/v6/plumbing"
-
 	"github.com/emirpasic/gods/trees/binaryheap"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 // NewCommitNodeIterDateOrder returns a CommitNodeIter that walks the commit history,

--- a/plumbing/object/commitgraph/commitnode_walker_helper.go
+++ b/plumbing/object/commitgraph/commitnode_walker_helper.go
@@ -3,9 +3,9 @@ package commitgraph
 import (
 	"math"
 
-	"github.com/go-git/go-git/v6/plumbing"
-
 	"github.com/emirpasic/gods/trees/binaryheap"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 // commitNodeStackable represents a common interface between heaps and stacks
@@ -88,7 +88,7 @@ func (h *commitNodeHeap) Size() int {
 // If the left CommitNode object is in a higher generation or is newer than the right one, it returns a -1.
 // If the left CommitNode object is in a lower generation or is older than the right one, it returns a 1.
 // If the two CommitNode objects have the same commit time and generation, it returns 0.
-func generationAndDateOrderComparator(left, right interface{}) int {
+func generationAndDateOrderComparator(left, right any) int {
 	leftCommit := left.(CommitNode)
 	rightCommit := right.(CommitNode)
 

--- a/plumbing/object/commitgraph/commitnode_walker_test.go
+++ b/plumbing/object/commitgraph/commitnode_walker_test.go
@@ -4,14 +4,14 @@ import (
 	"strings"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	commitgraph "github.com/go-git/go-git/v6/plumbing/format/commitgraph"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/assert"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 func TestCommitNodeIter(t *testing.T) {

--- a/plumbing/object/commitgraph/commitnode_walker_topo_order.go
+++ b/plumbing/object/commitgraph/commitnode_walker_topo_order.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 	"io"
 
+	"github.com/emirpasic/gods/trees/binaryheap"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
-
-	"github.com/emirpasic/gods/trees/binaryheap"
 )
 
 type commitNodeIteratorTopological struct {

--- a/plumbing/object/difftree_test.go
+++ b/plumbing/object/difftree_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -14,7 +16,6 @@ import (
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/go-git/go-git/v6/utils/merkletrie"
-	"github.com/stretchr/testify/suite"
 )
 
 type DiffTreeSuite struct {
@@ -32,8 +33,8 @@ func (s *DiffTreeSuite) SetupSuite() {
 }
 
 func (s *DiffTreeSuite) commitFromStorer(sto storer.EncodedObjectStorer,
-	h plumbing.Hash) *Commit {
-
+	h plumbing.Hash,
+) *Commit {
 	commit, err := GetCommit(sto, h)
 	s.NoError(err)
 	return commit

--- a/plumbing/object/file_test.go
+++ b/plumbing/object/file_test.go
@@ -5,14 +5,14 @@ import (
 	"io"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type FileSuite struct {

--- a/plumbing/object/merge_base.go
+++ b/plumbing/object/merge_base.go
@@ -77,7 +77,6 @@ func ancestorsIndex(excluded, starting *Commit) (map[plumbing.Hash]struct{}, err
 		startingHistory[commit.Hash] = struct{}{}
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +121,6 @@ func Independents(commits []*Commit) ([]*Commit, error) {
 			seen[fromAncestor.Hash] = struct{}{}
 			return nil
 		})
-
 		if err != nil {
 			return nil, err
 		}

--- a/plumbing/object/merge_base_test.go
+++ b/plumbing/object/merge_base_test.go
@@ -5,12 +5,12 @@ import (
 	"sort"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 func alphabeticSortCommits(commits []*Commit) {

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -133,7 +133,7 @@ func (s *Signature) decodeTimeAndTimeZone(b []byte) {
 	}
 
 	s.When = time.Unix(ts, 0).In(time.UTC)
-	var tzStart = space + 1
+	tzStart := space + 1
 	if tzStart >= len(b) || tzStart+timeZoneLength > len(b) {
 		return
 	}

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -6,17 +6,17 @@ import (
 	"time"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 )
 
-type BaseObjectsFixtureSuite struct {
-}
+type BaseObjectsFixtureSuite struct{}
 
 type BaseObjectsSuite struct {
 	Storer  storer.EncodedObjectStorer

--- a/plumbing/object/patch_stats_test.go
+++ b/plumbing/object/patch_stats_test.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/util"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 type PatchStatsSuite struct {
@@ -32,7 +33,7 @@ func (s *PatchStatsSuite) TestStatsWithRename() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo\nbar\n"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo\nbar\n"), 0o644)
 
 	_, err = w.Add("foo")
 	s.NoError(err)

--- a/plumbing/object/patch_test.go
+++ b/plumbing/object/patch_test.go
@@ -3,12 +3,12 @@ package object
 import (
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type PatchSuite struct {
@@ -57,7 +57,6 @@ func (s *PatchSuite) TestFileStatsString() {
 		input       FileStats
 		expected    string
 	}{
-
 		{
 			description: "no files changed",
 			input:       []FileStat{},

--- a/plumbing/object/rename.go
+++ b/plumbing/object/rename.go
@@ -97,7 +97,7 @@ func (d *renameDetector) detectExactRenames() {
 				d.modified = append(d.modified, &Change{From: bestMatch.From, To: c.To})
 				delete(deletes, hash)
 
-				var newDeletes = make([]*Change, 0, len(deleted)-1)
+				newDeletes := make([]*Change, 0, len(deleted)-1)
 				for _, d := range deleted {
 					if d != bestMatch {
 						newDeletes = append(newDeletes, d)
@@ -182,7 +182,7 @@ func (d *renameDetector) detectExactRenames() {
 				}
 			}
 
-			var newDeletes = make([]*Change, 0, len(deleted)-len(usedDeletes))
+			newDeletes := make([]*Change, 0, len(deleted)-len(usedDeletes))
 			for _, c := range deleted {
 				if _, ok := usedDeletes[c]; !ok && c != nil {
 					newDeletes = append(newDeletes, c)
@@ -358,7 +358,7 @@ func sameMode(a, b *Change) bool {
 }
 
 func groupChangesByHash(changes []*Change) map[plumbing.Hash][]*Change {
-	var result = make(map[plumbing.Hash][]*Change)
+	result := make(map[plumbing.Hash][]*Change)
 	for _, c := range changes {
 		hash := changeHash(c)
 		result[hash] = append(result[hash], c)
@@ -572,7 +572,7 @@ func (i *similarityIndex) hash(f *File) error {
 }
 
 func (i *similarityIndex) hashContent(r io.Reader, size int64, isBin bool) error {
-	var buf = make([]byte, 4096)
+	buf := make([]byte, 4096)
 	var ptr, cnt int
 	remaining := size
 
@@ -636,7 +636,7 @@ func (i *similarityIndex) hashContent(r io.Reader, size int64, isBin bool) error
 // two empty files.
 // The similarity score is symmetrical; i.e. a.score(b) == b.score(a).
 func (i *similarityIndex) score(other *similarityIndex, maxScore int) int {
-	var maxHashed = i.hashed
+	maxHashed := i.hashed
 	if maxHashed < other.hashed {
 		maxHashed = other.hashed
 	}

--- a/plumbing/object/rename_test.go
+++ b/plumbing/object/rename_test.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 type RenameSuite struct {
@@ -308,7 +309,7 @@ func detectRenames(s *RenameSuite, changes Changes, opts *DiffTreeOptions, expec
 	return result
 }
 
-func assertRename(s *RenameSuite, from, to *Change, rename *Change) {
+func assertRename(s *RenameSuite, from, to, rename *Change) {
 	s.Equal(rename, &Change{From: from.From, To: to.To})
 }
 
@@ -510,7 +511,7 @@ func makeDelete(s *RenameSuite, f *File) *Change {
 	return makeChange(s, f, nil)
 }
 
-func makeChange(s *RenameSuite, from *File, to *File) *Change {
+func makeChange(s *RenameSuite, from, to *File) *Change {
 	if from == nil {
 		return &Change{To: makeChangeEntry(to)}
 	}

--- a/plumbing/object/signature.go
+++ b/plumbing/object/signature.go
@@ -28,15 +28,13 @@ var (
 	}
 )
 
-var (
-	// knownSignatureFormats is a map of known signature formats, indexed by
-	// their signatureType.
-	knownSignatureFormats = map[signatureType]signatureFormat{
-		signatureTypeOpenPGP: openPGPSignatureFormat,
-		signatureTypeX509:    x509SignatureFormat,
-		signatureTypeSSH:     sshSignatureFormat,
-	}
-)
+// knownSignatureFormats is a map of known signature formats, indexed by
+// their signatureType.
+var knownSignatureFormats = map[signatureType]signatureFormat{
+	signatureTypeOpenPGP: openPGPSignatureFormat,
+	signatureTypeX509:    x509SignatureFormat,
+	signatureTypeSSH:     sshSignatureFormat,
+}
 
 // signatureType represents the type of the signature.
 type signatureType int8
@@ -83,10 +81,10 @@ func typeForSignature(b []byte) signatureType {
 // This logic is on par with git's gpg-interface.c:parse_signed_buffer().
 // https://github.com/git/git/blob/7c2ef319c52c4997256f5807564523dfd4acdfc7/gpg-interface.c#L668
 func parseSignedBytes(b []byte) (int, signatureType) {
-	var n, match = 0, -1
+	n, match := 0, -1
 	var t signatureType
 	for n < len(b) {
-		var i = b[n:]
+		i := b[n:]
 		if st := typeForSignature(i); st != signatureTypeUnknown {
 			match = n
 			t = st

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/utils/ioutil"

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 type TagSuite struct {
@@ -465,7 +466,7 @@ eQnkGpsz85DfEviLtk8cZjY/t6o8lPDLiwVjIzUBaA==
 }
 
 func (s *TagSuite) TestEncodeWithoutSignature() {
-	//Similar to TestString since no signature
+	// Similar to TestString since no signature
 	encoded := &plumbing.MemoryObject{}
 	tag := s.tag(plumbing.NewHash("b742a2a9fa0afcfa9a6fad080980fbc26b007c69"))
 	err := tag.EncodeWithoutSignature(encoded)

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -429,13 +429,13 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 		if current < 0 {
 			// Nothing left on the stack so we're finished
 			err = io.EOF
-			return
+			return name, entry, err
 		}
 
 		if current > maxTreeDepth {
 			// We're probably following bad data or some self-referencing tree
 			err = ErrMaxTreeDepth
-			return
+			return name, entry, err
 		}
 
 		entry, err = w.stack[current].Next()
@@ -448,7 +448,7 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 		}
 
 		if err != nil {
-			return
+			return name, entry, err
 		}
 
 		if w.seen[entry.Hash] {
@@ -463,14 +463,14 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 
 		if err != nil {
 			err = io.EOF
-			return
+			return name, entry, err
 		}
 
 		break
 	}
 
 	if !w.recursive {
-		return
+		return name, entry, err
 	}
 
 	if obj != nil {
@@ -478,7 +478,7 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 		w.base = simpleJoin(w.base, entry.Name)
 	}
 
-	return
+	return name, entry, err
 }
 
 // Tree returns the tree that the tree walker most recently operated on.

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
 )
 
 type TreeSuite struct {
@@ -1494,7 +1495,8 @@ func (s *TreeSuite) TestTreeDecodeReadBug() {
 				Name: "test_quota.c", Mode: filemode.Regular,
 				Hash: plumbing.NewHash("e590996ca4b8574ab1e4185d577756664ad2495f"),
 			},
-			{Name: "test_quota.h", Mode: filemode.Regular,
+			{
+				Name: "test_quota.h", Mode: filemode.Regular,
 				Hash: plumbing.NewHash("2d767a19ab7c3a421cdba6a349204367c22c81"),
 			},
 			{

--- a/plumbing/objectid_test.go
+++ b/plumbing/objectid_test.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
 var input = strings.Repeat("43aec75c611f22c73b27ece2841e6ccca592f2", 50000000)
@@ -83,7 +84,8 @@ func TestReadFrom(t *testing.T) {
 			expected: "43aec75c611f22c73b27ece2841e6ccca592f285",
 			bytes:    []byte{67, 174, 199, 92, 97, 31, 34, 199, 59, 39, 236, 226, 132, 30, 108, 204, 165, 146, 242, 133},
 			len:      20,
-		}, {
+		},
+		{
 			expected: "3b27ece2841e6ccca592f28543aec75c611f22c73b27ece2841e6ccca592f285",
 			bytes:    []byte{59, 39, 236, 226, 132, 30, 108, 204, 165, 146, 242, 133, 67, 174, 199, 92, 97, 31, 34, 199, 59, 39, 236, 226, 132, 30, 108, 204, 165, 146, 242, 133},
 			len:      32,

--- a/plumbing/protocol/packp/advrefs_decode.go
+++ b/plumbing/protocol/packp/advrefs_decode.go
@@ -53,7 +53,7 @@ func (d *advRefsDecoder) Decode(v *AdvRefs) error {
 type decoderStateFn func(*advRefsDecoder) decoderStateFn
 
 // fills out the parser sticky error
-func (d *advRefsDecoder) error(format string, a ...interface{}) {
+func (d *advRefsDecoder) error(format string, a ...any) {
 	msg := fmt.Sprintf(
 		"pkt-line %d: %s", d.nLine,
 		fmt.Sprintf(format, a...),

--- a/plumbing/protocol/packp/advrefs_decode_test.go
+++ b/plumbing/protocol/packp/advrefs_decode_test.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/stretchr/testify/suite"
 )
 
 type AdvRefsDecodeSuite struct {

--- a/plumbing/protocol/packp/advrefs_encode_test.go
+++ b/plumbing/protocol/packp/advrefs_encode_test.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/stretchr/testify/suite"
 )
 
 type AdvRefsEncodeSuite struct {

--- a/plumbing/protocol/packp/advrefs_test.go
+++ b/plumbing/protocol/packp/advrefs_test.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/stretchr/testify/suite"
 )
 
 type AdvRefSuite struct {
@@ -168,7 +169,7 @@ func TestAdvRefsDecodeEncodeSuite(t *testing.T) {
 	suite.Run(t, new(AdvRefsDecodeEncodeSuite))
 }
 
-func (s *AdvRefsDecodeEncodeSuite) test(in []string, exp []string, isEmpty bool) {
+func (s *AdvRefsDecodeEncodeSuite) test(in, exp []string, isEmpty bool) {
 	s.T().Helper()
 
 	var input io.Reader

--- a/plumbing/protocol/packp/common.go
+++ b/plumbing/protocol/packp/common.go
@@ -48,10 +48,8 @@ func isFlush(payload []byte) bool {
 	return len(payload) == 0
 }
 
-var (
-	// ErrNilWriter is returned when a nil writer is passed to the encoder.
-	ErrNilWriter = fmt.Errorf("nil writer")
-)
+// ErrNilWriter is returned when a nil writer is passed to the encoder.
+var ErrNilWriter = fmt.Errorf("nil writer")
 
 // ErrUnexpectedData represents an unexpected data decoding a message
 type ErrUnexpectedData struct {

--- a/plumbing/protocol/packp/common_test.go
+++ b/plumbing/protocol/packp/common_test.go
@@ -6,8 +6,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
 // returns a byte slice with the pkt-lines for the given payloads.

--- a/plumbing/protocol/packp/filter_test.go
+++ b/plumbing/protocol/packp/filter_test.go
@@ -3,8 +3,9 @@ package packp
 import (
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 func TestFilterBlobNone(t *testing.T) {

--- a/plumbing/protocol/packp/report_status_test.go
+++ b/plumbing/protocol/packp/report_status_test.go
@@ -6,8 +6,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type ReportStatusSuite struct {

--- a/plumbing/protocol/packp/shallowupd_test.go
+++ b/plumbing/protocol/packp/shallowupd_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type ShallowUpdateSuite struct {

--- a/plumbing/protocol/packp/sideband/demux_test.go
+++ b/plumbing/protocol/packp/sideband/demux_test.go
@@ -6,8 +6,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
 type SidebandSuite struct {

--- a/plumbing/protocol/packp/srvresp.go
+++ b/plumbing/protocol/packp/srvresp.go
@@ -111,7 +111,7 @@ func (r *ServerResponse) decodeACKLine(line []byte) (err error) {
 	}
 
 	r.ACKs = append(r.ACKs, ack)
-	return
+	return err
 }
 
 // Encode encodes the ServerResponse into a writer.

--- a/plumbing/protocol/packp/srvresp_test.go
+++ b/plumbing/protocol/packp/srvresp_test.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type ServerResponseSuite struct {

--- a/plumbing/protocol/packp/ulreq_decode.go
+++ b/plumbing/protocol/packp/ulreq_decode.go
@@ -43,7 +43,7 @@ func (d *ulReqDecoder) Decode(v *UploadRequest) error {
 }
 
 // fills out the parser sticky error
-func (d *ulReqDecoder) error(format string, a ...interface{}) {
+func (d *ulReqDecoder) error(format string, a ...any) {
 	msg := fmt.Sprintf(
 		"pkt-line %d: %s", d.nLine,
 		fmt.Sprintf(format, a...),

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/stretchr/testify/suite"
 )
 
 type UlReqDecodeSuite struct {

--- a/plumbing/protocol/packp/ulreq_encode_test.go
+++ b/plumbing/protocol/packp/ulreq_encode_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/stretchr/testify/suite"
 )
 
 type UlReqEncodeSuite struct {

--- a/plumbing/protocol/packp/updreq_decode_test.go
+++ b/plumbing/protocol/packp/updreq_decode_test.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
-	"github.com/stretchr/testify/suite"
 )
 
 type UpdReqDecodeSuite struct {
@@ -313,7 +314,7 @@ func (s *UpdReqDecodeSuite) testDecodeOkExpected(expected *UpdateRequests, paylo
 	s.Equal(expected, req)
 }
 
-func (s *UpdReqDecodeSuite) compareReaders(a io.ReadCloser, b io.ReadCloser) {
+func (s *UpdReqDecodeSuite) compareReaders(a, b io.ReadCloser) {
 	pba, err := io.ReadAll(a)
 	s.NoError(err)
 	s.NoError(a.Close())

--- a/plumbing/protocol/packp/updreq_encode_test.go
+++ b/plumbing/protocol/packp/updreq_encode_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/stretchr/testify/suite"
 )
 
 type UpdReqEncodeSuite struct {

--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -128,9 +128,7 @@ func (r ReferenceName) Short() string {
 	return res
 }
 
-var (
-	ctrlSeqs = regexp.MustCompile(`[\000-\037\177]`)
-)
+var ctrlSeqs = regexp.MustCompile(`[\000-\037\177]`)
 
 // Validate validates a reference name.
 // This follows the git-check-ref-format rules.

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -3,14 +3,14 @@ package revlist
 import (
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type RevListFixtureSuite struct{}
@@ -182,7 +182,6 @@ func (s *RevListSuite) TestRevListObjectsWithBlobsAndTrees() {
 }
 
 func (s *RevListSuite) TestRevListObjectsReverse() {
-
 	localHist, err := Objects(s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(secondCommit)}, nil)
 	s.NoError(err)
@@ -219,7 +218,8 @@ func (s *RevListSuite) TestRevListObjectsNewBranch() {
 	remoteHist, err := Objects(
 		s.Storer, []plumbing.Hash{
 			plumbing.NewHash(someCommitBranch),
-			plumbing.NewHash(someCommitOtherBranch)}, localHist)
+			plumbing.NewHash(someCommitOtherBranch),
+		}, localHist)
 	s.NoError(err)
 
 	revList := map[string]bool{

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -8,10 +8,8 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
-var (
-	//ErrStop is used to stop a ForEach function in an Iter
-	ErrStop = errors.New("stop iter")
-)
+// ErrStop is used to stop a ForEach function in an Iter
+var ErrStop = errors.New("stop iter")
 
 // EncodedObjectStorer generic storage of objects
 type EncodedObjectStorer interface {
@@ -134,7 +132,8 @@ type EncodedObjectLookupIter struct {
 // NewEncodedObjectLookupIter returns an object iterator given an object storage
 // and a slice of object hashes.
 func NewEncodedObjectLookupIter(
-	storage EncodedObjectStorer, t plumbing.ObjectType, series []plumbing.Hash) *EncodedObjectLookupIter {
+	storage EncodedObjectStorer, t plumbing.ObjectType, series []plumbing.Hash,
+) *EncodedObjectLookupIter {
 	return &EncodedObjectLookupIter{
 		storage: storage,
 		series:  series,

--- a/plumbing/storer/object_test.go
+++ b/plumbing/storer/object_test.go
@@ -5,8 +5,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type ObjectSuite struct {
@@ -98,7 +99,7 @@ func (s *ObjectSuite) TestObjectSliceIter() {
 func (s *ObjectSuite) TestObjectSliceIterStop() {
 	i := NewEncodedObjectSliceIter(s.Objects)
 
-	var count = 0
+	count := 0
 	err := i.ForEach(func(o plumbing.EncodedObject) error {
 		s.NotNil(o)
 		s.Equal(s.Hash[count].String(), o.Hash().String())
@@ -148,7 +149,8 @@ func (o *MockObjectStorage) HasEncodedObject(h plumbing.Hash) error {
 }
 
 func (o *MockObjectStorage) EncodedObjectSize(h plumbing.Hash) (
-	size int64, err error) {
+	size int64, err error,
+) {
 	for _, o := range o.db {
 		if o.Hash() == h {
 			return o.Size(), nil

--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -44,7 +44,8 @@ type referenceFilteredIter struct {
 // Iterator. This iterator will iterate only references that accomplish the
 // provided function.
 func NewReferenceFilteredIter(
-	ff func(r *plumbing.Reference) bool, iter ReferenceIter) ReferenceIter {
+	ff func(r *plumbing.Reference) bool, iter ReferenceIter,
+) ReferenceIter {
 	return &referenceFilteredIter{ff, iter}
 }
 

--- a/plumbing/storer/reference_test.go
+++ b/plumbing/storer/reference_test.go
@@ -5,8 +5,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type ReferenceSuite struct {

--- a/plumbing/transport/build_update_requests_test.go
+++ b/plumbing/transport/build_update_requests_test.go
@@ -4,11 +4,12 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBuildUpdateRequestsWithReportStatus(t *testing.T) {

--- a/plumbing/transport/file/client.go
+++ b/plumbing/transport/file/client.go
@@ -161,7 +161,7 @@ func (c *command) Close() (err error) {
 	closeDiscriptors(c.parentIOFiles)
 	c.closed = true
 
-	return
+	return err
 }
 
 func closeDiscriptors(fds []io.Closer) {

--- a/plumbing/transport/file/client_test.go
+++ b/plumbing/transport/file/client_test.go
@@ -5,10 +5,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestClientSuite(t *testing.T) {

--- a/plumbing/transport/file/receive_pack_test.go
+++ b/plumbing/transport/file/receive_pack_test.go
@@ -6,14 +6,14 @@ import (
 	"regexp"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 func TestReceivePackSuite(t *testing.T) {

--- a/plumbing/transport/file/upload_pack_test.go
+++ b/plumbing/transport/file/upload_pack_test.go
@@ -5,14 +5,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 func TestUploadPackSuite(t *testing.T) {

--- a/plumbing/transport/git/common_test.go
+++ b/plumbing/transport/git/common_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-git/go-git/v6/internal/transport/test"
-	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/plumbing/transport"
 )
 
 func newEndpoint(t testing.TB, port int, name string) *transport.Endpoint {
@@ -28,7 +29,7 @@ func setupTest(t testing.TB) (base string, port int) {
 	port, err = test.FreePort()
 	require.NoError(t, err)
 	base = filepath.Join(t.TempDir(), fmt.Sprintf("go-git-protocol-%d", port))
-	return
+	return base, port
 }
 
 func startDaemon(t testing.TB, base string, port int) *exec.Cmd {

--- a/plumbing/transport/git/receive_pack_test.go
+++ b/plumbing/transport/git/receive_pack_test.go
@@ -5,11 +5,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-git/go-git/v6/internal/transport/test"
-	"github.com/go-git/go-git/v6/storage/filesystem"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/suite"
 
-	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
 func TestReceivePackSuite(t *testing.T) {

--- a/plumbing/transport/git/upload_pack_test.go
+++ b/plumbing/transport/git/upload_pack_test.go
@@ -5,11 +5,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-git/go-git/v6/internal/transport/test"
-	"github.com/go-git/go-git/v6/storage/filesystem"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/suite"
 
-	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
 func TestUploadPackSuite(t *testing.T) {

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/golang/groupcache/lru"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
@@ -24,7 +26,6 @@ import (
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 	"github.com/go-git/go-git/v6/utils/trace"
-	"github.com/golang/groupcache/lru"
 )
 
 func init() {

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -11,18 +12,17 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"errors"
 	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 func TestClientSuite(t *testing.T) {
@@ -169,9 +169,9 @@ func (s *ClientSuite) TestCheckError() {
 		})
 	}
 
-	statusCodesTests := []struct{
-		code int
-		errType error
+	statusCodesTests := []struct {
+		code      int
+		errType   error
 		isWrapped bool
 	}{
 		{
@@ -202,9 +202,9 @@ func (s *ClientSuite) TestCheckError() {
 		s.Run(fmt.Sprintf("HTTP Error Status: %d", test.code), func() {
 			req, _ := http.NewRequest("GET", "foo", nil)
 			res := &http.Response{
-				Request: req,
+				Request:    req,
 				StatusCode: test.code,
-				Body: io.NopCloser(strings.NewReader(reason)),
+				Body:       io.NopCloser(strings.NewReader(reason)),
 			}
 			err := checkError(res)
 			s.Error(err)
@@ -279,5 +279,5 @@ func setupServer(t testing.TB, smart bool) (base string, port int) {
 		<-done
 	})
 
-	return
+	return base, port
 }

--- a/plumbing/transport/http/dumb.go
+++ b/plumbing/transport/http/dumb.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/plumbing/format/objfile"

--- a/plumbing/transport/http/dumb_test.go
+++ b/plumbing/transport/http/dumb_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/internal/trace"
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 // The dumb http transport only supports git-upload-pack service so there's no

--- a/plumbing/transport/http/proxy_test.go
+++ b/plumbing/transport/http/proxy_test.go
@@ -15,12 +15,13 @@ import (
 
 	"github.com/elazarl/goproxy"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
-	"github.com/go-git/go-git/v6/internal/transport/test"
-	"github.com/go-git/go-git/v6/plumbing/transport"
-	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
 // This test tests proxy support via an env var, i.e. `HTTPS_PROXY`.

--- a/plumbing/transport/http/receive_pack_test.go
+++ b/plumbing/transport/http/receive_pack_test.go
@@ -3,11 +3,11 @@ package http
 import (
 	"testing"
 
-	"github.com/go-git/go-git/v6/internal/transport/test"
-	"github.com/go-git/go-git/v6/storage/filesystem"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/suite"
 
-	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
 func TestReceivePackSuite(t *testing.T) {

--- a/plumbing/transport/http/upload_pack_test.go
+++ b/plumbing/transport/http/upload_pack_test.go
@@ -5,13 +5,13 @@ import (
 	"net/url"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 func TestUploadPackSuite(t *testing.T) {

--- a/plumbing/transport/loader.go
+++ b/plumbing/transport/loader.go
@@ -3,13 +3,13 @@ package transport
 import (
 	"path/filepath"
 
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/osfs"
+
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-
-	"github.com/go-git/go-billy/v6"
-	"github.com/go-git/go-billy/v6/osfs"
 )
 
 // DefaultLoader is a filesystem loader ignoring host and resolving paths to /.

--- a/plumbing/transport/loader_test.go
+++ b/plumbing/transport/loader_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 type loaderSuiteRepo struct {

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -222,7 +222,7 @@ func NegotiatePack(
 	return shallowInfo, nil
 }
 
-func isSubset(needle []plumbing.Hash, haystack []plumbing.Hash) bool {
+func isSubset(needle, haystack []plumbing.Hash) bool {
 	for _, h := range needle {
 		found := false
 		for _, oh := range haystack {

--- a/plumbing/transport/pack_test.go
+++ b/plumbing/transport/pack_test.go
@@ -6,8 +6,9 @@ import (
 	"io"
 	"testing"
 
-	"github.com/go-git/go-git/v6/utils/ioutil"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
 func TestCmdStartEOFSuite(t *testing.T) {

--- a/plumbing/transport/registry_test.go
+++ b/plumbing/transport/registry_test.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/storage"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestClientSuite(t *testing.T) {

--- a/plumbing/transport/send_pack_test.go
+++ b/plumbing/transport/send_pack_test.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/go-git/go-git/v6/utils/trace"
-	"github.com/stretchr/testify/assert"
 )
 
 // mockConnection implements the Connection interface for testing

--- a/plumbing/transport/serve_test.go
+++ b/plumbing/transport/serve_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/utils/ioutil"
-	"github.com/stretchr/testify/require"
 )
 
 func testServe[T UploadPackOptions | ReceivePackOptions](

--- a/plumbing/transport/serverinfo.go
+++ b/plumbing/transport/serverinfo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/internal/repository"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"

--- a/plumbing/transport/serverinfo_test.go
+++ b/plumbing/transport/serverinfo_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 type ServerInfoSuite struct {

--- a/plumbing/transport/ssh/auth_method.go
+++ b/plumbing/transport/ssh/auth_method.go
@@ -8,12 +8,12 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"golang.org/x/crypto/ssh"
+
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh/knownhosts"
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh/sshagent"
 	"github.com/go-git/go-git/v6/utils/trace"
-
-	"golang.org/x/crypto/ssh"
 )
 
 const DefaultUsername = "git"

--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -10,12 +10,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-git/go-git/v6/plumbing/transport"
-	"github.com/go-git/go-git/v6/utils/trace"
-
 	"github.com/kevinburke/ssh_config"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/proxy"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 func init() {
@@ -238,7 +238,7 @@ func (c *command) getHostWithPort() string {
 
 func (c *command) doGetHostWithPortFromSSHConfig() (addr string, found bool) {
 	if DefaultSSHConfig == nil {
-		return
+		return addr, found
 	}
 
 	hostname := c.endpoint.Hostname()
@@ -251,7 +251,7 @@ func (c *command) doGetHostWithPortFromSSHConfig() (addr string, found bool) {
 	}
 
 	if !found {
-		return
+		return addr, found
 	}
 
 	configPort := DefaultSSHConfig.Get(c.endpoint.Hostname(), "Port")
@@ -262,7 +262,7 @@ func (c *command) doGetHostWithPortFromSSHConfig() (addr string, found bool) {
 	}
 
 	addr = net.JoinHostPort(hostname, port)
-	return
+	return addr, found
 }
 
 func (c *command) setAuthFromEndpoint() error {
@@ -279,7 +279,7 @@ func endpointToCommand(cmd string, ep *transport.Endpoint) string {
 	return fmt.Sprintf("%s '%s'", cmd, ep.Path)
 }
 
-func overrideConfig(overrides *ssh.ClientConfig, c *ssh.ClientConfig) {
+func overrideConfig(overrides, c *ssh.ClientConfig) {
 	if overrides == nil {
 		return
 	}

--- a/plumbing/transport/ssh/common_test.go
+++ b/plumbing/transport/ssh/common_test.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/transport"
-	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/require"
-
 	"github.com/gliderlabs/ssh"
 	"github.com/kevinburke/ssh_config"
+	"github.com/stretchr/testify/require"
 	stdssh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/testdata"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/memory"
 )
 
 func (s *SuiteCommon) TestOverrideConfig() {

--- a/plumbing/transport/ssh/knownhosts/knownhosts.go
+++ b/plumbing/transport/ssh/knownhosts/knownhosts.go
@@ -30,9 +30,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-git/go-git/v6/utils/trace"
 	"golang.org/x/crypto/ssh"
 	xknownhosts "golang.org/x/crypto/ssh/knownhosts"
+
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 // HostKeyDB wraps logic in golang.org/x/crypto/ssh/knownhosts with additional

--- a/plumbing/transport/ssh/knownhosts/knownhosts_test.go
+++ b/plumbing/transport/ssh/knownhosts/knownhosts_test.go
@@ -278,7 +278,7 @@ func TestIsHostKeyChanged(t *testing.T) {
 
 	// Append the key for a known host that doesn't already have that key type,
 	// re-init the known_hosts, and check again: should return false
-	f, err := os.OpenFile(khPath, os.O_APPEND|os.O_WRONLY, 0600)
+	f, err := os.OpenFile(khPath, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		t.Fatalf("Unable to open %s for writing: %v", khPath, err)
 	}
@@ -315,7 +315,7 @@ func TestIsHostUnknown(t *testing.T) {
 
 	// Append the key for an unknown host, re-init the known_hosts, and check
 	// again: should return false
-	f, err := os.OpenFile(khPath, os.O_APPEND|os.O_WRONLY, 0600)
+	f, err := os.OpenFile(khPath, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		t.Fatalf("Unable to open %s for writing: %v", khPath, err)
 	}
@@ -434,7 +434,7 @@ func getTestKnownHosts(t *testing.T) string {
 	if len(testKnownHostsContents) > 0 {
 		dir := t.TempDir()
 		khPath := filepath.Join(dir, "known_hosts")
-		if err := os.WriteFile(khPath, testKnownHostsContents, 0600); err != nil {
+		if err := os.WriteFile(khPath, testKnownHostsContents, 0o600); err != nil {
 			t.Fatalf("Unable to write to %s: %v", khPath, err)
 		}
 		return khPath
@@ -464,7 +464,7 @@ func writeTestKnownHosts(t *testing.T) string {
 
 	dir := t.TempDir()
 	khPath := filepath.Join(dir, "known_hosts")
-	f, err := os.OpenFile(khPath, os.O_WRONLY|os.O_CREATE, 0600)
+	f, err := os.OpenFile(khPath, os.O_WRONLY|os.O_CREATE, 0o600)
 	if err != nil {
 		t.Fatalf("Unable to open %s for writing: %v", khPath, err)
 	}
@@ -508,7 +508,7 @@ func appendCertTestKnownHosts(t *testing.T, filePath, hostPattern, keyType strin
 		testCertKeys[cacheKey] = pubKey
 	}
 
-	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
 	if err != nil {
 		t.Fatalf("Unable to open %s for writing: %v", filePath, err)
 	}

--- a/plumbing/transport/ssh/proxy_test.go
+++ b/plumbing/transport/ssh/proxy_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/armon/go-socks5"
+	"github.com/stretchr/testify/suite"
+	stdssh "golang.org/x/crypto/ssh"
+
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/transport"
-	"github.com/stretchr/testify/suite"
-
-	stdssh "golang.org/x/crypto/ssh"
 )
 
 type ProxySuite struct {

--- a/plumbing/transport/ssh/sshagent/sshagent.go
+++ b/plumbing/transport/ssh/sshagent/sshagent.go
@@ -27,8 +27,9 @@ import (
 	"net"
 	"os"
 
-	"github.com/go-git/go-git/v6/utils/trace"
 	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 // New returns a new agent.Agent that uses a unix socket

--- a/plumbing/transport/ssh/sshagent/sshagent_windows.go
+++ b/plumbing/transport/ssh/sshagent/sshagent_windows.go
@@ -32,8 +32,9 @@ import (
 	"sync"
 
 	"github.com/Microsoft/go-winio"
-	"github.com/go-git/go-git/v6/utils/trace"
 	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 const (

--- a/plumbing/transport/ssh/upload_pack_test.go
+++ b/plumbing/transport/ssh/upload_pack_test.go
@@ -11,15 +11,15 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/gliderlabs/ssh"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	stdssh "golang.org/x/crypto/ssh"
+
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-
-	"github.com/gliderlabs/ssh"
-	fixtures "github.com/go-git/go-git-fixtures/v5"
-	stdssh "golang.org/x/crypto/ssh"
 )
 
 type UploadPackSuite struct {
@@ -146,13 +146,12 @@ func handlerSSH(s ssh.Session) {
 	if err := cmd.Wait(); err != nil {
 		return
 	}
-
 }
 
 func buildCommand(c []string) (cmd *exec.Cmd, stdin io.WriteCloser, stderr, stdout io.ReadCloser, err error) {
 	if len(c) != 2 {
 		err = fmt.Errorf("invalid command")
-		return
+		return cmd, stdin, stderr, stdout, err
 	}
 
 	// fix for Windows environments
@@ -166,18 +165,18 @@ func buildCommand(c []string) (cmd *exec.Cmd, stdin io.WriteCloser, stderr, stdo
 	cmd = exec.Command(c[0], path)
 	stdout, err = cmd.StdoutPipe()
 	if err != nil {
-		return
+		return cmd, stdin, stderr, stdout, err
 	}
 
 	stdin, err = cmd.StdinPipe()
 	if err != nil {
-		return
+		return cmd, stdin, stderr, stdout, err
 	}
 
 	stderr, err = cmd.StderrPipe()
 	if err != nil {
-		return
+		return cmd, stdin, stderr, stdout, err
 	}
 
-	return
+	return cmd, stdin, stderr, stdout, err
 }

--- a/plumbing/transport/transport_test.go
+++ b/plumbing/transport/transport_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
 )
 
 func TestNewEndpoint(t *testing.T) {

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 )
 
 type UploadPackSuite struct {

--- a/plumbing/transport/version_test.go
+++ b/plumbing/transport/version_test.go
@@ -5,9 +5,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDiscoverVersion(t *testing.T) {

--- a/prune.go
+++ b/prune.go
@@ -8,14 +8,16 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/storer"
 )
 
-type PruneHandler func(unreferencedObjectHash plumbing.Hash) error
-type PruneOptions struct {
-	// OnlyObjectsOlderThan if set to non-zero value
-	// selects only objects older than the time provided.
-	OnlyObjectsOlderThan time.Time
-	// Handler is called on matching objects
-	Handler PruneHandler
-}
+type (
+	PruneHandler func(unreferencedObjectHash plumbing.Hash) error
+	PruneOptions struct {
+		// OnlyObjectsOlderThan if set to non-zero value
+		// selects only objects older than the time provided.
+		OnlyObjectsOlderThan time.Time
+		// Handler is called on matching objects
+		Handler PruneHandler
+	}
+)
 
 var ErrLooseObjectsNotSupported = errors.New("loose objects not supported")
 

--- a/prune_test.go
+++ b/prune_test.go
@@ -4,14 +4,14 @@ import (
 	"testing"
 	"time"
 
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type PruneSuite struct {

--- a/remote.go
+++ b/remote.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-billy/v6/osfs"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/internal/reference"
 	"github.com/go-git/go-git/v6/internal/repository"
@@ -1164,7 +1165,7 @@ func (r *Remote) updateLocalReferenceStorage(
 		err = ErrForceNeeded
 	}
 
-	return
+	return updated, err
 }
 
 func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, err error) {
@@ -1192,7 +1193,7 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 		}
 	}
 
-	return
+	return updated, err
 }
 
 // List the references on the remote repository.

--- a/remote_test.go
+++ b/remote_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/util"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/config"
@@ -28,8 +29,6 @@ import (
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type RemoteSuite struct {

--- a/repository.go
+++ b/repository.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/osfs"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/internal/path_util"
 	"github.com/go-git/go-git/v6/internal/revision"
@@ -1148,7 +1149,7 @@ func (r *Repository) updateReferences(spec []config.RefSpec,
 		}
 	}
 
-	return
+	return updated, err
 }
 
 func (r *Repository) calculateRemoteHeadReference(spec []config.RefSpec,
@@ -1903,5 +1904,5 @@ func expandPartialHash(st storer.EncodedObjectStorer, prefix []byte) (hashes []p
 		}
 		return nil
 	})
-	return
+	return hashes
 }

--- a/repository_common_test.go
+++ b/repository_common_test.go
@@ -4,10 +4,10 @@ import (
 	"testing"
 	"time"
 
-	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -16,19 +16,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	openpgperr "github.com/ProtonMail/go-crypto/openpgp/errors"
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
-	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/ProtonMail/go-crypto/openpgp/armor"
-	openpgperr "github.com/ProtonMail/go-crypto/openpgp/errors"
-
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -36,11 +39,6 @@ import (
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-
-	"github.com/go-git/go-billy/v6"
-	"github.com/go-git/go-billy/v6/memfs"
-	"github.com/go-git/go-billy/v6/osfs"
-	"github.com/go-git/go-billy/v6/util"
 )
 
 func TestInit(t *testing.T) {

--- a/repository_windows_test.go
+++ b/repository_windows_test.go
@@ -10,9 +10,10 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6/util"
-	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/storage/memory"
 )
 
 // preReceiveHook returns the bytes of a pre-receive hook script
@@ -27,7 +28,7 @@ func TestCloneFileUrlWindows(t *testing.T) {
 	r, err := PlainInit(dir, false)
 	require.NoError(t, err)
 
-	err = util.WriteFile(r.wt, "foo", nil, 0755)
+	err = util.WriteFile(r.wt, "foo", nil, 0o755)
 	require.NoError(t, err)
 
 	w, err := r.Worktree()

--- a/signer_test.go
+++ b/signer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-billy/v6/memfs"
+
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/memory"
 )

--- a/status_test.go
+++ b/status_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
-	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/storage/memory"
 )
 
 func TestStatusReturnsFullPaths(t *testing.T) {

--- a/storage/filesystem/config_test.go
+++ b/storage/filesystem/config_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
-	"github.com/stretchr/testify/suite"
 )
 
 type ConfigSuite struct {

--- a/storage/filesystem/deltaobject.go
+++ b/storage/filesystem/deltaobject.go
@@ -15,7 +15,8 @@ func newDeltaObject(
 	obj plumbing.EncodedObject,
 	hash plumbing.Hash,
 	base plumbing.Hash,
-	size int64) plumbing.DeltaObject {
+	size int64,
+) plumbing.DeltaObject {
 	return &deltaObject{
 		EncodedObject: obj,
 		hash:          hash,

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -16,12 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/helper/chroot"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
-
-	"github.com/go-git/go-billy/v6"
-	"github.com/go-git/go-billy/v6/helper/chroot"
 )
 
 const (
@@ -866,7 +866,7 @@ func (d *DotGit) openAndLockPackedRefs(doCreate bool) (
 		if time.Since(start) > 15*time.Second {
 			return nil, errors.New("timeout trying to lock packed refs")
 		}
-		f, err = d.fs.OpenFile(packedRefsPath, openFlags, 0600)
+		f, err = d.fs.OpenFile(packedRefsPath, openFlags, 0o600)
 		if err != nil {
 			if os.IsNotExist(err) && !doCreate {
 				return nil, nil
@@ -1150,7 +1150,7 @@ func (d *DotGit) Module(name string) (billy.Filesystem, error) {
 func (d *DotGit) AddAlternate(remote string) error {
 	altpath := d.fs.Join(objectsPath, infoPath, alternatesPath)
 
-	f, err := d.fs.OpenFile(altpath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	f, err := d.fs.OpenFile(altpath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640)
 	if err != nil {
 		return fmt.Errorf("cannot open file: %w", err)
 	}
@@ -1283,9 +1283,9 @@ func incBytes(in []byte) (out []byte, overflow bool) {
 	for i := len(out) - 1; i >= 0; i-- {
 		out[i]++
 		if out[i] != 0 {
-			return // Didn't overflow.
+			return out, overflow // Didn't overflow.
 		}
 	}
 	overflow = true
-	return
+	return out, overflow
 }

--- a/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
+++ b/storage/filesystem/dotgit/dotgit_rewrite_packed_refs.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
@@ -19,7 +20,8 @@ func (d *DotGit) openAndLockPackedRefsMode() int {
 }
 
 func (d *DotGit) rewritePackedRefsWhileLocked(
-	tmp billy.File, pr billy.File) error {
+	tmp, pr billy.File,
+) error {
 	// Try plain rename. If we aren't using the bare Windows filesystem as the
 	// storage layer, we might be able to get away with a rename over a locked
 	// file.
@@ -63,7 +65,7 @@ func (d *DotGit) copyToExistingFile(tmp, pr billy.File) error {
 	return err
 }
 
-func (d *DotGit) copyNewFile(tmp billy.File, pr billy.File) (err error) {
+func (d *DotGit) copyNewFile(tmp, pr billy.File) (err error) {
 	prWrite, err := d.fs.Create(pr.Name())
 	if err != nil {
 		return err

--- a/storage/filesystem/dotgit/dotgit_setref.go
+++ b/storage/filesystem/dotgit/dotgit_setref.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/utils/ioutil"
-
-	"github.com/go-git/go-billy/v6"
 )
 
 func (d *DotGit) setRef(fileName, content string, old *plumbing.Reference) (err error) {
@@ -25,7 +25,7 @@ func (d *DotGit) setRefRwfs(fileName, content string, old *plumbing.Reference) (
 		mode |= os.O_TRUNC
 	}
 
-	f, err := d.fs.OpenFile(fileName, mode, 0666)
+	f, err := d.fs.OpenFile(fileName, mode, 0o666)
 	if err != nil {
 		return err
 	}

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -17,10 +17,11 @@ import (
 	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/storage"
 )
 
 type SuiteDotGit struct {
@@ -300,7 +301,7 @@ func (s *SuiteDotGit) TestRemoveRefInvalidPackedRefs() {
 
 	brokenContent := "BROKEN STUFF REALLY BROKEN"
 
-	err := util.WriteFile(fs, packedRefsPath, []byte(brokenContent), os.FileMode(0755))
+	err := util.WriteFile(fs, packedRefsPath, []byte(brokenContent), os.FileMode(0o755))
 	s.Require().NoError(err)
 
 	name := plumbing.ReferenceName("refs/heads/nonexistent")
@@ -319,7 +320,7 @@ func (s *SuiteDotGit) TestRemoveRefInvalidPackedRefs2() {
 
 	brokenContent := strings.Repeat("a", bufio.MaxScanTokenSize*2)
 
-	err := util.WriteFile(fs, packedRefsPath, []byte(brokenContent), os.FileMode(0755))
+	err := util.WriteFile(fs, packedRefsPath, []byte(brokenContent), os.FileMode(0o755))
 	s.Require().NoError(err)
 
 	name := plumbing.ReferenceName("refs/heads/nonexistent")
@@ -639,7 +640,7 @@ func (s *SuiteDotGit) TestObject() {
 	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "tmp_objdir-incoming-123456")
 	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
-	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
+	fs.MkdirAll(incomingDirPath, os.FileMode(0o755))
 	fs.Create(incomingFilePath)
 
 	_, err = dir.Object(plumbing.NewHash(incomingHash))
@@ -659,7 +660,7 @@ func (s *SuiteDotGit) TestPreGit235Object() {
 	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "incoming-123456")
 	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
-	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
+	fs.MkdirAll(incomingDirPath, os.FileMode(0o755))
 	fs.Create(incomingFilePath)
 
 	_, err = dir.Object(plumbing.NewHash(incomingHash))
@@ -676,7 +677,7 @@ func (s *SuiteDotGit) TestObjectStat() {
 	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", "tmp_objdir-incoming-123456")
 	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
-	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
+	fs.MkdirAll(incomingDirPath, os.FileMode(0o755))
 	fs.Create(incomingFilePath)
 
 	_, err = dir.ObjectStat(plumbing.NewHash(incomingHash))
@@ -696,7 +697,7 @@ func (s *SuiteDotGit) TestObjectDelete() {
 	incomingSubDirPath := fs.Join(incomingDirPath, incomingHash[0:2])
 	incomingFilePath := fs.Join(incomingSubDirPath, incomingHash[2:40])
 
-	err = fs.MkdirAll(incomingSubDirPath, os.FileMode(0755))
+	err = fs.MkdirAll(incomingSubDirPath, os.FileMode(0o755))
 	s.Require().NoError(err)
 
 	f, err := fs.Create(incomingFilePath)

--- a/storage/filesystem/dotgit/repository_filesystem_test.go
+++ b/storage/filesystem/dotgit/repository_filesystem_test.go
@@ -7,12 +7,12 @@ import (
 func (s *SuiteDotGit) TestRepositoryFilesystem() {
 	fs := s.EmptyFS()
 
-	err := fs.MkdirAll("dotGit", 0777)
+	err := fs.MkdirAll("dotGit", 0o777)
 	s.Require().NoError(err)
 	dotGitFs, err := fs.Chroot("dotGit")
 	s.Require().NoError(err)
 
-	err = fs.MkdirAll("commonDotGit", 0777)
+	err = fs.MkdirAll("commonDotGit", 0o777)
 	s.Require().NoError(err)
 	commonDotGitFs, err := fs.Chroot("commonDotGit")
 	s.Require().NoError(err)
@@ -35,7 +35,7 @@ func (s *SuiteDotGit) TestRepositoryFilesystem() {
 	err = file.Close()
 	s.Require().NoError(err)
 
-	file, err = repositoryFs.OpenFile("somefile", os.O_RDONLY, 0666)
+	file, err = repositoryFs.OpenFile("somefile", os.O_RDONLY, 0o666)
 	s.Require().NoError(err)
 	err = file.Close()
 	s.Require().NoError(err)
@@ -71,7 +71,7 @@ func (s *SuiteDotGit) TestRepositoryFilesystem() {
 
 	dirs := []string{objectsPath, refsPath, packedRefsPath, configPath, branchesPath, hooksPath, infoPath, remotesPath, logsPath, shallowPath, worktreesPath}
 	for _, dir := range dirs {
-		err := repositoryFs.MkdirAll(dir, 0777)
+		err := repositoryFs.MkdirAll(dir, 0o777)
 		s.Require().NoError(err)
 		_, err = commonDotGitFs.Stat(dir)
 		s.Require().NoError(err)
@@ -89,21 +89,21 @@ func (s *SuiteDotGit) TestRepositoryFilesystem() {
 		s.Require().NoError(err)
 	}
 
-	err = repositoryFs.MkdirAll("refs/heads", 0777)
+	err = repositoryFs.MkdirAll("refs/heads", 0o777)
 	s.Require().NoError(err)
 	_, err = commonDotGitFs.Stat("refs/heads")
 	s.Require().NoError(err)
 	_, err = dotGitFs.Stat("refs/heads")
 	s.True(os.IsNotExist(err))
 
-	err = repositoryFs.MkdirAll("objects/pack", 0777)
+	err = repositoryFs.MkdirAll("objects/pack", 0o777)
 	s.Require().NoError(err)
 	_, err = commonDotGitFs.Stat("objects/pack")
 	s.Require().NoError(err)
 	_, err = dotGitFs.Stat("objects/pack")
 	s.True(os.IsNotExist(err))
 
-	err = repositoryFs.MkdirAll("a/b/c", 0777)
+	err = repositoryFs.MkdirAll("a/b/c", 0o777)
 	s.Require().NoError(err)
 	_, err = commonDotGitFs.Stat("a/b/c")
 	s.True(os.IsNotExist(err))

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -8,13 +8,13 @@ import (
 	"io"
 	"sync/atomic"
 
+	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/plumbing/format/objfile"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/format/revfile"
-
-	"github.com/go-git/go-billy/v6"
 )
 
 // PackWriter is a io.Writer that generates the packfile index simultaneously,
@@ -205,7 +205,7 @@ func (s *syncedReader) Write(p []byte) (n int, err error) {
 	}()
 
 	n, err = s.w.Write(p)
-	return
+	return n, err
 }
 
 func (s *syncedReader) Read(p []byte) (n int, err error) {
@@ -221,7 +221,7 @@ func (s *syncedReader) Read(p []byte) (n int, err error) {
 		break
 	}
 
-	return
+	return n, err
 }
 
 func (s *syncedReader) isDone() bool {

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
-	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 )
 
 func BenchmarkNewObjectPack(b *testing.B) {

--- a/storage/filesystem/object_iter.go
+++ b/storage/filesystem/object_iter.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type FsSuite struct {
@@ -251,7 +251,6 @@ func (s *FsSuite) TestIterWithType() {
 
 			s.Require().NoError(err)
 		}
-
 	}
 }
 
@@ -289,11 +288,11 @@ func copyFile(fs billy.Filesystem, dstFilename string, srcFile billy.File) error
 		return err
 	}
 
-	if err := fs.MkdirAll(filepath.Dir(dstFilename), 0750|os.ModeDir); err != nil {
+	if err := fs.MkdirAll(filepath.Dir(dstFilename), 0o750|os.ModeDir); err != nil {
 		return err
 	}
 
-	dst, err := fs.OpenFile(dstFilename, os.O_CREATE|os.O_WRONLY, 0666)
+	dst, err := fs.OpenFile(dstFilename, os.O_CREATE|os.O_WRONLY, 0o666)
 	if err != nil {
 		return err
 	}
@@ -465,7 +464,6 @@ func BenchmarkPackfileIter(b *testing.B) {
 							}
 							return nil
 						})
-
 						if err != nil {
 							b.Fatal(err)
 						}
@@ -521,7 +519,6 @@ func BenchmarkPackfileIterReadContent(b *testing.B) {
 
 							return r.Close()
 						})
-
 						if err != nil {
 							b.Fatal(err)
 						}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -2,12 +2,12 @@
 package filesystem
 
 import (
+	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
-
-	"github.com/go-git/go-billy/v6"
 )
 
 // Storage is an implementation of git.Storer that stores data on disk in the

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -3,13 +3,13 @@ package filesystem_test
 import (
 	"testing"
 
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/go-git/go-billy/v6/memfs"
-	"github.com/go-git/go-billy/v6/osfs"
 )
 
 var (

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -176,7 +176,8 @@ func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
 }
 
 func (o *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (
-	size int64, err error) {
+	size int64, err error,
+) {
 	obj, ok := o.Objects[h]
 	if !ok {
 		return 0, plumbing.ErrObjectNotFound
@@ -243,6 +244,7 @@ func (o *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 func (o *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
 	return nil, nil
 }
+
 func (o *ObjectStorage) DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error {
 	return nil
 }
@@ -252,6 +254,7 @@ var errNotSupported = fmt.Errorf("not supported")
 func (o *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {
 	return time.Time{}, errNotSupported
 }
+
 func (o *ObjectStorage) DeleteLooseObject(plumbing.Hash) error {
 	return errNotSupported
 }

--- a/storage/tests/storage_test.go
+++ b/storage/tests/storage_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/osfs"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
@@ -17,8 +20,6 @@ import (
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/go-git/go-git/v6/storage/transactional"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type Storer interface {

--- a/storage/transactional/config_test.go
+++ b/storage/transactional/config_test.go
@@ -3,9 +3,10 @@ package transactional
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestConfigSuite(t *testing.T) {

--- a/storage/transactional/index_test.go
+++ b/storage/transactional/index_test.go
@@ -3,9 +3,10 @@ package transactional
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestIndexSuite(t *testing.T) {

--- a/storage/transactional/object_test.go
+++ b/storage/transactional/object_test.go
@@ -3,9 +3,10 @@ package transactional
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestObjectSuite(t *testing.T) {

--- a/storage/transactional/reference_test.go
+++ b/storage/transactional/reference_test.go
@@ -3,9 +3,10 @@ package transactional
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestReferenceSuite(t *testing.T) {
@@ -159,5 +160,4 @@ func (s *ReferenceSuite) TestCommitDelete() {
 	ref, err := rs.Reference(refC.Name())
 	s.NoError(err)
 	s.Equal("c3f4688a08fd86f1bf8e055724c84b7a40a09733", ref.Hash().String())
-
 }

--- a/storage/transactional/shallow_test.go
+++ b/storage/transactional/shallow_test.go
@@ -3,9 +3,10 @@ package transactional
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 func TestShallowSuite(t *testing.T) {

--- a/storage/transactional/storage_test.go
+++ b/storage/transactional/storage_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCommit(t *testing.T) {

--- a/submodule.go
+++ b/submodule.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/index"

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
+	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
-
-	fixtures "github.com/go-git/go-git-fixtures/v5"
 )
 
 type SubmoduleSuite struct {

--- a/utils/binary/read.go
+++ b/utils/binary/read.go
@@ -11,7 +11,7 @@ import (
 // Read reads structured binary data from r into data. Bytes are read and
 // decoded in BigEndian order
 // https://golang.org/pkg/encoding/binary/#Read
-func Read(r io.Reader, data ...interface{}) error {
+func Read(r io.Reader, data ...any) error {
 	for _, v := range data {
 		if err := binary.Read(r, binary.BigEndian, v); err != nil {
 			return err
@@ -87,7 +87,7 @@ func ReadVariableWidthInt(r io.Reader) (int64, error) {
 		return 0, err
 	}
 
-	var v = int64(c & maskLength)
+	v := int64(c & maskLength)
 	for c&maskContinue > 0 {
 		v++
 		if err := Read(r, &c); err != nil {

--- a/utils/binary/write.go
+++ b/utils/binary/write.go
@@ -7,7 +7,7 @@ import (
 
 // Write writes the binary representation of data into w, using BigEndian order
 // https://golang.org/pkg/encoding/binary/#Write
-func Write(w io.Writer, data ...interface{}) error {
+func Write(w io.Writer, data ...any) error {
 	for _, v := range data {
 		if err := binary.Write(w, binary.BigEndian, v); err != nil {
 			return err

--- a/utils/diff/diff_ext_test.go
+++ b/utils/diff/diff_ext_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-git/go-git/v6/utils/diff"
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/go-git/go-git/v6/utils/diff"
 )
 
 type suiteCommon struct {

--- a/utils/ioutil/common.go
+++ b/utils/ioutil/common.go
@@ -171,7 +171,7 @@ func (r *readerOnError) Read(buf []byte) (n int, err error) {
 		r.notify(err)
 	}
 
-	return
+	return n, err
 }
 
 type writerOnError struct {
@@ -197,7 +197,7 @@ func (r *writerOnError) Write(p []byte) (n int, err error) {
 		r.notify(err)
 	}
 
-	return
+	return n, err
 }
 
 // CloserFunc implements the io.Closer interface with a function.

--- a/utils/ioutil/common_test.go
+++ b/utils/ioutil/common_test.go
@@ -158,6 +158,7 @@ func (s *CommonSuite) TestNewReadCloserOnError() {
 
 	s.NotNil(called)
 }
+
 func ExampleCheckClose() {
 	// CheckClose is commonly used with named return values
 	f := func() (err error) {

--- a/utils/ioutil/sync.go
+++ b/utils/ioutil/sync.go
@@ -14,5 +14,5 @@ func CopyBufferPool(dst io.Writer, src io.Reader) (n int64, err error) {
 	n, err = io.CopyBuffer(dst, src, *buf)
 	sync.PutByteSlice(buf)
 
-	return
+	return n, err
 }

--- a/utils/merkletrie/change.go
+++ b/utils/merkletrie/change.go
@@ -8,9 +8,7 @@ import (
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 )
 
-var (
-	ErrEmptyFileName = errors.New("empty filename in tree entry")
-)
+var ErrEmptyFileName = errors.New("empty filename in tree entry")
 
 // Action values represent the kind of things a Change can represent:
 // insertion, deletions or modifications of files.

--- a/utils/merkletrie/change_test.go
+++ b/utils/merkletrie/change_test.go
@@ -3,10 +3,11 @@ package merkletrie_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/utils/merkletrie"
 	"github.com/go-git/go-git/v6/utils/merkletrie/internal/fsnoder"
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
-	"github.com/stretchr/testify/suite"
 )
 
 type ChangeSuite struct {

--- a/utils/merkletrie/difftree.go
+++ b/utils/merkletrie/difftree.go
@@ -255,10 +255,8 @@ import (
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 )
 
-var (
-	// ErrCanceled is returned whenever the operation is canceled.
-	ErrCanceled = errors.New("operation canceled")
-)
+// ErrCanceled is returned whenever the operation is canceled.
+var ErrCanceled = errors.New("operation canceled")
 
 // DiffTree calculates the list of changes between two merkletries.  It
 // uses the provided hashEqual callback to compare noders.
@@ -275,7 +273,8 @@ func DiffTree(
 // Error will be returned if context expires
 // Provided context must be non nil
 func DiffTreeContext(ctx context.Context, fromTree, toTree noder.Noder,
-	hashEqual noder.Equal) (Changes, error) {
+	hashEqual noder.Equal,
+) (Changes, error) {
 	ret := NewChanges()
 
 	ii, err := newDoubleIter(fromTree, toTree, hashEqual)

--- a/utils/merkletrie/difftree_test.go
+++ b/utils/merkletrie/difftree_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"unicode"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/utils/merkletrie"
 	"github.com/go-git/go-git/v6/utils/merkletrie/internal/fsnoder"
-	"github.com/stretchr/testify/suite"
 )
 
 type DiffTreeSuite struct {
@@ -496,5 +497,4 @@ func (s *DiffTreeSuite) TestCancel() {
 	results, err := merkletrie.DiffTreeContext(context, a, b, fsnoder.HashEqual)
 	s.Nil(results, comment)
 	s.ErrorContains(err, "operation canceled")
-
 }

--- a/utils/merkletrie/doubleiter.go
+++ b/utils/merkletrie/doubleiter.go
@@ -36,7 +36,8 @@ type doubleIter struct {
 // to compare the hash of the noders in the merkletries.  The doubleIter
 // will be initialized to the first elements in each merkletrie if any.
 func newDoubleIter(from, to noder.Noder, hashEqual noder.Equal) (
-	*doubleIter, error) {
+	*doubleIter, error,
+) {
 	var ii doubleIter
 	var err error
 
@@ -159,7 +160,7 @@ func (d *doubleIter) compare() (s comparison, err error) {
 	s.fromIsEmptyDir = fromIsDir && fromNumChildren == 0
 	s.toIsEmptyDir = toIsDir && toNumChildren == 0
 
-	return
+	return s, err
 }
 
 // Answers to a lot of questions you can ask about how to noders are

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
@@ -12,8 +14,6 @@ import (
 	"github.com/go-git/go-git/v6/utils/ioutil"
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 	"github.com/go-git/go-git/v6/utils/sync"
-
-	"github.com/go-git/go-billy/v6"
 )
 
 var ignore = map[string]bool{

--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -10,14 +10,14 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/utils/merkletrie"
-	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
-	"github.com/stretchr/testify/suite"
-
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/utils/merkletrie"
+	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 )
 
 type NoderSuite struct {
@@ -30,15 +30,15 @@ func TestNoderSuite(t *testing.T) {
 
 func (s *NoderSuite) TestDiff() {
 	fsA := memfs.New()
-	WriteFile(fsA, "foo", []byte("foo"), 0644)
-	WriteFile(fsA, "qux/bar", []byte("foo"), 0644)
-	WriteFile(fsA, "qux/qux", []byte("foo"), 0644)
+	WriteFile(fsA, "foo", []byte("foo"), 0o644)
+	WriteFile(fsA, "qux/bar", []byte("foo"), 0o644)
+	WriteFile(fsA, "qux/qux", []byte("foo"), 0o644)
 	fsA.Symlink("foo", "bar")
 
 	fsB := memfs.New()
-	WriteFile(fsB, "foo", []byte("foo"), 0644)
-	WriteFile(fsB, "qux/bar", []byte("foo"), 0644)
-	WriteFile(fsB, "qux/qux", []byte("foo"), 0644)
+	WriteFile(fsB, "foo", []byte("foo"), 0o644)
+	WriteFile(fsB, "qux/bar", []byte("foo"), 0o644)
+	WriteFile(fsB, "qux/qux", []byte("foo"), 0o644)
 	fsB.Symlink("foo", "bar")
 
 	ch, err := merkletrie.DiffTree(
@@ -53,15 +53,15 @@ func (s *NoderSuite) TestDiff() {
 
 func (s *NoderSuite) TestDiffCRLF() {
 	fsA := memfs.New()
-	WriteFile(fsA, "foo", []byte("foo\n"), 0644)
-	WriteFile(fsA, "qux/bar", []byte("foo\n"), 0644)
-	WriteFile(fsA, "qux/qux", []byte("foo\n"), 0644)
+	WriteFile(fsA, "foo", []byte("foo\n"), 0o644)
+	WriteFile(fsA, "qux/bar", []byte("foo\n"), 0o644)
+	WriteFile(fsA, "qux/qux", []byte("foo\n"), 0o644)
 	fsA.Symlink("foo", "bar")
 
 	fsB := memfs.New()
-	WriteFile(fsB, "foo", []byte("foo\r\n"), 0644)
-	WriteFile(fsB, "qux/bar", []byte("foo\r\n"), 0644)
-	WriteFile(fsB, "qux/qux", []byte("foo\r\n"), 0644)
+	WriteFile(fsB, "foo", []byte("foo\r\n"), 0o644)
+	WriteFile(fsB, "qux/bar", []byte("foo\r\n"), 0o644)
+	WriteFile(fsB, "qux/qux", []byte("foo\r\n"), 0o644)
 	fsB.Symlink("foo", "bar")
 
 	ch, err := merkletrie.DiffTree(
@@ -93,14 +93,14 @@ func (s *NoderSuite) TestDiffChangeLink() {
 
 func (s *NoderSuite) TestDiffChangeContent() {
 	fsA := memfs.New()
-	WriteFile(fsA, "foo", []byte("foo"), 0644)
-	WriteFile(fsA, "qux/bar", []byte("foo"), 0644)
-	WriteFile(fsA, "qux/qux", []byte("foo"), 0644)
+	WriteFile(fsA, "foo", []byte("foo"), 0o644)
+	WriteFile(fsA, "qux/bar", []byte("foo"), 0o644)
+	WriteFile(fsA, "qux/qux", []byte("foo"), 0o644)
 
 	fsB := memfs.New()
-	WriteFile(fsB, "foo", []byte("foo"), 0644)
-	WriteFile(fsB, "qux/bar", []byte("bar"), 0644)
-	WriteFile(fsB, "qux/qux", []byte("foo"), 0644)
+	WriteFile(fsB, "foo", []byte("foo"), 0o644)
+	WriteFile(fsB, "qux/bar", []byte("bar"), 0o644)
+	WriteFile(fsB, "qux/qux", []byte("foo"), 0o644)
 
 	ch, err := merkletrie.DiffTree(
 		NewRootNode(fsA, nil),
@@ -114,11 +114,11 @@ func (s *NoderSuite) TestDiffChangeContent() {
 
 func (s *NoderSuite) TestDiffSymlinkDirOnA() {
 	fsA := memfs.New()
-	WriteFile(fsA, "qux/qux", []byte("foo"), 0644)
+	WriteFile(fsA, "qux/qux", []byte("foo"), 0o644)
 
 	fsB := memfs.New()
 	fsB.Symlink("qux", "foo")
-	WriteFile(fsB, "qux/qux", []byte("foo"), 0644)
+	WriteFile(fsB, "qux/qux", []byte("foo"), 0o644)
 
 	ch, err := merkletrie.DiffTree(
 		NewRootNode(fsA, nil),
@@ -133,10 +133,10 @@ func (s *NoderSuite) TestDiffSymlinkDirOnA() {
 func (s *NoderSuite) TestDiffSymlinkDirOnB() {
 	fsA := memfs.New()
 	fsA.Symlink("qux", "foo")
-	WriteFile(fsA, "qux/qux", []byte("foo"), 0644)
+	WriteFile(fsA, "qux/qux", []byte("foo"), 0o644)
 
 	fsB := memfs.New()
-	WriteFile(fsB, "qux/qux", []byte("foo"), 0644)
+	WriteFile(fsB, "qux/qux", []byte("foo"), 0o644)
 
 	ch, err := merkletrie.DiffTree(
 		NewRootNode(fsA, nil),
@@ -150,10 +150,10 @@ func (s *NoderSuite) TestDiffSymlinkDirOnB() {
 
 func (s *NoderSuite) TestDiffChangeMissing() {
 	fsA := memfs.New()
-	WriteFile(fsA, "foo", []byte("foo"), 0644)
+	WriteFile(fsA, "foo", []byte("foo"), 0o644)
 
 	fsB := memfs.New()
-	WriteFile(fsB, "bar", []byte("bar"), 0644)
+	WriteFile(fsB, "bar", []byte("bar"), 0o644)
 
 	ch, err := merkletrie.DiffTree(
 		NewRootNode(fsA, nil),
@@ -167,10 +167,10 @@ func (s *NoderSuite) TestDiffChangeMissing() {
 
 func (s *NoderSuite) TestDiffChangeMode() {
 	fsA := memfs.New()
-	WriteFile(fsA, "foo", []byte("foo"), 0644)
+	WriteFile(fsA, "foo", []byte("foo"), 0o644)
 
 	fsB := memfs.New()
-	WriteFile(fsB, "foo", []byte("foo"), 0755)
+	WriteFile(fsB, "foo", []byte("foo"), 0o755)
 
 	ch, err := merkletrie.DiffTree(
 		NewRootNode(fsA, nil),
@@ -184,10 +184,10 @@ func (s *NoderSuite) TestDiffChangeMode() {
 
 func (s *NoderSuite) TestDiffChangeModeNotRelevant() {
 	fsA := memfs.New()
-	WriteFile(fsA, "foo", []byte("foo"), 0644)
+	WriteFile(fsA, "foo", []byte("foo"), 0o644)
 
 	fsB := memfs.New()
-	WriteFile(fsB, "foo", []byte("foo"), 0655)
+	WriteFile(fsB, "foo", []byte("foo"), 0o655)
 
 	ch, err := merkletrie.DiffTree(
 		NewRootNode(fsA, nil),
@@ -202,10 +202,10 @@ func (s *NoderSuite) TestDiffChangeModeNotRelevant() {
 func (s *NoderSuite) TestDiffDirectory() {
 	dir := path.Join("qux", "bar")
 	fsA := memfs.New()
-	fsA.MkdirAll(dir, 0644)
+	fsA.MkdirAll(dir, 0o644)
 
 	fsB := memfs.New()
-	fsB.MkdirAll(dir, 0644)
+	fsB.MkdirAll(dir, 0o644)
 
 	ch, err := merkletrie.DiffTree(
 		NewRootNode(fsA, map[string]plumbing.Hash{
@@ -237,7 +237,7 @@ func (s *NoderSuite) TestSocket() {
 	defer sock.Close()
 
 	fsA := osfs.New(td)
-	WriteFile(fsA, "foo", []byte("foo"), 0644)
+	WriteFile(fsA, "foo", []byte("foo"), 0o644)
 
 	noder := NewRootNode(fsA, nil)
 	childs, err := noder.Children()

--- a/utils/merkletrie/index/node_test.go
+++ b/utils/merkletrie/index/node_test.go
@@ -5,12 +5,13 @@ import (
 	"path"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/utils/merkletrie"
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
-	"github.com/stretchr/testify/suite"
 )
 
 type NoderSuite struct {

--- a/utils/merkletrie/internal/frame/frame_test.go
+++ b/utils/merkletrie/internal/frame/frame_test.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/utils/merkletrie/internal/fsnoder"
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
-	"github.com/stretchr/testify/suite"
 )
 
 type FrameSuite struct {

--- a/utils/merkletrie/internal/fsnoder/dir_test.go
+++ b/utils/merkletrie/internal/fsnoder/dir_test.go
@@ -4,9 +4,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 )
 
 type DirSuite struct {

--- a/utils/merkletrie/internal/fsnoder/doc.go
+++ b/utils/merkletrie/internal/fsnoder/doc.go
@@ -9,12 +9,12 @@ For example:
 
 will create a noder as follows:
 
-       root        - "root" is an unnamed dir containing "a", "b" and "B".
-       / | \       - "a" is a file containing the string "1".
-      /  |  \      - "b" is a file containing the string "2".
-     a   b   B     - "B" is a directory containing "c" and "d".
-            / \    - "c" is a file containing the string "3".
-           c   d   - "D" is an empty directory.
+	  root        - "root" is an unnamed dir containing "a", "b" and "B".
+	  / | \       - "a" is a file containing the string "1".
+	 /  |  \      - "b" is a file containing the string "2".
+	a   b   B     - "B" is a directory containing "c" and "d".
+	       / \    - "c" is a file containing the string "3".
+	      c   d   - "D" is an empty directory.
 
 Files are expressed as:
 
@@ -43,10 +43,10 @@ respective contents, inside a directory called "D".
 
 - (b(c<1> d(e<2>)) f<>) : an unamed directory containing:
 
-    ├── b              --> directory
-    │   ├── c          --> file containing "1"
-    │   └── d          --> directory
-    │       └── e      --> file containing "2"
-    └── f              --> empty file
+	├── b              --> directory
+	│   ├── c          --> file containing "1"
+	│   └── d          --> directory
+	│       └── e      --> file containing "2"
+	└── f              --> empty file
 */
 package fsnoder

--- a/utils/merkletrie/internal/fsnoder/file_test.go
+++ b/utils/merkletrie/internal/fsnoder/file_test.go
@@ -3,8 +3,9 @@ package fsnoder
 import (
 	"testing"
 
-	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 )
 
 type FileSuite struct {

--- a/utils/merkletrie/internal/fsnoder/new_test.go
+++ b/utils/merkletrie/internal/fsnoder/new_test.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 )
 
 type FSNoderSuite struct {

--- a/utils/merkletrie/iter_test.go
+++ b/utils/merkletrie/iter_test.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/utils/merkletrie"
 	"github.com/go-git/go-git/v6/utils/merkletrie/internal/fsnoder"
 	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 )
 
 type IterSuite struct {
@@ -56,8 +57,8 @@ type test struct {
 // returned values are correct.  If not, the treeDescription value is
 // printed along with information about mismatch.
 func (t test) run(s *IterSuite, iter *merkletrie.Iter,
-	treeDescription string, testNumber int) {
-
+	treeDescription string, testNumber int,
+) {
 	expectedChunks := strings.Split(t.expected, " ")
 	if t.expected == "" {
 		expectedChunks = []string{}

--- a/utils/merkletrie/noder/noder.go
+++ b/utils/merkletrie/noder/noder.go
@@ -53,7 +53,7 @@ type Noder interface {
 	// implement NumChildren in O(1) while Children is usually more
 	// complex.
 	NumChildren() (int, error)
-	Skip()	bool
+	Skip() bool
 }
 
 // NoChildren represents the children of a noder without children.

--- a/utils/sync/bufio.go
+++ b/utils/sync/bufio.go
@@ -7,7 +7,7 @@ import (
 )
 
 var bufioReader = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return bufio.NewReader(nil)
 	},
 }

--- a/utils/sync/bytes.go
+++ b/utils/sync/bytes.go
@@ -9,13 +9,13 @@ var (
 	size = 32 * 1024
 
 	byteSlice = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			b := make([]byte, size)
 			return &b
 		},
 	}
 	bytesBuffer = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return bytes.NewBuffer(nil)
 		},
 	}

--- a/utils/sync/zlib.go
+++ b/utils/sync/zlib.go
@@ -10,7 +10,7 @@ import (
 var (
 	zlibInitBytes = []byte{0x78, 0x9c, 0x01, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01}
 	zlibReader    = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			r, _ := zlib.NewReader(bytes.NewReader(zlibInitBytes))
 			return &ZLibReader{
 				reader: r.(zlibReadCloser),
@@ -19,7 +19,7 @@ var (
 		},
 	}
 	zlibWriter = sync.Pool{
-		New: func() interface{} {
+		New: func() any {
 			return zlib.NewWriter(nil)
 		},
 	}

--- a/utils/trace/trace.go
+++ b/utils/trace/trace.go
@@ -51,14 +51,14 @@ func SetLogger(l *log.Logger) {
 }
 
 // Print prints the given message only if the target is enabled.
-func (t Target) Print(args ...interface{}) {
+func (t Target) Print(args ...any) {
 	if t.Enabled() {
 		logger.Output(2, fmt.Sprint(args...)) // nolint: errcheck
 	}
 }
 
 // Printf prints the given message only if the target is enabled.
-func (t Target) Printf(format string, args ...interface{}) {
+func (t Target) Printf(format string, args ...any) {
 	if t.Enabled() {
 		logger.Output(2, fmt.Sprintf(format, args...)) // nolint: errcheck
 	}

--- a/worktree_bsd.go
+++ b/worktree_bsd.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+	fillSystemInfo = func(e *index.Entry, sys any) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
 			e.CreatedAt = time.Unix(os.Atimespec.Unix())
 			e.Dev = uint32(os.Dev)
@@ -22,6 +22,6 @@ func init() {
 	}
 }
 
-func isSymlinkWindowsNonAdmin(err error) bool {
+func isSymlinkWindowsNonAdmin(error) bool {
 	return false
 }

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -9,16 +9,16 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
+	"github.com/go-git/go-billy/v6"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/merkletrie"
-
-	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/ProtonMail/go-crypto/openpgp/packet"
-	"github.com/go-git/go-billy/v6"
 )
 
 var (
@@ -346,9 +346,9 @@ func (sortableEntries) sortName(te object.TreeEntry) string {
 	}
 	return te.Name
 }
-func (se sortableEntries) Len() int               { return len(se) }
-func (se sortableEntries) Less(i int, j int) bool { return se.sortName(se[i]) < se.sortName(se[j]) }
-func (se sortableEntries) Swap(i int, j int)      { se[i], se[j] = se[j], se[i] }
+func (se sortableEntries) Len() int           { return len(se) }
+func (se sortableEntries) Less(i, j int) bool { return se.sortName(se[i]) < se.sortName(se[j]) }
+func (se sortableEntries) Swap(i, j int)      { se[i], se[j] = se[j], se[i] }
 
 func (h *buildTreeHelper) copyTreeToStorageRecursive(parent string, t *object.Tree) (plumbing.Hash, error) {
 	sort.Sort(sortableEntries(t.Entries))

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -12,21 +12,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/errors"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/ProtonMail/go-crypto/openpgp/armor"
-	"github.com/ProtonMail/go-crypto/openpgp/errors"
-	"github.com/go-git/go-billy/v6/memfs"
-	"github.com/go-git/go-billy/v6/util"
 )
 
 func (s *WorktreeSuite) TestCommitEmptyOptions() {
@@ -37,7 +37,7 @@ func (s *WorktreeSuite) TestCommitEmptyOptions() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	_, err = w.Add("foo")
 	s.NoError(err)
@@ -63,7 +63,7 @@ func (s *WorktreeSuite) TestCommitInitial() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	_, err = w.Add("foo")
 	s.NoError(err)
@@ -101,7 +101,7 @@ func (s *WorktreeSuite) TestNothingToCommitNonEmptyRepo() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	err = util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.NoError(err)
 
 	w.Add("foo")
@@ -124,7 +124,7 @@ func (s *WorktreeSuite) TestRemoveAndCommitToMakeEmptyRepo() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	err = util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.NoError(err)
 
 	_, err = w.Add("foo")
@@ -155,7 +155,7 @@ func (s *WorktreeSuite) TestCommitParent() {
 	err := w.Checkout(&CheckoutOptions{})
 	s.NoError(err)
 
-	err = util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.NoError(err)
 
 	_, err = w.Add("foo")
@@ -178,7 +178,7 @@ func (s *WorktreeSuite) TestCommitAmendWithoutChanges() {
 	err := w.Checkout(&CheckoutOptions{})
 	s.NoError(err)
 
-	err = util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.NoError(err)
 
 	_, err = w.Add("foo")
@@ -213,7 +213,7 @@ func (s *WorktreeSuite) TestCommitAmendWithChanges() {
 	err := w.Checkout(&CheckoutOptions{})
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	_, err = w.Add("foo")
 	s.NoError(err)
@@ -221,7 +221,7 @@ func (s *WorktreeSuite) TestCommitAmendWithChanges() {
 	_, err = w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
 	s.NoError(err)
 
-	util.WriteFile(fs, "bar", []byte("bar"), 0644)
+	util.WriteFile(fs, "bar", []byte("bar"), 0o644)
 
 	_, err = w.Add("bar")
 	s.NoError(err)
@@ -264,7 +264,7 @@ func (s *WorktreeSuite) TestCommitAmendNothingToCommit() {
 	err := w.Checkout(&CheckoutOptions{})
 	s.NoError(err)
 
-	err = util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.NoError(err)
 
 	_, err = w.Add("foo")
@@ -341,8 +341,8 @@ func TestAddAndCommitWithSkipStatus(t *testing.T) {
 	err := w.Checkout(&CheckoutOptions{})
 	require.NoError(t, err)
 
-	util.WriteFile(fs, "LICENSE", []byte("foo"), 0644)
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "LICENSE", []byte("foo"), 0o644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	err = w.AddWithOptions(&AddOptions{
 		Path:       "foo",
@@ -393,7 +393,7 @@ func (s *WorktreeSuite) TestAddAndCommitWithSkipStatusPathNotModified() {
 	err := w.Checkout(&CheckoutOptions{})
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	status, err := w.Status()
 	s.NoError(err)
@@ -413,7 +413,8 @@ func (s *WorktreeSuite) TestAddAndCommitWithSkipStatusPathNotModified() {
 	s.Equal(Added, foo.Staging)
 	s.Equal(Unmodified, foo.Worktree)
 
-	hash, err := w.Commit("commit foo only\n", &CommitOptions{All: true,
+	hash, err := w.Commit("commit foo only\n", &CommitOptions{
+		All:    true,
 		Author: defaultSignature(),
 	})
 	s.Equal(expected, hash)
@@ -478,8 +479,8 @@ func (s *WorktreeSuite) TestCommitAll() {
 	err := w.Checkout(&CheckoutOptions{})
 	s.NoError(err)
 
-	util.WriteFile(fs, "LICENSE", []byte("foo"), 0644)
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "LICENSE", []byte("foo"), 0o644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	hash, err := w.Commit("foo\n", &CommitOptions{
 		All:    true,
@@ -504,7 +505,7 @@ func (s *WorktreeSuite) TestRemoveAndCommitAll() {
 	err := w.Checkout(&CheckoutOptions{})
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	_, err = w.Add("foo")
 	s.NoError(err)
 
@@ -538,7 +539,7 @@ func (s *WorktreeSuite) TestCommitSign() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	_, err = w.Add("foo")
 	s.NoError(err)
@@ -574,7 +575,7 @@ func (s *WorktreeSuite) TestCommitSignBadKey() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	_, err = w.Add("foo")
 	s.NoError(err)
@@ -585,7 +586,6 @@ func (s *WorktreeSuite) TestCommitSignBadKey() {
 }
 
 func (s *WorktreeSuite) TestCherryPick() {
-
 	fs := memfs.New()
 
 	r, err := Init(memory.NewStorage(), WithWorkTree(fs))
@@ -594,7 +594,7 @@ func (s *WorktreeSuite) TestCherryPick() {
 	w, err := r.Worktree()
 	s.NoError(err)
 	// add README.md to the worktree
-	err = util.WriteFile(fs, "README.md", []byte("README File"), 0644)
+	err = util.WriteFile(fs, "README.md", []byte("README File"), 0o644)
 	s.NoError(err)
 	w.Add("README.md")
 
@@ -602,10 +602,10 @@ func (s *WorktreeSuite) TestCherryPick() {
 	s.NoError(err)
 
 	// add two files to worktree
-	err = util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.NoError(err)
 
-	err = util.WriteFile(fs, "foobar", []byte("foo**bar"), 0644)
+	err = util.WriteFile(fs, "foobar", []byte("foo**bar"), 0o644)
 	s.NoError(err)
 
 	_, err = w.Add("foo")
@@ -618,7 +618,7 @@ func (s *WorktreeSuite) TestCherryPick() {
 	s.NoError(err)
 	s.False(commitHash1.IsZero(), "commit hash is zero")
 	// modify the "foo" file
-	err = util.WriteFile(fs, "foo", []byte("foo=bar"), 0644)
+	err = util.WriteFile(fs, "foo", []byte("foo=bar"), 0o644)
 	s.NoError(err)
 	_, err = w.Add("foo")
 	s.NoError(err)
@@ -696,6 +696,7 @@ func (s *WorktreeSuite) TestCherryPick() {
 	err = w.CherryPick(nil, OursMergeStrategy, rmCommit)
 	s.ErrorIs(err, ErrCannotCherryPickWithoutCommitOptions)
 }
+
 func (s *WorktreeSuite) TestCommitTreeSort() {
 	fs := s.TemporalFilesystem()
 
@@ -712,11 +713,11 @@ func (s *WorktreeSuite) TestCommitTreeSort() {
 
 	mfs := w.Filesystem
 
-	err = mfs.MkdirAll("delta", 0755)
+	err = mfs.MkdirAll("delta", 0o755)
 	s.NoError(err)
 
 	for _, p := range []string{"delta_last", "Gamma", "delta/middle", "Beta", "delta-first", "alpha"} {
-		util.WriteFile(mfs, p, []byte("foo"), 0644)
+		util.WriteFile(mfs, p, []byte("foo"), 0o644)
 		_, err = w.Add(p)
 		s.NoError(err)
 	}
@@ -757,7 +758,7 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 	s.NoError(err)
 
 	// Step 1: Write LICENSE
-	util.WriteFile(fs, "LICENSE", []byte("license"), 0644)
+	util.WriteFile(fs, "LICENSE", []byte("license"), 0o644)
 	hLicense, err := w.Add("LICENSE")
 	s.NoError(err)
 	s.Equal(plumbing.NewHash("0484eba0d41636ba71fa612c78559cd6c3006cde"), hLicense)
@@ -774,7 +775,7 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 
 	// Step 2: Write foo.
 	time.Sleep(5 * time.Millisecond) // uncool, but we need to get different timestamps...
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	hFoo, err := w.Add("foo")
 	s.NoError(err)
 	s.Equal(plumbing.NewHash("19102815663d23f8b75a47e7a01965dcdc96468c"), hFoo)
@@ -816,7 +817,7 @@ func (s *WorktreeSuite) TestCommitInvalidCharactersInAuthorInfos() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
 	_, err = w.Add("foo")
 	s.NoError(err)
@@ -836,7 +837,6 @@ func (s *WorktreeSuite) TestCommitInvalidCharactersInAuthorInfos() {
 
 	s.Equal("foo bad", commit.Author.Name)
 	s.Equal("badfoo@foo.foo", commit.Author.Email)
-
 }
 
 func assertStorageStatus(

--- a/worktree_js.go
+++ b/worktree_js.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+	fillSystemInfo = func(e *index.Entry, sys any) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
 			e.CreatedAt = time.Unix(int64(os.Ctime), int64(os.CtimeNsec))
 			e.Dev = uint32(os.Dev)
@@ -22,6 +22,6 @@ func init() {
 	}
 }
 
-func isSymlinkWindowsNonAdmin(err error) bool {
+func isSymlinkWindowsNonAdmin(error) bool {
 	return false
 }

--- a/worktree_linux.go
+++ b/worktree_linux.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+	fillSystemInfo = func(e *index.Entry, sys any) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
 			e.CreatedAt = time.Unix(os.Ctim.Unix())
 			e.Dev = uint32(os.Dev)
@@ -22,6 +22,6 @@ func init() {
 	}
 }
 
-func isSymlinkWindowsNonAdmin(_ error) bool {
+func isSymlinkWindowsNonAdmin(error) bool {
 	return false
 }

--- a/worktree_plan9.go
+++ b/worktree_plan9.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+	fillSystemInfo = func(e *index.Entry, sys any) {
 		if os, ok := sys.(*syscall.Dir); ok {
 			// Plan 9 doesn't have a CreatedAt field.
 			e.CreatedAt = time.Unix(int64(os.Mtime), 0)
@@ -26,6 +26,6 @@ func init() {
 	}
 }
 
-func isSymlinkWindowsNonAdmin(err error) bool {
+func isSymlinkWindowsNonAdmin(error) bool {
 	return true
 }

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-billy/v6/util"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/format/gitignore"
@@ -323,13 +324,13 @@ func (w *Worktree) doAddDirectory(idx *index.Index, s Status, directory string, 
 		var a bool
 		a, _, err = w.doAddFile(idx, s, name, ignorePattern)
 		if err != nil {
-			return
+			return added, err
 		}
 
 		added = added || a
 	}
 
-	return
+	return added, err
 }
 
 func isPathInDirectory(path, directory string) bool {
@@ -479,7 +480,7 @@ func (w *Worktree) doAddFile(idx *index.Index, s Status, path string, ignorePatt
 			h, err = w.deleteFromIndex(idx, path)
 		}
 
-		return
+		return added, h, err
 	}
 
 	if err := w.addOrUpdateFileToIndex(idx, path, h); err != nil {
@@ -647,7 +648,7 @@ func (w *Worktree) doRemoveDirectory(idx *index.Index, directory string) (remove
 		}
 
 		if err != nil {
-			return
+			return removed, err
 		}
 
 		if !removed && r {
@@ -656,7 +657,7 @@ func (w *Worktree) doRemoveDirectory(idx *index.Index, directory string) (remove
 	}
 
 	err = w.removeEmptyDirectory(directory)
-	return
+	return removed, err
 }
 
 func (w *Worktree) removeEmptyDirectory(path string) error {

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/osfs"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
-	"github.com/go-git/go-git/v6/plumbing/cache"
-	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
 // For additional context: #1159.

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -14,7 +14,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
@@ -24,15 +33,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-
-	"github.com/go-git/go-billy/v6"
-	"github.com/go-git/go-billy/v6/memfs"
-	"github.com/go-git/go-billy/v6/osfs"
-	"github.com/go-git/go-billy/v6/util"
-	"golang.org/x/text/unicode/norm"
 )
 
 func defaultTestCommitOptions() *CommitOptions {
@@ -1737,7 +1737,7 @@ func (s *WorktreeSuite) TestSubmodules_URLResolution() {
 			w, err := r.Worktree()
 			s.NoError(err)
 
-			err = util.WriteFile(fs, ".gitmodules", []byte(tc.gitmodules), 0644)
+			err = util.WriteFile(fs, ".gitmodules", []byte(tc.gitmodules), 0o644)
 			s.NoError(err)
 
 			submodules, err := w.Submodules()
@@ -3646,7 +3646,7 @@ func setupForRestore(s *WorktreeSuite) (fs billy.Filesystem, w *Worktree, names 
 		{Worktree: Unmodified, Staging: Deleted},
 	})
 
-	return
+	return fs, w, names
 }
 
 func verifyStatus(s *WorktreeSuite, marker string, w *Worktree, files []string, statuses []FileStatus) {

--- a/worktree_unix_other.go
+++ b/worktree_unix_other.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+	fillSystemInfo = func(e *index.Entry, sys any) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
 			e.CreatedAt = time.Unix(os.Atim.Unix())
 			e.Dev = uint32(os.Dev)
@@ -22,6 +22,6 @@ func init() {
 	}
 }
 
-func isSymlinkWindowsNonAdmin(err error) bool {
+func isSymlinkWindowsNonAdmin(error) bool {
 	return false
 }

--- a/worktree_wasi.go
+++ b/worktree_wasi.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+	fillSystemInfo = func(e *index.Entry, sys any) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
 			e.CreatedAt = time.Unix(int64(os.Ctime), 0)
 			e.Dev = uint32(os.Dev)
@@ -22,10 +22,10 @@ func init() {
 	}
 }
 
-func isSymlinkWindowsNonAdmin(_ error) bool {
+func isSymlinkWindowsNonAdmin(error) bool {
 	return false
 }
 
-func preReceiveHook(_ string) []byte {
+func preReceiveHook(string) []byte {
 	return []byte{}
 }

--- a/worktree_windows.go
+++ b/worktree_windows.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+	fillSystemInfo = func(e *index.Entry, sys any) {
 		if os, ok := sys.(*syscall.Win32FileAttributeData); ok {
 			seconds := os.CreationTime.Nanoseconds() / 1000000000
 			nanoseconds := os.CreationTime.Nanoseconds() - seconds*1000000000


### PR DESCRIPTION
fixes #1751

* not enabling goimports because gci covers same functionality.