### PR TITLE
storage: filesystem/dotgit, fixing issue where absolute paths to commonDotGitFs ended up in dotGitFs

### DIFF
--- a/storage/filesystem/dotgit/repository_filesystem_test.go
+++ b/storage/filesystem/dotgit/repository_filesystem_test.go
@@ -110,3 +110,127 @@ func (s *SuiteDotGit) TestRepositoryFilesystem() {
 	_, err = dotGitFs.Stat("a/b/c")
 	s.Require().NoError(err)
 }
+
+// TestRepositoryFilesystemTempFileRename tests the TempFile + Rename flow
+// which is used by ObjectWriter.save(). This is critical for worktree support
+// where temp files are created in commonDotGitFs.
+func (s *SuiteDotGit) TestRepositoryFilesystemTempFileRename() {
+	fs := s.EmptyFS()
+
+	err := fs.MkdirAll("dotGit", 0o777)
+	s.Require().NoError(err)
+	dotGitFs, err := fs.Chroot("dotGit")
+	s.Require().NoError(err)
+
+	err = fs.MkdirAll("commonDotGit", 0o777)
+	s.Require().NoError(err)
+	commonDotGitFs, err := fs.Chroot("commonDotGit")
+	s.Require().NoError(err)
+
+	repositoryFs := NewRepositoryFilesystem(dotGitFs, commonDotGitFs)
+
+	// Create objects/pack directory in commonDotGitFs
+	err = repositoryFs.MkdirAll("objects/pack", 0o777)
+	s.Require().NoError(err)
+
+	// Create a temp file in objects/pack (should go to commonDotGitFs)
+	tempFile, err := repositoryFs.TempFile("objects/pack", "tmp_obj_")
+	s.Require().NoError(err)
+	tempFilePath := tempFile.Name()
+	err = tempFile.Close()
+	s.Require().NoError(err)
+
+	// Create target directory for rename
+	err = repositoryFs.MkdirAll("objects/ab", 0o777)
+	s.Require().NoError(err)
+
+	// Rename using the temp file path should work
+	// This simulates what ObjectWriter.save() does
+	err = repositoryFs.Rename(tempFilePath, "objects/ab/cdef1234")
+	s.Require().NoError(err, "rename should work")
+
+	// Verify the file was renamed in commonDotGitFs
+	_, err = commonDotGitFs.Stat("objects/ab/cdef1234")
+	s.Require().NoError(err, "renamed file should exist in commonDotGitFs")
+
+	// Verify the file doesn't exist in dotGitFs
+	_, err = dotGitFs.Stat("objects/ab/cdef1234")
+	s.True(os.IsNotExist(err), "renamed file should NOT exist in dotGitFs")
+}
+
+// TestRepositoryFilesystemTempFileRenameToDotGitFs tests the TempFile + Rename flow
+// for paths that route to dotGitFs (worktree-specific, non-commondir paths).
+func (s *SuiteDotGit) TestRepositoryFilesystemTempFileRenameToDotGitFs() {
+	fs := s.EmptyFS()
+
+	err := fs.MkdirAll("dotGit", 0o777)
+	s.Require().NoError(err)
+	dotGitFs, err := fs.Chroot("dotGit")
+	s.Require().NoError(err)
+
+	err = fs.MkdirAll("commonDotGit", 0o777)
+	s.Require().NoError(err)
+	commonDotGitFs, err := fs.Chroot("commonDotGit")
+	s.Require().NoError(err)
+
+	repositoryFs := NewRepositoryFilesystem(dotGitFs, commonDotGitFs)
+
+	// Create a worktree-specific directory (non-commondir paths go to dotGitFs)
+	err = repositoryFs.MkdirAll("worktree-data", 0o777)
+	s.Require().NoError(err)
+
+	// Verify directory was created in dotGitFs
+	_, err = dotGitFs.Stat("worktree-data")
+	s.Require().NoError(err, "worktree-data should exist in dotGitFs")
+
+	// Create a temp file in worktree-data (should go to dotGitFs)
+	tempFile, err := repositoryFs.TempFile("worktree-data", "tmp_wt_")
+	s.Require().NoError(err)
+	tempFilePath := tempFile.Name()
+	err = tempFile.Close()
+	s.Require().NoError(err)
+
+	// Rename using the temp file path (absolute path from dotGitFs)
+	err = repositoryFs.Rename(tempFilePath, "worktree-data/renamed-file")
+	s.Require().NoError(err, "rename should work for dotGitFs paths")
+
+	// Verify the file was renamed in dotGitFs
+	_, err = dotGitFs.Stat("worktree-data/renamed-file")
+	s.Require().NoError(err, "renamed file should exist in dotGitFs")
+
+	// Verify the file doesn't exist in commonDotGitFs
+	_, err = commonDotGitFs.Stat("worktree-data/renamed-file")
+	s.True(os.IsNotExist(err), "renamed file should NOT exist in commonDotGitFs")
+}
+
+// TestRepositoryFilesystemAbsolutePathFallback tests that absolute paths not matching
+// either filesystem root default to dotGitFs.
+func (s *SuiteDotGit) TestRepositoryFilesystemAbsolutePathFallback() {
+	fs := s.EmptyFS()
+
+	err := fs.MkdirAll("dotGit", 0o777)
+	s.Require().NoError(err)
+	dotGitFs, err := fs.Chroot("dotGit")
+	s.Require().NoError(err)
+
+	err = fs.MkdirAll("commonDotGit", 0o777)
+	s.Require().NoError(err)
+	commonDotGitFs, err := fs.Chroot("commonDotGit")
+	s.Require().NoError(err)
+
+	repositoryFs := NewRepositoryFilesystem(dotGitFs, commonDotGitFs)
+
+	// Test that mapToRepositoryFsByPath returns dotGitFs for unmatched absolute paths
+	// We can't directly test mapToRepositoryFsByPath, but we can verify behavior
+	// by checking that operations on arbitrary paths go to dotGitFs
+
+	err = repositoryFs.MkdirAll("arbitrary/path", 0o777)
+	s.Require().NoError(err)
+
+	// Verify it went to dotGitFs (default for non-commondir paths)
+	_, err = dotGitFs.Stat("arbitrary/path")
+	s.Require().NoError(err, "arbitrary path should exist in dotGitFs")
+
+	_, err = commonDotGitFs.Stat("arbitrary/path")
+	s.True(os.IsNotExist(err), "arbitrary path should NOT exist in commonDotGitFs")
+}


