### PR TITLE
git: worktree, fix Add silently failing for absolute paths

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -408,6 +409,17 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 	}
 
 	path = filepath.Clean(path)
+	if filepath.IsAbs(path) {
+		root := w.Filesystem.Root()
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return plumbing.ZeroHash, fmt.Errorf("path %q is not inside the worktree root %q: %w", path, root, err)
+		}
+		if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+			return plumbing.ZeroHash, fmt.Errorf("path %q is outside the worktree root %q", path, root)
+		}
+		path = relPath
+	}
 
 	if err != nil || !fi.IsDir() {
 		added, h, err = w.doAddFile(idx, s, path, ignorePattern)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2283,6 +2283,39 @@ func (s *WorktreeSuite) TestAddUntracked() {
 	s.Equal(int64(3), obj.Size())
 }
 
+func (s *WorktreeSuite) TestAddAbsolutePath() {
+	dir := s.T().TempDir()
+
+	r, err := PlainInit(dir, false)
+	s.NoError(err)
+
+	w, err := r.Worktree()
+	s.NoError(err)
+
+	err = util.WriteFile(w.Filesystem, "foo.txt", []byte("FOO"), 0o644)
+	s.NoError(err)
+
+	absPath := filepath.Join(dir, "foo.txt")
+	_, err = w.Add(absPath)
+	s.NoError(err)
+
+	idx, err := w.r.Storer.Index()
+	s.NoError(err)
+
+	_, err = idx.Entry("foo.txt")
+	s.NoError(err)
+
+	_, err = idx.Entry(absPath)
+	s.Error(err)
+
+	status, err := w.Status()
+	s.NoError(err)
+
+	file := status.File("foo.txt")
+	s.Equal(Added, file.Staging)
+	s.Equal(Unmodified, file.Worktree)
+}
+
 func (s *WorktreeSuite) TestAddCRLF() {
 	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
 		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())


### PR DESCRIPTION
#### Description

`Worktree.Add()` silently fails when given an absolute path. No error is returned, but the file is not added to the index because the index stores relative paths.

The fix converts absolute paths to worktree-relative paths using `filepath.Rel()` before updating the index. If the path is outside the worktree root, an error is returned.

#### Link to tracking issue
Fixes #1460

#### Testing

Added `TestAddAbsolutePath` which:
1. Creates a repo with a real filesystem
2. Writes a file
3. Calls `w.Add()` with the absolute path
4. Verifies the index contains the relative path
5. Verifies status shows the file as staged

`go test ./...` and `go vet ./...` pass.

#### Documentation

N/A - behavior now matches `git add /absolute/path`.

This contribution was developed with AI assistance (Codex).