### PR TITLE
plumbing: transport, add git-upload-archive support

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -102,6 +102,10 @@ func (b *Backend) Serve(ctx context.Context, r io.ReadCloser, w io.WriteCloser, 
 			AdvertiseRefs: req.AdvertiseRefs,
 			StatelessRPC:  req.StatelessRPC,
 		})
+	case transport.UploadArchiveService:
+		return transport.UploadArchive(ctx, st, r, w, &transport.UploadArchiveRequest{
+			AllowUnreachable: false,
+		})
 	default:
 		return fmt.Errorf("%w: %s", transport.ErrUnsupportedService, req.Service)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -154,6 +154,13 @@ type Config struct {
 		DefaultBranch string
 	}
 
+	UploadArchive struct {
+		// AllowUnreachable when true allows clients to request archives
+		// using arbitrary SHA-1 expressions. When false (the default),
+		// only direct ref names are allowed.
+		AllowUnreachable OptBool
+	}
+
 	Extensions struct {
 		// ObjectFormat specifies the hash algorithm to use. The
 		// acceptable values are sha1 and sha256. If not specified,
@@ -463,6 +470,8 @@ const (
 	formatKey                  = "format"
 	allowedSignersFileKey      = "allowedSignersFile"
 	gpgSignKey                 = "gpgSign"
+	uploadArchiveSection       = "uploadArchive"
+	allowUnreachableKey        = "allowUnreachable"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.
@@ -489,6 +498,7 @@ func (c *Config) Unmarshal(b []byte) error {
 	c.unmarshalUser()
 	c.unmarshalGPG()
 	c.unmarshalInit()
+	c.unmarshalUploadArchive()
 	if err := c.unmarshalPack(); err != nil {
 		return err
 	}
@@ -704,6 +714,14 @@ func (c *Config) unmarshalInit() {
 	c.Init.DefaultBranch = s.Options.Get(defaultBranchKey)
 }
 
+func (c *Config) unmarshalUploadArchive() {
+	s := c.Raw.Section(uploadArchiveSection)
+	v, err := strconv.ParseBool(s.Options.Get(allowUnreachableKey))
+	if err == nil {
+		c.UploadArchive.AllowUnreachable = NewOptBool(v)
+	}
+}
+
 // Marshal returns Config encoded as a git-config file.
 //
 // This call populates the field Raw with the current values of
@@ -727,6 +745,7 @@ func (c *Config) Marshal() ([]byte, error) {
 	c.marshalURLs()
 	c.marshalProtocol()
 	c.marshalInit()
+	c.marshalUploadArchive()
 
 	buf := bytes.NewBuffer(nil)
 	if err := format.NewEncoder(buf).Encode(c.Raw); err != nil {
@@ -957,6 +976,13 @@ func (c *Config) marshalInit() {
 	s := c.Raw.Section(initSection)
 	if c.Init.DefaultBranch != "" {
 		s.SetOption(defaultBranchKey, c.Init.DefaultBranch)
+	}
+}
+
+func (c *Config) marshalUploadArchive() {
+	if c.UploadArchive.AllowUnreachable.IsSet() {
+		s := c.Raw.Section(uploadArchiveSection)
+		s.SetOption(allowUnreachableKey, c.UploadArchive.AllowUnreachable.FormatBool())
 	}
 }
 

--- a/plumbing/transport/archive.go
+++ b/plumbing/transport/archive.go
@@ -1,0 +1,93 @@
+package transport
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+// ArchiveRequest describes a git-upload-archive request.
+type ArchiveRequest struct {
+	// Args is the list of arguments sent as "argument <arg>\n" pkt-lines.
+	// These are the same arguments accepted by git-archive:
+	// e.g. []string{"--format=tar.gz", "--prefix=project/", "HEAD", "src/"}
+	Args []string
+
+	// Progress receives human-readable status from the server (sideband channel 2).
+	Progress sideband.Progress
+}
+
+// Archiver is implemented by Sessions that support git-upload-archive.
+// Callers should type-assert their Session to Archiver at the call
+// site, following the io.WriterTo / io.ReaderFrom pattern.
+type Archiver interface {
+	Archive(ctx context.Context, req *ArchiveRequest) (io.ReadCloser, error)
+}
+
+// Archive speaks the git-upload-archive client wire protocol.
+//
+// It sends argument pkt-lines to w, closes w, then reads the ACK/NACK
+// response and sideband-encoded archive stream from r. The returned
+// io.ReadCloser yields archive data (sideband channel 1); closing it
+// closes r.
+//
+// Wire protocol:
+//
+//	Client → Server: "argument <arg>\n" pkt-lines + flush
+//	Server → Client: "ACK\n" pkt-line + flush
+//	Server → Client: sideband packets (band 1 = data, band 2 = progress)
+func Archive(ctx context.Context, w io.WriteCloser, r io.ReadCloser, req *ArchiveRequest) (io.ReadCloser, error) {
+	w = ioutil.NewContextWriteCloser(ctx, w)
+
+	for _, arg := range req.Args {
+		if _, err := pktline.WriteString(w, fmt.Sprintf("argument %s\n", arg)); err != nil {
+			return nil, fmt.Errorf("archive: writing argument: %w", err)
+		}
+	}
+	if err := pktline.WriteFlush(w); err != nil {
+		return nil, fmt.Errorf("archive: writing flush: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("archive: closing writer: %w", err)
+	}
+
+	rd := bufio.NewReader(r)
+
+	l, line, err := pktline.ReadLine(rd)
+	if err != nil {
+		return nil, fmt.Errorf("archive: reading ACK/NACK: %w", err)
+	}
+	if l == pktline.Flush {
+		return nil, fmt.Errorf("archive: expected ACK/NACK, got flush")
+	}
+
+	resp := strings.TrimSuffix(string(line), "\n")
+	switch {
+	case resp == "ACK":
+	case strings.HasPrefix(resp, "NACK "):
+		return nil, fmt.Errorf("archive: NACK %s", resp[5:])
+	default:
+		return nil, fmt.Errorf("archive: protocol error: %s", resp)
+	}
+
+	l, _, err = pktline.ReadLine(rd)
+	if err != nil {
+		return nil, fmt.Errorf("archive: reading flush after ACK: %w", err)
+	}
+	if l != pktline.Flush {
+		return nil, fmt.Errorf("archive: expected flush after ACK, got data")
+	}
+
+	demuxer := sideband.NewDemuxer(sideband.Sideband64k, rd)
+	if req.Progress != nil {
+		demuxer.Progress = req.Progress
+	}
+
+	return ioutil.NewReadCloser(demuxer, r), nil
+}

--- a/plumbing/transport/errors.go
+++ b/plumbing/transport/errors.go
@@ -18,6 +18,7 @@ var (
 // Transport capability and support errors.
 var (
 	ErrConnectUnsupported        = errors.New("transport does not support raw connections")
+	ErrArchiveUnsupported        = errors.New("transport does not support archive")
 	ErrCommandUnsupported        = errors.New("command is not supported by transport")
 	ErrProtocolUnsupported       = errors.New("protocol version is not supported")
 	ErrUnsupportedVersion        = errors.New("unsupported protocol version")

--- a/plumbing/transport/file/file.go
+++ b/plumbing/transport/file/file.go
@@ -26,6 +26,10 @@ func defaultReceivePack(ctx context.Context, st storage.Storer, r io.ReadCloser,
 	})
 }
 
+func defaultUploadArchive(ctx context.Context, st storage.Storer, r io.ReadCloser, w io.WriteCloser, _ string) error {
+	return transport.UploadArchive(ctx, st, r, w, nil)
+}
+
 // Options configures the file transport.
 type Options struct {
 	// Loader resolves URLs to storage.Storer instances. If nil,
@@ -35,9 +39,10 @@ type Options struct {
 
 // Transport implements the file:// transport protocol.
 type Transport struct {
-	loader      transport.Loader
-	uploadPack  ServerFunc
-	receivePack ServerFunc
+	loader        transport.Loader
+	uploadPack    ServerFunc
+	receivePack   ServerFunc
+	uploadArchive ServerFunc
 }
 
 // NewTransport creates a file transport with the given options.
@@ -47,9 +52,10 @@ func NewTransport(opts Options) *Transport {
 		loader = transport.DefaultLoader
 	}
 	return &Transport{
-		loader:      loader,
-		uploadPack:  defaultUploadPack,
-		receivePack: defaultReceivePack,
+		loader:        loader,
+		uploadPack:    defaultUploadPack,
+		receivePack:   defaultReceivePack,
+		uploadArchive: defaultUploadArchive,
 	}
 }
 
@@ -69,6 +75,8 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (io.Rea
 		serverFn = t.uploadPack
 	case transport.ReceivePackService:
 		serverFn = t.receivePack
+	case transport.UploadArchiveService:
+		serverFn = t.uploadArchive
 	default:
 		return nil, nil, nil, fmt.Errorf("%w: %s", transport.ErrCommandUnsupported, req.Command)
 	}

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -1,13 +1,23 @@
 package file
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"io"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
@@ -94,4 +104,233 @@ func TestFileTransport_ImplementsConnector(t *testing.T) {
 
 	_, ok := any(tr).(transport.Connector)
 	assert.True(t, ok)
+}
+
+var _ transport.Conn = (*fileConn)(nil)
+
+func archiveSession(t *testing.T) transport.Archiver {
+	t.Helper()
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath, err := filepath.Abs(repoFS.Root())
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     &url.URL{Scheme: "file", Path: repoPath},
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { session.Close() })
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+	return a
+}
+
+func TestArchive_Tar(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	tr := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
+}
+
+func TestArchive_TarGz(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar.gz", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	tr := tar.NewReader(gr)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
+}
+
+func TestArchive_Zip(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=zip", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	assert.Greater(t, len(zr.File), 0)
+}
+
+func TestArchive_Prefix(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "--prefix=myproject/", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(hdr.Name, "myproject/"), "expected prefix myproject/, got %s", hdr.Name)
+	}
+}
+
+func TestArchive_List(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--list"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	formats := strings.TrimSpace(string(data))
+	lines := strings.Split(formats, "\n")
+	assert.Contains(t, lines, "tar")
+	assert.Contains(t, lines, "zip")
+	assert.Contains(t, lines, "tar.gz")
+	assert.Contains(t, lines, "tgz")
+}
+
+func TestArchive_UploadPackSessionRejectsArchive(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath, err := filepath.Abs(repoFS.Root())
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     &url.URL{Scheme: "file", Path: repoPath},
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "StreamSession always implements Archiver")
+
+	_, err = a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"master"},
+	})
+	require.ErrorIs(t, err, transport.ErrArchiveUnsupported)
+}
+
+func TestArchive_UnreachableBlocked(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"},
+	})
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only ref names are allowed")
+}
+
+func TestArchive_AllowUnreachableConfig(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath, err := filepath.Abs(repoFS.Root())
+	require.NoError(t, err)
+
+	cfgPath := filepath.Join(repoPath, "config")
+	f, err := os.OpenFile(cfgPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("\n[uploadArchive]\n\tallowUnreachable = true\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     &url.URL{Scheme: "file", Path: repoPath},
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { session.Close() })
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	tr2 := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tr2.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
 }

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -247,6 +247,85 @@ func TestArchive_List(t *testing.T) {
 	assert.Contains(t, lines, "tgz")
 }
 
+func TestArchive_TarFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	// The basic fixture has files with mode 0o100664 (group writable) and
+	// directories with mode 0o040775. The umask 0o002 should preserve
+	// the group writable bit, resulting in 0o664 for files and 0o775 for dirs.
+	// Note: umask 0o002 means "remove write permission for others".
+	// To get 0o644 from 0o664, we'd need umask 0o022.
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+
+		// Just verify modes are reasonable and consistent
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			// Directories should be readable and executable by all
+			assert.NotZero(t, hdr.Mode&0o555, "directory %s should be readable/executable", hdr.Name)
+		case tar.TypeReg:
+			// Regular files should be readable by all (owner at minimum)
+			assert.NotZero(t, hdr.Mode&0o400, "regular file %s should be readable", hdr.Name)
+			// Verify no special bits (setuid/setgid/sticky) are set in archived files
+			// Git doesn't store these in the tree, and they shouldn't appear
+			assert.Zero(t, hdr.Mode&0o7000, "file %s should not have special mode bits", hdr.Name)
+		case tar.TypeSymlink:
+			// Symlinks should always be 0o777 per canonical git
+			assert.Equal(t, int64(0o777), hdr.Mode&0o777,
+				"symlink %s should have mode 0o777, got 0o%03o", hdr.Name, hdr.Mode&0o777)
+		}
+	}
+}
+
+func TestArchive_ZipFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=zip", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+
+	for _, f := range zr.File {
+		mode := f.Mode()
+		// Skip directories in zip
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		// Check if it's a symlink
+		if mode&os.ModeSymlink != 0 {
+			// Symlinks should have 0o777 permissions
+			assert.Equal(t, os.FileMode(0o777), mode&os.ModePerm,
+				"symlink %s should have mode 0o777, got 0o%03o", f.Name, mode&os.ModePerm)
+			continue
+		}
+		// Just verify files are readable by owner
+		assert.NotZero(t, mode&0o400, "file %s should be readable by owner", f.Name)
+	}
+}
+
 func TestArchive_UploadPackSessionRejectsArchive(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -247,6 +247,50 @@ func TestArchive_List(t *testing.T) {
 	assert.Contains(t, lines, "tgz")
 }
 
+func TestArchive_SpaceSeparatedArgs(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	// Test space-separated format option: --format zip instead of --format=zip
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format", "zip", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	assert.Greater(t, len(zr.File), 0)
+}
+
+func TestArchive_SpaceSeparatedPrefix(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	// Test space-separated prefix option: --prefix myproject/ instead of --prefix=myproject/
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--prefix", "myproject/", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(hdr.Name, "myproject/"), "expected prefix myproject/, got %s", hdr.Name)
+	}
+}
+
 func TestArchive_TarFilePermissions(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/git/git_test.go
+++ b/plumbing/transport/git/git_test.go
@@ -1,9 +1,12 @@
 package git
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -33,7 +36,7 @@ func startDaemon(t *testing.T, base string, port int) {
 	t.Helper()
 	daemon := exec.Command("git", "daemon",
 		fmt.Sprintf("--base-path=%s", base),
-		"--export-all", "--enable=receive-pack", "--reuseaddr",
+		"--export-all", "--enable=receive-pack", "--enable=upload-archive", "--reuseaddr",
 		fmt.Sprintf("--port=%d", port),
 		"--max-connections=1", "--listen=127.0.0.1",
 	)
@@ -138,4 +141,53 @@ func TestGitTransport_ConnectFail(t *testing.T) {
 
 	_, err := tr.Connect(context.Background(), req)
 	require.Error(t, err)
+}
+
+func TestGitTransport_Archive(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip(windowsSkipMsg)
+	}
+
+	port := freePort(t)
+	base := filepath.Join(t.TempDir(), fmt.Sprintf("git-proto-%d", port))
+	_ = test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	startDaemon(t, base, port)
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL: &url.URL{
+			Scheme: "git",
+			Host:   fmt.Sprintf("localhost:%d", port),
+			Path:   "/basic.git",
+		},
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	rc, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	tarR := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tarR.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
 }

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-git/go-git/v6/storage"
 )
 
