### PR TITLE
build: establish DCO sign-off requirement for all contributions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -30,3 +30,39 @@ jobs:
           excludeTitle: 'true'
           checkAllCommitMessages: 'true'
           accessToken: ${{ secrets.GITHUB_TOKEN }}
+
+  check-dco:
+    name: Check DCO Sign-off
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Verify all commits carry Signed-off-by
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          missing=0
+          while IFS= read -r sha; do
+            body=$(git log -1 --format="%B" "$sha")
+            if ! printf '%s\n' "$body" | grep -qE '^Signed-off-by: .+ <.+>$'; then
+              echo "MISSING sign-off: $sha $(git log -1 --format='%s' "$sha")"
+              missing=1
+            fi
+          done < <(git log --format="%H" "$BASE_SHA..$HEAD_SHA")
+          if [ "$missing" -eq 1 ]; then
+            echo ""
+            echo "One or more commits are missing a DCO Signed-off-by line."
+            echo "Fix with:"
+            echo "  git commit --amend --signoff --no-edit   # last commit"
+            echo "  git rebase --signoff HEAD~N              # last N commits"
+            echo ""
+            echo "See CONTRIBUTING.md for details."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,31 @@ we will only be accepting bug fixes or CVE related dependency bumps for the
 
 Bug fixes that also impact `main`, should be fixed there first, and then backported to `v5`.
 
+### Developer Certificate of Origin
+
+go-git requires all commits to be signed off with a [Developer Certificate of Origin (DCO)](https://developercertificate.org/) sign-off. This is a lightweight way for contributors to certify that they wrote, or have the right to submit, the code being contributed.
+
+The sign-off is a single line added to the end of each commit message:
+
+```
+Signed-off-by: Jane Smith <jane.smith@example.com>
+```
+
+Git makes this easy — pass `-s` (or `--signoff`) when committing:
+
+```sh
+git commit -s -m "plumbing: packp, fix capability parsing"
+```
+
+To sign off commits you have already made:
+
+```sh
+git commit --amend --signoff --no-edit  # amend the last commit
+git rebase --signoff HEAD~N             # sign off the last N commits
+```
+
+DCO sign-off is verified automatically on every pull request. PRs with unsigned commits will not be merged.
+
 ### Format of the commit message
 
 Every commit message should describe what was changed, under which context and, if applicable, the GitHub issue it relates to:


### PR DESCRIPTION
Introduce a Developer Certificate of Origin (DCO) check into the PR validation workflow and document the process in CONTRIBUTING.md.

Open source projects depend on clear provenance for every line of code they accept. Without it, the project and its users are exposed to potential IP disputes — a contributor could later claim their employer owned the code, or that it was derived from an incompatible source. The DCO (https://developercertificate.org/) is the lightweight, widely-adopted answer to this: by adding a Signed-off-by trailer to each commit, contributors certify in writing that they have the right to submit the work under the project's license (Apache 2.0).

This is particularly important as go-git grows in adoption. Downstream users — especially those in regulated industries or with strict supply chain policies — need confidence that the project has proper IP hygiene. Many ecosystems (Linux kernel, CNCF projects) already require this as a baseline.