### PR TITLE
Add promisor remote and on-demand object fetch for partial clone

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -184,6 +184,12 @@ type Config struct {
 		// When true, each worktree may have a config.worktree file that
 		// overrides settings in the common .git/config.
 		WorktreeConfig bool
+		// PartialClone holds the name of the promisor remote when the
+		// repository was created with a partial clone. This is a legacy
+		// config key (extensions.partialClone); modern Git uses
+		// remote.<name>.promisor instead. This field is read for backward
+		// compatibility but not written by new partial clones.
+		PartialClone string
 	}
 
 	Protocol struct {
@@ -473,7 +479,10 @@ const (
 	repositoryFormatVersionKey = "repositoryformatversion"
 	objectFormatKey            = "objectformat"
 	worktreeConfigKey          = "worktreeConfig"
+	partialCloneKey            = "partialClone"
 	mirrorKey                  = "mirror"
+	promisorKey                = "promisor"
+	partialCloneFilterKey      = "partialCloneFilter"
 	versionKey                 = "version"
 	autoCRLFKey                = "autocrlf"
 	fileModeKey                = "filemode"
@@ -566,6 +575,7 @@ func (c *Config) unmarshalExtensions() {
 	s := c.Raw.Section(extensionsSection)
 	c.Extensions.ObjectFormat = format.ObjectFormat(s.Options.Get(objectFormatKey))
 	c.Extensions.WorktreeConfig = strings.EqualFold(s.Options.Get(worktreeConfigKey), "true")
+	c.Extensions.PartialClone = s.Options.Get(partialCloneKey)
 }
 
 func (c *Config) unmarshalTag() {
@@ -819,7 +829,8 @@ func (c *Config) marshalExtensions() {
 	// Only marshal the [extensions] section if there are extension options to write.
 	// This avoids introducing an empty [extensions] section on round-trips.
 	if c.Extensions.ObjectFormat == format.UnsetObjectFormat &&
-		!c.Extensions.WorktreeConfig {
+		!c.Extensions.WorktreeConfig &&
+		c.Extensions.PartialClone == "" {
 		return
 	}
 
@@ -830,6 +841,10 @@ func (c *Config) marshalExtensions() {
 
 	if c.Extensions.WorktreeConfig {
 		s.SetOption(worktreeConfigKey, "true")
+	}
+
+	if c.Extensions.PartialClone != "" {
+		s.SetOption(partialCloneKey, c.Extensions.PartialClone)
 	}
 }
 
@@ -1036,6 +1051,13 @@ type RemoteConfig struct {
 	// Fetch the default set of "refspec" for fetch operation
 	Fetch []RefSpec
 
+	// Promisor indicates this remote is a promisor remote that can
+	// supply missing objects on demand for partial clone repositories.
+	Promisor bool
+	// PartialCloneFilter holds the filter-spec used when the partial
+	// clone was created (e.g. "blob:none", "blob:limit=1m").
+	PartialCloneFilter string
+
 	// raw representation of the subsection, filled by marshal or unmarshal are
 	// called
 	raw *format.Subsection
@@ -1082,6 +1104,8 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 	c.URLs = append(c.URLs, c.raw.Options.GetAll(pushurlKey)...)
 	c.Fetch = fetch
 	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
+	c.Promisor = c.raw.Options.Get(promisorKey) == "true"
+	c.PartialCloneFilter = c.raw.Options.Get(partialCloneFilterKey)
 
 	return nil
 }
@@ -1116,6 +1140,18 @@ func (c *RemoteConfig) marshal() *format.Subsection {
 
 	if c.Mirror {
 		c.raw.SetOption(mirrorKey, strconv.FormatBool(c.Mirror))
+	}
+
+	if c.Promisor {
+		c.raw.SetOption(promisorKey, "true")
+	} else {
+		c.raw.RemoveOption(promisorKey)
+	}
+
+	if c.PartialCloneFilter != "" {
+		c.raw.SetOption(partialCloneFilterKey, c.PartialCloneFilter)
+	} else {
+		c.raw.RemoveOption(partialCloneFilterKey)
 	}
 
 	return c.raw

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -321,6 +321,133 @@ func TestMarshalExtensions(t *testing.T) {
 	}
 }
 
+func TestMarshalExtensionsPartialClone(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PartialClone writes section when V1", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewConfig()
+		cfg.Core.RepositoryFormatVersion = config.Version1
+		cfg.Extensions.PartialClone = "origin"
+
+		out, err := cfg.Marshal()
+		require.NoError(t, err)
+
+		s := string(out)
+		assert.Contains(t, s, "[extensions]")
+		assert.Contains(t, s, "partialClone = origin")
+	})
+
+	t.Run("PartialClone ignored when V0", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewConfig()
+		cfg.Core.RepositoryFormatVersion = config.Version0
+		cfg.Extensions.PartialClone = "origin"
+
+		out, err := cfg.Marshal()
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "[extensions]")
+	})
+
+	t.Run("PartialClone round-trips", func(t *testing.T) {
+		t.Parallel()
+		input := []byte(`[core]
+	repositoryformatversion = 1
+[extensions]
+	partialClone = origin
+`)
+		cfg := NewConfig()
+		err := cfg.Unmarshal(input)
+		require.NoError(t, err)
+		assert.Equal(t, "origin", cfg.Extensions.PartialClone)
+
+		out, err := cfg.Marshal()
+		require.NoError(t, err)
+		assert.Contains(t, string(out), "partialClone = origin")
+	})
+}
+
+func TestRemoteConfigPromisor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unmarshal promisor and partialclonefilter", func(t *testing.T) {
+		t.Parallel()
+		input := []byte(`[remote "origin"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	promisor = true
+	partialclonefilter = blob:none
+`)
+		cfg := NewConfig()
+		err := cfg.Unmarshal(input)
+		require.NoError(t, err)
+
+		remote := cfg.Remotes["origin"]
+		require.NotNil(t, remote)
+		assert.True(t, remote.Promisor)
+		assert.Equal(t, "blob:none", remote.PartialCloneFilter)
+	})
+
+	t.Run("marshal promisor and partialclonefilter", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewConfig()
+		cfg.Remotes["origin"] = &RemoteConfig{
+			Name:               "origin",
+			URLs:               []string{"https://github.com/go-git/go-git.git"},
+			Promisor:           true,
+			PartialCloneFilter: "blob:none",
+		}
+
+		out, err := cfg.Marshal()
+		require.NoError(t, err)
+
+		s := string(out)
+		assert.Contains(t, s, "promisor = true")
+		assert.Contains(t, s, "partialCloneFilter = blob:none")
+	})
+
+	t.Run("round-trip preserves promisor fields", func(t *testing.T) {
+		t.Parallel()
+		input := []byte(`[core]
+	repositoryformatversion = 1
+[remote "origin"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	promisor = true
+	partialclonefilter = blob:none
+`)
+		cfg := NewConfig()
+		err := cfg.Unmarshal(input)
+		require.NoError(t, err)
+
+		out, err := cfg.Marshal()
+		require.NoError(t, err)
+
+		cfg2 := NewConfig()
+		err = cfg2.Unmarshal(out)
+		require.NoError(t, err)
+
+		remote := cfg2.Remotes["origin"]
+		require.NotNil(t, remote)
+		assert.True(t, remote.Promisor)
+		assert.Equal(t, "blob:none", remote.PartialCloneFilter)
+	})
+
+	t.Run("promisor false is not written", func(t *testing.T) {
+		t.Parallel()
+		cfg := NewConfig()
+		cfg.Remotes["origin"] = &RemoteConfig{
+			Name: "origin",
+			URLs: []string{"https://github.com/go-git/go-git.git"},
+		}
+
+		out, err := cfg.Marshal()
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "promisor")
+		assert.NotContains(t, string(out), "partialclonefilter")
+	})
+}
+
 func (s *ConfigSuite) TestLoadConfigXDG() {
 	cfg := NewConfig()
 	cfg.User.Name = "foo"
@@ -808,6 +935,7 @@ func TestMerge(t *testing.T) {
 					Extensions: struct {
 						ObjectFormat   config.ObjectFormat
 						WorktreeConfig bool
+						PartialClone   string
 					}{
 						ObjectFormat:   config.SHA256,
 						WorktreeConfig: true,
@@ -822,6 +950,7 @@ func TestMerge(t *testing.T) {
 				Extensions: struct {
 					ObjectFormat   config.ObjectFormat
 					WorktreeConfig bool
+					PartialClone   string
 				}{
 					ObjectFormat:   config.SHA256,
 					WorktreeConfig: true,

--- a/options.go
+++ b/options.go
@@ -818,6 +818,20 @@ type PlainOpenOptions struct {
 // Validate validates the fields and sets the default values.
 func (o *PlainOpenOptions) Validate() error { return nil }
 
+// OpenOptions describes how opening a repository should be performed.
+type OpenOptions struct {
+	// ClientOptions are forwarded to the transport when the opened
+	// repository is a partial clone (promisor remote) and performs
+	// on-demand object fetches. Operations such as BlobObject, Checkout,
+	// and Reset can trigger lazy fetches without an options struct of
+	// their own, so without this hook there is no way to supply
+	// authentication or TLS settings for those fetches after Open.
+	ClientOptions []client.Option
+}
+
+// Validate validates the fields and sets the default values.
+func (o *OpenOptions) Validate() error { return nil }
+
 // ErrNoRestorePaths is returned when no paths are specified to restore.
 var ErrNoRestorePaths = errors.New("you must specify path(s) to restore")
 

--- a/promisor.go
+++ b/promisor.go
@@ -1,0 +1,455 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/client"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+// objectFetcher is the interface for fetching missing objects on demand.
+type objectFetcher interface {
+	FetchObjects(ctx context.Context, hashes []plumbing.Hash) error
+}
+
+// promiserStorer wraps a storage.Storer and intercepts object lookups.
+// When an object is not found in the inner storer (ErrObjectNotFound),
+// it attempts to fetch the missing object from a promisor remote before
+// returning the error. This enables partial clone (--filter) support.
+//
+// Only EncodedObject, HasEncodedObject, and EncodedObjectSize are
+// overridden. All other Storer methods delegate to the inner storer
+// via embedding. Optional interfaces that both filesystem.Storage and
+// memory.Storage implement (PackedObjectStorer, LooseObjectStorer,
+// io.Closer) are delegated unconditionally. PackfileWriter is delegated
+// conditionally via promiserStorerPW because not all storers implement it.
+type promiserStorer struct {
+	storage.Storer // delegate all other methods to the inner storer
+
+	fetcher objectFetcher
+	mu      sync.Mutex
+}
+
+// promiserStorerPW extends promiserStorer with PackfileWriter delegation.
+// It is returned by newPromiserStorer when the inner storer implements
+// storer.PackfileWriter (e.g. filesystem.Storage).
+type promiserStorerPW struct {
+	*promiserStorer
+	pw storer.PackfileWriter
+}
+
+// PackfileWriter delegates to the inner storer's PackfileWriter.
+func (s *promiserStorerPW) PackfileWriter() (io.WriteCloser, error) {
+	return s.pw.PackfileWriter()
+}
+
+// newPromiserStorer wraps inner with on-demand object fetching via fetcher.
+// If inner implements storer.PackfileWriter, the returned storer also
+// implements it (via promiserStorerPW).
+func newPromiserStorer(inner storage.Storer, fetcher objectFetcher) storage.Storer {
+	ps := &promiserStorer{
+		Storer:  inner,
+		fetcher: fetcher,
+	}
+
+	if pw, ok := inner.(storer.PackfileWriter); ok {
+		return &promiserStorerPW{promiserStorer: ps, pw: pw}
+	}
+	return ps
+}
+
+// setClientOptions updates the transport options used for future lazy fetches.
+// This lets operations such as Pull/Fetch provide credentials for subsequent
+// checkout-triggered on-demand fetches on an already-opened partial clone.
+func (s *promiserStorer) setClientOptions(opts []client.Option) {
+	if f, ok := s.fetcher.(*promiserObjectFetcher); ok {
+		f.setClientOptions(opts)
+	}
+}
+
+// getPromiserStorer extracts the *promiserStorer from a storage.Storer,
+// handling both promiserStorer and promiserStorerPW.
+func getPromiserStorer(s storage.Storer) (*promiserStorer, bool) {
+	switch v := s.(type) {
+	case *promiserStorer:
+		return v, true
+	case *promiserStorerPW:
+		return v.promiserStorer, true
+	}
+	return nil, false
+}
+
+// unwrapPromiserStorer returns the inner storer for code paths that must only
+// inspect local objects and must not trigger on-demand promisor fetches.
+func unwrapPromiserStorer(s storage.Storer) storage.Storer {
+	if ps, ok := getPromiserStorer(s); ok {
+		return ps.Storer
+	}
+	return s
+}
+
+// EncodedObject returns an object from the storer. If a normal Git object is
+// not found locally, an on-demand fetch from the promisor remote is attempted.
+// When the lazy fetch itself fails, the network error is returned wrapped so
+// that callers can distinguish it from a true "object missing locally" miss
+// (plumbing.ErrObjectNotFound). Callers that need to special-case "missing"
+// should keep using errors.Is(err, plumbing.ErrObjectNotFound).
+func (s *promiserStorer) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	obj, err := s.Storer.EncodedObject(t, h)
+	if err != nil && isObjectNotFound(err) && shouldFetch(t) {
+		if fetchErr := s.fetchObject(h); fetchErr != nil {
+			return nil, fmt.Errorf("promisor on-demand fetch %s: %w", h, fetchErr)
+		}
+		return s.Storer.EncodedObject(t, h)
+	}
+	return obj, err
+}
+
+// HasEncodedObject reports whether the object is present locally. It does NOT
+// trigger an on-demand fetch from the promisor remote: callers use this as a
+// cheap existence check (e.g. revwalk, pack negotiation, batch prefetch) and
+// would suffer pathological per-call network round-trips otherwise. Use
+// EncodedObject (or EncodedObjectSize) when the goal is "give me the object,
+// fetching if needed".
+func (s *promiserStorer) HasEncodedObject(h plumbing.Hash) error {
+	return s.Storer.HasEncodedObject(h)
+}
+
+// EncodedObjectSize returns the size of an object. If not found locally, an
+// on-demand fetch from the promisor remote is attempted; on fetch failure the
+// network error is returned wrapped (not joined with ErrObjectNotFound) so the
+// two conditions remain distinguishable.
+func (s *promiserStorer) EncodedObjectSize(h plumbing.Hash) (int64, error) {
+	sz, err := s.Storer.EncodedObjectSize(h)
+	if err != nil && isObjectNotFound(err) {
+		if fetchErr := s.fetchObject(h); fetchErr != nil {
+			return 0, fmt.Errorf("promisor on-demand fetch %s: %w", h, fetchErr)
+		}
+		return s.Storer.EncodedObjectSize(h)
+	}
+	return sz, err
+}
+
+// fetchObjects fetches missing objects from the promisor remote. Access is
+// serialized to avoid duplicate concurrent fetches and overlapping pack writes.
+func (s *promiserStorer) fetchObjects(ctx context.Context, hashes []plumbing.Hash) error {
+	if len(hashes) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	missing := make([]plumbing.Hash, 0, len(hashes))
+	seen := make(map[plumbing.Hash]struct{}, len(hashes))
+	for _, h := range hashes {
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+
+		err := s.Storer.HasEncodedObject(h)
+		if err == nil {
+			continue
+		}
+		if !isObjectNotFound(err) {
+			return err
+		}
+
+		missing = append(missing, h)
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	return s.fetcher.FetchObjects(ctx, missing)
+}
+
+// fetchObject fetches a single object from the promisor remote.
+func (s *promiserStorer) fetchObject(h plumbing.Hash) error {
+	return s.fetchObjects(context.Background(), []plumbing.Hash{h})
+}
+
+// Close delegates to the inner storer's Close if it implements io.Closer.
+func (s *promiserStorer) Close() error {
+	if c, ok := s.Storer.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// ObjectPacks delegates to the inner storer's PackedObjectStorer.
+func (s *promiserStorer) ObjectPacks() ([]plumbing.Hash, error) {
+	if pos, ok := s.Storer.(storer.PackedObjectStorer); ok {
+		return pos.ObjectPacks()
+	}
+	return nil, plumbing.ErrObjectNotFound
+}
+
+// DeleteOldObjectPackAndIndex delegates to the inner storer's PackedObjectStorer.
+func (s *promiserStorer) DeleteOldObjectPackAndIndex(h plumbing.Hash, t time.Time) error {
+	if pos, ok := s.Storer.(storer.PackedObjectStorer); ok {
+		return pos.DeleteOldObjectPackAndIndex(h, t)
+	}
+	return transport.ErrPackedObjectsNotSupported
+}
+
+// ForEachObjectHash delegates to the inner storer's LooseObjectStorer.
+func (s *promiserStorer) ForEachObjectHash(f func(plumbing.Hash) error) error {
+	if los, ok := s.Storer.(storer.LooseObjectStorer); ok {
+		return los.ForEachObjectHash(f)
+	}
+	return ErrLooseObjectsNotSupported
+}
+
+// LooseObjectTime delegates to the inner storer's LooseObjectStorer.
+func (s *promiserStorer) LooseObjectTime(h plumbing.Hash) (time.Time, error) {
+	if los, ok := s.Storer.(storer.LooseObjectStorer); ok {
+		return los.LooseObjectTime(h)
+	}
+	return time.Time{}, plumbing.ErrObjectNotFound
+}
+
+// DeleteLooseObject delegates to the inner storer's LooseObjectStorer.
+func (s *promiserStorer) DeleteLooseObject(h plumbing.Hash) error {
+	if los, ok := s.Storer.(storer.LooseObjectStorer); ok {
+		return los.DeleteLooseObject(h)
+	}
+	return ErrLooseObjectsNotSupported
+}
+
+// promiserObjectFetcher fetches missing objects from a promisor remote.
+// It uses the inner storer directly (not the promiserStorer wrapper) to
+// avoid infinite recursion when writing received packfiles.
+type promiserObjectFetcher struct {
+	remoteName      string
+	inner           storage.Storer // unwrapped storer for writing fetched objects
+	clientOptionsMu sync.RWMutex
+	clientOptions   []client.Option // transport options for on-demand fetch
+}
+
+func (f *promiserObjectFetcher) setClientOptions(opts []client.Option) {
+	f.clientOptionsMu.Lock()
+	defer f.clientOptionsMu.Unlock()
+	f.clientOptions = append([]client.Option(nil), opts...)
+}
+
+func (f *promiserObjectFetcher) clientOptionsSnapshot() []client.Option {
+	f.clientOptionsMu.RLock()
+	defer f.clientOptionsMu.RUnlock()
+	return append([]client.Option(nil), f.clientOptions...)
+}
+
+// FetchObjects fetches the given objects from the promisor remote in a
+// single request. This corresponds to git's promisor_remote_get_direct(),
+// which runs: git fetch <remote> --no-tags --no-write-fetch-head --stdin
+// with the object IDs piped to stdin.
+//
+// The session is closed via defer (matching remote.fetch) so that a Handshake
+// success followed by a panic — or a Fetch error path — cannot leak the
+// underlying connection. The named return lets ioutil.CheckClose join any
+// Close error with the operation error.
+func (f *promiserObjectFetcher) FetchObjects(ctx context.Context, hashes []plumbing.Hash) (err error) {
+	if len(hashes) == 0 {
+		return nil
+	}
+
+	cfg, err := f.inner.Config()
+	if err != nil {
+		return fmt.Errorf("promisor fetch: read config: %w", err)
+	}
+
+	rc, ok := cfg.Remotes[f.remoteName]
+	if !ok || len(rc.URLs) == 0 {
+		return fmt.Errorf("promisor fetch: remote %q not found or has no URLs", f.remoteName)
+	}
+
+	cl, req, err := newClient(rc.URLs[0], f.clientOptionsSnapshot())
+	if err != nil {
+		return fmt.Errorf("promisor fetch: new client: %w", err)
+	}
+
+	req.Command = transport.UploadPackService
+	sess, err := cl.Handshake(ctx, req)
+	if err != nil {
+		return fmt.Errorf("promisor fetch: handshake: %w", err)
+	}
+	defer ioutil.CheckClose(sess, &err)
+
+	fetchReq := &transport.FetchRequest{
+		Wants: hashes,
+	}
+
+	if err := sess.Fetch(ctx, withPromisorPackfileWriter(f.inner), fetchReq); err != nil {
+		return fmt.Errorf("promisor fetch: %w", err)
+	}
+
+	return nil
+}
+
+// findPromisorRemote returns the name of the promisor remote from the config.
+// It first checks for remote.<name>.promisor = true (modern git),
+// then falls back to extensions.partialClone (legacy).
+// Returns empty string if no promisor remote is configured.
+//
+// NOTE: when multiple remotes have Promisor=true, selection is
+// non-deterministic because cfg.Remotes is a map. This matches the
+// common single-promisor-remote case; deterministic multi-remote
+// ordering would require preserving config-file order.
+func findPromisorRemote(cfg *config.Config) string {
+	for name, rc := range cfg.Remotes {
+		if rc.Promisor {
+			return name
+		}
+	}
+
+	// Legacy: extensions.partialClone = <remote-name>
+	if cfg.Extensions.PartialClone != "" {
+		return cfg.Extensions.PartialClone
+	}
+
+	return ""
+}
+
+// promisorOptions holds transport options for on-demand object fetching.
+type promisorOptions struct {
+	ClientOptions []client.Option
+}
+
+// wrapStorerIfPromisor reads the config from s and, if a promisor remote is
+// configured, wraps s with a promiserStorer for on-demand object fetching.
+func wrapStorerIfPromisor(s storage.Storer, opts *promisorOptions) storage.Storer {
+	if ps, ok := getPromiserStorer(s); ok {
+		if opts != nil {
+			ps.setClientOptions(opts.ClientOptions)
+		}
+		return s
+	}
+
+	cfg, err := s.Config()
+	if err != nil {
+		return s
+	}
+
+	remoteName := findPromisorRemote(cfg)
+	if remoteName == "" {
+		return s
+	}
+
+	fetcher := &promiserObjectFetcher{
+		remoteName: remoteName,
+		inner:      s,
+	}
+	if opts != nil {
+		fetcher.clientOptions = append([]client.Option(nil), opts.ClientOptions...)
+	}
+	return newPromiserStorer(s, fetcher)
+}
+
+// isObjectNotFound reports whether err indicates that an object was not found.
+func isObjectNotFound(err error) bool {
+	return errors.Is(err, plumbing.ErrObjectNotFound)
+}
+
+// shouldFetch reports whether on-demand fetching should be attempted for
+// the given object type. Promisor repositories may be filtered by blob, tree,
+// or other object filters, so any normal Git object can be demand-fetched.
+func shouldFetch(t plumbing.ObjectType) bool {
+	switch t {
+	case plumbing.AnyObject, plumbing.CommitObject, plumbing.TreeObject, plumbing.BlobObject, plumbing.TagObject:
+		return true
+	default:
+		return false
+	}
+}
+
+type promisorMarker interface {
+	SetPromisor(bool)
+}
+
+type promisorPackfileWriter struct {
+	storage.Storer
+}
+
+func withPromisorPackfileWriter(s storage.Storer) storage.Storer {
+	if _, ok := s.(*promisorPackfileWriter); ok {
+		return s
+	}
+	if _, ok := s.(storer.PackfileWriter); !ok {
+		return s
+	}
+	return &promisorPackfileWriter{Storer: s}
+}
+
+func (s *promisorPackfileWriter) PackfileWriter() (io.WriteCloser, error) {
+	pw := s.Storer.(storer.PackfileWriter)
+	w, err := pw.PackfileWriter()
+	if err != nil {
+		return nil, err
+	}
+	if marker, ok := w.(promisorMarker); ok {
+		marker.SetPromisor(true)
+	}
+	return w, nil
+}
+
+func fetchFilterFromConfig(rc *config.RemoteConfig, requested packp.Filter) packp.Filter {
+	if requested != "" {
+		return requested
+	}
+	if rc != nil && rc.Promisor && rc.PartialCloneFilter != "" {
+		return packp.Filter(rc.PartialCloneFilter)
+	}
+	return ""
+}
+
+// savePartialCloneConfigToStorer marks a repository as a partial clone in its
+// configuration. It writes three pieces that upstream Git also writes:
+//
+//   - core.repositoryFormatVersion = 1, required so the [extensions] section
+//     is honoured.
+//   - extensions.partialClone = <remote>, which (a) names the fallback
+//     promisor remote that modern Git tries last after every
+//     remote.<name>.promisor remote, and (b) acts as a forward-compatibility
+//     guard that makes older Git refuse the repository rather than fail
+//     mid-operation on a missing object it cannot lazy-fetch.
+//   - remote.<name>.promisor = true and remote.<name>.partialCloneFilter,
+//     the modern per-remote promisor configuration.
+//
+// When requireRemote is false and the remote does not exist (e.g. a stand-alone
+// filtered Fetch where the remote was created on the fly elsewhere), no config
+// is written rather than persisting half-state.
+func savePartialCloneConfigToStorer(s storage.Storer, remoteName string, filter packp.Filter, requireRemote bool) error {
+	cfg, err := s.Config()
+	if err != nil {
+		return err
+	}
+
+	rc, ok := cfg.Remotes[remoteName]
+	if !ok {
+		if requireRemote {
+			return fmt.Errorf("remote %q not found in config", remoteName)
+		}
+		return nil
+	}
+
+	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+	cfg.Extensions.PartialClone = remoteName
+	rc.Promisor = true
+	rc.PartialCloneFilter = string(filter)
+
+	return s.SetConfig(cfg)
+}

--- a/promisor_test.go
+++ b/promisor_test.go
@@ -1,0 +1,671 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/client"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// mockObjectFetcher records fetch calls and injects objects into the storer.
+type mockObjectFetcher struct {
+	calls   int
+	objects map[plumbing.Hash]plumbing.EncodedObject
+	storer  *memory.Storage
+}
+
+func (f *mockObjectFetcher) FetchObjects(_ context.Context, hashes []plumbing.Hash) error {
+	f.calls++
+	for _, h := range hashes {
+		obj, ok := f.objects[h]
+		if !ok {
+			return plumbing.ErrObjectNotFound
+		}
+		if _, err := f.storer.SetEncodedObject(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func makeObject(sto *memory.Storage, typ plumbing.ObjectType, content string) (plumbing.Hash, plumbing.EncodedObject) {
+	obj := sto.NewEncodedObject()
+	obj.SetType(typ)
+	obj.SetSize(int64(len(content)))
+	w, _ := obj.Writer()
+	_, _ = w.Write([]byte(content))
+	_ = w.Close()
+	h, _ := sto.SetEncodedObject(obj)
+	return h, obj
+}
+
+func makeBlob(sto *memory.Storage, content string) (plumbing.Hash, plumbing.EncodedObject) {
+	return makeObject(sto, plumbing.BlobObject, content)
+}
+
+func TestPromiserStorer_EncodedObject_Found(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	h, _ := makeBlob(sto, "found")
+
+	ps := newPromiserStorer(sto, &mockObjectFetcher{storer: sto})
+	obj, err := ps.EncodedObject(plumbing.BlobObject, h)
+	require.NoError(t, err)
+	assert.Equal(t, h, obj.Hash())
+}
+
+func TestPromiserStorer_EncodedObject_FetchOnMiss(t *testing.T) {
+	t.Parallel()
+
+	// Create a blob in a temporary storage to get its hash and object.
+	tmpSto := memory.NewStorage()
+	h, blob := makeBlob(tmpSto, "lazy-blob")
+
+	// The actual storer starts empty.
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{
+		storer:  sto,
+		objects: map[plumbing.Hash]plumbing.EncodedObject{h: blob},
+	}
+
+	ps := newPromiserStorer(sto, fetcher)
+	obj, err := ps.EncodedObject(plumbing.BlobObject, h)
+	require.NoError(t, err)
+	assert.Equal(t, h, obj.Hash())
+	assert.Equal(t, 1, fetcher.calls)
+}
+
+func TestPromiserStorer_EncodedObject_TreeFetchOnMiss(t *testing.T) {
+	t.Parallel()
+
+	tmpSto := memory.NewStorage()
+	h, tree := makeObject(tmpSto, plumbing.TreeObject, "")
+
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{
+		storer:  sto,
+		objects: map[plumbing.Hash]plumbing.EncodedObject{h: tree},
+	}
+
+	ps := newPromiserStorer(sto, fetcher)
+	obj, err := ps.EncodedObject(plumbing.TreeObject, h)
+	require.NoError(t, err)
+	assert.Equal(t, h, obj.Hash())
+	assert.Equal(t, 1, fetcher.calls)
+}
+
+func TestPromiserStorer_EncodedObject_CommitFetchOnMiss(t *testing.T) {
+	t.Parallel()
+
+	tmpSto := memory.NewStorage()
+	h, commit := makeObject(tmpSto, plumbing.CommitObject, "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\nmsg\n")
+
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{
+		storer:  sto,
+		objects: map[plumbing.Hash]plumbing.EncodedObject{h: commit},
+	}
+
+	ps := newPromiserStorer(sto, fetcher)
+	obj, err := ps.EncodedObject(plumbing.CommitObject, h)
+	require.NoError(t, err)
+	assert.Equal(t, h, obj.Hash())
+	assert.Equal(t, 1, fetcher.calls)
+}
+
+// networkErrorFetcher simulates a transport failure (auth error, 502, ...) by
+// returning a non-ErrObjectNotFound error from FetchObjects.
+type networkErrorFetcher struct {
+	calls int
+	err   error
+}
+
+func (f *networkErrorFetcher) FetchObjects(_ context.Context, _ []plumbing.Hash) error {
+	f.calls++
+	return f.err
+}
+
+func TestPromiserStorer_EncodedObject_NetworkFailureIsNotMissing(t *testing.T) {
+	t.Parallel()
+
+	// A network failure on the on-demand fetch must NOT be reported as
+	// plumbing.ErrObjectNotFound: callers (and downstream users of go-git)
+	// rely on that sentinel meaning "the object is missing locally", and
+	// silently turning network errors into "missing" leads to data
+	// integrity bugs (the caller treats data loss as a clean miss).
+	sto := memory.NewStorage()
+	netErr := errors.New("simulated 502 from promisor remote")
+	fetcher := &networkErrorFetcher{err: netErr}
+
+	ps := newPromiserStorer(sto, fetcher)
+	_, err := ps.EncodedObject(plumbing.BlobObject, plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, plumbing.ErrObjectNotFound),
+		"network failure must not masquerade as ErrObjectNotFound")
+	assert.ErrorIs(t, err, netErr, "the underlying network error must be surfaced via errors.Is")
+	assert.Contains(t, err.Error(), "promisor on-demand fetch")
+	assert.Equal(t, 1, fetcher.calls)
+}
+
+func TestPromiserStorer_EncodedObject_RemoteMissingIsMissing(t *testing.T) {
+	t.Parallel()
+
+	// When the promisor remote also does not have the object, the error
+	// is a legitimate "missing" verdict and errors.Is(ErrObjectNotFound)
+	// remains true so callers can keep treating it as such.
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{
+		storer:  sto,
+		objects: map[plumbing.Hash]plumbing.EncodedObject{},
+	}
+
+	ps := newPromiserStorer(sto, fetcher)
+	_, err := ps.EncodedObject(plumbing.BlobObject, plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound,
+		"remote-also-missing must remain reportable as ErrObjectNotFound")
+	assert.Equal(t, 1, fetcher.calls)
+}
+
+func TestPromiserStorer_HasEncodedObject_DoesNotLazyFetch(t *testing.T) {
+	t.Parallel()
+
+	// Even with an object the fetcher could supply, HasEncodedObject must
+	// remain a cheap local existence probe. Otherwise call sites like
+	// revwalk or pack negotiation would silently turn O(N) local checks
+	// into O(N) network round-trips.
+	tmpSto := memory.NewStorage()
+	h, blob := makeBlob(tmpSto, "has-test")
+
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{
+		storer:  sto,
+		objects: map[plumbing.Hash]plumbing.EncodedObject{h: blob},
+	}
+
+	ps := newPromiserStorer(sto, fetcher)
+	err := ps.HasEncodedObject(h)
+	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+	assert.Equal(t, 0, fetcher.calls, "HasEncodedObject must not trigger an on-demand fetch")
+}
+
+func TestPromiserStorer_EncodedObjectSize_FetchOnMiss(t *testing.T) {
+	t.Parallel()
+
+	tmpSto := memory.NewStorage()
+	h, blob := makeBlob(tmpSto, "size-test")
+
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{
+		storer:  sto,
+		objects: map[plumbing.Hash]plumbing.EncodedObject{h: blob},
+	}
+
+	ps := newPromiserStorer(sto, fetcher)
+	sz, err := ps.EncodedObjectSize(h)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("size-test")), sz)
+	assert.Equal(t, 1, fetcher.calls)
+}
+
+func TestFindPromisorRemote_NewStyle(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Remotes["origin"] = &config.RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"https://example.com/repo.git"},
+		Promisor: true,
+	}
+
+	assert.Equal(t, "origin", findPromisorRemote(cfg))
+}
+
+func TestFindPromisorRemote_Legacy(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Extensions.PartialClone = "upstream"
+	cfg.Remotes["upstream"] = &config.RemoteConfig{
+		Name: "upstream",
+		URLs: []string{"https://example.com/repo.git"},
+	}
+
+	assert.Equal(t, "upstream", findPromisorRemote(cfg))
+}
+
+func TestFindPromisorRemote_None(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Remotes["origin"] = &config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://example.com/repo.git"},
+	}
+
+	assert.Equal(t, "", findPromisorRemote(cfg))
+}
+
+func TestFindPromisorRemote_NewStyleOverLegacy(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Extensions.PartialClone = "legacy-remote"
+	cfg.Remotes["origin"] = &config.RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"https://example.com/repo.git"},
+		Promisor: true,
+	}
+	cfg.Remotes["legacy-remote"] = &config.RemoteConfig{
+		Name: "legacy-remote",
+		URLs: []string{"https://example.com/legacy.git"},
+	}
+
+	// New style (remote.*.promisor) should take priority over legacy.
+	assert.Equal(t, "origin", findPromisorRemote(cfg))
+}
+
+func TestWrapStorerIfPromisor(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	r, err := Init(sto, nil)
+	require.NoError(t, err)
+
+	// No promisor remote: storer should not be wrapped.
+	wrapped := wrapStorerIfPromisor(sto, nil)
+	assert.Equal(t, sto, wrapped)
+
+	// Add a promisor remote.
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"https://example.com/repo.git"},
+		Promisor: true,
+	})
+	require.NoError(t, err)
+
+	wrapped = wrapStorerIfPromisor(sto, nil)
+	_, ok := wrapped.(*promiserStorer)
+	assert.True(t, ok, "storer should be wrapped as promiserStorer")
+}
+
+func TestOpenWrapsStorerIfPromisor(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	r, err := Init(sto, nil)
+	require.NoError(t, err)
+
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"https://example.com/repo.git"},
+		Promisor: true,
+	})
+	require.NoError(t, err)
+
+	opened, err := Open(sto, nil)
+	require.NoError(t, err)
+
+	_, ok := getPromiserStorer(opened.Storer)
+	assert.True(t, ok, "Open should wrap promisor repositories regardless of storage source")
+}
+
+// makeSentinelOption returns a client.Option that increments *applied when
+// run. We use it to verify that ClientOptions are not just stored but actually
+// flow through to where the transport would apply them. Function-typed values
+// in Go cannot be compared with reflect.DeepEqual, so identity is checked by
+// triggering the side-effect rather than by direct equality.
+func makeSentinelOption(applied *int) client.Option {
+	return client.WithTransport("promisor-test-sentinel", &fakeNoOpTransport{onUse: func() { *applied++ }})
+}
+
+type fakeNoOpTransport struct{ onUse func() }
+
+func (f *fakeNoOpTransport) Handshake(context.Context, *transport.Request) (transport.Session, error) {
+	if f.onUse != nil {
+		f.onUse()
+	}
+	// Return a session that immediately errors on use; we only care that
+	// Handshake was reached, which proves the option installed the transport.
+	return nil, transport.ErrInvalidRequest
+}
+
+func TestOpenWithOptions_PropagatesClientOptions(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	r, err := Init(sto, nil)
+	require.NoError(t, err)
+
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"promisor-test-sentinel://repo"},
+		Promisor: true,
+	})
+	require.NoError(t, err)
+
+	opened, err := OpenWithOptions(sto, nil, &OpenOptions{
+		ClientOptions: []client.Option{makeSentinelOption(new(int))},
+	})
+	require.NoError(t, err)
+
+	ps, ok := getPromiserStorer(opened.Storer)
+	require.True(t, ok)
+	pof, ok := ps.fetcher.(*promiserObjectFetcher)
+	require.True(t, ok)
+	assert.Len(t, pof.clientOptionsSnapshot(), 1,
+		"OpenWithOptions must forward ClientOptions to the promisor fetcher")
+}
+
+func TestSetPromisorClientOptions_OverridesAfterOpen(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	r, err := Init(sto, nil)
+	require.NoError(t, err)
+
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"promisor-test-sentinel://repo"},
+		Promisor: true,
+	})
+	require.NoError(t, err)
+
+	opened, err := Open(sto, nil)
+	require.NoError(t, err)
+	ps, ok := getPromiserStorer(opened.Storer)
+	require.True(t, ok)
+	pof, ok := ps.fetcher.(*promiserObjectFetcher)
+	require.True(t, ok)
+	require.Empty(t, pof.clientOptionsSnapshot(),
+		"plain Open should leave ClientOptions empty")
+
+	// Open() left ClientOptions empty; supply them lazily.
+	opened.SetPromisorClientOptions([]client.Option{makeSentinelOption(new(int))})
+	assert.Len(t, pof.clientOptionsSnapshot(), 1)
+}
+
+func TestSetPromisorClientOptions_WrapsLateConfiguredPromisor(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	_, err := Init(sto, nil)
+	require.NoError(t, err)
+
+	// Open before any promisor remote exists: storer remains unwrapped.
+	opened, err := Open(sto, nil)
+	require.NoError(t, err)
+	_, ok := getPromiserStorer(opened.Storer)
+	require.False(t, ok)
+
+	// Add a promisor remote afterwards.
+	_, err = opened.CreateRemote(&config.RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"promisor-test-sentinel://repo"},
+		Promisor: true,
+	})
+	require.NoError(t, err)
+
+	opened.SetPromisorClientOptions([]client.Option{makeSentinelOption(new(int))})
+
+	ps, ok := getPromiserStorer(opened.Storer)
+	require.True(t, ok, "SetPromisorClientOptions should wrap a late-configured promisor")
+	pof, ok := ps.fetcher.(*promiserObjectFetcher)
+	require.True(t, ok)
+	assert.Len(t, pof.clientOptionsSnapshot(), 1)
+}
+
+func TestPromiserStorer_PackfileWriter_NotSupported(t *testing.T) {
+	t.Parallel()
+
+	// memory.Storage does not implement PackfileWriter, so the
+	// wrapper should not expose it either.
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{storer: sto, objects: map[plumbing.Hash]plumbing.EncodedObject{}}
+	s := newPromiserStorer(sto, fetcher)
+
+	_, ok := s.(storer.PackfileWriter)
+	assert.False(t, ok, "promiserStorer wrapping memory.Storage should NOT implement storer.PackfileWriter")
+}
+
+func TestPromiserStorerPW_PackfileWriter(t *testing.T) {
+	t.Parallel()
+
+	// Use filesystem.Storage as inner which implements PackfileWriter.
+	dir := t.TempDir()
+	fs := osfs.New(dir)
+	fsSto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	fetcher := &mockObjectFetcher{storer: memory.NewStorage(), objects: map[plumbing.Hash]plumbing.EncodedObject{}}
+	s := newPromiserStorer(fsSto, fetcher)
+
+	pw, ok := s.(storer.PackfileWriter)
+	assert.True(t, ok, "promiserStorerPW wrapping filesystem.Storage should implement storer.PackfileWriter")
+
+	if ok {
+		wc, err := pw.PackfileWriter()
+		require.NoError(t, err)
+		assert.NotNil(t, wc)
+		_ = wc.Close()
+	}
+}
+
+func TestGetPromiserStorer(t *testing.T) {
+	t.Parallel()
+
+	// promiserStorer (memory inner)
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{storer: sto, objects: map[plumbing.Hash]plumbing.EncodedObject{}}
+	s := newPromiserStorer(sto, fetcher)
+	ps, ok := getPromiserStorer(s)
+	assert.True(t, ok)
+	assert.NotNil(t, ps)
+
+	// promiserStorerPW (filesystem inner)
+	dir := t.TempDir()
+	fs := osfs.New(dir)
+	fsSto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	s2 := newPromiserStorer(fsSto, fetcher)
+	ps2, ok2 := getPromiserStorer(s2)
+	assert.True(t, ok2)
+	assert.NotNil(t, ps2)
+
+	// plain storer (not wrapped)
+	_, ok3 := getPromiserStorer(sto)
+	assert.False(t, ok3)
+}
+
+type fetchNegotiationTransport struct {
+	session *fetchNegotiationSession
+}
+
+func (t *fetchNegotiationTransport) Handshake(context.Context, *transport.Request) (transport.Session, error) {
+	return t.session, nil
+}
+
+type fetchNegotiationSession struct {
+	refs       []*plumbing.Reference
+	objects    map[plumbing.Hash]plumbing.EncodedObject
+	fetchCalls int
+	wants      []plumbing.Hash
+}
+
+func (s *fetchNegotiationSession) Capabilities() *capability.List {
+	return &capability.List{}
+}
+
+func (s *fetchNegotiationSession) GetRemoteRefs(context.Context) ([]*plumbing.Reference, error) {
+	return s.refs, nil
+}
+
+func (s *fetchNegotiationSession) Fetch(_ context.Context, st storage.Storer, req *transport.FetchRequest) error {
+	s.fetchCalls++
+	s.wants = append([]plumbing.Hash(nil), req.Wants...)
+	for _, h := range req.Wants {
+		obj, ok := s.objects[h]
+		if !ok {
+			return plumbing.ErrObjectNotFound
+		}
+		if _, err := st.SetEncodedObject(obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *fetchNegotiationSession) Push(context.Context, storage.Storer, *transport.PushRequest) error {
+	return nil
+}
+
+func (s *fetchNegotiationSession) Close() error {
+	return nil
+}
+
+func TestRemoteFetchDoesNotLazyFetchWhenComputingWants(t *testing.T) {
+	t.Parallel()
+
+	tmpSto := memory.NewStorage()
+	h, commit := makeObject(tmpSto, plumbing.CommitObject, "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n\nmsg\n")
+
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{
+		storer:  sto,
+		objects: map[plumbing.Hash]plumbing.EncodedObject{h: commit},
+	}
+	wrapped := newPromiserStorer(sto, fetcher)
+
+	session := &fetchNegotiationSession{
+		refs: []*plumbing.Reference{
+			plumbing.NewHashReference(plumbing.NewBranchReferenceName("main"), h),
+		},
+		objects: map[plumbing.Hash]plumbing.EncodedObject{h: commit},
+	}
+	remote := NewRemote(wrapped, &config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"promisor-test://repo"},
+	})
+
+	err := remote.FetchContext(context.Background(), &FetchOptions{
+		RemoteName: "origin",
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("+refs/heads/main:refs/remotes/origin/main"),
+		},
+		ClientOptions: []client.Option{
+			client.WithTransport("promisor-test", &fetchNegotiationTransport{session: session}),
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, fetcher.calls)
+	assert.Equal(t, 1, session.fetchCalls)
+	assert.Equal(t, []plumbing.Hash{h}, session.wants)
+}
+
+func TestPromiserStorer_PackedObjectStorer(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{storer: sto, objects: map[plumbing.Hash]plumbing.EncodedObject{}}
+	s := newPromiserStorer(sto, fetcher)
+
+	pos, ok := s.(storer.PackedObjectStorer)
+	assert.True(t, ok, "promiserStorer should implement storer.PackedObjectStorer")
+
+	packs, err := pos.ObjectPacks()
+	require.NoError(t, err)
+	assert.Empty(t, packs)
+}
+
+func TestPromiserStorer_LooseObjectStorer(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	fetcher := &mockObjectFetcher{storer: sto, objects: map[plumbing.Hash]plumbing.EncodedObject{}}
+	s := newPromiserStorer(sto, fetcher)
+
+	los, ok := s.(storer.LooseObjectStorer)
+	assert.True(t, ok, "promiserStorer should implement storer.LooseObjectStorer")
+
+	err := los.ForEachObjectHash(func(_ plumbing.Hash) error { return nil })
+	assert.NoError(t, err)
+}
+
+func TestShouldFetch(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, shouldFetch(plumbing.BlobObject))
+	assert.True(t, shouldFetch(plumbing.AnyObject))
+	assert.True(t, shouldFetch(plumbing.TreeObject))
+	assert.True(t, shouldFetch(plumbing.CommitObject))
+	assert.True(t, shouldFetch(plumbing.TagObject))
+	assert.False(t, shouldFetch(plumbing.OFSDeltaObject))
+}
+
+type markerWriteCloser struct {
+	bytes.Buffer
+	promisor bool
+}
+
+func (w *markerWriteCloser) Close() error { return nil }
+
+func (w *markerWriteCloser) SetPromisor(v bool) {
+	w.promisor = v
+}
+
+type markerPackfileStorage struct {
+	*memory.Storage
+	writer *markerWriteCloser
+}
+
+func (s *markerPackfileStorage) PackfileWriter() (io.WriteCloser, error) {
+	return s.writer, nil
+}
+
+func TestWithPromisorPackfileWriterMarksWriter(t *testing.T) {
+	t.Parallel()
+
+	sto := &markerPackfileStorage{
+		Storage: memory.NewStorage(),
+		writer:  &markerWriteCloser{},
+	}
+
+	wrapped := withPromisorPackfileWriter(sto)
+	pw, ok := wrapped.(storer.PackfileWriter)
+	require.True(t, ok)
+
+	w, err := pw.PackfileWriter()
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	assert.True(t, sto.writer.promisor)
+}
+
+func TestFetchFilterFromConfig(t *testing.T) {
+	t.Parallel()
+
+	rc := &config.RemoteConfig{
+		Name:               "origin",
+		Promisor:           true,
+		PartialCloneFilter: "blob:none",
+	}
+
+	assert.Equal(t, "blob:limit=1m", string(fetchFilterFromConfig(rc, "blob:limit=1m")))
+	assert.Equal(t, "blob:none", string(fetchFilterFromConfig(rc, "")))
+	assert.Equal(t, "", string(fetchFilterFromConfig(&config.RemoteConfig{Promisor: true}, "")))
+	assert.Equal(t, "", string(fetchFilterFromConfig(&config.RemoteConfig{PartialCloneFilter: "blob:none"}, "")))
+}

