### PR TITLE
config parser rejects branch.*.merge values 

### DIFF
--- a/config/branch.go
+++ b/config/branch.go
@@ -10,7 +10,6 @@ import (
 
 var (
 	errBranchEmptyName     = errors.New("branch config: empty name")
-	errBranchInvalidMerge  = errors.New("branch config: invalid merge")
 	errBranchInvalidRebase = errors.New("branch config: rebase must be one of 'true' or 'interactive'")
 )
 
@@ -37,30 +36,14 @@ type Branch struct {
 	raw *format.Subsection
 }
 
-// Validate validates fields of branch
+// Validate validates fields of branch.
+// It does not reject Merge values that lack a "refs/" prefix,
+// matching the behaviour of real git during config read and write.
 func (b *Branch) Validate() error {
 	if b.Name == "" {
 		return errBranchEmptyName
 	}
 
-	if b.Merge != "" && !strings.HasPrefix(string(b.Merge), "refs/") {
-		return errBranchInvalidMerge
-	}
-
-	return b.validateShared()
-}
-
-// validate performs relaxed validation suitable for reading existing configs.
-// It skips the refs/ prefix check on Merge, since real git allows any value.
-func (b *Branch) validate() error {
-	if b.Name == "" {
-		return errBranchEmptyName
-	}
-
-	return b.validateShared()
-}
-
-func (b *Branch) validateShared() error {
 	if b.Rebase != "" &&
 		b.Rebase != "true" &&
 		b.Rebase != "interactive" &&
@@ -126,7 +109,7 @@ func (b *Branch) unmarshal(s *format.Subsection) error {
 	b.Rebase = b.raw.Options.Get(rebaseKey)
 	b.Description = unquoteDescription(b.raw.Options.Get(descriptionKey))
 
-	return b.validate()
+	return b.Validate()
 }
 
 // hack to enable conditional quoting in the

--- a/config/branch_test.go
+++ b/config/branch_test.go
@@ -32,18 +32,19 @@ func (b *BranchSuite) TestValidateName() {
 }
 
 func (b *BranchSuite) TestValidateMerge() {
-	goodBranch := Branch{
+	// Real git allows any value for branch.*.merge.
+	refsBranch := Branch{
 		Name:   "master",
 		Remote: "some_remote",
 		Merge:  "refs/heads/master",
 	}
-	badBranch := Branch{
+	nonRefsBranch := Branch{
 		Name:   "master",
 		Remote: "some_remote",
 		Merge:  "blah",
 	}
-	b.Nil(goodBranch.Validate())
-	b.NotNil(badBranch.Validate())
+	b.Nil(refsBranch.Validate())
+	b.Nil(nonRefsBranch.Validate())
 }
 
 func (b *BranchSuite) TestMarshal() {
@@ -123,4 +124,8 @@ func (b *BranchSuite) TestUnmarshalNonRefsPrefix() {
 	b.Equal("foo", branch.Name)
 	b.Equal("origin", branch.Remote)
 	b.Equal(plumbing.ReferenceName("main"), branch.Merge)
+
+	// Validate must also accept this value so that SetConfig (which
+	// calls Validate) works for configs read from disk.
+	b.NoError(branch.Validate())
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -429,7 +429,9 @@ func (s *ConfigSuite) TestValidateInvalidBranchKey() {
 	s.ErrorIs(config.Validate(), ErrInvalid)
 }
 
-func (s *ConfigSuite) TestValidateInvalidBranch() {
+func (s *ConfigSuite) TestValidateBranchNonRefsPrefix() {
+	// Real git allows any value for branch.*.merge, including values
+	// without a refs/ prefix. Validate should accept them.
 	config := &Config{
 		Branches: map[string]*Branch{
 			"bar": {
@@ -445,7 +447,7 @@ func (s *ConfigSuite) TestValidateInvalidBranch() {
 		},
 	}
 
-	s.ErrorIs(config.Validate(), errBranchInvalidMerge)
+	s.NoError(config.Validate())
 }
 
 func (s *ConfigSuite) TestRemoteConfigDefaultValues() {


### PR DESCRIPTION
Git documentation [(git-config, branch.<name>.merge)](https://git-scm.com/docs/git-branch/2.40.0#Documentation/git-branch.txt-branchnamemerge) says the value "must match a ref which is fetched from the remote" but does not mandate a refs/ prefix. It's described as being "handled like the remote part of a refspec."

With this change go-gits current implementation would only allow values starting with `ref/`

Links to the git source code: 

Config read (no validation, just stores the value):
https://github.com/git/git/blob/1080981ddb03a072f1e6b55c6325c2af731e733c/remote.c#L451-L455

add_merge() (just xstrdup, no prefix check):
https://github.com/git/git/blob/1080981ddb03a072f1e6b55c6325c2af731e733c/remote.c#L184-L195