### PR TITLE
git: worktree, don't delete untracked files on HardReset / Force checkout

### DIFF
--- a/plumbing/format/index/index.go
+++ b/plumbing/format/index/index.go
@@ -216,7 +216,10 @@ type EndOfIndexEntry struct {
 }
 
 // SkipUnless applies patterns in the form of A, A/B, A/B/C
-// to the index to prevent the files from being checked out
+// to the index to prevent the files from being checked out.
+// Files whose names match one of the patterns have SkipWorktree cleared;
+// all other files have it set. This handles sparse-checkout dir switching
+// correctly: files moving into the active set are un-skipped.
 func (i *Index) SkipUnless(patterns []string) {
 	for _, e := range i.Entries {
 		var include bool
@@ -226,7 +229,9 @@ func (i *Index) SkipUnless(patterns []string) {
 				break
 			}
 		}
-		if !include {
+		if include {
+			e.SkipWorktree = false
+		} else {
 			e.SkipWorktree = true
 		}
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -349,6 +349,18 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		}
 	}
 
+	// For HardReset, capture the current HEAD tree before resetting HEAD.
+	// resetWorktreeToTree will diff prevTree→t and apply only those changes
+	// to the worktree. Since the diff is tree-to-tree, untracked files are
+	// invisible and are never deleted — matching real git reset --hard.
+	var prevTree *object.Tree
+	if opts.Mode == HardReset {
+		prevTree, err = w.headTree()
+		if err != nil {
+			return err
+		}
+	}
+
 	if err := w.setHEADCommit(opts.Commit); err != nil {
 		return err
 	}
