### PR TITLE
file: use buffered pipes to prevent deadlock during pack negotiation

### DIFF
--- a/plumbing/transport/file/buffered_pipe.go
+++ b/plumbing/transport/file/buffered_pipe.go
@@ -1,0 +1,109 @@
+package file
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"sync"
+)
+
+// ErrBufferFull is returned when the pipe buffer exceeds its maximum size.
+// This indicates a protocol issue where one side is writing faster than
+// the other can read, which would cause deadlock with unbuffered pipes.
+var ErrBufferFull = errors.New("pipe buffer full: would deadlock")
+
+// maxBufferSize is the maximum buffer size for the pipe.
+// 10MB is far more than needed for pack negotiation (typically <100KB).
+const maxBufferSize = 10 * 1024 * 1024
+
+// bufferedPipe creates a pipe with an intermediate buffer to prevent deadlocks.
+// Unlike io.Pipe which has zero buffer (writes block until reads), this allows
+// writes to proceed up to maxBufferSize before returning an error.
+type bufferedPipe struct {
+	buf    bytes.Buffer
+	mu     sync.Mutex
+	cond   *sync.Cond
+	closed bool
+	err    error
+}
+
+// bufferedPipeReader is the read half of a buffered pipe.
+type bufferedPipeReader struct {
+	p *bufferedPipe
+}
+
+// bufferedPipeWriter is the write half of a buffered pipe.
+type bufferedPipeWriter struct {
+	p *bufferedPipe
+}
+
+// newBufferedPipe creates a new buffered pipe pair.
+func newBufferedPipe() (*bufferedPipeReader, *bufferedPipeWriter) {
+	p := &bufferedPipe{}
+	p.cond = sync.NewCond(&p.mu)
+	return &bufferedPipeReader{p: p}, &bufferedPipeWriter{p: p}
+}
+
+// Read reads data from the pipe, blocking until data is available or the pipe is closed.
+func (r *bufferedPipeReader) Read(data []byte) (n int, err error) {
+	r.p.mu.Lock()
+	defer r.p.mu.Unlock()
+
+	for r.p.buf.Len() == 0 && !r.p.closed && r.p.err == nil {
+		r.p.cond.Wait()
+	}
+
+	if r.p.buf.Len() > 0 {
+		return r.p.buf.Read(data)
+	}
+
+	if r.p.err != nil {
+		return 0, r.p.err
+	}
+
+	return 0, io.EOF
+}
+
+// Close closes the read half of the pipe.
+func (r *bufferedPipeReader) Close() error {
+	r.p.mu.Lock()
+	defer r.p.mu.Unlock()
+
+	if !r.p.closed {
+		r.p.closed = true
+		r.p.err = io.ErrClosedPipe
+		r.p.cond.Broadcast()
+	}
+	return nil
+}
+
+// Write writes data to the pipe buffer.
+// Returns ErrBufferFull if the buffer would exceed maxBufferSize.
+func (w *bufferedPipeWriter) Write(data []byte) (n int, err error) {
+	w.p.mu.Lock()
+	defer w.p.mu.Unlock()
+
+	if w.p.closed {
+		return 0, io.ErrClosedPipe
+	}
+
+	if w.p.buf.Len()+len(data) > maxBufferSize {
+		return 0, ErrBufferFull
+	}
+
+	n, err = w.p.buf.Write(data)
+	w.p.cond.Broadcast()
+	return n, err
+}
+
+// Close closes the write half of the pipe.
+func (w *bufferedPipeWriter) Close() error {
+	w.p.mu.Lock()
+	defer w.p.mu.Unlock()
+
+	if !w.p.closed {
+		w.p.closed = true
+		w.p.cond.Broadcast()
+	}
+	return nil
+}

