### PR TITLE
git: worktree, add KeepReset mode (git reset --keep)

### DIFF
--- a/options.go
+++ b/options.go
@@ -439,6 +439,12 @@ const (
 	// resets the head to <commit>, just like all modes do). This leaves all
 	// your changed files "Changes to be committed", as git status would put it.
 	SoftReset
+	// KeepReset resets the index and updates files in the working tree that
+	// differ between Commit and HEAD, like HardReset. However, if a file that
+	// differs between Commit and HEAD has local modifications (staged or
+	// unstaged), the reset is aborted. Untracked files are never deleted.
+	// Equivalent to git reset --keep.
+	KeepReset
 )
 
 // ResetOptions describes how a reset operation should be performed.

--- a/worktree.go
+++ b/worktree.go
@@ -41,6 +41,9 @@ var (
 	ErrSubmoduleNotFound = errors.New("submodule not found")
 	// ErrUnstagedChanges is returned when the worktree has unstaged changes.
 	ErrUnstagedChanges = errors.New("worktree contains unstaged changes")
+	// ErrLocalChanges is returned when a KeepReset is attempted but a file
+	// that would be changed by the reset has local modifications.
+	ErrLocalChanges = errors.New("worktree contains local changes that would be overwritten by reset")
 	// ErrGitModulesSymlink is returned when .gitmodules is a symlink.
 	ErrGitModulesSymlink = errors.New(gitmodulesFile + " is a symlink")
 	// ErrNonFastForwardUpdate is returned when a non-fast-forward update is attempted.
@@ -344,14 +347,20 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		}
 	}
 
-	// For HardReset, capture the current HEAD tree before resetting HEAD.
-	// resetWorktreeToTree will diff prevTree→t and apply only those changes
-	// to the worktree. Since the diff is tree-to-tree, untracked files are
-	// invisible and are never deleted — matching real git reset --hard.
+	// For HardReset and KeepReset, capture the current HEAD tree before
+	// resetting HEAD. resetWorktreeToTree will diff prevTree→t and apply only
+	// those changes to the worktree. Since the diff is tree-to-tree, untracked
+	// files are invisible and are never deleted — matching real git reset --hard.
 	var prevTree *object.Tree
-	if opts.Mode == HardReset {
+	if opts.Mode == HardReset || opts.Mode == KeepReset {
 		prevTree, err = w.headTree()
 		if err != nil {
+			return err
+		}
+	}
+
+	if opts.Mode == KeepReset {
+		if err := w.checkKeepResetConflicts(prevTree, t, opts.SparseDirs, opts.Files); err != nil {
 			return err
 		}
 	}
@@ -361,7 +370,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	}
 
 	var removedFiles []string
-	if opts.Mode == MixedReset || opts.Mode == MergeReset || opts.Mode == HardReset {
+	if opts.Mode == MixedReset || opts.Mode == MergeReset || opts.Mode == HardReset || opts.Mode == KeepReset {
 		if removedFiles, err = w.resetIndex(t, opts.SparseDirs, opts.Files); err != nil {
 			return err
 		}
@@ -373,7 +382,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		}
 	}
 
