### PR TITLE
plumbing: packp, fix update-request shallow decoder rejecting trailing newline

### DIFF
--- a/plumbing/protocol/packp/updreq_decode.go
+++ b/plumbing/protocol/packp/updreq_decode.go
@@ -11,7 +11,6 @@ import (
 )
 
 var (
-	shallowLineLength       = len(shallow) + sha1HexSize
 	minCommandLength        = sha1HexSize*2 + 2 + 1
 	minCommandAndCapsLength = minCommandLength + 1
 )
@@ -34,8 +33,8 @@ func errInvalidHash(hash string) error {
 
 func errInvalidShallowLineLength(got int) error {
 	return errMalformedRequest(fmt.Sprintf(
-		"invalid shallow line length: expected %d, got %d",
-		shallowLineLength, got))
+		"invalid shallow line length: expected %d or %d, got %d",
+		len(shallow)+sha1HexSize, len(shallow)+sha256HexSize, got))
 }
 
 func errInvalidCommandCapabilitiesLineLength(got int) error {
@@ -131,13 +130,14 @@ func (d *updReqDecoder) scanLine() error {
 }
 
 func (d *updReqDecoder) decodeShallow() error {
-	b := d.payload
+	b := bytes.TrimSuffix(d.payload, eol)
 
 	if !bytes.HasPrefix(b, shallowNoSp) {
 		return nil
 	}
 
-	if len(b) != shallowLineLength {
+	hashLen := len(b) - len(shallow)
+	if hashLen != sha1HexSize && hashLen != sha256HexSize {
 		return errInvalidShallowLineLength(len(b))
 	}
 

--- a/plumbing/protocol/packp/updreq_decode_test.go
+++ b/plumbing/protocol/packp/updreq_decode_test.go
@@ -40,28 +40,28 @@ func (s *UpdReqDecodeSuite) TestInvalidShadow() {
 		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00",
 		"",
 	}
-	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow line length: expected 48, got 7$")
+	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow line length: expected 48 or 72, got 7$")
 
 	payloads = []string{
 		"shallow ",
 		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00",
 		"",
 	}
-	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow line length: expected 48, got 8$")
+	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow line length: expected 48 or 72, got 8$")
 
 	payloads = []string{
 		"shallow 1ecf0ef2c2dffb796033e5a02219af86ec65",
 		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00",
 		"",
 	}
-	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow line length: expected 48, got 44$")
+	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow line length: expected 48 or 72, got 44$")
 
 	payloads = []string{
 		"shallow 1ecf0ef2c2dffb796033e5a02219af86ec6584e54",
 		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00",
 		"",
 	}
-	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow line length: expected 48, got 49$")
+	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow line length: expected 48 or 72, got 49$")
 
 	payloads = []string{
 		"shallow 1ecf0ef2c2dffb796033e5a02219af86ec6584eu",
@@ -69,6 +69,27 @@ func (s *UpdReqDecodeSuite) TestInvalidShadow() {
 		"",
 	}
 	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: invalid shallow object id: invalid hash: .*")
+}
+
+func (s *UpdReqDecodeSuite) TestShallowWithTrailingNewline() {
+	hash1 := plumbing.NewHash("1ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	hash2 := plumbing.NewHash("2ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+
+	expected := NewUpdateRequests()
+	expected.Commands = []*Command{
+		{Name: plumbing.ReferenceName("myref"), Old: hash1, New: hash2},
+	}
+	expected.Capabilities.Add("shallow")
+	expected.Shallow = &hash1
+
+	// Shallow line with trailing newline (49 bytes), as sent by reference Git.
+	payloads := []string{
+		"shallow 1ecf0ef2c2dffb796033e5a02219af86ec6584e5\n",
+		"1ecf0ef2c2dffb796033e5a02219af86ec6584e5 2ecf0ef2c2dffb796033e5a02219af86ec6584e5 myref\x00shallow",
+		"",
+	}
+
+	s.testDecodeOkExpected(expected, payloads)
 }
 
 func (s *UpdReqDecodeSuite) TestMalformedCommand() {


### PR DESCRIPTION
## Summary

- Fix `updReqDecoder.decodeShallow()` rejecting shallow lines with a trailing newline (`"shallow <hash>\n"`, 49 bytes), as sent by reference Git's `send-pack.c`
- Add SHA-256 hash support to shallow line validation (previously hardcoded to SHA-1 only)

## Problem

Reference Git's [`send-pack.c:297`](https://github.com/git/git/blob/master/send-pack.c#L297) writes shallow lines with a trailing newline:
```c
packet_buf_write(sb, "shallow %s\n", oid_to_hex(&graft->oid));
```

Reference Git's `receive-pack.c` handles this via `PACKET_READ_CHOMP_NEWLINE`, but go-git's `updReqDecoder.decodeShallow()` read the raw pktline payload without trimming, then rejected anything not exactly 48 bytes.

All three other shallow decoders in the codebase (`shallowupd.go`, `ulreq_decode.go`, `advrefs_decode.go`) already trim trailing newlines defensively. `updreq_decode.go` was the only one that didn't.

## Fix

- Trim trailing newline with `bytes.TrimSuffix(d.payload, eol)` before validation
- Validate hash length against both SHA-1 (40) and SHA-256 (64) instead of hardcoded total length
- Remove unused `shallowLineLength` variable

## Test plan

- [x] Updated `TestInvalidShadow` error patterns for new message format
- [x] Added `TestShallowWithTrailingNewline` — verifies 49-byte shallow lines from reference Git are accepted


🤖 Generated with [Claude Code](https://claude.ai/claude-code)