### PR TITLE
plumbing: idxfile, fix sharedFile timer race on Windows

### DIFF
--- a/plumbing/format/idxfile/shared_file.go
+++ b/plumbing/format/idxfile/shared_file.go
@@ -30,6 +30,7 @@ type sharedFile struct {
 	refs       int
 	closed     bool
 	closeTimer *time.Timer
+	timerGen   uint64 // incremented each time a timer is stopped/replaced
 }
 
 var errSharedFileClosed = errors.New("shared file is closed")
@@ -56,6 +57,7 @@ func (sf *sharedFile) acquire() (io.ReaderAt, error) {
 	if sf.closeTimer != nil {
 		sf.closeTimer.Stop()
 		sf.closeTimer = nil
+		sf.timerGen++ // invalidate any already-queued timer callback
 	}
 
 	if sf.file == nil {
@@ -92,10 +94,11 @@ func (sf *sharedFile) release() {
 		return
 	}
 
+	gen := sf.timerGen
 	sf.closeTimer = time.AfterFunc(sf.gracePeriod, func() {
 		sf.mu.Lock()
 		defer sf.mu.Unlock()
-		if sf.refs == 0 && sf.file != nil {
+		if sf.timerGen == gen && sf.refs == 0 && sf.file != nil {
 			sf.closeLocked()
 		}
 	})
@@ -113,6 +116,7 @@ func (sf *sharedFile) Close() error {
 	if sf.closeTimer != nil {
 		sf.closeTimer.Stop()
 		sf.closeTimer = nil
+		sf.timerGen++ // invalidate any already-queued timer callback
 	}
 	if sf.refs == 0 && sf.file != nil {
 		err := sf.file.Close()


### PR DESCRIPTION
`time.AfterFunc` does not guarantee that a goroutine already queued to run (i.e. after `Stop()` returns `false`) will not execute. On Windows, where timer resolution is ~15ms, a `time.Sleep(50ms)` can overshoot past the 80ms grace period, causing the original timer goroutine to fire and queue up before `acquire()` can call `Stop()`.

The race:
1. `release()` at t=0: timer created (`gen=0`), expires at t=80ms
2. `time.Sleep(50ms)` overshoots to t=85ms on a loaded CI machine
3. Timer fires at t=80ms, goroutine queued, waiting for `sf.mu.Lock()`
4. `acquire()` at t=85ms: `Stop()` returns `false` (already fired), `closeTimer = nil`
5. `release()` at t=85ms: refs=0, new timer created (`gen=0` still), expires at t=165ms
6. Stale goroutine gets lock: `refs==0 && file!=nil` → **closes the file**
7. `time.Sleep(50ms)` → assert file still open → **FAILS**

Fix: add a `timerGen uint64` counter that is incremented each time a timer is stopped or invalidated. The timer callback captures the generation at creation time and aborts if it has changed. This means a stale goroutine always self-identifies and does nothing, regardless of what `Stop()` returned.