--- a/plumbing/transport/file/buffered_pipe_test.go
+++ b/plumbing/transport/file/buffered_pipe_test.go
@@ -1,0 +1,127 @@
+package file
+
+import (
+	"io"
+	"testing"
+)
+
+func TestBufferedPipe_BasicReadWrite(t *testing.T) {
+	pr, pw := newBufferedPipe()
+
+	// Write some data
+	data := []byte("hello world")
+	n, err := pw.Write(data)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if n != len(data) {
+		t.Fatalf("Write returned %d, want %d", n, len(data))
+	}
+
+	// Read it back
+	buf := make([]byte, 100)
+	n, err = pr.Read(buf)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if string(buf[:n]) != "hello world" {
+		t.Fatalf("Read returned %q, want %q", string(buf[:n]), "hello world")
+	}
+}
+
+func TestBufferedPipe_WriteBeforeRead(t *testing.T) {
+	pr, pw := newBufferedPipe()
+
+	// Write multiple times before reading (this would deadlock with io.Pipe)
+	for i := 0; i < 100; i++ {
+		_, err := pw.Write([]byte("test data "))
+		if err != nil {
+			t.Fatalf("Write %d failed: %v", i, err)
+		}
+	}
+
+	// Now read all the data
+	buf := make([]byte, 2000)
+	total := 0
+	for total < 1000 {
+		n, err := pr.Read(buf[total:])
+		if err != nil {
+			t.Fatalf("Read failed: %v", err)
+		}
+		total += n
+	}
+}
+
+func TestBufferedPipe_CloseWriter(t *testing.T) {
+	pr, pw := newBufferedPipe()
+
+	pw.Write([]byte("data"))
+	pw.Close()
+
+	// Should still be able to read buffered data
+	buf := make([]byte, 100)
+	n, err := pr.Read(buf)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if string(buf[:n]) != "data" {
+		t.Fatalf("Read returned %q, want %q", string(buf[:n]), "data")
+	}
+
+	// Next read should return EOF
+	_, err = pr.Read(buf)
+	if err != io.EOF {
+		t.Fatalf("Read after close returned %v, want EOF", err)
+	}
+}
+
+func TestBufferedPipe_CloseReader(t *testing.T) {
+	pr, pw := newBufferedPipe()
+
+	pr.Close()
+
+	// Write should fail
+	_, err := pw.Write([]byte("data"))
+	if err != io.ErrClosedPipe {
+		t.Fatalf("Write after reader close returned %v, want ErrClosedPipe", err)
+	}
+}
+
+func TestBufferedPipe_BufferFull(t *testing.T) {
+	pr, pw := newBufferedPipe()
+	_ = pr // silence unused warning
+
+	// Write more than maxBufferSize
+	bigData := make([]byte, maxBufferSize+1)
+	_, err := pw.Write(bigData)
+	if err != ErrBufferFull {
+		t.Fatalf("Write of %d bytes returned %v, want ErrBufferFull", len(bigData), err)
+	}
+}
+
+func TestBufferedPipe_BufferFullIncremental(t *testing.T) {
+	pr, pw := newBufferedPipe()
+	_ = pr // silence unused warning
+
+	// Fill the buffer incrementally
+	chunk := make([]byte, 1024*1024) // 1MB chunks
+	written := 0
+	for {
+		_, err := pw.Write(chunk)
+		if err == ErrBufferFull {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		written += len(chunk)
+		if written > maxBufferSize {
+			t.Fatal("Should have hit buffer limit")
+		}
+	}
+
+	// Should have written close to maxBufferSize
+	if written < maxBufferSize-len(chunk) {
+		t.Fatalf("Only wrote %d bytes, expected close to %d", written, maxBufferSize)
+	}
+}


### PR DESCRIPTION
## Summary

The file transport uses in-process pipes to communicate between client and server. With unbuffered `io.Pipe`, both sides can deadlock when cloning repositories with many refs (e.g., 300+ branches).

The deadlock occurs because:
1. Client writes "have" lines to stdin pipe
2. Server writes advertised refs and ACKs to stdout pipe
3. Both pipes fill up (`io.Pipe` has zero buffer)
4. Both sides block waiting for the other to read

## Solution

This PR introduces a buffered pipe implementation that allows writes to proceed up to a configurable limit (10MB) before returning an error. If the buffer is exceeded, `ErrBufferFull` is returned rather than deadlocking indefinitely.

The 10MB limit is far more than needed for pack negotiation - even with 1000 refs, the data is typically under 100KB.

## Changes

- `buffered_pipe.go`: New buffered pipe implementation with configurable max size
- `client.go`: Use buffered pipes for stdin and stdout instead of `io.Pipe`
- `buffered_pipe_test.go`: Tests for the buffered pipe implementation

## Testing

All existing file transport tests pass:
```
ok  	github.com/go-git/go-git/v6/plumbing/transport/file	0.270s
```

New tests added for the buffered pipe:
- Basic read/write
- Multiple writes before read (would deadlock with io.Pipe)
- Close behavior
- Buffer overflow error