### PR TITLE
internal: revision, fix resolution for tags containing @ and /

### DIFF
--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -565,6 +565,10 @@ func (p *Parser) parseRef() (Revisioner, error) {
 
 		if endOfRef {
 			p.unscan()
+			if buf == "@" {
+				return Ref("HEAD"), nil
+			}
+
 			return Ref(buf), nil
 		}
 

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -177,6 +177,13 @@ func (s *ParserSuite) TestParseWithValidExpression() {
 			CaretPath{1},
 			CaretPath{1},
 		},
+		"@scope/package@v1.0.1": []Revisioner{
+			Ref("@scope/package@v1.0.1"),
+		},
+		"@scope/package@v1.0.1~1": []Revisioner{
+			Ref("@scope/package@v1.0.1"),
+			TildePath{1},
+		},
 	}
 
 	for d, expected := range datas {

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -88,7 +88,24 @@ func (s *scanner) scan() (token, string, error) {
 	case '-':
 		return minus, string(ch), nil
 	case '@':
-		return at, string(ch), nil
+		next, _, err := s.r.ReadRune()
+		if err == io.EOF || next == zeroRune {
+			return at, string(ch), nil
+		}
+
+		if err != nil {
+			return tokenError, "", err
+		}
+
+		if err := s.r.UnreadRune(); err != nil {
+			return tokenError, "", err
+		}
+
+		if next == '{' {
+			return at, string(ch), nil
+		}
+
+		return word, string(ch), nil
 	case '\\':
 		return aslash, string(ch), nil
 	case '?':

--- a/internal/revision/scanner_test.go
+++ b/internal/revision/scanner_test.go
@@ -133,6 +133,24 @@ func (s *ScannerSuite) TestReadAt() {
 	s.Equal(at, tok)
 }
 
+func (s *ScannerSuite) TestReadAtBeforeBrace() {
+	scanner := newScanner(bytes.NewBufferString("@{1}"))
+	tok, data, err := scanner.scan()
+
+	s.NoError(err)
+	s.Equal("@", data)
+	s.Equal(at, tok)
+}
+
+func (s *ScannerSuite) TestReadAtAsWord() {
+	scanner := newScanner(bytes.NewBufferString("@scope"))
+	tok, data, err := scanner.scan()
+
+	s.NoError(err)
+	s.Equal("@", data)
+	s.Equal(word, tok)
+}
+
 func (s *ScannerSuite) TestReadAntislash() {
 	scanner := newScanner(bytes.NewBufferString("\\"))
 	tok, data, err := scanner.scan()


### PR DESCRIPTION
The revision scanner unconditionally tokenized `@` as an `at` operator token, which broke tag names like `@scope/package@v1.0.1`. The parser then interpreted the leading `@` as a reflog operator and failed to resolve the reference.

Now `@` is only emitted as an operator token when followed by `{` (reflog syntax like `@{1}`, `@{upstream}`). Otherwise it's treated as part of the reference name. The parser maps a standalone `@` ref to HEAD to preserve the git shorthand (`@` = `HEAD`).

### Changes

- `internal/revision/scanner.go`: peek at the next character after `@`. Emit `at` token only for `@{`, otherwise emit `word` so the `@` is included in the ref name.
- `internal/revision/parser.go`: map a parsed ref of exactly `"@"` to `Ref("HEAD")` to preserve the `@` shorthand.
- Tests added for `@scope/package@v1.0.1`, `@scope/package@v1.0.1~1`, and scanner tokenization of `@{1}` vs `@scope`.

Fixes #1612

This contribution was developed with AI assistance (Codex).