### PR TITLE
[v5] plumbing: format/idxfile, Fix version and fanout checks

### DIFF
--- a/plumbing/format/idxfile/decoder.go
+++ b/plumbing/format/idxfile/decoder.go
@@ -91,8 +91,8 @@ func readVersion(idx *MemoryIndex, r io.Reader) error {
 		return err
 	}
 
-	if v > VersionSupported {
-		return ErrUnsupportedVersion
+	if v != VersionSupported {
+		return fmt.Errorf("%w: v%d", ErrUnsupportedVersion, v)
 	}
 
 	idx.Version = v
@@ -104,6 +104,10 @@ func readFanout(idx *MemoryIndex, r io.Reader) error {
 		n, err := binary.ReadUint32(r)
 		if err != nil {
 			return err
+		}
+
+		if k > 0 && n < idx.Fanout[k-1] {
+			return fmt.Errorf("%w: fanout table is not monotonically non-decreasing at entry %d", ErrMalformedIdxFile, k)
 		}
 
 		idx.Fanout[k] = n
@@ -155,7 +159,7 @@ func readCRC32(idx *MemoryIndex, r io.Reader) error {
 }
 
 func readOffsets(idx *MemoryIndex, r io.Reader) error {
-	var o64cnt int
+	var o64cnt int64
 	for k := 0; k < fanout; k++ {
 		if pos := idx.FanoutMapping[k]; pos != noMapping {
 			if _, err := io.ReadFull(r, idx.Offset32[pos]); err != nil {

--- a/plumbing/format/idxfile/decoder_test.go
+++ b/plumbing/format/idxfile/decoder_test.go
@@ -3,9 +3,9 @@ package idxfile_test
 import (
 	"bytes"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -137,28 +137,155 @@ func BenchmarkDecode(b *testing.B) {
 	}
 }
 
-func TestChecksumMismatch(t *testing.T) {
+func TestDecodeErrors(t *testing.T) {
 	t.Parallel()
 
-	f, err := os.CreateTemp(t.TempDir(), "temp.idx")
-	require.NoError(t, err)
-	defer f.Close()
-
-	_, err = io.Copy(f, fixtures.Basic().One().Idx())
+	idx := fixtures.Basic().One().Idx()
+	t.Cleanup(func() { idx.Close() })
+	validIdx, err := io.ReadAll(idx)
 	require.NoError(t, err)
 
-	_, err = f.Seek(-1, io.SeekEnd)
-	require.NoError(t, err)
+	tests := []struct {
+		name            string
+		input           func() []byte
+		wantErr         error
+		wantErrContains string
+	}{
+		{
+			name:    "empty input",
+			input:   func() []byte { return nil },
+			wantErr: io.EOF,
+		},
+		{
+			name:    "wrong magic",
+			input:   func() []byte { return []byte{0, 0, 0, 0, 0, 0, 0, 2} },
+			wantErr: ErrMalformedIdxFile,
+		},
+		{
+			name:    "truncated header",
+			input:   func() []byte { return []byte{255, 't'} },
+			wantErr: io.ErrUnexpectedEOF,
+		},
+		{
+			name: "unsupported version 1",
+			input: func() []byte {
+				var buf bytes.Buffer
+				buf.Write([]byte{255, 't', 'O', 'c'})
+				binary.Write(&buf, binary.BigEndian, uint32(1))
+				return buf.Bytes()
+			},
+			wantErr:         ErrUnsupportedVersion,
+			wantErrContains: "v1",
+		},
+		{
+			name: "unsupported version 3",
+			input: func() []byte {
+				var buf bytes.Buffer
+				buf.Write([]byte{255, 't', 'O', 'c'})
+				binary.Write(&buf, binary.BigEndian, uint32(3))
+				return buf.Bytes()
+			},
+			wantErr:         ErrUnsupportedVersion,
+			wantErrContains: "v3",
+		},
+		{
+			name: "truncated fanout table",
+			input: func() []byte {
+				buf := idxV2Header()
+				// Only 10 fanout entries instead of 256.
+				for range 10 {
+					buf = binary.BigEndian.AppendUint32(buf, 0)
+				}
+				return buf
+			},
+			wantErr: io.EOF,
+		},
+		{
+			name: "non-monotonic fanout at entry 1",
+			input: func() []byte {
+				buf := idxV2Header()
+				// entry[0]=5, entry[1]=3 (decrease), rest=5
+				buf = append(buf, writeFanout(5, map[int]uint32{0: 5, 1: 3})...)
+				return buf
+			},
+			wantErr:         ErrMalformedIdxFile,
+			wantErrContains: "not monotonically non-decreasing",
+		},
+		{
+			name: "non-monotonic fanout at last entry",
+			input: func() []byte {
+				buf := idxV2Header()
+				// all entries = 10, except entry[255] = 5
+				buf = append(buf, writeFanout(10, map[int]uint32{255: 5})...)
+				return buf
+			},
+			wantErr:         ErrMalformedIdxFile,
+			wantErrContains: "not monotonically non-decreasing",
+		},
+		{
+			name: "truncated object names",
+			input: func() []byte {
+				buf := idxV2Header()
+				// Fanout claims 1 object, but no name data follows.
+				buf = append(buf, writeFanout(1, nil)...)
+				return buf
+			},
+			wantErr: io.EOF,
+		},
+		{
+			name: "checksum mismatch",
+			input: func() []byte {
+				corrupted := make([]byte, len(validIdx))
+				copy(corrupted, validIdx)
+				// Flip the last byte of the idx checksum.
+				corrupted[len(corrupted)-1] ^= 0xff
+				return corrupted
+			},
+			wantErr:         ErrMalformedIdxFile,
+			wantErrContains: "checksum mismatch",
+		},
+	}
 
-	_, err = f.Write([]byte{0})
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err = f.Seek(0, io.SeekStart)
-	require.NoError(t, err)
+			idx := new(MemoryIndex)
+			d := NewDecoder(bytes.NewReader(tt.input()))
 
-	idx := new(MemoryIndex)
-	d := NewDecoder(f)
+			err := d.Decode(idx)
+			require.Error(t, err)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			}
+			if tt.wantErrContains != "" {
+				require.ErrorContains(t, err, tt.wantErrContains)
+			}
+		})
+	}
+}
 
-	err = d.Decode(idx)
-	require.ErrorContains(t, err, "checksum mismatch")
+// writeFanout writes a 256-entry fanout table where every entry is set to total,
+// except for overrides specified as index→value pairs applied afterwards.
+func writeFanout(total uint32, overrides map[int]uint32) []byte {
+	var buf bytes.Buffer
+	entries := [256]uint32{}
+	for i := range entries {
+		entries[i] = total
+	}
+	for k, v := range overrides {
+		entries[k] = v
+	}
+	for _, v := range entries {
+		binary.Write(&buf, binary.BigEndian, v)
+	}
+	return buf.Bytes()
+}
+
+// idxV2Header returns the 8-byte idx v2 header (magic + version).
+func idxV2Header() []byte {
+	var buf bytes.Buffer
+	buf.Write([]byte{255, 't', 'O', 'c'})
+	binary.Write(&buf, binary.BigEndian, uint32(2))
+	return buf.Bytes()
 }


### PR DESCRIPTION
Tightens idxfile decoding validation by enforcing strict version matching and detecting corrupted fanout tables.

Backport of #1936.