### PR TITLE
fix(submodule): fallback to full fetch when shallow/exact SHA1 fetch is not supported

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -246,6 +246,10 @@ func (s *Submodule) fetchAndCheckout(
 ) error {
 	if !o.NoFetch {
 		err := r.FetchContext(ctx, &FetchOptions{Auth: o.Auth, Depth: o.Depth})
+		if errors.Is(err, transport.ErrShallowNotSupported) && o.Depth > 0 {
+			err = r.FetchContext(ctx, &FetchOptions{Auth: o.Auth})
+		}
+
 		if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) {
 			return err
 		}
@@ -269,7 +273,21 @@ func (s *Submodule) fetchAndCheckout(
 				RefSpecs: []config.RefSpec{refSpec},
 				Depth:    o.Depth,
 			})
-			if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) && !errors.Is(err, ErrExactSHA1NotSupported) {
+
+			if (errors.Is(err, ErrExactSHA1NotSupported) || errors.Is(err, transport.ErrShallowNotSupported)) && o.Depth > 0 {
+				err = r.FetchContext(ctx, &FetchOptions{
+					Auth:     o.Auth,
+					RefSpecs: []config.RefSpec{refSpec},
+				})
+			}
+
+			if errors.Is(err, ErrExactSHA1NotSupported) {
+				err = r.FetchContext(ctx, &FetchOptions{
+					Auth: o.Auth,
+				})
+			}
+
+			if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) {
 				return err
 			}
 		}


### PR DESCRIPTION
When updating a submodule with Depth: 1, if the target commit is not at the tip of a branch, go-git tries to fetch it by its exact SHA1. If the server does not support `allow-reachable-sha1-in-want` or `shallow`, it returns `ErrExactSHA1NotSupported` or `transport.ErrShallowNotSupported`.

Previously, these errors were ignored, leading to an 'object not found' error during the checkout step.

This change catches those errors and falls back to fetching without Depth restrictions, or fetching all branches as a last resort, ensuring the required commit is retrieved.

Fixes #1785