### PR TITLE
*: enable govet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -3,6 +3,7 @@ linters:
   default: none
   enable:
     - dupl
+    - govet
     - ineffassign
     - misspell
     - modernize
@@ -10,6 +11,13 @@ linters:
     - staticcheck
     - unused
     - whitespace
+  settings:
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment # An optimization check, not something we strictly need enabled.
+        - shadow # Produces a large number of findings and would require quite a bit of cleanup.
+        - unsafeptr # TODO: Requires Windows environment to fix.
 
 formatters:
   enable:

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -58,7 +58,7 @@ func TestParserHashes(t *testing.T) {
 			parser := packfile.NewParser(f.Packfile(), packfile.WithScannerObservers(obs),
 				packfile.WithStorage(tc.storage), tc.option)
 
-			field := reflect.ValueOf(*parser).FieldByName("lowMemoryMode")
+			field := reflect.ValueOf(parser).Elem().FieldByName("lowMemoryMode")
 			got := field.Bool()
 			assert.Equal(t, tc.wantLowMemoryMode, got)
 

--- a/plumbing/object/rename_test.go
+++ b/plumbing/object/rename_test.go
@@ -69,7 +69,7 @@ func (s *RenameSuite) TestExactRename_DifferentObjects() {
 func (s *RenameSuite) TestExactRename_OneRenameOneModify() {
 	c1 := makeAdd(s, makeFile(s, pathA, filemode.Regular, "foo"))
 	c2 := makeDelete(s, makeFile(s, pathQ, filemode.Regular, "foo"))
-	c3 := makeChange(s,
+	c3 := makeChange(
 		makeFile(s, pathH, filemode.Regular, "bar"),
 		makeFile(s, pathH, filemode.Regular, "bar"),
 	)
@@ -504,24 +504,20 @@ func makeChangeEntry(f *File) ChangeEntry {
 }
 
 func makeAdd(s *RenameSuite, f *File) *Change {
-	return makeChange(s, nil, f)
+	return makeChange(nil, f)
 }
 
 func makeDelete(s *RenameSuite, f *File) *Change {
-	return makeChange(s, f, nil)
+	return makeChange(f, nil)
 }
 
-func makeChange(s *RenameSuite, from, to *File) *Change {
+func makeChange(from, to *File) *Change {
 	if from == nil {
 		return &Change{To: makeChangeEntry(to)}
 	}
 
 	if to == nil {
 		return &Change{From: makeChangeEntry(from)}
-	}
-
-	if from == nil && to == nil {
-		s.Fail("cannot make change without from or to")
 	}
 
 	return &Change{From: makeChangeEntry(from), To: makeChangeEntry(to)}

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -1628,9 +1628,6 @@ func (s *TreeSuite) TestTreeDecodeReadBug() {
 				Hash: plumbing.NewHash("e614f4a6d864e7ec4328dbdb254e3ac9f0d287"),
 			},
 		},
-		Hash: plumbing.ZeroHash,
-		s:    (storer.EncodedObjectStorer)(nil),
-		m:    map[string]*TreeEntry(nil),
 	}
 
 	var obtained Tree

--- a/plumbing/protocol/packp/shallowupd.go
+++ b/plumbing/protocol/packp/shallowupd.go
@@ -48,11 +48,11 @@ func (r *ShallowUpdate) Decode(reader io.Reader) error {
 		}
 	}
 
-	if err != nil && err != io.EOF {
-		return err
+	if err == io.EOF {
+		return nil
 	}
 
-	return nil
+	return err
 }
 
 func (r *ShallowUpdate) decodeShallowLine(line []byte) error {

--- a/plumbing/transport/ssh/sshagent/pageant_windows.go
+++ b/plumbing/transport/ssh/sshagent/pageant_windows.go
@@ -21,7 +21,6 @@
 // MIT LICENSE: https://github.com/davidmz/go-pageant/blob/master/LICENSE.txt
 
 //go:build windows
-// +build windows
 
 package sshagent
 

--- a/plumbing/transport/ssh/sshagent/sshagent.go
+++ b/plumbing/transport/ssh/sshagent/sshagent.go
@@ -17,7 +17,6 @@
 // Originally from: https://github.com/xanzy/ssh-agent/blob/main/sshagent.go
 
 //go:build !windows
-// +build !windows
 
 package sshagent
 

--- a/plumbing/transport/ssh/sshagent/sshagent_windows.go
+++ b/plumbing/transport/ssh/sshagent/sshagent_windows.go
@@ -21,7 +21,6 @@
 // MIT LICENSE: https://github.com/davidmz/go-pageant/blob/master/LICENSE.txt
 
 //go:build windows
-// +build windows
 
 package sshagent
 

--- a/repository_plan9_test.go
+++ b/repository_plan9_test.go
@@ -1,5 +1,4 @@
 //go:build plan9 && !unix && !windows
-// +build plan9,!unix,!windows
 
 package git
 

--- a/repository_unix_test.go
+++ b/repository_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && unix && !windows
-// +build !plan9,unix,!windows
 
 package git
 

--- a/repository_wasi_test.go
+++ b/repository_wasi_test.go
@@ -1,5 +1,4 @@
 //go:build wasip1
-// +build wasip1
 
 package git
 

--- a/repository_windows_test.go
+++ b/repository_windows_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !unix && windows
-// +build !plan9,!unix,windows
 
 package git
 

--- a/worktree_bsd.go
+++ b/worktree_bsd.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd || netbsd
-// +build darwin freebsd netbsd
 
 package git
 

--- a/worktree_js.go
+++ b/worktree_js.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 package git
 

--- a/worktree_linux.go
+++ b/worktree_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package git
 

--- a/worktree_unix_other.go
+++ b/worktree_unix_other.go
@@ -1,5 +1,4 @@
 //go:build openbsd || dragonfly || solaris
-// +build openbsd dragonfly solaris
 
 package git
 

--- a/worktree_wasi.go
+++ b/worktree_wasi.go
@@ -1,5 +1,4 @@
 //go:build wasip1
-// +build wasip1
 
 package git
 

--- a/worktree_windows.go
+++ b/worktree_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package git
 


### PR DESCRIPTION
This PR fixes the [`govet`](https://golangci-lint.run/docs/linters/configuration/#govet) lint issues except `fieldalignment`, `shadow`, and `unsafeptr`.

Related to #1753.

```console
$ golangci-lint run
plumbing/format/packfile/parser_test.go:61:29: copylocks: call of reflect.ValueOf copies lock value: github.com/go-git/go-git/v6/plumbing/format/packfile.Parser contains sync.Mutex (govet)
			field := reflect.ValueOf(*parser).FieldByName("lowMemoryMode")
			                         ^
plumbing/object/rename_test.go:523:10: nilness: impossible condition: non-nil == nil (govet)
	if from == nil && to == nil {
	        ^
plumbing/object/tree_test.go:1631:7: unusedwrite: unused write to field Hash (govet)
		Hash: plumbing.ZeroHash,
		    ^
plumbing/object/tree_test.go:1632:4: unusedwrite: unused write to field s (govet)
		s:    (storer.EncodedObjectStorer)(nil),
		 ^
plumbing/object/tree_test.go:1633:4: unusedwrite: unused write to field m (govet)
		m:    map[string]*TreeEntry(nil),
		 ^
plumbing/protocol/packp/shallowupd.go:51:9: nilness: tautological condition: non-nil != nil (govet)
	if err != nil && err != io.EOF {
	       ^
plumbing/transport/ssh/sshagent/pageant_windows.go:24:1: buildtag: +build line is no longer needed (govet)
// +build windows
^
plumbing/transport/ssh/sshagent/sshagent.go:20:1: buildtag: +build line is no longer needed (govet)
// +build !windows
^
plumbing/transport/ssh/sshagent/sshagent_windows.go:24:1: buildtag: +build line is no longer needed (govet)
// +build windows
^
repository_plan9_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build plan9,!unix,!windows
^
repository_unix_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build !plan9,unix,!windows
^
repository_wasi_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build wasip1
^
repository_windows_test.go:2:1: buildtag: +build line is no longer needed (govet)
// +build !plan9,!unix,windows
^
worktree_bsd.go:2:1: buildtag: +build line is no longer needed (govet)
// +build darwin freebsd netbsd
^
worktree_js.go:2:1: buildtag: +build line is no longer needed (govet)
// +build js
^
worktree_linux.go:2:1: buildtag: +build line is no longer needed (govet)
// +build linux
^
worktree_unix_other.go:2:1: buildtag: +build line is no longer needed (govet)
// +build openbsd dragonfly solaris
^
worktree_wasi.go:2:1: buildtag: +build line is no longer needed (govet)
// +build wasip1
^
worktree_windows.go:2:1: buildtag: +build line is no longer needed (govet)
// +build windows
^
19 issues:
* govet: 19
```