### PR TITLE
plumbing: transport, Ignore io.EOF to avoid intermittent errors

### DIFF
--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -216,7 +216,7 @@ func NegotiatePack(
 	}
 
 	if !conn.StatelessRPC() {
-		if err := writer.Close(); err != nil && err != io.EOF {
+		if err := writer.Close(); err != nil && !errors.Is(err, io.EOF) {
 			return nil, fmt.Errorf("closing writer: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary
Fix `closing writer: EOF` error that occurs during fetch operations over SSH when the server closes the connection before the client closes its writer.

This fixes https://github.com/go-git/go-git/issues/1685

In [NegotiatePack](https://github.com/go-git/go-git/blob/29ae690a9f193c642f1e546c6342bd2b07226a52/plumbing/transport/negotiate.go#L219), function may receive `io.EOF` during closing procedure, this may lead to occasional error.

This PR fixes this by ignoring `io.EOF`.