-	if opts.Mode == HardReset {
+	if opts.Mode == HardReset || opts.Mode == KeepReset {
 		if err := w.resetWorktreeToTree(prevTree, t, opts.Files); err != nil {
 			return err
 		}
@@ -523,6 +532,113 @@ func (w *Worktree) headTree() (*object.Tree, error) {
 		return nil, err
 	}
 	return c.Tree()
+}
+
+// checkKeepResetConflicts implements the safety check for KeepReset
+// (git reset --keep): it aborts if any file that would be modified by the
+// reset has local staged or unstaged modifications in the worktree.
+//
+// Two categories of "touched" paths are checked:
+//
+//  1. Files that differ between fromTree and toTree (filtered by files when
+//     non-empty). Among these, paths that will be *written* to disk (Insert or
+//     Modify) are additionally checked for untracked-overwrite collisions.
+//
+//  2. When sparseDirs is non-empty: currently-on-disk tracked files that will
+//     become SkipWorktree because their path is no longer under any of the new
+//     sparse directories. Step 3 of resetWorktreeToTree removes them from disk,
+//     so KeepReset must refuse if they carry local modifications.
+func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparseDirs, files []string) error {
+	changes, err := diffTrees(fromTree, toTree)
+	if err != nil {
+		return err
+	}
+
+	filesMap := buildFilePathMap(files)
+
+	// touched: all paths that the reset will affect (checked for local mods).
+	// writtenPaths: subset of touched that will be written to disk (Insert /
+	// Modify). An untracked file at such a path would be silently overwritten,
+	// which KeepReset must refuse — matching git reset --keep behaviour.
+	touched := make(map[string]struct{})
+	writtenPaths := make(map[string]struct{})
+
+	for _, ch := range changes {
+		// Canonical path for the files-filter: prefer To (Insert/Modify),
+		// fall back to From (Delete).
+		var name string
+		if ch.To != nil {
+			name = ch.To.String()
+		} else {
+			name = ch.From.String()
+		}
+		if len(files) > 0 && !inFiles(filesMap, name) {
+			continue
+		}
+		if ch.From != nil {
+			touched[ch.From.String()] = struct{}{}
+		}
+		if ch.To != nil {
+			touched[ch.To.String()] = struct{}{}
+			writtenPaths[ch.To.String()] = struct{}{}
+		}
+	}
+
+	// When SparseDirs is changing, any currently-on-disk tracked file that
+	// falls outside the new sparse set will be removed from disk by step 3 of
+	// resetWorktreeToTree. KeepReset must refuse if such a file has local mods.
+	if len(sparseDirs) > 0 {
+		idx, err := w.r.Storer.Index()
+		if err != nil {
+			return err
+		}
+		for _, e := range idx.Entries {
+			if e.SkipWorktree {
+				continue // already excluded from the worktree
+			}
+			if len(files) > 0 && !inFiles(filesMap, e.Name) {
+				continue
+			}
+			included := false
+			for _, dir := range sparseDirs {
+				if strings.HasPrefix(e.Name, dir+"/") || e.Name == dir {
+					included = true
+					break
+				}
+			}
+			if !included {
+				touched[e.Name] = struct{}{}
+			}
+		}
+	}
+
+	if len(touched) == 0 {
+		return nil
+	}
+
+	// Check worktree status for local modifications on touched paths.
+	status, err := w.Status()
+	if err != nil {
+		return err
+	}
+	for path, st := range status {
+		if _, willChange := touched[path]; !willChange {
+			continue
+		}
+		// Tracked file with staged or unstaged local changes → conflict.
+		if (st.Staging != Unmodified && st.Staging != Untracked) ||
+			(st.Worktree != Unmodified && st.Worktree != Untracked) {
+			return fmt.Errorf("%w: %s", ErrLocalChanges, path)
+		}
+		// Untracked file at a path that will be written to disk → the reset
+		// would silently overwrite it, which KeepReset must refuse.
+		if st.Staging == Untracked && st.Worktree == Untracked {
+			if _, willWrite := writtenPaths[path]; willWrite {
+				return fmt.Errorf("%w: %s", ErrLocalChanges, path)
+			}
+		}
+	}
+	return nil
 }
 
 // resetWorktreeToTree updates the worktree to match toTree, mirroring

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1423,6 +1423,253 @@ func (s *WorktreeSuite) TestResetMerge() {
 	s.Equal(commitA, branch.Hash())
 }
 
