### PR TITLE
config: add Core.HooksPath field for core.hooksPath setting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,8 @@ type Config struct {
 		// against local file, 0644 will be used as the value of its mode. The original
 		// value of mode is left unchanged in the index.
 		FileMode bool
+		// HooksPath is the path to look for hooks instead of $GIT_DIR/hooks.
+		HooksPath string
 	}
 
 	User struct {
@@ -408,6 +410,7 @@ const (
 	versionKey                 = "version"
 	autoCRLFKey                = "autocrlf"
 	fileModeKey                = "filemode"
+	hooksPathKey               = "hooksPath"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.
@@ -459,6 +462,7 @@ func (c *Config) unmarshalCore() {
 	c.Core.Worktree = s.Options.Get(worktreeKey)
 	c.Core.CommentChar = s.Options.Get(commentCharKey)
 	c.Core.AutoCRLF = s.Options.Get(autoCRLFKey)
+	c.Core.HooksPath = s.Options.Get(hooksPathKey)
 
 	if fileMode := s.Options.Get(fileModeKey); fileMode == "false" {
 		c.Core.FileMode = false
@@ -651,6 +655,10 @@ func (c *Config) marshalCore() {
 	}
 
 	s.SetOption(fileModeKey, fmt.Sprintf("%t", c.Core.FileMode))
+
+	if c.Core.HooksPath != "" {
+		s.SetOption(hooksPathKey, c.Core.HooksPath)
+	}
 }
 
 func (c *Config) marshalExtensions() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,7 @@ func (s *ConfigSuite) TestUnmarshal() {
 		commentchar = bar
 		autocrlf = true
 		filemode = false
+		hooksPath = custom-hooks
 [user]
 		name = John Doe
 		email = john@example.com
@@ -79,6 +80,7 @@ func (s *ConfigSuite) TestUnmarshal() {
 	s.Equal("bar", cfg.Core.CommentChar)
 	s.Equal("true", cfg.Core.AutoCRLF)
 	s.False(cfg.Core.FileMode)
+	s.Equal("custom-hooks", cfg.Core.HooksPath)
 	s.Equal("John Doe", cfg.User.Name)
 	s.Equal("john@example.com", cfg.User.Email)
 	s.Equal("Jane Roe", cfg.Author.Name)
@@ -112,6 +114,7 @@ func (s *ConfigSuite) TestMarshal() {
 	worktree = bar
 	autocrlf = true
 	filemode = true
+	hooksPath = custom-hooks
 [pack]
 	window = 20
 [remote "alt"]
@@ -141,6 +144,7 @@ func (s *ConfigSuite) TestMarshal() {
 	cfg.Core.IsBare = true
 	cfg.Core.Worktree = "bar"
 	cfg.Core.AutoCRLF = "true"
+	cfg.Core.HooksPath = "custom-hooks"
 	cfg.Pack.Window = 20
 	cfg.Init.DefaultBranch = "main"
 	cfg.Remotes["origin"] = &RemoteConfig{


### PR DESCRIPTION
## Summary

Adds `HooksPath` field to `Config.Core` struct, supporting the git `core.hooksPath` configuration option. This allows setting a custom hooks directory via the go-git API instead of requiring raw config manipulation.

## Why this matters

Users who need to set `core.hooksPath` currently have to use `config.Raw.SetOption()` as a workaround (see #1429). Other Core fields like `Worktree`, `CommentChar`, and `AutoCRLF` are already supported as struct fields - `HooksPath` follows the same pattern.

## Changes

- `config/config.go`: Added `HooksPath string` field to `Core` struct, `hooksPathKey` constant, unmarshal via `s.Options.Get()`, and conditional marshal
- `config/config_test.go`: Added `hooksPath` to both unmarshal and marshal test fixtures with assertions

## Testing

`go test ./config/... -run "TestUnmarshal|TestMarshal"` - all pass.

Fixes #1429

This contribution was developed with AI assistance (Claude Code).