### PR TITLE
Cleanup leftover directory when cloning a non-existing repo

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
@@ -578,6 +579,13 @@ func PlainClone(path string, o *CloneOptions) (*Repository, error) {
 // operation is complete, an error is returned. The context only affects the
 // transport operations.
 func PlainCloneContext(ctx context.Context, path string, o *CloneOptions) (*Repository, error) {
+	targetDirExisted := false
+	if _, statErr := osfs.Default.Stat(path); statErr == nil {
+		targetDirExisted = true
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return nil, statErr
+	}
+
 	empty, err := checkTargetDirIsEmpty(path)
 	if err != nil {
 		return nil, err
@@ -595,7 +603,12 @@ func PlainCloneContext(ctx context.Context, path string, o *CloneOptions) (*Repo
 		return nil, err
 	}
 
-	return r, r.clone(ctx, o)
+	err = r.clone(ctx, o)
+	if err != nil && !targetDirExisted && errors.Is(err, transport.ErrRepositoryNotFound) {
+		_ = os.RemoveAll(path)
+	}
+
+	return r, err
 }
 
 func newRepository(s storage.Storer, worktree billy.Filesystem) *Repository {

--- a/repository_test.go
+++ b/repository_test.go
@@ -1246,19 +1246,47 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithExistentDir() {
 
 	dir, err := util.TempDir(fs, "", "")
 	s.NoError(err)
+	repoPath := fs.Join(fs.Root(), dir)
 
-	r, err := PlainCloneContext(ctx, dir, &CloneOptions{
+	r, err := PlainCloneContext(ctx, repoPath, &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	s.NotNil(r)
 	s.ErrorIs(err, transport.ErrRepositoryNotFound)
 
-	_, err = fs.Stat(dir)
-	s.False(os.IsNotExist(err))
-
-	names, err := fs.ReadDir(dir)
+	fi, err := os.Stat(repoPath)
 	s.NoError(err)
-	s.Len(names, 0)
+	s.True(fi.IsDir())
+
+	names, err := os.ReadDir(repoPath)
+	s.NoError(err)
+	s.Len(names, 1)
+	s.Equal(".git", names[0].Name())
+}
+
+func (s *RepositorySuite) TestPlainCloneContextNonExistentWithPreExistingAbsoluteDir() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	parent := s.T().TempDir()
+	repoPath := filepath.Join(parent, "repo")
+	err := os.Mkdir(repoPath, 0o755)
+	s.NoError(err)
+
+	r, err := PlainCloneContext(ctx, repoPath, &CloneOptions{
+		URL: "incorrectOnPurpose",
+	})
+	s.NotNil(r)
+	s.ErrorIs(err, transport.ErrRepositoryNotFound)
+
+	fi, err := os.Stat(repoPath)
+	s.NoError(err)
+	s.True(fi.IsDir())
+
+	names, err := os.ReadDir(repoPath)
+	s.NoError(err)
+	s.Len(names, 1)
+	s.Equal(".git", names[0].Name())
 }
 
 func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNonExistentDir() {
@@ -1271,14 +1299,15 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNonExistentDir() {
 	s.NoError(err)
 
 	repoDir := filepath.Join(tmpDir, "repoDir")
+	repoPath := fs.Join(fs.Root(), repoDir)
 
-	r, err := PlainCloneContext(ctx, repoDir, &CloneOptions{
+	r, err := PlainCloneContext(ctx, repoPath, &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	s.NotNil(r)
 	s.ErrorIs(err, transport.ErrRepositoryNotFound)
 
-	_, err = fs.Stat(repoDir)
+	_, err = os.Stat(repoPath)
 	s.True(os.IsNotExist(err))
 }
 


### PR DESCRIPTION
The `TestPlainCloneContextNonExistentWithNonExistentDir` existed but it didn't actually test the right thing because it was using relative paths in the working directory instead of the new test filesystem.

Commenting out the code change and running the new test I get:
```
go test . -v -run TestRepositorySuite -testify.m TestPlainCloneContextNonExistentWithNonExistentDir
=== RUN   TestRepositorySuite
=== PAUSE TestRepositorySuite
=== CONT  TestRepositorySuite
=== RUN   TestRepositorySuite/TestPlainCloneContextNonExistentWithNonExistentDir
    repository_test.go:1283:
                Error Trace:    /Users/nodo/work/go-git/repository_test.go:1283
                Error:          Should be true
                Test:           TestRepositorySuite/TestPlainCloneContextNonExistentWithNonExistentDir
--- FAIL: TestRepositorySuite (0.01s)
    --- FAIL: TestRepositorySuite/TestPlainCloneContextNonExistentWithNonExistentDir (0.00s)
FAIL
FAIL    github.com/go-git/go-git/v6     0.595s
FAIL
```