--- a/remote.go
+++ b/remote.go
@@ -372,6 +372,8 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		o.RemoteURL = r.c.URLs[0]
 	}
 
+	o.Filter = fetchFilterFromConfig(r.c, o.Filter)
+
 	cl, req, err := newClient(o.RemoteURL, o.ClientOptions)
 	if err != nil {
 		return nil, err
@@ -394,7 +396,8 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	}
 
 	remoteRefs := referenceStorageFromRefs(rRefs, true)
-	localRefs, err := reference.References(r.s)
+	negotiationStorer := unwrapPromiserStorer(r.s)
+	localRefs, err := reference.References(negotiationStorer)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +408,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 
 	var shallows []plumbing.Hash
 	if o.Depth != 0 {
-		shallows, err = r.s.Shallow()
+		shallows, err = negotiationStorer.Shallow()
 		if err != nil {
 			return nil, err
 		}
@@ -420,9 +423,12 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	}
 
 	var haves []plumbing.Hash
-	wants, _ := getWants(r.s, refs, o.Depth)
+	wants, err := getWants(negotiationStorer, refs, o.Depth)
+	if err != nil {
+		return nil, err
+	}
 	if len(wants) > 0 {
-		haves, err = getHaves(localRefs, remoteRefs, r.s, o.Depth)
+		haves, err = getHaves(localRefs, remoteRefs, negotiationStorer, o.Depth)
 		if err != nil {
 			return nil, err
 		}
@@ -458,11 +464,24 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 			Filter:      o.Filter,
 		}
 
