### PR TITLE
git: worktree, fix RemoveGlob not removing directories

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -743,6 +743,14 @@ func (w *Worktree) RemoveGlob(pattern string) error {
 	if err != nil {
 		return err
 	}
+	if len(entries) == 0 {
+		prefix := filepath.ToSlash(filepath.Clean(pattern)) + "/"
+		for _, e := range idx.Entries {
+			if strings.HasPrefix(e.Name, prefix) {
+				entries = append(entries, e)
+			}
+		}
+	}
 
 	for _, e := range entries {
 		file := filepath.FromSlash(e.Name)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -3060,6 +3060,29 @@ func (s *WorktreeSuite) TestRemoveGlobDirectory() {
 	s.True(os.IsNotExist(err))
 }
 
+func (s *WorktreeSuite) TestRemoveGlobExactDirectory() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	err := w.Checkout(&CheckoutOptions{Force: true})
+	s.NoError(err)
+
+	err = w.RemoveGlob("json")
+	s.NoError(err)
+
+	status, err := w.Status()
+	s.NoError(err)
+	s.Len(status, 2)
+	s.Equal(Deleted, status.File("json/short.json").Staging)
+	s.Equal(Deleted, status.File("json/long.json").Staging)
+
+	_, err = w.Filesystem.Stat("json")
+	s.True(os.IsNotExist(err))
+}
+
 func (s *WorktreeSuite) TestRemoveGlobDirectoryDeleted() {
 	fs := memfs.New()
 	w := &Worktree{


### PR DESCRIPTION
#### Description

`RemoveGlob("dirname")` has no effect when the pattern is an exact directory path. `RemoveGlob("dir*")` works because the glob matches directory contents, but the exact name doesn't expand.

The fix falls back to prefix matching when `idx.Glob(pattern)` returns no entries: it checks if any index entries have `pattern + "/"` as a prefix, collecting all files under that directory.

This matches `git rm -r dirname` behavior.

#### Link to tracking issue
Fixes #1190

#### Testing

Added `TestRemoveGlobExactDirectory` which calls `RemoveGlob("json")` on a directory and verifies all files under it are staged for deletion.

`go test ./...` and `go vet ./...` pass.

#### Documentation

N/A

This contribution was developed with AI assistance (Codex).