### PR TITLE
git: repository, fix DeleteBranch failing with full ref name

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -860,6 +860,8 @@ func (r *Repository) CreateBranch(c *config.Branch) error {
 
 // DeleteBranch delete a Branch from the repository and delete the config
 func (r *Repository) DeleteBranch(name string) error {
+	name = strings.TrimPrefix(name, "refs/heads/")
+
 	cfg, err := r.Config()
 	if err != nil {
 		return err

--- a/repository_test.go
+++ b/repository_test.go
@@ -1190,6 +1190,24 @@ func (s *RepositorySuite) TestDeleteBranch() {
 	s.ErrorIs(err, ErrBranchNotFound)
 }
 
+func (s *RepositorySuite) TestDeleteBranchFullRefName() {
+	r, _ := Init(memory.NewStorage())
+	testBranch := &config.Branch{
+		Name:   "foo",
+		Remote: "origin",
+		Merge:  "refs/heads/foo",
+	}
+	err := r.CreateBranch(testBranch)
+	s.NoError(err)
+
+	err = r.DeleteBranch("refs/heads/foo")
+	s.NoError(err)
+
+	b, err := r.Branch("foo")
+	s.ErrorIs(err, ErrBranchNotFound)
+	s.Nil(b)
+}
+
 func (s *RepositorySuite) TestPlainInitAlreadyExists() {
 	dir := s.T().TempDir()
 	r, err := PlainInit(dir, true)


### PR DESCRIPTION
#### Description

`DeleteBranch("refs/heads/test")` returns `ErrBranchNotFound` even when the branch exists. This happens because `Branches()` returns full reference names but `DeleteBranch()` looks up `cfg.Branches` by short name only.

The fix strips the `refs/heads/` prefix before the config lookup, so both `DeleteBranch("test")` and `DeleteBranch("refs/heads/test")` work. This matches `git branch -d` which accepts both forms.

#### Link to tracking issue
Fixes #1189

#### Testing

Added `TestDeleteBranchFullRefName` which creates a branch and deletes it using the full `refs/heads/` name.

`go test ./...` and `go vet ./...` pass.

#### Documentation

N/A

This contribution was developed with AI assistance (Codex).