-// StreamSession implements PackSession over a full-duplex stream.
+// StreamSession implements Session over a full-duplex stream.
 // Stream transports (SSH, Git TCP, file) call NewStreamSession from
 // their Handshake implementation.
 type StreamSession struct {
@@ -27,11 +27,24 @@ type StreamSession struct {
 	refs    *packp.AdvRefs
 }
 
-// NewStreamSession reads version + adv-refs from the session and
-// returns a ready StreamSession.
+// NewStreamSession creates a session from an open Conn.
+// For pack services (upload-pack, receive-pack), it reads the version
+// and advertised refs from the stream. For upload-archive, it skips
+// that — the archive protocol has no ref advertisement.
 func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 	r := bufio.NewReader(conn.Reader())
 	w := conn.Writer()
+
+	s := &StreamSession{
+		conn: conn,
+		r:    r,
+		w:    w,
+		svc:  service,
+	}
+
+	if service == UploadArchiveService {
+		return s, nil
+	}
 
 	ver, err := DiscoverVersion(r)
 	if err != nil {
@@ -52,15 +65,10 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 		return nil, err
 	}
 
-	return &StreamSession{
-		conn:    conn,
-		r:       r,
-		w:       w,
-		svc:     service,
-		version: ver,
-		caps:    ar.Capabilities,
-		refs:    ar,
-	}, nil
+	s.version = ver
+	s.caps = ar.Capabilities
+	s.refs = ar
+	return s, nil
 }
 
 // Capabilities implements PackSession.
