### PR TITLE
internal: server/loader, avoid re-extracting fixture tarball on every server request

### DIFF
--- a/internal/server/loader.go
+++ b/internal/server/loader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-git/go-billy/v6"
 	fixtures "github.com/go-git/go-git-fixtures/v5"
 
 	"github.com/go-git/go-git/v6/plumbing/transport"
@@ -12,23 +13,31 @@ import (
 )
 
 type fixturesLoader struct {
-	fix *fixtures.Fixture
-	t   *testing.T
+	dot billy.Filesystem
 }
 
 var _ transport.Loader = &fixturesLoader{}
 
 func (f *fixturesLoader) Load(ep *transport.Endpoint) (storage.Storer, error) {
-	if f.fix == nil {
+	if f.dot == nil {
 		return nil, fmt.Errorf("cannot load endpoint: fixture not set")
 	}
 
-	dot := f.fix.DotGit(fixtures.WithTargetDir(f.t.TempDir))
-	st := filesystem.NewStorage(dot, nil)
-	return st, nil
+	// Re-use the pre-extracted filesystem for every request. The server is
+	// read-only (upload-pack only), so sharing the underlying billy.Filesystem
+	// across storage instances is safe and avoids re-extracting the tgz on
+	// every clone or fetch.
+	return filesystem.NewStorage(f.dot, nil), nil
 }
 
-// Load implements transport.Loader.
-func Loader(t *testing.T, fix *fixtures.Fixture) transport.Loader {
-	return &fixturesLoader{t: t, fix: fix}
+// Loader returns a transport.Loader backed by fix. The fixture's .git directory
+// is extracted exactly once (into memory) when Loader is called; all subsequent
+// server requests share the same extracted filesystem.
+func Loader(t testing.TB, fix *fixtures.Fixture) transport.Loader {
+	t.Helper()
+	if fix == nil {
+		t.Fatal("Loader: fixture must not be nil")
+	}
+	dot := fix.DotGit(fixtures.WithMemFS())
+	return &fixturesLoader{dot: dot}
 }


### PR DESCRIPTION
fixturesLoader.Load() called fix.DotGit(WithTargetDir(...)) on every upload-pack request, decompressing the embedded tarball and writing it to a new OS temp directory each time. For a test that performs multiple clones or fetches against the same server this meant repeated disk I/O and tgz decompression per request.

Fix: extract the fixture exactly once into a memfs when Loader() is called, then wrap the same billy.Filesystem in a new filesystem.Storage for every subsequent Load() call. The server only performs upload-pack (reads), so sharing the underlying filesystem across Storage instances is safe and produces identical results.

Also widen the Loader() parameter from `*testing.T` to `testing.TB` so it can be used from both tests and benchmarks.