### PR TITLE
git: fix isFastForward for shallow clones

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1064,7 +1064,12 @@ func checkFastForwardUpdate(s storer.EncodedObjectStorer, remoteRefs storer.Refe
 		return fmt.Errorf("non-fast-forward update: %s", cmd.Name.String())
 	}
 
-	ff, err := isFastForward(s, cmd.Old, cmd.New, nil)
+	var shallows []plumbing.Hash
+	if ss, ok := s.(storer.ShallowStorer); ok {
+		shallows, _ = ss.Shallow()
+	}
+
+	ff, err := isFastForward(s, cmd.Old, cmd.New, shallows)
 	if err != nil {
 		return err
 	}
@@ -1076,29 +1081,53 @@ func checkFastForwardUpdate(s storer.EncodedObjectStorer, remoteRefs storer.Refe
 	return nil
 }
 
-func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, earliestShallow *plumbing.Hash) (bool, error) {
+// isFastForward reports whether newHash is a descendant of old in the commit
+// graph stored in s. shallows is the list of commits that act as boundary
+// nodes for a shallow clone; commits reachable only through those boundaries
+// are not locally available.
+//
+// When shallows are present and the ancestry of newHash cannot be fully
+// traced back to old using only local commits, we conservatively return
+// true (assume fast-forward) to avoid a false negative caused by the
+// shallow boundary. This mirrors git(1)'s behavior for shallow fetches:
+// ancestry checks are relaxed once history is truncated, at the cost of
+// not being able to prove fast-forward strictly from local data.
+func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, shallows []plumbing.Hash) (bool, error) {
 	c, err := object.GetCommit(s, newHash)
 	if err != nil {
 		return false, err
 	}
 
-	parentsToIgnore := []plumbing.Hash{}
-	if earliestShallow != nil {
-		earliestCommit, err := object.GetCommit(s, *earliestShallow)
+	// Build a set of shallow commits so we can detect when the walk actually
+	// reaches a shallow boundary (as opposed to merely knowing shallows exist).
+	shallowsSet := make(map[plumbing.Hash]struct{}, len(shallows))
+	for _, sh := range shallows {
+		shallowsSet[sh] = struct{}{}
+	}
+
+	// For each known shallow commit, mark its parent hashes as boundaries so
+	// the walker never tries to load commits that are not stored locally.
+	parentsToIgnore := make([]plumbing.Hash, 0, len(shallows))
+	for _, sh := range shallows {
+		shallowCommit, err := object.GetCommit(s, sh)
 		if err != nil {
+			if errors.Is(err, plumbing.ErrObjectNotFound) {
+				// Shallow marker may reference a commit we no longer have; skip.
+				continue
+			}
 			return false, err
 		}
-
-		parentsToIgnore = earliestCommit.ParentHashes
+		parentsToIgnore = append(parentsToIgnore, shallowCommit.ParentHashes...)
 	}
 
 	found := false
-	// stop iterating at the earliest shallow commit, ignoring its parents
-	// note: when pull depth is smaller than the number of new changes on the remote, this fails due to missing parents.
-	//       as far as i can tell, without the commits in-between the shallow pull and the earliest shallow, there's no
-	//       real way of telling whether it will be a fast-forward merge.
+	boundedByShallow := false
 	iter := object.NewCommitPreorderIter(c, nil, parentsToIgnore)
 	err = iter.ForEach(func(c *object.Commit) error {
+		if _, isShallow := shallowsSet[c.Hash]; isShallow {
+			// The walk reached a shallow commit; history is truncated here.
+			boundedByShallow = true
+		}
 		if c.Hash != old {
 			return nil
 		}
@@ -1106,7 +1135,16 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, ear
 		found = true
 		return storer.ErrStop
 	})
-	return found, err
+	if err != nil {
+		return false, err
+	}
+	if !found && boundedByShallow {
+		// The walk was bounded by shallow markers and could not reach `old`.
+		// We cannot disprove fast-forward from local data alone, so allow the
+		// update. This matches the behaviour of git(1) for shallow fetches.
+		return true, nil
+	}
+	return found, nil
 }
 
 func (r *Remote) isSupportedRefSpec(refs []config.RefSpec, caps *capability.List) error {
@@ -1139,6 +1177,8 @@ func (r *Remote) updateLocalReferenceStorage(
 	isWildcard := true
 	forceNeeded := false
 
+	shallows, _ := r.s.Shallow()
+
 	for i, spec := range specs {
 		if !spec.IsWildcard() {
 			isWildcard = false
@@ -1169,7 +1209,7 @@ func (r *Remote) updateLocalReferenceStorage(
 			// If the ref exists locally as a non-tag and force is not
 			// specified, only update if the new ref is an ancestor of the old
 			if old != nil && !old.Name().IsTag() && !force && !spec.IsForceUpdate() {
-				ff, err := isFastForward(r.s, old.Hash(), newRef.Hash(), nil)
+				ff, err := isFastForward(r.s, old.Hash(), newRef.Hash(), shallows)
 				if err != nil {
 					return updated, err
 				}

--- a/remote_test.go
+++ b/remote_test.go
@@ -1775,6 +1775,65 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 	})
 }
 
+// TestFetchAfterShallowClone_NoForceRefspec is a regression test for
+// https://github.com/go-git/go-git/issues/207.
+//
+// When a shallow clone is followed by a depth-limited fetch using a plain
+// (non-force) refspec, the local ancestor walk would fail with
+// plumbing.ErrObjectNotFound because intermediate commits (between the old
+// local tip and the new shallow tip) are absent from the local store.
+// The fix makes isFastForward aware of shallow boundaries: when ancestry
+// cannot be proven due to missing shallow history, it conservatively assumes
+// fast-forward (matching the behaviour of git(1)).
+func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
+	tempDir := s.T().TempDir()
+	remoteURL := filepath.Join(tempDir, "remote")
+	repoDir := filepath.Join(tempDir, "repo")
+
+	// Build a remote with two commits so we can take a shallow clone.
+	remoteRepo, err := PlainInit(remoteURL, false)
+	s.Require().NoError(err)
+	_ = CommitNewFile(s.T(), remoteRepo, "File1")
+	_ = CommitNewFile(s.T(), remoteRepo, "File2")
+
+	// Shallow clone at depth=1 — only the latest commit is stored locally.
+	repo, err := PlainClone(repoDir, &CloneOptions{
+		URL:           remoteURL,
+		Depth:         1,
+		Tags:          plumbing.NoTags,
+		SingleBranch:  true,
+		ReferenceName: "master",
+	})
+	s.Require().NoError(err)
+
+	// Push two more commits to the remote while the local clone is still shallow.
+	_ = CommitNewFile(s.T(), remoteRepo, "File3")
+	sha4 := CommitNewFile(s.T(), remoteRepo, "File4")
+
+	// Fetch with depth=1 and a plain (non-force) refspec.
+	// This means only File4's commit is fetched; File3's commit is absent
+	// locally, so the ancestry walk from sha4 back to our current tip would
+	// hit a missing object without the fix.
+	r, err := repo.Remote(DefaultRemoteName)
+	s.Require().NoError(err)
+
+	err = r.Fetch(&FetchOptions{
+		Depth: 1,
+		Tags:  plumbing.NoTags,
+		RefSpecs: []config.RefSpec{
+			// No leading '+' — this is a fast-forward-only refspec.
+			"refs/heads/master:refs/heads/master",
+			"refs/heads/master:refs/remotes/origin/master",
+		},
+	})
+	s.Require().NoError(err, "shallow fetch with non-force refspec must not return an error")
+
+	// Confirm the local branch was updated to the new tip.
+	head, err := repo.Reference(plumbing.NewBranchReferenceName("master"), true)
+	s.Require().NoError(err)
+	s.Equal(sha4, head.Hash(), "local master must point to the new remote tip")
+}
+
 func TestFetchFastForwardForCustomRef(t *testing.T) {
 	t.Parallel()
 	customRef := "refs/custom/branch"

--- a/repository.go
+++ b/repository.go
@@ -1929,17 +1929,13 @@ func (r *Repository) Merge(ref plumbing.Reference, opts MergeOptions) error {
 
 	// Ignore error as not having a shallow list is optional here.
 	shallowList, _ := r.Storer.Shallow()
-	var earliestShallow *plumbing.Hash
-	if len(shallowList) > 0 {
-		earliestShallow = &shallowList[0]
-	}
 
 	head, err := r.Head()
 	if err != nil {
 		return err
 	}
 
-	ff, err := isFastForward(r.Storer, head.Hash(), ref.Hash(), earliestShallow)
+	ff, err := isFastForward(r.Storer, head.Hash(), ref.Hash(), shallowList)
 	if err != nil {
 		return err
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -125,12 +125,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		// if we don't have a shallows list, just ignore it
 		shallowList, _ := w.r.Storer.Shallow()
 
-		var earliestShallow *plumbing.Hash
-		if len(shallowList) > 0 {
-			earliestShallow = &shallowList[0]
-		}
-
-		headAheadOfRef, err := isFastForward(w.r.Storer, ref.Hash(), head.Hash(), earliestShallow)
+		headAheadOfRef, err := isFastForward(w.r.Storer, ref.Hash(), head.Hash(), shallowList)
 		if err != nil {
 			return err
 		}
@@ -139,7 +134,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 			return NoErrAlreadyUpToDate
 		}
 
-		ff, err := isFastForward(w.r.Storer, head.Hash(), ref.Hash(), earliestShallow)
+		ff, err := isFastForward(w.r.Storer, head.Hash(), ref.Hash(), shallowList)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Fixes #207

When a shallow clone is followed by a depth-limited fetch using a non-force refspec, `isFastForward` would fail with `plumbing.ErrObjectNotFound` because the ancestry walk hit parent commits that are absent from the local store.

## Root cause

Two problems combined:

1. All callers passed `nil` (or only the first shallow commit) to `isFastForward`. The function only ever stopped the walk at a single shallow boundary, leaving every other missing parent reachable — causing an object-not-found error when the walk attempted to load them.

2. When the ancestry walk cannot reach `old` within locally available history, the correct interpretation for a shallow repo is *we don't know* — not *non-fast-forward*. The old code propagated the error; PR #1887 proposed returning `false, nil` which turns the crash into a misleading "non-fast-forward update" error. Neither is correct.

## Fix

- Change `isFastForward` to accept `[]plumbing.Hash` (all shallow commits) instead of a single `*plumbing.Hash`.
- Build `parentsToIgnore` from the parent hashes of **all** shallow commits so the walk never attempts to load locally absent commits, eliminating the `ErrObjectNotFound`.
- If the walk terminates without finding `old` **and** shallows are present, return `(true, nil)`: the server would not advertise a non-force ref update that is not a fast-forward, so we conservatively allow the update — matching `git(1)` behaviour for shallow fetches.
- Update all callers (`remote.go`, `repository.go`, `worktree.go`) to pass the full shallow list. `checkFastForwardUpdate` type-asserts its `storer.EncodedObjectStorer` argument to `storer.ShallowStorer` to obtain shallows without a signature change.

**Note on PR #1887:** returning `false, nil` still causes a "non-fast-forward update" error for a legitimate shallow fetch. This PR avoids both the crash and the false-negative by walking only locally-available history and assuming fast-forward when the walk is bounded by shallow markers.

## Changes

- `remote.go`: rewrite `isFastForward` (new signature + shallow-aware walker + shallow-boundary assumption); update `checkFastForwardUpdate`; update the fetch-path caller in `updateLocalReferenceStorage`
- `repository.go`: pass full shallow list to `isFastForward` in `Merge` (also fixes a pre-existing bug where only `shallowList[0]` was used)
- `worktree.go`: pass full shallow list to both `isFastForward` calls in `pull`
- `remote_test.go`: add `TestFetchAfterShallowClone_NoForceRefspec` regression test
