### PR TITLE
Clean up empty parent dirs when removing a loose reference

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -804,6 +804,9 @@ func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
 	_, err := d.fs.Stat(path)
 	if err == nil {
 		err = d.fs.Remove(path)
+		if err == nil {
+			d.cleanUpEmptyRefDirs(path)
+		}
 		// Drop down to remove it from the packed refs file, too.
 	}
 
@@ -812,6 +815,25 @@ func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
 	}
 
 	return d.rewritePackedRefsWithoutRef(name)
+}
+
+// cleanUpEmptyRefDirs removes empty parent directories left behind after
+// deleting a loose reference file. It walks up from the deleted file's
+// parent toward the repository root, stopping as soon as a directory is
+// non-empty or at the root level. Errors are silently ignored since
+// leftover empty directories are harmless.
+func (d *DotGit) cleanUpEmptyRefDirs(refPath string) {
+	dir := filepath.Dir(refPath)
+	for dir != "." && dir != string(filepath.Separator) {
+		entries, err := d.fs.ReadDir(dir)
+		if err != nil || len(entries) > 0 {
+			break
+		}
+		if err := d.fs.Remove(dir); err != nil {
+			break
+		}
+		dir = filepath.Dir(dir)
+	}
 }
 
 func refsRecvFunc(refs *[]*plumbing.Reference, seen map[plumbing.ReferenceName]bool) refsRecv {


### PR DESCRIPTION
When a reference like `refs/heads/bugfix/issue-1` is deleted via `RemoveRef`, the parent directory `refs/heads/bugfix/` is left behind. This prevents creating a new reference named `refs/heads/bugfix` because the directory conflicts with the file path.

After removing a loose reference file, `RemoveRef` now walks up the directory tree and removes any empty parent directories, stopping as soon as a non-empty directory is found. This matches the behavior of the git CLI. Errors during cleanup are silently ignored since leftover empty directories are harmless.

Fixes #1822