-		if err := sess.Fetch(ctx, r.s, req); err != nil && !errors.Is(err, transport.ErrNoChange) {
+		fetchStorer := r.s
+		if o.Filter != "" {
+			fetchStorer = withPromisorPackfileWriter(fetchStorer)
+		}
+
+		if err := sess.Fetch(ctx, fetchStorer, req); err != nil && !errors.Is(err, transport.ErrNoChange) {
 			// Note: We receive ErrNoChange when remote is the same as local. At
 			// this point, we have everything we're asking for.
 			return nil, err
 		}
+	}
+
+	if o.Filter != "" {
+		if err := savePartialCloneConfigToStorer(r.s, o.RemoteName, o.Filter, false); err != nil {
+			return nil, err
+		}
+		r.c.Promisor = true
+		r.c.PartialCloneFilter = string(o.Filter)
 	}
 
 	var updatedPrune bool
@@ -479,7 +498,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	}
 
 	if !updated {
-		updated, err = depthChanged(shallows, r.s)
+		updated, err = depthChanged(shallows, negotiationStorer)
 		if err != nil {
 			return nil, fmt.Errorf("error checking depth change: %v", err)
 		}
@@ -488,7 +507,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	if !updated && !updatedPrune {
 		// No references updated, but may have fetched new objects, check if we now have any of our wants
 		for _, hash := range wants {
-			exists, _ := objectExists(r.s, hash)
+			exists, _ := objectExists(negotiationStorer, hash)
 			if exists {
 				updated = true
 				break

--- a/repository.go
+++ b/repository.go
@@ -27,6 +27,7 @@ import (
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/plumbing/transport"
@@ -272,13 +273,33 @@ func setConfigWorktree(r *Repository, worktree, storage billy.Filesystem) error 
 // if the given storer is complete empty ErrRepositoryNotExists is returned.
 // The worktree can be nil when the repository being opened is bare, if the
 // repository is a normal one (not bare) and worktree is nil the err
-// ErrWorktreeNotProvided is returned
+// ErrWorktreeNotProvided is returned.
+//
+// Open does not accept ClientOptions, so any subsequent on-demand fetch on a
+// partial clone (e.g. BlobObject, Checkout) runs without credentials. For
+// authenticated promisor remotes, use OpenWithOptions or call
+// Repository.SetPromisorClientOptions on the returned *Repository.
 func Open(s storage.Storer, worktree billy.Filesystem) (*Repository, error) {
+	return OpenWithOptions(s, worktree, nil)
+}
+
+// OpenWithOptions opens a git repository like Open and additionally forwards
+// the supplied OpenOptions to the partial-clone wrapper, so on-demand fetches
+// triggered later (e.g. Checkout, Reset, BlobObject) inherit the configured
+// ClientOptions (auth, TLS, custom transports).
+func OpenWithOptions(s storage.Storer, worktree billy.Filesystem, o *OpenOptions) (*Repository, error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
 			trace.Performance.Printf("performance: %.9f s: open", time.Since(start).Seconds())
 		}()
+	}
+
+	if o == nil {
+		o = &OpenOptions{}
+	}
+	if err := o.Validate(); err != nil {
+		return nil, err
 	}
 
 	_, err := s.Reference(plumbing.HEAD)
@@ -296,7 +317,11 @@ func Open(s storage.Storer, worktree billy.Filesystem) (*Repository, error) {
 		return nil, err
 	}
 
-	return newRepository(s, worktree), nil
+	r := newRepository(s, worktree)
+	r.Storer = wrapStorerIfPromisor(r.Storer, &promisorOptions{
+		ClientOptions: o.ClientOptions,
+	})
+	return r, nil
 }
 
 // Clone a repository into the given Storer and worktree Filesystem with the
@@ -1148,9 +1173,30 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		return err
 	}
 
+	if err := r.updateRemoteConfigIfNeeded(o, c, ref); err != nil {
+		return err
+	}
+
+	// For partial clones, persist promisor remote config and upgrade
+	// the repository format version to 1.
+	if o.Filter != "" {
+		if err := r.savePartialCloneConfig(o.RemoteName, o.Filter); err != nil {
+			return err
+		}
+	}
+
 	err = r.setWorktreeAndStoragePaths()
 	if err != nil {
 		return err
+	}
+
+	// Wrap the storer after setWorktreeAndStoragePaths (which needs the
+	// unwrapped fsBased interface) but before checkout (which needs
+	// on-demand fetch for missing blobs).
+	if o.Filter != "" {
+		r.Storer = wrapStorerIfPromisor(r.Storer, &promisorOptions{
+			ClientOptions: o.ClientOptions,
+		})
 	}
 
 	if r.wt != nil && !o.NoCheckout {
@@ -1187,10 +1233,6 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		}
 	}
 
-	if err := r.updateRemoteConfigIfNeeded(o, c, ref); err != nil {
-		return err
-	}
-
 	if !o.Mirror && ref.Name().IsBranch() {
 		branchRef := ref.Name()
 		branchName := strings.Split(string(branchRef), "refs/heads/")[1]
@@ -1212,6 +1254,13 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 	}
 
 	return nil
+}
+
+// savePartialCloneConfig upgrades the repository format version to 1 and
+// persists the promisor remote config for a partial clone, matching the
+// behavior of modern git.
+func (r *Repository) savePartialCloneConfig(remoteName string, filter packp.Filter) error {
+	return savePartialCloneConfigToStorer(r.Storer, remoteName, filter, true)
 }
 
 const (
@@ -1263,6 +1312,11 @@ func (r *Repository) updateRemoteConfigIfNeeded(o *CloneOptions, c *config.Remot
 	cfg, err := r.Config()
 	if err != nil {
 		return err
+	}
+
+	if existing, ok := cfg.Remotes[c.Name]; ok {
+		c.Promisor = existing.Promisor
+		c.PartialCloneFilter = existing.PartialCloneFilter
 	}
 
 	cfg.Remotes[c.Name] = c
@@ -1426,7 +1480,41 @@ func (r *Repository) FetchContext(ctx context.Context, o *FetchOptions) error {
 		return err
 	}
 
-	return remote.FetchContext(ctx, o)
+	err = remote.FetchContext(ctx, o)
+	ok := err == nil || errors.Is(err, NoErrAlreadyUpToDate) || errors.Is(err, ErrForceNeeded)
+	if ok {
+		switch {
+		case o.Filter != "":
+			// First-time filtered fetch on a normal repo: wrap now so the
+			// returned *Repository performs on-demand fetches with the same
+			// transport options that were just used for the explicit fetch.
+			r.Storer = wrapStorerIfPromisor(r.Storer, &promisorOptions{
+				ClientOptions: o.ClientOptions,
+			})
+		case len(o.ClientOptions) > 0:
+			// Re-fetch with credentials on an already-wrapped partial clone:
+			// propagate the options so subsequent lazy fetches (Checkout,
+			// BlobObject, ...) reuse them rather than running unauthenticated.
+			if ps, ok := getPromiserStorer(r.Storer); ok {
+				ps.setClientOptions(o.ClientOptions)
+			}
+		}
+	}
+	return err
+}
+
+// SetPromisorClientOptions configures the transport options used by on-demand
+// fetches when this repository is a partial clone. Use it after Open (or after
+// adding a promisor remote at runtime) to supply credentials/TLS for operations
+// such as BlobObject, Checkout, or Reset that may lazy-fetch missing objects
+// without an Options struct of their own. If the storer is not yet wrapped
+// (e.g. a promisor remote was created after Open), this wraps it.
+func (r *Repository) SetPromisorClientOptions(opts []client.Option) {
+	if ps, ok := getPromiserStorer(r.Storer); ok {
+		ps.setClientOptions(opts)
+		return
+	}
+	r.Storer = wrapStorerIfPromisor(r.Storer, &promisorOptions{ClientOptions: opts})
 }
 
 // Push performs a push to the remote. Returns NoErrAlreadyUpToDate if

--- a/repository_extensions.go
+++ b/repository_extensions.go
@@ -41,6 +41,11 @@ var (
 		// noop-v1 does not change git’s behavior at all.
 		// It is useful only for testing format-1 compatibility.
 		"noop-v1": {},
+
+		// partialclone indicates that the repo was created with a
+		// partial clone (--filter) and that a promisor remote can
+		// supply any missing objects on demand.
+		"partialclone": {},
 	}
 
 	// Some Git extensions were supported upstream before the introduction

--- a/repository_test.go
+++ b/repository_test.go
@@ -1894,10 +1894,23 @@ func (s *RepositorySuite) TestFetchWithFiltersReal() {
 	err = r.Fetch(&FetchOptions{
 		Filter: packp.FilterBlobNone(),
 	})
-	s.NoError(err)
+	s.Require().NoError(err)
+
+	cfg, err := r.Config()
+	s.Require().NoError(err)
+	rc := cfg.Remotes[DefaultRemoteName]
+	s.Require().NotNil(rc)
+	s.True(rc.Promisor)
+	s.Equal("blob:none", rc.PartialCloneFilter)
+	s.Equal(DefaultRemoteName, cfg.Extensions.PartialClone,
+		"filtered fetch should also persist extensions.partialClone")
+
+	_, ok := getPromiserStorer(r.Storer)
+	s.True(ok, "storer should be wrapped as promiserStorer after filtered fetch")
+
 	blob, err := r.BlobObject(plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"))
-	s.NotNil(err)
-	s.Nil(blob)
+	s.NoError(err)
+	s.NotNil(blob)
 }
 
 func (s *RepositorySuite) TestCloneWithProgress() {
@@ -2265,9 +2278,108 @@ func (s *RepositorySuite) TestCloneWithFilter() {
 		Filter: packp.FilterTreeDepth(0),
 	})
 	s.Require().NoError(err)
+
+	// With the promiserStorer wrapper, on-demand fetch retrieves the
+	// blob from the promisor remote transparently.
 	blob, err := r.BlobObject(plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"))
-	s.Require().Error(err)
-	s.Nil(blob)
+	s.Require().NoError(err)
+	s.NotNil(blob)
+}
+
+func (s *RepositorySuite) TestCloneWithFilterBlobNone_Config() {
+	r, _ := Init(memory.NewStorage())
+
+	err := r.clone(context.Background(), &CloneOptions{
+		URL:    "https://github.com/git-fixtures/basic.git",
+		Filter: packp.FilterBlobNone(),
+	})
+	s.Require().NoError(err)
+
+	// Verify config was persisted correctly.
+	cfg, err := r.Config()
+	s.Require().NoError(err)
+	s.Equal(
+		formatcfg.RepositoryFormatVersion(formatcfg.Version1),
+		cfg.Core.RepositoryFormatVersion,
+		"repositoryformatversion should be 1",
+	)
+
+	rc := cfg.Remotes["origin"]
+	s.Require().NotNil(rc)
+	s.True(rc.Promisor, "remote.origin.promisor should be true")
+	s.Equal("blob:none", rc.PartialCloneFilter)
+	s.Equal("origin", cfg.Extensions.PartialClone,
+		"extensions.partialClone should name the promisor remote for upstream-git interop")
+
+	// Storer should be wrapped with promiserStorer.
+	_, ok := r.Storer.(*promiserStorer)
+	s.True(ok, "storer should be wrapped as promiserStorer after filtered clone")
+}
+
+func (s *RepositorySuite) TestCloneWithFilterBlobNone_OnDemandFetch() {
+	r, _ := Init(memory.NewStorage())
+
+	err := r.clone(context.Background(), &CloneOptions{
+		URL:    "https://github.com/git-fixtures/basic.git",
+		Filter: packp.FilterBlobNone(),
+	})
+	s.Require().NoError(err)
+
+	// A blob that was excluded by the filter should be fetchable on demand.
+	blob, err := r.BlobObject(plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"))
+	s.Require().NoError(err)
+	s.NotNil(blob)
+
+	reader, err := blob.Reader()
+	s.Require().NoError(err)
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	s.Require().NoError(err)
+	s.NotEmpty(content, "blob content should not be empty")
+}
+
+func (s *RepositorySuite) TestCloneWithFilterBlobNone_DepthAndSparse() {
+	fs := memfs.New()
+	r, _ := Init(memory.NewStorage(), WithWorkTree(fs))
+
+	err := r.clone(context.Background(), &CloneOptions{
+		URL:        "https://github.com/git-fixtures/basic.git",
+		Filter:     packp.FilterBlobNone(),
+		Depth:      1,
+		NoCheckout: true,
+	})
+	s.Require().NoError(err)
+
+	// Verify partial clone config.
+	cfg, err := r.Config()
+	s.Require().NoError(err)
+	s.True(cfg.Remotes["origin"].Promisor)
+	s.Equal("blob:none", cfg.Remotes["origin"].PartialCloneFilter)
+
+	// Sparse checkout: only the "json" directory.
+	w, err := r.Worktree()
+	s.Require().NoError(err)
+	err = w.Checkout(&CheckoutOptions{
+		Branch:                    "refs/heads/master",
+		SparseCheckoutDirectories: []string{"json"},
+	})
+	s.Require().NoError(err)
+
+	// Verify only the json directory was checked out.
+	fis, err := fs.ReadDir(".")
+	s.Require().NoError(err)
+	s.Require().NotEmpty(fis)
+
+	for _, fi := range fis {
+		s.True(fi.IsDir(), "expected only directories at root")
+		s.Equal("json", fi.Name(), "only json/ should be checked out")
+	}
+
+	// Verify a file inside the sparse directory exists and has content.
+	jsonDir, err := fs.ReadDir("json")
+	s.Require().NoError(err)
+	s.NotEmpty(jsonDir, "json/ should contain files")
 }
 
 func (s *RepositorySuite) TestPush() {
@@ -4460,4 +4572,83 @@ func setupArchiveRepo(t *testing.T) *Repository {
 	r, err := Open(st, memfs.New())
 	require.NoError(t, err)
 	return r
+}
+
+func TestSavePartialCloneConfig(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	r, err := Init(sto, nil)
+	require.NoError(t, err)
+
+	// Create a remote so savePartialCloneConfig can find it.
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://github.com/go-git/go-git.git"},
+	})
+	require.NoError(t, err)
+
+	err = r.savePartialCloneConfig("origin", packp.FilterBlobNone())
+	require.NoError(t, err)
+
+	cfg, err := r.Config()
+	require.NoError(t, err)
+
+	assert.Equal(t, formatcfg.RepositoryFormatVersion(formatcfg.Version1), cfg.Core.RepositoryFormatVersion)
+	assert.Equal(t, "origin", cfg.Extensions.PartialClone,
+		"extensions.partialClone should be set to the promisor remote name")
+
+	rc := cfg.Remotes["origin"]
+	require.NotNil(t, rc)
+	assert.True(t, rc.Promisor)
+	assert.Equal(t, "blob:none", rc.PartialCloneFilter)
+}
+
+func TestSavePartialCloneConfig_RemoteNotFound(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	r, err := Init(sto, nil)
+	require.NoError(t, err)
+
+	err = r.savePartialCloneConfig("nonexistent", packp.FilterBlobNone())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent")
+}
+
+func TestUpdateRemoteConfigIfNeededPreservesPartialCloneConfig(t *testing.T) {
+	t.Parallel()
+
+	sto := memory.NewStorage()
+	r, err := Init(sto, nil)
+	require.NoError(t, err)
+
+	_, err = r.CreateRemote(&config.RemoteConfig{
+		Name:               "origin",
+		URLs:               []string{"https://github.com/go-git/go-git.git"},
+		Promisor:           true,
+		PartialCloneFilter: "blob:none",
+	})
+	require.NoError(t, err)
+
+	staleRemote := &config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://github.com/go-git/go-git.git"},
+	}
+
+	err = r.updateRemoteConfigIfNeeded(&CloneOptions{
+		RemoteName:    "origin",
+		ReferenceName: plumbing.HEAD,
+		SingleBranch:  true,
+	}, staleRemote, nil)
+	require.NoError(t, err)
+
+	cfg, err := r.Config()
+	require.NoError(t, err)
+
+	rc := cfg.Remotes["origin"]
+	require.NotNil(t, rc)
+	assert.True(t, rc.Promisor)
+	assert.Equal(t, "blob:none", rc.PartialCloneFilter)
+	assert.Equal(t, []config.RefSpec{config.RefSpec("+HEAD:refs/remotes/origin/HEAD")}, rc.Fetch)
 }

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -567,10 +567,11 @@ func (d *DotGit) CloseIdleDescriptors() error {
 }
 
 // DeleteOldObjectPackAndIndex removes a pack and its index if older than t.
-// The .pack, .idx and .rev files are each attempted independently; any
-// failures are joined into the returned error so a partial failure cannot
-// leave orphaned siblings on disk. A missing .rev is not an error — the
-// reverse index is optional and may have been generated only in memory.
+// The .pack, .idx, .rev and .promisor files are each attempted independently;
+// any failures are joined into the returned error so a partial failure cannot
+// leave orphaned siblings on disk. A missing .rev or .promisor is not an
+// error — the reverse index is optional (may have been generated only in
+// memory) and the promisor marker only exists for partial clone packs.
 func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) error {
 	var errs []error
 	if err := d.cleanPackList(); err != nil {
@@ -590,9 +591,10 @@ func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) er
 		}
 	}
 
