### PR TITLE
storage: filesystem: add stat-based index cache

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -206,6 +206,11 @@ func (d *DotGit) Index() (billy.File, error) {
 	return d.fs.Open(indexPath)
 }
 
+// StatIndex returns the os.FileInfo for the index file without opening it.
+func (d *DotGit) StatIndex() (os.FileInfo, error) {
+	return d.fs.Stat(indexPath)
+}
+
 // ShallowWriter returns a file pointer for write to the shallow file
 func (d *DotGit) ShallowWriter() (billy.File, error) {
 	return d.fs.Create(shallowPath)

--- a/storage/filesystem/index.go
+++ b/storage/filesystem/index.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"bufio"
+	"errors"
 	"hash"
 	"os"
 	"time"
@@ -13,11 +14,31 @@ import (
 )
 
 type IndexStorage struct {
-	dir *dotgit.DotGit
-	h   hash.Hash
+	dir   *dotgit.DotGit
+	h     hash.Hash
+	cache IndexCache
 }
 
 func (s *IndexStorage) SetIndex(idx *index.Index) (err error) {
+	if err := s.writeIndex(idx); err != nil {
+		return err
+	}
+
+	if s.cache != nil {
+		fi, statErr := s.dir.StatIndex()
+		if statErr == nil {
+			cp := copyIndex(idx)
+			cp.ModTime = fi.ModTime()
+			s.cache.Set(cp, fi.ModTime(), fi.Size())
+		} else {
+			s.cache.Clear()
+		}
+	}
+
+	return nil
+}
+
+func (s *IndexStorage) writeIndex(idx *index.Index) (err error) {
 	f, err := s.dir.IndexWriter()
 	if err != nil {
 		return err
@@ -32,8 +53,7 @@ func (s *IndexStorage) SetIndex(idx *index.Index) (err error) {
 	}()
 
 	e := index.NewEncoder(bw, s.h)
-	err = e.Encode(idx)
-	return err
+	return e.Encode(idx)
 }
 
 func (s *IndexStorage) Index() (i *index.Index, err error) {
@@ -44,27 +64,63 @@ func (s *IndexStorage) Index() (i *index.Index, err error) {
 		}()
 	}
 
+	if s.cache != nil {
+		fi, err := s.dir.StatIndex()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				s.cache.Clear()
+				return &index.Index{Version: 2}, nil
+			}
+			return nil, err
+		}
+
+		if cached := s.cache.Get(fi.ModTime(), fi.Size()); cached != nil {
+			return copyIndex(cached), nil
+		}
+	}
+
 	idx := &index.Index{
 		Version: 2,
 	}
 
 	f, err := s.dir.Index()
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return idx, nil
 		}
-
 		return nil, err
 	}
 
 	defer ioutil.CheckClose(f, &err)
 
 	fi, err := f.Stat()
+	var sz int64
 	if err == nil {
 		idx.ModTime = fi.ModTime()
+		sz = fi.Size()
 	}
 
 	d := index.NewDecoder(f, s.h)
 	err = d.Decode(idx)
-	return idx, err
+	if err != nil {
+		return nil, err
+	}
+
+	if s.cache != nil {
+		s.cache.Set(idx, idx.ModTime, sz)
+	}
+
+	return copyIndex(idx), nil
+}
+
+// copyIndex returns a shallow copy of the Index struct with its own
+// copy of the Entries slice, so that callers can append/remove entries
+// without affecting the cached copy. Individual *Entry pointers are
+// shared; this is safe because callers replace entries rather than
+// mutating them in place.
+func copyIndex(idx *index.Index) *index.Index {
+	cp := *idx
+	cp.Entries = make([]*index.Entry, len(idx.Entries))
+	copy(cp.Entries, idx.Entries)
+	return &cp
 }

