### PR TITLE
Fix Windows file handle leak in file transport

### DIFF
--- a/plumbing/transport/file/file.go
+++ b/plumbing/transport/file/file.go
@@ -83,9 +83,22 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (io.Rea
 	pr, pw := io.Pipe()
 	sr, sw := io.Pipe()
 
-	closeAll := func() error { _ = pw.Close(); return sr.Close() }
+	done := make(chan struct{})
+
+	closeAll := func() error {
+		_ = pw.Close()
+		closeErr := sr.Close()
+		<-done // Wait for server goroutine to finish
+		if closer, ok := st.(io.Closer); ok {
+			if err := closer.Close(); err != nil && closeErr == nil {
+				closeErr = err
+			}
+		}
+		return closeErr
+	}
 
 	go func() {
+		defer close(done)
 		err := serverFn(ctx, st, io.NopCloser(pr), sw, gitProtocol)
 		_ = sw.CloseWithError(err)
 		_ = pr.Close()


### PR DESCRIPTION
## Summary

Fixes intermittent Windows CI failures in `TestFetchWithFilters` caused by file handle leaks in the file transport.

## Problem

The file transport's `Loader.Load()` creates a `storage.Storer` instance when executing git operations, but the storage was never being closed. This left file handles open on pack index (`.idx`) files until garbage collection occurred.

On Windows, open file handles prevent file/directory deletion, causing test cleanup to fail with:
```
The process cannot access the file because it is being used by another process.
```

## Solution

Modified the `closeAll` function in `file.go` to properly close the loaded storage if it implements `io.Closer`. This ensures file handles are released when the connection is closed, rather than waiting for garbage collection.

## Test plan

- [x] Existing tests pass locally
- [x] Linting passes
- [x] Rebased onto latest main (after #1983 refactored file transport)
- [ ] Verify Windows CI no longer fails intermittently

🤖 Generated with [Claude Code](https://claude.com/claude-code)