-	for _, ext := range []string{`pack`, `idx`, `rev`} {
+	for _, ext := range []string{`pack`, `idx`, `rev`, `promisor`} {
 		if err := d.fs.Remove(d.objectPackPath(hash, ext)); err != nil {
-			if ext == `rev` && os.IsNotExist(err) {
+			// .rev and .promisor are optional siblings; missing is not an error.
+			if (ext == `rev` || ext == `promisor`) && os.IsNotExist(err) {
 				continue
 			}
 			errs = append(errs, err)

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -36,6 +36,19 @@ type PackWriter struct {
 	result   chan error
 	format   formatcfg.ObjectFormat
 	writeRev bool
+	// promisor, when true, creates a .promisor marker file alongside
+	// the packfile. This marks the pack as coming from a partial clone
+	// (filtered fetch) where missing objects can be fetched on demand.
+	// Set via SetPromisor; not exported to keep the configuration
+	// surface single (the dual field+setter form was misuse-prone).
+	promisor bool
+}
+
+// SetPromisor configures whether Close creates a .promisor marker next to the
+// finalized packfile. Must be called before Close; calling it afterwards has
+// no effect.
+func (w *PackWriter) SetPromisor(v bool) {
+	w.promisor = v
 }
 
 func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev bool) (*PackWriter, error) {
@@ -205,9 +218,36 @@ func (w *PackWriter) save() error {
 		fixPermissions(w.fs, packPath)
 	} else {
 		// Pack already exists, clean up the temp file.
-		return w.clean()
+		if err := w.clean(); err != nil {
+			return err
+		}
 	}
 
+	if w.promisor {
+		return w.savePromisorMarker(base)
+	}
+
+	return nil
+}
+
+func (w *PackWriter) savePromisorMarker(base string) error {
+	promisorPath := fmt.Sprintf("%s.promisor", base)
+	exists, err := fileExists(w.fs, promisorPath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	f, err := w.fs.Create(promisorPath)
+	if err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	fixPermissions(w.fs, promisorPath)
 	return nil
 }
 

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -327,6 +327,82 @@ func TestPackWriterRejectsNonRegularFile(t *testing.T) {
 	}
 }
 
+func TestPackWriterPromisor(t *testing.T) {
+	t.Parallel()
+
+	f := fixtures.Basic().One()
+	fs := osfs.New(t.TempDir())
+	dot := New(fs)
+
+	w, err := dot.NewObjectPack()
+	require.NoError(t, err)
+	w.SetPromisor(true)
+
+	pf, pfErr := f.Packfile()
+	require.NoError(t, pfErr)
+	_, err = io.Copy(w, pf)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	promisorPath := fmt.Sprintf("objects/pack/pack-%s.promisor", f.PackfileHash)
+	stat, err := fs.Stat(promisorPath)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stat.Size())
+}
+
+func TestPackWriterPromisorExistingPack(t *testing.T) {
+	t.Parallel()
+
+	f := fixtures.Basic().One()
+	fs := osfs.New(t.TempDir())
+	dot := New(fs)
+
+	writePack := func(promisor bool) {
+		w, err := dot.NewObjectPack()
+		require.NoError(t, err)
+		w.SetPromisor(promisor)
+
+		pf, pfErr := f.Packfile()
+		require.NoError(t, pfErr)
+		_, err = io.Copy(w, pf)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	}
+
+	promisorPath := fmt.Sprintf("objects/pack/pack-%s.promisor", f.PackfileHash)
+
+	writePack(false)
+	_, err := fs.Stat(promisorPath)
+	assert.True(t, os.IsNotExist(err), ".promisor file should not exist after the first non-promisor write")
+
+	writePack(true)
+	stat, err := fs.Stat(promisorPath)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), stat.Size())
+}
+
+func TestPackWriterNoPromisor(t *testing.T) {
+	t.Parallel()
+
+	f := fixtures.Basic().One()
+	fs := osfs.New(t.TempDir())
+	dot := New(fs)
+
+	w, err := dot.NewObjectPack()
+	require.NoError(t, err)
+	// promisor is false by default; SetPromisor not called.
+
+	pf, pfErr := f.Packfile()
+	require.NoError(t, pfErr)
+	_, err = io.Copy(w, pf)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	promisorPath := fmt.Sprintf("objects/pack/pack-%s.promisor", f.PackfileHash)
+	_, err = fs.Stat(promisorPath)
+	assert.True(t, os.IsNotExist(err), ".promisor file should not exist when promisor is unset")
+}
+
 func TestObjectWriterPermissions(t *testing.T) {
 	t.Parallel()
 

--- a/worktree.go
+++ b/worktree.go
@@ -101,20 +101,27 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		return err
 	}
 