--- a/storage/filesystem/index_test.go
+++ b/storage/filesystem/index_test.go
@@ -1,0 +1,261 @@
+package filesystem_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/format/index"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+)
+
+func TestIndexCacheHit(t *testing.T) {
+	t.Parallel()
+	sto, spy := newIndexStorageWithSpy(t)
+
+	orig := &index.Index{
+		Version: 2,
+		Entries: []*index.Entry{
+			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
+		},
+	}
+	require.NoError(t, sto.SetIndex(orig))
+	assert.Equal(t, 1, spy.sets) // write-through
+
+	// First Index() — cache hit from write-through.
+	idx1, err := sto.Index()
+	require.NoError(t, err)
+	assert.Len(t, idx1.Entries, 1)
+	assert.Equal(t, "foo.go", idx1.Entries[0].Name)
+	assert.Equal(t, 1, spy.hits)
+	assert.Equal(t, 0, spy.misses)
+
+	// Second Index() — still a cache hit.
+	idx2, err := sto.Index()
+	require.NoError(t, err)
+	assert.Len(t, idx2.Entries, 1)
+	assert.Equal(t, "foo.go", idx1.Entries[0].Name)
+	assert.Equal(t, 2, spy.hits)
+	assert.Equal(t, 0, spy.misses)
+}
+
+func TestIndexCacheReturnsCopy(t *testing.T) {
+	t.Parallel()
+	sto, spy := newIndexStorageWithSpy(t)
+
+	require.NoError(t, sto.SetIndex(&index.Index{
+		Version: 2,
+		Entries: []*index.Entry{
+			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
+		},
+	}))
+
+	idx1, err := sto.Index()
+	require.NoError(t, err)
+	assert.Equal(t, 1, spy.hits)
+	idx1.Version = 99
+
+	idx2, err := sto.Index()
+	assert.Equal(t, 2, spy.hits)
+	require.NoError(t, err)
+	assert.NotSame(t, idx1, idx2)
+	assert.Equal(t, uint32(2), idx2.Version)
+}
+
+func TestIndexCacheIsolatesEntrySliceMutation(t *testing.T) {
+	t.Parallel()
+	sto, spy := newIndexStorageWithSpy(t)
+
+	require.NoError(t, sto.SetIndex(&index.Index{
+		Version: 2,
+		Entries: []*index.Entry{
+			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
+		},
+	}))
+
+	idx1, err := sto.Index()
+	require.NoError(t, err)
+	assert.Equal(t, 1, spy.hits)
+
+	idx1.Entries = append(idx1.Entries, &index.Entry{
+		Hash: plumbing.NewHash("def460562de28eb7e7ac40e0ee1e0603a33a9a00"),
+		Name: "bar.go",
+	})
+	assert.Len(t, idx1.Entries, 2)
+
+	idx2, err := sto.Index()
+	require.NoError(t, err)
+	assert.Equal(t, 2, spy.hits)
+	assert.Len(t, idx2.Entries, 1)
+	assert.Equal(t, "foo.go", idx2.Entries[0].Name)
+}
+
+func TestIndexCacheIsolatesSetIndexCallerMutation(t *testing.T) {
+	t.Parallel()
+	sto, spy := newIndexStorageWithSpy(t)
+
+	idx := &index.Index{
+		Version: 2,
+		Entries: []*index.Entry{
+			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
+		},
+	}
+	require.NoError(t, sto.SetIndex(idx))
+	assert.Equal(t, 1, spy.sets)
+
+	// Caller mutates the index after SetIndex — simulates worktree code.
+	idx.Entries = append(idx.Entries, &index.Entry{
+		Hash: plumbing.NewHash("def460562de28eb7e7ac40e0ee1e0603a33a9a00"),
+		Name: "bar.go",
+	})
+	idx.Version = 3
+
+	// The cache must be unaffected - only SetIndex can update the cached index.
+	got, err := sto.Index()
+	require.NoError(t, err)
+	assert.Equal(t, 1, spy.hits)
+	assert.Equal(t, uint32(2), got.Version)
+	assert.Len(t, got.Entries, 1)
+	assert.Equal(t, "foo.go", got.Entries[0].Name)
+}
+
+func TestIndexCacheInvalidatedByExternalChange(t *testing.T) {
+	t.Parallel()
+	sto, spy := newIndexStorageWithSpy(t)
+
+	require.NoError(t, sto.SetIndex(&index.Index{
+		Version: 2,
+		Entries: []*index.Entry{
+			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
+		},
+	}))
+
+	_, err := sto.Index()
+	require.NoError(t, err)
+	assert.Equal(t, 1, spy.hits)
+
+	lastHour := time.Now().Add(-time.Hour)
+	err = os.Chtimes(filepath.Join(sto.Filesystem().Root(), "index"), lastHour, lastHour)
+	require.NoError(t, err)
+
+	idx, err := sto.Index()
+	require.NoError(t, err)
+	assert.Len(t, idx.Entries, 1)
+	assert.Equal(t, 1, spy.hits)
+	assert.Equal(t, 1, spy.misses)
+}
+
+func TestIndexCacheWriteThrough(t *testing.T) {
+	t.Parallel()
+	sto, spy := newIndexStorageWithSpy(t)
+
+	require.NoError(t, sto.SetIndex(&index.Index{
+		Version: 2,
+		Entries: []*index.Entry{
+			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "a.go"},
+		},
+	}))
+	assert.Equal(t, 1, spy.sets)
+
+	got, err := sto.Index()
+	require.NoError(t, err)
+	assert.Len(t, got.Entries, 1)
+	assert.Equal(t, "a.go", got.Entries[0].Name)
+	assert.Equal(t, 1, spy.hits)
+	assert.Equal(t, 0, spy.misses)
+}
+
+func TestIndexCacheMissingFile(t *testing.T) {
+	t.Parallel()
+	sto, spy := newIndexStorageWithSpy(t)
+
+	idx, err := sto.Index()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), idx.Version)
+	assert.Empty(t, idx.Entries)
+
+	assert.Equal(t, 0, spy.hits)
+	assert.Equal(t, 0, spy.misses)
+	assert.Equal(t, 1, spy.clears)
+}
+
+func TestIndexCacheClearedWhenFileDeleted(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fs := osfs.New(tmp)
+	spy := newSpyIndexCache()
+	sto := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{IndexCache: spy})
+	require.NoError(t, sto.Init())
+
+	require.NoError(t, sto.SetIndex(&index.Index{
+		Version: 2,
+		Entries: []*index.Entry{
+			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "a.go"},
+		},
+	}))
+
+	_, err := sto.Index()
+	require.NoError(t, err)
+	assert.Equal(t, 1, spy.hits)
+
+	err = os.Remove(filepath.Join(sto.Filesystem().Root(), "index"))
+	require.NoError(t, err)
+
+	got, err := sto.Index()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), got.Version)
+	assert.Empty(t, got.Entries)
+	assert.Equal(t, 1, spy.clears) // cleared when stat returns ErrNotExist
+}
+
+// spyIndexCache wraps a real IndexCache and records calls.
+type spyIndexCache struct {
+	inner  filesystem.IndexCache
+	hits   int
+	misses int
+	sets   int
+	clears int
+}
+
+func newSpyIndexCache() *spyIndexCache {
+	return &spyIndexCache{inner: filesystem.NewIndexCache()}
+}
+
+func (s *spyIndexCache) Get(modTime time.Time, fileSize int64) *index.Index {
+	idx := s.inner.Get(modTime, fileSize)
+	if idx != nil {
+		s.hits++
+	} else {
+		s.misses++
+	}
+	return idx
+}
+
+func (s *spyIndexCache) Set(idx *index.Index, modTime time.Time, fileSize int64) {
+	s.sets++
+	s.inner.Set(idx, modTime, fileSize)
+}
+
+func (s *spyIndexCache) Clear() {
+	s.clears++
+	s.inner.Clear()
+}
+
+func newIndexStorageWithSpy(t *testing.T) (*filesystem.Storage, *spyIndexCache) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	fs := osfs.New(tmp)
+	spy := newSpyIndexCache()
+	sto := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{IndexCache: spy})
+	require.NoError(t, sto.Init())
+
+	return sto, spy
+}

