### PR TITLE
transport: fix opening relative paths

### DIFF
--- a/plumbing/transport/loader.go
+++ b/plumbing/transport/loader.go
@@ -13,7 +13,7 @@ import (
 )
 
 // DefaultLoader is a filesystem loader ignoring host and resolving paths to /.
-var DefaultLoader = NewFilesystemLoader(osfs.New(""), false)
+var DefaultLoader = NewFilesystemLoader(osfs.New("", osfs.WithBoundOS()), false)
 
 // Loader loads repository's storer.Storer based on an optional host and a path.
 type Loader interface {

--- a/plumbing/transport/transport.go
+++ b/plumbing/transport/transport.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -169,7 +170,17 @@ func parseFile(endpoint string) (*Endpoint, bool) {
 		return nil, false
 	}
 
+	relative := ".." + string(filepath.Separator)
+
 	path := endpoint
+	if strings.HasPrefix(endpoint, relative) {
+		var err error
+		path, err = filepath.Abs(endpoint)
+		if err != nil {
+			return nil, false
+		}
+	}
+
 	return &Endpoint{
 		URL: url.URL{
 			Scheme: "file",

--- a/plumbing/transport/transport.go
+++ b/plumbing/transport/transport.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -170,17 +169,7 @@ func parseFile(endpoint string) (*Endpoint, bool) {
 		return nil, false
 	}
 
-	relative := ".." + string(filepath.Separator)
-
 	path := endpoint
-	if strings.HasPrefix(endpoint, relative) {
-		var err error
-		path, err = filepath.Abs(endpoint)
-		if err != nil {
-			return nil, false
-		}
-	}
-
 	return &Endpoint{
 		URL: url.URL{
 			Scheme: "file",

--- a/repository_test.go
+++ b/repository_test.go
@@ -1661,7 +1661,8 @@ func (s *RepositorySuite) TestCloneWithFilter() {
 // opened.
 func (s *RepositorySuite) TestCloneRelative() {
 	fs := memfs.New()
-	r, _ := Init(memory.NewStorage(), WithWorkTree(fs))
+	r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+	s.NoError(err)
 
 	head, err := r.Head()
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)

--- a/repository_test.go
+++ b/repository_test.go
@@ -1657,6 +1657,32 @@ func (s *RepositorySuite) TestCloneWithFilter() {
 	s.Nil(blob)
 }
 
+// TestCloneRelative checks that a repository with a relative path can be
+// opened.
+func (s *RepositorySuite) TestCloneRelative() {
+	fs := memfs.New()
+	r, _ := Init(memory.NewStorage(), WithWorkTree(fs))
+
+	head, err := r.Head()
+	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
+	s.Nil(head)
+
+	cwd, err := os.Getwd()
+	s.NoError(err)
+
+	path, err := filepath.Rel(cwd, s.GetBasicLocalRepositoryURL())
+	s.NoError(err)
+
+	err = r.clone(context.Background(), &CloneOptions{
+		URL: path,
+	})
+	s.NoError(err)
+
+	remotes, err := r.Remotes()
+	s.NoError(err)
+	s.Len(remotes, 1)
+}
+
 func (s *RepositorySuite) TestPush() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)


### PR DESCRIPTION
go-billy checks that in a chroot filesystem the paths do not start by `../`. This causes opening or cloning relative paths to fail. This check is good to find repository links that point to files outside the repository but for opening path is not that useful as the default filesystem is based at `/`.

The change to `parseFile` does the same as v5. The test and the embedded function to generate the relative path is quite naive but checks that the change fixes the issue.

Fixes #1723