### PR TITLE
plumbing: handle @ symbol in tag names

### DIFF
--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -147,8 +147,17 @@ func (p *Parser) Parse() ([]Revisioner, error) {
 		}
 
 		switch tok {
-		case at:
+	case at:
+		// Check if @ starts an @{...} statement
+		peekTok, _, _ := p.s.scan()
+		p.unscan()
+		if peekTok == obrace {
 			rev, err = p.parseAt()
+		} else {
+			// @ is part of reference name, not special syntax
+			p.unscan()
+			rev, err = p.parseRef()
+		}
 		case tilde:
 			rev, err = p.parseTilde()
 		case caret:


### PR DESCRIPTION
Tag names containing @ characters were being incorrectly interpreted as
branch@commit references.

Fix adds single character lookahead when @ character is encountered.
Only if next character is { we treat it as special @{} syntax, otherwise
we treat @ as normal character in reference name.

Fixes #1612
