### PR TITLE
submodule: add URLRewriter for custom submodule URL resolution

### DIFF
--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -45,9 +45,10 @@ var args = map[string][]string{
 
 // tests not working / set-up
 var ignored = map[string]bool{
-	"ls":              true,
-	"sha256":          true,
-	"submodule":       true,
+	"local-clone":    true,
+	"ls":             true,
+	"sha256":         true,
+	"submodule":      true,
 	"tag-create-push": true,
 }
 

--- a/_examples/local-clone/main.go
+++ b/_examples/local-clone/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-git/go-git/v6"
+	. "github.com/go-git/go-git/v6/_examples"
+)
+
+// Example of cloning a local repository with recursive submodules.
+// When SubmoduleURLRewriter is set with LocalSubmoduleRewriter,
+// submodules are fetched from the source repo's .git/modules/ directory
+// instead of from the remote URLs recorded in .gitmodules.
+func main() {
+	CheckArgs("<local-repo-path>", "<directory>")
+	repoPath := os.Args[1]
+	directory := os.Args[2]
+
+	Info("git clone %s %s --recursive (local submodules)", repoPath, directory)
+
+	r, err := git.PlainClone(directory, &git.CloneOptions{
+		URL:                  repoPath,
+		RecurseSubmodules:    git.DefaultSubmoduleRecursionDepth,
+		SubmoduleURLRewriter: git.LocalSubmoduleRewriter(repoPath),
+		Progress:             os.Stderr,
+	})
+	CheckIfError(err)
+
+	ref, err := r.Head()
+	CheckIfError(err)
+
+	commit, err := r.CommitObject(ref.Hash())
+	CheckIfError(err)
+
+	fmt.Println(commit)
+
+	w, err := r.Worktree()
+	CheckIfError(err)
+
+	subs, err := w.Submodules()
+	CheckIfError(err)
+
+	fmt.Printf("\n%d submodules cloned\n", len(subs))
+	for _, sub := range subs {
+		cfg := sub.Config()
+		fmt.Printf("  %s -> %s\n", cfg.Name, cfg.URL)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -97,6 +97,10 @@ type CloneOptions struct {
 	// will not return an error. The resulting repository will be initialized
 	// with the remote configured but no commits.
 	AllowEmptyRepo bool
+	// SubmoduleURLRewriter, if non-nil, is passed to SubmoduleUpdateOptions
+	// when recursively initializing submodules during clone. See
+	// SubmoduleUpdateOptions.URLRewriter for details.
+	SubmoduleURLRewriter func(submoduleName, remoteURL string) string
 
 	// worktree defines the worktree filesystem for non-bare clone operations.
 	// This is only used internally due to partial inits.
@@ -368,6 +372,10 @@ type SubmoduleUpdateOptions struct {
 	// Depth limit fetching to the specified number of commits from the tip of
 	// each remote branch history.
 	Depth int
+	// URLRewriter, if non-nil, is called to rewrite each submodule's remote URL
+	// before fetching. It receives the submodule name and the resolved URL from
+	// .gitmodules. The return value is used as the remote URL for the submodule.
+	URLRewriter func(submoduleName, remoteURL string) string
 }
 
 // Checkout errors.

--- a/repository.go
+++ b/repository.go
@@ -1159,7 +1159,8 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 					}
 					return 0
 				}(),
-				Auth: o.Auth,
+				Auth:        o.Auth,
+				URLRewriter: o.SubmoduleURLRewriter,
 			}); err != nil {
 				return err
 			}
@@ -1191,6 +1192,29 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 	}
 
 	return nil
+}
+
+// LocalSubmoduleRewriter returns a URLRewriter that maps submodule names to
+// .git/modules/<name>/ paths under the given local repository path. If the
+// module directory does not exist, the original URL is returned unchanged so
+// the fetch falls back to the remote.
+//
+// This is intended for use with CloneOptions.SubmoduleURLRewriter or
+// SubmoduleUpdateOptions.URLRewriter when cloning from a local repository
+// whose submodules should be fetched from the source's .git/modules/
+// directory rather than from the remote URLs in .gitmodules.
+//
+// Note: this only handles top-level submodules. Nested submodules are stored
+// under their parent's module directory (e.g. .git/modules/<parent>/modules/<child>)
+// and will fall back to the remote URL.
+func LocalSubmoduleRewriter(repoPath string) func(string, string) string {
+	return func(name, originalURL string) string {
+		candidate := filepath.Join(repoPath, GitDirName, "modules", filepath.FromSlash(name))
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		return originalURL
+	}
 }
 
 const (

--- a/submodule.go
+++ b/submodule.go
@@ -192,6 +192,12 @@ func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, force
 		}
 	}
 
+	if o.URLRewriter != nil {
+		origURL := s.c.URL
+		s.c.URL = o.URLRewriter(s.c.Name, s.c.URL)
+		defer func() { s.c.URL = origURL }()
+	}
+
 	idx, err := s.w.r.Storer.Index()
 	if err != nil {
 		return err


### PR DESCRIPTION
Add URLRewriter callback to SubmoduleUpdateOptions and SubmoduleURLRewriter to CloneOptions, allowing callers to rewrite submodule remote URLs before fetching.

This is useful when cloning from a local repository where submodules should be fetched from the source repo's .git/modules/ directory rather than from the remote URLs recorded in .gitmodules.

Add LocalSubmoduleRewriter helper that maps submodule names to .git/modules/<name>/ paths under a given local repository path, falling back to the original URL when the module directory does not exist.

No existing behavior is changed; the rewriter is nil by default.

This is part of a set of optimizations for speeding up the clone operation against a Git repository on disk (file path) which has many and/or large Git submodules.