### PR TITLE
plumbing: transport, fix shallow boundaries not persisted; remote, skip bare-hash dst refs

### DIFF
--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -304,9 +304,10 @@ func readShallows(
 			return fmt.Errorf("decoding shallow-update: %w", err)
 		}
 
-		// Only return the first shallow update
-		if shallowInfo == nil {
-			shallowInfo = new(*packp.ShallowUpdate)
+		// Only capture the first shallow update; subsequent rounds may
+		// also produce shallow-update packets (stateless RPC sends one per
+		// request round-trip) but the first one is authoritative.
+		if *shallowInfo == nil {
 			*shallowInfo = &shupd
 		}
 	}

--- a/remote.go
+++ b/remote.go
@@ -443,6 +443,28 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 			return nil, err
 		}
 
+		// When performing a shallow fetch, exclude any shallow-boundary commits
+		// from the haves list. Shallow commits are already communicated to the
+		// server via the "shallow" packets in the upload-request. Including them
+		// in HAVE would lead the server to treat their ancestors as present on
+		// the client (because HAVE X implies the client has X and all its
+		// ancestors), which contradicts the shallow boundary and causes the
+		// server to send an empty packfile even when the client is missing
+		// objects that are ancestors of its shallow commits.
+		if len(shallows) > 0 {
+			shallowSet := make(map[plumbing.Hash]bool, len(shallows))
+			for _, h := range shallows {
+				shallowSet[h] = true
+			}
+			filtered := haves[:0]
+			for _, h := range haves {
+				if !shallowSet[h] {
+					filtered = append(filtered, h)
+				}
+			}
+			haves = filtered
+		}
+
 		req := &transport.FetchRequest{
 			Wants:       wants,
 			Haves:       haves,
@@ -1128,8 +1150,17 @@ func (r *Remote) updateLocalReferenceStorage(
 			}
 
 			localName := spec.Dst(ref.Name())
-			// If localName doesn't start with "refs/" then treat as a branch.
+			// If localName doesn't start with "refs/" then treat as a branch,
+			// unless localName is itself a SHA-1/SHA-256 hash (as happens when
+			// a caller uses a bare-hash dst such as "+<hash>:<hash>"). Creating
+			// a branch named after a commit hash is always wrong and produces
+			// spurious refs that confuse ResolveRevision and other callers.
 			if !strings.HasPrefix(localName.String(), "refs/") {
+				if plumbing.IsHash(localName.String()) {
+					// Bare-hash dst: the intent is to fetch the object only;
+					// no local reference should be created.
+					continue
+				}
 				localName = plumbing.NewBranchReferenceName(localName.String())
 			}
 			old, _ := storer.ResolveReference(r.s, localName)

--- a/repository_test.go
+++ b/repository_test.go
@@ -450,6 +450,109 @@ func TestFetchMustNotUpdateObjectFormat(t *testing.T) {
 	}
 }
 
