### PR TITLE
internal: server/http, fix double-close of net.Listener in server.Close()

### DIFF
--- a/internal/server/http/http.go
+++ b/internal/server/http/http.go
@@ -62,8 +62,8 @@ func (s *server) Endpoint() (string, error) {
 }
 
 func (s *server) Close() error {
-	err1 := s.ln.Close()
-	err2 := s.srv.Close()
-
-	return errors.Join(err1, err2)
+	// s.srv.Close() closes the listener internally; calling s.ln.Close()
+	// separately would close it twice and return "use of closed network
+	// connection" from the second close.
+	return s.srv.Close()
 }


### PR DESCRIPTION
## Summary

\`server.Close()\` in \`internal/server/http\` called both \`s.ln.Close()\` and \`s.srv.Close()\`. However, [\`http.Server.Close()\`](https://pkg.go.dev/net/http#Server.Close) already closes the listener it was passed to \`Serve()\` — so \`s.ln\` was being closed twice.

The double-close is timing-dependent: it only manifests when the client has already dropped the connection before \`Close()\` is called, which made the failure appear intermittently in \`TestFailSafeUnsupportedStorage\`.

Fix: remove the redundant \`s.ln.Close()\` and let \`s.srv.Close()\` manage the listener lifecycle.

fix https://github.com/go-git/go-git/issues/1856