### PR TITLE
plumbing: gitignore, Fix negation in subdirectory with path-based parent ignore. Fixes #877

### DIFF
--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -52,6 +52,10 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 // recursively traversing through the directory structure. The result is in
 // the ascending order of priority (last higher).
 func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) {
+	return readPatterns(fs, path, nil)
+}
+
+func readPatterns(fs billy.Filesystem, path []string, parentPatterns []Pattern) (ps []Pattern, err error) {
 	ps, _ = readIgnoreFile(fs, path, infoExcludeFile)
 
 	subps, _ := readIgnoreFile(fs, path, gitignoreFile)
@@ -65,12 +69,17 @@ func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) 
 
 	for _, fi := range fis {
 		if fi.IsDir() && fi.Name() != gitDir {
-			if NewMatcher(ps).Match(append(path, fi.Name()), true) {
+			// Use both parent and local patterns to check if the directory
+			// is ignored. This ensures that path patterns from ancestor
+			// .gitignore files (e.g., "grandparent/parent") correctly
+			// prevent recursion into ignored directories.
+			allPatterns := append(parentPatterns, ps...)
+			if NewMatcher(allPatterns).Match(append(path, fi.Name()), true) {
 				continue
 			}
 
 			var subps []Pattern
-			subps, err = ReadPatterns(fs, append(path, fi.Name()))
+			subps, err = readPatterns(fs, append(path, fi.Name()), allPatterns)
 			if err != nil {
 				return ps, err
 			}

--- a/plumbing/format/gitignore/dir_test.go
+++ b/plumbing/format/gitignore/dir_test.go
@@ -357,3 +357,45 @@ func (s *MatcherSuite) TestDir_LoadSystemPatterns() {
 	s.True(m.Match([]string{"go-git.v4.iml"}, true))
 	s.True(m.Match([]string{".idea"}, true))
 }
+
+// TestDir_ReadPatterns_NestedPathIgnoreWithNegation tests that negation
+// patterns in subdirectory .gitignore files cannot override path-based
+// ignore patterns from ancestor .gitignore files. This exercises the fix
+// for https://github.com/go-git/go-git/issues/877 where a root pattern
+// like "a/b" ignores a nested directory, and a .gitignore inside that
+// directory tries to negate files with "!file".
+func (s *MatcherSuite) TestDir_ReadPatterns_NestedPathIgnoreWithNegation() {
+	fs := memfs.New()
+
+	err := fs.MkdirAll(".git/info", os.ModePerm)
+	s.NoError(err)
+
+	// Root .gitignore uses a path pattern to ignore a nested directory
+	f, err := fs.Create(".gitignore")
+	s.NoError(err)
+	_, err = f.Write([]byte("a/b\n"))
+	s.NoError(err)
+	err = f.Close()
+	s.NoError(err)
+
+	// a/b/.gitignore tries to negate a file
+	err = fs.MkdirAll("a/b", os.ModePerm)
+	s.NoError(err)
+	f, err = fs.Create("a/b/.gitignore")
+	s.NoError(err)
+	_, err = f.Write([]byte("!file\n"))
+	s.NoError(err)
+	err = f.Close()
+	s.NoError(err)
+	f, err = fs.Create("a/b/file")
+	s.NoError(err)
+	err = f.Close()
+	s.NoError(err)
+
+	ps, err := ReadPatterns(fs, nil)
+	s.NoError(err)
+
+	m := NewMatcher(ps)
+	s.True(m.Match([]string{"a", "b"}, true), "a/b should be ignored")
+	s.True(m.Match([]string{"a", "b", "file"}, false), "a/b/file should be ignored (negation in subdir cannot override parent path ignore)")
+}


### PR DESCRIPTION
## Summary

- Fix `ReadPatterns` to pass parent ignore patterns down through recursive calls, so path-based patterns from ancestor `.gitignore` files (e.g., `a/b` in root `.gitignore`) correctly prevent descending into ignored directories
- Without this fix, `ReadPatterns` would enter the ignored directory, load its `.gitignore` negation patterns (e.g., `!file`), and incorrectly un-ignore files that git treats as ignored
- Add test case `TestDir_ReadPatterns_NestedPathIgnoreWithNegation` that reproduces the bug and verifies the fix

## Problem

When a root `.gitignore` uses a **path pattern** to ignore a nested directory (e.g., `a/b`), and that directory's own `.gitignore` contains a negation (e.g., `!file`), go-git incorrectly treats `a/b/file` as not-ignored. Real git treats it as ignored, per the [gitignore spec](https://git-scm.com/docs/gitignore#_pattern_format): "It is not possible to re-include a file if a parent directory of that file is excluded."

The prior fix in #1114 handled the case where the ignore pattern matched at the **same directory level** (e.g., simple name `abc` in root `.gitignore`). However, path-based patterns that match at a deeper level (e.g., `a/b`) were not visible during the recursive call into `a/`, so the check on directory `b` would miss the ignore and recurse into it.

## Solution

Introduce an internal `readPatterns` helper that threads accumulated parent patterns down through the recursion. The public `ReadPatterns` signature is unchanged. The directory-skip check now uses the combined parent + local patterns, so path-based patterns from any ancestor are visible at every recursion level.

## Test plan

- [x] New test `TestDir_ReadPatterns_NestedPathIgnoreWithNegation` fails without fix, passes with fix
- [x] All existing `gitignore` tests pass: `go test ./plumbing/format/gitignore/... -v`
- [x] `go vet` and `gofmt` clean

Fixes #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)