### PR TITLE
git: include shallow references in object walker

### DIFF
--- a/object_walker.go
+++ b/object_walker.go
@@ -1,7 +1,9 @@
 package git
 
 import (
+	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -72,6 +74,13 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 		for _, h := range obj.ParentHashes {
 			err = p.walkObjectTree(h)
 			if err != nil {
+				shallow, serr := p.Storer.Shallow()
+				if serr != nil {
+					return errors.Join(err, serr)
+				}
+				if slices.Contains(shallow, obj.ID()) {
+					return nil
+				}
 				return err
 			}
 		}

--- a/object_walker.go
+++ b/object_walker.go
@@ -73,7 +73,7 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 		}
 		for _, h := range obj.ParentHashes {
 			err = p.walkObjectTree(h)
-			if err != nil {
+			if errors.Is(err, plumbing.ErrObjectNotFound) {
 				shallow, serr := p.Storer.Shallow()
 				if serr != nil {
 					return errors.Join(err, serr)

--- a/object_walker.go
+++ b/object_walker.go
@@ -62,7 +62,7 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 	// Fetch the object.
 	obj, err := object.GetObject(p.Storer, hash)
 	if err != nil {
-		return fmt.Errorf("getting object %s failed: %v", hash, err)
+		return fmt.Errorf("getting object %s failed: %w", hash, err)
 	}
 	// Walk all children depending on object type.
 	switch obj := obj.(type) {

--- a/object_walker.go
+++ b/object_walker.go
@@ -1,9 +1,7 @@
 package git
 
 import (
-	"errors"
 	"fmt"
-	"slices"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -17,10 +15,30 @@ type objectWalker struct {
 	// seen map can become huge if walking over large
 	// repos. Thus using struct{} as the value type.
 	seen map[plumbing.Hash]struct{}
+	// shallows is the set of shallow roots, loaded lazily
+	// on the first commit walked.
+	shallows map[plumbing.Hash]struct{}
 }
 
 func newObjectWalker(s storage.Storer) *objectWalker {
-	return &objectWalker{s, map[plumbing.Hash]struct{}{}}
+	return &objectWalker{Storer: s, seen: map[plumbing.Hash]struct{}{}}
+}
+
+// isShallow reports whether hash is a shallow root, meaning its
+// parents are not present in the repository.
+func (p *objectWalker) isShallow(hash plumbing.Hash) (bool, error) {
+	if p.shallows == nil {
+		shallows, err := p.Storer.Shallow()
+		if err != nil {
+			return false, err
+		}
+		p.shallows = make(map[plumbing.Hash]struct{}, len(shallows))
+		for _, h := range shallows {
+			p.shallows[h] = struct{}{}
+		}
+	}
+	_, ok := p.shallows[hash]
+	return ok, nil
 }
 
 // walkAllRefs walks all (hash) references from the repo.
@@ -71,16 +89,18 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 		if err != nil {
 			return err
 		}
+		// Parents of a shallow root are not present in the
+		// repository, so don't attempt to walk them.
+		shallow, err := p.isShallow(obj.ID())
+		if err != nil {
+			return err
+		}
+		if shallow {
+			break
+		}
 		for _, h := range obj.ParentHashes {
 			err = p.walkObjectTree(h)
-			if errors.Is(err, plumbing.ErrObjectNotFound) {
-				shallow, serr := p.Storer.Shallow()
-				if serr != nil {
-					return errors.Join(err, serr)
-				}
-				if slices.Contains(shallow, obj.ID()) {
-					return nil
-				}
+			if err != nil {
 				return err
 			}
 		}

--- a/object_walker_test.go
+++ b/object_walker_test.go
@@ -1,0 +1,82 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type objectWalkerSuite struct {
+	BaseSuite
+}
+
+func TestObjectWalkerSuite(t *testing.T) {
+	suite.Run(t, new(objectWalkerSuite))
+}
+
+func (s *objectWalkerSuite) TestNormalClonedRepo() {
+	t := s.T()
+	local := t.TempDir()
+
+	cmd := exec.Command(
+		"git",
+		"clone",
+		"--no-checkout",
+		"file://"+s.GetBasicLocalRepositoryURL(),
+		local,
+	)
+	cmd.Dir = local
+	cmd.Env = os.Environ()
+	buf := &bytes.Buffer{}
+	cmd.Stderr = buf
+	cmd.Stdout = buf
+	err := cmd.Run()
+	s.NoError(err, buf.String())
+
+	r, err := PlainOpen(local)
+	s.Require().NoError(err)
+
+	shallow, err := r.Storer.Shallow()
+	s.Require().NoError(err)
+	s.Empty(shallow)
+
+	walker := newObjectWalker(r.Storer)
+	err = walker.walkAllRefs()
+	s.Require().NoError(err)
+}
+
+func (s *objectWalkerSuite) TestShallowClonedRepo() {
+	t := s.T()
+	local := t.TempDir()
+
+	cmd := exec.Command(
+		"git",
+		"clone",
+		"--no-checkout",
+		"--bare",
+		"--depth", "2",
+		"file://"+s.GetBasicLocalRepositoryURL(),
+		local,
+	)
+	cmd.Dir = local
+	cmd.Env = os.Environ()
+	buf := &bytes.Buffer{}
+	cmd.Stderr = buf
+	cmd.Stdout = buf
+	err := cmd.Run()
+	s.NoError(err, buf.String())
+
+	r, err := PlainOpen(local)
+	s.Require().NoError(err)
+
+	shallow, err := r.Storer.Shallow()
+	s.Require().NoError(err)
+	s.NotEmpty(shallow)
+
+	walker := newObjectWalker(r.Storer)
+	err = walker.walkAllRefs()
+	s.Require().NoError(err)
+}

--- a/object_walker_test.go
+++ b/object_walker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/stretchr/testify/suite"
 )
@@ -15,10 +16,16 @@ import (
 type errObjectStorer struct {
 	*memory.Storage
 	err error
+	// failOn limits the failure to a single hash.
+	// The zero value fails every lookup.
+	failOn plumbing.Hash
 }
 
 func (s *errObjectStorer) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
-	return nil, s.err
+	if s.failOn.IsZero() || h == s.failOn {
+		return nil, s.err
+	}
+	return s.Storage.EncodedObject(t, h)
 }
 
 type objectWalkerSuite struct {
@@ -40,7 +47,6 @@ func (s *objectWalkerSuite) TestNormalClonedRepo() {
 		"file://"+s.GetBasicLocalRepositoryURL(),
 		local,
 	)
-	cmd.Dir = local
 	cmd.Env = os.Environ()
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
@@ -73,7 +79,6 @@ func (s *objectWalkerSuite) TestShallowClonedRepo() {
 		"file://"+s.GetBasicLocalRepositoryURL(),
 		local,
 	)
-	cmd.Dir = local
 	cmd.Env = os.Environ()
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
@@ -91,11 +96,15 @@ func (s *objectWalkerSuite) TestShallowClonedRepo() {
 	walker := newObjectWalker(r.Storer)
 	err = walker.walkAllRefs()
 	s.Require().NoError(err)
+
+	// The shallow root is reachable from the cloned refs and
+	// must have been covered by the walk.
+	s.Contains(walker.seen, shallow[0])
 }
 
 func (s *objectWalkerSuite) TestUnexpectedErrors() {
 	memStorage := memory.NewStorage()
-	hash := plumbing.NewHash("c0ffee00000000000000000000000000000000000")
+	hash := plumbing.NewHash("c0ffee0000000000000000000000000000000000")
 	ref := plumbing.NewHashReference(plumbing.HEAD, hash)
 	err := memStorage.SetReference(ref)
 	s.Require().NoError(err)
@@ -103,6 +112,46 @@ func (s *objectWalkerSuite) TestUnexpectedErrors() {
 	errStorer := &errObjectStorer{
 		Storage: memStorage,
 		err:     io.ErrUnexpectedEOF,
+	}
+
+	walker := newObjectWalker(errStorer)
+	err = walker.walkAllRefs()
+	s.Error(err)
+	s.ErrorIs(err, io.ErrUnexpectedEOF)
+}
+
+func (s *objectWalkerSuite) TestParentUnexpectedErrors() {
+	memStorage := memory.NewStorage()
+
+	treeObj := memStorage.NewEncodedObject()
+	treeObj.SetType(plumbing.TreeObject)
+	w, err := treeObj.Writer()
+	s.Require().NoError(err)
+	s.Require().NoError(w.Close())
+	treeHash, err := memStorage.SetEncodedObject(treeObj)
+	s.Require().NoError(err)
+
+	parentHash := plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	commit := &object.Commit{
+		TreeHash:     treeHash,
+		ParentHashes: []plumbing.Hash{parentHash},
+		Author:       object.Signature{Name: "go-git", Email: "go-git@example.com"},
+		Committer:    object.Signature{Name: "go-git", Email: "go-git@example.com"},
+		Message:      "tip",
+	}
+	commitObj := memStorage.NewEncodedObject()
+	s.Require().NoError(commit.Encode(commitObj))
+	commitHash, err := memStorage.SetEncodedObject(commitObj)
+	s.Require().NoError(err)
+
+	ref := plumbing.NewHashReference(plumbing.HEAD, commitHash)
+	s.Require().NoError(memStorage.SetReference(ref))
+
+	errStorer := &errObjectStorer{
+		Storage: memStorage,
+		err:     io.ErrUnexpectedEOF,
+		failOn:  parentHash,
 	}
 
 	walker := newObjectWalker(errStorer)

--- a/object_walker_test.go
+++ b/object_walker_test.go
@@ -2,12 +2,24 @@ package git
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"os/exec"
 	"testing"
 
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/stretchr/testify/suite"
 )
+
+type errObjectStorer struct {
+	*memory.Storage
+	err error
+}
+
+func (s *errObjectStorer) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	return nil, s.err
+}
 
 type objectWalkerSuite struct {
 	BaseSuite
@@ -79,4 +91,22 @@ func (s *objectWalkerSuite) TestShallowClonedRepo() {
 	walker := newObjectWalker(r.Storer)
 	err = walker.walkAllRefs()
 	s.Require().NoError(err)
+}
+
+func (s *objectWalkerSuite) TestUnexpectedErrors() {
+	memStorage := memory.NewStorage()
+	hash := plumbing.NewHash("c0ffee00000000000000000000000000000000000")
+	ref := plumbing.NewHashReference(plumbing.HEAD, hash)
+	err := memStorage.SetReference(ref)
+	s.Require().NoError(err)
+
+	errStorer := &errObjectStorer{
+		Storage: memStorage,
+		err:     io.ErrUnexpectedEOF,
+	}
+
+	walker := newObjectWalker(errStorer)
+	err = walker.walkAllRefs()
+	s.Error(err)
+	s.ErrorIs(err, io.ErrUnexpectedEOF)
 }

--- a/object_walker_test.go
+++ b/object_walker_test.go
@@ -7,10 +7,11 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/stretchr/testify/suite"
 )
 
 type errObjectStorer struct {
@@ -33,6 +34,8 @@ type objectWalkerSuite struct {
 }
 
 func TestObjectWalkerSuite(t *testing.T) {
+	t.Parallel()
+
 	suite.Run(t, new(objectWalkerSuite))
 }
 


### PR DESCRIPTION
When walking objects in a repository, the objectWalker should check shallow references in addition to regular refs. This ensures that shallow clones are properly handled during operations like pruning or repacking.

Similar to #1785