--- a/storage/filesystem/indexcache.go
+++ b/storage/filesystem/indexcache.go
@@ -1,0 +1,63 @@
+package filesystem
+
+import (
+	"sync"
+	"time"
+
+	"github.com/go-git/go-git/v6/plumbing/format/index"
+)
+
+// IndexCache is a cache for the git index. Implementations must be safe
+// for concurrent use.
+type IndexCache interface {
+	// Get returns the cached index when modTime and fileSize match the
+	// stored values. On a miss it returns nil.
+	Get(modTime time.Time, fileSize int64) *index.Index
+	// Set stores idx together with the file stat values used for
+	// subsequent invalidation checks.
+	Set(idx *index.Index, modTime time.Time, fileSize int64)
+	// Clear removes any cached index.
+	Clear()
+}
+
+// statIndexCache is the default stat-based IndexCache.
+type statIndexCache struct {
+	mu       sync.RWMutex
+	cached   *index.Index
+	modTime  time.Time
+	fileSize int64
+}
+
+// NewIndexCache returns an IndexCache that invalidates when the file's
+// modification time or size changes.
+func NewIndexCache() IndexCache {
+	return &statIndexCache{}
+}
+
+func (c *statIndexCache) Get(modTime time.Time, fileSize int64) *index.Index {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.cached != nil && modTime.Equal(c.modTime) && fileSize == c.fileSize {
+		return c.cached
+	}
+	return nil
+}
+
+func (c *statIndexCache) Set(idx *index.Index, modTime time.Time, fileSize int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cached = idx
+	c.modTime = modTime
+	c.fileSize = fileSize
+}
+
+func (c *statIndexCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cached = nil
+	c.modTime = time.Time{}
+	c.fileSize = 0
+}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -58,6 +58,10 @@ type Options struct {
 	// existing dotgit. In such cases the repository config will define the
 	// ObjectFormat - even if implicitly (e.g. SHA1).
 	ObjectFormat formatcfg.ObjectFormat
+
+	// IndexCache provides an optional cache implementation for index data.
+	// If left as nil, a default stat-based implementation is created automatically.
+	IndexCache IndexCache
 }
 
 // NewStorage returns a new Storage backed by a given `fs.Filesystem` and cache.
