### PR TITLE
repository: fix v0 extension casing checks

### DIFF
--- a/repository_extensions.go
+++ b/repository_extensions.go
@@ -41,6 +41,12 @@ var (
 		// noop-v1 does not change git’s behavior at all.
 		// It is useful only for testing format-1 compatibility.
 		"noop-v1": {},
+
+		// These extensions are accepted by Git in v0 repositories and are treated
+		// as known extensions by Git regardless of repositoryFormatVersion.
+		"partialclone":    {},
+		"preciousobjects": {},
+		"worktreeconfig":  {},
 	}
 
 	// Some Git extensions were supported upstream before the introduction
@@ -48,9 +54,9 @@ var (
 	// enabled while core.repositoryformatversion is unset or set to 0.
 	extensionsValidForV0 = map[string]struct{}{
 		"noop":            {},
-		"partialClone":    {},
-		"preciousObjects": {},
-		"worktreeConfig":  {},
+		"partialclone":    {},
+		"preciousobjects": {},
+		"worktreeconfig":  {},
 	}
 )
 

--- a/repository_extensions_test.go
+++ b/repository_extensions_test.go
@@ -36,6 +36,44 @@ func TestVerifyExtensions(t *testing.T) {
 			},
 		},
 		{
+			name: "repositoryformatversion=0: allows worktreeConfig",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version0
+				cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
+			},
+		},
+		{
+			name: "repositoryformatversion=0: allows partialClone",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version0
+				cfg.Raw.Section("extensions").SetOption("partialClone", "origin")
+			},
+		},
+		{
+			name: "repositoryformatversion=0: allows preciousObjects",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version0
+				cfg.Raw.Section("extensions").SetOption("preciousObjects", "true")
+			},
+		},
+		{
+			name: "repositoryformatversion=0: allows WORKTREECONFIG (case-insensitive)",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version0
+				cfg.Raw.Section("extensions").SetOption("WORKTREECONFIG", "true")
+			},
+		},
+		{
+			name: "repositoryformatversion=0: allows multiple v0 extensions together",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version0
+				ext := cfg.Raw.Section("extensions")
+				ext.SetOption("worktreeConfig", "true")
+				ext.SetOption("partialClone", "origin")
+				ext.SetOption("preciousObjects", "true")
+			},
+		},
+		{
 			name: "repositoryformatversion='': allows supported noop",
 			setup: func(t *testing.T, cfg *config.Config) {
 				cfg.Raw.Section("extensions").SetOption("noop", "bar")


### PR DESCRIPTION
## Error
```
core.repositoryformatversion does not support extension: worktreeconfig
```

## Summary
- Fix `extensionsValidForV0` lookups by using lowercase keys to match the existing `strings.ToLower()` normalization.
- Treat Git's historically-v0 extensions (`partialclone`, `preciousobjects`, `worktreeconfig`) as known during verification.
- Add unit tests covering mixed-case extension keys for v0 repositories.

## Test plan
- [x] `go test . -run '^TestVerifyExtensions$' -count=1`


