### PR TITLE
git: remote: handle shallow clone in isFastForward

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1072,9 +1072,6 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, ear
 
 	found := false
 	// stop iterating at the earliest shallow commit, ignoring its parents
-	// note: when pull depth is smaller than the number of new changes on the remote, this fails due to missing parents.
-	//       as far as i can tell, without the commits in-between the shallow pull and the earliest shallow, there's no
-	//       real way of telling whether it will be a fast-forward merge.
 	iter := object.NewCommitPreorderIter(c, nil, parentsToIgnore)
 	err = iter.ForEach(func(c *object.Commit) error {
 		if c.Hash != old {
@@ -1084,6 +1081,13 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, ear
 		found = true
 		return storer.ErrStop
 	})
+	if errors.Is(err, plumbing.ErrObjectNotFound) {
+		// When pull depth is smaller than the number of new changes on the remote,
+		// this fails due to missing parents. Without the commits in-between the
+		// shallow pull and the earliest shallow, there's no real way of telling
+		// whether it will be a fast-forward merge, so return false.
+		return false, nil
+	}
 	return found, err
 }
 


### PR DESCRIPTION
Fixes #207

## Summary

When doing a shallow clone and then pulling with depth 0 (unlimited), the `isFastForward` function would return `plumbing.ErrObjectNotFound` because the commit iterator cannot find parent commits that don't exist in the shallow clone.

This change makes `isFastForward` return `false` (not a fast-forward) instead of an error when encountering missing objects during iteration. This matches the behavior already implemented in `getHavesFromRef` which ignores errors from the commit iterator for the same reason.

## Changes

- Modified `isFastForward` in `remote.go` to handle `plumbing.ErrObjectNotFound` gracefully
- When the error occurs during commit iteration, return `false, nil` instead of propagating the error
- Moved the explanatory comment to where the error is actually handled

## Testing

- Verified existing test `TestFetchAfterShallowClone` passes
- Verified all `RemoteSuite` tests pass
- The fix follows the same pattern already used in `getHavesFromRef` (line 849)

```
 remote.go | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)
```