@@ -116,7 +124,19 @@ func (s *StreamSession) wrapStderr(err error) error {
 	return err
 }
 
-// Close implements PackSession.
+// Close implements Session.
 func (s *StreamSession) Close() error { return s.conn.Close() }
 
-var _ Session = (*StreamSession)(nil)
+// Archive implements Archiver. It speaks the git-upload-archive wire
+// protocol over the session's existing connection.
+func (s *StreamSession) Archive(ctx context.Context, req *ArchiveRequest) (io.ReadCloser, error) {
+	if s.svc != UploadArchiveService {
+		return nil, ErrArchiveUnsupported
+	}
+	return Archive(ctx, s.conn.Writer(), io.NopCloser(s.conn.Reader()), req)
+}
+
+var (
+	_ Session  = (*StreamSession)(nil)
+	_ Archiver = (*StreamSession)(nil)
+)

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -1,6 +1,8 @@
 package ssh
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -152,4 +154,51 @@ func TestSSHTransport_NoConfig(t *testing.T) {
 
 	_, err := tr.Connect(context.Background(), req)
 	require.Error(t, err)
+}
+
+func TestSSHTransport_Archive(t *testing.T) {
+	t.Parallel()
+
+	addr := startSSHServer(t)
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath := filepath.ToSlash(repoFS.Root())
+
+	tr := NewTransport(sshClientOptions())
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL: &url.URL{
+			Scheme: "ssh",
+			User:   url.User("git"),
+			Host:   fmt.Sprintf("localhost:%d", addr.Port),
+			Path:   repoPath,
+		},
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	rc, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	tarR := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tarR.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
 }

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"path"
 	"strings"
 	"time"
