### PR TITLE
*: clone, resolve relative local URLs against CWD in CloneOptions.Validate

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package git
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/go-git/go-billy/v6"
 
 	"github.com/go-git/go-git/v6/config"
+	giturl "github.com/go-git/go-git/v6/internal/url"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/client"
 	"github.com/go-git/go-git/v6/plumbing/object"
@@ -134,6 +136,22 @@ const (
 func (o *CloneOptions) Validate() error {
 	if o.URL == "" {
 		return ErrMissingURL
+	}
+
+	// Resolve ..-relative local paths to absolute paths before they reach
+	// the transport layer. The billy chroot-based FilesystemLoader rejects
+	// any path whose clean form starts with ".." with "chroot boundary
+	// crossed". Real git resolves such paths against the working directory
+	// at the command level, before any transport code runs.
+	if giturl.IsLocalEndpoint(o.URL) && !filepath.IsAbs(o.URL) {
+		cleaned := filepath.Clean(o.URL)
+		if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			abs, err := filepath.Abs(o.URL)
+			if err != nil {
+				return fmt.Errorf("resolve local clone URL %q to absolute path: %w", o.URL, err)
+			}
+			o.URL = abs
+		}
 	}
 
 	if o.RemoteName == "" {

--- a/options_test.go
+++ b/options_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -99,6 +100,21 @@ func (s *OptionsSuite) TestCreateTagOptionsLoadGlobal() {
 
 	s.Equal("foo", o.Tagger.Name)
 	s.Equal("foo@foo.com", o.Tagger.Email)
+}
+
+// TestCloneOptionsValidate_RelativeDotDot verifies that ..-relative local
+// paths in CloneOptions.URL are resolved to absolute paths by Validate, so
+// that the billy chroot-based FilesystemLoader never sees a ".." component.
+//
+// Fixes: https://github.com/go-git/go-git/issues/1723
+func (s *OptionsSuite) TestCloneOptionsValidate_RelativeDotDot() {
+	for _, input := range []string{"../../", "../foo", ".."} {
+		o := &CloneOptions{URL: input}
+		err := o.Validate()
+		s.NoError(err, "input %q", input)
+		s.True(filepath.IsAbs(o.URL),
+			"..-relative URL %q must be resolved to absolute after Validate, got %q", input, o.URL)
+	}
 }
 
 // registerGlobalConfig registers a static ConfigSource plugin with the


### PR DESCRIPTION
When a caller passes a URL like "../../some-repo" to Clone, the billy chroot-based FilesystemLoader rejects any path whose cleaned form starts with ".." ("chroot boundary crossed"), regardless of the chroot root.

Fix: in CloneOptions.Validate, detect local URLs whose cleaned form starts with ".." and resolve them to absolute paths via filepath.Abs before the URL reaches the transport layer. This matches the behaviour of `git clone`: relative paths are resolved against the caller's working directory at the command level, before any transport code runs.

Adds TestCloneOptionsValidate_RelativeDotDot as a regression test.

Note: This fix only applies to code paths that call CloneOptions.Validate (e.g., Repository.Clone). Direct calls to transport.NewEndpoint or transport.ParseURL will not have ../-relative paths normalized. A future PR may add normalization at the transport layer to cover all code paths.

Fixes: https://github.com/go-git/go-git/issues/1723