### PR TITLE
plumbing: transport/serve, fix detached HEAD advertised as broken symref

### DIFF
--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -112,8 +112,13 @@ func addReferences(st storage.Storer, ar *packp.AdvRefs, addHead bool) error {
 			if !addHead {
 				return nil
 			}
-			// Add default branch HEAD symref
-			_ = ar.Capabilities.Add(capability.SymRef, fmt.Sprintf("%s:%s", name, r.Target()))
+			// Only advertise a symref when HEAD is symbolic. A detached HEAD
+			// (HashReference) has no branch target to advertise; emitting
+			// "HEAD:" with an empty target corrupts the capability list and
+			// causes the client to store an unresolvable HEAD symref.
+			if r.Type() == plumbing.SymbolicReference {
+				_ = ar.Capabilities.Add(capability.SymRef, fmt.Sprintf("%s:%s", name, r.Target()))
+			}
 			ar.Head = &hash
 		}
 		ar.References[name.String()] = hash

--- a/repository_test.go
+++ b/repository_test.go
@@ -561,6 +561,79 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 	assert.Equal(t, "origin", reopenedRemotes[0].Config().Name)
 }
 
+// TestPlainCloneContext_DetachedHeadSource is a regression test for a bug
+// where PlainCloneContext returns plumbing.ErrReferenceNotFound when the
+// source repository has a detached HEAD.
+//
+// A detached HEAD is the normal state of a repository after
+// Worktree.Checkout is called with CheckoutOptions{Hash: someHash}.
+// Cloning FROM such a repo (e.g. when using a local filesystem directory
+// as a "remote") must succeed, just as `git clone` does.
+func TestPlainCloneContext_DetachedHeadSource(t *testing.T) {
+	t.Parallel()
+
+	// ── Build the source repo using PlainInit + Worktree.Commit ──────────
+	// Self-contained: no network access required.
+	srcDir := t.TempDir()
+	src, err := PlainInit(srcDir, false)
+	require.NoError(t, err)
+
+	wt, err := src.Worktree()
+	require.NoError(t, err)
+
+	// Write a file and create an initial commit so HEAD resolves to a real hash.
+	err = os.WriteFile(filepath.Join(srcDir, "README.md"), []byte("hello"), 0o644)
+	require.NoError(t, err)
+	_, err = wt.Add("README.md")
+	require.NoError(t, err)
+	commitHash, err := wt.Commit("initial commit", &CommitOptions{
+		Author: &object.Signature{Name: "Test", Email: "t@t.com"},
+	})
+	require.NoError(t, err)
+
+	// Verify HEAD is a symbolic reference before detaching.
+	rawHead, err := src.Storer.Reference(plumbing.HEAD)
+	require.NoError(t, err)
+	require.Equal(t, plumbing.SymbolicReference, rawHead.Type(),
+		"HEAD should be a symbolic ref after commit")
+
+	// Detach HEAD by checking out by hash.
+	err = wt.Checkout(&CheckoutOptions{Hash: commitHash, Force: true})
+	require.NoError(t, err)
+
+	detachedHead, err := src.Storer.Reference(plumbing.HEAD)
+	require.NoError(t, err)
+	require.Equal(t, plumbing.HashReference, detachedHead.Type(),
+		"HEAD must be a hash-reference (detached) after Checkout{Hash:...}")
+
+	// ── Clone from the detached-HEAD source ───────────────────────────────
+	// The branch ref (refs/heads/master) still exists in the source object
+	// store; only HEAD is detached. PlainCloneContext must succeed — just as
+	// `git clone` does — by advertising the available refs rather than
+	// requiring HEAD to be symbolic.
+	dstDir := filepath.Join(t.TempDir(), "dst")
+	dst, err := PlainCloneContext(context.Background(), dstDir, &CloneOptions{
+		URL: srcDir,
+	})
+	assert.NoError(t, err,
+		"PlainCloneContext must succeed when the source repo has a detached HEAD")
+
+	// ── Verify the cloned repo behaves like `git clone` ──────────────────────
+	// git clone creates a symbolic HEAD (→ refs/heads/<branch>) in the clone
+	// even when the source has a detached HEAD; the resolved commit must match.
+	require.NotNil(t, dst, "cloned repository must not be nil")
+
+	rawClonedHead, err := dst.Storer.Reference(plumbing.HEAD)
+	require.NoError(t, err)
+	assert.Equal(t, plumbing.SymbolicReference, rawClonedHead.Type(),
+		"cloned repo HEAD must be a symbolic ref (as git clone produces), not detached")
+
+	resolvedHead, err := dst.Head()
+	require.NoError(t, err)
+	assert.Equal(t, commitHash, resolvedHead.Hash(),
+		"cloned repo HEAD must resolve to the same commit as the source")
+}
+
 // sha1OnlyStorage wraps a storage.Storer to hide the ExtensionChecker
 // implementation, simulating a storage backend that does not implement
 // that interface.


### PR DESCRIPTION
## Summary

Fix a bug where cloning from a source repository with a detached HEAD fails with `ErrReferenceNotFound`.

## Root Cause

When the source has a detached HEAD (a `HashReference`), `AdvertiseReferences` was unconditionally emitting a `symref=HEAD:` capability with an empty target — because `r.Target()` returns `""` for a `HashReference`. The client's `addSymbolicRefs` then stored `HEAD` as a symbolic ref pointing to the empty string. Any subsequent `storer.ResolveReference(HEAD)` followed that broken symref and returned `ErrReferenceNotFound`.

## Fix

Guard the `symref` capability emission behind `r.Type() == plumbing.SymbolicReference`. A detached HEAD is now advertised only as a hash in `ar.Head` and `ar.References`, matching the behaviour of the reference `git` implementation.

## Changes

- `plumbing/transport/serve.go`: only emit `symref=HEAD:<target>` when HEAD is a symbolic reference.
- `repository_test.go`: adds `TestPlainCloneContext_DetachedHeadSource` as a regression test (self-contained, no network access).