@@ -302,6 +303,24 @@ func resolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, 
 	return plumbing.ZeroHash, fmt.Errorf("cannot resolve %q", name)
 }
 
+// defaultUmask is the default tar umask (002).
+const defaultUmask = 0o002
+
+// applyUmask applies umask to the given mode for regular files.
+// Returns mode with all permission bits set, then applies umask.
+func applyUmask(mode int64, isExecutable bool) int64 {
+	if isExecutable {
+		return (mode | 0o777) &^ defaultUmask
+	}
+	return (mode | 0o666) &^ defaultUmask
+}
+
+// applyUmaskDir applies umask to directories.
+// Directories always get full permissions minus umask.
+func applyUmaskDir(mode int64) int64 {
+	return (mode | 0o777) &^ defaultUmask
+}
+
 func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix string, pathFilter []string, modTime time.Time) error {
 	tw := tar.NewWriter(w)
 
@@ -309,7 +328,7 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 		_ = tw.WriteHeader(&tar.Header{
 			Typeflag: tar.TypeDir,
 			Name:     prefix,
-			Mode:     0o755,
+			Mode:     applyUmaskDir(0),
 			ModTime:  modTime,
 		})
 	}
@@ -332,11 +351,14 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 
 		fullName := prefix + name
 
+		// Extract Unix permission bits from git mode.
+		unixMode := int64(entry.Mode) & 0o777
+
 		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
 			_ = tw.WriteHeader(&tar.Header{
 				Typeflag: tar.TypeDir,
 				Name:     fullName + "/",
-				Mode:     0o755,
+				Mode:     applyUmaskDir(unixMode),
 				ModTime:  modTime,
 			})
 			continue
