### PR TITLE
internal/server/http: handle net.ErrClosed in server Close

### DIFF
--- a/internal/server/http/http.go
+++ b/internal/server/http/http.go
@@ -65,5 +65,11 @@ func (s *server) Close() error {
 	err1 := s.ln.Close()
 	err2 := s.srv.Close()
 
+	// net.ErrClosed is returned when closing an already-closed listener,
+	// which can happen because http.Server.Close also closes listeners.
+	if errors.Is(err1, net.ErrClosed) {
+		err1 = nil
+	}
+
 	return errors.Join(err1, err2)
 }


### PR DESCRIPTION
Fixes #1856

## Summary

Fix flaky test `TestFailSafeUnsupportedStorage/clone` by handling `net.ErrClosed` in the HTTP server's Close method.

The `http.Server.Close` method closes all active listeners, including the one stored in `s.ln`. When `s.ln.Close()` is subsequently called, it returns `net.ErrClosed` due to a race condition. This error propagates up and causes the test to fail intermittently.

## Changes

- Modified `internal/server/http/http.go` to ignore `net.ErrClosed` when closing the listener, since an already-closed listener is not an error condition

## Testing

- Ran `TestFailSafeUnsupportedStorage/clone` 10 times consecutively - all passed
- Ran `go build ./...` - compiles successfully

```
 internal/server/http/http.go | 6 ++++++
 1 file changed, 6 insertions(+)
```