-	fetchHead, err := remote.fetch(ctx, &FetchOptions{
+	fetchOptions := &FetchOptions{
 		RemoteName:    o.RemoteName,
 		RemoteURL:     o.RemoteURL,
 		Depth:         o.Depth,
 		ClientOptions: o.ClientOptions,
 		Progress:      o.Progress,
 		Force:         o.Force,
-	})
+	}
+	fetchHead, err := remote.fetch(ctx, fetchOptions)
 
 	updated := true
 	if errors.Is(err, NoErrAlreadyUpToDate) {
 		updated = false
 	} else if err != nil {
 		return err
+	}
+
+	if fetchOptions.Filter != "" {
+		w.r.Storer = wrapStorerIfPromisor(w.r.Storer, &promisorOptions{
+			ClientOptions: o.ClientOptions,
+		})
 	}
 
 	ref, err := storer.ResolveReference(fetchHead, o.ReferenceName)
@@ -702,6 +709,10 @@ func (w *Worktree) resetWorktreeToTree(fromTree, toTree *object.Tree, files []st
 		return err
 	}
 
+	// Batch-prefetch missing blobs for partial clone repositories.
+	// This reduces N individual on-demand fetches to a single request.
+	w.prefetchBlobs(worktreeChanges, toTree, files, filesMap)
+
 	idx, err := w.r.Storer.Index()
 	if err != nil {
 		return err
@@ -805,6 +816,50 @@ func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
 
 	b.Write(idx)
 	return w.r.Storer.SetIndex(idx)
+}
+
+// prefetchBlobs collects blob hashes that will be needed during checkout
+// and fetches them in a single batch request from the promisor remote.
+// This is a performance optimization for partial clone repositories;
+// errors are logged and ignored because the individual on-demand fetch
+// in promiserStorer serves as a fallback.
+func (w *Worktree) prefetchBlobs(changes merkletrie.Changes, toTree *object.Tree, files []string, filesMap map[string]struct{}) {
+	ps, ok := getPromiserStorer(w.r.Storer)
+	if !ok {
+		return
+	}
+
+	var hashes []plumbing.Hash
+	for _, ch := range changes {
+		a, err := ch.Action()
+		if err != nil || a == merkletrie.Delete {
+			continue
+		}
+
+		name := ch.To.String()
+		if len(files) > 0 && !inFiles(filesMap, name) {
+			continue
+		}
+
+		e, err := toTree.FindEntry(name)
+		if err != nil || e.Mode == filemode.Submodule {
+			continue
+		}
+
+		// Check the inner storer directly to avoid triggering
+		// individual on-demand fetches via promiserStorer.
+		if isObjectNotFound(ps.Storer.HasEncodedObject(e.Hash)) {
+			hashes = append(hashes, e.Hash)
+		}
+	}
+
+	if len(hashes) == 0 {
+		return
+	}
+
+	if err := ps.fetchObjects(context.Background(), hashes); err != nil {
+		trace.General.Printf("prefetchBlobs: batch fetch of %d objects failed: %v", len(hashes), err)
+	}
 }
 
 func (w *Worktree) checkoutChange(ch merkletrie.Change, t *object.Tree, idx *indexBuilder) error {

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -4270,3 +4270,100 @@ func (s *WorktreeSuite) TestRestoreBoth() {
 		{Worktree: Untracked, Staging: Untracked},
 	})
 }
