### PR TITLE
plumbing: Include reference name in validation errors

### DIFF
--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -169,7 +169,7 @@ var ctrlSeqs = regexp.MustCompile(`[\000-\037\177]`)
 func (r ReferenceName) Validate() error {
 	s := string(r)
 	if len(s) == 0 {
-		return ErrInvalidReferenceName
+		return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 	}
 
 	// HEAD is a special case
@@ -179,13 +179,13 @@ func (r ReferenceName) Validate() error {
 
 	// rule 7
 	if strings.HasSuffix(s, ".") {
-		return ErrInvalidReferenceName
+		return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 	}
 
 	// rule 2
 	parts := strings.Split(s, "/")
 	if len(parts) < 2 {
-		return ErrInvalidReferenceName
+		return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 	}
 
 	isBranch := r.IsBranch()
@@ -193,7 +193,7 @@ func (r ReferenceName) Validate() error {
 	for i, part := range parts {
 		// rule 6
 		if len(part) == 0 {
-			return ErrInvalidReferenceName
+			return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 		}
 
 		if strings.HasPrefix(part, ".") || // rule 1
@@ -204,11 +204,11 @@ func (r ReferenceName) Validate() error {
 			part == "@" || // rule 9
 			strings.Contains(part, "\\") || // rule 10
 			strings.HasSuffix(part, ".lock") { // rule 1
-			return ErrInvalidReferenceName
+			return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 		}
 
 		if (isBranch || isTag) && strings.HasPrefix(part, "-") && (i == 2) { // branches & tags can't start with -
-			return ErrInvalidReferenceName
+			return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 		}
 	}
 

--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -165,8 +165,14 @@ func (s *ReferenceSuite) TestValidReferenceNames() {
 
 	for i, v := range invalid {
 		comment := fmt.Sprintf("invalid reference name case %d: %s", i, v)
-		s.Error(v.Validate(), comment)
-		s.ErrorContains(v.Validate(), "invalid reference name", comment)
+		err := v.Validate()
+		s.Error(err, comment)
+		s.ErrorIs(err, ErrInvalidReferenceName, comment)
+		s.ErrorContains(err, "invalid reference name", comment)
+		// The reference name is included in the error using %q formatting,
+		// so we check for the quoted form to handle control characters.
+		quoted := fmt.Sprintf("%q", string(v))
+		s.ErrorContains(err, quoted, comment)
 	}
 }
 


### PR DESCRIPTION
`ReferenceName.Validate()` currently returns a bare `ErrInvalidReferenceName`
sentinel with no context about which reference failed. When this error surfaces
through callers that add their own wrapping (e.g. config parsing via
`unmarshalBranches`), users see messages like:

```
failed to get remote origin: invalid reference name
```

...with no way to identify the problematic entry in their `.git/config`.

This change wraps the sentinel with `fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)`
so the offending reference name is included while preserving `errors.Is` compatibility.

### Before
```
invalid reference name
```

### After
```
invalid reference name: "refs/heads/-my-branch"
```

Tests are updated to assert both `errors.Is` compatibility and that the
reference name appears in the error message.