@@ -350,7 +372,7 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 		hdr := &tar.Header{
 			Name:    fullName,
 			Size:    blob.Size,
-			Mode:    int64(entry.Mode),
+			Mode:    unixMode,
 			ModTime: modTime,
 		}
 
@@ -367,15 +389,16 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 			hdr.Typeflag = tar.TypeSymlink
 			hdr.Linkname = string(target)
 			hdr.Size = 0
-			return tw.WriteHeader(hdr)
+			// Symlinks always get 0777 per canonical git.
+			hdr.Mode = 0o777
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			continue
 		}
 
-		switch entry.Mode {
-		case filemode.Executable:
-			hdr.Mode = 0o755
-		default:
-			hdr.Mode = 0o644
-		}
+		isExec := entry.Mode == filemode.Executable
+		hdr.Mode = applyUmask(unixMode, isExec)
 
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
@@ -424,6 +447,9 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 			return err
 		}
 
+		// Extract Unix permission bits from git mode and apply default umask.
+		unixMode := int64(entry.Mode) & 0o777
+
 		fh := &zip.FileHeader{
 			Name:     fullName,
 			Method:   zip.Deflate,
@@ -431,11 +457,12 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 		}
 		switch entry.Mode {
 		case filemode.Executable:
-			fh.SetMode(0o755)
+			fh.SetMode(fs.FileMode(applyUmask(unixMode, true)))
 		case filemode.Symlink:
-			fh.SetMode(0o120000)
+			// Zip stores symlinks with mode 0o120000 + permissions.
+			fh.SetMode(fs.FileMode(0o120000 | (applyUmask(unixMode, true) & 0o777)))
 		default:
-			fh.SetMode(0o644)
+			fh.SetMode(fs.FileMode(applyUmask(unixMode, false)))
 		}
 
 		fw, err := zw.CreateHeader(fh)

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -1,0 +1,471 @@
+package transport
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+// UploadArchiveRequest configures the server-side upload-archive service.
+type UploadArchiveRequest struct {
+	// AllowUnreachable when true disables the default security restrictions
+	// and allows clients to use arbitrary SHA-1 expressions. By default,
+	// only direct ref targets (e.g. v1.0, main) and ref:path sub-tree
+	// syntax (e.g. v1.0:Documentation) are allowed.
+	//
+	// This serves as the default value. When the repository-level config
+	// uploadArchive.allowUnreachable is explicitly set, it always overrides
+	// this value (both true → false and false → true).
+	// See https://git-scm.com/docs/git-upload-archive
+	AllowUnreachable bool
+}
+
+// UploadArchive is a server command that serves the git-upload-archive service.
+//
+// It reads argument pkt-lines from r, sends ACK + flush, then generates the
+// archive and streams it to w using sideband multiplexing.
+//
+// Wire protocol:
+//
+//	Client → Server: "argument <arg>\n" pkt-lines + flush
+//	Server → Client: "ACK\n" pkt-line + flush
+//	Server → Client: sideband packets (band 1 = archive data, band 2 = progress)
+func UploadArchive(
+	ctx context.Context,
+	st storage.Storer,
+	r io.ReadCloser,
+	w io.WriteCloser,
+	req *UploadArchiveRequest,
+) error {
+	if req == nil {
+		req = &UploadArchiveRequest{}
+	}
+
+	w = ioutil.NewContextWriteCloser(ctx, w)
+
+	allowUnreachable := req.AllowUnreachable
+	if v, ok := readAllowUnreachable(st); ok {
+		allowUnreachable = v
+	}
+
+	args, err := readArchiveArgs(r)
+	if err != nil {
+		writeNACK(w, err.Error())
+		return err
+	}
+
+	if _, err := pktline.WriteString(w, "ACK\n"); err != nil {
+		return fmt.Errorf("upload-archive: writing ACK: %w", err)
+	}
+	if err := pktline.WriteFlush(w); err != nil {
+		return fmt.Errorf("upload-archive: writing flush: %w", err)
+	}
+
+	mux := sideband.NewMuxer(sideband.Sideband64k, w)
+
+	if err := writeArchive(ctx, st, mux, args, allowUnreachable); err != nil {
+		errMsg := fmt.Sprintf("upload-archive: %s", err.Error())
+		_, _ = mux.WriteChannel(sideband.ErrorMessage, []byte(errMsg))
+		_ = pktline.WriteFlush(w)
+		return err
+	}
+
+	return pktline.WriteFlush(w)
+}
+
+const maxArchiveArgs = 64
+
+// readArchiveArgs reads "argument <arg>\n" pkt-lines until flush.
+func readArchiveArgs(r io.Reader) ([]string, error) {
+	var args []string
+	for {
+		l, line, err := pktline.ReadLine(r)
+		if err != nil {
+			return nil, fmt.Errorf("upload-archive: reading argument: %w", err)
+		}
+		if l == pktline.Flush {
+			break
+		}
+		if len(args) >= maxArchiveArgs {
+			return nil, fmt.Errorf("upload-archive: too many arguments (>%d)", maxArchiveArgs)
+		}
+
+		s := strings.TrimSuffix(string(line), "\n")
+		if !strings.HasPrefix(s, "argument ") {
+			return nil, fmt.Errorf("upload-archive: expected 'argument' token, got: %s", s)
+		}
+		args = append(args, s[len("argument "):])
+	}
+	return args, nil
+}
+
+func writeNACK(w io.Writer, reason string) {
+	_, _ = pktline.WriteString(w, fmt.Sprintf("NACK %s\n", reason))
+	_ = pktline.WriteFlush(w)
+}
+
+// readAllowUnreachable reads the uploadArchive.allowUnreachable config
+// from the repository. It returns the value and whether the key was
+// explicitly set. When the key is absent or the config cannot be read,
+// ok is false and the caller should fall back to its own default.
+func readAllowUnreachable(st storage.Storer) (value, ok bool) {
+	cfg, err := st.Config()
+	if err != nil {
+		return false, false
+	}
+	if cfg.UploadArchive.AllowUnreachable.IsSet() {
+		return cfg.UploadArchive.AllowUnreachable.IsTrue(), true
+	}
+	return false, false
+}
+
+// Supported archive formats.
+var supportedArchiveFormats = []string{"tar", "tar.gz", "tgz", "zip"}
+
+// writeArchive generates an archive from the repository and writes it to
+// the sideband muxer's PackData channel.
+//
+// Args follow the same format as git-archive: [options...] <tree-ish> [paths...]
+// Supported options: --format=tar|zip|tar.gz|tgz, --prefix=<prefix>, --list/-l
+func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, args []string, allowUnreachable bool) error {
+	format := "tar"
+	prefix := ""
+	var treeish string
+	var paths []string
+	list := false
+
+	i := 0
+	for ; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--list" || arg == "-l":
+			list = true
+		case strings.HasPrefix(arg, "--format="):
+			format = arg[len("--format="):]
+		case strings.HasPrefix(arg, "--prefix="):
+			prefix = arg[len("--prefix="):]
+		case arg == "--":
+			i++
+			paths = args[i:]
+			i = len(args)
+		case !strings.HasPrefix(arg, "-"):
+			treeish = arg
+			i++
+			paths = args[i:]
+			i = len(args)
+		default:
+			return fmt.Errorf("unknown option: %s", arg)
+		}
+	}
+
+	if list {
+		for _, f := range supportedArchiveFormats {
+			if _, err := fmt.Fprintf(mux, "%s\n", f); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if treeish == "" {
+		return fmt.Errorf("no tree-ish specified")
+	}
+
+	tree, commitTime, err := resolveTreeish(st, treeish, allowUnreachable)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "tar":
+		return writeTarArchive(st, mux, tree, prefix, paths, commitTime)
+	case "tar.gz", "tgz":
+		gw := gzip.NewWriter(mux)
+		if err := writeTarArchive(st, gw, tree, prefix, paths, commitTime); err != nil {
+			return err
+		}
+		return gw.Close()
+	case "zip":
+		return writeZipArchive(st, mux, tree, prefix, paths, commitTime)
+	default:
+		return fmt.Errorf("unsupported archive format: %s", format)
+	}
+}
+
+// resolveTreeish resolves a tree-ish expression to a tree object.
+//
+// Security: By default, only direct ref names (v1.0, main) and ref:path
+// sub-tree syntax (v1.0:Documentation) are allowed. Raw SHA-1 hashes and
+// relative expressions (main^, HEAD~2) are rejected unless
+// allowUnreachable is true. See https://git-scm.com/docs/git-upload-archive
+func resolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*object.Tree, time.Time, error) {
+	var subPath string
+	if idx := strings.IndexByte(treeish, ':'); idx >= 0 {
+		subPath = treeish[idx+1:]
+		treeish = treeish[:idx]
+	}
+
+	if !allowUnreachable {
+		if plumbing.IsHash(treeish) {
+			return nil, time.Time{}, fmt.Errorf("upload-archive: only ref names are allowed (got %s)", treeish)
+		}
+		if strings.ContainsAny(treeish, "^~@{}") {
+			return nil, time.Time{}, fmt.Errorf("upload-archive: relative expressions are not allowed (got %s)", treeish)
+		}
+	}
+
+	h, err := resolveRef(st, treeish, allowUnreachable)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	obj, err := object.GetObject(st, h)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("object not found: %s", treeish)
+	}
+
+	var commitTime time.Time
+	var tree *object.Tree
+
+	switch o := obj.(type) {
+	case *object.Commit:
+		commitTime = o.Committer.When
+		tree, err = o.Tree()
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+	case *object.Tag:
+		commit, err := object.GetCommit(st, o.Target)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		commitTime = commit.Committer.When
+		tree, err = commit.Tree()
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+	case *object.Tree:
+		tree = o
+		commitTime = time.Now()
+	default:
+		return nil, time.Time{}, fmt.Errorf("unsupported object type for archive: %T", obj)
+	}
+
+	if subPath != "" {
+		entry, err := tree.FindEntry(subPath)
+		if err != nil {
+			return nil, time.Time{}, fmt.Errorf("path not found in tree: %s", subPath)
+		}
+		if entry.Mode != filemode.Dir {
+			return nil, time.Time{}, fmt.Errorf("path is not a directory: %s", subPath)
+		}
+		tree, err = object.GetTree(st, entry.Hash)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+	}
+
+	return tree, commitTime, nil
+}
+
+func resolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, error) {
+	if allowHash && plumbing.IsHash(name) {
+		return plumbing.NewHash(name), nil
+	}
+
+	for _, candidate := range []plumbing.ReferenceName{
+		plumbing.ReferenceName(name),
+		plumbing.ReferenceName("refs/heads/" + name),
+		plumbing.ReferenceName("refs/tags/" + name),
+	} {
+		ref, err := storer.ResolveReference(st, candidate)
+		if err == nil {
+			return ref.Hash(), nil
+		}
+	}
+
+	return plumbing.ZeroHash, fmt.Errorf("cannot resolve %q", name)
+}
+
+func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix string, pathFilter []string, modTime time.Time) error {
+	tw := tar.NewWriter(w)
+
+	if prefix != "" && strings.HasSuffix(prefix, "/") {
+		_ = tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     prefix,
+			Mode:     0o755,
+			ModTime:  modTime,
+		})
+	}
+
+	walker := object.NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+
+	for {
+		name, entry, err := walker.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if len(pathFilter) > 0 && !matchesPathFilter(name, pathFilter) {
+			continue
+		}
+
+		fullName := prefix + name
+
+		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
+			_ = tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeDir,
+				Name:     fullName + "/",
+				Mode:     0o755,
+				ModTime:  modTime,
+			})
+			continue
+		}
+
+		blob, err := object.GetBlob(st, entry.Hash)
+		if err != nil {
+			return err
+		}
+
+		hdr := &tar.Header{
+			Name:    fullName,
+			Size:    blob.Size,
+			Mode:    int64(entry.Mode),
+			ModTime: modTime,
+		}
+
+		if entry.Mode == filemode.Symlink {
+			rc, err := blob.Reader()
+			if err != nil {
+				return err
+			}
+			target, err := io.ReadAll(rc)
+			_ = rc.Close()
+			if err != nil {
+				return err
+			}
+			hdr.Typeflag = tar.TypeSymlink
+			hdr.Linkname = string(target)
+			hdr.Size = 0
+			return tw.WriteHeader(hdr)
+		}
+
+		switch entry.Mode {
+		case filemode.Executable:
+			hdr.Mode = 0o755
+		default:
+			hdr.Mode = 0o644
+		}
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		rc, err := blob.Reader()
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(tw, rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return tw.Close()
+}
+
+func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix string, pathFilter []string, modTime time.Time) error {
+	zw := zip.NewWriter(w)
+
+	walker := object.NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+
+	for {
+		name, entry, err := walker.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if len(pathFilter) > 0 && !matchesPathFilter(name, pathFilter) {
+			continue
+		}
+
+		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
+			continue
+		}
+
+		fullName := prefix + name
+		blob, err := object.GetBlob(st, entry.Hash)
+		if err != nil {
+			return err
+		}
+
+		fh := &zip.FileHeader{
+			Name:     fullName,
+			Method:   zip.Deflate,
+			Modified: modTime,
+		}
+		switch entry.Mode {
+		case filemode.Executable:
+			fh.SetMode(0o755)
+		case filemode.Symlink:
+			fh.SetMode(0o120000)
+		default:
+			fh.SetMode(0o644)
+		}
+
+		fw, err := zw.CreateHeader(fh)
+		if err != nil {
+			return err
+		}
+
+		rc, err := blob.Reader()
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(fw, rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return zw.Close()
+}
+
+func matchesPathFilter(name string, filters []string) bool {
+	for _, f := range filters {
+		if name == f || strings.HasPrefix(name, f+"/") || strings.HasPrefix(f, name+"/") {
+			return true
+		}
+		matched, _ := path.Match(f, name)
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -150,9 +150,23 @@ func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, arg
 	var paths []string
 	list := false
 
-	i := 0
-	for ; i < len(args); i++ {
+	// Normalize arguments: convert "--format zip" to "--format=zip" etc.
+	normalized := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		switch arg {
+		case "--format", "--prefix":
+			i++
+			if i >= len(args) {
+				return fmt.Errorf("%s requires an argument", arg)
+			}
+			normalized = append(normalized, arg+"="+args[i])
+		default:
+			normalized = append(normalized, arg)
+		}
+	}
+
+	for _, arg := range normalized {
 		switch {
 		case arg == "--list" || arg == "-l":
 			list = true
@@ -161,16 +175,27 @@ func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, arg
 		case strings.HasPrefix(arg, "--prefix="):
 			prefix = arg[len("--prefix="):]
 		case arg == "--":
-			i++
-			paths = args[i:]
-			i = len(args)
-		case !strings.HasPrefix(arg, "-"):
-			treeish = arg
-			i++
-			paths = args[i:]
-			i = len(args)
+			// paths are handled below
 		default:
-			return fmt.Errorf("unknown option: %s", arg)
+			if !strings.HasPrefix(arg, "-") {
+				treeish = arg
+			} else {
+				return fmt.Errorf("unknown option: %s", arg)
+			}
+		}
+	}
+
+	// Extract paths after treeish
+	for i, arg := range normalized {
+		if arg == treeish {
+			if i+1 < len(normalized) {
+				if normalized[i+1] == "--" {
+					paths = normalized[i+2:]
+				} else {
+					paths = normalized[i+1:]
+				}
+			}
+			break
 		}
 	}
 


### PR DESCRIPTION
This PR adds support for the `git-upload-archive` service to the transport layer, allowing fetching of archives from remote git repositories over SSH, HTTP, and local file transports.

## Background

The `git-upload-archive` protocol command is used by `git archive --remote` to fetch archives from remote repositories without cloning them. This is useful for CI/CD pipelines, release automation, and tools that need specific files from a repo.

## Changes

### Client-Side Types

**Archiver interface** - Sessions that implement this can perform archive operations:
```go
type Archiver interface {
    Archive(ctx context.Context, req *ArchiveRequest) (io.ReadCloser, error)
}
```

**ArchiveRequest** - Client archive request:
- `Args []string`: arguments sent as "argument <arg>" pkt-lines (format, prefix, tree-ish, paths)
- `Progress sideband.Progress`: optional progress callback for status messages

### Server-Side Types

**UploadArchiveRequest** - Server archive request configuration:
- `AllowUnreachable bool`: disables security restrictions allowing arbitrary refs

**UploadArchive function** - Server-side handler for the git-upload-archive protocol.

### Backend Support

**SSH/TCP/Unix transports** - Backend now dispatches to `UploadArchive`:
```go
case transport.UploadArchiveService:
    return transport.UploadArchive(...)
```

**HTTP** - Left for future protocol-v2 work (HTTP archive requires command-based protocol)

### Wire Protocol

Implements the git-upload-archive protocol:
- Client sends "argument <arg>" pkt-lines for format, prefix, tree-ish, etc.
- Server sends "ACK" or "NACK <reason>"
- Archive data streamed via sideband (channel 1 = data, channel 2 = progress)

### Supported Formats

Supported formats parsed from args:
- `tar`, `tar.gz`, `tgz`, `zip`
- `--prefix=path/` adds prefix to archive entries
- `--list` lists available archives
- Tree-ish (commit, tag, branch) specifies what to archive

## Testing

- `TestArchive_Tar`, `TestArchive_TarGz`, `TestArchive_Zip` (file transport)
- `TestGitTransport_Archive` (git daemon transport)
- `TestSSHTransport_Archive` (SSH transport)

All tests verify archive contents against git's output.

## Security

The `uploadArchive.allowUnreachable` config option controls whether arbitrary SHA-1 expressions are allowed. By default, only ref targets (e.g., `v1.0`, `main`) and `ref:path` sub-tree syntax are allowed.

## Follow-up Work

A future PR will add porcelain-level support:
- `git.Archive()` convenience method
- `ArchiveOptions` with parametrized fields:
  - `Format`: tar, tar.gz, zip
  - `Prefix`: prefix path for archive entries
  - `Remote`: tree-ish reference to archive
  - `Paths`: optional path filter
  - Additional `git archive --remote` flags

## Usage Example

```go
sess, _ := client.Dial("git@github.com:go-git/go-git.git")
req := &transport.ArchiveRequest{
    Args: []string{"--format=tar.gz", "--prefix=go-git/", "v5.12.0"},
}
rc, _ := sess.Archive(ctx, req)
defer rc.Close()
// Write rc to file or pipe to tar/gzip
```