+
+func TestPrefetchBlobsCollectsMissingBlobs(t *testing.T) {
+	t.Parallel()
+
+	// Set up a repo with a commit containing a blob.
+	fs := memfs.New()
+	sto := memory.NewStorage()
+	r, err := Init(sto, WithWorkTree(fs))
+	require.NoError(t, err)
+
+	w, err := r.Worktree()
+	require.NoError(t, err)
+
+	// Create a file and commit it.
+	require.NoError(t, util.WriteFile(fs, "test.txt", []byte("hello"), 0o644))
+	_, err = w.Add("test.txt")
+	require.NoError(t, err)
+	commitHash, err := w.Commit("initial", defaultTestCommitOptions())
+	require.NoError(t, err)
+
+	commit, err := r.CommitObject(commitHash)
+	require.NoError(t, err)
+	tree, err := commit.Tree()
+	require.NoError(t, err)
+
+	// Get the blob hash.
+	entry, err := tree.FindEntry("test.txt")
+	require.NoError(t, err)
+	blobHash := entry.Hash
+
+	// Wrap the storer with a mock fetcher and remove the worktree file
+	// so that diffStagingWithWorktree produces an Insert change.
+	require.NoError(t, fs.Remove("test.txt"))
+
+	fetcher := &prefetchTestFetcher{}
+	ps := newPromiserStorer(sto, fetcher)
+	r.Storer = ps
+
+	changes, err := w.diffStagingWithWorktree(true, false)
+	require.NoError(t, err)
+	require.NotEmpty(t, changes, "should detect missing worktree file")
+
+	// Blob exists in the inner storer → prefetch should skip it.
+	w.prefetchBlobs(changes, tree, nil, nil)
+	assert.Equal(t, 0, fetcher.calls, "should not fetch blobs that already exist")
+
+	// Now use a storer that lacks the blob to simulate partial clone.
+	sto2 := memory.NewStorage()
+	iter, err := sto.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	defer iter.Close()
+	err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+		if obj.Hash() == blobHash {
+			return nil // skip the blob
+		}
+		_, err := sto2.SetEncodedObject(obj)
+		return err
+	})
+	require.NoError(t, err)
+	// Copy refs so the worktree diff still works.
+	refIter, err := sto.IterReferences()
+	require.NoError(t, err)
+	defer refIter.Close()
+	err = refIter.ForEach(func(ref *plumbing.Reference) error {
+		return sto2.SetReference(ref)
+	})
+	require.NoError(t, err)
+	// Copy index.
+	idx, err := sto.Index()
+	require.NoError(t, err)
+	require.NoError(t, sto2.SetIndex(idx))
+
+	fetcher2 := &prefetchTestFetcher{}
+	ps2 := newPromiserStorer(sto2, fetcher2)
+	r.Storer = ps2
+
+	changes2, err := w.diffStagingWithWorktree(true, false)
+	require.NoError(t, err)
+
+	w.prefetchBlobs(changes2, tree, nil, nil)
+	assert.Equal(t, 1, fetcher2.calls, "should batch-fetch missing blobs once")
+	if len(fetcher2.hashes) > 0 {
+		assert.Contains(t, fetcher2.hashes[0], blobHash)
+	}
+}
+
+// prefetchTestFetcher records FetchObjects calls for testing.
+type prefetchTestFetcher struct {
+	calls  int
+	hashes [][]plumbing.Hash
+}
+
+func (f *prefetchTestFetcher) FetchObjects(_ context.Context, hashes []plumbing.Hash) error {
+	f.calls++
+	f.hashes = append(f.hashes, hashes)
+	return nil
+}