### PR DESCRIPTION
When using the v6 implementation with worktree repos we got this error: 

```
Add failed: "/tmp/gogit-worktree-test/main-repo/.git/objects/pack/tmp_obj_847737165": path outside base dir "/tmp/gogit-worktree-test/main-repo/.git/worktrees/worktree": file does not exist
```

The current implementation assumes path are relativ but for tmp files (in combination with worktree!?) they are absolute. So the current logic that decides which filesystem should be returned isn't working at all and always returns `dotGitFs` but it should return `commonDotGitFs` instead.

This came out of a debugging session with Claude Code first on our code base and then on go-git main branch. I reviewed the code and I'm pretty confident it's a good approach but still wanted to flag it for transparency. Especially the amount of comments is a bit on the verbose side, so happy to remove/reduce if that's too much. 

Here is a script to replicate this: 
<details>
<summary>open for source</summary>

```
package main

  import (
      "fmt"
      "os"
      "os/exec"
      "path/filepath"
      "time"

      "github.com/go-git/go-git/v6"
      "github.com/go-git/go-git/v6/plumbing/object"
  )

  func main() {
      // Create test structure
      tmpDir := "/tmp/gogit-worktree-test"
      os.RemoveAll(tmpDir)
      os.MkdirAll(tmpDir, 0755)

      mainRepoDir := filepath.Join(tmpDir, "main-repo")
      worktreeDir := filepath.Join(tmpDir, "worktree")

      // Init main repo
      exec.Command("git", "init", mainRepoDir).Run()

      // Create initial commit
      os.WriteFile(filepath.Join(mainRepoDir, "file.txt"), []byte("test"), 0644)
      exec.Command("git", "-C", mainRepoDir, "add", ".").Run()
      exec.Command("git", "-C", mainRepoDir, "commit", "-m", "initial").Run()

      // Create worktree
      exec.Command("git", "-C", mainRepoDir, "worktree", "add", worktreeDir, "-b", "test-branch").Run()

      // Change to worktree directory
      os.Chdir(worktreeDir)

      // Open with go-git v6
      repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
          EnableDotGitCommonDir: true,
      })
      if err != nil {
          fmt.Printf("Open failed: %v\n", err)
          return
      }

      wt, _ := repo.Worktree()

      // Create a new file
      os.WriteFile(filepath.Join(worktreeDir, "newfile.txt"), []byte("content"), 0644)

      // Try to add it - THIS FAILS
      _, err = wt.Add("newfile.txt")
      if err != nil {
          fmt.Printf("Add failed: %v\n", err)
          return
      }

      // Try to commit
      _, err = wt.Commit("test commit", &git.CommitOptions{
          Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
      })
      if err != nil {
          fmt.Printf("Commit failed: %v\n", err)
          return
      }

      fmt.Println("Success!")
  }
```
</details>

