### PR TITLE
[v5] repository: fix extension validation for worktreeConfig repositories

### DIFF
--- a/repository_extensions.go
+++ b/repository_extensions.go
@@ -40,16 +40,30 @@ var (
 		// noop-v1 does not change git’s behavior at all.
 		// It is useful only for testing format-1 compatibility.
 		"noop-v1": {},
+
+		// worktreeconfig signals that per-worktree config files
+		// (.git/config.worktree) may be present. go-git reads the
+		// shared config like upstream git would when the extension
+		// is absent; worktree-specific overrides are ignored but do
+		// not prevent the repository from being opened.
+		//
+		// Modern git enables this extension automatically on
+		// `git sparse-checkout set` and `git sparse-checkout disable`,
+		// so rejecting it would break common workflows.
+		"worktreeconfig": {},
 	}
 
 	// Some Git extensions were supported upstream before the introduction
 	// of repositoryformatversion. These are the only extensions that can be
 	// enabled while core.repositoryformatversion is unset or set to 0.
+	//
+	// Keys must be lowercase to match the output of extensions(), which
+	// normalises extension names with strings.ToLower.
 	extensionsValidForV0 = map[string]struct{}{
 		"noop":            {},
-		"partialClone":    {},
-		"preciousObjects": {},
-		"worktreeConfig":  {},
+		"partialclone":    {},
+		"preciousobjects": {},
+		"worktreeconfig":  {},
 	}
 )
 

--- a/repository_extensions_test.go
+++ b/repository_extensions_test.go
@@ -65,6 +65,44 @@ func TestVerifyExtensions(t *testing.T) {
 			},
 			wantErr: "unknown extension: objectformat",
 		},
+		{
+			// Regression: modern git sets extensions.worktreeConfig = true
+			// automatically on `git sparse-checkout set/disable`. Prior to
+			// this being handled correctly, go-git rejected the extension
+			// first via the v0 gate (because extensionsValidForV0 stored
+			// map keys in camelCase while lookups were lowercased), and
+			// then via the builtin-extensions gate (because worktreeconfig
+			// was not in builtinExtensions).
+			name: "repositoryformatversion=0: allows worktreeConfig (camelCase on disk)",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_0
+				cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
+			},
+		},
+		{
+			name: "repositoryformatversion=1: allows worktreeConfig",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_1
+				cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
+			},
+		},
+		{
+			// Regression: partialClone and preciousObjects share the same
+			// camelCase/lowercase lookup bug as worktreeConfig. The v0 gate
+			// must accept their canonical camelCase on-disk names.
+			name: "repositoryformatversion=0: allows partialClone and preciousObjects",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_0
+				cfg.Raw.Section("extensions").SetOption("partialClone", "origin")
+				cfg.Raw.Section("extensions").SetOption("preciousObjects", "true")
+			},
+			// partialClone and preciousObjects are valid-for-v0 but are
+			// not in builtinExtensions, so the post-v0 gate surfaces them
+			// as unknown. This is pre-existing behaviour and outside the
+			// scope of this patch — the important assertion is that they
+			// no longer trip the v0 gate with the wrong error.
+			wantErr: "unknown extension",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Fixes the v5.17.0 regression in which opening a repository that has `extensions.worktreeConfig = true` fails with:

```
core.repositoryformatversion does not support extension: worktreeconfig
```

…or, after the first case bug is fixed:

```
unknown extension: worktreeconfig
```

## Why

`extensions.worktreeConfig = true` is set automatically by modern git on `git sparse-checkout set` and `git sparse-checkout disable` (see `git-sparse-checkout(1)`). Any consumer of go-git v5 that opens a repository touched by those commands is currently broken on v5.17.x — this includes at least [`tea`](https://gitea.com/gitea/tea), [Google Antigravity](https://discuss.ai.google.dev/t/antigravity-agent-breaks-on-git-worktree-repos-with-extensions-worktreeconfig/137246), and CI environments that use `actions/checkout` (which [had to add an explicit `git config --unset`](https://github.com/actions/checkout/pull/1692) to work around similar tooling breakage).

## The two bugs

**1. Case mismatch in `extensionsValidForV0`.** `extensions()` normalises every extension name with `strings.ToLower` before lookup, but the map keys were stored in camelCase (`"worktreeConfig"`, `"partialClone"`, `"preciousObjects"`). Go map lookups are case-sensitive, so the V0 gate rejected every one of these extensions even though they were explicitly intended to be allowed.

**2. `worktreeconfig` missing from `builtinExtensions`.** After passing the V0 gate, `verifyExtensions` also checks every extension against `builtinExtensions`. This patch adds `worktreeconfig` so v5 will open the repository. Per-worktree config files (`.git/config.worktree`) are not read — that matches the behaviour the library had prior to v5.17.0 and avoids pulling in the larger storage changes from #1877.

## Scope

This is the **minimum viable backport** for v5. It is not a port of #1877 — that's a much larger change involving the `ExtensionChecker` interface and filesystem storage support, and the maintainer has noted v5 is in maintenance mode. This patch restores the pre-v5.17.0 behaviour of opening worktreeConfig-enabled repositories without breaking anything else.

## Testing

Three new table-driven cases added to `TestVerifyExtensions`:

- `repositoryformatversion=0: allows worktreeConfig (camelCase on disk)` — the primary regression case. Verified to fail on unpatched `v5.17.2` with the original error (`core.repositoryformatversion does not support extension: worktreeconfig`) and pass with this patch.
- `repositoryformatversion=1: allows worktreeConfig` — covers the v1 path through `builtinExtensions`.
- `repositoryformatversion=0: allows partialClone and preciousObjects` — covers the other two camelCase v0 extensions affected by bug #1. They still hit `unknown extension` at the builtin-extensions gate (pre-existing behaviour, out of scope), but the assertion confirms they no longer trip the v0 gate with the wrong error.

`go build ./...` and `go vet ./...` pass clean. Full `go test .` pack still green.

## Refs

- #1861 — introduced the regression
- #1939 — closed as duplicate, identified the case-sensitivity bug
- #1943 — open, reported by a consumer affected by this
- #1877 — full fix on `main` (v6), not backported