### PR TITLE
git: apply global URL insteadOf rules during clone

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -910,7 +910,7 @@ func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
 	copy(originalURLs, c.URLs)
 
 	for i, url := range c.URLs {
-		if matchingURLRule := findLongestInsteadOfMatch(url, urlRules); matchingURLRule != nil {
+		if matchingURLRule := FindLongestInsteadOfMatch(url, urlRules); matchingURLRule != nil {
 			c.URLs[i] = matchingURLRule.ApplyInsteadOf(c.URLs[i])
 			c.insteadOfRulesApplied = true
 		}

--- a/config/url.go
+++ b/config/url.go
@@ -54,7 +54,10 @@ func (u *URL) marshal() *format.Subsection {
 	return u.raw
 }
 
-func findLongestInsteadOfMatch(remoteURL string, urls map[string]*URL) *URL {
+// FindLongestInsteadOfMatch returns the URL rule that provides the longest
+// insteadOf match for the given remote URL. Returns nil if no match is found.
+// When multiple insteadOf strings match, the longest match is used per git spec.
+func FindLongestInsteadOfMatch(remoteURL string, urls map[string]*URL) *URL {
 	var longestMatch *URL
 	var longestMatchLength int
 

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -138,7 +138,7 @@ func (b *URLSuite) TestFindLongestInsteadOfMatch() {
 		},
 	}
 
-	longestURL := findLongestInsteadOfMatch("http://github.com/foobar/bingbash.git", urlRules)
+	longestURL := FindLongestInsteadOfMatch("http://github.com/foobar/bingbash.git", urlRules)
 
 	b.Equal("ssh://somethingelse.com", longestURL.Name)
 }

--- a/repository.go
+++ b/repository.go
@@ -966,6 +966,21 @@ func (r *Repository) resolveToCommitHash(h plumbing.Hash) (plumbing.Hash, error)
 	}
 }
 
+// applyURLInsteadOfRules applies global URL rewrite rules (insteadOf) to the given URL.
+// It loads the global gitconfig and applies any matching URL rewrite rules.
+func applyURLInsteadOfRules(remoteURL string) string {
+	cfg, err := config.LoadConfig(config.GlobalScope)
+	if err != nil || cfg == nil {
+		return remoteURL
+	}
+
+	if matchingURLRule := config.FindLongestInsteadOfMatch(remoteURL, cfg.URLs); matchingURLRule != nil {
+		return matchingURLRule.ApplyInsteadOf(remoteURL)
+	}
+
+	return remoteURL
+}
+
 // Clone clones a remote repository
 func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 	if trace.Performance.Enabled() {
@@ -983,6 +998,9 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		return err
 	}
 
+	// Apply global URL rewrite rules (insteadOf) to the clone URL
+	cloneURL := applyURLInsteadOfRules(o.URL)
+
 	// PlainClone and Clone have two different execution paths, the former
 	// populates r.wt, while the latter doesn't. A refactoring is in order to
 	// better align both approaches.
@@ -992,7 +1010,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 
 	c := &config.RemoteConfig{
 		Name:   o.RemoteName,
-		URLs:   []string{o.URL},
+		URLs:   []string{cloneURL},
 		Fetch:  r.cloneRefSpec(o),
 		Mirror: o.Mirror,
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -3655,6 +3655,78 @@ func BenchmarkObjects(b *testing.B) {
 	}
 }
 
+func TestApplyURLInsteadOfRules(t *testing.T) {
+	tests := []struct {
+		name        string
+		remoteURL   string
+		wantURL     string
+		setupConfig bool
+		configURLs  map[string]string
+	}{
+		{
+			name:        "no config - returns original URL",
+			remoteURL:   "https://github.com/example/repo.git",
+			wantURL:     "https://github.com/example/repo.git",
+			setupConfig: false,
+		},
+		{
+			name:        "matching rule - rewrites URL",
+			remoteURL:   "https://github.com/example/repo.git",
+			wantURL:     "ssh://git@github.com/example/repo.git",
+			setupConfig: true,
+			configURLs: map[string]string{
+				"ssh://git@github.com/": "https://github.com/",
+			},
+		},
+		{
+			name:        "no matching rule - returns original URL",
+			remoteURL:   "https://gitlab.com/example/repo.git",
+			wantURL:     "https://gitlab.com/example/repo.git",
+			setupConfig: true,
+			configURLs: map[string]string{
+				"ssh://git@github.com/": "https://github.com/",
+			},
+		},
+		{
+			name:        "longest match wins",
+			remoteURL:   "https://github.com/org/repo.git",
+			wantURL:     "ssh://git@github.com/org/repo.git",
+			setupConfig: true,
+			configURLs: map[string]string{
+				"ssh://git@github.com/org/": "https://github.com/org/",
+				"ssh://git@gitlab.com/":     "https://github.com/",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setupConfig {
+				// Create a temporary directory for the gitconfig
+				tmpDir := t.TempDir()
+				configPath := filepath.Join(tmpDir, ".gitconfig")
+
+				// Build the config content
+				var configContent strings.Builder
+				for newName, insteadOf := range tc.configURLs {
+					configContent.WriteString(fmt.Sprintf("[url \"%s\"]\n", newName))
+					configContent.WriteString(fmt.Sprintf("    insteadOf = %s\n", insteadOf))
+				}
+
+				err := os.WriteFile(configPath, []byte(configContent.String()), 0o600)
+				require.NoError(t, err)
+
+				// Set HOME to the temporary directory
+				t.Setenv("HOME", tmpDir)
+			}
+
+			// Test the function
+			result := applyURLInsteadOfRules(tc.remoteURL)
+			assert.Equal(t, tc.wantURL, result)
+		})
+	}
+}
+
 func BenchmarkPlainClone(b *testing.B) {
 	b.StopTimer()
 	clone := func(b *testing.B) {


### PR DESCRIPTION
Fixes #844

## Summary

This PR adds support for applying global URL `insteadOf` rules (defined in `~/.gitconfig`) during `Clone()` and `PlainClone()` operations. Previously, these rules were only applied when loading config from existing repositories, but not when cloning new repositories.

## Changes

- Export `FindLongestInsteadOfMatch` function in `config/url.go` to make it accessible from other packages
- Add `applyURLInsteadOfRules` helper function in `repository.go` that loads global config and applies URL rewrite rules
- Modify the `clone()` method to apply URL rules to the clone URL before creating the remote
- Add comprehensive tests for the new functionality

## Testing

Added `TestApplyURLInsteadOfRules` test that verifies:
- URL is returned unchanged when no config exists
- URL is rewritten when a matching rule exists
- URL is returned unchanged when no matching rule exists
- Longest match wins when multiple rules could apply

All existing tests pass and the new functionality has been verified.

## Diff Stats

```
 config/config.go   |  2 +-
 config/url.go      |  5 +++-
 config/url_test.go |  2 +-
 repository.go      | 20 ++++++++++++++-
 repository_test.go | 72 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 97 insertions(+), 4 deletions(-)
```