### PR TITLE
Re-enable the bump of go-billy

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -12,6 +12,14 @@
       "matchBaseBranches": [
         "releases/v5.x"
       ]
+    },
+    {
+      "description": "Enable minor and patch updates for go-billy",
+      "matchPackageNames": [
+        "github.com/go-git/go-billy",
+      ],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": true
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
This PR re-enables the bump of go-billy in the `renovaterc.json`

Related to: https://github.com/go-git/go-git/issues/1772