### PR DESCRIPTION
## Summary

Implements promisor remote support for partial clone repositories (Fixes [#1381](https://github.com/go-git/go-git/issues/1381)).

When cloning with `--filter` (e.g. `blob:none`), go-git now:
- Persists `remote.<name>.promisor` and `remote.<name>.partialclonefilter` in config
- Upgrades `core.repositoryformatversion` to 1
- Creates `.promisor` marker files for filtered packfiles
- Automatically fetches missing objects on demand via `promiserStorer` wrapper
- Batch-prefetches blobs before checkout to minimize network round-trips

Also supports reading the legacy `extensions.partialClone` config for backward compatibility with repositories created by older git versions.

## Design

- **No interface changes**: `storage.Storer` is unchanged. A `promiserStorer` wrapper intercepts `EncodedObject`, `HasEncodedObject`, and `EncodedObjectSize` to add on-demand fetch fallback.
- **Follows git's architecture**: Config format, `.promisor` files, and on-demand fetch behavior match modern git.
- **Only blobs are fetched on demand**: Trees and commits are always received during clone/fetch with `blob:none`.

## Upstream references

- [partial-clone](https://git-scm.com/docs/partial-clone) — Promisor remote, `.promisor` files, on-demand fetch design
- [repository-version](https://git-scm.com/docs/repository-version) — `extensions.partialClone` config spec, V0/V1 format
- [git-clone --filter](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--filterltfilter-specgtcode) — Filter spec
- [git/promisor-remote.c](https://github.com/git/git/blob/master/promisor-remote.c) — Reference C implementation

## Test plan

- [x] Config round-trip tests for `remote.*.promisor`, `remote.*.partialclonefilter`, `extensions.partialClone`
- [x] `.promisor` file creation/deletion tests
- [x] `promiserStorer` unit tests (found, fetch-on-miss, tree/commit skip, fetch failure)
- [x] `promiserStorer` optional interface delegation tests (Close, PackfileWriter, PackedObjectStorer, LooseObjectStorer)
- [x] `findPromisorRemote` tests (new style, legacy, priority)
- [x] `prefetchBlobs` tests (no-op for non-promisor, skip existing, batch-fetch missing)
- [x] Integration: `blob:none` clone → config verification
- [x] Integration: `blob:none` clone → on-demand blob fetch with content read
- [x] Integration: `depth:1` + `blob:none` + sparse checkout combination

## AI disclosure

This PR was developed with assistance from Claude Opus 4.6. All commits include the `Assisted-by: Claude Opus 4.6` trailer.
