### PR TITLE
plumbing: object, Fix timezone comparison in encode/decode tests.

### DIFF
--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -228,8 +228,9 @@ change
 %s
 `, pgpsignature)
 
-	ts, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05-07:00")
+	ts, err := time.ParseInLocation(time.RFC3339, "2006-01-02T15:04:05-07:00", time.UTC)
 	s.NoError(err)
+
 	commits := []*Commit{
 		{
 			Author:       Signature{Name: "Foo", Email: "foo@example.local", When: ts},
@@ -280,7 +281,7 @@ change
 	}
 	for _, commit := range commits {
 		obj := &plumbing.MemoryObject{}
-		err = commit.Encode(obj)
+		err := commit.Encode(obj)
 		s.NoError(err)
 		newCommit := &Commit{}
 		err = newCommit.Decode(obj)

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -181,7 +181,7 @@ func (s *TagSuite) TestTagDecodeWrongType() {
 }
 
 func (s *TagSuite) TestTagEncodeDecodeIdempotent() {
-	ts, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05-07:00")
+	ts, err := time.ParseInLocation(time.RFC3339, "2006-01-02T15:04:05-07:00", time.UTC)
 	s.NoError(err)
 	tags := []*Tag{
 		{
@@ -200,7 +200,7 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent() {
 	}
 	for _, tag := range tags {
 		obj := &plumbing.MemoryObject{}
-		err = tag.Encode(obj)
+		err := tag.Encode(obj)
 		s.NoError(err)
 		newTag := &Tag{}
 		err = newTag.Decode(obj)


### PR DESCRIPTION
Fixes #1755

time.Parse attaches a rich *time.Location from the system timezone database (with DST rules, named zones, transition tables), while Signature.Decode uses time.FixedZone which creates a minimal fixed-offset zone.

Use time.Unix with time.FixedZone to construct test timestamps that match exactly what the decode function produces, ensuring encode/decode idempotency tests compare equivalent timezone representations.