### PR TITLE
Verify plugin

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,6 +106,17 @@ type Config struct {
 		Email string
 	}
 
+	GPG struct {
+		// Format specifies the signature format to use when signing commits and tags.
+		// Valid values are "openpgp" (default) and "ssh".
+		Format string
+		// SSH contains SSH-specific GPG configuration.
+		SSH struct {
+			// AllowedSignersFile is the path to the file containing allowed SSH signing keys.
+			AllowedSignersFile string
+		}
+	}
+
 	Pack struct {
 		// Window controls the size of the sliding window for delta
 		// compression.  The default is 10.  A value of 0 turns off
@@ -339,6 +350,7 @@ const (
 	userSection                = "user"
 	authorSection              = "author"
 	committerSection           = "committer"
+	gpgSection                 = "gpg"
 	initSection                = "init"
 	urlSection                 = "url"
 	extensionsSection          = "extensions"
@@ -362,6 +374,8 @@ const (
 	versionKey                 = "version"
 	autoCRLFKey                = "autocrlf"
 	fileModeKey                = "filemode"
+	formatKey                  = "format"
+	allowedSignersFileKey      = "allowedSignersFile"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.
@@ -383,6 +397,7 @@ func (c *Config) Unmarshal(b []byte) error {
 	c.unmarshalCore()
 	c.unmarshalExtensions()
 	c.unmarshalUser()
+	c.unmarshalGPG()
 	c.unmarshalInit()
 	if err := c.unmarshalPack(); err != nil {
 		return err
@@ -440,6 +455,18 @@ func (c *Config) unmarshalUser() {
 	s = c.Raw.Section(committerSection)
 	c.Committer.Name = s.Options.Get(nameKey)
 	c.Committer.Email = s.Options.Get(emailKey)
+}
+
+func (c *Config) unmarshalGPG() {
+	s := c.Raw.Section(gpgSection)
+	c.GPG.Format = s.Options.Get(formatKey)
+
+	// SSH subsection is parsed separately since it uses subsections
+	for _, sub := range s.Subsections {
+		if sub.Name == "ssh" {
+			c.GPG.SSH.AllowedSignersFile = sub.Options.Get(allowedSignersFileKey)
+		}
+	}
 }
 
 func (c *Config) unmarshalPack() error {
@@ -561,6 +588,7 @@ func (c *Config) Marshal() ([]byte, error) {
 	c.marshalCore()
 	c.marshalExtensions()
 	c.marshalUser()
+	c.marshalGPG()
 	c.marshalPack()
 	c.marshalRemotes()
 	c.marshalSubmodules()
@@ -631,6 +659,19 @@ func (c *Config) marshalUser() {
 
 	if c.Committer.Email != "" {
 		s.SetOption(emailKey, c.Committer.Email)
+	}
+}
+
+func (c *Config) marshalGPG() {
+	s := c.Raw.Section(gpgSection)
+	if c.GPG.Format != "" {
+		s.SetOption(formatKey, c.GPG.Format)
+	}
+
+	// SSH subsection
+	if c.GPG.SSH.AllowedSignersFile != "" {
+		sub := s.Subsection("ssh")
+		sub.SetOption(allowedSignersFileKey, c.GPG.SSH.AllowedSignersFile)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -85,12 +85,7 @@ type Config struct {
 		FileMode bool
 	}
 
-	User struct {
-		// Name is the personal name of the author and the committer of a commit.
-		Name string
-		// Email is the email of the author and the committer of a commit.
-		Email string
-	}
+	User user
 
 	Author struct {
 		// Name is the personal name of the author of a commit.
@@ -106,9 +101,19 @@ type Config struct {
 		Email string
 	}
 
+	Tag struct {
+		// GpgSign indicates whether all new tags should be GPG signed.
+		GpgSign bool
+	}
+
+	Commit struct {
+		// GpgSign indicates whether all new commits should be GPG signed.
+		GpgSign bool
+	}
+
 	GPG struct {
 		// Format specifies the signature format to use when signing commits and tags.
-		// Valid values are "openpgp" (default) and "ssh".
+		// Valid values are "openpgp" (default), "x509" and "ssh".
 		Format string
 		// SSH contains SSH-specific GPG configuration.
 		SSH struct {
@@ -172,6 +177,25 @@ type Config struct {
 	// preserve the parsed information from the original format, to avoid
 	// dropping unsupported fields.
 	Raw *format.Config
+}
+
+type user struct {
+	// Name is the personal name of the author and the committer of a commit.
+	Name string
+	// Email is the email of the author and the committer of a commit.
+	Email string
+
+	// SigningKey defines what key should be used when automatically
+	// signing tags or commits, and more than one key is available.
+	//
+	// If gpg.format is set to ssh this can contain the path to either
+	// your private ssh key or the public key when ssh-agent is used.
+	// Alternatively it can contain a public key prefixed with key::
+	// directly (e.g.: "key::ssh-rsa XXXXXX identifier"). The private
+	// key needs to be available via ssh-agent.
+	//
+	// If not set go-git will use the first key available.
+	SigningKey string
 }
 
 // Merge combines all the src Config objects into one.
@@ -348,6 +372,8 @@ const (
 	coreSection                = "core"
 	packSection                = "pack"
 	userSection                = "user"
+	tagSection                 = "tag"
+	commitSection              = "commit"
 	authorSection              = "author"
 	committerSection           = "committer"
 	gpgSection                 = "gpg"
@@ -366,6 +392,7 @@ const (
 	rebaseKey                  = "rebase"
 	nameKey                    = "name"
 	emailKey                   = "email"
+	signingKey                 = "signingKey"
 	descriptionKey             = "description"
 	defaultBranchKey           = "defaultBranch"
 	repositoryFormatVersionKey = "repositoryformatversion"
@@ -376,6 +403,7 @@ const (
 	fileModeKey                = "filemode"
 	formatKey                  = "format"
 	allowedSignersFileKey      = "allowedSignersFile"
+	gpgSignKey                 = "gpgSign"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.
@@ -396,6 +424,8 @@ func (c *Config) Unmarshal(b []byte) error {
 
 	c.unmarshalCore()
 	c.unmarshalExtensions()
+	c.unmarshalTag()
+	c.unmarshalCommit()
 	c.unmarshalUser()
 	c.unmarshalGPG()
 	c.unmarshalInit()
@@ -443,10 +473,27 @@ func (c *Config) unmarshalExtensions() {
 	c.Extensions.ObjectFormat = format.ObjectFormat(s.Options.Get(objectFormatKey))
 }
 
+func (c *Config) unmarshalTag() {
+	s := c.Raw.Section(tagSection)
+	v, err := strconv.ParseBool(s.Options.Get(gpgSignKey))
+	if err == nil {
+		c.Tag.GpgSign = v
+	}
+}
+
+func (c *Config) unmarshalCommit() {
+	s := c.Raw.Section(commitSection)
+	v, err := strconv.ParseBool(s.Options.Get(gpgSignKey))
+	if err == nil {
+		c.Commit.GpgSign = v
+	}
+}
+
 func (c *Config) unmarshalUser() {
 	s := c.Raw.Section(userSection)
 	c.User.Name = s.Options.Get(nameKey)
 	c.User.Email = s.Options.Get(emailKey)
+	c.User.SigningKey = s.Options.Get(signingKey)
 
 	s = c.Raw.Section(authorSection)
 	c.Author.Name = s.Options.Get(nameKey)
@@ -587,6 +634,8 @@ func (c *Config) unmarshalInit() {
 func (c *Config) Marshal() ([]byte, error) {
 	c.marshalCore()
 	c.marshalExtensions()
+	c.marshalTag()
+	c.marshalCommit()
 	c.marshalUser()
 	c.marshalGPG()
 	c.marshalPack()
@@ -633,6 +682,20 @@ func (c *Config) marshalExtensions() {
 	}
 }
 
+func (c *Config) marshalTag() {
+	s := c.Raw.Section(tagSection)
+	if c.Tag.GpgSign {
+		s.SetOption(gpgSignKey, strconv.FormatBool(c.Tag.GpgSign))
+	}
+}
+
+func (c *Config) marshalCommit() {
+	s := c.Raw.Section(commitSection)
+	if c.Commit.GpgSign {
+		s.SetOption(gpgSignKey, strconv.FormatBool(c.Commit.GpgSign))
+	}
+}
+
 func (c *Config) marshalUser() {
 	s := c.Raw.Section(userSection)
 	if c.User.Name != "" {
@@ -641,6 +704,10 @@ func (c *Config) marshalUser() {
 
 	if c.User.Email != "" {
 		s.SetOption(emailKey, c.User.Email)
+	}
+
+	if c.User.SigningKey != "" {
+		s.SetOption(signingKey, c.User.SigningKey)
 	}
 
 	s = c.Raw.Section(authorSection)

--- a/options.go
+++ b/options.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-billy/v6"
 
 	"github.com/go-git/go-git/v6/config"
@@ -676,9 +675,9 @@ type CreateTagOptions struct {
 	// validation into the format expected by git - no leading whitespace and
 	// ending in a newline.
 	Message string
-	// SignKey denotes a key to sign the tag with. A nil value here means the tag
-	// will not be signed. The private key must be present and already decrypted.
-	SignKey *openpgp.Entity
+	// Signer denotes a cryptographic signer to sign the tag with.
+	// A nil value here means the tag will not be signed.
+	Signer Signer
 }
 
 // Validate validates the fields and sets the default values.

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/ProtonMail/go-crypto/openpgp"
-
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/utils/ioutil"
@@ -66,6 +64,7 @@ type Commit struct {
 	ExtraHeaders []ExtraHeader
 
 	s storer.EncodedObjectStorer
+	v Verifier
 }
 
 // ExtraHeader holds any non-standard header
@@ -111,19 +110,20 @@ func parseExtraHeader(line []byte) (ExtraHeader, bool) {
 }
 
 // GetCommit gets a commit from an object storer and decodes it.
-func GetCommit(s storer.EncodedObjectStorer, h plumbing.Hash) (*Commit, error) {
+func GetCommit(s storer.EncodedObjectStorer, h plumbing.Hash, opts ...ObjectOption) (*Commit, error) {
 	o, err := s.EncodedObject(plumbing.CommitObject, h)
 	if err != nil {
 		return nil, err
 	}
 
-	return DecodeCommit(s, o)
+	return DecodeCommit(s, o, opts...)
 }
 
 // DecodeCommit decodes an encoded object into a *Commit and associates it to
 // the given object storer.
-func DecodeCommit(s storer.EncodedObjectStorer, o plumbing.EncodedObject) (*Commit, error) {
-	c := &Commit{s: s}
+func DecodeCommit(s storer.EncodedObjectStorer, o plumbing.EncodedObject, opts ...ObjectOption) (*Commit, error) {
+	resolved := applyObjectOptions(opts)
+	c := &Commit{s: s, v: resolved.Verifier}
 	if err := c.Decode(o); err != nil {
 		return nil, err
 	}
@@ -168,8 +168,9 @@ func (c *Commit) Patch(to *Commit) (*Patch, error) {
 
 // Parents return a CommitIter to the parent Commits.
 func (c *Commit) Parents() CommitIter {
-	return NewCommitIter(c.s,
+	return newCommitIterWithVerifier(c.s,
 		storer.NewEncodedObjectLookupIter(c.s, plumbing.CommitObject, c.ParentHashes),
+		c.v,
 	)
 }
 
@@ -187,7 +188,7 @@ func (c *Commit) Parent(i int) (*Commit, error) {
 		return nil, ErrParentNotFound
 	}
 
-	return GetCommit(c.s, c.ParentHashes[i])
+	return GetCommit(c.s, c.ParentHashes[i], WithVerifier(c.v))
 }
 
 // File returns the file with the specified "path" in the commit and a
@@ -474,29 +475,50 @@ func (c *Commit) String() string {
 	)
 }
 
-// Verify performs PGP verification of the commit with a provided armored
-// keyring and returns openpgp.Entity associated with verifying key on success.
-func (c *Commit) Verify(armoredKeyRing string) (*openpgp.Entity, error) {
-	keyRingReader := strings.NewReader(armoredKeyRing)
-	keyring, err := openpgp.ReadArmoredKeyRing(keyRingReader)
-	if err != nil {
-		return nil, err
+// Verify verifies the cryptographic signature on the commit using the
+// verifier injected at construction time (via WithVerifier).
+// Returns a VerificationResult on success.
+//
+// If the commit has no signature, ErrNoSignature is returned.
+// If no verifier was injected, ErrNilVerifier is returned.
+func (c *Commit) Verify() (*VerificationResult, error) {
+	return c.VerifyWith(c.v)
+}
+
+// VerifyWith verifies the cryptographic signature on the commit using the
+// provided Verifier explicitly.
+// Returns a VerificationResult on success.
+//
+// If the commit has no signature, ErrNoSignature is returned.
+// If v is nil, ErrNilVerifier is returned.
+func (c *Commit) VerifyWith(v Verifier) (*VerificationResult, error) {
+	if v == nil {
+		return nil, ErrNilVerifier
+	}
+	if c.Signature == "" {
+		return nil, ErrNoSignature
 	}
 
-	// Extract signature.
-	signature := strings.NewReader(c.Signature)
-
 	encoded := &plumbing.MemoryObject{}
-	// Encode commit components, excluding signature and get a reader object.
 	if err := c.EncodeWithoutSignature(encoded); err != nil {
 		return nil, err
 	}
-	er, err := encoded.Reader()
+	message, err := io.ReadAll(must(encoded.Reader()))
 	if err != nil {
 		return nil, err
 	}
 
-	return openpgp.CheckArmoredDetachedSignature(keyring, er, signature, nil)
+	return v.Verify([]byte(c.Signature), message)
+}
+
+// must is a small helper that returns r, panicking if err is non-nil.
+// It is only used in contexts where the error is structurally impossible
+// (e.g. MemoryObject.Reader).
+func must[T any](r T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return r
 }
 
 // Less defines a compare function to determine which commit is 'earlier' by:
@@ -534,6 +556,7 @@ type CommitIter interface {
 type storerCommitIter struct {
 	storer.EncodedObjectIter
 	s storer.EncodedObjectStorer
+	v Verifier
 }
 
 // NewCommitIter takes a storer.EncodedObjectStorer and a
@@ -542,7 +565,13 @@ type storerCommitIter struct {
 //
 // Any non-commit object returned by the storer.EncodedObjectIter is skipped.
 func NewCommitIter(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter) CommitIter {
-	return &storerCommitIter{iter, s}
+	return &storerCommitIter{iter, s, nil}
+}
+
+// newCommitIterWithVerifier creates a CommitIter that propagates a verifier
+// to each decoded commit.
+func newCommitIterWithVerifier(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter, v Verifier) CommitIter {
+	return &storerCommitIter{iter, s, v}
 }
 
 // Next moves the iterator to the next commit and returns a pointer to it. If
@@ -553,7 +582,7 @@ func (iter *storerCommitIter) Next() (*Commit, error) {
 		return nil, err
 	}
 
-	return DecodeCommit(iter.s, obj)
+	return DecodeCommit(iter.s, obj, WithVerifier(iter.v))
 }
 
 // ForEach call the cb function for each commit contained on this iter until
@@ -561,7 +590,7 @@ func (iter *storerCommitIter) Next() (*Commit, error) {
 // the iteration is stopped but no error is returned. The iterator is closed.
 func (iter *storerCommitIter) ForEach(cb func(*Commit) error) error {
 	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
-		c, err := DecodeCommit(iter.s, obj)
+		c, err := DecodeCommit(iter.s, obj, WithVerifier(iter.v))
 		if err != nil {
 			return err
 		}

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -477,20 +477,21 @@ func (c *Commit) String() string {
 
 // Verify verifies the cryptographic signature on the commit using the
 // verifier injected at construction time (via WithVerifier).
-// Returns a VerificationResult on success.
 //
-// If the commit has no signature, ErrNoSignature is returned.
-// If no verifier was injected, ErrNilVerifier is returned.
+// A nil error means the signature is valid and the key is trusted.
+// On failure the error is (or wraps) one of the verification sentinel errors
+// defined in this package.
 func (c *Commit) Verify() (*VerificationResult, error) {
 	return c.VerifyWith(c.v)
 }
 
 // VerifyWith verifies the cryptographic signature on the commit using the
 // provided Verifier explicitly.
-// Returns a VerificationResult on success.
 //
-// If the commit has no signature, ErrNoSignature is returned.
-// If v is nil, ErrNilVerifier is returned.
+// A nil error means the signature is valid and the key is trusted.
+// On failure the error is (or wraps) one of the verification sentinel errors
+// defined in this package (e.g. ErrNoSignature, ErrNilVerifier,
+// ErrSignatureInvalid, ErrKeyNotTrusted, etc.).
 func (c *Commit) VerifyWith(v Verifier) (*VerificationResult, error) {
 	if v == nil {
 		return nil, ErrNilVerifier

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -492,27 +492,68 @@ TssDKHUR2taa53bQYjkZQBpvvwOrLgc=
 `,
 	}
 
-	armoredKeyRing := `
------BEGIN PGP PUBLIC KEY BLOCK-----
+	// Test with no verifier (nil) returns ErrNilVerifier.
+	_, err := commit.Verify()
+	s.ErrorIs(err, ErrNilVerifier)
 
-mDMEYGeSihYJKwYBBAHaRw8BAQdAIs9A3YD/EghhAOkHDkxlUkpqYrXUXebLfmmX
-+pdEK6C0D2dvLWdpdCB0ZXN0IGtleYiPBBMWCgA3FiEEzKlNMnEN3+oNzzKFjJpp
-heC7lfEFAmBnkooCGyMECwkIBwUVCgkICwUWAwIBAAIeAQIXgAAKCRCMmmmF4LuV
-8a3jAQCi4hSqjj6J3ch290FvQaYPGwR+EMQTMBG54t+NN6sDfgD/aZy41+0dnFKl
-qM/wLW5Wr9XvwH+1zXXbuSvfxasHowq4OARgZ5KKEgorBgEEAZdVAQUBAQdAXoQz
-VTYug16SisAoSrxFnOmxmFu6efYgCAwXu0ZuvzsDAQgHiHgEGBYKACAWIQTMqU0y
-cQ3f6g3PMoWMmmmF4LuV8QUCYGeSigIbDAAKCRCMmmmF4LuV8Q4QAQCKW5FnEdWW
-lHYKeByw3JugnlZ0U3V/R20bCwDglst5UQEAtkN2iZkHtkPly9xapsfNqnrt2gTt
-YIefGtzXfldDxg4=
-=Psht
------END PGP PUBLIC KEY BLOCK-----
-`
-
-	e, err := commit.Verify(armoredKeyRing)
+	// Test VerifyWith with a mock verifier.
+	mock := &mockVerifier{result: &VerificationResult{
+		Type:  SignatureTypeOpenPGP,
+		Valid: true,
+		KeyID: "test-key",
+	}}
+	result, err := commit.VerifyWith(mock)
 	s.NoError(err)
+	s.True(result.Valid)
+	s.Equal("test-key", result.KeyID)
 
-	_, ok := e.Identities["go-git test key"]
-	s.True(ok)
+	// Verify the mock received the signature bytes.
+	s.NotEmpty(mock.gotSignature)
+	s.NotEmpty(mock.gotMessage)
+
+	// Test unsigned commit returns ErrNoSignature.
+	unsigned := &Commit{
+		Hash:    plumbing.NewHash("1eca38290a3131d0c90709496a9b2207a872631e"),
+		Message: "unsigned",
+	}
+	_, err = unsigned.VerifyWith(mock)
+	s.ErrorIs(err, ErrNoSignature)
+}
+
+func (s *SuiteCommit) TestVerifyWithInjectedVerifier() {
+	ts := time.Unix(1617402711, 0)
+	loc, _ := time.LoadLocation("UTC")
+
+	mock := &mockVerifier{result: &VerificationResult{
+		Type:  SignatureTypeOpenPGP,
+		Valid: true,
+		KeyID: "injected-key",
+	}}
+
+	commit := &Commit{
+		Hash:      plumbing.NewHash("1eca38290a3131d0c90709496a9b2207a872631e"),
+		Author:    Signature{Name: "go-git", Email: "go-git@example.com", When: ts.In(loc)},
+		Committer: Signature{Name: "go-git", Email: "go-git@example.com", When: ts.In(loc)},
+		Message: `test
+`,
+		TreeHash:     plumbing.NewHash("52a266a58f2c028ad7de4dfd3a72fdf76b0d4e24"),
+		ParentHashes: []plumbing.Hash{plumbing.NewHash("e4fbb611cd14149c7a78e9c08425f59f4b736a9a")},
+		Signature: `
+-----BEGIN PGP SIGNATURE-----
+
+iHUEABYKAB0WIQTMqU0ycQ3f6g3PMoWMmmmF4LuV8QUCYGebVwAKCRCMmmmF4LuV
+8VtyAP9LbuXAhtK6FQqOjKybBwlV70rLcXVP24ubDuz88VVwSgD+LuObsasWq6/U
+TssDKHUR2taa53bQYjkZQBpvvwOrLgc=
+=YQUf
+-----END PGP SIGNATURE-----
+`,
+		v: mock,
+	}
+
+	result, err := commit.Verify()
+	s.NoError(err)
+	s.True(result.Valid)
+	s.Equal("injected-key", result.KeyID)
 }
 
 func (s *SuiteCommit) TestPatchCancel() {
@@ -743,4 +784,18 @@ func (s *SuiteCommit) TestLess() {
 		}
 		s.Equal(t.Exp, commit1.Less(commit2))
 	}
+}
+
+// mockVerifier is a test helper that implements the Verifier interface.
+type mockVerifier struct {
+	result       *VerificationResult
+	err          error
+	gotSignature []byte
+	gotMessage   []byte
+}
+
+func (m *mockVerifier) Verify(signature, message []byte) (*VerificationResult, error) {
+	m.gotSignature = signature
+	m.gotMessage = message
+	return m.result, m.err
 }

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -48,27 +48,27 @@ type Object interface {
 }
 
 // GetObject gets an object from an object storer and decodes it.
-func GetObject(s storer.EncodedObjectStorer, h plumbing.Hash) (Object, error) {
+func GetObject(s storer.EncodedObjectStorer, h plumbing.Hash, opts ...ObjectOption) (Object, error) {
 	o, err := s.EncodedObject(plumbing.AnyObject, h)
 	if err != nil {
 		return nil, err
 	}
 
-	return DecodeObject(s, o)
+	return DecodeObject(s, o, opts...)
 }
 
 // DecodeObject decodes an encoded object into an Object and associates it to
 // the given object storer.
-func DecodeObject(s storer.EncodedObjectStorer, o plumbing.EncodedObject) (Object, error) {
+func DecodeObject(s storer.EncodedObjectStorer, o plumbing.EncodedObject, opts ...ObjectOption) (Object, error) {
 	switch o.Type() {
 	case plumbing.CommitObject:
-		return DecodeCommit(s, o)
+		return DecodeCommit(s, o, opts...)
 	case plumbing.TreeObject:
 		return DecodeTree(s, o)
 	case plumbing.BlobObject:
 		return DecodeBlob(o)
 	case plumbing.TagObject:
-		return DecodeTag(s, o)
+		return DecodeTag(s, o, opts...)
 	default:
 		return nil, plumbing.ErrInvalidType
 	}

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -225,10 +225,10 @@ func (iter *ObjectIter) toObject(obj plumbing.EncodedObject) (Object, error) {
 		tree := &Tree{s: iter.s}
 		return tree, tree.Decode(obj)
 	case plumbing.CommitObject:
-		commit := &Commit{}
+		commit := &Commit{s: iter.s}
 		return commit, commit.Decode(obj)
 	case plumbing.TagObject:
-		tag := &Tag{}
+		tag := &Tag{s: iter.s}
 		return tag, tag.Decode(obj)
 	default:
 		return nil, plumbing.ErrInvalidType

--- a/plumbing/object/object_options.go
+++ b/plumbing/object/object_options.go
@@ -1,0 +1,29 @@
+package object
+
+// ObjectOption is a functional option for configuring object construction.
+type ObjectOption func(*ObjectOptions)
+
+// ObjectOptions holds configuration for object construction.
+type ObjectOptions struct {
+	// Verifier is the signature verifier to inject into the object.
+	Verifier Verifier
+}
+
+// WithVerifier returns an ObjectOption that injects a Verifier into the object.
+// The verifier propagates through object navigation (e.g. commit.Parent(),
+// tag.Commit()) so that Verify() works on the resulting objects without
+// requiring the caller to pass a verifier each time.
+func WithVerifier(v Verifier) ObjectOption {
+	return func(o *ObjectOptions) {
+		o.Verifier = v
+	}
+}
+
+// applyObjectOptions applies all ObjectOptions and returns the result.
+func applyObjectOptions(opts []ObjectOption) ObjectOptions {
+	var o ObjectOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}

--- a/plumbing/object/signature.go
+++ b/plumbing/object/signature.go
@@ -2,12 +2,33 @@ package object
 
 import "bytes"
 
+// SignatureType represents the type of a cryptographic signature.
+type SignatureType int8
+
 const (
-	signatureTypeUnknown signatureType = iota
-	signatureTypeOpenPGP
-	signatureTypeX509
-	signatureTypeSSH
+	// SignatureTypeUnknown indicates an unrecognized signature format.
+	SignatureTypeUnknown SignatureType = iota
+	// SignatureTypeOpenPGP indicates an OpenPGP (GPG) signature.
+	SignatureTypeOpenPGP
+	// SignatureTypeX509 indicates an X.509 (S/MIME) signature.
+	SignatureTypeX509
+	// SignatureTypeSSH indicates an SSH signature.
+	SignatureTypeSSH
 )
+
+// String returns the string representation of the signature type.
+func (t SignatureType) String() string {
+	switch t {
+	case SignatureTypeOpenPGP:
+		return "OpenPGP"
+	case SignatureTypeX509:
+		return "X.509"
+	case SignatureTypeSSH:
+		return "SSH"
+	default:
+		return "unknown"
+	}
+}
 
 var (
 	// openPGPSignatureFormat is the format of an OpenPGP signature.
@@ -19,6 +40,7 @@ var (
 	// a PKCS#7 (S/MIME) signature.
 	x509SignatureFormat = signatureFormat{
 		[]byte("-----BEGIN SIGNED MESSAGE-----"),
+		[]byte("-----BEGIN CERTIFICATE-----"),
 	}
 
 	// sshSignatureFormat is the format of an SSH signature.
@@ -28,21 +50,23 @@ var (
 )
 
 // knownSignatureFormats is a map of known signature formats, indexed by
-// their signatureType.
-var knownSignatureFormats = map[signatureType]signatureFormat{
-	signatureTypeOpenPGP: openPGPSignatureFormat,
-	signatureTypeX509:    x509SignatureFormat,
-	signatureTypeSSH:     sshSignatureFormat,
+// their SignatureType.
+var knownSignatureFormats = map[SignatureType]signatureFormat{
+	SignatureTypeOpenPGP: openPGPSignatureFormat,
+	SignatureTypeX509:    x509SignatureFormat,
+	SignatureTypeSSH:     sshSignatureFormat,
 }
-
-// signatureType represents the type of the signature.
-type signatureType int8
 
 // signatureFormat represents the beginning of a signature.
 type signatureFormat [][]byte
 
+// DetectSignatureType returns the SignatureType for the given signature bytes.
+func DetectSignatureType(sig []byte) SignatureType {
+	return typeForSignature(sig)
+}
+
 // typeForSignature returns the type of the signature based on its format.
-func typeForSignature(b []byte) signatureType {
+func typeForSignature(b []byte) SignatureType {
 	for t, i := range knownSignatureFormats {
 		for _, begin := range i {
 			if bytes.HasPrefix(b, begin) {
@@ -50,7 +74,7 @@ func typeForSignature(b []byte) signatureType {
 			}
 		}
 	}
-	return signatureTypeUnknown
+	return SignatureTypeUnknown
 }
 
 // parseSignedBytes returns the position of the last signature block found in
@@ -79,12 +103,12 @@ func typeForSignature(b []byte) signatureType {
 //
 // This logic is on par with git's gpg-interface.c:parse_signed_buffer().
 // https://github.com/git/git/blob/7c2ef319c52c4997256f5807564523dfd4acdfc7/gpg-interface.c#L668
-func parseSignedBytes(b []byte) (int, signatureType) {
+func parseSignedBytes(b []byte) (int, SignatureType) {
 	n, match := 0, -1
-	var t signatureType
+	var t SignatureType
 	for n < len(b) {
 		i := b[n:]
-		if st := typeForSignature(i); st != signatureTypeUnknown {
+		if st := typeForSignature(i); st != SignatureTypeUnknown {
 			match = n
 			t = st
 		}

--- a/plumbing/object/signature_test.go
+++ b/plumbing/object/signature_test.go
@@ -10,7 +10,7 @@ func Test_typeForSignature(t *testing.T) {
 	tests := []struct {
 		name string
 		b    []byte
-		want signatureType
+		want SignatureType
 	}{
 		{
 			name: "known signature format (PGP)",
@@ -21,7 +21,7 @@ iHUEABYKAB0WIQTMqU0ycQ3f6g3PMoWMmmmF4LuV8QUCYGebVwAKCRCMmmmF4LuV
 TssDKHUR2taa53bQYjkZQBpvvwOrLgc=
 =YQUf
 -----END PGP SIGNATURE-----`),
-			want: signatureTypeOpenPGP,
+			want: SignatureTypeOpenPGP,
 		},
 		{
 			name: "known signature format (SSH)",
@@ -31,7 +31,7 @@ U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgij/EfHS8tCjolj5uEANXgKzFfp
 AAAAQIYHMhSVV9L2xwJuV8eWMLjThya8yXgCHDzw3p01D19KirrabW0veiichPB5m+Ihtr
 MKEQruIQWJb+8HVXwssA4=
 -----END SSH SIGNATURE-----`),
-			want: signatureTypeSSH,
+			want: SignatureTypeSSH,
 		},
 		{
 			name: "known signature format (X.509)",
@@ -44,21 +44,21 @@ AlNFMQ4wDAYDVQQIDAVUZXhhczEOMAwGA1UEBwwFVGV4YXMxDjAMBgNVBAoMBVRl
 eGFzMQ4wDAYDVQQLDAVUZXhhczEYMBYGA1UEAwwPVGV4YXMgQ2VydGlmaWNhdGUw
 ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDQZ9Z3Z9Z3Z9Z3Z9Z3Z9Z3
 -----END SIGNED MESSAGE-----`),
-			want: signatureTypeX509,
+			want: SignatureTypeX509,
 		},
 		{
 			name: "unknown signature format",
 			b: []byte(`-----BEGIN ARBITRARY SIGNATURE-----
 U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgij/EfHS8tCjolj5uEANXgKzFfp
 -----END UNKNOWN SIGNATURE-----`),
-			want: signatureTypeUnknown,
+			want: SignatureTypeUnknown,
 		},
 		{
-			name: "unknown signature format CERTIFICATE",
+			name: "known signature format CERTIFICATE",
 			b: []byte(`-----BEGIN CERTIFICATE-----
 MIIDZjCCAk6gAwIBAgIJALZ9Z3Z9Z3Z9MA0GCSqGSIb3DQEBCwUAMIGIMQswCQYD
 -----END CERTIFICATE-----`),
-			want: signatureTypeUnknown,
+			want: SignatureTypeX509,
 		},
 	}
 	for _, tt := range tests {
@@ -77,7 +77,7 @@ func Test_parseSignedBytes(t *testing.T) {
 		name          string
 		b             []byte
 		wantSignature []byte
-		wantType      signatureType
+		wantType      SignatureType
 	}{
 		{
 			name: "detects signature and type",
@@ -110,7 +110,7 @@ pAe1/EFuhv2UDLucAiWM8iDZIcw8iN0OYMOGUmnk0WuGIo7dzLeqMGY+ND5n5Z8J
 sZC//k6m
 =VhHy
 -----END PGP SIGNATURE-----`),
-			wantType: signatureTypeOpenPGP,
+			wantType: SignatureTypeOpenPGP,
 		},
 		{
 			name: "last signature for multiple signatures",
@@ -141,7 +141,7 @@ U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgij/EfHS8tCjolj5uEANXgKzFfp
 AAAAQIYHMhSVV9L2xwJuV8eWMLjThya8yXgCHDzw3p01D19KirrabW0veiichPB5m+Ihtr
 MKEQruIQWJb+8HVXwssA4=
 -----END SSH SIGNATURE-----`),
-			wantType: signatureTypeSSH,
+			wantType: SignatureTypeSSH,
 		},
 		{
 			name: "signature with trailing data",
@@ -163,13 +163,13 @@ MKEQruIQWJb+8HVXwssA4=
 -----END SSH SIGNATURE-----
 
 signed tag`),
-			wantType: signatureTypeSSH,
+			wantType: SignatureTypeSSH,
 		},
 		{
 			name:          "data without signature",
 			b:             []byte(`Some message`),
 			wantSignature: []byte(``),
-			wantType:      signatureTypeUnknown,
+			wantType:      SignatureTypeUnknown,
 		},
 	}
 	for _, tt := range tests {

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"strings"
-
-	"github.com/ProtonMail/go-crypto/openpgp"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -40,22 +37,24 @@ type Tag struct {
 	Target plumbing.Hash
 
 	s storer.EncodedObjectStorer
+	v Verifier
 }
 
 // GetTag gets a tag from an object storer and decodes it.
-func GetTag(s storer.EncodedObjectStorer, h plumbing.Hash) (*Tag, error) {
+func GetTag(s storer.EncodedObjectStorer, h plumbing.Hash, opts ...ObjectOption) (*Tag, error) {
 	o, err := s.EncodedObject(plumbing.TagObject, h)
 	if err != nil {
 		return nil, err
 	}
 
-	return DecodeTag(s, o)
+	return DecodeTag(s, o, opts...)
 }
 
-// DecodeTag decodes an encoded object into a *Commit and associates it to the
+// DecodeTag decodes an encoded object into a *Tag and associates it to the
 // given object storer.
-func DecodeTag(s storer.EncodedObjectStorer, o plumbing.EncodedObject) (*Tag, error) {
-	t := &Tag{s: s}
+func DecodeTag(s storer.EncodedObjectStorer, o plumbing.EncodedObject, opts ...ObjectOption) (*Tag, error) {
+	resolved := applyObjectOptions(opts)
+	t := &Tag{s: s, v: resolved.Verifier}
 	if err := t.Decode(o); err != nil {
 		return nil, err
 	}
@@ -202,7 +201,7 @@ func (t *Tag) Commit() (*Commit, error) {
 		return nil, err
 	}
 
-	return DecodeCommit(t.s, o)
+	return DecodeCommit(t.s, o, WithVerifier(t.v))
 }
 
 // Tree returns the tree pointed to by the tag. If the tag points to a commit
@@ -241,7 +240,7 @@ func (t *Tag) Object() (Object, error) {
 		return nil, err
 	}
 
-	return DecodeObject(t.s, o)
+	return DecodeObject(t.s, o, WithVerifier(t.v))
 }
 
 // String returns the meta information contained in the tag as a formatted
@@ -256,35 +255,47 @@ func (t *Tag) String() string {
 	)
 }
 
-// Verify performs PGP verification of the tag with a provided armored
-// keyring and returns openpgp.Entity associated with verifying key on success.
-func (t *Tag) Verify(armoredKeyRing string) (*openpgp.Entity, error) {
-	keyRingReader := strings.NewReader(armoredKeyRing)
-	keyring, err := openpgp.ReadArmoredKeyRing(keyRingReader)
-	if err != nil {
-		return nil, err
+// Verify verifies the cryptographic signature on the tag using the
+// verifier injected at construction time (via WithVerifier).
+// Returns a VerificationResult on success.
+//
+// If the tag has no signature, ErrNoSignature is returned.
+// If no verifier was injected, ErrNilVerifier is returned.
+func (t *Tag) Verify() (*VerificationResult, error) {
+	return t.VerifyWith(t.v)
+}
+
+// VerifyWith verifies the cryptographic signature on the tag using the
+// provided Verifier explicitly.
+// Returns a VerificationResult on success.
+//
+// If the tag has no signature, ErrNoSignature is returned.
+// If v is nil, ErrNilVerifier is returned.
+func (t *Tag) VerifyWith(v Verifier) (*VerificationResult, error) {
+	if v == nil {
+		return nil, ErrNilVerifier
+	}
+	if t.Signature == "" {
+		return nil, ErrNoSignature
 	}
 
-	// Extract signature.
-	signature := strings.NewReader(t.Signature)
-
 	encoded := &plumbing.MemoryObject{}
-	// Encode tag components, excluding signature and get a reader object.
 	if err := t.EncodeWithoutSignature(encoded); err != nil {
 		return nil, err
 	}
-	er, err := encoded.Reader()
+	message, err := io.ReadAll(must(encoded.Reader()))
 	if err != nil {
 		return nil, err
 	}
 
-	return openpgp.CheckArmoredDetachedSignature(keyring, er, signature, nil)
+	return v.Verify([]byte(t.Signature), message)
 }
 
 // TagIter provides an iterator for a set of tags.
 type TagIter struct {
 	storer.EncodedObjectIter
 	s storer.EncodedObjectStorer
+	v Verifier
 }
 
 // NewTagIter takes a storer.EncodedObjectStorer and a
@@ -293,7 +304,13 @@ type TagIter struct {
 //
 // Any non-tag object returned by the storer.EncodedObjectIter is skipped.
 func NewTagIter(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter) *TagIter {
-	return &TagIter{iter, s}
+	return &TagIter{iter, s, nil}
+}
+
+// newTagIterWithVerifier creates a TagIter that propagates a verifier
+// to each decoded tag.
+func newTagIterWithVerifier(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter, v Verifier) *TagIter {
+	return &TagIter{iter, s, v}
 }
 
 // Next moves the iterator to the next tag and returns a pointer to it. If
@@ -304,7 +321,7 @@ func (iter *TagIter) Next() (*Tag, error) {
 		return nil, err
 	}
 
-	return DecodeTag(iter.s, obj)
+	return DecodeTag(iter.s, obj, WithVerifier(iter.v))
 }
 
 // ForEach call the cb function for each tag contained on this iter until
@@ -312,7 +329,7 @@ func (iter *TagIter) Next() (*Tag, error) {
 // the iteration is stop but no error is returned. The iterator is closed.
 func (iter *TagIter) ForEach(cb func(*Tag) error) error {
 	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
-		t, err := DecodeTag(iter.s, obj)
+		t, err := DecodeTag(iter.s, obj, WithVerifier(iter.v))
 		if err != nil {
 			return err
 		}

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -257,20 +257,21 @@ func (t *Tag) String() string {
 
 // Verify verifies the cryptographic signature on the tag using the
 // verifier injected at construction time (via WithVerifier).
-// Returns a VerificationResult on success.
 //
-// If the tag has no signature, ErrNoSignature is returned.
-// If no verifier was injected, ErrNilVerifier is returned.
+// A nil error means the signature is valid and the key is trusted.
+// On failure the error is (or wraps) one of the verification sentinel errors
+// defined in this package.
 func (t *Tag) Verify() (*VerificationResult, error) {
 	return t.VerifyWith(t.v)
 }
 
 // VerifyWith verifies the cryptographic signature on the tag using the
 // provided Verifier explicitly.
-// Returns a VerificationResult on success.
 //
-// If the tag has no signature, ErrNoSignature is returned.
-// If v is nil, ErrNilVerifier is returned.
+// A nil error means the signature is valid and the key is trusted.
+// On failure the error is (or wraps) one of the verification sentinel errors
+// defined in this package (e.g. ErrNoSignature, ErrNilVerifier,
+// ErrSignatureInvalid, ErrKeyNotTrusted, etc.).
 func (t *Tag) VerifyWith(v Verifier) (*VerificationResult, error) {
 	if v == nil {
 		return nil, ErrNilVerifier

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -362,27 +362,29 @@ iHUEABYKAB0WIQTMqU0ycQ3f6g3PMoWMmmmF4LuV8QUCYGeciQAKCRCMmmmF4LuV
 `,
 	}
 
-	armoredKeyRing := `
------BEGIN PGP PUBLIC KEY BLOCK-----
+	// Test with no verifier (nil) returns ErrNilVerifier.
+	_, err := tag.Verify()
+	s.ErrorIs(err, ErrNilVerifier)
 
-mDMEYGeSihYJKwYBBAHaRw8BAQdAIs9A3YD/EghhAOkHDkxlUkpqYrXUXebLfmmX
-+pdEK6C0D2dvLWdpdCB0ZXN0IGtleYiPBBMWCgA3FiEEzKlNMnEN3+oNzzKFjJpp
-heC7lfEFAmBnkooCGyMECwkIBwUVCgkICwUWAwIBAAIeAQIXgAAKCRCMmmmF4LuV
-8a3jAQCi4hSqjj6J3ch290FvQaYPGwR+EMQTMBG54t+NN6sDfgD/aZy41+0dnFKl
-qM/wLW5Wr9XvwH+1zXXbuSvfxasHowq4OARgZ5KKEgorBgEEAZdVAQUBAQdAXoQz
-VTYug16SisAoSrxFnOmxmFu6efYgCAwXu0ZuvzsDAQgHiHgEGBYKACAWIQTMqU0y
-cQ3f6g3PMoWMmmmF4LuV8QUCYGeSigIbDAAKCRCMmmmF4LuV8Q4QAQCKW5FnEdWW
-lHYKeByw3JugnlZ0U3V/R20bCwDglst5UQEAtkN2iZkHtkPly9xapsfNqnrt2gTt
-YIefGtzXfldDxg4=
-=Psht
------END PGP PUBLIC KEY BLOCK-----
-`
-
-	e, err := tag.Verify(armoredKeyRing)
+	// Test VerifyWith with a mock verifier.
+	mock := &mockVerifier{result: &VerificationResult{
+		Type:  SignatureTypeOpenPGP,
+		Valid: true,
+		KeyID: "test-key",
+	}}
+	result, err := tag.VerifyWith(mock)
 	s.NoError(err)
+	s.True(result.Valid)
+	s.Equal("test-key", result.KeyID)
 
-	_, ok := e.Identities["go-git test key"]
-	s.True(ok)
+	// Verify the mock received the signature bytes.
+	s.NotEmpty(mock.gotSignature)
+	s.NotEmpty(mock.gotMessage)
+
+	// Test unsigned tag returns ErrNoSignature.
+	unsigned := &Tag{Name: "unsigned", Message: "unsigned tag\n"}
+	_, err = unsigned.VerifyWith(mock)
+	s.ErrorIs(err, ErrNoSignature)
 }
 
 func (s *TagSuite) TestDecodeAndVerify() {
@@ -408,50 +410,6 @@ sZC//k6m
 -----END PGP SIGNATURE-----
 `
 
-	armoredKeyRing := `
------BEGIN PGP PUBLIC KEY BLOCK-----
-
-mQGNBGB5V8gBDACfWWMs+YiDpTGG+GcBqjB5BxqGvJGg3GOcDRDyCAJ/OH69jYzB
-eArmZ6SNvv0iSdYC70xE0Y6hDSTKHvu3O3zZE7I4loD1NJutUAh5MR68W+tYI/rL
-+2ZALQhAYD/nd4bJIlrmKsEB56NHcFwbjQDOGW17mX6WjwsgNb6eOvA7xOctChyL
-Ypnfe+oiwML25tz5NgjoSr8OmYQqO/ZtSDvnRQdN865HLlusvaBtcdyrk1q00YSs
-RpL1isowqdFyFUfF+WO5Sr+oa05pVZhlB7eu59x6vEmhEPW2MEz7SmfQPFdP952/
-Ilkr/tMZgkOidlL5fHiVgxEsblPwvESQb7hPnJlgpejEy61W1wRMFw01lpYUf0/k
-BsmBhY/ll6+hROqSXVFrvQsW8SHosS6/nNBQNEO+Q6cQNeK+a4Ir38mlv572Ro67
-p3+E/IxFaia7x1OLsnvO/L9K1xEeKKiTIPzwKZLH5xOCJEAm0UgJEfS16pmWSlaF
-58Yg4YnOUqKgDFEAEQEAAbQtZ28tZ2l0IGNvbnRyaWJ1dG9yIDxjb250cmlidXRv
-ckBnby1naXQubG9jYWw+iQHOBBMBCAA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4B
-AheAFiEE/h5sbbqJFh9j1AdUSqtFFGopTmwFAmB5WeYACgkQSqtFFGopTmwVhQv9
-ERYz6Gv2M5VWnU5kvMzrCdiSf21lMzeM/sr/p4WHomrBnbpIFvfY/21M/38991F5
-Sz1XUuf3UEV5jPrX7q5oMJNXoRbkauM04H4bqoP/a5Z+2DoUh3w5A8djsRDpM+V/
-7AeInes3SHyB2wg22gFMyQ0VYYzJokfyPpyq2JIyhN6tc9Om4t+wychzwUfey60f
-mT+JrMReTpaaCYzjJJDClzoZKaAEDdVu2BomqtWDsbL91Tm8D7oUw9vFol+u+dZm
-092t4OmMex07FqNpz6wLX0QKAZNwVd/vATIQb07C9E+Dy9EfRXiz/pllMNBNnPWC
-vSoPaIC3gkzM4dbYsi5lxHAhxIRQliCD6mAyOcc9PvPhoHeUWtTjSGEA/ApByszA
-+tUrvmZCsrw2P/vzRJgIDcDP9EvzSqfTsVumRrCxwORGjZZNxBQ2wcEZbGH84M8X
-fv8TTLzENcnxWVdm8dVaqcpBCodY0dJNSV5cZIdoFFWDVygvvbL03G7KEev0ZenT
-uQGNBGB5V8gBDACx6l7svv9hlNJbTlcWZWrBG92kl7Xw+klRwr2sYreMAEbUYS3w
-FfEPyj0yrP3s+QVIR5mmLAXeChAR8hXsgbYvXjPku9qOEntxp8/KPi4RFeCOAvye
-eFnOPSf7ARWptAJAIztso8Z5A1yjPjGOuvvaX6YCxxWrTuFAiOAc7+Ih7JbSizVj
-6r+baUqpIUTseT2RnKfgFp6N3EG/lajXCAh0k7RHD7WoMpGJEpS1dyFji2b9MY29
-hGiaDH+XW6eYfU3K4ZFXySwksbVjiAEoFJXq6uf1mSgwJXtcu5YxAy462iaZ4nOk
-6zHzpu66X9LwTA5x6mgqGDNoCXbaIg9xSXugsRwwy5U+F4Hue9MUsJDD64RHF4sQ
-H/tjtjyUnD8nmkFOyj2jJcArKnIsN22e2/diFCfjVsUBbIu2pWrDHGqpC0aimCzV
-h2Bj94TJTcZvfuuA2Z3KdPJScaTFjT5BBOk1LjR7y0fDWsRMNm+gdYLOTCb2QrqK
-E9pPJMRjOadTIZkAEQEAAYkBvAQYAQgAJhYhBP4ebG26iRYfY9QHVEqrRRRqKU5s
-BQJgeVfIAhsMBQkDwmcAAAoJEEqrRRRqKU5s15ML/i/d72VcQ/edE4fMKHY/Mipi
-O448UjNvPpoPoxmr4kbE9wEvJZrPYKI8Bco1lXWw0Z0GmibD3VkAAPs5dKo7GDbs
-3najOEHTXq07XUrAWkrNLJ+U9iiniGSAxB4fsof+Sl9Pmpy1kzT/0WA8M0NhmtXr
-nfb922OWx37Kj5EiQkO9QcqBZm4aqaI5YhtG5blqax22URIKrkZ2OM8Xn/poYlcY
-9nVYE/dikM7fjxozcWZHAGdpdQTuD3fzstJmACraUv0FfejmCP6EN5B8oGsLwoMc
-91YY8vidLAzciVdSty/MztGgKftcfM5v/xnivh+2KBv3cLYBQoxC9tjp6f8nRJsb
-mRSIIiXqVc77oLNxJbH5d/xLH0GycIKAGLvWgFK5BvoLeYMhu3VlVUujj8lQxIhM
-Wl3F+LWVJc4oqFlX9ablgujtTg/d1X7YP9rw2/uJcMFXQ3yJv3xNDPsM7qbu/Bjh
-eQnkGpsz85DfEviLtk8cZjY/t6o8lPDLiwVjIzUBaA==
-=oYTT
------END PGP PUBLIC KEY BLOCK-----
-`
-
 	tagEncodedObject := &plumbing.MemoryObject{}
 
 	_, err := tagEncodedObject.Write([]byte(objectText))
@@ -462,7 +420,12 @@ eQnkGpsz85DfEviLtk8cZjY/t6o8lPDLiwVjIzUBaA==
 	err = tag.Decode(tagEncodedObject)
 	s.NoError(err)
 
-	_, err = tag.Verify(armoredKeyRing)
+	mock := &mockVerifier{result: &VerificationResult{
+		Type:  SignatureTypeOpenPGP,
+		Valid: true,
+		KeyID: "test-key",
+	}}
+	_, err = tag.VerifyWith(mock)
 	s.NoError(err)
 }
 

--- a/plumbing/object/verification.go
+++ b/plumbing/object/verification.go
@@ -1,0 +1,113 @@
+package object
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrNoSignature is returned when attempting to verify an unsigned object.
+var ErrNoSignature = errors.New("object has no signature")
+
+// ErrNilVerifier is returned when a nil verifier is passed to a verification method.
+var ErrNilVerifier = errors.New("verifier is nil")
+
+// TrustLevel represents the trust level of a signing key.
+// The levels follow Git's trust model, from lowest to highest.
+type TrustLevel int8
+
+const (
+	// TrustUndefined indicates the trust level is not set or unknown.
+	TrustUndefined TrustLevel = iota
+	// TrustNever indicates the key should never be trusted.
+	TrustNever
+	// TrustMarginal indicates marginal trust in the key.
+	TrustMarginal
+	// TrustFull indicates full trust in the key.
+	TrustFull
+	// TrustUltimate indicates ultimate trust (typically for own keys).
+	TrustUltimate
+)
+
+// String returns the string representation of the trust level.
+func (t TrustLevel) String() string {
+	switch t {
+	case TrustNever:
+		return "never"
+	case TrustMarginal:
+		return "marginal"
+	case TrustFull:
+		return "full"
+	case TrustUltimate:
+		return "ultimate"
+	default:
+		return "undefined"
+	}
+}
+
+// AtLeast returns true if this trust level meets or exceeds the required level.
+func (t TrustLevel) AtLeast(required TrustLevel) bool {
+	return t >= required
+}
+
+// VerificationResult contains the result of signature verification.
+type VerificationResult struct {
+	// Type is the signature format (OpenPGP, SSH, X.509).
+	Type SignatureType
+
+	// Valid is true if the cryptographic signature is valid.
+	// Note: A valid signature doesn't imply trust - check TrustLevel.
+	Valid bool
+
+	// TrustLevel indicates the trust level of the signing key.
+	TrustLevel TrustLevel
+
+	// KeyID is the identifier of the signing key.
+	// For OpenPGP: the key ID (last 16 hex chars of fingerprint)
+	// For SSH: the key fingerprint (SHA256:...)
+	KeyID string
+
+	// PrimaryKeyFingerprint is the full fingerprint of the primary key.
+	// For OpenPGP subkeys, this differs from the signing key fingerprint.
+	PrimaryKeyFingerprint string
+
+	// Signer is the identity associated with the key (name <email>).
+	Signer string
+
+	// SignedAt is the timestamp when the signature was created.
+	// May be zero if the signature doesn't include timing info.
+	SignedAt time.Time
+
+	// Error contains details if verification failed.
+	Error error
+}
+
+// IsValid returns true if the signature is cryptographically valid.
+func (r *VerificationResult) IsValid() bool {
+	return r.Valid && r.Error == nil
+}
+
+// IsTrusted returns true if the signature is valid AND the key meets
+// the minimum trust level.
+func (r *VerificationResult) IsTrusted(minTrust TrustLevel) bool {
+	return r.IsValid() && r.TrustLevel.AtLeast(minTrust)
+}
+
+// String returns a human-readable summary of the verification result.
+func (r *VerificationResult) String() string {
+	validity := "invalid"
+	if r.Valid {
+		validity = "valid"
+	}
+	return fmt.Sprintf(
+		"%s signature: %s, trust: %s, key: %s, signer: %s",
+		r.Type, validity, r.TrustLevel, r.KeyID, r.Signer,
+	)
+}
+
+// Verifier is an interface for verifying cryptographic signatures.
+// This interface is defined locally to avoid circular imports with the git package.
+// The git.Verifier, git.VerifierChain, and other implementations satisfy this interface.
+type Verifier interface {
+	Verify(signature, message []byte) (*VerificationResult, error)
+}

--- a/plumbing/object/verification.go
+++ b/plumbing/object/verification.go
@@ -6,61 +6,67 @@ import (
 	"time"
 )
 
-// ErrNoSignature is returned when attempting to verify an unsigned object.
-var ErrNoSignature = errors.New("object has no signature")
+// Verification sentinel errors.
+//
+// These errors represent distinct verification outcomes. Verifier implementations
+// return them (possibly wrapped with additional context) so that callers can
+// inspect the result with errors.Is().
+//
+// A nil error from Verify means the signature is cryptographically valid AND the
+// signing key is trusted. Any non-nil error describes why verification did not
+// fully succeed; the accompanying VerificationResult (when non-nil) still carries
+// whatever metadata could be extracted from the signature.
+var (
+	// ErrNoSignature is returned when attempting to verify an unsigned object.
+	ErrNoSignature = errors.New("no signature")
 
-// ErrNilVerifier is returned when a nil verifier is passed to a verification method.
-var ErrNilVerifier = errors.New("verifier is nil")
+	// ErrNilVerifier is returned when a nil verifier is passed to a verification method.
+	ErrNilVerifier = errors.New("verifier is nil")
 
-// TrustLevel represents the trust level of a signing key.
-// The levels follow Git's trust model, from lowest to highest.
-type TrustLevel int8
+	// ErrSignatureFormatInvalid is returned when the signature cannot be parsed
+	// or is structurally malformed.
+	ErrSignatureFormatInvalid = errors.New("signature format is invalid")
 
-const (
-	// TrustUndefined indicates the trust level is not set or unknown.
-	TrustUndefined TrustLevel = iota
-	// TrustNever indicates the key should never be trusted.
-	TrustNever
-	// TrustMarginal indicates marginal trust in the key.
-	TrustMarginal
-	// TrustFull indicates full trust in the key.
-	TrustFull
-	// TrustUltimate indicates ultimate trust (typically for own keys).
-	TrustUltimate
+	// ErrSignatureInvalid is returned when the cryptographic verification of
+	// the signature fails (e.g. wrong key, tampered content).
+	ErrSignatureInvalid = errors.New("signature is invalid")
+
+	// ErrKeyNotTrusted is returned when the signature is cryptographically
+	// valid but the signing key is not present in any trust store or allowed
+	// signers list. This maps to concepts like GitHub's "Unverified" status.
+	ErrKeyNotTrusted = errors.New("signing key is not trusted")
+
+	// ErrKeyExpired is returned when the signing key has expired.
+	ErrKeyExpired = errors.New("signing key has expired")
+
+	// ErrKeyRevoked is returned when the signing key has been revoked.
+	ErrKeyRevoked = errors.New("signing key has been revoked")
+
+	// ErrUnknownSignatureType is returned when no registered verifier
+	// supports the detected signature format.
+	ErrUnknownSignatureType = errors.New("unknown signature type")
 )
 
-// String returns the string representation of the trust level.
-func (t TrustLevel) String() string {
-	switch t {
-	case TrustNever:
-		return "never"
-	case TrustMarginal:
-		return "marginal"
-	case TrustFull:
-		return "full"
-	case TrustUltimate:
-		return "ultimate"
-	default:
-		return "undefined"
-	}
-}
-
-// AtLeast returns true if this trust level meets or exceeds the required level.
-func (t TrustLevel) AtLeast(required TrustLevel) bool {
-	return t >= required
-}
-
-// VerificationResult contains the result of signature verification.
+// VerificationResult contains metadata extracted from a signature during
+// verification.
+//
+// A VerificationResult may be returned alongside a non-nil error when the
+// verifier was able to extract metadata (key ID, signer, etc.) even though
+// verification did not fully succeed. Callers should always check the
+// accompanying error to determine the verification outcome:
+//
+//   - nil error: signature is valid and the key is trusted.
+//   - errors.Is(err, ErrSignatureInvalid): cryptographic check failed.
+//   - errors.Is(err, ErrKeyNotTrusted): valid signature, but the key is not
+//     in any trust store.
+//   - errors.Is(err, ErrKeyExpired): valid signature, but the key expired.
+//   - errors.Is(err, ErrKeyRevoked): valid signature, but the key was revoked.
+//   - errors.Is(err, ErrSignatureFormatInvalid): signature could not be parsed.
+//   - errors.Is(err, ErrUnknownSignatureType): no verifier for this format.
+//   - errors.Is(err, ErrNoSignature): the object has no signature.
 type VerificationResult struct {
 	// Type is the signature format (OpenPGP, SSH, X.509).
 	Type SignatureType
-
-	// Valid is true if the cryptographic signature is valid.
-	// Note: A valid signature doesn't imply trust - check TrustLevel.
-	Valid bool
-
-	// TrustLevel indicates the trust level of the signing key.
-	TrustLevel TrustLevel
 
 	// KeyID is the identifier of the signing key.
 	// For OpenPGP: the key ID (last 16 hex chars of fingerprint)
@@ -77,35 +83,25 @@ type VerificationResult struct {
 	// SignedAt is the timestamp when the signature was created.
 	// May be zero if the signature doesn't include timing info.
 	SignedAt time.Time
-
-	// Error contains details if verification failed.
-	Error error
-}
-
-// IsValid returns true if the signature is cryptographically valid.
-func (r *VerificationResult) IsValid() bool {
-	return r.Valid && r.Error == nil
-}
-
-// IsTrusted returns true if the signature is valid AND the key meets
-// the minimum trust level.
-func (r *VerificationResult) IsTrusted(minTrust TrustLevel) bool {
-	return r.IsValid() && r.TrustLevel.AtLeast(minTrust)
 }
 
 // String returns a human-readable summary of the verification result.
 func (r *VerificationResult) String() string {
-	validity := "invalid"
-	if r.Valid {
-		validity = "valid"
-	}
 	return fmt.Sprintf(
-		"%s signature: %s, trust: %s, key: %s, signer: %s",
-		r.Type, validity, r.TrustLevel, r.KeyID, r.Signer,
+		"%s signature: key: %s, signer: %s",
+		r.Type, r.KeyID, r.Signer,
 	)
 }
 
 // Verifier is an interface for verifying cryptographic signatures.
+//
+// Verify checks the given signature against the message content.
+// On success (nil error), the returned VerificationResult contains metadata
+// about the valid, trusted signature.
+// On failure, the error is one of the sentinel verification errors (or wraps
+// one); a non-nil VerificationResult may still be returned with whatever
+// metadata could be extracted.
+//
 // This interface is defined locally to avoid circular imports with the git package.
 // The git.Verifier, git.VerifierChain, and other implementations satisfy this interface.
 type Verifier interface {

--- a/plumbing/object/verification.go
+++ b/plumbing/object/verification.go
@@ -83,6 +83,12 @@ type VerificationResult struct {
 	// SignedAt is the timestamp when the signature was created.
 	// May be zero if the signature doesn't include timing info.
 	SignedAt time.Time
+
+	// Details holds plugin-specific verification metadata.
+	// Each verifier implementation may populate this with its own
+	// concrete type (e.g. key expiry, trust chain, key source).
+	// Consumers can type-assert to access the extended information.
+	Details any
 }
 
 // String returns a human-readable summary of the verification result.

--- a/plumbing/object/verification_test.go
+++ b/plumbing/object/verification_test.go
@@ -1,0 +1,143 @@
+package object
+
+import (
+	"testing"
+)
+
+func TestTrustLevel_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		level TrustLevel
+		want  string
+	}{
+		{TrustUndefined, "undefined"},
+		{TrustNever, "never"},
+		{TrustMarginal, "marginal"},
+		{TrustFull, "full"},
+		{TrustUltimate, "ultimate"},
+		{TrustLevel(99), "undefined"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.level.String(); got != tt.want {
+			t.Errorf("TrustLevel(%d).String() = %q, want %q", tt.level, got, tt.want)
+		}
+	}
+}
+
+func TestTrustLevel_AtLeast(t *testing.T) {
+	t.Parallel()
+
+	if !TrustFull.AtLeast(TrustMarginal) {
+		t.Error("Full should be at least Marginal")
+	}
+	if !TrustFull.AtLeast(TrustFull) {
+		t.Error("Full should be at least Full")
+	}
+	if TrustMarginal.AtLeast(TrustFull) {
+		t.Error("Marginal should not be at least Full")
+	}
+}
+
+func TestVerificationResult_IsValid(t *testing.T) {
+	t.Parallel()
+
+	valid := &VerificationResult{Valid: true}
+	if !valid.IsValid() {
+		t.Error("expected IsValid() to return true")
+	}
+
+	invalid := &VerificationResult{Valid: false}
+	if invalid.IsValid() {
+		t.Error("expected IsValid() to return false")
+	}
+
+	validWithError := &VerificationResult{Valid: true, Error: ErrNoSignature}
+	if validWithError.IsValid() {
+		t.Error("expected IsValid() to return false when Error is set")
+	}
+}
+
+func TestVerificationResult_IsTrusted(t *testing.T) {
+	t.Parallel()
+
+	trusted := &VerificationResult{Valid: true, TrustLevel: TrustFull}
+	if !trusted.IsTrusted(TrustMarginal) {
+		t.Error("expected IsTrusted(Marginal) to be true for Full trust")
+	}
+	if !trusted.IsTrusted(TrustFull) {
+		t.Error("expected IsTrusted(Full) to be true for Full trust")
+	}
+	if trusted.IsTrusted(TrustUltimate) {
+		t.Error("expected IsTrusted(Ultimate) to be false for Full trust")
+	}
+
+	invalid := &VerificationResult{Valid: false, TrustLevel: TrustUltimate}
+	if invalid.IsTrusted(TrustUndefined) {
+		t.Error("expected IsTrusted to be false for invalid signature regardless of trust")
+	}
+}
+
+func TestVerificationResult_String(t *testing.T) {
+	t.Parallel()
+
+	result := &VerificationResult{
+		Type:       SignatureTypeOpenPGP,
+		Valid:      true,
+		TrustLevel: TrustFull,
+		KeyID:      "ABC123",
+		Signer:     "test <test@example.com>",
+	}
+	s := result.String()
+	if s != "OpenPGP signature: valid, trust: full, key: ABC123, signer: test <test@example.com>" {
+		t.Errorf("unexpected String(): %s", s)
+	}
+}
+
+func TestSignatureType_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		st   SignatureType
+		want string
+	}{
+		{SignatureTypeUnknown, "unknown"},
+		{SignatureTypeOpenPGP, "OpenPGP"},
+		{SignatureTypeX509, "X.509"},
+		{SignatureTypeSSH, "SSH"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.st.String(); got != tt.want {
+			t.Errorf("SignatureType(%d).String() = %q, want %q", tt.st, got, tt.want)
+		}
+	}
+}
+
+func TestDetectSignatureType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sig  []byte
+		want SignatureType
+	}{
+		{"OpenPGP", []byte("-----BEGIN PGP SIGNATURE-----\ndata"), SignatureTypeOpenPGP},
+		{"SSH", []byte("-----BEGIN SSH SIGNATURE-----\ndata"), SignatureTypeSSH},
+		{"X509 SIGNED", []byte("-----BEGIN SIGNED MESSAGE-----\ndata"), SignatureTypeX509},
+		{"X509 CERT", []byte("-----BEGIN CERTIFICATE-----\ndata"), SignatureTypeX509},
+		{"PGP MESSAGE", []byte("-----BEGIN PGP MESSAGE-----\ndata"), SignatureTypeOpenPGP},
+		{"Unknown", []byte("not a signature"), SignatureTypeUnknown},
+		{"Empty", []byte{}, SignatureTypeUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := DetectSignatureType(tt.sig); got != tt.want {
+				t.Errorf("DetectSignatureType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/repository.go
+++ b/repository.go
@@ -914,6 +914,30 @@ func (r *Repository) buildTagSignature(tag *object.Tag, signer Signer) (string, 
 	return string(b), nil
 }
 
+// resolveVerifier returns the registered ObjectVerifier plugin, or nil if none
+// is available. This follows the same pattern as signer resolution: the plugin
+// is optional, and a nil verifier simply means objects won't have a default
+// verifier injected (callers can still use VerifyWith explicitly).
+func (r *Repository) resolveVerifier() object.Verifier {
+	if !plugin.Has(plugin.ObjectVerifier()) {
+		return nil
+	}
+	v, err := plugin.Get(plugin.ObjectVerifier())
+	if err != nil {
+		return nil
+	}
+	return v
+}
+
+// verifierOpts returns an ObjectOption slice that injects the resolved verifier.
+// If no verifier is available, it returns nil (a nil slice is harmless as variadic args).
+func (r *Repository) verifierOpts() []object.ObjectOption {
+	if v := r.resolveVerifier(); v != nil {
+		return []object.ObjectOption{object.WithVerifier(v)}
+	}
+	return nil
+}
+
 // Tag returns a tag from the repository.
 //
 // If you want to check to see if the tag is an annotated tag, you can call
@@ -1546,7 +1570,7 @@ func (r *Repository) TreeObjects() (*object.TreeIter, error) {
 // CommitObject return a Commit with the given hash. If not found
 // plumbing.ErrObjectNotFound is returned.
 func (r *Repository) CommitObject(h plumbing.Hash) (*object.Commit, error) {
-	return object.GetCommit(r.Storer, h)
+	return object.GetCommit(r.Storer, h, r.verifierOpts()...)
 }
 
 // CommitObjects returns an unsorted CommitIter with all the commits in the repository.
@@ -1579,7 +1603,7 @@ func (r *Repository) BlobObjects() (*object.BlobIter, error) {
 // plumbing.ErrObjectNotFound is returned. This method only returns
 // annotated Tags, no lightweight Tags.
 func (r *Repository) TagObject(h plumbing.Hash) (*object.Tag, error) {
-	return object.GetTag(r.Storer, h)
+	return object.GetTag(r.Storer, h, r.verifierOpts()...)
 }
 
 // TagObjects returns a unsorted TagIter that can step through all of the annotated
@@ -1601,7 +1625,7 @@ func (r *Repository) Object(t plumbing.ObjectType, h plumbing.Hash) (object.Obje
 		return nil, err
 	}
 
-	return object.DecodeObject(r.Storer, obj)
+	return object.DecodeObject(r.Storer, obj, r.verifierOpts()...)
 }
 
 // Objects returns an unsorted ObjectIter with all the objects in the repository.

--- a/repository_test.go
+++ b/repository_test.go
@@ -3606,7 +3606,7 @@ func BenchmarkPlainClone(b *testing.B) {
 	}
 }
 
-func TestCreateTagSignerSelection(t *testing.T) {
+func TestCreateTagSignerSelection(t *testing.T) { //nolint:paralleltest // modifies global plugin state
 	tests := []struct {
 		name           string
 		registerPlugin bool
@@ -3654,7 +3654,7 @@ func TestCreateTagSignerSelection(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest // modifies global plugin state
 		t.Run(tt.name, func(t *testing.T) {
 			resetPluginEntry("object-signer")
 			t.Cleanup(func() { resetPluginEntry("object-signer") })

--- a/repository_test.go
+++ b/repository_test.go
@@ -17,9 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/ProtonMail/go-crypto/openpgp/armor"
-	openpgperr "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/osfs"
@@ -41,6 +38,7 @@ import (
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
+	"github.com/go-git/go-git/v6/x/plugin"
 	xstorage "github.com/go-git/go-git/v6/x/storage"
 )
 
@@ -2871,68 +2869,6 @@ func (s *RepositorySuite) TestCreateTagAnnotatedBadHash() {
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 }
 
-func (s *RepositorySuite) TestCreateTagSigned() {
-	url := s.GetLocalRepositoryURL(
-		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
-	)
-
-	r, _ := Init(memory.NewStorage())
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
-	s.NoError(err)
-
-	h, err := r.Head()
-	s.NoError(err)
-
-	key := commitSignKey(s.T(), true)
-	_, err = r.CreateTag("foobar", h.Hash(), &CreateTagOptions{
-		Tagger:  defaultSignature(),
-		Message: "foo bar baz qux",
-		SignKey: key,
-	})
-	s.NoError(err)
-
-	tag, err := r.Tag("foobar")
-	s.NoError(err)
-
-	obj, err := r.TagObject(tag.Hash())
-	s.NoError(err)
-
-	// Verify the tag.
-	pks := new(bytes.Buffer)
-	pkw, err := armor.Encode(pks, openpgp.PublicKeyType, nil)
-	s.NoError(err)
-
-	err = key.Serialize(pkw)
-	s.NoError(err)
-	err = pkw.Close()
-	s.NoError(err)
-
-	actual, err := obj.Verify(pks.String())
-	s.NoError(err)
-	s.Equal(key.PrimaryKey, actual.PrimaryKey)
-}
-
-func (s *RepositorySuite) TestCreateTagSignedBadKey() {
-	url := s.GetLocalRepositoryURL(
-		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
-	)
-
-	r, _ := Init(memory.NewStorage())
-	err := r.clone(context.Background(), &CloneOptions{URL: url})
-	s.NoError(err)
-
-	h, err := r.Head()
-	s.NoError(err)
-
-	key := commitSignKey(s.T(), false)
-	_, err = r.CreateTag("foobar", h.Hash(), &CreateTagOptions{
-		Tagger:  defaultSignature(),
-		Message: "foo bar baz qux",
-		SignKey: key,
-	})
-	s.ErrorIs(err, openpgperr.InvalidArgumentError("signing key is encrypted"))
-}
-
 func (s *RepositorySuite) TestCreateTagCanonicalize() {
 	url := s.GetLocalRepositoryURL(
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
@@ -2945,11 +2881,9 @@ func (s *RepositorySuite) TestCreateTagCanonicalize() {
 	h, err := r.Head()
 	s.NoError(err)
 
-	key := commitSignKey(s.T(), true)
 	_, err = r.CreateTag("foobar", h.Hash(), &CreateTagOptions{
 		Tagger:  defaultSignature(),
 		Message: "\n\nfoo bar baz qux\n\nsome message here",
-		SignKey: key,
 	})
 	s.NoError(err)
 
@@ -2961,20 +2895,6 @@ func (s *RepositorySuite) TestCreateTagCanonicalize() {
 
 	// Assert the new canonicalized message.
 	s.Equal("foo bar baz qux\n\nsome message here\n", obj.Message)
-
-	// Verify the tag.
-	pks := new(bytes.Buffer)
-	pkw, err := armor.Encode(pks, openpgp.PublicKeyType, nil)
-	s.NoError(err)
-
-	err = key.Serialize(pkw)
-	s.NoError(err)
-	err = pkw.Close()
-	s.NoError(err)
-
-	actual, err := obj.Verify(pks.String())
-	s.NoError(err)
-	s.Equal(key.PrimaryKey, actual.PrimaryKey)
 }
 
 func (s *RepositorySuite) TestTagLightweight() {
@@ -3683,5 +3603,108 @@ func BenchmarkPlainClone(b *testing.B) {
 	b.StartTimer()
 	for b.Loop() {
 		clone(b)
+	}
+}
+
+func TestCreateTagSignerSelection(t *testing.T) {
+	tests := []struct {
+		name           string
+		registerPlugin bool
+		optionsSigner  Signer
+		wantSignature  bool
+		wantPluginUsed bool
+		wantOptionUsed bool
+	}{
+		{
+			name:          "no signer at all produces unsigned tag",
+			wantSignature: false,
+		},
+		{
+			name:           "CreateTagOptions.Signer works without plugin registered",
+			optionsSigner:  &mockSigner{},
+			wantSignature:  true,
+			wantOptionUsed: true,
+		},
+		{
+			name:           "plugin signer is used when CreateTagOptions.Signer is nil",
+			registerPlugin: true,
+			wantSignature:  true,
+			wantPluginUsed: true,
+		},
+		{
+			name:           "CreateTagOptions.Signer takes precedence over plugin",
+			registerPlugin: true,
+			optionsSigner:  &mockSigner{},
+			wantSignature:  true,
+			wantOptionUsed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetPluginEntry("object-signer")
+			t.Cleanup(func() { resetPluginEntry("object-signer") })
+
+			// Create a repo with an initial commit to tag.
+			// This must happen before registering the plugin signer,
+			// otherwise buildCommitObject would call the plugin signer.
+			fs := memfs.New()
+			r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+			require.NoError(t, err)
+
+			w, err := r.Worktree()
+			require.NoError(t, err)
+
+			util.WriteFile(fs, "file.txt", []byte("content"), 0o644)
+			_, err = w.Add("file.txt")
+			require.NoError(t, err)
+
+			commitHash, err := w.Commit("initial commit\n", &CommitOptions{
+				Author: defaultSignature(),
+			})
+			require.NoError(t, err)
+
+			var pluginSigner *mockSigner
+			if tt.registerPlugin {
+				pluginSigner = &mockSigner{}
+				err = plugin.Register(plugin.ObjectSigner(), func() plugin.Signer { return pluginSigner })
+				require.NoError(t, err)
+			}
+
+			_, err = r.CreateTag("test-tag", commitHash, &CreateTagOptions{
+				Tagger:  defaultSignature(),
+				Message: "tag message",
+				Signer:  tt.optionsSigner,
+			})
+			require.NoError(t, err)
+
+			tagRef, err := r.Tag("test-tag")
+			require.NoError(t, err)
+
+			tagObj, err := r.TagObject(tagRef.Hash())
+			require.NoError(t, err)
+
+			if tt.wantSignature {
+				assert.NotEmpty(t, tagObj.Signature)
+			} else {
+				assert.Empty(t, tagObj.Signature)
+			}
+
+			if tt.wantPluginUsed {
+				require.NotNil(t, pluginSigner)
+				assert.True(t, pluginSigner.called, "expected plugin signer to be called")
+			}
+
+			if tt.wantOptionUsed {
+				optSigner, ok := tt.optionsSigner.(*mockSigner)
+				require.True(t, ok)
+				assert.True(t, optSigner.called, "expected options signer to be called")
+			}
+
+			if pluginSigner != nil && tt.optionsSigner != nil {
+				assert.False(t, pluginSigner.called,
+					"plugin signer should not be called when CreateTagOptions.Signer is set")
+			}
+		})
 	}
 }

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -1,16 +1,13 @@
 package git
 
 import (
-	"bytes"
 	"errors"
-	"io"
+	"fmt"
 	"path"
 	"regexp"
 	"sort"
 	"strings"
 
-	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/go-git/go-billy/v6"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -253,19 +250,6 @@ func (w *Worktree) sanitize(signature object.Signature) object.Signature {
 		Email: invalidCharactersRe.ReplaceAllString(signature.Email, ""),
 		When:  signature.When,
 	}
-}
-
-type gpgSigner struct {
-	key *openpgp.Entity
-	cfg *packet.Config
-}
-
-func (s *gpgSigner) Sign(message io.Reader) ([]byte, error) {
-	var b bytes.Buffer
-	if err := openpgp.ArmoredDetachSign(&b, s.key, message, s.cfg); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
 }
 
 // buildTreeHelper converts a given index.Index file into multiple git objects

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -847,7 +847,7 @@ func (m *mockSigner) Sign(_ io.Reader) ([]byte, error) {
 //go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
 func resetPluginEntry(name plugin.Name)
 
-func TestBuildCommitObjectSignerSelection(t *testing.T) {
+func TestBuildCommitObjectSignerSelection(t *testing.T) { //nolint:paralleltest // modifies global plugin state
 	tests := []struct {
 		name           string
 		registerPlugin bool
@@ -898,7 +898,7 @@ func TestBuildCommitObjectSignerSelection(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest // modifies global plugin state
 		t.Run(tt.name, func(t *testing.T) {
 			resetPluginEntry("object-signer")
 			t.Cleanup(func() { resetPluginEntry("object-signer") })

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -14,6 +15,7 @@ import (
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/ProtonMail/go-crypto/openpgp/armor"
 	"github.com/ProtonMail/go-crypto/openpgp/errors"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
@@ -906,6 +908,19 @@ func commitSignKey(t *testing.T, decrypt bool) *openpgp.Entity {
 	}
 
 	return key
+}
+
+type gpgSigner struct {
+	key *openpgp.Entity
+	cfg *packet.Config
+}
+
+func (s *gpgSigner) Sign(message io.Reader) ([]byte, error) {
+	var b bytes.Buffer
+	if err := openpgp.ArmoredDetachSign(&b, s.key, message, s.cfg); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 const armoredKeyRing = `

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -8,14 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/ProtonMail/go-crypto/openpgp/armor"
-	"github.com/ProtonMail/go-crypto/openpgp/errors"
-	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/go-git/go-billy/v6/memfs"
 	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
@@ -536,62 +531,6 @@ func (s *WorktreeSuite) TestRemoveAndCommitAll() {
 	assertStorageStatus(s, s.Repository, 13, 11, 11, expected)
 }
 
-func (s *WorktreeSuite) TestCommitSign() {
-	fs := memfs.New()
-	storage := memory.NewStorage()
-
-	r, err := Init(storage, WithWorkTree(fs))
-	s.Require().NoError(err)
-
-	w, err := r.Worktree()
-	s.Require().NoError(err)
-
-	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
-
-	_, err = w.Add("foo")
-	s.Require().NoError(err)
-
-	key := commitSignKey(s.T(), true)
-	hash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature(), Signer: &gpgSigner{key: key}})
-	s.Require().NoError(err)
-
-	// Verify the commit.
-	pks := new(bytes.Buffer)
-	pkw, err := armor.Encode(pks, openpgp.PublicKeyType, nil)
-	s.Require().NoError(err)
-
-	err = key.Serialize(pkw)
-	s.Require().NoError(err)
-	err = pkw.Close()
-	s.Require().NoError(err)
-
-	expectedCommit, err := r.CommitObject(hash)
-	s.Require().NoError(err)
-	actual, err := expectedCommit.Verify(pks.String())
-	s.Require().NoError(err)
-	s.Equal(key.PrimaryKey, actual.PrimaryKey)
-}
-
-func (s *WorktreeSuite) TestCommitSignBadKey() {
-	fs := memfs.New()
-	storage := memory.NewStorage()
-
-	r, err := Init(storage, WithWorkTree(fs))
-	s.Require().NoError(err)
-
-	w, err := r.Worktree()
-	s.Require().NoError(err)
-
-	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
-
-	_, err = w.Add("foo")
-	s.Require().NoError(err)
-
-	key := commitSignKey(s.T(), false)
-	_, err = w.Commit("foo\n", &CommitOptions{Author: defaultSignature(), Signer: &gpgSigner{key: key}})
-	s.ErrorIs(err, errors.InvalidArgumentError("signing key is encrypted"))
-}
-
 func (s *WorktreeSuite) TestCherryPick() {
 	fs := memfs.New()
 
@@ -894,106 +833,15 @@ func invalidSignature() *object.Signature {
 	}
 }
 
-func commitSignKey(t *testing.T, decrypt bool) *openpgp.Entity {
-	s := strings.NewReader(armoredKeyRing)
-	es, err := openpgp.ReadArmoredKeyRing(s)
-	assert.NoError(t, err)
-
-	assert.Len(t, es, 1)
-	assert.Len(t, es[0].Identities, 1)
-	_, ok := es[0].Identities["foo bar <foo@foo.foo>"]
-	assert.True(t, ok)
-
-	key := es[0]
-	if decrypt {
-		err = key.PrivateKey.Decrypt([]byte(keyPassphrase))
-		assert.NoError(t, err)
-	}
-
-	return key
-}
-
-type gpgSigner struct {
-	key *openpgp.Entity
-	cfg *packet.Config
-}
-
-func (s *gpgSigner) Sign(message io.Reader) ([]byte, error) {
-	var b bytes.Buffer
-	if err := openpgp.ArmoredDetachSign(&b, s.key, message, s.cfg); err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
-}
-
-const armoredKeyRing = `
------BEGIN PGP PRIVATE KEY BLOCK-----
-
-lQdGBFt89QIBEAC8du0Purt9yeFuLlBYHcexnZvcbaci2pY+Ejn1VnxM7caFxRX/
-b2weZi9E6+I0F+K/hKIaidPdcbK92UCL0Vp6F3izjqategZ7o44vlK/HfWFME4wv
-sou6lnig9ovA73HRyzngi3CmqWxSdg8lL0kIJLNzlvCFEd4Z34BnEkagklQJRymo
-0WnmLJjSnZFT5Nk7q5jrcR7ApbD98cakvgivDlUBPJCk2JFPWheCkouWPHMvLXQz
-bZXW5RFz4lJsMUWa/S3ofvIOnjG5Etnil3IA4uksS8fSDkGus998mBvUwzqX7xBh
-dK17ZEbxDdO4PuVJDkjvq618rMu8FVk5yVd59rUketSnGrehd/+vdh6qtgQC4tu1
-RldbUVAuKZGg79H61nWnvrDZmbw4eoqCEuv1+aZsM9ElSC5Ps2J0rtpHRyBndKn+
-8Jlc/KTH04/O+FAhEv0IgMTFEm3iAq8udBhRBgu6Y4gJyn4tqy6+6ZjPUNos8GOG
-+ZJPdrgHHHfQged1ygeceN6W2AwQRet/B3/rieHf2V93uHJy/DjYUEuBhPm9nxqi
-R6ILUr97Sj2EsvLyfQO9pFpIctoNKEJmDx/C9tkFMNNlQhpsBitSdR2/wancw9ND
-iWV/J9roUdC0qns7eNSbiFe3Len8Xir7srnjAFgbGvOu9jDBUuiKGT5F3wARAQAB
-/gcDAl+0SktmjrUW8uwpvru6GeIeo5kc4rXuD7iIxH6nDl3nmjZMX7qWvp+pRTHH
-0hEDH44899PDvzclBN3ouehfFUbJ+DBy8umBiLqF8Mu2PrKjdmyv3BvnbTkqPM3m
-2Su7WmUDBhG00X07lfl8fTpZJG80onEGzGynryP/xVm4ymzoHyYGksntXLYr2HJ5
-aV6L7sL2/STsaaOVHoa/oEmVBo1+NRsTxRRUcFVLs3g0OIi6ZCeSevBdavMwf9Iv
-b5Bs/e0+GLpP71XzFpdrGcL6oGjZH/dgdeypzbGA+FHtQJqynN3qEE9eCc9cfTGL
-2zN2OtnMA28NtPVN4SnSxQIDvycWx68NZjfwLOK+gswfKpimp+6xMWSnNIRDyU9M
-w0hdNPMK9JAxm/MlnkR7x6ysX/8vrVVFl9gWOmxzJ5L4kvfMsHcV5ZFRP8OnVA6a
-NFBWIBGXF1uQC4qrXup/xKyWJOoH++cMo2cjPT3+3oifZgdBydVfHXjS9aQ/S3Sa
-A6henWyx/qeBGPVRuXWdXIOKDboOPK8JwQaGd6yazKkH9c5tDohmQHzZ6ho0gyAt
-dh+g9ZyiZVpjc6excfK/DP/RdUOYKw3Ur9652hKephvYZzHvPjTbqVkhS7JjZkVY
-rukQ64d5T0pE1B4y+If4hLFXMNQtfo0TIsATNA69jop+KFnJpLzAB+Ee33EA/HUl
-YC5EJCJaXt6kdtYFac0HvVWiz5ZuMhdtzpJfvOe+Olp/xR9nIPW3XZojQoHIZKwu
-gXeZeVMvfeoq+ymKAKNH5Np4WaUDF7Wh9VLl045jGyF5viyy61ivC0eyAzp5W1uy
-gJBZwafVma5MhmZUS2dFs0hBwBrKRzZZhN65VvfSYw6CnXp83ryUjReDvrLmqZDM
-FNpSMDKRk1+k9Wwi3m+fzLAvlxoHscJ5Any7ApsvBRbyehP8MAAG7UV3jImugTLi
-yN6FKVwziQXiC4/97oKbA1YYNjTT7Qw9gWTXvLRspn4f9997brcA9dm0M0seTjLa
-lc5hTJwJQdvPPI2klf+YgPvsD6nrP1moeWBb8irICqG1/BoE0JHPS+bqJ1J+m1iV
-kRV/+4pV2bLlXKqg1LEvqANW+1P1eM2nbbVB7EQn8ZOPIKMoCLoC1QWUPNfnemsW
-U5ynAbhsbm16PDJql0ApEgUCEDfsXTu1ui6SIO3bs/gWyD9HEmnfaYMYDKF+j+0r
-jXd4GnCxb+Yu3wV5WyewOHouzC+++h/3WcDLkOYZ9pcIbA86qT+v6b9MuTAU0D3c
-wlDv8r5J59zOcXl4HpMb2BY5F9dZn8hjgeVJRhJdij9x1TQ8qlVasSi4Eq8SiPmZ
-PZz33Pk6yn2caQ6wd47A79LXCbFQqJqA5aA6oS4DOpENGS5fh7WUZq/MTcmm9GsG
-w2gHxocASK9RCUYgZFWVYgLDuviMMWvc/2TJcTMxdF0Amu3erYAD90smFs0g/6fZ
-4pRLnKFuifwAMGMOx7jbW5tmOaSPx6XkuYvkDJeLMHoN3z/8bZEG5VpayypwFGyV
-bk/YIUWg/KM/43juDPdTvab9tZzYIjxC6on7dtYIAGjZis97XZou3KYKTaMe1VY6
-IhrnVzJ0JAHpd1prf9NUz96e1vjGdn3I61JgjNp5sWklIJEZzvaD28Eovf/LH1BO
-gYFFCvsWXaRoPHNQ5a9m7CROkLeHUFgRu5uriqHxxQHgogDznc8/3fnvDAHNpNb6
-Jnk4zaeVR3tTyIjiNM+wxUFPDNFpJWmQbSDCcPVYTbpznzVRnhqrw7q0FWZvbyBi
-YXIgPGZvb0Bmb28uZm9vPokCVAQTAQgAPgIbAwULCQgHAgYVCAkKCwIEFgIDAQIe
-AQIXgBYhBJOhf/AeVDKFRgh8jgKTlUAu/M1TBQJbfPU4BQkSzAM2AAoJEAKTlUAu
-/M1TVTIQALA6ocNc2fXz1loLykMxlfnX/XxiyNDOUPDZkrZtscqqWPYaWvJK3OiD
-32bdVEbftnAiFvJYkinrCXLEmwwf5wyOxKFmCHwwKhH0UYt60yF4WwlOVNstGSAy
-RkPMEEmVfMXS9K1nzKv/9A5YsqMQob7sN5CMN66Vrm0RKSvOF/NhhM9v8fC0QSU2
-GZNO0tnRfaS4wMnFr5L4FuDST+14F5sJT7ZEJz7HfbxXKLvvWbvqLlCYHJOdz56s
-X/eKde8eT9/LSzcmgsd7rGS2np5901kubww5jllUl1CFnk3Mdg9FTJl5u9Epuhnn
-823Jpdy1ZNbyLqZ266Z/q2HepDA7P/GqIXgWdHjwG2y1YAC4JIkA4RBbesQwqAXs
-6cX5gqRFRl5iDGEP5zclS0y5mWi/J8bLYxMYfqxs9EZtHd9DumWISi87804TEzYa
-WDijMlW7PR8QRW0vdmtYOhJZOlTnomLQx2v27iqpVXRh12J1aYVBFC+IvG1vhCf9
-FL3LzAHHEGlIoDaKJMd+Wg/Lm/f1PqqQx3lWIh9hhKh5Qx6hcuJH669JOWuEdxfo
-1so50aItG+tdDKqXflmOi7grrUURchYYKteaW2fC2SQgzDClprALI7aj9s/lDrEN
-CgLH6twOqdSFWqB/4ASDMsNeLeKX3WOYKYYMlE01cj3T1m6dpRUO
-=gIM9
------END PGP PRIVATE KEY BLOCK-----
-`
-
-const keyPassphrase = "abcdef0123456789"
-
 type mockSigner struct {
 	called bool
 }
 
+const mockSignature = "-----BEGIN PGP SIGNATURE-----\n\nmock-signature\n-----END PGP SIGNATURE-----"
+
 func (m *mockSigner) Sign(_ io.Reader) ([]byte, error) {
 	m.called = true
-	return []byte("mock-signature"), nil
+	return []byte(mockSignature), nil
 }
 
 //go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
@@ -1015,20 +863,20 @@ func TestBuildCommitObjectSignerSelection(t *testing.T) {
 		{
 			name:           "CommitOptions.Signer works without plugin registered",
 			optionsSigner:  &mockSigner{},
-			wantSignature:  "mock-signature\n",
+			wantSignature:  mockSignature + "\n",
 			wantOptionUsed: true,
 		},
 		{
 			name:           "plugin signer is used when CommitOptions.Signer is nil",
 			registerPlugin: true,
-			wantSignature:  "mock-signature\n",
+			wantSignature:  mockSignature + "\n",
 			wantPluginUsed: true,
 		},
 		{
 			name:           "CommitOptions.Signer takes precedence over plugin",
 			registerPlugin: true,
 			optionsSigner:  &mockSigner{},
-			wantSignature:  "mock-signature\n",
+			wantSignature:  mockSignature + "\n",
 			wantOptionUsed: true,
 		},
 	}

--- a/x/plugin/plugin.go
+++ b/x/plugin/plugin.go
@@ -1,0 +1,121 @@
+// Package plugin provides a generic, thread-safe registry for plugin factory
+// functions. It enables off-tree implementations to be registered and
+// retrieved at runtime.
+//
+// Each plugin entry is identified by a [Key] value, which is a lightweight
+// value type parameterized on the Go type it manages. This means a factory for
+// type A cannot be registered under a Key meant for type B — the compiler
+// will reject it.
+//
+// The registry freezes automatically on the first call to [Get] for a given
+// key: all registrations must happen before the first resolution (typically
+// during package init).
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	// ErrFrozen is returned by [Register] when the plugin entry has already
+	// been resolved via [Get] and can no longer accept new registrations.
+	ErrFrozen = errors.New("plugin registry is frozen")
+	// ErrNotFound is returned by [Get] when no factory has been registered
+	// for the requested plugin key.
+	ErrNotFound = errors.New("plugin not found")
+	// ErrNilFactory is returned by [Register] when a nil factory is provided.
+	ErrNilFactory = errors.New("factory must not be nil")
+)
+
+var (
+	mu      sync.RWMutex
+	entries = map[Name]*entry{}
+)
+
+// Name represents the Plugin name.
+type Name string
+
+// Register sets the factory for the given key.
+// It returns [ErrFrozen] if the key has already been resolved (via [Get]),
+// or [ErrNilFactory] if factory is nil.
+// Calling Register again on the same key replaces the previous factory.
+func Register[T any](key key[T], factory func() T) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	e := entries[key.name]
+	if e == nil {
+		return fmt.Errorf("plugin: uninitialized key %q", key.name)
+	}
+
+	if e.frozen {
+		return fmt.Errorf("%w: cannot register %q", ErrFrozen, key.name)
+	}
+
+	if factory == nil {
+		return ErrNilFactory
+	}
+
+	e.factory = factory
+	return nil
+}
+
+// Get calls the factory registered under key and returns a new T.
+// The first call to Get for a given key freezes that plugin entry,
+// preventing further registrations.
+// It returns [ErrNotFound] if no factory has been registered for the key.
+func Get[T any](key key[T]) (T, error) {
+	mu.Lock()
+	e := entries[key.name]
+	if e == nil {
+		mu.Unlock()
+		var zero T
+		return zero, fmt.Errorf("plugin: uninitialized key %q", key.name)
+	}
+
+	e.frozen = true
+	f := e.factory
+	mu.Unlock()
+
+	if f == nil {
+		var zero T
+		return zero, fmt.Errorf("%w: %q", ErrNotFound, key.name)
+	}
+	return f.(func() T)(), nil
+}
+
+// Has reports whether a plugin has been registered for the given key.
+func Has[T any](key key[T]) bool {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	e := entries[key.name]
+	return e != nil && e.factory != nil
+}
+
+// Key identifies a typed plugin entry.
+// It is a value type — safe to copy, cannot be nil.
+type key[T any] struct {
+	name Name
+}
+
+// newKey creates a new plugin entry key with the given name.
+// It panics if a key with the same name has already been created.
+func newKey[T any](name Name) key[T] {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, exists := entries[name]; exists {
+		panic("plugin: duplicate key name: " + name)
+	}
+	entries[name] = &entry{}
+	return key[T]{name: name}
+}
+
+// entry holds the internal state for a single plugin entry.
+type entry struct {
+	frozen  bool
+	factory any // func() T stored as any; nil means not registered
+}

--- a/x/plugin/plugin.go
+++ b/x/plugin/plugin.go
@@ -121,7 +121,10 @@ type entry struct {
 }
 
 // resetEntry clears the factory and unfreezes the plugin entry identified by
-// name, restoring it to its initial state. It is intended for use in tests only.
+// name, restoring it to its initial state. It is intended for use in tests
+// via go:linkname.
+//
+//nolint:unused // accessed via go:linkname from worktree_commit_test.go
 func resetEntry(name Name) {
 	mu.Lock()
 	defer mu.Unlock()

--- a/x/plugin/plugin.go
+++ b/x/plugin/plugin.go
@@ -119,3 +119,15 @@ type entry struct {
 	frozen  bool
 	factory any // func() T stored as any; nil means not registered
 }
+
+// resetEntry clears the factory and unfreezes the plugin entry identified by
+// name, restoring it to its initial state. It is intended for use in tests only.
+func resetEntry(name Name) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if e := entries[name]; e != nil {
+		e.frozen = false
+		e.factory = nil
+	}
+}

--- a/x/plugin/plugin_signer.go
+++ b/x/plugin/plugin_signer.go
@@ -1,0 +1,18 @@
+package plugin
+
+import "io"
+
+const objectSignerPlugin Name = "object-signer"
+
+var objectSigner = newKey[Signer](objectSignerPlugin)
+
+type Signer interface {
+	Sign(message io.Reader) ([]byte, error)
+}
+
+// ObjectSigner is key used to represent the plugin for object signing.
+// When set, this plugin will set the default signer for new commits and
+// tags.
+func ObjectSigner() key[Signer] {
+	return objectSigner
+}

--- a/x/plugin/plugin_test.go
+++ b/x/plugin/plugin_test.go
@@ -1,0 +1,161 @@
+package plugin
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resetGlobal() {
+	mu.Lock()
+	defer mu.Unlock()
+	entries = map[Name]*entry{}
+}
+
+func TestRegisterAndGet(t *testing.T) {
+	resetGlobal()
+	key := newKey[string]("greeting")
+
+	require.NoError(t, Register(key, func() string { return "hello" }))
+
+	got, err := Get(key)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", got)
+}
+
+func TestGetNotFound(t *testing.T) {
+	resetGlobal()
+	key := newKey[int]("empty")
+
+	got, err := Get(key)
+	require.Zero(t, got)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestRegisterNilFactory(t *testing.T) {
+	resetGlobal()
+	key := newKey[int]("nil-factory")
+
+	err := Register(key, nil)
+	assert.ErrorIs(t, err, ErrNilFactory)
+}
+
+func TestRegisterOverwrite(t *testing.T) {
+	resetGlobal()
+	key := newKey[string]("overwrite")
+
+	Register(key, func() string { return "first" })
+	Register(key, func() string { return "second" })
+
+	got, err := Get(key)
+	require.NoError(t, err)
+	assert.Equal(t, "second", got)
+}
+
+func TestAutoFreeze(t *testing.T) {
+	resetGlobal()
+	key := newKey[int]("freeze")
+
+	Register(key, func() int { return 1 })
+
+	got, err := Get(key)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got)
+
+	err = Register(key, func() int { return 2 })
+	assert.ErrorIs(t, err, ErrFrozen)
+
+	got, err = Get(key)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got)
+}
+
+func TestGetNotFoundAlsoFreezes(t *testing.T) {
+	resetGlobal()
+	key := newKey[int]("freeze-on-miss")
+
+	got, err := Get(key)
+	require.ErrorIs(t, err, ErrNotFound)
+	assert.Zero(t, got)
+
+	err = Register(key, func() int { return 1 })
+	assert.ErrorIs(t, err, ErrFrozen)
+}
+
+func TestHas(t *testing.T) {
+	resetGlobal()
+	key := newKey[int]("has-test")
+
+	assert.False(t, Has(key))
+
+	Register(key, func() int { return 1 })
+
+	assert.True(t, Has(key))
+}
+
+func TestGetReturnsNewInstance(t *testing.T) {
+	resetGlobal()
+	counter := 0
+	key := newKey[int]("counter")
+	Register(key, func() int {
+		counter++
+		return counter
+	})
+
+	a, err := Get(key)
+	require.NoError(t, err)
+
+	b, err := Get(key)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, a, b, "factory should be called each time")
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	resetGlobal()
+	key := newKey[int]("concurrent")
+	Register(key, func() int { return 42 })
+
+	var wg sync.WaitGroup
+	for i := range 100 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			Get(key)
+			Has(key)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestMultipleKeysSameType(t *testing.T) {
+	resetGlobal()
+	type Signer struct{ name string }
+
+	gpgSigner := newKey[Signer]("gpg-signer")
+	sshSigner := newKey[Signer]("ssh-signer")
+
+	Register(gpgSigner, func() Signer { return Signer{name: "gpg"} })
+	Register(sshSigner, func() Signer { return Signer{name: "ssh"} })
+
+	gs, _ := Get(gpgSigner)
+	ss, _ := Get(sshSigner)
+	assert.Equal(t, "gpg", gs.name)
+	assert.Equal(t, "ssh", ss.name)
+}
+
+func TestPerKeyFreezeIsolation(t *testing.T) {
+	resetGlobal()
+	a := newKey[string]("a")
+	b := newKey[string]("b")
+
+	Register(a, func() string { return "ax" })
+	Register(b, func() string { return "bx" })
+
+	Get(a)
+
+	assert.ErrorIs(t, Register(a, func() string { return "ay" }), ErrFrozen)
+	assert.NoError(t, Register(b, func() string { return "by" }))
+}

--- a/x/plugin/plugin_test.go
+++ b/x/plugin/plugin_test.go
@@ -14,7 +14,7 @@ func resetGlobal() {
 	entries = map[Name]*entry{}
 }
 
-func TestRegisterAndGet(t *testing.T) {
+func TestRegisterAndGet(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	key := newKey[string]("greeting")
 
@@ -25,7 +25,7 @@ func TestRegisterAndGet(t *testing.T) {
 	assert.Equal(t, "hello", got)
 }
 
-func TestGetNotFound(t *testing.T) {
+func TestGetNotFound(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	key := newKey[int]("empty")
 
@@ -34,7 +34,7 @@ func TestGetNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 }
 
-func TestRegisterNilFactory(t *testing.T) {
+func TestRegisterNilFactory(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	key := newKey[int]("nil-factory")
 
@@ -42,7 +42,7 @@ func TestRegisterNilFactory(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNilFactory)
 }
 
-func TestRegisterOverwrite(t *testing.T) {
+func TestRegisterOverwrite(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	key := newKey[string]("overwrite")
 
@@ -54,7 +54,7 @@ func TestRegisterOverwrite(t *testing.T) {
 	assert.Equal(t, "second", got)
 }
 
-func TestAutoFreeze(t *testing.T) {
+func TestAutoFreeze(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	key := newKey[int]("freeze")
 
@@ -72,7 +72,7 @@ func TestAutoFreeze(t *testing.T) {
 	assert.Equal(t, 1, got)
 }
 
-func TestGetNotFoundAlsoFreezes(t *testing.T) {
+func TestGetNotFoundAlsoFreezes(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	key := newKey[int]("freeze-on-miss")
 
@@ -84,7 +84,7 @@ func TestGetNotFoundAlsoFreezes(t *testing.T) {
 	assert.ErrorIs(t, err, ErrFrozen)
 }
 
-func TestHas(t *testing.T) {
+func TestHas(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	key := newKey[int]("has-test")
 
@@ -95,7 +95,7 @@ func TestHas(t *testing.T) {
 	assert.True(t, Has(key))
 }
 
-func TestGetReturnsNewInstance(t *testing.T) {
+func TestGetReturnsNewInstance(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	counter := 0
 	key := newKey[int]("counter")
@@ -113,7 +113,7 @@ func TestGetReturnsNewInstance(t *testing.T) {
 	assert.NotEqual(t, a, b, "factory should be called each time")
 }
 
-func TestConcurrentAccess(t *testing.T) {
+func TestConcurrentAccess(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	key := newKey[int]("concurrent")
 	Register(key, func() int { return 42 })
@@ -130,7 +130,7 @@ func TestConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestMultipleKeysSameType(t *testing.T) {
+func TestMultipleKeysSameType(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	type Signer struct{ name string }
 
@@ -146,7 +146,7 @@ func TestMultipleKeysSameType(t *testing.T) {
 	assert.Equal(t, "ssh", ss.name)
 }
 
-func TestPerKeyFreezeIsolation(t *testing.T) {
+func TestPerKeyFreezeIsolation(t *testing.T) { //nolint:paralleltest // modifies global trace target
 	resetGlobal()
 	a := newKey[string]("a")
 	b := newKey[string]("b")

--- a/x/plugin/plugin_verifier.go
+++ b/x/plugin/plugin_verifier.go
@@ -1,0 +1,21 @@
+package plugin
+
+import "github.com/go-git/go-git/v6/plumbing/object"
+
+const objectVerifierPlugin Name = "object-verifier"
+
+var objectVerifier = newKey[Verifier](objectVerifierPlugin)
+
+// Verifier is an interface for verifying cryptographic signatures on git objects.
+// This is defined locally in the plugin package to avoid import cycles with the
+// git package.
+type Verifier interface {
+	Verify(signature, message []byte) (*object.VerificationResult, error)
+}
+
+// ObjectVerifier is key used to represent the plugin for object verification.
+// When set, this plugin will provide the default verifier for commits and tags
+// retrieved through higher-level APIs (e.g. Repository.CommitObject).
+func ObjectVerifier() key[Verifier] {
+	return objectVerifier
+}


### PR DESCRIPTION
Added on top of #1860 a verify plugin that could be used like so:
```go
import (
    "errors"
    "fmt"
    "os"

    git "github.com/go-git/go-git/v6"
    "github.com/go-git/go-git/v6/plumbing/object"
    "github.com/go-git/go-git/v6/x/plugin"

    // Out-of-tree verifier implementations (e.g. from github.com/go-git/x)
    gossh "github.com/go-git/x/plugin/objectverifier/ssh"
    // "github.com/go-git/x/plugin/objectverifier/gpg"
)

func main() {
    // Register a verifier plugin globally — once at startup.
    // All commits/tags fetched via Repository methods will auto-verify.
    plugin.Register(plugin.ObjectVerifier(),
        func() plugin.Verifier {
            v, _ := gossh.FromAllowedSignersFile("~/.ssh/allowed_signers")
            return v
            // return gpg.FromArmoredKeyRing(keyring)
        })

    r, _ := git.PlainOpen("/path/to/repo")

    // Commits retrieved via the repo auto-carry the verifier
    commit, _ := r.CommitObject(someHash)

    result, err := commit.Verify()
    switch {
    case err == nil:
        fmt.Printf("Verified: %s (signed by %s)\n", result.KeyID, result.Signer)
    case errors.Is(err, object.ErrKeyNotTrusted):
        fmt.Printf("Valid signature from unknown key: %s\n", result.KeyID)
    case errors.Is(err, object.ErrSignatureInvalid):
        fmt.Println("Signature is invalid — content may have been tampered with")
    case errors.Is(err, object.ErrNoSignature):
        fmt.Println("Commit is unsigned")
    default:
        fmt.Printf("Verification failed: %v\n", err)
    }
}
```

This is trying to address the discussion from #1869 . I couldn't figure out a way to do this PR against PR #1860, so it does have all the commit from it too :-(