### PR TITLE
dotgit: skip writing pack files that already exist on disk

### DIFF
--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -140,50 +140,90 @@ func (w *PackWriter) clean() error {
 func (w *PackWriter) save() error {
 	base := w.fs.Join(objectsPath, packPath, fmt.Sprintf("pack-%s", w.checksum))
 
-	idx, err := w.fs.Create(fmt.Sprintf("%s.idx", base))
-	if err != nil {
-		return err
-	}
-
 	h := crypto.SHA1.New()
 	if w.checksum.Size() == crypto.SHA256.Size() {
 		h = crypto.SHA256.New()
 	}
 
-	if err := w.encodeIdx(idx, h); err != nil {
-		_ = idx.Close()
+	// Pack files are content addressable. Each file is checked
+	// individually — if it already exists on disk, skip creating it.
+	idxPath := fmt.Sprintf("%s.idx", base)
+	exists, err := fileExists(w.fs, idxPath)
+	if err != nil {
 		return err
 	}
-
-	if err := idx.Close(); err != nil {
-		return err
-	}
-	fixPermissions(w.fs, fmt.Sprintf("%s.idx", base))
-
-	if w.writeRev {
-		rev, err := w.fs.Create(fmt.Sprintf("%s.rev", base))
+	if !exists {
+		idx, err := w.fs.Create(idxPath)
 		if err != nil {
 			return err
 		}
 
-		if err := w.encodeRev(rev, h); err != nil {
-			_ = rev.Close()
+		if err := w.encodeIdx(idx, h); err != nil {
+			_ = idx.Close()
 			return err
 		}
 
-		if err := rev.Close(); err != nil {
+		if err := idx.Close(); err != nil {
 			return err
 		}
-		fixPermissions(w.fs, fmt.Sprintf("%s.rev", base))
+		fixPermissions(w.fs, idxPath)
+	}
+
+	if w.writeRev {
+		revPath := fmt.Sprintf("%s.rev", base)
+		exists, err := fileExists(w.fs, revPath)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			rev, err := w.fs.Create(revPath)
+			if err != nil {
+				return err
+			}
+
+			if err := w.encodeRev(rev, h); err != nil {
+				_ = rev.Close()
+				return err
+			}
+
+			if err := rev.Close(); err != nil {
+				return err
+			}
+			fixPermissions(w.fs, revPath)
+		}
 	}
 
 	packPath := fmt.Sprintf("%s.pack", base)
-	if err := w.fs.Rename(w.fw.Name(), packPath); err != nil {
+	exists, err = fileExists(w.fs, packPath)
+	if err != nil {
 		return err
 	}
-	fixPermissions(w.fs, packPath)
+	if !exists {
+		if err := w.fs.Rename(w.fw.Name(), packPath); err != nil {
+			return err
+		}
+		fixPermissions(w.fs, packPath)
+	} else {
+		// Pack already exists, clean up the temp file.
+		return w.clean()
+	}
 
 	return nil
+}
+
+// fileExists checks whether path already exists as a regular file.
+// It returns (true, nil) for an existing regular file, (false, nil) when the
+// path does not exist, and (false, err) if the path exists but is not a
+// regular file (e.g. a directory or symlink).
+func fileExists(fs billy.Filesystem, path string) (bool, error) {
+	fi, err := fs.Lstat(path)
+	if err != nil {
+		return false, nil
+	}
+	if !fi.Mode().IsRegular() {
+		return false, fmt.Errorf("unexpected file type for %q: %s", path, fi.Mode().Type())
+	}
+	return true, nil
 }
 
 func (w *PackWriter) encodeIdx(writer io.Writer, h hash.Hash) error {
@@ -330,7 +370,7 @@ func (w *ObjectWriter) save() error {
 	// Loose objects are content addressable, if they already exist
 	// we can safely delete the temporary file and short-circuit the
 	// operation.
-	if _, err := w.fs.Stat(file); err == nil {
+	if _, err := w.fs.Lstat(file); err == nil {
 		return w.fs.Remove(w.f.Name())
 	}
 

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -205,6 +205,121 @@ func TestPackWriterPermissions(t *testing.T) {
 	}
 }
 
+func TestPackWriterExistingReadOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		fs       billy.Filesystem
+		writeRev bool
+	}{
+		{"BoundOS", osfs.New(t.TempDir(), osfs.WithBoundOS()), false},
+		{"ChrootOS", osfs.New(t.TempDir(), osfs.WithChrootOS()), false},
+		{"BoundOS_Rev", osfs.New(t.TempDir(), osfs.WithBoundOS()), true},
+		{"ChrootOS_Rev", osfs.New(t.TempDir(), osfs.WithChrootOS()), true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := fixtures.Basic().One()
+
+			dot := New(tc.fs)
+			dot.options.WriteReverseIndex = tc.writeRev
+			require.NoError(t, dot.Initialize())
+
+			pfPath := filepath.Join("objects", "pack", fmt.Sprintf("pack-%s.pack", f.PackfileHash))
+			idxPath := filepath.Join("objects", "pack", fmt.Sprintf("pack-%s.idx", f.PackfileHash))
+			revPath := filepath.Join("objects", "pack", fmt.Sprintf("pack-%s.rev", f.PackfileHash))
+
+			writePack := func() {
+				t.Helper()
+				w, err := dot.NewObjectPack()
+				require.NoError(t, err)
+
+				_, err = io.Copy(w, f.Packfile())
+				require.NoError(t, err)
+				require.NoError(t, w.Close())
+			}
+
+			writePack()
+
+			ro, err := isReadOnly(tc.fs, pfPath)
+			require.NoError(t, err)
+			assert.True(t, ro, "file %q is not read-only", pfPath)
+
+			ro, err = isReadOnly(tc.fs, idxPath)
+			require.NoError(t, err)
+			assert.True(t, ro, "file %q is not read-only", idxPath)
+
+			if tc.writeRev {
+				ro, err = isReadOnly(tc.fs, revPath)
+				require.NoError(t, err)
+				assert.True(t, ro, "file %q is not read-only", revPath)
+			}
+
+			// Writing the same pack again must not fail on read-only files.
+			writePack()
+
+			// Remove .idx only, keep .pack — the next write must
+			// recreate .idx without touching the existing .pack.
+			require.NoError(t, tc.fs.Remove(idxPath))
+			writePack()
+
+			_, err = tc.fs.Lstat(idxPath)
+			require.NoError(t, err, ".idx should have been recreated")
+
+			ro, err = isReadOnly(tc.fs, idxPath)
+			require.NoError(t, err)
+			assert.True(t, ro, "recreated %q is not read-only", idxPath)
+
+			if tc.writeRev {
+				// Remove .rev only — the next write must recreate it.
+				require.NoError(t, tc.fs.Remove(revPath))
+				writePack()
+
+				_, err = tc.fs.Lstat(revPath)
+				require.NoError(t, err, ".rev should have been recreated")
+
+				ro, err = isReadOnly(tc.fs, revPath)
+				require.NoError(t, err)
+				assert.True(t, ro, "recreated %q is not read-only", revPath)
+			}
+		})
+	}
+}
+
+func TestPackWriterRejectsNonRegularFile(t *testing.T) {
+	t.Parallel()
+
+	for _, ext := range []string{".idx", ".pack", ".rev"} {
+		t.Run(ext, func(t *testing.T) {
+			t.Parallel()
+
+			f := fixtures.Basic().One()
+			fs := osfs.New(t.TempDir(), osfs.WithBoundOS())
+
+			dot := New(fs)
+			dot.options.WriteReverseIndex = (ext == ".rev")
+			require.NoError(t, dot.Initialize())
+
+			// Place a directory where the pack file should go.
+			path := filepath.Join("objects", "pack",
+				fmt.Sprintf("pack-%s%s", f.PackfileHash, ext))
+			require.NoError(t, fs.MkdirAll(path, 0o755))
+
+			w, err := dot.NewObjectPack()
+			require.NoError(t, err)
+
+			_, err = io.Copy(w, f.Packfile())
+			require.NoError(t, err)
+
+			err = w.Close()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unexpected file type")
+		})
+	}
+}
+
 func TestObjectWriterPermissions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
PackWriter.save() used fs.Create() unconditionally for .idx, .pack and .rev files. After the first write, fixPermissions() sets these to read-only (0o444), so a subsequent fetch/pull producing the same pack hash would fail with "permission denied" when Create() tried to truncate the existing read-only file.

Each file (.idx, .pack, .rev) is now checked individually with Lstat before creation — if it already exists on disk, the write is skipped. A new fileExists() helper validates that any existing path is a regular file, returning an error for unexpected types (directories, symlinks). This mirrors the existing pattern in ObjectWriter.save() for loose objects.

Also switches ObjectWriter.save() from Stat to Lstat for consistency.

Relates to #1942.