### PR TITLE
git: PlainCloneContext, clean up directory on failed clone

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -590,12 +590,30 @@ func PlainCloneContext(ctx context.Context, path string, o *CloneOptions) (*Repo
 	if o.Mirror {
 		isBare = true
 	}
+	// Record whether the directory existed before we touched it so we can
+	// roll back correctly on failure, matching the behaviour of `git clone`:
+	//   - directory didn't exist → remove it entirely on failure
+	//   - directory already existed (empty) → remove only content we added
+	_, preErr := os.Stat(path)
+	dirPreexisted := !os.IsNotExist(preErr)
+
 	r, err := PlainInit(path, isBare, withPartialInit())
 	if err != nil {
 		return nil, err
 	}
 
-	return r, r.clone(ctx, o)
+	if err := r.clone(ctx, o); err != nil {
+		if dirPreexisted {
+			// Restore the directory to its original empty state.
+			_ = os.RemoveAll(filepath.Join(path, GitDirName))
+		} else {
+			// We created the directory; remove it entirely.
+			_ = os.RemoveAll(path)
+		}
+		return r, err
+	}
+
+	return r, nil
 }
 
 func newRepository(s storage.Storer, worktree billy.Filesystem) *Repository {

--- a/repository_test.go
+++ b/repository_test.go
@@ -450,6 +450,54 @@ func TestFetchMustNotUpdateObjectFormat(t *testing.T) {
 	}
 }
 
+// TestPlainCloneContext_FailedCloneRemovesCreatedDirectory is a regression test
+// for a v6 behaviour difference vs v5 and the reference git implementation.
+//
+// When PlainCloneContext creates the destination directory (i.e. it did not
+// exist before the call) and the clone subsequently fails, it must remove the
+// directory it created — just as `git clone` does. Without this cleanup a
+// caller that retries with different credentials (e.g. iterating over auth
+// methods) gets "destination path already exists" on the second attempt.
+func TestPlainCloneContext_FailedCloneRemovesCreatedDirectory(t *testing.T) {
+	t.Parallel()
+
+	// dest does not exist yet; PlainCloneContext must create and then remove it.
+	dest := filepath.Join(t.TempDir(), "repo")
+
+	_, err := PlainCloneContext(context.Background(), dest, &CloneOptions{
+		URL: "incorrectOnPurpose",
+	})
+	require.Error(t, err)
+
+	_, statErr := os.Stat(dest)
+	assert.True(t, os.IsNotExist(statErr),
+		"PlainCloneContext must remove the directory it created when the clone fails")
+}
+
+// TestPlainCloneContext_FailedClonePreservesPreexistingEmptyDirectory verifies
+// that a directory which already existed (but was empty) before the call is
+// preserved after a failed clone — matching `git clone` behaviour.
+func TestPlainCloneContext_FailedClonePreservesPreexistingEmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	// dest exists and is empty before the clone attempt.
+	dest := t.TempDir()
+
+	_, err := PlainCloneContext(context.Background(), dest, &CloneOptions{
+		URL: "incorrectOnPurpose",
+	})
+	require.Error(t, err)
+
+	// The directory itself must still be there …
+	_, statErr := os.Stat(dest)
+	assert.NoError(t, statErr, "PlainCloneContext must not remove a pre-existing directory")
+
+	// … and must be empty (any .git content added by PlainInit must be removed).
+	entries, _ := os.ReadDir(dest)
+	assert.Empty(t, entries,
+		"PlainCloneContext must remove any content it added to a pre-existing empty directory")
+}
+
 // sha1OnlyStorage wraps a storage.Storer to hide the ExtensionChecker
 // implementation, simulating a storage backend that does not implement
 // that interface.


### PR DESCRIPTION
## Summary

Fix a regression where PlainCloneContext does not clean up the destination directory when a clone fails, causing subsequent retries to get ErrTargetDirNotEmpty.

Matches the behaviour of real git clone: if the directory was created by the call it is removed on failure; if it pre-existed only the .git content is removed.

## Background

A common auth-retry pattern clones the same path repeatedly with different credentials. Without this fix the first failure leaves .git behind and every retry gets ErrTargetDirNotEmpty.

## Changes

- repository.go: PlainCloneContext records whether the destination directory pre-existed and cleans up correctly on r.clone failure.
- repository_test.go: Two new regression tests.
