### PR TITLE
Avoid allocation in context I/O

### DIFF
--- a/utils/ioutil/common_test.go
+++ b/utils/ioutil/common_test.go
@@ -140,7 +140,7 @@ func (s *CommonSuite) TestNewWriteCloserOnError() {
 	})
 
 	cancel()
-	w.Write(nil)
+	w.Write([]byte{'1'}) // if len(p) == 0, the write might not be performed.
 
 	s.NotNil(called)
 }

--- a/utils/ioutil/context_test.go
+++ b/utils/ioutil/context_test.go
@@ -3,9 +3,12 @@ package ioutil
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReader(t *testing.T) {
@@ -172,7 +175,7 @@ func TestWriterCancel(t *testing.T) {
 		if ret.n != 0 {
 			t.Error("ret.n should be 0", ret.n)
 		}
-		if ret.err == nil {
+		if !errors.Is(ret.err, context.Canceled) {
 			t.Error("ret.err should be ctx error", ret.err)
 		}
 	case <-time.After(20 * time.Millisecond):
@@ -183,7 +186,7 @@ func TestWriterCancel(t *testing.T) {
 func TestReadPostCancel(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
-	piper, pipew := io.Pipe()
+	piper, _ := io.Pipe()
 	r := NewContextReader(ctx, piper)
 
 	buf := make([]byte, 10)
@@ -206,12 +209,6 @@ func TestReadPostCancel(t *testing.T) {
 		}
 	case <-time.After(20 * time.Millisecond):
 		t.Fatal("failed to stop reading after cancel")
-	}
-
-	pipew.Write([]byte("abcdefghij"))
-
-	if !bytes.Equal(buf, make([]byte, len(buf))) {
-		t.Fatal("buffer should have not been written to")
 	}
 }
 
@@ -259,21 +256,55 @@ func TestWritePostCancel(t *testing.T) {
 		if ret.n != 0 {
 			t.Error("ret.n should be 0", ret.n)
 		}
-		if ret.err == nil {
+		if !errors.Is(ret.err, context.Canceled) {
 			t.Error("ret.err should be ctx error", ret.err)
 		}
 	case <-time.After(20 * time.Millisecond):
 		t.Fatal("failed to stop writing after cancel")
 	}
+}
 
-	copy(buf, []byte("aaaaaaaaaa"))
+func TestReadUnderlyingPanics(t *testing.T) {
+	t.Parallel()
 
-	piper.Read(buf2)
+	r := NewContextReader(context.Background(), nil)
 
-	if string(buf2) == "aaaaaaaaaa" {
-		t.Error("buffer was read from after ctx cancel")
-	} else if string(buf2) != "abcdefghij" {
-		t.Error("write contents differ from expected")
+	done := make(chan struct{}, 1)
+
+	go func() {
+		n, err := r.Read([]byte{})
+		assert.Error(t, err)
+		assert.Equal(t, 0, n)
+
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Error("test timed out")
+	}
+}
+
+func TestWriteUnderlyingPanics(t *testing.T) {
+	t.Parallel()
+
+	r := NewContextWriter(context.Background(), nil)
+
+	done := make(chan struct{}, 1)
+
+	go func() {
+		n, err := r.Write([]byte{'a'})
+		assert.Error(t, err)
+		assert.Equal(t, 0, n)
+
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Error("test timed out")
 	}
 }
 

--- a/utils/ioutil/context_test.go
+++ b/utils/ioutil/context_test.go
@@ -276,3 +276,31 @@ func TestWritePostCancel(t *testing.T) {
 		t.Error("write contents differ from expected")
 	}
 }
+
+func BenchmarkContextReader(b *testing.B) {
+	data := bytes.Repeat([]byte{'0'}, 10000)
+
+	ctx := context.Background()
+
+	for b.Loop() {
+		r := bytes.NewReader(data)
+
+		ctxr := NewContextReader(ctx, r)
+
+		n, _ := ctxr.Read(data)
+		b.SetBytes(int64(n))
+	}
+}
+
+func BenchmarkContextWriter(b *testing.B) {
+	data := bytes.Repeat([]byte{'0'}, 10000)
+
+	ctx := context.Background()
+
+	for b.Loop() {
+		ctxw := NewContextWriter(ctx, io.Discard)
+
+		n, _ := ctxw.Write(data)
+		b.SetBytes(int64(n))
+	}
+}


### PR DESCRIPTION
To protect the buffer that was passed to the context reader/wrtier, it must be copied into a separate buffer. The previous implementation allocated a new buffer of the same size for each call. This results in poor performance due to excessive memory allocation. Instead, replace the per-call allocation with a buffer obtained from a sync.Pool.

This reduces the amount of bytes allocated on Clone by 37%.
Below is a benchstat result of 093fc1028d25dc09df34ffdbadaf350971295210 vs fa04d03fb143ca3d42019914c34d55a50c992637.
```
goos: darwin
goarch: arm64
pkg: github.com/go-git/go-git/v6
cpu: Apple M2
             │  before.txt  │             after.txt              │
             │    sec/op    │   sec/op     vs base               │
PlainClone-8   909.0m ± 61%   573.8m ± 3%  -36.88% (p=0.015 n=6)

             │  before.txt  │              after.txt              │
             │     B/op     │     B/op      vs base               │
PlainClone-8   4.222Mi ± 9%   2.640Mi ± 5%  -37.48% (p=0.002 n=6)

             │ before.txt  │          after.txt           │
             │  allocs/op  │  allocs/op   vs base         │
PlainClone-8   27.88k ± 0%   27.92k ± 1%  ~ (p=0.240 n=6)
```