### PR TITLE
x: storage, Drop ObjectFormatGetter interface

### DIFF
--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -4,11 +4,11 @@ import (
 	"io"
 	"time"
 
+	"github.com/go-git/go-git/v6/config"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 	"github.com/go-git/go-git/v6/utils/trace"
-	xstorer "github.com/go-git/go-git/v6/x/storage"
 )
 
 var signature = []byte{'P', 'A', 'C', 'K'}
@@ -37,8 +37,11 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
 	}
 
 	of := formatcfg.DefaultObjectFormat
-	if getter, ok := s.(xstorer.ObjectFormatGetter); ok {
-		of = getter.ObjectFormat()
+	if c, ok := s.(config.ConfigStorer); ok {
+		cfg, err := c.Config()
+		if err == nil {
+			of = cfg.Extensions.ObjectFormat
+		}
 	}
 
 	p := NewParser(packfile, WithStorage(s), WithObjectFormat(of))

--- a/repository_test.go
+++ b/repository_test.go
@@ -450,9 +450,9 @@ func TestFetchMustNotUpdateObjectFormat(t *testing.T) {
 	}
 }
 
-// sha1OnlyStorage wraps a storage.Storer to hide any ObjectFormatGetter
-// or ObjectFormatSetter implementations, simulating a storage backend
-// that only supports SHA1.
+// sha1OnlyStorage wraps a storage.Storer to hide the ExtensionChecker
+// implementation, simulating a storage backend that does not implement
+// that interface.
 type sha1OnlyStorage struct {
 	storage.Storer
 }
@@ -475,11 +475,8 @@ func TestFailSafeUnsupportedStorage(t *testing.T) {
 			})
 
 			st := &sha1OnlyStorage{memory.NewStorage()}
-			_, okGetter := storage.Storer(st).(xstorage.ObjectFormatGetter)
-			assert.False(t, okGetter, "sha1OnlyStorage must not implement ObjectFormatGetter")
-
-			_, okSetter := storage.Storer(st).(xstorage.ObjectFormatSetter)
-			assert.False(t, okSetter, "sha1OnlyStorage must not implement ObjectFormatSetter")
+			_, okGetter := storage.Storer(st).(xstorage.ExtensionChecker)
+			assert.False(t, okGetter, "sha1OnlyStorage must not implement ExtensionChecker")
 
 			_, err = Clone(st, nil, &CloneOptions{URL: endpoint})
 			require.Error(t, err)
