### PR TITLE
build: update GitHub workflows to use stable and oldstable Go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [oldstable, stable]
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     permissions:
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [oldstable, stable]
 
     permissions:
       contents: read


### PR DESCRIPTION
As per [rfc-0001](https://github.com/go-git/go-git/blob/main/rfcs/0001-supported-go-versions.md#testing-matrix), GitHub workflows that depend on Go versions should be updated to `stable` whenever the current supported Go version is needed, and `oldstable` for the previous one.

Closes #1918