### PR TITLE
*: prevent panic

### DIFF
--- a/options.go
+++ b/options.go
@@ -33,6 +33,8 @@ const (
 
 var ErrMissingURL = errors.New("URL field is required")
 
+var ErrNilOptions = errors.New("nil options")
+
 // CloneOptions describes how a clone should be performed.
 type CloneOptions struct {
 	// The (possibly remote) repository URL to clone from.
@@ -127,6 +129,10 @@ const (
 
 // Validate validates the fields and sets the default values.
 func (o *CloneOptions) Validate() error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if o.URL == "" {
 		return ErrMissingURL
 	}
@@ -180,6 +186,10 @@ type PullOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *PullOptions) Validate() error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if o.RemoteName == "" {
 		o.RemoteName = DefaultRemoteName
 	}
@@ -242,6 +252,10 @@ type FetchOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *FetchOptions) Validate() error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if o.RemoteName == "" {
 		o.RemoteName = DefaultRemoteName
 	}
@@ -323,6 +337,10 @@ type ForceWithLease struct {
 
 // Validate validates the fields and sets the default values.
 func (o *PushOptions) Validate() error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if o.RemoteName == "" {
 		o.RemoteName = DefaultRemoteName
 	}
@@ -389,6 +407,10 @@ type CheckoutOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *CheckoutOptions) Validate() error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if !o.Create && !o.Hash.IsZero() && o.Branch != "" {
 		return ErrBranchHashExclusive
 	}
@@ -451,6 +473,10 @@ type ResetOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *ResetOptions) Validate(r *Repository) error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if o.Commit == plumbing.ZeroHash {
 		ref, err := r.Head()
 		if err != nil {
@@ -544,6 +570,10 @@ type AddOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *AddOptions) Validate(r *Repository) error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if o.Path != "" && o.Glob != "" {
 		return fmt.Errorf("fields Path and Glob are mutual exclusive")
 	}
@@ -584,6 +614,10 @@ type CommitOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *CommitOptions) Validate(r *Repository) error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if o.All && o.Amend {
 		return errors.New("all and amend cannot be used together")
 	}
