### PR TITLE
git: status, Use head tree on Status to determine unmodified file

### DIFF
--- a/status.go
+++ b/status.go
@@ -3,69 +3,10 @@ package git
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
+	"iter"
 
-	mindex "github.com/go-git/go-git/v6/utils/merkletrie/index"
-	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
+	"github.com/go-git/go-git/v6/plumbing/object"
 )
-
-// Status represents the current status of a Worktree.
-// The key of the map is the path of the file.
-type Status map[string]*FileStatus
-
-// File returns the FileStatus for a given path, if the FileStatus doesn't
-// exists a new FileStatus is added to the map using the path as key.
-func (s Status) File(path string) *FileStatus {
-	if _, ok := (s)[path]; !ok {
-		s[path] = &FileStatus{Worktree: Untracked, Staging: Untracked}
-	}
-
-	return s[path]
-}
-
-// IsUntracked checks if file for given path is 'Untracked'
-func (s Status) IsUntracked(path string) bool {
-	stat, ok := (s)[filepath.ToSlash(path)]
-	return ok && stat.Worktree == Untracked
-}
-
-// IsClean returns true if all the files are in Unmodified status.
-func (s Status) IsClean() bool {
-	for _, status := range s {
-		if status.Worktree != Unmodified || status.Staging != Unmodified {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (s Status) String() string {
-	buf := bytes.NewBuffer(nil)
-	for path, status := range s {
-		if status.Staging == Unmodified && status.Worktree == Unmodified {
-			continue
-		}
-
-		if status.Staging == Renamed {
-			path = fmt.Sprintf("%s -> %s", path, status.Extra)
-		}
-
-		fmt.Fprintf(buf, "%c%c %s\n", status.Staging, status.Worktree, path)
-	}
-
-	return buf.String()
-}
-
-// FileStatus contains the status of a file in the worktree
-type FileStatus struct {
-	// Staging is the status of a file in the staging area
-	Staging StatusCode
-	// Worktree is the status of a file in the worktree
-	Worktree StatusCode
-	// Extra contains extra information, such as the previous name in a rename
-	Extra string
-}
 
 // StatusCode status code of a file in the Worktree
 type StatusCode byte
@@ -82,75 +23,77 @@ const (
 	UpdatedButUnmerged StatusCode = 'U'
 )
 
-// StatusStrategy defines the different types of strategies when processing
-// the worktree status.
-type StatusStrategy int
-
-const (
-	// TODO: (V6) Review the default status strategy.
-	// TODO: (V6) Review the type used to represent Status, to enable lazy
-	// processing of statuses going direct to the backing filesystem.
-	defaultStatusStrategy = Empty
-
-	// Empty starts its status map from empty. Missing entries for a given
-	// path means that the file is untracked. This causes a known issue (#119)
-	// whereby unmodified files can be incorrectly reported as untracked.
-	//
-	// This can be used when returning the changed state within a modified Worktree.
-	// For example, to check whether the current worktree is clean.
-	Empty StatusStrategy = 0
-	// Preload goes through all existing nodes from the index and add them to the
-	// status map as unmodified. This is currently the most reliable strategy
-	// although it comes at a performance cost in large repositories.
-	//
-	// This method is recommended when fetching the status of unmodified files.
-	// For example, to confirm the status of a specific file that is either
-	// untracked or unmodified.
-	Preload StatusStrategy = 1
-)
-
-func (s StatusStrategy) new(w *Worktree) (Status, error) {
-	switch s {
-	case Preload:
-		return preloadStatus(w)
-	case Empty:
-		return make(Status), nil
-	}
-	return nil, fmt.Errorf("%w: %+v", ErrUnsupportedStatusStrategy, s)
+// FileStatus contains the status of a file in the worktree
+type FileStatus struct {
+	// Staging is the status of a file in the staging area
+	Staging StatusCode
+	// Worktree is the status of a file in the worktree
+	Worktree StatusCode
+	// Extra contains extra information, such as the previous name in a rename
+	Extra string
 }
 
-func preloadStatus(w *Worktree) (Status, error) {
-	idx, err := w.r.Storer.Index()
-	if err != nil {
-		return nil, err
-	}
+// Status represents the current status of a Worktree.
+type Status struct {
+	// head is needed to figure out whether the file is unmodified or untracked.
+	head *object.Tree
+	// m consists of statuses of files that are changed.
+	m map[string]FileStatus
+}
 
-	c, err := w.r.Config()
-	if err != nil {
-		return nil, err
-	}
+// File returns the FileStatus for a given path.
+func (s Status) File(path string) FileStatus {
+	if _, ok := s.m[path]; !ok {
+		// The file hasn't changed or cannot be seen by git.
 
-	idxRoot := mindex.NewRootNodeWithOptions(idx, mindex.RootNodeOptions{
-		UpholdExecutableBit: c.Core.FileMode,
-	})
-	nodes := []noder.Noder{idxRoot}
-
-	status := make(Status)
-	for len(nodes) > 0 {
-		var node noder.Noder
-		node, nodes = nodes[0], nodes[1:]
-		if node.IsDir() {
-			children, err := node.Children()
-			if err != nil {
-				return nil, err
+		if s.head != nil {
+			if _, err := s.head.FindEntry(path); err == nil {
+				return FileStatus{Staging: Unmodified, Worktree: Unmodified}
 			}
-			nodes = append(nodes, children...)
-			continue
 		}
-		fs := status.File(node.String())
-		fs.Worktree = Unmodified
-		fs.Staging = Unmodified
+
+		return FileStatus{Staging: Untracked, Worktree: Untracked}
 	}
 
-	return status, nil
+	return s.m[path]
+}
+
+// IsUntracked checks if file for given path is 'Untracked'
+func (s Status) IsUntracked(path string) bool {
+	stat := s.File(path)
+	return stat.Worktree == Untracked
+}
+
+// IsClean returns true if all the files are in Unmodified status.
+func (s Status) IsClean() bool {
+	return len(s.m) == 0
+}
+
+// Len returns the total count of the file statuses.
+func (s Status) Len() int {
+	return len(s.m)
+}
+
+// Iter returns the iterator of file statuses.
+func (s Status) Iter() iter.Seq2[string, FileStatus] {
+	return func(yield func(path string, file FileStatus) bool) {
+		for path, file := range s.m {
+			if !yield(path, file) {
+				return
+			}
+		}
+	}
+}
+
+func (s Status) String() string {
+	buf := bytes.NewBuffer(nil)
+	for path, status := range s.m {
+		if status.Staging == Renamed {
+			path = fmt.Sprintf("%s -> %s", path, status.Extra)
+		}
+
+		fmt.Fprintf(buf, "%c%c %s\n", status.Staging, status.Worktree, path)
+	}
+
+	return buf.String()
 }

--- a/status_test.go
+++ b/status_test.go
@@ -21,104 +21,55 @@ func TestStatusReturnsFullPaths(t *testing.T) {
 		filepath.Join("e", "b", "c", "a"),
 	}
 
-	tests := []struct {
-		name     string
-		doChange bool
-		strategy StatusStrategy
-		expected map[string]bool
-	}{
-		{
-			name:     "strategy:Empty with changes",
-			doChange: true,
-			strategy: Empty,
-			expected: map[string]bool{
-				"a/a":   true,
-				"b/a":   true,
-				"c/b/a": true,
-			},
-		},
-		{
-			name:     "strategy:Empty without changes",
-			doChange: false,
-			strategy: Empty,
-			expected: map[string]bool{},
-		},
-		{
-			name:     "strategy:Preload with changes",
-			doChange: true,
-			strategy: Preload,
-			expected: map[string]bool{
-				"a/a":     true,
-				"b/a":     true,
-				"c/b/a":   true,
-				"d/b/a":   true,
-				"e/b/c/a": true,
-			},
-		},
-		{
-			name:     "strategy:Preload without changes",
-			doChange: false,
-			strategy: Preload,
-			expected: map[string]bool{
-				"a/a":     true,
-				"b/a":     true,
-				"c/b/a":   true,
-				"d/b/a":   true,
-				"e/b/c/a": true,
-			},
-		},
+	expected := map[string]bool{
+		"a/a":     true,
+		"b/a":     true,
+		"c/b/a":   true,
+		"d/b/a":   true,
+		"e/b/c/a": true,
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			r, err := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
-			require.NoError(t, err)
+	r, err := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	require.NoError(t, err)
 
-			w, err := r.Worktree()
-			require.NoError(t, err)
+	w, err := r.Worktree()
+	require.NoError(t, err)
 
-			for _, fname := range files {
-				file, err := w.Filesystem.Create(fname)
-				require.NoError(t, err)
+	for _, fname := range files {
+		file, err := w.Filesystem.Create(fname)
+		require.NoError(t, err)
 
-				_, err = file.Write([]byte("foo"))
-				require.NoError(t, err)
-				file.Close()
+		_, err = file.Write([]byte("foo"))
+		require.NoError(t, err)
+		file.Close()
 
-				_, err = w.Add(file.Name())
-				require.NoError(t, err)
-			}
-
-			_, err = w.Commit("foo", &CommitOptions{All: true})
-			require.NoError(t, err)
-
-			if tc.doChange {
-				for _, fname := range (files)[:len(files)-2] {
-					file, err := w.Filesystem.Create(fname)
-					require.NoError(t, err)
-
-					_, err = file.Write([]byte("fooo"))
-					require.NoError(t, err)
-
-					err = file.Close()
-					require.NoError(t, err)
-				}
-			}
-
-			status, err := w.StatusWithOptions(
-				StatusOptions{
-					Strategy: tc.strategy,
-				},
-			)
-			require.NoError(t, err)
-
-			for file := range status {
-				yes, ok := tc.expected[file]
-				assert.True(t, ok, "unexpected file %q", file)
-				assert.True(t, yes, "%q should not be marked as changed", file)
-			}
-			assert.Len(t, status, len(tc.expected), "length mismatch between status and expected files")
-		})
+		_, err = w.Add(file.Name())
+		require.NoError(t, err)
 	}
+
+	_, err = w.Commit("foo", &CommitOptions{All: true})
+	require.NoError(t, err)
+
+	// Change file contents
+	for _, fname := range files {
+		file, err := w.Filesystem.Create(fname)
+		require.NoError(t, err)
+
+		_, err = file.Write([]byte("fooo"))
+		require.NoError(t, err)
+
+		err = file.Close()
+		require.NoError(t, err)
+	}
+
+	status, err := w.StatusWithOptions(StatusOptions{})
+	require.NoError(t, err)
+
+	for file := range status.Iter() {
+		yes, ok := expected[file]
+		assert.True(t, ok, "unexpected file %q", file)
+		assert.True(t, yes, "%q should not be marked as changed", file)
+	}
+
+	assert.Equal(t, len(expected), status.Len(), "length mismatch between status and expected files")
 }

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -195,12 +195,12 @@ func (w *Worktree) autoAddModifiedAndDeleted() error {
 		return err
 	}
 
-	for path, fs := range s {
+	for path, fs := range s.Iter() {
 		if fs.Worktree != Modified && fs.Worktree != Deleted {
 			continue
 		}
 
-		if _, _, err := w.doAddFile(idx, s, path, nil); err != nil {
+		if _, _, err := w.doAddFile(idx, &s, path, nil); err != nil {
 			return err
 		}
 	}

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -428,8 +428,8 @@ func (s *WorktreeSuite) TestAddAndCommitWithSkipStatusPathNotModified() {
 	status, err = w.Status()
 	s.Require().NoError(err)
 	foo = status.File("foo")
-	s.Equal(Untracked, foo.Staging)
-	s.Equal(Untracked, foo.Worktree)
+	s.Equal(Unmodified, foo.Staging)
+	s.Equal(Unmodified, foo.Worktree)
 
 	assertStorageStatus(s, s.Repository, 13, 11, 10, expected)
 
@@ -442,8 +442,8 @@ func (s *WorktreeSuite) TestAddAndCommitWithSkipStatusPathNotModified() {
 	status, err = w.Status()
 	s.Require().NoError(err)
 	foo = status.File("foo")
-	s.Equal(Untracked, foo.Staging)
-	s.Equal(Untracked, foo.Worktree)
+	s.Equal(Unmodified, foo.Staging)
+	s.Equal(Unmodified, foo.Worktree)
 
 	hash, err = w.Commit("commit with no changes\n", &CommitOptions{
 		Author:            defaultSignature(),
@@ -458,8 +458,8 @@ func (s *WorktreeSuite) TestAddAndCommitWithSkipStatusPathNotModified() {
 	status, err = w.Status()
 	s.Require().NoError(err)
 	foo = status.File("foo")
-	s.Equal(Untracked, foo.Staging)
-	s.Equal(Untracked, foo.Worktree)
+	s.Equal(Unmodified, foo.Staging)
+	s.Equal(Unmodified, foo.Worktree)
 
 	patch, err := commit2.Patch(commit1)
 	s.Require().NoError(err)

--- a/worktree_status_bench_test.go
+++ b/worktree_status_bench_test.go
@@ -141,7 +141,7 @@ func benchmarkStatusModified(wt *Worktree, numFiles, numSubdirs int) func(b *tes
 				b.Fatalf("expected modified status, got clean")
 			}
 			modCount := 0
-			for _, fileStatus := range status {
+			for _, fileStatus := range status.Iter() {
 				if fileStatus.Worktree == Modified {
 					modCount++
 				}

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -2,17 +2,22 @@ package git
 
 import (
 	"os"
+	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
@@ -93,23 +98,151 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 }
 
 func BenchmarkWorktreeStatus(b *testing.B) {
-	b.StopTimer()
+	repositories := []struct {
+		name string
+		new  func(b *testing.B) *Repository
+		run  func() bool
+	}{
+		{
+			name: "basic-fixture(memfs)",
+			run:  func() bool { return true },
+			new: func(b *testing.B) *Repository {
+				f := fixtures.Basic().One()
+				st := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 
-	f := fixtures.Basic().One()
-	st := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
+				r, err := Open(st, memfs.New())
+				require.NoError(b, err)
 
-	r, err := Open(st, memfs.New())
-	require.NoError(b, err)
+				wt, err := r.Worktree()
+				require.NoError(b, err)
 
-	wt, err := r.Worktree()
-	require.NoError(b, err)
+				err = wt.Reset(&ResetOptions{Mode: HardReset})
+				require.NoError(b, err)
 
-	err = wt.Reset(&ResetOptions{Mode: HardReset})
-	require.NoError(b, err)
+				return r
+			},
+		},
 
-	b.StartTimer()
+		{
+			name: "basic-fixture(osfs)",
+			run:  func() bool { return true },
+			new: func(b *testing.B) *Repository {
+				temp := b.TempDir()
 
-	for b.Loop() {
-		wt.Status()
+				f := fixtures.Basic().One()
+				dotgit := f.DotGit(fixtures.WithTargetDir(func() string {
+					return filepath.Join(temp, GitDirName)
+				}))
+
+				st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+
+				r, err := Open(st, osfs.New(temp))
+				require.NoError(b, err)
+
+				wt, err := r.Worktree()
+				require.NoError(b, err)
+
+				err = wt.Reset(&ResetOptions{Mode: HardReset})
+				require.NoError(b, err)
+
+				return r
+			},
+		},
+		{
+			name: "linux-kernel",
+			new: func(b *testing.B) *Repository {
+				r, err := PlainOpen("./tests/testdata/repos/linux")
+				require.NoError(b, err)
+
+				return r
+			},
+			run: func() bool {
+				_, err := os.Stat("./tests/testdata/repos/linux")
+				return err == nil
+			},
+		},
 	}
+
+	b.Run("unmodified(default)", func(b *testing.B) {
+		for _, repo := range repositories {
+			if !repo.run() {
+				continue
+			}
+
+			b.Run(repo.name, func(b *testing.B) {
+				r := repo.new(b)
+
+				wt, err := r.Worktree()
+				require.NoError(b, err)
+
+				for b.Loop() {
+					wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+				}
+			})
+		}
+	})
+
+	b.Run("ignored-files", func(b *testing.B) {
+		addFiles := func(b *testing.B, fs billy.Filesystem) {
+			count := 10_000
+			base := "ignored"
+
+			require.NoError(b, fs.MkdirAll(base, os.ModeDir|os.ModePerm))
+
+			for i := range count {
+				path := path.Join(base, strconv.Itoa(i)+".jar") // *.jar is ignored in basic fixture.
+
+				err := util.WriteFile(fs, path, []byte(path), 0o755)
+				require.NoError(b, err)
+			}
+		}
+
+		for _, repo := range repositories {
+			if !strings.Contains(repo.name, "basic-fixture") || !repo.run() {
+				// We can only run this in basic repositories.
+				continue
+			}
+
+			b.Run(repo.name, func(b *testing.B) {
+				r := repo.new(b)
+
+				wt, err := r.Worktree()
+				require.NoError(b, err)
+
+				addFiles(b, wt.Filesystem)
+
+				for b.Loop() {
+					wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+				}
+			})
+		}
+	})
+
+	b.Run("all-changed", func(b *testing.B) {
+		for _, repo := range repositories {
+			if !repo.run() {
+				continue
+			}
+
+			b.Run(repo.name, func(b *testing.B) {
+				r := repo.new(b)
+
+				// Remove all the files from the worktree.
+				// TODO: use wt.Remove() when it supports index.
+				idx, err := r.Storer.Index()
+				require.NoError(b, err)
+				newIdx := &index.Index{Version: idx.Version}
+
+				b.Cleanup(func() { require.NoError(b, r.Storer.SetIndex(idx)) })
+				require.NoError(b, r.Storer.SetIndex(newIdx))
+
+				wt, err := r.Worktree()
+				require.NoError(b, err)
+
+				for b.Loop() {
+					wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+				}
+			})
+		}
+	})
 }

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -54,10 +54,10 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 	_, err = wt.Commit("add file", &CommitOptions{})
 	require.NoError(t, err)
 
-	st, err := wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+	st, err := wt.StatusWithOptions(StatusOptions{})
 	require.NoError(t, err)
 	assert.Equal(t,
-		&FileStatus{Worktree: Unmodified, Staging: Unmodified},
+		FileStatus{Worktree: Unmodified, Staging: Unmodified},
 		st.File(file))
 
 	// Make the file not regular. The same would apply to a transition
@@ -82,10 +82,10 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 	// reports the unstaged file was modified while "git diff" would return
 	// empty, as the files are the same but the index has the incorrect file
 	// size.
-	st, err = wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+	st, err = wt.StatusWithOptions(StatusOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t,
-		&FileStatus{Worktree: Unmodified, Staging: Modified},
+		FileStatus{Worktree: Unmodified, Staging: Modified},
 		st.File(file))
 
 	idx, err := wt.r.Storer.Index()
@@ -176,7 +176,7 @@ func BenchmarkWorktreeStatus(b *testing.B) {
 				require.NoError(b, err)
 
 				for b.Loop() {
-					wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+					wt.Status()
 				}
 			})
 		}
@@ -212,7 +212,7 @@ func BenchmarkWorktreeStatus(b *testing.B) {
 				addFiles(b, wt.Filesystem)
 
 				for b.Loop() {
-					wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+					wt.Status()
 				}
 			})
 		}
@@ -240,7 +240,7 @@ func BenchmarkWorktreeStatus(b *testing.B) {
 				require.NoError(b, err)
 
 				for b.Loop() {
-					wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+					wt.Status()
 				}
 			})
 		}


### PR DESCRIPTION
To determine whether a file is unmodified, previous implementaion preloaded all the entries of the index to the status map. Instead, we can use head tree directly from Status. This way we can allign with upstream git while maintaining small amount of elements in status map.

How it works:
1. The status map only consists of the statuses of files that are changed.
2. If a file doesn't exist in status map, it's either not modified or invisible to git.
3. If the file from step 2 exists in head tree, it's not modified(=unmodified).
4. If not, it's invisible to git(=untracked).

Since head tree is now included in Status, it had to be changed to a struct. This resulted in changes of the API. Changes include:
1. Addition of Iter() and Len() as the map is now unexported.
2. Removal of pointer on FileStatus as it's unnecessary.

Unlike previous implementation where determining unmodified is opt-in method, now it is the one and only behavior for Status(). This lead to test failures as some of them depended on how previous default behavior of Status(). I fixed those tests as well by replacing 'Untracked' with 'Unmodified'.