@@ -94,6 +98,10 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 		c = cache.NewObjectLRUDefault()
 	}
 
+	if ops.IndexCache == nil {
+		ops.IndexCache = NewIndexCache()
+	}
+
 	s := &Storage{
 		fs:     fs,
 		dir:    dir,
@@ -101,7 +109,7 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 
 		ObjectStorage:    *NewObjectStorageWithOptions(dir, c, ops),
 		ReferenceStorage: ReferenceStorage{dir: dir},
-		IndexStorage:     IndexStorage{dir: dir, h: hasher.Hash},
+		IndexStorage:     IndexStorage{dir: dir, h: hasher.Hash, cache: ops.IndexCache},
 		ShallowStorage:   ShallowStorage{dir: dir},
 		ConfigStorage:    ConfigStorage{dir: dir, objectFormat: ops.ObjectFormat},
 		ModuleStorage:    ModuleStorage{dir: dir},

--- a/storage/tests/storage_test.go
+++ b/storage/tests/storage_test.go
@@ -568,6 +568,8 @@ func TestSetIndexAndIndex(t *testing.T) {
 
 		idx, err := sto.Index()
 		require.NoError(t, err)
+		assert.NotNil(t, idx)
+
 		// ModTime is set by memory storage's SetIndex to enable racy git detection.
 		// Verify it was set, then clear for structural comparison.
 		assert.False(t, idx.ModTime.IsZero())

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -839,6 +840,48 @@ func (s *WorktreeSuite) TestCommitInvalidCharactersInAuthorInfos() {
 
 	s.Equal("foo bad", commit.Author.Name)
 	s.Equal("badfoo@foo.foo", commit.Author.Email)
+}
+
+func BenchmarkCommit(b *testing.B) {
+	const (
+		numFiles      = 100
+		numSubdirs    = 5
+		numGoroutines = 4
+	)
+
+	wt := setupBenchmarkRepo(b, numFiles, numSubdirs, numGoroutines)
+
+	sig := &object.Signature{
+		Name:  "Benchmark",
+		Email: "benchmark@test.com",
+		When:  time.Now(),
+	}
+
+	seq := 0
+	b.Run("Commit", func(b *testing.B) {
+		for range b.N {
+			b.StopTimer()
+			fileName := filepath.Join("dir0", fmt.Sprintf("bench_%d.txt", seq))
+			err := util.WriteFile(wt.Filesystem, fileName, fmt.Appendf(nil, "content %d", seq), 0o644)
+			require.NoError(b, err)
+
+			_, err = wt.Add(fileName)
+			require.NoError(b, err)
+
+			sig.When = time.Now()
+
+			// Isolate the benchmark to the commit operation.
+			b.StartTimer()
+			_, err = wt.Commit(fmt.Sprintf("commit %d\n", seq), &CommitOptions{
+				Author:    sig,
+				Committer: sig,
+			})
+			b.StopTimer()
+
+			require.NoError(b, err)
+			seq++
+		}
+	})
 }
 
 func assertStorageStatus(


### PR DESCRIPTION
Introduce an `IndexCache` interface and a default stat-based implementation that avoids redundant disk reads and decoding of the git index file. On each `Index()` call the file is stat'd and the cached copy is returned when modification time and size match, falling back to a full read+decode on a miss. `SetIndex()` populates the cache via write-through so the immediately following Index() is served from memory.

Both read and write paths use `copyIndex()` which copies the Index struct value and clones the Entries slice, ensuring callers cannot corrupt the cached data through post-call mutations.

The cache can be injected via `Options.IndexCache` for testing or custom invalidation strategies; a stat-based default is created automatically when none is provided.

A new benchmark to assess commits was introduced, there is a large variance on sec/op and B/op between the first call and the subsequent ones - due to other performance issues that will be looked as a follow-up. However, the impact of the new cache has a clear impact on allocations:

```
goos: linux
goarch: amd64
pkg: github.com/go-git/go-git/v6
cpu: AMD Ryzen AI 9 HX PRO 370 w/ Radeon 890M
                 │ /tmp/before  │           /tmp/after           │
                 │    sec/op    │    sec/op     vs base          │
Commit/Commit-24   6.299m ± 42%   5.719m ± 27%  ~ (p=0.579 n=10)

                 │  /tmp/before  │           /tmp/after            │
                 │     B/op      │     B/op       vs base          │
Commit/Commit-24   2.963Mi ± 41%   2.498Mi ± 29%  ~ (p=0.280 n=10)

                 │ /tmp/before  │              /tmp/after              │
                 │  allocs/op   │  allocs/op    vs base                │
Commit/Commit-24   73.38k ± 40%   29.82k ± 29%  -59.36% (p=0.001 n=10)
```

The impact is observable by running the performance trace for the [commit example](https://github.com/go-git/go-git/blob/main/_examples/commit/main.go) in a very large repository (i.e. Linux Kernel).

Before these changes, the 3 calls to `Store.Index()` accounted for `0.3s`:
```
11:06:24.362677 index.go:49: performance: 0.104357395 s: storage/filesystem: get index()
11:06:24.448323 index.go:49: performance: 0.085250701 s: storage/filesystem: get index()
11:06:26.925873 index.go:49: performance: 0.060172693 s: storage/filesystem: get index()
11:06:27.542282 index.go:49: performance: 0.060106399 s: storage/filesystem: get index()
```

With the new cache, the cost for subsequent calls are considerably reduced. In this example, the total time dropped to `0.11s`:
```
11:06:00.865018 index.go:61: performance: 0.107215545 s: storage/filesystem: get index()
11:06:00.867021 index.go:61: performance: 0.001620462 s: storage/filesystem: get index()
11:06:03.346510 index.go:61: performance: 0.000107721 s: storage/filesystem: get index()
11:06:03.958044 index.go:61: performance: 0.000076523 s: storage/filesystem: get index()
```

Follow-up from #1747.