@@ -367,7 +379,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	}
 
 	if opts.Mode == HardReset {
-		if err := w.resetWorktree(t, opts.Files); err != nil {
+		if err := w.resetWorktreeToTree(prevTree, t, opts.Files); err != nil {
 			return err
 		}
 	}
@@ -501,6 +513,141 @@ func inFiles(files map[string]struct{}, v string) bool {
 	return exists
 }
 
+// headTree returns the tree for the current HEAD commit.
+// Returns nil, nil if there is no HEAD yet (e.g. an unborn branch).
+func (w *Worktree) headTree() (*object.Tree, error) {
+	head, err := w.r.Head()
+	if err != nil {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	c, err := w.r.CommitObject(head.Hash())
+	if err != nil {
+		return nil, err
+	}
+	return c.Tree()
+}
+
+// resetWorktreeToTree updates the worktree to match toTree, mirroring
+// real git reset --hard / checkout -f:
+//
+//  1. Tree-to-tree diff (fromTree→toTree): remove files that were tracked in
+//     fromTree but deleted in toTree. Because the diff is purely object-graph,
+//     untracked files never appear and are never deleted.
+//
+//  2. New-index-to-worktree diff: write files that are in the new index but
+//     absent or different on disk. For Delete actions (file on disk, but absent
+//     from the index): the file is truly untracked and is preserved.
+//     (SkipWorktree entries are invisible to the merkletrie diff; they are
+//     handled in step 3.)
+//
+//  3. Remove SkipWorktree files from disk: diffStagingWithWorktree never
+//     surfaces SkipWorktree-flagged entries as Delete actions because the
+//     merkletrie marks them skip=true. Mirror git's behaviour: any tracked
+//     file with SkipWorktree=true must not exist in the worktree.
+//
+// files optionally restricts the operation to a specific subset of paths.
+func (w *Worktree) resetWorktreeToTree(fromTree, toTree *object.Tree, files []string) error {
+	filesMap := buildFilePathMap(files)
+
+	// Step 1: delete files removed from the tracked tree.
+	treeChanges, err := diffTrees(fromTree, toTree)
+	if err != nil {
+		return err
+	}
+	for _, ch := range treeChanges {
+		a, err := ch.Action()
+		if err != nil {
+			return err
+		}
+		if a != merkletrie.Delete {
+			continue
+		}
+		name := ch.From.String()
+		if len(files) > 0 && !inFiles(filesMap, name) {
+			continue
+		}
+		if err := w.validChange(ch); err != nil {
+			return err
+		}
+		if err := rmFileAndDirsIfEmpty(w.Filesystem, name); err != nil {
+			return err
+		}
+	}
+
+	// Step 2: write files that are in the new index but missing or stale
+	// in the worktree. We use diffStagingWithWorktree(reverse=true) which
+	// gives Insert for "in index, not on disk" and Modify for "differs".
+	// Delete means "on disk, not in index" = untracked → always skip.
+	// Note: SkipWorktree entries are invisible to the merkletrie diff;
+	// they are cleaned up in step 3 below.
+	worktreeChanges, err := w.diffStagingWithWorktree(true, false)
+	if err != nil {
+		return err
+	}
+
+	idx, err := w.r.Storer.Index()
+	if err != nil {
+		return err
+	}
+	b := newIndexBuilder(idx)
+
+	for _, ch := range worktreeChanges {
+		a, err := ch.Action()
+		if err != nil {
+			return err
+		}
+		if a == merkletrie.Delete {
+			// In the reverse diff, Delete means the file exists on disk but is
+			// absent from the index node tree. SkipWorktree entries are marked
+			// skip=true in the merkletrie and never appear here; they are removed
+			// in step 3 below. A Delete action here therefore always means the
+			// file is truly untracked — preserve it.
+			continue
+		}
+
+		if len(files) > 0 {
+			file := ch.To.String()
+			if !inFiles(filesMap, file) {
+				continue
+			}
+		}
+
+		if err := w.validChange(ch); err != nil {
+			return err
+		}
+		if err := w.checkoutChange(ch, toTree, b); err != nil {
+			return err
+		}
+	}
+
+	// Step 3: remove tracked files that are SkipWorktree=true from disk.
+	// diffStagingWithWorktree builds the index node tree with skip=true for
+	// SkipWorktree entries, so they never appear as Delete actions in step 2.
+	// git removes these files when the sparse-checkout contract excludes them.
+	for _, e := range idx.Entries {
+		if !e.SkipWorktree {
+			continue
+		}
+		if len(files) > 0 && !inFiles(filesMap, e.Name) {
+			continue
+		}
+		if _, statErr := w.Filesystem.Lstat(e.Name); os.IsNotExist(statErr) {
+			continue
+		}
+		if err := rmFileAndDirsIfEmpty(w.Filesystem, e.Name); err != nil {
+			return err
+		}
+	}
+
+	b.Write(idx)
+	return w.r.Storer.SetIndex(idx)
+}
+
+// resetWorktree updates the worktree to match the staging area.
+// files restricts the operation to the named paths; nil means all files.
 func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
 	changes, err := w.diffStagingWithWorktree(true, false)
 	if err != nil {

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -277,6 +277,19 @@ func (w *Worktree) diffTreeWithStaging(t *object.Tree, reverse bool) (merkletrie
 	return merkletrie.DiffTree(from, to, diffTreeIsEquals)
 }
 
+// diffTrees returns the changes between two tree objects.
+// Either tree may be nil, which is treated as the empty tree.
+func diffTrees(from, to *object.Tree) (merkletrie.Changes, error) {
+	var fromNode, toNode noder.Noder
+	if from != nil {
+		fromNode = object.NewTreeRootNode(from)
+	}
+	if to != nil {
+		toNode = object.NewTreeRootNode(to)
+	}
+	return merkletrie.DiffTree(fromNode, toNode, diffTreeIsEquals)
+}
+
 var emptyNoderHash = make([]byte, 24)
 
 // diffTreeIsEquals is a implementation of noder.Equals, used to compare

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -344,6 +344,67 @@ func (s *WorktreeSuite) TestPullAfterShallowClone() {
 	s.NoError(err)
 }
 
+// TestPullAfterShallowClone_UntrackedFilesPreserved checks that an untracked
+// file in a shallow-cloned worktree is not deleted by a subsequent pull.
+// Regression test for https://github.com/go-git/go-git/issues/1719.
+func (s *WorktreeSuite) TestPullAfterShallowClone_UntrackedFilesPreserved() {
+	tempDir := s.T().TempDir()
+	remoteURL := filepath.Join(tempDir, "remote")
+	repoDir := filepath.Join(tempDir, "repo")
+
+	remote, err := PlainInit(remoteURL, false)
+	s.Require().NoError(err)
+
+	_ = CommitNewFile(s.T(), remote, "File1")
+	_ = CommitNewFile(s.T(), remote, "File2")
+
+	repo, err := PlainClone(repoDir, &CloneOptions{
+		URL:           remoteURL,
+		Depth:         1,
+		Tags:          plumbing.NoTags,
+		SingleBranch:  true,
+		ReferenceName: "master",
+	})
+	s.Require().NoError(err)
+
+	// Create an untracked file in the cloned worktree.
+	untrackedPath := filepath.Join(repoDir, "untracked.txt")
+	s.Require().NoError(os.WriteFile(untrackedPath, []byte("do not delete me"), 0o644))
+
+	// Push new commits to the remote so the pull has actual work to do.
+	_ = CommitNewFile(s.T(), remote, "File3")
+	_ = CommitNewFile(s.T(), remote, "File4")
+
+	w, err := repo.Worktree()
+	s.Require().NoError(err)
+
+	// Test without Force first.
+	err = w.Pull(&PullOptions{
+		RemoteName:    DefaultRemoteName,
+		SingleBranch:  true,
+		ReferenceName: plumbing.NewBranchReferenceName("master"),
+	})
+	s.Require().NoError(err)
+
+	// The untracked file must survive the pull (mirrors real git behaviour).
+	_, statErr := os.Stat(untrackedPath)
+	s.Require().NoError(statErr, "untracked file was removed by pull (no Force) on a shallow clone")
+
+	// Push another commit and test with Force: true.
+	_ = CommitNewFile(s.T(), remote, "File5")
+
+	err = w.Pull(&PullOptions{
+		RemoteName:    DefaultRemoteName,
+		SingleBranch:  true,
+		ReferenceName: plumbing.NewBranchReferenceName("master"),
+		Force:         true,
+	})
+	s.Require().NoError(err)
+
+	_, statErr = os.Stat(untrackedPath)
+	s.Require().NoError(statErr, "untracked file was removed by pull (Force: true) on a shallow clone")
+}
+
 func (s *WorktreeSuite) TestCheckout() {
 	fs := memfs.New()
 	w := &Worktree{
@@ -804,6 +865,91 @@ func (s *WorktreeSuite) TestCheckoutBranchUntracked() {
 	s.NoError(err)
 	// After deleting the untracked file it should now be clean
 	s.True(status.IsClean())
+}
+
+// TestCheckoutForceUntracked verifies that Checkout with Force:true (HardReset)
+// does not delete untracked files, matching real git checkout -f behaviour.
+func (s *WorktreeSuite) TestCheckoutForceUntracked() {
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: memfs.New(),
+	}
+
+	// Populate the worktree first.
+	err := w.Checkout(&CheckoutOptions{})
+	s.Require().NoError(err)
+
+	// Create an untracked file.
+	uf, err := w.Filesystem.Create("untracked_file")
+	s.Require().NoError(err)
+	_, err = uf.Write([]byte("don't delete me"))
+	s.Require().NoError(err)
+	s.Require().NoError(uf.Close())
+
+	// Force checkout (HardReset) — should leave untracked files alone.
+	err = w.Checkout(&CheckoutOptions{Force: true})
+	s.Require().NoError(err)
+
+	status, err := w.Status()
+	s.Require().NoError(err)
+	// Untracked file must still be present.
+	s.True(status.IsUntracked("untracked_file"), "untracked file was deleted by Force checkout")
+}
+
+// TestCheckoutForceSparseUntrackedPreserved verifies that when switching
+// SparseCheckoutDirectories with Force:true, tracked files outside the new
+// sparse set are removed from disk but untracked files inside those directories
+// are preserved — matching real git behaviour (git keeps the untracked file
+// and prints a warning).
+func (s *WorktreeSuite) TestCheckoutForceSparseUntrackedPreserved() {
+	fs := memfs.New()
+	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
+		URL:        s.GetBasicLocalRepositoryURL(),
+		NoCheckout: true,
+	})
+	s.Require().NoError(err)
+
+	w, err := r.Worktree()
+	s.Require().NoError(err)
+
+	// Initial sparse checkout: only the "go" directory.
+	s.Require().NoError(w.Checkout(&CheckoutOptions{
+		SparseCheckoutDirectories: []string{"go"},
+	}))
+
+	// Confirm that at least one tracked file is present inside "go/".
+	goFiles, err := fs.ReadDir("go")
+	s.Require().NoError(err)
+	s.Require().NotEmpty(goFiles, "expected tracked files in go/ after sparse checkout")
+
+	// Create an untracked file inside the soon-to-be-removed sparse directory.
+	uf, err := w.Filesystem.Create("go/untracked.txt")
+	s.Require().NoError(err)
+	_, err = uf.Write([]byte("do not delete me"))
+	s.Require().NoError(err)
+	s.Require().NoError(uf.Close())
+
+	// Force checkout: switch sparse set from "go" to "php".
+	// Real git removes tracked "go/" files from the worktree but preserves
+	// untracked files (showing a warning). go-git must match this behaviour.
+	s.Require().NoError(w.Checkout(&CheckoutOptions{
+		Force:                     true,
+		SparseCheckoutDirectories: []string{"php"},
+	}))
+
+	// Untracked file inside the removed sparse directory must be preserved.
+	_, statErr := w.Filesystem.Stat("go/untracked.txt")
+	s.Require().NoError(statErr, "untracked file inside removed sparse dir was deleted by Force checkout")
+
+	// Tracked files that moved out of the sparse set must be removed from disk.
+	firstGoFile := filepath.Join("go", goFiles[0].Name())
+	_, statErr = w.Filesystem.Stat(firstGoFile)
+	s.Require().Error(statErr, "tracked file %q in removed sparse dir should have been removed by Force checkout", firstGoFile)
+
+	// The "php" directory must now be present and populated.
+	phpFiles, err := fs.ReadDir("php")
+	s.Require().NoError(err)
+	s.NotEmpty(phpFiles, "expected php/ files after sparse checkout switch")
 }
 
 func (s *WorktreeSuite) TestCheckoutCreateWithHash() {


### PR DESCRIPTION
## Summary

`Checkout` with `Force: true` (and `Reset` in `HardReset` mode) was deleting untracked files from the worktree. Real `git checkout -f` and `git reset --hard` never remove untracked files -- only `git clean -f` does.

Fixes #796, #1719, #365, and #633 (HardReset / Force checkout path).

### Root cause

`resetWorktree` computed a reverse diff between the worktree filesystem and the index (`diffStagingWithWorktree(reverse=true)`). A `Delete` action in this diff means "file exists on disk but is not in the index" -- covering both:

1. A tracked file deleted from the new target tree -- should be removed.
2. An untracked file -- must not be removed.

Previously all `Delete` actions were processed, so untracked files were deleted.

### Fix -- matching real git

Real `git reset --hard` / `git checkout -f` operates in three phases on tracked-file sets only:

1. **Tree-to-tree diff** (`fromTree -> toTree`): delete files tracked in `fromTree` but removed in `toTree`. Untracked files are invisible to this diff.

2. **Index-to-worktree**: write files in the new index but absent or stale on disk. `Delete` actions (file on disk, absent from the index node tree) are always truly untracked -- `SkipWorktree` entries are marked `skip=true` in the merkletrie and invisible to this diff, never surfaced as Delete actions here.

3. **SkipWorktree cleanup**: iterate all index entries directly; for any entry with `SkipWorktree=true` that still exists on disk, remove it. `diffStagingWithWorktree` never surfaces these as Delete actions (see phase 2). Untracked files in the same directories are untouched.

This PR introduces `diffTrees` and a new `resetWorktreeToTree` implementing this three-phase approach for `HardReset`. The old `resetWorktree` (used by `MergeReset`) is unchanged.

### Also fixed: `Index.SkipUnless`

`Index.SkipUnless` only ever set `SkipWorktree=true` for newly-excluded files but never cleared it for files moving back into the active set. Fixed by also setting `SkipWorktree=false` for included entries.

### Tests added

- `TestCheckoutForceUntracked` -- `Checkout{Force: true}` must not delete an untracked file.
- `TestPullAfterShallowClone_UntrackedFilesPreserved` -- untracked file must survive a subsequent `Pull`.
- `TestCheckoutForceSparseUntrackedPreserved` -- switching `SparseCheckoutDirectories` with `Force: true` must (a) remove tracked files outside the new sparse set from disk and (b) preserve untracked files inside those directories.