### PR TITLE
[v5] git: worktree, Don't delete local untracked files when resetting worktree

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -310,13 +310,20 @@ func (w *Worktree) ResetSparsely(opts *ResetOptions, dirs []string) error {
 		return err
 	}
 
+	var removedFiles []string
 	if opts.Mode == MixedReset || opts.Mode == MergeReset || opts.Mode == HardReset {
-		if err := w.resetIndex(t, dirs, opts.Files); err != nil {
+		if removedFiles, err = w.resetIndex(t, dirs, opts.Files); err != nil {
 			return err
 		}
 	}
 
-	if opts.Mode == MergeReset || opts.Mode == HardReset {
+	if opts.Mode == MergeReset && len(removedFiles) > 0 {
+		if err := w.resetWorktree(t, removedFiles); err != nil {
+			return err
+		}
+	}
+
+	if opts.Mode == HardReset {
 		if err := w.resetWorktree(t, opts.Files); err != nil {
 			return err
 		}
@@ -365,23 +372,24 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	return w.ResetSparsely(opts, nil)
 }
 
-func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) error {
+func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) ([]string, error) {
 	idx, err := w.r.Storer.Index()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	b := newIndexBuilder(idx)
 
 	changes, err := w.diffTreeWithStaging(t, true)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	var removedFiles []string
 	for _, ch := range changes {
 		a, err := ch.Action()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		var name string
@@ -392,7 +400,7 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) err
 			name = ch.To.String()
 			e, err = t.FindEntry(name)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		case merkletrie.Delete:
 			name = ch.From.String()
@@ -406,6 +414,7 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) err
 		}
 
 		b.Remove(name)
+		removedFiles = append(removedFiles, name)
 		if e == nil {
 			continue
 		}
@@ -424,7 +433,7 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs []string, files []string) err
 		idx.SkipUnless(dirs)
 	}
 
-	return w.r.Storer.SetIndex(idx)
+	return removedFiles, w.r.Storer.SetIndex(idx)
 }
 
 func inFiles(files []string, v string) bool {


### PR DESCRIPTION
Backporting https://github.com/go-git/go-git/pull/1564/changes/aa09c632f192bba78b2e37526ffee00070269845 to v5.