### PR TITLE
config: allow branch merge to point to any refs/* path

### DIFF
--- a/config/branch.go
+++ b/config/branch.go
@@ -43,7 +43,7 @@ func (b *Branch) Validate() error {
 		return errBranchEmptyName
 	}
 
-	if b.Merge != "" && !b.Merge.IsBranch() {
+	if b.Merge != "" && !strings.HasPrefix(string(b.Merge), "refs/") {
 		return errBranchInvalidMerge
 	}
 

--- a/config/branch_test.go
+++ b/config/branch_test.go
@@ -87,3 +87,21 @@ func (b *BranchSuite) TestUnmarshal() {
 	b.Equal(plumbing.ReferenceName("refs/heads/branch-tracking-on-clone"), branch.Merge)
 	b.Equal("interactive", branch.Rebase)
 }
+
+func (b *BranchSuite) TestValidateMergeWithPullRef() {
+	// Regression test for https://github.com/go-git/go-git/issues/1871
+	// branch.merge should allow refs/pull/<ID>/head (used by GitHub/GitLab PRs)
+	prBranch := Branch{
+		Name:   "contributor/fix-9999",
+		Remote: "upstream",
+		Merge:  "refs/pull/9999/head",
+	}
+	b.Nil(prBranch.Validate())
+
+	mrBranch := Branch{
+		Name:   "contributor/fix-42",
+		Remote: "origin",
+		Merge:  "refs/merge-requests/42/head",
+	}
+	b.Nil(mrBranch.Validate())
+}


### PR DESCRIPTION
## Summary

Fixes #1871

## Problem

`git.Open` fails with `branch config: invalid merge` when a repository config contains a branch with `merge` pointing to `refs/pull/<ID>/head` (GitHub PR refs) or `refs/merge-requests/<ID>/head` (GitLab MR refs).

This is a valid git configuration — `git` itself allows `branch.<name>.merge` to point to any reference, but the go-git validation restricted it to `refs/heads/*` only.

## Steps to reproduce

1. `git init`
2. Add to `.git/config`:
```
[branch "contributor/fix-9999"]
    remote = upstream
    merge = refs/pull/9999/head
```
3. `git.Open` returns `error: branch config: invalid merge`

## Fix

Changed the validation in `config/Branch.Validate()` to accept any reference starting with `refs/`, which matches git's own behaviour.

## Tests

Added `TestValidateMergeWithPullRef` covering both GitHub (`refs/pull/`) and GitLab (`refs/merge-requests/`) style PR refs.