### PR TITLE
plumbing: object, fix Change.PatchContext hardcoded 1-hour internal timeout 

### DIFF
--- a/plumbing/object/patch.go
+++ b/plumbing/object/patch.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	dmp "github.com/sergi/go-diff/diffmatchpatch"
 
@@ -54,6 +55,11 @@ func filePatchWithContext(ctx context.Context, c *Change) (fdiff.FilePatch, erro
 	if err != nil {
 		return nil, err
 	}
+	// avoids reading file content if the context is already done.
+	if err := ctx.Err(); err != nil {
+		return nil, ErrCanceled
+	}
+
 	fromContent, fIsBinary, err := fileContent(from)
 	if err != nil {
 		return nil, err
@@ -68,7 +74,23 @@ func filePatchWithContext(ctx context.Context, c *Change) (fdiff.FilePatch, erro
 		return &textFilePatch{from: c.From, to: c.To}, nil
 	}
 
-	diffs := diff.Do(fromContent, toContent)
+	var diffs []dmp.Diff
+	// Check whether the ctx has a configured deadline (timeout),
+	// and compute the remaining time until the deadline if present.
+	deadline, ok := ctx.Deadline()
+	if ok {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return nil, ErrCanceled
+		}
+
+		// diff.DoWithTimeout silently returns a best-effort (potentially incomplete)
+		// diff when its internal timeout fires — it doesn't surface an error.
+		// The ctx.Done() check in the loop below won't reliably catch this.
+		diffs = diff.DoWithTimeout(fromContent, toContent, remaining)
+	} else {
+		diffs = diff.Do(fromContent, toContent)
+	}
 
 	chunks := make([]fdiff.Chunk, 0, len(diffs))
 	for _, d := range diffs {

--- a/plumbing/object/patch_test.go
+++ b/plumbing/object/patch_test.go
@@ -1,13 +1,16 @@
 package object
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	fixtures "github.com/go-git/go-git-fixtures/v5"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
@@ -159,4 +162,70 @@ func (s *PatchSuite) TestFileStatsString() {
 		s.T().Log("Executing test cases:", tc.description)
 		s.Equal(tc.expected, printStat(tc.input))
 	}
+}
+
+// modifyChange returns a Change representing a modification to a known file
+// in the go-git fixture, suitable for exercising filePatchWithContext.
+func (s *PatchSuite) modifyChange() *Change {
+	path := "utils/difftree/difftree.go"
+	name := "difftree.go"
+	mode := filemode.Regular
+	fromBlob := plumbing.NewHash("05f583ace3a9a078d8150905a53a4d82567f125f")
+	fromTree := plumbing.NewHash("b1f01b730b855c82431918cb338ad47ed558999b")
+	toBlob := plumbing.NewHash("de927fad935d172929aacf20e71f3bf0b91dd6f9")
+	toTree := plumbing.NewHash("8b0af31d2544acb5c4f3816a602f11418cbd126e")
+	return &Change{
+		From: ChangeEntry{
+			Name:      path,
+			Tree:      s.tree(fromTree),
+			TreeEntry: TreeEntry{Name: name, Mode: mode, Hash: fromBlob},
+		},
+		To: ChangeEntry{
+			Name:      path,
+			Tree:      s.tree(toTree),
+			TreeEntry: TreeEntry{Name: name, Mode: mode, Hash: toBlob},
+		},
+	}
+}
+
+// TestPatchContextDeadlineExpired verifies that filePatchWithContext returns
+// ErrCanceled when the context deadline has already expired before the call.
+func (s *PatchSuite) TestPatchContextDeadlineExpired() {
+	change := s.modifyChange()
+
+	// Deadline already in the past — filePatchWithContext must detect this
+	// immediately and return ErrCanceled without performing any diff work.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	fp, err := filePatchWithContext(ctx, change)
+	s.Nil(fp)
+	s.ErrorIs(err, ErrCanceled)
+}
+
+// TestPatchContextWithActiveDeadline verifies that filePatchWithContext
+// succeeds and returns a non-empty patch when given a context with ample time
+// remaining, exercising the diff.DoWithTimeout code path.
+func (s *PatchSuite) TestPatchContextWithActiveDeadline() {
+	change := s.modifyChange()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	fp, err := filePatchWithContext(ctx, change)
+	s.NoError(err)
+	s.NotNil(fp)
+	s.NotEmpty(fp.Chunks())
+}
+
+// TestPatchContextWithoutDeadline verifies that filePatchWithContext
+// succeeds and returns a non-empty patch when given a context without
+// deadline, exercising the diff.Do code path.
+func (s *PatchSuite) TestPatchContextWithoutDeadline() {
+	change := s.modifyChange()
+
+	fp, err := filePatchWithContext(context.TODO(), change)
+	s.NoError(err)
+	s.NotNil(fp)
+	s.NotEmpty(fp.Chunks())
 }


### PR DESCRIPTION
There is a hidden bug in the Change.PatchContext method: even when users call this function with a ctx that has a timeout of only a few seconds, filePatchWithContext always uses diff.Do(fromContent, toContent) — which has a one-hour execution timeout. This is extremely confusing for users.
