### PR TITLE
fix: add mutex to Tree to prevent data race in FindEntry

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	gosync "sync"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -37,9 +38,10 @@ type Tree struct {
 	Entries []TreeEntry
 	Hash    plumbing.Hash
 
-	s storer.EncodedObjectStorer
-	m map[string]*TreeEntry
-	t map[string]*Tree // tree path cache
+	s  storer.EncodedObjectStorer
+	mu gosync.RWMutex
+	m  map[string]*TreeEntry
+	t  map[string]*Tree // tree path cache
 }
 
 // GetTree gets a tree from an object storer and decodes it.
@@ -128,27 +130,31 @@ func (t *Tree) TreeEntryFile(e *TreeEntry) (*File, error) {
 
 // FindEntry search a TreeEntry in this tree or any subtree.
 func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
+	t.mu.Lock()
 	if t.t == nil {
 		t.t = make(map[string]*Tree)
 	}
+	t.mu.Unlock()
 
 	pathParts := strings.Split(path, "/")
 	startingTree := t
 	pathCurrent := ""
 
 	// search for the longest path in the tree path cache
+	t.mu.RLock()
 	for i := len(pathParts) - 1; i >= 1; i-- {
-		path := filepath.Join(pathParts[:i]...)
+		p := filepath.Join(pathParts[:i]...)
 
-		tree, ok := t.t[path]
+		tree, ok := t.t[p]
 		if ok {
 			startingTree = tree
 			pathParts = pathParts[i:]
-			pathCurrent = path
+			pathCurrent = p
 
 			break
 		}
 	}
+	t.mu.RUnlock()
 
 	var tree *Tree
 	var err error
@@ -158,7 +164,9 @@ func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
 		}
 
 		pathCurrent = filepath.Join(pathCurrent, pathParts[0])
+		t.mu.Lock()
 		t.t[pathCurrent] = tree
+		t.mu.Unlock()
 	}
 
 	return tree.entry(pathParts[0])
@@ -182,11 +190,15 @@ func (t *Tree) dir(baseName string) (*Tree, error) {
 }
 
 func (t *Tree) entry(baseName string) (*TreeEntry, error) {
+	t.mu.Lock()
 	if t.m == nil {
 		t.buildMap()
 	}
+	t.mu.Unlock()
 
+	t.mu.RLock()
 	entry, ok := t.m[baseName]
+	t.mu.RUnlock()
 	if !ok {
 		return nil, ErrEntryNotFound
 	}

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -38,10 +38,16 @@ type Tree struct {
 	Entries []TreeEntry
 	Hash    plumbing.Hash
 
-	s  storer.EncodedObjectStorer
-	mu gosync.RWMutex
-	m  map[string]*TreeEntry
-	t  map[string]*Tree // tree path cache
+	s storer.EncodedObjectStorer
+
+	// Write-once map: initialized once by buildMap(), never modified afterward.
+	mOnce gosync.Once
+	m     map[string]*TreeEntry
+
+	// Continuously updated path cache.
+	tOnce gosync.Once
+	tMu   gosync.RWMutex
+	t     map[string]*Tree
 }
 
 // GetTree gets a tree from an object storer and decodes it.
@@ -130,18 +136,16 @@ func (t *Tree) TreeEntryFile(e *TreeEntry) (*File, error) {
 
 // FindEntry search a TreeEntry in this tree or any subtree.
 func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
-	t.mu.Lock()
-	if t.t == nil {
+	t.tOnce.Do(func() {
 		t.t = make(map[string]*Tree)
-	}
-	t.mu.Unlock()
+	})
 
 	pathParts := strings.Split(path, "/")
 	startingTree := t
 	pathCurrent := ""
 
 	// search for the longest path in the tree path cache
-	t.mu.RLock()
+	t.tMu.RLock()
 	for i := len(pathParts) - 1; i >= 1; i-- {
 		p := filepath.Join(pathParts[:i]...)
 
@@ -154,7 +158,7 @@ func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
 			break
 		}
 	}
-	t.mu.RUnlock()
+	t.tMu.RUnlock()
 
 	var tree *Tree
 	var err error
@@ -164,9 +168,9 @@ func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
 		}
 
 		pathCurrent = filepath.Join(pathCurrent, pathParts[0])
-		t.mu.Lock()
+		t.tMu.Lock()
 		t.t[pathCurrent] = tree
-		t.mu.Unlock()
+		t.tMu.Unlock()
 	}
 
 	return tree.entry(pathParts[0])
@@ -190,15 +194,13 @@ func (t *Tree) dir(baseName string) (*Tree, error) {
 }
 
 func (t *Tree) entry(baseName string) (*TreeEntry, error) {
-	t.mu.Lock()
-	if t.m == nil {
+	t.mOnce.Do(func() {
 		t.buildMap()
-	}
-	t.mu.Unlock()
+	})
 
-	t.mu.RLock()
+	// No lock needed: sync.Once provides happens-before, and t.m is never
+	// modified after init.
 	entry, ok := t.m[baseName]
-	t.mu.RUnlock()
 	if !ok {
 		return nil, ErrEntryNotFound
 	}

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -1724,3 +1724,32 @@ func (s *TreeSuite) TestTreeDecodeReadBug() {
 		}
 	}
 }
+
+func (s *TreeSuite) TestFindEntryConcurrent() {
+	// Regression test for https://github.com/go-git/go-git/issues/1917
+	// FindEntry must be safe for concurrent use on the same Tree.
+	const goroutines = 10
+
+	entries := make([]string, 0, len(s.Tree.Entries))
+	for _, e := range s.Tree.Entries {
+		entries = append(entries, e.Name)
+	}
+	s.Require().NotEmpty(entries)
+
+	errCh := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			for _, name := range entries {
+				if _, err := s.Tree.FindEntry(name); err != nil {
+					errCh <- err
+					return
+				}
+			}
+			errCh <- nil
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		s.NoError(<-errCh)
+	}
+}


### PR DESCRIPTION
Fixes #1917

## Problem

`Tree.FindEntry()` and `Tree.entry()` lazily initialize internal maps (`t.t` and `t.m`) without synchronization. When multiple goroutines call `FindEntry` on the same `Tree` concurrently, this causes a data race:

```
WARNING: DATA RACE
Read at 0x00c00042a060 by goroutine 82:
  object.(*Tree).FindEntry()
      plumbing/object/tree.go:131 +0x64

Previous write at 0x00c00042a060 by goroutine 83:
  object.(*Tree).FindEntry()
      plumbing/object/tree.go:132 +0x8d
```

## Fix

Added a `sync.RWMutex` to the `Tree` struct. Write lock protects lazy map initialization and cache updates, read lock protects map lookups. This keeps the overhead low for the common case (maps already initialized).

**Before:** concurrent `FindEntry` calls trigger the race detector
**After:** clean run with `-race`, no data races

## Tests

Added `TestFindEntryConcurrent` that spawns 10 goroutines all calling `FindEntry` on the same tree simultaneously. This reliably triggers the race detector without the fix.

## AI Disclosure

Used Claude as a coding assistant for this fix. I reviewed and verified the synchronization logic and can discuss the implementation.