+func (s *WorktreeSuite) TestResetKeep() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
+
+	err := w.Checkout(&CheckoutOptions{})
+	s.Require().NoError(err)
+
+	// KeepReset with no local changes should succeed and update the worktree.
+	err = w.Reset(&ResetOptions{Mode: KeepReset, Commit: commit})
+	s.Require().NoError(err)
+
+	branch, err := w.r.Reference(plumbing.Master, false)
+	s.NoError(err)
+	s.Equal(commit, branch.Hash())
+
+	// CHANGELOG was added in the commit being reset away; it should be gone.
+	_, statErr := fs.Stat("CHANGELOG")
+	s.Error(statErr, "CHANGELOG should have been removed by KeepReset")
+}
+
+// TestResetKeepConflict verifies that KeepReset is aborted when a file that
+// would be changed by the reset has local modifications — matching
+// git reset --keep behaviour.
+func (s *WorktreeSuite) TestResetKeepConflict() {
+	tempDir := s.T().TempDir()
+	repoDir := filepath.Join(tempDir, "repo")
+
+	// Build a repo with two commits that both touch "tracked.txt".
+	r, err := PlainInit(repoDir, false)
+	s.Require().NoError(err)
+	w, err := r.Worktree()
+	s.Require().NoError(err)
+
+	commitA := CommitNewFile(s.T(), r, "tracked.txt")
+
+	// Advance to commitB by changing tracked.txt.
+	s.Require().NoError(util.WriteFile(w.Filesystem, "tracked.txt", []byte("version B"), 0o644))
+	_, err = w.Add("tracked.txt")
+	s.Require().NoError(err)
+	commitB, err := w.Commit("second", &CommitOptions{Author: defaultSignature()})
+	s.Require().NoError(err)
+
+	// Go back to commitA cleanly.
+	err = w.Reset(&ResetOptions{Mode: HardReset, Commit: commitA})
+	s.Require().NoError(err)
+
+	// Make a local (unstaged) modification to tracked.txt, which differs
+	// between commitA and commitB.
+	s.Require().NoError(util.WriteFile(w.Filesystem, "tracked.txt", []byte("local change"), 0o644))
+
+	// KeepReset to commitB should be aborted.
+	err = w.Reset(&ResetOptions{Mode: KeepReset, Commit: commitB})
+	s.ErrorIs(err, ErrLocalChanges)
+
+	// HEAD must not have moved.
+	head, err := r.Head()
+	s.NoError(err)
+	s.Equal(commitA, head.Hash())
+}
+
+// TestResetKeepUntrackedPreserved verifies that KeepReset never deletes
+// untracked files, just like real git reset --keep.
+func (s *WorktreeSuite) TestResetKeepUntrackedPreserved() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
+
+	err := w.Checkout(&CheckoutOptions{})
+	s.Require().NoError(err)
+
+	// Create an untracked file.
+	s.Require().NoError(util.WriteFile(fs, "untracked.txt", []byte("keep me"), 0o644))
+
+	err = w.Reset(&ResetOptions{Mode: KeepReset, Commit: commit})
+	s.Require().NoError(err)
+
+	_, statErr := fs.Stat("untracked.txt")
+	s.NoError(statErr, "untracked file was deleted by KeepReset")
+}
+
+// TestResetKeepSparselyUntracked verifies that KeepReset with SparseDirs
+// removes tracked files outside the new sparse set from disk, writes files
+// in the new sparse set, and preserves untracked files in the removed dirs —
+// matching real git reset --keep behaviour.
+func (s *WorktreeSuite) TestResetKeepSparselyUntracked() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	// Sparse-populate the "go" directory first.
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: KeepReset, SparseDirs: []string{"go"}}))
+
+	goFiles, err := fs.ReadDir("go")
+	s.Require().NoError(err)
+	s.Require().NotEmpty(goFiles, "expected tracked files in go/ after KeepReset with SparseDirs=[go]")
+
+	// Create an untracked file inside the soon-to-be-removed sparse dir.
+	s.Require().NoError(util.WriteFile(fs, "go/untracked.txt", []byte("do not delete me"), 0o644))
+
+	// Switch sparse set from "go" to "php" using KeepReset. There are no
+	// local modifications to tracked files, so the keep-check must pass.
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: KeepReset, SparseDirs: []string{"php"}}))
+
+	// Tracked files in the removed "go" sparse dir must be removed from disk;
+	// git always removes SkipWorktree-marked files from the worktree.
+	firstGoFile := filepath.Join("go", goFiles[0].Name())
+	_, statErr := fs.Stat(firstGoFile)
+	s.Require().Error(statErr, "tracked file %q in removed sparse dir should have been removed", firstGoFile)
+
+	// Untracked file in the removed sparse dir must be preserved.
+	_, statErr = fs.Stat("go/untracked.txt")
+	s.Require().NoError(statErr, "untracked file inside removed sparse dir was deleted by KeepReset")
+
+	// Files in the new sparse dir must now be present.
+	phpFiles, err := fs.ReadDir("php")
+	s.Require().NoError(err)
+	s.NotEmpty(phpFiles, "expected php/ files after KeepReset sparse switch")
+}
+
+// TestResetKeepConflictNotOnSparseExcluded verifies that KeepReset does not
+// abort when a file that changes between commits is SkipWorktree (i.e. outside
+// the current sparse set). Such a file is absent from the worktree and has no
+// local modifications, so it must not be counted as a conflict.
+func (s *WorktreeSuite) TestResetKeepConflictNotOnSparseExcluded() {
+	tempDir := s.T().TempDir()
+	repoDir := filepath.Join(tempDir, "repo")
+
+	r, err := PlainInit(repoDir, false)
+	s.Require().NoError(err)
+	w, err := r.Worktree()
+	s.Require().NoError(err)
+
+	// commitA: create tracked.txt and subdir/other.txt
+	commitA := CommitNewFile(s.T(), r, "tracked.txt")
+
+	// commitB: change tracked.txt (so it appears in the tree-to-tree diff)
+	s.Require().NoError(util.WriteFile(w.Filesystem, "tracked.txt", []byte("version B"), 0o644))
+	_, err = w.Add("tracked.txt")
+	s.Require().NoError(err)
+	commitB, err := w.Commit("second", &CommitOptions{Author: defaultSignature()})
+	s.Require().NoError(err)
+
+	// Go back to commitA and apply a sparse checkout that excludes tracked.txt
+	// by resetting with a SparseDirs that doesn't contain it.
+	// We use a subdirectory "subdir" that doesn't actually exist in the tree;
+	// we skip validation so we can force SkipWorktree onto all files.
+	err = w.Reset(&ResetOptions{
+		Mode:                    HardReset,
+		Commit:                  commitA,
+		SparseDirs:              []string{"subdir"},
+		SkipSparseDirValidation: true,
+	})
+	s.Require().NoError(err)
+
+	// Now tracked.txt should be SkipWorktree=true (not on disk). A KeepReset
+	// to commitB touches tracked.txt in the tree diff, but since it isn't
+	// locally modified (it's sparse-excluded), the check must pass.
+	err = w.Reset(&ResetOptions{
+		Mode:                    KeepReset,
+		Commit:                  commitB,
+		SparseDirs:              []string{"subdir"},
+		SkipSparseDirValidation: true,
+	})
+	s.Require().NoError(err)
+
+	head, err := r.Head()
+	s.Require().NoError(err)
+	s.Equal(commitB, head.Hash(), "HEAD should advance to commitB")
+}
+
+// TestResetKeepSparseConflict verifies that KeepReset is aborted when a change
+// in SparseDirs would remove a currently-on-disk tracked file that has local
+// modifications — matching git reset --keep behaviour.
+func (s *WorktreeSuite) TestResetKeepSparseConflict() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	// Sparse-populate the "go" directory so its tracked files are on disk.
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: KeepReset, SparseDirs: []string{"go"}}))
+
+	// Find a tracked file inside go/ to dirty.
+	goFiles, err := fs.ReadDir("go")
+	s.Require().NoError(err)
+	s.Require().NotEmpty(goFiles, "expected tracked files in go/ after sparse reset")
+
+	dirtyFile := filepath.Join("go", goFiles[0].Name())
+	s.Require().NoError(util.WriteFile(fs, dirtyFile, []byte("local modification"), 0o644))
+
+	// Switching SparseDirs from "go" to "php" (same commit) would remove
+	// dirty go/ files from disk — KeepReset must refuse.
+	err = w.Reset(&ResetOptions{Mode: KeepReset, SparseDirs: []string{"php"}})
+	s.ErrorIs(err, ErrLocalChanges, "KeepReset should abort when SparseDirs removal would discard local mods")
+}
+
+// TestResetKeepUntrackedOverwrite verifies that KeepReset is aborted when an
+// untracked file exists at a path that the target commit would write — matching
+// git reset --keep behaviour (would otherwise silently overwrite the file).
+func (s *WorktreeSuite) TestResetKeepUntrackedOverwrite() {
+	tempDir := s.T().TempDir()
+	repoDir := filepath.Join(tempDir, "repo")
+
+	r, err := PlainInit(repoDir, false)
+	s.Require().NoError(err)
+	w, err := r.Worktree()
+	s.Require().NoError(err)
+
+	// commitA: only tracked.txt exists.
+	commitA := CommitNewFile(s.T(), r, "tracked.txt")
+
+	// commitB: add new.txt alongside tracked.txt.
+	s.Require().NoError(util.WriteFile(w.Filesystem, "new.txt", []byte("tracked content"), 0o644))
+	_, err = w.Add("new.txt")
+	s.Require().NoError(err)
+	commitB, err := w.Commit("add new.txt", &CommitOptions{Author: defaultSignature()})
+	s.Require().NoError(err)
+
+	// Go back to commitA so new.txt is absent from the worktree.
+	err = w.Reset(&ResetOptions{Mode: HardReset, Commit: commitA})
+	s.Require().NoError(err)
+
+	// Place an untracked file at the path that commitB will insert.
+	s.Require().NoError(util.WriteFile(w.Filesystem, "new.txt", []byte("untracked content"), 0o644))
+
+	// KeepReset to commitB must abort because new.txt would be overwritten.
+	err = w.Reset(&ResetOptions{Mode: KeepReset, Commit: commitB})
+	s.ErrorIs(err, ErrLocalChanges, "KeepReset should abort when an untracked file would be overwritten")
+
+	// HEAD must not have moved.
+	head, err := r.Head()
+	s.NoError(err)
+	s.Equal(commitA, head.Hash())
+}
+
 func (s *WorktreeSuite) TestResetHard() {
 	fs := memfs.New()
 	w := &Worktree{


### PR DESCRIPTION
## Summary

Adds `KeepReset` as a new `ResetMode`, implementing the behaviour of `git reset --keep`.
Fixes #1031.

### What `git reset --keep` does

`git reset --keep <commit>` resets the index and worktree to `<commit>`, but **aborts** if any file that would be changed by the reset has local staged or unstaged modifications. Untracked files are never deleted.

### Implementation

1. **Pre-flight check** (`checkKeepResetConflicts`): diffs `fromTree -> toTree` to find files that will change; returns `ErrLocalChanges` (wrapping the conflicting path) if any of those files have staged or unstaged modifications. `SkipWorktree` (sparse-excluded) files are not present in the worktree and are never counted as conflicting.

2. **Apply**: if the check passes, the reset proceeds identically to `HardReset` -- index updated via `resetIndex`, worktree updated via `resetWorktreeToTree` (tree-to-tree, untracked files untouched, SkipWorktree files cleaned up by phase 3 of `resetWorktreeToTree`).

### Tests added

- `TestResetKeep` -- basic success: no local conflicts, worktree updated.
- `TestResetKeepConflict` -- aborted when a to-be-changed file has local modifications; HEAD does not move.
- `TestResetKeepUntrackedPreserved` -- untracked files survive the reset.
- `TestResetKeepSparselyUntracked` -- switching `SparseDirs` via `KeepReset` removes tracked files from the old sparse dir, populates the new sparse dir, and preserves untracked files in the removed dir.
- `TestResetKeepConflictNotOnSparseExcluded` -- `SkipWorktree` files that change between commits do not falsely trigger the conflict check.

closes #1031