### PR TITLE
internal/transport/test: close filesystem storers in TearDownTest

### DIFF
--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -35,6 +35,14 @@ type ReceivePackSuite struct {
 	Client              transport.Transport
 }
 
+func (s *ReceivePackSuite) TearDownTest() {
+	for _, st := range []storage.Storer{s.Storer, s.EmptyStorer, s.NonExistentStorer} {
+		if c, ok := st.(io.Closer); ok {
+			_ = c.Close()
+		}
+	}
+}
+
 func (s *ReceivePackSuite) TestAdvertisedReferencesEmpty() {
 	r, err := s.Client.NewSession(s.EmptyStorer, s.EmptyEndpoint, s.EmptyAuth)
 	s.Require().NoError(err)

--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -4,6 +4,7 @@ package test
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -24,6 +25,14 @@ type UploadPackSuite struct {
 	NonExistentStorer   storage.Storer
 	EmptyAuth           transport.AuthMethod
 	Client              transport.Transport
+}
+
+func (s *UploadPackSuite) TearDownTest() {
+	for _, st := range []storage.Storer{s.Storer, s.EmptyStorer, s.NonExistentStorer} {
+		if c, ok := st.(io.Closer); ok {
+			_ = c.Close()
+		}
+	}
 }
 
 func (s *UploadPackSuite) TestAdvertisedReferencesEmpty() {


### PR DESCRIPTION
## Summary

On Windows, `LazyIndex` keeps `.idx` pack index files open until explicitly closed. The transport test suites (`UploadPackSuite`, `ReceivePackSuite`, `DumbSuite`) create `filesystem.Storage` instances but never close them. When the test's `TempDir` is cleaned up after the test, Windows refuses to delete the open file:

```
testing.go:1369: TempDir RemoveAll cleanup: unlinkat ...\pack-....idx: The process cannot access the file because it is being used by another process.
```

## Fix

Add `TearDownTest` to the shared `UploadPackSuite` and `ReceivePackSuite` base suites that closes any storer implementing `io.Closer`. This covers all derived suites (HTTP upload-pack, receive-pack, dumb) in one place.