@@ -496,11 +493,8 @@ func TestFailSafeUnsupportedStorage(t *testing.T) {
 		st := filesystem.NewStorage(f.DotGit(fixtures.WithMemFS()), cache.NewObjectLRUDefault())
 
 		wrapped := &sha1OnlyStorage{st}
-		_, okGetter := storage.Storer(wrapped).(xstorage.ObjectFormatGetter)
-		assert.False(t, okGetter, "sha1OnlyStorage must not implement ObjectFormatGetter")
-
-		_, okSetter := storage.Storer(wrapped).(xstorage.ObjectFormatSetter)
-		assert.False(t, okSetter, "sha1OnlyStorage must not implement ObjectFormatSetter")
+		_, okGetter := storage.Storer(wrapped).(xstorage.ExtensionChecker)
+		assert.False(t, okGetter, "sha1OnlyStorage must not implement ExtensionChecker")
 
 		r, err := Open(wrapped, nil)
 		assert.Error(t, err)

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
-	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/plumbing/format/objfile"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
@@ -53,10 +52,6 @@ func NewObjectStorageWithOptions(dir *dotgit.DotGit, objectCache cache.Object, o
 		dir:         dir,
 		oh:          plumbing.FromObjectFormat(ops.ObjectFormat),
 	}
-}
-
-func (s *ObjectStorage) ObjectFormat() formatcfg.ObjectFormat {
-	return s.options.ObjectFormat
 }
 
 func (s *ObjectStorage) requireIndex() error {

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -22,14 +22,13 @@ var (
 	sto = filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
 	// Ensure interfaces are implemented.
-	_ storer.EncodedObjectStorer  = sto
-	_ storer.IndexStorer          = sto
-	_ storer.ReferenceStorer      = sto
-	_ storer.ShallowStorer        = sto
-	_ storer.DeltaObjectStorer    = sto
-	_ storer.PackfileWriter       = sto
-	_ xstorage.ObjectFormatGetter = sto
-	_ xstorage.ExtensionChecker   = sto
+	_ storer.EncodedObjectStorer = sto
+	_ storer.IndexStorer         = sto
+	_ storer.ReferenceStorer     = sto
+	_ storer.ShallowStorer       = sto
+	_ storer.DeltaObjectStorer   = sto
+	_ storer.PackfileWriter      = sto
+	_ xstorage.ExtensionChecker  = sto
 )
 
 func TestFilesystem(t *testing.T) {
@@ -207,7 +206,7 @@ func TestNewStorageWithOptions(t *testing.T) {
 			name:             "empty fs, SHA1 opts format",
 			fs:               osfs.New(t.TempDir()),
 			inObjectFormat:   formatcfg.SHA1,
-			wantObjectFormat: formatcfg.SHA1,
+			wantObjectFormat: formatcfg.UnsetObjectFormat,
 		},
 		{
 			name:             "empty fs, SHA256 opts format",
@@ -227,7 +226,10 @@ func TestNewStorageWithOptions(t *testing.T) {
 				filesystem.Options{ObjectFormat: tt.inObjectFormat},
 			)
 
-			assert.Equal(t, tt.wantObjectFormat, sto.ObjectFormat())
+			cfg, err := sto.Config()
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantObjectFormat, cfg.Extensions.ObjectFormat)
 		})
 	}
 }

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -67,12 +67,6 @@ func NewStorage(o ...StorageOption) *Storage {
 	return s
 }
 
-func (s *Storage) ObjectFormat() formatcfg.ObjectFormat {
-	cfg, _ := s.Config()
-
-	return cfg.Extensions.ObjectFormat
-}
-
 func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
 	switch of {
 	case formatcfg.SHA1, formatcfg.SHA256:

--- a/storage/memory/storage_test.go
+++ b/storage/memory/storage_test.go
@@ -21,7 +21,6 @@ var (
 	_ storer.IndexStorer          = sto
 	_ storer.ReferenceStorer      = sto
 	_ storer.ShallowStorer        = sto
-	_ xstorage.ObjectFormatGetter = sto
 	_ xstorage.ObjectFormatSetter = sto
 	_ xstorage.ExtensionChecker   = sto
 )

--- a/x/storage/storer.go
+++ b/x/storage/storer.go
@@ -15,16 +15,6 @@ type ObjectFormatSetter interface {
 	SetObjectFormat(config.ObjectFormat) error
 }
 
-// ObjectFormatGetter expands a Storer so that it can support different Object Formats.
-// Note that storage.Storer do not require this as they expose ConfigStorers, which is
-// the source of truth for this information.
-//
-// Storers that don't implement this interface will default to the default Object Format.
-type ObjectFormatGetter interface {
-	// ObjectFormat returns the object format (hash algorithm) used by the Storer.
-	ObjectFormat() config.ObjectFormat
-}
-
 // ExtensionChecker expands a Storer enabling it to confirm whether it supports
 // a given Git extension.
 //


### PR DESCRIPTION
The SHA256 implementation introduced a temporary `ObjectFormatGetter` interface
that had two key goals:
- Provide a way to access the `ObjectFormat` from a `storer.Storer`, without
  changing the existing API.
- Be able to distinguish between `storer.Storer` implementations that support
  the objectformat extension.

The PR https://github.com/go-git/go-git/pull/1850 ensures that the `storer.Storer` being used supports the required
objectformat. With that, this interface can be replaced by `config.ConfigStorer`,
making the config the single source of truth for objectformat.

Relates to #706.