### PR TITLE
plumbing: object, make Tree.FindEntry thread-safe

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	stdsync "sync"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -37,9 +38,11 @@ type Tree struct {
 	Entries []TreeEntry
 	Hash    plumbing.Hash
 
-	s storer.EncodedObjectStorer
-	m map[string]*TreeEntry
-	t map[string]*Tree // tree path cache
+	s       storer.EncodedObjectStorer
+	m       map[string]*TreeEntry
+	mOnce   stdsync.Once
+	t       map[string]*Tree // tree path cache
+	tMutex  stdsync.Mutex
 }
 
 // GetTree gets a tree from an object storer and decodes it.
@@ -128,6 +131,7 @@ func (t *Tree) TreeEntryFile(e *TreeEntry) (*File, error) {
 
 // FindEntry search a TreeEntry in this tree or any subtree.
 func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
+	t.tMutex.Lock()
 	if t.t == nil {
 		t.t = make(map[string]*Tree)
 	}
@@ -154,12 +158,14 @@ func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
 	var err error
 	for tree = startingTree; len(pathParts) > 1; pathParts = pathParts[1:] {
 		if tree, err = tree.dir(pathParts[0]); err != nil {
+			t.tMutex.Unlock()
 			return nil, err
 		}
 
 		pathCurrent = filepath.Join(pathCurrent, pathParts[0])
 		t.t[pathCurrent] = tree
 	}
+	t.tMutex.Unlock()
 
 	return tree.entry(pathParts[0])
 }
@@ -182,9 +188,7 @@ func (t *Tree) dir(baseName string) (*Tree, error) {
 }
 
 func (t *Tree) entry(baseName string) (*TreeEntry, error) {
-	if t.m == nil {
-		t.buildMap()
-	}
+	t.mOnce.Do(t.buildMap)
 
 	entry, ok := t.m[baseName]
 	if !ok {
@@ -225,6 +229,7 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 
 	t.Entries = nil
 	t.m = nil
+	t.mOnce = stdsync.Once{}
 
 	reader, err := o.Reader()
 	if err != nil {

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"sort"
+	stdsync "sync"
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
@@ -135,6 +136,37 @@ func (s *TreeSuite) TestFindEntryNotFound() {
 	e, err = s.Tree.FindEntry("not-found/not-found/not-found")
 	s.Nil(e)
 	s.ErrorIs(err, ErrDirectoryNotFound)
+}
+
+// TestFindEntryConcurrent verifies that concurrent calls to FindEntry
+// on the same Tree do not trigger a data race. This is a regression test
+// for https://github.com/go-git/go-git/issues/1917.
+func (s *TreeSuite) TestFindEntryConcurrent() {
+	hash := plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")
+	tree, err := GetTree(s.Storer, hash)
+	s.Require().NoError(err)
+
+	paths := []string{
+		"vendor/foo.go",
+		"json/short.json",
+		"json/long.json",
+		"LICENSE",
+		".gitignore",
+	}
+
+	const goroutines = 10
+	var wg stdsync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			p := paths[id%len(paths)]
+			e, err := tree.FindEntry(p)
+			s.NoError(err)
+			s.NotNil(e)
+		}(i)
+	}
+	wg.Wait()
 }
 
 // countingStorer wraps a storer and counts EncodedObject calls per hash


### PR DESCRIPTION
## Summary

Fixes #1917 — data race in `Tree.FindEntry()` when called concurrently.

The race has three vectors:
1. **`t.t` field** (tree path cache) — concurrent goroutines read/write the map without synchronization
2. **`t.m` field** (entry name map) — concurrent goroutines race on the nil-check and `buildMap()` call
3. **`t.m` map contents** — one goroutine reads while another populates

### Fix

- **`sync.Once`** for `t.m` — replaces the `if t.m == nil { t.buildMap() }` pattern in `entry()` with `t.mOnce.Do(t.buildMap)`. This is the idiomatic Go pattern for lazy one-time initialization and guarantees that `buildMap()` runs exactly once, with proper happens-before ordering so all goroutines see the fully populated map.
- **`sync.Mutex`** for `t.t` — the tree path cache is written to on each `FindEntry` call (not just once), so a mutex protects all reads and writes within `FindEntry`. The lock is released before calling `tree.entry()` to avoid holding it during the final lookup.
- **`mOnce` reset in `Decode`** — `Decode` clears `t.m`, so `mOnce` is also reset to allow re-initialization if `Decode` is called again on the same `Tree`.

Both caches are preserved (no performance regression).

### Before (race detector output)

```
WARNING: DATA RACE
Read at 0x00c0001c4060 by goroutine 36:
  runtime.mapaccess2_faststr()
  github.com/go-git/go-git/v6/plumbing/object.(*Tree).FindEntry()
      plumbing/object/tree.go:145 +0x264

Previous write at 0x00c0001c4060 by goroutine 34:
  runtime.mapassign_faststr()
  github.com/go-git/go-git/v6/plumbing/object.(*Tree).FindEntry()
      plumbing/object/tree.go:161 +0x3f4
```

### After

`go test -race -run TestFindEntryConcurrent ./plumbing/object/...` passes cleanly.

### Test plan

- [x] Added `TestFindEntryConcurrent` — spawns 10 goroutines calling `FindEntry` on the same `Tree` with different paths
- [x] Run with `-race` flag to verify no data races
- [x] Existing tests continue to pass