### PR TITLE
x: worktree, fix worktreeNameRE, tests

### DIFF
--- a/x/plumbing/worktree/worktree.go
+++ b/x/plumbing/worktree/worktree.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	worktreeNameRE = regexp.MustCompile(`^[a-zA-Z0-9\-]+$`)
+	worktreeNameRE = regexp.MustCompile(`^[a-zA-Z0-9._\-]+$`)
 
 	// ErrWorktreeNotFound is returned when attempting to remove a worktree that does not exist.
 	ErrWorktreeNotFound = errors.New("worktree not found")

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -1279,22 +1279,34 @@ func TestWorktreeConfig(t *testing.T) {
 }
 
 func FuzzAdd(f *testing.F) {
-	f.Add("test")
-	f.Add("test-worktree")
-	f.Add("test123")
-	f.Add("TEST-123")
-	f.Add("")
-	f.Add("test worktree")
-	f.Add("test@worktree")
-	f.Add("test/worktree")
-	f.Add("test.worktree")
-	f.Add("test_worktree")
-	f.Add("-")
-	f.Add("a")
-	f.Add("123")
-	f.Add("test-")
-	f.Add("-test")
-	f.Add("../../../test")
+	type tc struct {
+		name       string
+		shouldPass bool
+	}
+	PASS, FAIL := true, false // For extra-explicit test intents
+	cases := []tc{
+		{"test", PASS},
+		{"test-worktree", PASS},
+		{"test123", PASS},
+		{"TEST-123", PASS},
+		{"", FAIL},
+		{"test worktree", FAIL},
+		{"test@worktree", FAIL},
+		{"test/worktree", FAIL},
+		{"test.worktree", PASS},
+		{"test_worktree", PASS},
+		{"-", PASS},
+		{"a", PASS},
+		{"123", PASS},
+		{"test-", PASS},
+		{"-test", PASS},
+		{"../../../test", FAIL},
+	}
+	expected := make(map[string]bool, len(cases))
+	for _, tc := range cases {
+		f.Add(tc.name)
+		expected[tc.name] = tc.shouldPass
+	}
 
 	f.Fuzz(func(t *testing.T, name string) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
@@ -1308,10 +1320,12 @@ func FuzzAdd(f *testing.F) {
 		commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
 
 		err = w.Add(wtFS, name, WithCommit(commit), WithDetachedHead())
-		if worktreeNameRE.MatchString(name) {
-			assert.NoError(t, err, "worktree name: %q", name)
-		} else {
-			assert.Error(t, err, "worktree name: %q", name)
+		if shouldPass, found := expected[name]; found {
+			if shouldPass {
+				assert.NoError(t, err, "worktree name: %q", name)
+			} else {
+				assert.Error(t, err, "worktree name: %q", name)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Update the FuzzAdd test in x/plumbing/worktree/worktree_test.go to capture whether the Add command should throw an error or not, rather than leaving it up to a regex expansion.  This can help surface bugs in the regex itself.

Also update the regex to expand what it considers a valid name.