### PR TITLE
git: prevent panic when tree entry has zero hash

### DIFF
--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -355,7 +355,7 @@ func (se sortableEntries) Swap(i, j int)      { se[i], se[j] = se[j], se[i] }
 func (h *buildTreeHelper) copyTreeToStorageRecursive(parent string, t *object.Tree) (plumbing.Hash, error) {
 	sort.Sort(sortableEntries(t.Entries))
 	for i, e := range t.Entries {
-		if e.Mode != filemode.Dir && !e.Hash.IsZero() {
+		if e.Mode != filemode.Dir {
 			continue
 		}
 


### PR DESCRIPTION
Files with zero hashes incorrectly passed
the skip condition, causing recursion
into wrong branch which doesn't exist for files.
Simplify to only recurse for directories.

fixes #1773