@@ -675,6 +709,10 @@ type CreateTagOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *CreateTagOptions) Validate(r *Repository, hash plumbing.Hash) error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if o.Tagger == nil {
 		if err := o.loadConfigTagger(r); err != nil {
 			return err
@@ -778,10 +816,18 @@ var ErrHashOrReference = errors.New("ambiguous options, only one of CommitHash o
 //
 // TODO: deprecate in favor of Validate(r *Repository) in v6.
 func (o *GrepOptions) Validate(w *Worktree) error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	return o.validate(w.r)
 }
 
 func (o *GrepOptions) validate(r *Repository) error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if !o.CommitHash.IsZero() && o.ReferenceName != "" {
 		return ErrHashOrReference
 	}
@@ -811,7 +857,13 @@ type PlainOpenOptions struct {
 }
 
 // Validate validates the fields and sets the default values.
-func (o *PlainOpenOptions) Validate() error { return nil }
+func (o *PlainOpenOptions) Validate() error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
+	return nil
+}
 
 var ErrNoRestorePaths = errors.New("you must specify path(s) to restore")
 
@@ -827,6 +879,10 @@ type RestoreOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *RestoreOptions) Validate() error {
+	if o == nil {
+		return ErrNilOptions
+	}
+
 	if len(o.Files) == 0 {
 		return ErrNoRestorePaths
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/suite"
 
@@ -121,4 +122,55 @@ func (s *OptionsSuite) writeGlobalConfig(cfg *config.Config) func() {
 	return func() {
 		os.Setenv("XDG_CONFIG_HOME", "")
 	}
+}
+
+func (s *OptionsSuite) TestGrepOptionsNil() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	g := (*GrepOptions)(nil)
+	s.Error(g.Validate(w))
+}
+
+func (s *OptionsSuite) TestPullOptionsNil() {
+	p := (*PullOptions)(nil)
+	s.Error(p.Validate())
+}
+
+func (s *OptionsSuite) TestFetchOptionsNil() {
+	f := (*FetchOptions)(nil)
+	s.Error(f.Validate())
+}
+
+func (s *OptionsSuite) TestCreateTagOptionsNil() {
+	c := (*CreateTagOptions)(nil)
+	s.Error(c.Validate(s.Repository, plumbing.ZeroHash))
+}
+
+func (s *OptionsSuite) TestPlainOpenOptionsNil() {
+	p := (*PlainOpenOptions)(nil)
+	s.Error(p.Validate())
+}
+
+func (s *OptionsSuite) TestCheckOptionsNil() {
+	c := (*CheckoutOptions)(nil)
+	s.Error(c.Validate())
+}
+
+func (s *OptionsSuite) TestResetoptionsNil() {
+	r := (*ResetOptions)(nil)
+	s.Error(r.Validate(s.Repository))
+}
+
+func (s *OptionsSuite) TestRestoreOptionsNil() {
+	r := (*RestoreOptions)(nil)
+	s.Error(r.Validate())
+}
+
+func (s *OptionsSuite) TestPushOptionsNil() {
+	p := (*PushOptions)(nil)
+	s.Error(p.Validate())
 }

--- a/remote.go
+++ b/remote.go
@@ -1205,6 +1205,10 @@ func (r *Remote) ListContext(ctx context.Context, o *ListOptions) (rfs []*plumbi
 }
 
 func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {
+	if o == nil {
+		o = &ListOptions{}
+	}
+
 	timeout := o.Timeout
 	// Default to the old hardcoded 10s value if a timeout is not explicitly set.
 	if timeout == 0 {
@@ -1219,6 +1223,10 @@ func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {
 }
 
 func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Reference, err error) {
+	if o == nil {
+		o = &ListOptions{}
+	}
+
 	if r.c == nil || len(r.c.URLs) == 0 {
 		return nil, ErrEmptyUrls
 	}

--- a/remote_test.go
+++ b/remote_test.go
@@ -372,7 +372,7 @@ func (s *RemoteSuite) TestFetchOfMissingObjects() {
 	s.Require().ErrorIs(err, plumbing.ErrObjectNotFound)
 
 	// Refetch to get all the missing objects
-	err = r.Fetch(&FetchOptions{})
+	err = r.Fetch(nil)
 	s.NoError(err)
 
 	// Confirm we now have the commit
@@ -1351,7 +1351,7 @@ func (s *RemoteSuite) TestList() {
 		URLs: []string{repo.URL},
 	})
 
-	refs, err := remote.List(&ListOptions{})
+	refs, err := remote.List(nil)
 	s.NoError(err)
 
 	expected := []*plumbing.Reference{
@@ -1426,7 +1426,7 @@ func (s *RemoteSuite) TestListTimeout() {
 		URLs: []string{srv.URL},
 	})
 
-	_, err := remote.ListContext(ctx, &ListOptions{})
+	_, err := remote.ListContext(ctx, nil)
 	s.ErrorIs(err, context.DeadlineExceeded)
 }
 

--- a/repository.go
+++ b/repository.go
@@ -342,6 +342,10 @@ func PlainOpen(path string) (*Repository, error) {
 // PlainOpenWithOptions opens a git repository from the given path with specific
 // options. See PlainOpen for more info.
 func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error) {
+	if err := o.Validate(); err != nil {
+		return nil, err
+	}
+
 	dot, wt, err := dotGitToOSFilesystems(path, o.DetectDotGit)
 	if err != nil {
 		return nil, err
@@ -1221,6 +1225,10 @@ func (r *Repository) Fetch(o *FetchOptions) error {
 // operation is complete, an error is returned. The context only affects the
 // transport operations.
 func (r *Repository) FetchContext(ctx context.Context, o *FetchOptions) error {
+	if o == nil {
+		o = &FetchOptions{}
+	}
+
 	if err := o.Validate(); err != nil {
 		return err
 	}
@@ -1262,6 +1270,10 @@ func (r *Repository) PushContext(ctx context.Context, o *PushOptions) error {
 
 // Log returns the commit history from the given LogOptions.
 func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
+	if o == nil {
+		o = &LogOptions{}
+	}
+
 	fn := commitIterFunc(o.Order)
 	if fn == nil {
 		return nil, fmt.Errorf("invalid Order=%v", o.Order)

--- a/repository_test.go
+++ b/repository_test.go
@@ -308,6 +308,11 @@ func (s *RepositorySuite) TestClone() {
 	s.Len(remotes, 1)
 }
 
+func (s *RepositorySuite) TestCloneNilOptions() {
+	_, err := Clone(memory.NewStorage(), nil, nil)
+	s.Error(err)
+}
+
 func (s *RepositorySuite) TestCloneContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -1202,7 +1207,7 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules() {
 	subRepo, err := submodule.Repository()
 	s.Require().NoError(err)
 
-	lr, err := subRepo.Log(&LogOptions{})
+	lr, err := subRepo.Log(nil)
 	s.Require().NoError(err)
 
 	commitCount := 0
@@ -1239,7 +1244,7 @@ func (s *RepositorySuite) TestFetch() {
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 	s.NoError(err)
-	s.Nil(r.Fetch(&FetchOptions{}))
+	s.Nil(r.Fetch(nil))
 
 	remotes, err := r.Remotes()
 	s.NoError(err)
@@ -1266,7 +1271,7 @@ func (s *RepositorySuite) TestFetchContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	s.NotNil(r.FetchContext(ctx, &FetchOptions{}))
+	s.NotNil(r.FetchContext(ctx, nil))
 }
 
 func (s *RepositorySuite) TestFetchWithFilters() {
@@ -1973,7 +1978,7 @@ func (s *RepositorySuite) TestLogHead() {
 
 	s.NoError(err)
 
-	cIter, err := r.Log(&LogOptions{})
+	cIter, err := r.Log(nil)
 
 	s.NoError(err)
 

--- a/submodule.go
+++ b/submodule.go
@@ -181,6 +181,10 @@ func (s *Submodule) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions
 }
 
 func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, forceHash plumbing.Hash) error {
+	if o == nil {
+		o = &SubmoduleUpdateOptions{}
+	}
+
 	if !s.initialized && !o.Init {
 		return ErrSubmoduleNotInitialized
 	}

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -93,7 +93,7 @@ func (s *SubmoduleSuite) TestUpdateWithoutInit() {
 	sm, err := s.Worktree.Submodule("basic")
 	s.Require().NoError(err)
 
-	err = sm.Update(&SubmoduleUpdateOptions{})
+	err = sm.Update(nil)
 	s.ErrorIs(err, ErrSubmoduleNotInitialized)
 }
 
@@ -157,7 +157,7 @@ func (s *SubmoduleSuite) TestUpdateWithInitAndUpdate() {
 	err = s.Repository.Storer.SetIndex(idx)
 	s.Require().NoError(err)
 
-	err = sm.Update(&SubmoduleUpdateOptions{})
+	err = sm.Update(nil)
 	s.Require().NoError(err)
 
 	r, err := sm.Repository()
@@ -239,7 +239,7 @@ func (s *SubmoduleSuite) TestSubmodulesFetchDepth() {
 	r, err := sm.Repository()
 	s.Require().NoError(err)
 
-	lr, err := r.Log(&LogOptions{})
+	lr, err := r.Log(nil)
 	s.Require().NoError(err)
 
 	commitCount := 0

--- a/worktree.go
+++ b/worktree.go
@@ -72,6 +72,10 @@ func (w *Worktree) Pull(o *PullOptions) error {
 // operation is complete, an error is returned. The context only affects the
 // transport operations.
 func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
+	if o == nil {
+		o = &PullOptions{}
+	}
+
 	if err := o.Validate(); err != nil {
 		return err
 	}
@@ -170,6 +174,10 @@ func (w *Worktree) updateSubmodules(ctx context.Context, o *SubmoduleUpdateOptio
 
 // Checkout switch branches or restore working tree files.
 func (w *Worktree) Checkout(opts *CheckoutOptions) error {
+	if opts == nil {
+		opts = &CheckoutOptions{}
+	}
+
 	if err := opts.Validate(); err != nil {
 		return err
 	}
@@ -1041,6 +1049,10 @@ func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
 // Clean the worktree by removing untracked files.
 // An empty dir could be removed - this is what  `git clean -f -d .` does.
 func (w *Worktree) Clean(opts *CleanOptions) error {
+	if opts == nil {
+		opts = &CleanOptions{}
+	}
+
 	s, err := w.Status()
 	if err != nil {
 		return err

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -151,7 +151,7 @@ func (s *WorktreeSuite) TestCommitParent() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
@@ -174,7 +174,7 @@ func (s *WorktreeSuite) TestCommitAmendWithoutChanges() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
@@ -209,7 +209,7 @@ func (s *WorktreeSuite) TestCommitAmendWithChanges() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
@@ -260,7 +260,7 @@ func (s *WorktreeSuite) TestCommitAmendNothingToCommit() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
@@ -337,7 +337,7 @@ func TestAddAndCommitWithSkipStatus(t *testing.T) {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	require.NoError(t, err)
 
 	util.WriteFile(fs, "LICENSE", []byte("foo"), 0o644)
@@ -389,7 +389,7 @@ func (s *WorktreeSuite) TestAddAndCommitWithSkipStatusPathNotModified() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
@@ -475,7 +475,7 @@ func (s *WorktreeSuite) TestCommitAll() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	util.WriteFile(fs, "LICENSE", []byte("foo"), 0o644)
@@ -501,7 +501,7 @@ func (s *WorktreeSuite) TestRemoveAndCommitAll() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
@@ -827,7 +827,7 @@ func (s *WorktreeSuite) TestCommitInvalidCharactersInAuthorInfos() {
 	assertStorageStatus(s, r, 1, 1, 1, expected)
 
 	// Check HEAD commit contains author informations with '<', '>' and '\n' stripped
-	lr, err := r.Log(&LogOptions{})
+	lr, err := r.Log(nil)
 	s.NoError(err)
 
 	commit, err := lr.Next()

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -66,7 +66,7 @@ func (s *WorktreeSuite) TestPullCheckout() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(nil)
 	s.NoError(err)
 
 	fi, err := fs.ReadDir("")
@@ -93,7 +93,7 @@ func (s *WorktreeSuite) TestPullFastForward() {
 	w, err = r.Worktree()
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(nil)
 	s.NoError(err)
 
 	head, err := r.Head()
@@ -124,7 +124,7 @@ func (s *WorktreeSuite) TestPullNonFastForward() {
 	_, err = w.Commit("bar", &CommitOptions{Author: defaultSignature()})
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(nil)
 	s.ErrorIs(err, ErrNonFastForwardUpdate)
 }
 
@@ -135,7 +135,7 @@ func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded() {
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	err := r.Fetch(&FetchOptions{})
+	err := r.Fetch(nil)
 	s.NoError(err)
 
 	_, err = r.Reference("refs/heads/master", false)
@@ -144,7 +144,7 @@ func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(nil)
 	s.NoError(err)
 
 	head, err := r.Reference(plumbing.HEAD, true)
@@ -155,7 +155,7 @@ func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded() {
 	s.NoError(err)
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branch.Hash().String())
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(nil)
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
 }
 
@@ -171,7 +171,7 @@ func (s *WorktreeSuite) TestPullInSingleBranch() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(nil)
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
 
 	branch, err := r.Reference("refs/heads/master", false)
@@ -286,7 +286,7 @@ func (s *WorktreeSuite) TestPullAlreadyUptodate() {
 	_, err = w.Commit("bar", &CommitOptions{Author: defaultSignature()})
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(nil)
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
 }
 
@@ -304,7 +304,7 @@ func (s *WorktreeSuite) TestPullDepth() {
 
 	w, err := r.Worktree()
 	s.NoError(err)
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(nil)
 	s.NoError(err)
 }
 
@@ -377,7 +377,7 @@ func (s *WorktreeSuite) TestCheckoutForce() {
 		Filesystem: memfs.New(),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	w.Filesystem = memfs.New()
@@ -452,7 +452,7 @@ func (s *WorktreeSuite) TestCheckoutSymlink() {
 	r.Storer.SetIndex(&index.Index{Version: 2})
 	w.Filesystem = osfs.New(filepath.Join(dir, "worktree-empty"))
 
-	err = w.Checkout(&CheckoutOptions{})
+	err = w.Checkout(nil)
 	s.NoError(err)
 
 	status, err := w.Status()
@@ -508,7 +508,7 @@ func (s *WorktreeSuite) TestCheckoutCRLF() {
 		wt, err := r.Worktree()
 		require.NoError(t, err)
 
-		require.NoError(t, wt.Checkout(&CheckoutOptions{}))
+		require.NoError(t, wt.Checkout(nil))
 
 		status, err := wt.Status()
 		require.NoError(t, err)
@@ -613,7 +613,7 @@ func (s *WorktreeSuite) TestCheckoutSubmodule() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	err = w.Checkout(&CheckoutOptions{})
+	err = w.Checkout(nil)
 	s.NoError(err)
 
 	status, err := w.Status()
@@ -703,7 +703,7 @@ func (s *WorktreeSuite) TestCheckoutIndexMem() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	idx, err := s.Repository.Storer.Index()
@@ -731,7 +731,7 @@ func (s *WorktreeSuite) TestCheckoutIndexOS() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	idx, err := s.Repository.Storer.Index()
@@ -907,7 +907,7 @@ func (s *WorktreeSuite) TestCheckoutTag() {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	err = w.Checkout(&CheckoutOptions{})
+	err = w.Checkout(nil)
 	s.NoError(err)
 	head, err := w.r.Head()
 	s.NoError(err)
@@ -994,7 +994,7 @@ func (s *WorktreeSuite) testCheckoutBisect(url string) {
 	w, err := r.Worktree()
 	s.NoError(err)
 
-	iter, err := w.r.Log(&LogOptions{})
+	iter, err := w.r.Log(nil)
 	s.NoError(err)
 
 	iter.ForEach(func(commit *object.Commit) error {
@@ -1140,7 +1140,7 @@ func (s *WorktreeSuite) TestReset() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	branch, err := w.r.Reference(plumbing.Master, false)
@@ -1168,7 +1168,7 @@ func (s *WorktreeSuite) TestResetWithUntracked() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = util.WriteFile(fs, "foo", nil, 0o755)
@@ -1200,7 +1200,7 @@ func (s *WorktreeSuite) TestResetSoft() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = w.Reset(&ResetOptions{Mode: SoftReset, Commit: commit})
@@ -1225,7 +1225,7 @@ func (s *WorktreeSuite) TestResetMixed() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = w.Reset(&ResetOptions{Mode: MixedReset, Commit: commit})
@@ -1251,7 +1251,7 @@ func (s *WorktreeSuite) TestResetMerge() {
 	commitA := plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294")
 	commitB := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = w.Reset(&ResetOptions{Mode: MergeReset, Commit: commitA})
@@ -1285,7 +1285,7 @@ func (s *WorktreeSuite) TestResetHard() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	f, err := fs.Create(".gitignore")
@@ -1310,7 +1310,7 @@ func (s *WorktreeSuite) TestResetHardSubFolders() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = fs.MkdirAll("dir", os.ModePerm)
@@ -1348,7 +1348,7 @@ func (s *WorktreeSuite) TestResetHardWithGitIgnore() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	tf, err := fs.Create("newTestFile.txt")
@@ -1490,7 +1490,7 @@ func (s *WorktreeSuite) TestStatusModified() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	f, err := fs.Create(".gitignore")
@@ -1513,7 +1513,7 @@ func (s *WorktreeSuite) TestStatusIgnored() {
 		Filesystem: fs,
 	}
 
-	w.Checkout(&CheckoutOptions{})
+	w.Checkout(nil)
 
 	fs.MkdirAll("another", os.ModePerm)
 	f, _ := fs.Create("another/file")
@@ -1581,7 +1581,7 @@ func (s *WorktreeSuite) TestStatusDeleted() {
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	err = fs.Remove(".gitignore")
@@ -2863,7 +2863,7 @@ func (s *WorktreeSuite) TestClean() {
 	s.NoError(err)
 	s.Len(status, 2)
 
-	err = wt.Clean(&CleanOptions{})
+	err = wt.Clean(nil)
 	s.NoError(err)
 
 	// Status after cleaning.
@@ -3314,7 +3314,7 @@ func (s *WorktreeSuite) TestAddAndCommit() {
 	}})
 	s.NoError(err)
 
-	iter, err := w.r.Log(&LogOptions{})
+	iter, err := w.r.Log(nil)
 	s.NoError(err)
 
 	filesFound := 0
@@ -3567,7 +3567,7 @@ func setupForRestore(s *WorktreeSuite) (fs billy.Filesystem, w *Worktree, names 
 		Filesystem: fs,
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(nil)
 	s.NoError(err)
 
 	names = []string{"foo", "CHANGELOG", "LICENSE", "binary.jpg"}
@@ -3717,4 +3717,62 @@ func (s *WorktreeSuite) TestRestoreBoth() {
 		{Worktree: Untracked, Staging: Untracked},
 		{Worktree: Untracked, Staging: Untracked},
 	})
+}
+
+func (s *WorktreeSuite) TestWorktreeCommitNilOptions() {
+	dir := s.T().TempDir()
+
+	repo, err := PlainInit(dir, false)
+	s.NoError(err)
+
+	w, err := repo.Worktree()
+	s.NoError(err)
+
+	_, err = w.Add(".")
+	s.NoError(err)
+
+	_, err = w.Commit("Test Add And Commit With Nil Options", nil)
+	s.Error(err)
+}
+
+func (s *WorktreeSuite) TestAddNilOptions() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	err := w.Checkout(&CheckoutOptions{Force: true})
+	s.NoError(err)
+
+	idx, err := w.r.Storer.Index()
+	s.NoError(err)
+	s.Len(idx.Entries, 9)
+
+	err = util.WriteFile(w.Filesystem, "file", []byte("file"), 0o644)
+	s.NoError(err)
+
+	err = w.AddWithOptions(nil)
+	s.Error(err)
+}
+
+func (s *WorktreeSuite) TestWorktreeGrepNilOptions() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	_, err := w.Grep(nil)
+	s.Error(err)
+}
+
+func (s *WorktreeSuite) TestRepositoryGrepNilOptions() {
+	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
+
+	r, err := Clone(memory.NewStorage(), nil, &CloneOptions{URL: url, Bare: true})
+	s.Require().NoError(err)
+
+	_, err = r.Grep(nil)
+	s.Error(err)
 }


### PR DESCRIPTION
Prevent panics if *Options are nil by adding checks in validators. Set default values where appropriate.

Fixes #1051

Hopefully I interpreted the discussion in #1051 properly and this is what is expected here. Please let me know if not.