### PR TITLE
worktree: handle nil CommitOptions in Commit()

### DIFF
--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -36,6 +36,9 @@ var (
 // Commit stores the current contents of the index in a new commit along with
 // a log message from the user describing the changes.
 func (w *Worktree) Commit(msg string, opts *CommitOptions) (plumbing.Hash, error) {
+	if opts == nil {
+		opts = &CommitOptions{}
+	}
 	if err := opts.Validate(w.r); err != nil {
 		return plumbing.ZeroHash, err
 	}

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -50,6 +50,28 @@ func (s *WorktreeSuite) TestCommitEmptyOptions() {
 	s.NotEqual("", commit.Author.Name)
 }
 
+func (s *WorktreeSuite) TestCommitWithNilOptions() {
+	fs := memfs.New()
+	r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+	s.NoError(err)
+
+	w, err := r.Worktree()
+	s.NoError(err)
+
+	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
+
+	_, err = w.Add("foo")
+	s.NoError(err)
+
+	// Commit with nil options should not panic.
+	// If git config has user info, commit succeeds with defaults.
+	// If not, it returns ErrMissingAuthor.
+	_, err = w.Commit("test commit", nil)
+	if err != nil {
+		s.ErrorIs(err, ErrMissingAuthor)
+	}
+}
+
 func (s *WorktreeSuite) TestCommitInitial() {
 	expected := plumbing.NewHash("98c4ac7c29c913f7461eae06e024dc18e80d23a4")
 


### PR DESCRIPTION
## Summary
- Fix `(*Worktree).Commit()` panic when `CommitOptions` parameter is nil
- Add test case `TestCommitWithNilOptions` to verify the fix

## Root Cause
When calling `Commit()` with a nil `CommitOptions` pointer, the function would immediately call `opts.Validate()` which causes a nil pointer dereference panic.

## Solution
Check if `opts` is nil before calling `Validate()`, and initialize it to an empty `CommitOptions{}` struct. The `Validate()` method already handles setting default values (Author from git config, Committer defaults to Author, Parents defaults to HEAD).

This follows the maintainer guidance from @pjbgf in the issue: "replacing nil to pointer to an empty struct" is fine when there's valid default options.

## Test Plan
- [x] Added `TestCommitWithNilOptions` test case
- [x] All existing tests pass (`go test ./...`)

Fixes #1051