### PR TITLE
ci: use stable and oldstable for Go versions in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [oldstable, stable]
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     permissions:
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [oldstable, stable]
 
     permissions:
       contents: read


### PR DESCRIPTION
Replaces hardcoded Go versions with stable/oldstable aliases.

## Why this matters

RFC-0001 says test workflows should use `stable` and `oldstable`. The git.yml workflow already does. test.yml was still pinned to 1.24.x/1.25.x. Now it auto-tracks Go releases.

## Changes

- **.github/workflows/test.yml**: Changed `go-version: [1.24.x, 1.25.x]` to `[oldstable, stable]` in both test matrices (lines 17 and 55)

## Testing

No code changes. CI will run on the resolved Go versions.

Fixes #1918

This contribution was developed with AI assistance (Claude Code).