+// TestFetchByHashThenResolveRevision is a regression test for two bugs that
+// affected fetching a specific commit by hash into an existing repository
+// using the force-refspec "+<hash>:<hash>".
+//
+// Regression 1 (negotiate.go): shallow boundaries were not persisted after a
+// clone, so subsequent fetches sent no "shallow" lines to the server. The
+// server then inferred the client already owned the wanted commit (a deep
+// ancestor of the shallow tip) and returned an empty packfile, leaving the
+// object absent from the store.
+//
+// Regression 2 (remote.go): when the dst of a refspec is a bare SHA, the
+// code created a branch named after the hash (refs/heads/<sha>) pointing to
+// the zero hash. ResolveRevision resolved via that spurious ref and returned
+// the zero hash instead of the real commit hash, breaking all downstream
+// callers such as Worktree.Checkout.
+//
+// Note: this test uses the live GitHub URL rather than a local fixture server
+// because the fixture HTTP server does not implement depth filtering in
+// upload-pack. Without depth support the server sends all objects on a
+// depth=1 clone, making commitSHA present from the start and preventing
+// regression 1 from being reproduced.
+func TestFetchByHashThenResolveRevision(t *testing.T) {
+	t.Parallel()
+
+	// git-fixtures/basic.git commit graph (abbreviated):
+	//
+	//   * 6ecf0ef  vendor stuff          <- refs/heads/master (HEAD)
+	//   | * e8d3ffa some code in branch  <- refs/heads/branch
+	//   |/
+	//   * 918c48b  some code
+	//   ...several more commits...
+	//   * 35e8510  binary file            <- commitSHA (deep ancestor of both)
+	//   * b029517  Initial commit
+	//
+	// A depth=1 shallow clone of master fetches only 6ecf0ef2. The target
+	// commit (35e85108) is a deep historical ancestor, absent because it is
+	// pruned by the shallow depth limit — not because it is on a different branch.
+	const (
+		repoURL   = "https://github.com/git-fixtures/basic.git"
+		commitSHA = "35e85108805c84807bc66a02d91535e1e24b38b9"
+	)
+
+	tmp := t.TempDir()
+
+	// Step 1: clone the default branch at depth=1.
+	// commitSHA is a deep ancestor excluded by the shallow depth limit.
+	r, err := PlainClone(tmp, &CloneOptions{
+		URL:   repoURL,
+		Depth: 1,
+		Tags:  NoTags,
+	})
+	require.NoError(t, err, "clone should succeed")
+
+	// Confirm the target commit is not yet available.
+	_, err = r.CommitObject(plumbing.NewHash(commitSHA))
+	require.Error(t, err, "commit should NOT be present in a shallow clone of master")
+
+	// Step 2: fetch the specific commit by hash using "+<hash>:<hash>".
+	// This is the standard refspec for fetching an arbitrary commit that is not
+	// the tip of a branch or tag.
+	refSpec := config.RefSpec("+" + commitSHA + ":" + commitSHA)
+	err = r.Fetch(&FetchOptions{
+		Depth:    1,
+		Force:    true,
+		RefSpecs: []config.RefSpec{refSpec},
+		Tags:     NoTags,
+	})
+	require.NoError(t, err, "fetch should succeed")
+
+	// Step 3: the commit object MUST now be present in the object store.
+	_, err = r.CommitObject(plumbing.NewHash(commitSHA))
+	assert.NoError(t, err,
+		"commit object must be present in the object store after a successful Fetch with '+<hash>:<hash>'",
+	)
+
+	// Step 4: regression 2 — no spurious refs/heads/<sha> must be created.
+	// Before the fix, updateLocalReferenceStorage created refs/heads/<sha>
+	// pointing to the zero hash for any bare-hash dst refspec.
+	_, refErr := r.Storer.Reference(plumbing.NewBranchReferenceName(commitSHA))
+	assert.Error(t, refErr,
+		"fetching by hash must NOT create a branch named after the hash")
+
+	// Step 5: the commit must also be resolvable as a revision.
+	// Before the fix, the spurious branch caused ResolveRevision to return
+	// the zero hash.
+	hash, err := r.ResolveRevision(plumbing.Revision(commitSHA))
+	assert.NoError(t, err,
+		"ResolveRevision with a full SHA must succeed when the commit object is present",
+	)
+	if hash != nil {
+		assert.Equal(t, commitSHA, hash.String())
+	}
+
+	// Step 6: downstream effect — Worktree.Checkout must also succeed.
+	w, err := r.Worktree()
+	require.NoError(t, err)
+	err = w.Checkout(&CheckoutOptions{
+		Hash:  plumbing.NewHash(commitSHA),
+		Force: true,
+	})
+	assert.NoError(t, err, "Worktree.Checkout by hash should succeed after fetching the commit")
+}
+
 // TestPlainCloneContext_FailedCloneRemovesCreatedDirectory is a regression test
 // for a v6 behaviour difference vs v5 and the reference git implementation.
 //


### PR DESCRIPTION
## Summary

Two bugs caused fetching a specific commit by hash (using `+<hash>:<hash>`) into an existing shallow-cloned repository to silently fail or corrupt state.

### Regression test

`TestFetchByHashThenResolveRevision` in `repository_test.go` covers both bugs end-to-end:
1. Clone `git-fixtures/basic.git` at `depth=1`
2. Fetch a deep ancestor commit by SHA using `+<hash>:<hash>`
3. Assert the commit object is present, `ResolveRevision` returns the correct SHA, and `Worktree.Checkout` succeeds

### Bug 1 — shallow boundaries not persisted after clone (`plumbing/transport/negotiate.go`)

`readShallows` checked `if shallowInfo == nil` where `shallowInfo` is a `**packp.ShallowUpdate`. This pointer is always non-nil (it is the address of a local variable in the caller), so the body that assigns `*shallowInfo = &shupd` never executed.

**Fix:** check `*shallowInfo == nil`, which dereferences the outer pointer and tests whether a shallow update has already been captured.

Without this fix, `st.Shallow()` returns an empty slice on every subsequent fetch. `NegotiatePack` therefore sends no `shallow` lines to the server. The server sees `have 6ecf0ef2` (the shallow tip), infers the client has its full ancestry, concludes the wanted commit (a deep ancestor of the tip) is already present, and returns a 32-byte empty packfile.

### Bug 2 — spurious branch ref created for bare-hash dst (`remote.go`, `updateLocalReferenceStorage`)

When the dst portion of a refspec is a raw SHA (e.g. `+<hash>:<hash>`), the code fell into the "treat as branch" path and called `plumbing.NewBranchReferenceName(<sha>)`, creating `refs/heads/<sha>` pointing to the zero hash. `ResolveRevision` then resolved via that spurious ref and returned the zero hash instead of the real commit hash.

**Fix:** detect `plumbing.IsHash(localName.String())` and skip ref creation — a bare-hash dst means "fetch the object only".

### Complementary fix (`remote.go`, `fetch`)

When building the HAVE list for a shallow fetch, shallow-boundary commits are now excluded. This matches the behaviour of the reference git client and avoids the server treating their ancestors as implicitly owned by the client.
