### PR TITLE
plumbing: transport, add git-upload-archive support

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -102,6 +102,10 @@ func (b *Backend) Serve(ctx context.Context, r io.ReadCloser, w io.WriteCloser, 
 			AdvertiseRefs: req.AdvertiseRefs,
 			StatelessRPC:  req.StatelessRPC,
 		})
+	case transport.UploadArchiveService:
+		return transport.UploadArchive(ctx, st, r, w, &transport.UploadArchiveRequest{
+			AllowUnreachable: false,
+		})
 	default:
 		return fmt.Errorf("%w: %s", transport.ErrUnsupportedService, req.Service)
 	}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -103,9 +103,7 @@ func (b *Backend) Serve(ctx context.Context, r io.ReadCloser, w io.WriteCloser, 
 			StatelessRPC:  req.StatelessRPC,
 		})
 	case transport.UploadArchiveService:
-		return transport.UploadArchive(ctx, st, r, w, &transport.UploadArchiveRequest{
-			AllowUnreachable: false,
-		})
+		return transport.UploadArchive(ctx, st, r, w, &transport.UploadArchiveRequest{})
 	default:
 		return fmt.Errorf("%w: %s", transport.ErrUnsupportedService, req.Service)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -154,6 +154,13 @@ type Config struct {
 		DefaultBranch string
 	}
 
+	UploadArchive struct {
+		// AllowUnreachable when true allows clients to request archives
+		// using arbitrary SHA-1 expressions. When false (the default),
+		// only direct ref names are allowed.
+		AllowUnreachable OptBool
+	}
+
 	Extensions struct {
 		// ObjectFormat specifies the hash algorithm to use. The
 		// acceptable values are sha1 and sha256. If not specified,
@@ -466,6 +473,8 @@ const (
 	formatKey                  = "format"
 	allowedSignersFileKey      = "allowedSignersFile"
 	gpgSignKey                 = "gpgSign"
+	uploadArchiveSection       = "uploadArchive"
+	allowUnreachableKey        = "allowUnreachable"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.
@@ -492,6 +501,7 @@ func (c *Config) Unmarshal(b []byte) error {
 	c.unmarshalUser()
 	c.unmarshalGPG()
 	c.unmarshalInit()
+	c.unmarshalUploadArchive()
 	if err := c.unmarshalPack(); err != nil {
 		return err
 	}
@@ -707,6 +717,14 @@ func (c *Config) unmarshalInit() {
 	c.Init.DefaultBranch = s.Options.Get(defaultBranchKey)
 }
 
+func (c *Config) unmarshalUploadArchive() {
+	s := c.Raw.Section(uploadArchiveSection)
+	v, err := strconv.ParseBool(s.Options.Get(allowUnreachableKey))
+	if err == nil {
+		c.UploadArchive.AllowUnreachable = NewOptBool(v)
+	}
+}
+
 // Marshal returns Config encoded as a git-config file.
 //
 // This call populates the field Raw with the current values of
@@ -730,6 +748,7 @@ func (c *Config) Marshal() ([]byte, error) {
 	c.marshalURLs()
 	c.marshalProtocol()
 	c.marshalInit()
+	c.marshalUploadArchive()
 
 	buf := bytes.NewBuffer(nil)
 	if err := format.NewEncoder(buf).Encode(c.Raw); err != nil {
@@ -960,6 +979,13 @@ func (c *Config) marshalInit() {
 	s := c.Raw.Section(initSection)
 	if c.Init.DefaultBranch != "" {
 		s.SetOption(defaultBranchKey, c.Init.DefaultBranch)
+	}
+}
+
+func (c *Config) marshalUploadArchive() {
+	if c.UploadArchive.AllowUnreachable.IsSet() {
+		s := c.Raw.Section(uploadArchiveSection)
+		s.SetOption(allowUnreachableKey, c.UploadArchive.AllowUnreachable.FormatBool())
 	}
 }
 

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -381,6 +381,17 @@ func WriteZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 }
 
 // MatchesPathFilter checks if a name matches any of the path filters.
+//
+// Note: This function assumes paths use forward slashes (/), which is the
+// format used by Git internally. The TreeWalker produces paths with forward
+// slashes regardless of the operating system, so this function is
+// platform-independent.
+//
+// Supported patterns:
+//   - Exact match: "README.md"
+//   - Prefix match: "docs/" matches "docs/guide.md"
+//   - Glob patterns: "*.go" matches "main.go"
+//   - Parent-child: "docs/guide.md" matches parent "docs"
 func MatchesPathFilter(name string, filters []string) bool {
 	for _, f := range filters {
 		if name == f || strings.HasPrefix(name, f+"/") || strings.HasPrefix(f, name+"/") {

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/fs"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -56,6 +57,10 @@ var (
 	// ErrSymlinkTargetTooLarge is returned when a symlink blob exceeds the
 	// maximum size accepted by the tar archive writer.
 	ErrSymlinkTargetTooLarge = errors.New("symlink target too large")
+
+	// ErrInvalidPrefix is returned when the requested archive prefix contains
+	// path traversal sequences.
+	ErrInvalidPrefix = errors.New("invalid archive prefix")
 )
 
 const maxTarSymlinkTargetSize = 64 * 1024
@@ -454,6 +459,9 @@ func WriteArchive(st storage.Storer, w io.Writer, treeish, format, prefix string
 	if treeish == "" {
 		return fmt.Errorf("no tree-ish specified")
 	}
+	if hasInvalidArchivePrefix(prefix) {
+		return fmt.Errorf("%w: %s", ErrInvalidPrefix, prefix)
+	}
 
 	tree, commitHash, commitTime, err := ResolveTreeish(st, treeish, allowUnreachable)
 	if err != nil {
@@ -474,4 +482,13 @@ func WriteArchive(st storage.Storer, w io.Writer, treeish, format, prefix string
 	default:
 		return fmt.Errorf("unsupported archive format: %s", format)
 	}
+}
+
+func hasInvalidArchivePrefix(prefix string) bool {
+	if strings.HasPrefix(prefix, "/") || strings.HasPrefix(prefix, "\\") {
+		return true
+	}
+	return slices.Contains(strings.FieldsFunc(prefix, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}), "..")
 }

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -52,7 +52,13 @@ var (
 
 	// ErrPathspecNoMatch is returned when pathspec filters don't match any files.
 	ErrPathspecNoMatch = errors.New("pathspec did not match any files")
+
+	// ErrSymlinkTargetTooLarge is returned when a symlink blob exceeds the
+	// maximum size accepted by the tar archive writer.
+	ErrSymlinkTargetTooLarge = errors.New("symlink target too large")
 )
+
+const maxTarSymlinkTargetSize = 64 * 1024
 
 // SupportedFormats returns the list of supported archive formats.
 func SupportedFormats() []string {
@@ -263,10 +269,13 @@ func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 			if err != nil {
 				return err
 			}
-			target, err := io.ReadAll(rc)
+			target, err := io.ReadAll(io.LimitReader(rc, maxTarSymlinkTargetSize+1))
 			_ = rc.Close()
 			if err != nil {
 				return err
+			}
+			if len(target) > maxTarSymlinkTargetSize {
+				return fmt.Errorf("%w: %s (%d bytes)", ErrSymlinkTargetTooLarge, fullName, len(target))
 			}
 			hdr.Typeflag = tar.TypeSymlink
 			hdr.Linkname = string(target)

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -108,6 +108,18 @@ func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 		return nil, nil, time.Time{}, fmt.Errorf("%w: %s", ErrObjectNotFound, treeish)
 	}
 
+	for {
+		tag, ok := obj.(*object.Tag)
+		if !ok {
+			break
+		}
+
+		obj, err = object.GetObject(st, tag.Target)
+		if err != nil {
+			return nil, nil, time.Time{}, fmt.Errorf("resolve annotated tag: %w", err)
+		}
+	}
+
 	var commitHash *plumbing.Hash
 	var commitTime time.Time
 	var tree *object.Tree
@@ -117,17 +129,6 @@ func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 		commitHash = &o.Hash
 		commitTime = o.Committer.When
 		tree, err = o.Tree()
-		if err != nil {
-			return nil, nil, time.Time{}, err
-		}
-	case *object.Tag:
-		commit, err := object.GetCommit(st, o.Target)
-		if err != nil {
-			return nil, nil, time.Time{}, err
-		}
-		commitHash = &commit.Hash
-		commitTime = commit.Committer.When
-		tree, err = commit.Tree()
 		if err != nil {
 			return nil, nil, time.Time{}, err
 		}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -216,12 +216,14 @@ func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 	}
 
 	if prefix != "" && strings.HasSuffix(prefix, "/") {
-		_ = tw.WriteHeader(&tar.Header{
+		if err := tw.WriteHeader(&tar.Header{
 			Typeflag: tar.TypeDir,
 			Name:     prefix,
 			Mode:     ApplyUmaskDir(0),
 			ModTime:  modTime,
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	walker := object.NewTreeWalker(tree, true, nil)
@@ -248,12 +250,14 @@ func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 		unixMode := int64(entry.Mode) & 0o777
 
 		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
-			_ = tw.WriteHeader(&tar.Header{
+			if err := tw.WriteHeader(&tar.Header{
 				Typeflag: tar.TypeDir,
 				Name:     fullName + "/",
 				Mode:     ApplyUmaskDir(unixMode),
 				ModTime:  modTime,
-			})
+			}); err != nil {
+				return err
+			}
 			continue
 		}
 
@@ -275,9 +279,12 @@ func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 				return err
 			}
 			target, err := io.ReadAll(io.LimitReader(rc, maxTarSymlinkTargetSize+1))
-			_ = rc.Close()
+			closeErr := rc.Close()
 			if err != nil {
 				return err
+			}
+			if closeErr != nil {
+				return closeErr
 			}
 			if len(target) > maxTarSymlinkTargetSize {
 				return fmt.Errorf("%w: %s (%d bytes)", ErrSymlinkTargetTooLarge, fullName, len(target))
@@ -305,9 +312,12 @@ func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 			return err
 		}
 		_, err = io.Copy(tw, rc)
-		_ = rc.Close()
+		closeErr := rc.Close()
 		if err != nil {
 			return err
+		}
+		if closeErr != nil {
+			return closeErr
 		}
 	}
 
@@ -378,9 +388,12 @@ func WriteZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 			return err
 		}
 		_, err = io.Copy(fw, rc)
-		_ = rc.Close()
+		closeErr := rc.Close()
 		if err != nil {
 			return err
+		}
+		if closeErr != nil {
+			return closeErr
 		}
 	}
 
@@ -391,7 +404,9 @@ func WriteZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 	// Store commit ID as ZIP file comment if available.
 	// This matches the behavior of git archive.
 	if commitHash != nil {
-		_ = zw.SetComment(commitHash.String())
+		if err := zw.SetComment(commitHash.String()); err != nil {
+			return err
+		}
 	}
 
 	return zw.Close()

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -1,0 +1,452 @@
+package archive
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/storage"
+)
+
+// PAXGlobalHeader is the name used for PAX global extended headers in
+// git-generated tar archives. This matches the name used by canonical git.
+const PAXGlobalHeader = "pax_global_header"
+
+// DefaultUmask is the default tar umask (002).
+const DefaultUmask = 0o002
+
+// Exported errors for archive operations.
+var (
+	// ErrOnlyRefNames is returned when raw hashes or relative expressions are used
+	// but allowUnreachable is not set.
+	ErrOnlyRefNames = errors.New("only ref names are allowed")
+
+	// ErrRelativeExpressions is returned when relative ref expressions are used
+	// but allowUnreachable is not set.
+	ErrRelativeExpressions = errors.New("relative expressions are not allowed")
+
+	// ErrObjectNotFound is returned when the specified object cannot be found.
+	ErrObjectNotFound = errors.New("object not found")
+
+	// ErrUnsupportedObjectType is returned when the object type is not supported for archiving.
+	ErrUnsupportedObjectType = errors.New("unsupported object type for archive")
+
+	// ErrPathNotFound is returned when a sub-path is not found in the tree.
+	ErrPathNotFound = errors.New("path not found in tree")
+
+	// ErrPathNotDirectory is returned when a sub-path is not a directory.
+	ErrPathNotDirectory = errors.New("path is not a directory")
+
+	// ErrPathspecNoMatch is returned when pathspec filters don't match any files.
+	ErrPathspecNoMatch = errors.New("pathspec did not match any files")
+)
+
+// SupportedFormats returns the list of supported archive formats.
+func SupportedFormats() []string {
+	return []string{"tar", "tar.gz", "tgz", "zip"}
+}
+
+// ApplyUmask applies umask to the given mode for regular files.
+// Returns mode with all permission bits set, then applies umask.
+func ApplyUmask(mode int64, isExecutable bool) int64 {
+	if isExecutable {
+		return (mode | 0o777) &^ DefaultUmask
+	}
+	return (mode | 0o666) &^ DefaultUmask
+}
+
+// ApplyUmaskDir applies umask to directories.
+// Directories always get full permissions minus umask.
+func ApplyUmaskDir(mode int64) int64 {
+	return (mode | 0o777) &^ DefaultUmask
+}
+
+// ResolveTreeish resolves a tree-ish expression to a tree object.
+//
+// Security: By default, only direct ref names (v1.0, main) and ref:path
+// sub-tree syntax (v1.0:Documentation) are allowed. Raw SHA-1 hashes and
+// relative expressions (main^, HEAD~2) are rejected unless
+// allowUnreachable is true. See https://git-scm.com/docs/git-upload-archive
+//
+// Returns the tree, commit hash (if applicable), commit time, and any error.
+func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*object.Tree, *plumbing.Hash, time.Time, error) {
+	var subPath string
+	if idx := strings.IndexByte(treeish, ':'); idx >= 0 {
+		subPath = treeish[idx+1:]
+		treeish = treeish[:idx]
+	}
+
+	if !allowUnreachable {
+		if plumbing.IsHash(treeish) {
+			return nil, nil, time.Time{}, fmt.Errorf("%w (got %s)", ErrOnlyRefNames, treeish)
+		}
+		if strings.ContainsAny(treeish, "^~@{}") {
+			return nil, nil, time.Time{}, fmt.Errorf("%w (got %s)", ErrRelativeExpressions, treeish)
+		}
+	}
+
+	h, err := ResolveRef(st, treeish, allowUnreachable)
+	if err != nil {
+		return nil, nil, time.Time{}, err
+	}
+
+	obj, err := object.GetObject(st, h)
+	if err != nil {
+		return nil, nil, time.Time{}, fmt.Errorf("%w: %s", ErrObjectNotFound, treeish)
+	}
+
+	var commitHash *plumbing.Hash
+	var commitTime time.Time
+	var tree *object.Tree
+
+	switch o := obj.(type) {
+	case *object.Commit:
+		commitHash = &o.Hash
+		commitTime = o.Committer.When
+		tree, err = o.Tree()
+		if err != nil {
+			return nil, nil, time.Time{}, err
+		}
+	case *object.Tag:
+		commit, err := object.GetCommit(st, o.Target)
+		if err != nil {
+			return nil, nil, time.Time{}, err
+		}
+		commitHash = &commit.Hash
+		commitTime = commit.Committer.When
+		tree, err = commit.Tree()
+		if err != nil {
+			return nil, nil, time.Time{}, err
+		}
+	case *object.Tree:
+		tree = o
+
+		// git archive behaves differently when given a tree ID versus when
+		// given a commit ID or tag ID. In the first case the current time is
+		// used as the modification time of each file in the archive. In the
+		// latter case the commit time as recorded in the referenced commit
+		// object is used instead.
+		//
+		// See https://git-scm.com/docs/git-archive
+		commitTime = time.Now()
+	default:
+		return nil, nil, time.Time{}, fmt.Errorf("unsupported object type for archive: %T", obj)
+	}
+
+	if subPath != "" {
+		entry, err := tree.FindEntry(subPath)
+		if err != nil {
+			return nil, nil, time.Time{}, fmt.Errorf("path not found in tree: %s", subPath)
+		}
+		if entry.Mode != filemode.Dir {
+			return nil, nil, time.Time{}, fmt.Errorf("path is not a directory: %s", subPath)
+		}
+		tree, err = object.GetTree(st, entry.Hash)
+		if err != nil {
+			return nil, nil, time.Time{}, err
+		}
+	}
+
+	return tree, commitHash, commitTime, nil
+}
+
+// ResolveRef resolves a ref name to a hash.
+func ResolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, error) {
+	if allowHash && plumbing.IsHash(name) {
+		return plumbing.NewHash(name), nil
+	}
+
+	for _, candidate := range []plumbing.ReferenceName{
+		plumbing.ReferenceName(name),
+		plumbing.ReferenceName("refs/heads/" + name),
+		plumbing.ReferenceName("refs/tags/" + name),
+	} {
+		ref, err := storer.ResolveReference(st, candidate)
+		if err == nil {
+			return ref.Hash(), nil
+		}
+	}
+
+	return plumbing.ZeroHash, fmt.Errorf("cannot resolve %q", name)
+}
+
+// WriteTarArchive writes a tar archive from a tree.
+func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
+	tw := tar.NewWriter(w)
+
+	// Write PAX global extended header with commit ID if available.
+	// This matches the behavior of git archive and allows extraction
+	// via git get-tar-commit-id.
+	if commitHash != nil {
+		err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeXGlobalHeader,
+			Name:     PAXGlobalHeader,
+			PAXRecords: map[string]string{
+				"comment": commitHash.String(),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("writing global PAX header: %w", err)
+		}
+	}
+
+	if prefix != "" && strings.HasSuffix(prefix, "/") {
+		_ = tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     prefix,
+			Mode:     ApplyUmaskDir(0),
+			ModTime:  modTime,
+		})
+	}
+
+	walker := object.NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+
+	var matchedAny bool
+	for {
+		name, entry, err := walker.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if len(pathFilter) > 0 && !MatchesPathFilter(name, pathFilter) {
+			continue
+		}
+		matchedAny = true
+
+		fullName := prefix + name
+
+		// Extract Unix permission bits from git mode.
+		unixMode := int64(entry.Mode) & 0o777
+
+		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
+			_ = tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeDir,
+				Name:     fullName + "/",
+				Mode:     ApplyUmaskDir(unixMode),
+				ModTime:  modTime,
+			})
+			continue
+		}
+
+		blob, err := object.GetBlob(st, entry.Hash)
+		if err != nil {
+			return err
+		}
+
+		hdr := &tar.Header{
+			Name:    fullName,
+			Size:    blob.Size,
+			Mode:    unixMode,
+			ModTime: modTime,
+		}
+
+		if entry.Mode == filemode.Symlink {
+			rc, err := blob.Reader()
+			if err != nil {
+				return err
+			}
+			target, err := io.ReadAll(rc)
+			_ = rc.Close()
+			if err != nil {
+				return err
+			}
+			hdr.Typeflag = tar.TypeSymlink
+			hdr.Linkname = string(target)
+			hdr.Size = 0
+			// Symlinks always get 0777 per canonical git.
+			hdr.Mode = 0o777
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			continue
+		}
+
+		isExec := entry.Mode == filemode.Executable
+		hdr.Mode = ApplyUmask(unixMode, isExec)
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		rc, err := blob.Reader()
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(tw, rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(pathFilter) > 0 && !matchedAny {
+		return fmt.Errorf("%w: '%s'", ErrPathspecNoMatch, strings.Join(pathFilter, " "))
+	}
+
+	return tw.Close()
+}
+
+// WriteZipArchive writes a zip archive from a tree.
+func WriteZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
+	zw := zip.NewWriter(w)
+
+	walker := object.NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+
+	var matchedAny bool
+	for {
+		name, entry, err := walker.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if len(pathFilter) > 0 && !MatchesPathFilter(name, pathFilter) {
+			continue
+		}
+		matchedAny = true
+
+		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
+			continue
+		}
+
+		fullName := prefix + name
+		blob, err := object.GetBlob(st, entry.Hash)
+		if err != nil {
+			return err
+		}
+
+		// Extract Unix permission bits from git mode and apply default umask.
+		unixMode := int64(entry.Mode) & 0o777
+
+		fh := &zip.FileHeader{
+			Name:     fullName,
+			Method:   zip.Deflate,
+			Modified: modTime,
+		}
+		switch entry.Mode {
+		case filemode.Executable:
+			fh.SetMode(fs.FileMode(ApplyUmask(unixMode, true)))
+		case filemode.Symlink:
+			// Zip stores symlinks with mode 0o120000 + permissions.
+			fh.SetMode(fs.FileMode(0o120000 | (ApplyUmask(unixMode, true) & 0o777)))
+		default:
+			fh.SetMode(fs.FileMode(ApplyUmask(unixMode, false)))
+		}
+
+		fw, err := zw.CreateHeader(fh)
+		if err != nil {
+			return err
+		}
+
+		rc, err := blob.Reader()
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(fw, rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(pathFilter) > 0 && !matchedAny {
+		return fmt.Errorf("pathspec '%s' did not match any files", strings.Join(pathFilter, " "))
+	}
+
+	// Store commit ID as ZIP file comment if available.
+	// This matches the behavior of git archive.
+	if commitHash != nil {
+		_ = zw.SetComment(commitHash.String())
+	}
+
+	return zw.Close()
+}
+
+// MatchesPathFilter checks if a name matches any of the path filters.
+func MatchesPathFilter(name string, filters []string) bool {
+	for _, f := range filters {
+		if name == f || strings.HasPrefix(name, f+"/") || strings.HasPrefix(f, name+"/") {
+			return true
+		}
+		matched, _ := path.Match(f, name)
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// GetTarCommitID extracts the commit ID from a git-generated tar archive.
+// It reads the PAX global extended header from the beginning of the archive
+// and returns the value of the "comment" field, which contains the commit hash.
+// If no global header is found or it doesn't contain a comment, it returns
+// an error.
+func GetTarCommitID(r io.Reader) (*plumbing.Hash, error) {
+	tr := tar.NewReader(r)
+	hdr, err := tr.Next()
+	if err != nil {
+		return nil, fmt.Errorf("reading tar header: %w", err)
+	}
+	// Check for PAX global extended header (typeflag 'g')
+	if hdr.Typeflag != tar.TypeXGlobalHeader {
+		return nil, fmt.Errorf("expected global PAX header, got typeflag %c", hdr.Typeflag)
+	}
+	// The PAX records should contain the commit ID in the "comment" field
+	comment, ok := hdr.PAXRecords["comment"]
+	if !ok {
+		return nil, fmt.Errorf("global header missing comment field")
+	}
+	hash := plumbing.NewHash(comment)
+	return &hash, nil
+}
+
+// WriteArchive generates an archive from the repository and writes it to w.
+//
+// Args follow the same format as git-archive: [options...] <tree-ish> [paths...]
+// Supported formats: tar, zip, tar.gz, tgz.
+// The prefix is prepended to all file paths in the archive.
+// The paths slice can be used to filter which files are included.
+// If allowUnreachable is false, only ref names are allowed (no raw hashes).
+func WriteArchive(st storage.Storer, w io.Writer, treeish string, format string, prefix string, paths []string, allowUnreachable bool) error {
+	if treeish == "" {
+		return fmt.Errorf("no tree-ish specified")
+	}
+
+	tree, commitHash, commitTime, err := ResolveTreeish(st, treeish, allowUnreachable)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "tar":
+		return WriteTarArchive(st, w, tree, commitHash, prefix, paths, commitTime)
+	case "tar.gz", "tgz":
+		gw := gzip.NewWriter(w)
+		if err := WriteTarArchive(st, gw, tree, commitHash, prefix, paths, commitTime); err != nil {
+			return err
+		}
+		return gw.Close()
+	case "zip":
+		return WriteZipArchive(st, w, tree, commitHash, prefix, paths, commitTime)
+	default:
+		return fmt.Errorf("unsupported archive format: %s", format)
+	}
+}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -1,3 +1,5 @@
+// Package archive provides archive generation functionality for git-upload-archive.
+// It supports tar and zip formats with proper security controls.
 package archive
 
 import (
@@ -436,7 +438,9 @@ func GetTarCommitID(r io.Reader) (*plumbing.Hash, error) {
 // The prefix is prepended to all file paths in the archive.
 // The paths slice can be used to filter which files are included.
 // If allowUnreachable is false, only ref names are allowed (no raw hashes).
-func WriteArchive(st storage.Storer, w io.Writer, treeish string, format string, prefix string, paths []string, allowUnreachable bool) error {
+func WriteArchive(st storage.Storer, w io.Writer, treeish, format, prefix string,
+	paths []string, allowUnreachable bool,
+) error {
 	if treeish == "" {
 		return fmt.Errorf("no tree-ish specified")
 	}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -1,0 +1,265 @@
+package archive
+
+import (
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+)
+
+func TestMatchesPathFilter(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		filters []string
+		want    bool
+	}{
+		{
+			name:    "exact match",
+			path:    "README.md",
+			filters: []string{"README.md"},
+			want:    true,
+		},
+		{
+			name:    "prefix match",
+			path:    "docs/guide.md",
+			filters: []string{"docs"},
+			want:    true,
+		},
+		{
+			name:    "glob pattern match",
+			path:    "test.go",
+			filters: []string{"*.go"},
+			want:    true,
+		},
+		{
+			name:    "glob pattern no match",
+			path:    "README.md",
+			filters: []string{"*.go"},
+			want:    false,
+		},
+		{
+			name:    "child match parent",
+			path:    "docs",
+			filters: []string{"docs/guide.md"},
+			want:    true,
+		},
+		{
+			name:    "exact directory no trailing slash",
+			path:    "docs/guide.md",
+			filters: []string{"docs/"},
+			want:    false,
+		},
+		{
+			name:    "no match",
+			path:    "src/main.go",
+			filters: []string{"docs", "*.md"},
+			want:    false,
+		},
+		{
+			name:    "multiple filters match",
+			path:    "docs/guide.md",
+			filters: []string{"src", "docs"},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MatchesPathFilter(tt.path, tt.filters)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveRef(t *testing.T) {
+	fixture := fixtures.Basic().One()
+	dotGit, err := fixture.DotGit()
+	require.NoError(t, err)
+	storer := filesystem.NewStorage(dotGit, nil)
+
+	// Get expected hashes from the fixture
+	masterRef, err := storer.Reference(plumbing.ReferenceName("refs/heads/master"))
+	require.NoError(t, err)
+	masterHash := masterRef.Hash()
+
+	tagRef, err := storer.Reference(plumbing.ReferenceName("refs/tags/v1.0.0"))
+	require.NoError(t, err)
+	tagHash := tagRef.Hash()
+
+	tests := []struct {
+		name       string
+		ref        string
+		allowHash  bool
+		wantHash   plumbing.Hash
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:     "resolve branch with full ref",
+			ref:      "refs/heads/master",
+			allowHash: false,
+			wantHash: masterHash,
+			wantErr:  false,
+		},
+		{
+			name:     "resolve short branch name",
+			ref:      "master",
+			allowHash: false,
+			wantHash: masterHash,
+			wantErr:  false,
+		},
+		{
+			name:     "resolve tag name",
+			ref:      "v1.0.0",
+			allowHash: false,
+			wantHash: tagHash,
+			wantErr:  false,
+		},
+		{
+			name:       "non-existent ref fails",
+			ref:        "nonexistent",
+			allowHash:  false,
+			wantHash:   plumbing.ZeroHash,
+			wantErr:    true,
+			errContain: "cannot resolve",
+		},
+		{
+			name:     "raw hash allowed when allowHash=true",
+			ref:      masterHash.String(),
+			allowHash: true,
+			wantHash: masterHash,
+			wantErr:  false,
+		},
+		{
+			name:       "raw hash rejected when allowHash=false",
+			ref:        masterHash.String(),
+			allowHash:  false,
+			wantHash:   plumbing.ZeroHash,
+			wantErr:    true,
+			errContain: "cannot resolve",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveRef(storer, tt.ref, tt.allowHash)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContain != "" {
+					assert.Contains(t, err.Error(), tt.errContain)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantHash, got)
+			}
+		})
+	}
+}
+
+func TestResolveTreeish_Errors(t *testing.T) {
+	fixture := fixtures.Basic().One()
+	dotGit, err := fixture.DotGit()
+	require.NoError(t, err)
+	storer := filesystem.NewStorage(dotGit, nil)
+
+	tests := []struct {
+		name       string
+		treeish    string
+		allowUnreachable bool
+		wantErr    bool
+		errIs      error
+		errContain string
+	}{
+		{
+			name:       "raw hash rejected without allowUnreachable",
+			treeish:    "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			allowUnreachable: false,
+			wantErr:    true,
+			errIs:      ErrOnlyRefNames,
+		},
+		{
+			name:       "relative ref expression rejected",
+			treeish:    "master~1",
+			allowUnreachable: false,
+			wantErr:    true,
+			errIs:      ErrRelativeExpressions,
+		},
+		{
+			name:       "non-existent ref fails",
+			treeish:    "nonexistent",
+			allowUnreachable: false,
+			wantErr:    true,
+			errContain: "cannot resolve",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := ResolveTreeish(storer, tt.treeish, tt.allowUnreachable)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errIs != nil {
+					assert.ErrorIs(t, err, tt.errIs)
+				}
+				if tt.errContain != "" {
+					assert.Contains(t, err.Error(), tt.errContain)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSupportedFormats(t *testing.T) {
+	formats := SupportedFormats()
+	assert.Contains(t, formats, "tar")
+	assert.Contains(t, formats, "zip")
+	assert.Contains(t, formats, "tar.gz")
+	assert.Contains(t, formats, "tgz")
+}
+
+func TestApplyUmask(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         int64
+		isExecutable bool
+		want         int64
+	}{
+		{
+			name:         "regular file",
+			mode:         0o000,
+			isExecutable: false,
+			want:         0o664,
+		},
+		{
+			name:         "executable file",
+			mode:         0o000,
+			isExecutable: true,
+			want:         0o775,
+		},
+		{
+			name:         "preserves existing bits",
+			mode:         0o640,
+			isExecutable: false,
+			want:         0o664,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplyUmask(tt.mode, tt.isExecutable)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyUmaskDir(t *testing.T) {
+	got := ApplyUmaskDir(0o000)
+	assert.Equal(t, int64(0o775), got)
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -436,9 +436,8 @@ func TestResolveTreeish_AnnotatedTags(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest // object / storer are not thread safe
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			tagRef, err := storer.Reference(plumbing.ReferenceName("refs/tags/" + tt.treeish))
 			require.NoError(t, err)
 

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -244,6 +244,136 @@ func TestResolveTreeish_Errors(t *testing.T) {
 	}
 }
 
+// TestResolveTreeish_AllowUnreachable tests the allowUnreachable flag enforcement
+// comprehensively with various tree-ish expressions.
+func TestResolveTreeish_AllowUnreachable(t *testing.T) {
+	fixture := fixtures.Basic().One()
+	dotGit, err := fixture.DotGit()
+	require.NoError(t, err)
+	storer := filesystem.NewStorage(dotGit, nil)
+
+	// Get the master commit hash for testing
+	masterRef, err := storer.Reference(plumbing.ReferenceName("refs/heads/master"))
+	require.NoError(t, err)
+	masterHash := masterRef.Hash().String()
+
+	tests := []struct {
+		name             string
+		treeish          string
+		allowUnreachable bool
+		wantErr          bool
+		errIs            error
+		errContain       string
+	}{
+		// allowUnreachable=false cases (secure mode)
+		{
+			name:             "raw hash blocked when allowUnreachable=false",
+			treeish:          masterHash,
+			allowUnreachable: false,
+			wantErr:          true,
+			errIs:            ErrOnlyRefNames,
+		},
+		{
+			name:             "parent expression blocked (~)",
+			treeish:          "master~1",
+			allowUnreachable: false,
+			wantErr:          true,
+			errIs:            ErrRelativeExpressions,
+		},
+		{
+			name:             "ancestor expression blocked (~N)",
+			treeish:          "master~3",
+			allowUnreachable: false,
+			wantErr:          true,
+			errIs:            ErrRelativeExpressions,
+		},
+		{
+			name:             "parent expression blocked (^)",
+			treeish:          "master^",
+			allowUnreachable: false,
+			wantErr:          true,
+			errIs:            ErrRelativeExpressions,
+		},
+		{
+			name:             "nth parent blocked (^N)",
+			treeish:          "master^2",
+			allowUnreachable: false,
+			wantErr:          true,
+			errIs:            ErrRelativeExpressions,
+		},
+		{
+			name:             "at-sign expression blocked (@)",
+			treeish:          "@{upstream}",
+			allowUnreachable: false,
+			wantErr:          true,
+			errIs:            ErrRelativeExpressions,
+		},
+		{
+			name:             "brace expression blocked",
+			treeish:          "master@{1}",
+			allowUnreachable: false,
+			wantErr:          true,
+			errIs:            ErrRelativeExpressions,
+		},
+		{
+			name:             "ref short name allowed",
+			treeish:          "master",
+			allowUnreachable: false,
+			wantErr:          false,
+		},
+		{
+			name:             "full ref path allowed",
+			treeish:          "refs/heads/master",
+			allowUnreachable: false,
+			wantErr:          false,
+		},
+		{
+			name:             "tag short name allowed",
+			treeish:          "v1.0.0",
+			allowUnreachable: false,
+			wantErr:          false,
+		},
+		// allowUnreachable=true cases
+		{
+			name:             "raw hash allowed when allowUnreachable=true",
+			treeish:          masterHash,
+			allowUnreachable: true,
+			wantErr:          false,
+		},
+		{
+			name:             "parent expression allowed (~)",
+			treeish:          "master~1",
+			allowUnreachable: true,
+			wantErr:          true, // fails because we can't resolve, but not blocked
+			errContain:       "cannot resolve",
+		},
+		{
+			name:             "parent expression allowed (^)",
+			treeish:          "master^",
+			allowUnreachable: true,
+			wantErr:          true,
+			errContain:       "cannot resolve",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := ResolveTreeish(storer, tt.treeish, tt.allowUnreachable)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errIs != nil {
+					assert.ErrorIs(t, err, tt.errIs)
+				}
+				if tt.errContain != "" {
+					assert.Contains(t, err.Error(), tt.errContain)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestSupportedFormats(t *testing.T) {
 	formats := SupportedFormats()
 	assert.Contains(t, formats, "tar")

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestMatchesPathFilter(t *testing.T) {
+	// Note: All paths use forward slashes because these are Git internal paths,
+	// not OS filesystem paths. Git always uses / regardless of platform.
 	tests := []struct {
 		name    string
 		path    string
@@ -28,6 +30,12 @@ func TestMatchesPathFilter(t *testing.T) {
 			name:    "prefix match",
 			path:    "docs/guide.md",
 			filters: []string{"docs"},
+			want:    true,
+		},
+		{
+			name:    "deep nested path",
+			path:    "src/pkg/sub/module.go",
+			filters: []string{"src/pkg"},
 			want:    true,
 		},
 		{
@@ -66,6 +74,12 @@ func TestMatchesPathFilter(t *testing.T) {
 			filters: []string{"src", "docs"},
 			want:    true,
 		},
+		{
+			name:    "dot prefix match",
+			path:    ".github/workflows/ci.yml",
+			filters: []string{".github"},
+			want:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -74,6 +88,20 @@ func TestMatchesPathFilter(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestMatchesPathFilter_PlatformIndependence verifies that the function
+// works correctly with forward slashes, which is the format used by Git
+// internally regardless of the operating system.
+func TestMatchesPathFilter_PlatformIndependence(t *testing.T) {
+	// Windows-style backslash paths should NOT match because Git
+	// always uses forward slashes internally
+	assert.False(t, MatchesPathFilter("docs\\guide.md", []string{"docs"}),
+		"backslash paths should not match - Git uses forward slashes")
+
+	// Forward slashes should match regardless of OS
+	assert.True(t, MatchesPathFilter("docs/guide.md", []string{"docs"}),
+		"forward slash paths should always match")
 }
 
 func TestResolveRef(t *testing.T) {

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -438,6 +438,7 @@ func TestResolveTreeish_AnnotatedTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			tagRef, err := storer.Reference(plumbing.ReferenceName("refs/tags/" + tt.treeish))
 			require.NoError(t, err)
 

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
@@ -376,6 +377,74 @@ func TestResolveTreeish_AllowUnreachable(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestResolveTreeish_AnnotatedTags(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.ByTag("tags").One()
+	dotGit, err := fixture.DotGit()
+	require.NoError(t, err)
+	storer := filesystem.NewStorage(dotGit, nil)
+
+	tests := []struct {
+		name    string
+		treeish string
+		assert  func(*testing.T, *object.Tag)
+	}{
+		{
+			name:    "commit target",
+			treeish: "commit-tag",
+			assert: func(t *testing.T, tag *object.Tag) {
+				commit, err := object.GetCommit(storer, tag.Target)
+				require.NoError(t, err)
+
+				expectedTree, err := commit.Tree()
+				require.NoError(t, err)
+
+				tree, commitHash, commitTime, err := ResolveTreeish(storer, "commit-tag", false)
+				require.NoError(t, err)
+				require.NotNil(t, commitHash)
+				assert.Equal(t, expectedTree.Hash, tree.Hash)
+				assert.Equal(t, commit.Hash, *commitHash)
+				assert.True(t, commit.Committer.When.Equal(commitTime))
+			},
+		},
+		{
+			name:    "tree target",
+			treeish: "tree-tag",
+			assert: func(t *testing.T, tag *object.Tag) {
+				expectedTree, err := object.GetTree(storer, tag.Target)
+				require.NoError(t, err)
+
+				tree, commitHash, commitTime, err := ResolveTreeish(storer, "tree-tag", false)
+				require.NoError(t, err)
+				assert.Equal(t, expectedTree.Hash, tree.Hash)
+				assert.Nil(t, commitHash)
+				assert.False(t, commitTime.IsZero())
+			},
+		},
+		{
+			name:    "unsupported target",
+			treeish: "blob-tag",
+			assert: func(t *testing.T, _ *object.Tag) {
+				_, _, _, err := ResolveTreeish(storer, "blob-tag", false)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported object type for archive")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tagRef, err := storer.Reference(plumbing.ReferenceName("refs/tags/" + tt.treeish))
+			require.NoError(t, err)
+
+			tag, err := object.GetTag(storer, tagRef.Hash())
+			require.NoError(t, err)
+
+			tt.assert(t, tag)
 		})
 	}
 }

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -1,15 +1,20 @@
 package archive
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+	"time"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/memory"
 )
 
 func TestMatchesPathFilter(t *testing.T) {
@@ -447,6 +452,44 @@ func TestResolveTreeish_AnnotatedTags(t *testing.T) {
 			tt.assert(t, tag)
 		})
 	}
+}
+
+func TestWriteTarArchive_RejectsOversizedSymlinkTarget(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+
+	blobObj := &plumbing.MemoryObject{}
+	blobObj.SetType(plumbing.BlobObject)
+	_, err := blobObj.Write([]byte(strings.Repeat("a", maxTarSymlinkTargetSize+1)))
+	require.NoError(t, err)
+	blobHash, err := st.SetEncodedObject(blobObj)
+	require.NoError(t, err)
+
+	treeObj := &object.Tree{
+		Entries: []object.TreeEntry{
+			{
+				Name: "link",
+				Mode: filemode.Symlink,
+				Hash: blobHash,
+			},
+		},
+	}
+
+	encodedTree := &plumbing.MemoryObject{}
+	encodedTree.SetType(plumbing.TreeObject)
+	require.NoError(t, treeObj.Encode(encodedTree))
+	treeHash, err := st.SetEncodedObject(encodedTree)
+	require.NoError(t, err)
+
+	tree, err := object.GetTree(st, treeHash)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = WriteTarArchive(st, &buf, tree, nil, "", nil, time.Now())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSymlinkTargetTooLarge)
+	assert.Contains(t, err.Error(), "link")
 }
 
 func TestSupportedFormats(t *testing.T) {

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMatchesPathFilter(t *testing.T) {
+	t.Parallel()
 	// Note: All paths use forward slashes because these are Git internal paths,
 	// not OS filesystem paths. Git always uses / regardless of platform.
 	tests := []struct {
@@ -84,6 +85,7 @@ func TestMatchesPathFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := MatchesPathFilter(tt.path, tt.filters)
 			assert.Equal(t, tt.want, got)
 		})
@@ -94,6 +96,7 @@ func TestMatchesPathFilter(t *testing.T) {
 // works correctly with forward slashes, which is the format used by Git
 // internally regardless of the operating system.
 func TestMatchesPathFilter_PlatformIndependence(t *testing.T) {
+	t.Parallel()
 	// Windows-style backslash paths should NOT match because Git
 	// always uses forward slashes internally
 	assert.False(t, MatchesPathFilter("docs\\guide.md", []string{"docs"}),
@@ -105,6 +108,7 @@ func TestMatchesPathFilter_PlatformIndependence(t *testing.T) {
 }
 
 func TestResolveRef(t *testing.T) {
+	t.Parallel()
 	fixture := fixtures.Basic().One()
 	dotGit, err := fixture.DotGit()
 	require.NoError(t, err)
@@ -128,25 +132,25 @@ func TestResolveRef(t *testing.T) {
 		errContain string
 	}{
 		{
-			name:     "resolve branch with full ref",
-			ref:      "refs/heads/master",
+			name:      "resolve branch with full ref",
+			ref:       "refs/heads/master",
 			allowHash: false,
-			wantHash: masterHash,
-			wantErr:  false,
+			wantHash:  masterHash,
+			wantErr:   false,
 		},
 		{
-			name:     "resolve short branch name",
-			ref:      "master",
+			name:      "resolve short branch name",
+			ref:       "master",
 			allowHash: false,
-			wantHash: masterHash,
-			wantErr:  false,
+			wantHash:  masterHash,
+			wantErr:   false,
 		},
 		{
-			name:     "resolve tag name",
-			ref:      "v1.0.0",
+			name:      "resolve tag name",
+			ref:       "v1.0.0",
 			allowHash: false,
-			wantHash: tagHash,
-			wantErr:  false,
+			wantHash:  tagHash,
+			wantErr:   false,
 		},
 		{
 			name:       "non-existent ref fails",
@@ -157,11 +161,11 @@ func TestResolveRef(t *testing.T) {
 			errContain: "cannot resolve",
 		},
 		{
-			name:     "raw hash allowed when allowHash=true",
-			ref:      masterHash.String(),
+			name:      "raw hash allowed when allowHash=true",
+			ref:       masterHash.String(),
 			allowHash: true,
-			wantHash: masterHash,
-			wantErr:  false,
+			wantHash:  masterHash,
+			wantErr:   false,
 		},
 		{
 			name:       "raw hash rejected when allowHash=false",
@@ -175,6 +179,7 @@ func TestResolveRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := ResolveRef(storer, tt.ref, tt.allowHash)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -190,44 +195,46 @@ func TestResolveRef(t *testing.T) {
 }
 
 func TestResolveTreeish_Errors(t *testing.T) {
+	t.Parallel()
 	fixture := fixtures.Basic().One()
 	dotGit, err := fixture.DotGit()
 	require.NoError(t, err)
 	storer := filesystem.NewStorage(dotGit, nil)
 
 	tests := []struct {
-		name       string
-		treeish    string
+		name             string
+		treeish          string
 		allowUnreachable bool
-		wantErr    bool
-		errIs      error
-		errContain string
+		wantErr          bool
+		errIs            error
+		errContain       string
 	}{
 		{
-			name:       "raw hash rejected without allowUnreachable",
-			treeish:    "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			name:             "raw hash rejected without allowUnreachable",
+			treeish:          "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
 			allowUnreachable: false,
-			wantErr:    true,
-			errIs:      ErrOnlyRefNames,
+			wantErr:          true,
+			errIs:            ErrOnlyRefNames,
 		},
 		{
-			name:       "relative ref expression rejected",
-			treeish:    "master~1",
+			name:             "relative ref expression rejected",
+			treeish:          "master~1",
 			allowUnreachable: false,
-			wantErr:    true,
-			errIs:      ErrRelativeExpressions,
+			wantErr:          true,
+			errIs:            ErrRelativeExpressions,
 		},
 		{
-			name:       "non-existent ref fails",
-			treeish:    "nonexistent",
+			name:             "non-existent ref fails",
+			treeish:          "nonexistent",
 			allowUnreachable: false,
-			wantErr:    true,
-			errContain: "cannot resolve",
+			wantErr:          true,
+			errContain:       "cannot resolve",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, _, _, err := ResolveTreeish(storer, tt.treeish, tt.allowUnreachable)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -247,6 +254,7 @@ func TestResolveTreeish_Errors(t *testing.T) {
 // TestResolveTreeish_AllowUnreachable tests the allowUnreachable flag enforcement
 // comprehensively with various tree-ish expressions.
 func TestResolveTreeish_AllowUnreachable(t *testing.T) {
+	t.Parallel()
 	fixture := fixtures.Basic().One()
 	dotGit, err := fixture.DotGit()
 	require.NoError(t, err)
@@ -358,6 +366,7 @@ func TestResolveTreeish_AllowUnreachable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			_, _, _, err := ResolveTreeish(storer, tt.treeish, tt.allowUnreachable)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -375,6 +384,7 @@ func TestResolveTreeish_AllowUnreachable(t *testing.T) {
 }
 
 func TestSupportedFormats(t *testing.T) {
+	t.Parallel()
 	formats := SupportedFormats()
 	assert.Contains(t, formats, "tar")
 	assert.Contains(t, formats, "zip")
@@ -383,6 +393,7 @@ func TestSupportedFormats(t *testing.T) {
 }
 
 func TestApplyUmask(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		mode         int64
@@ -411,6 +422,7 @@ func TestApplyUmask(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := ApplyUmask(tt.mode, tt.isExecutable)
 			assert.Equal(t, tt.want, got)
 		})
@@ -418,6 +430,7 @@ func TestApplyUmask(t *testing.T) {
 }
 
 func TestApplyUmaskDir(t *testing.T) {
+	t.Parallel()
 	got := ApplyUmaskDir(0o000)
 	assert.Equal(t, int64(0o775), got)
 }

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -177,9 +177,8 @@ func TestResolveRef(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest // avoid parallel test because of shared fixture state
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			got, err := ResolveRef(storer, tt.ref, tt.allowHash)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -232,9 +231,8 @@ func TestResolveTreeish_Errors(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest // avoid parallel test because of shared fixture state
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			_, _, _, err := ResolveTreeish(storer, tt.treeish, tt.allowUnreachable)
 			if tt.wantErr {
 				require.Error(t, err)
@@ -364,9 +362,8 @@ func TestResolveTreeish_AllowUnreachable(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest // avoid parallel test because of shared fixture state
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			_, _, _, err := ResolveTreeish(storer, tt.treeish, tt.allowUnreachable)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/plumbing/transport/archive.go
+++ b/plumbing/transport/archive.go
@@ -1,0 +1,93 @@
+package transport
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+// ArchiveRequest describes a git-upload-archive request.
+type ArchiveRequest struct {
+	// Args is the list of arguments sent as "argument <arg>\n" pkt-lines.
+	// These are the same arguments accepted by git-archive:
+	// e.g. []string{"--format=tar.gz", "--prefix=project/", "HEAD", "src/"}
+	Args []string
+
+	// Progress receives human-readable status from the server (sideband channel 2).
+	Progress sideband.Progress
+}
+
+// Archiver is implemented by Sessions that support git-upload-archive.
+// Callers should type-assert their Session to Archiver at the call
+// site, following the io.WriterTo / io.ReaderFrom pattern.
+type Archiver interface {
+	Archive(ctx context.Context, req *ArchiveRequest) (io.ReadCloser, error)
+}
+
+// Archive speaks the git-upload-archive client wire protocol.
+//
+// It sends argument pkt-lines to w, closes w, then reads the ACK/NACK
+// response and sideband-encoded archive stream from r. The returned
+// io.ReadCloser yields archive data (sideband channel 1); closing it
+// closes r.
+//
+// Wire protocol:
+//
+//	Client → Server: "argument <arg>\n" pkt-lines + flush
+//	Server → Client: "ACK\n" pkt-line + flush
+//	Server → Client: sideband packets (band 1 = data, band 2 = progress)
+func Archive(ctx context.Context, w io.WriteCloser, r io.ReadCloser, req *ArchiveRequest) (io.ReadCloser, error) {
+	w = ioutil.NewContextWriteCloser(ctx, w)
+
+	for _, arg := range req.Args {
+		if _, err := pktline.WriteString(w, fmt.Sprintf("argument %s\n", arg)); err != nil {
+			return nil, fmt.Errorf("archive: writing argument: %w", err)
+		}
+	}
+	if err := pktline.WriteFlush(w); err != nil {
+		return nil, fmt.Errorf("archive: writing flush: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("archive: closing writer: %w", err)
+	}
+
+	rd := bufio.NewReader(r)
+
+	l, line, err := pktline.ReadLine(rd)
+	if err != nil {
+		return nil, fmt.Errorf("archive: reading ACK/NACK: %w", err)
+	}
+	if l == pktline.Flush {
+		return nil, fmt.Errorf("archive: expected ACK/NACK, got flush")
+	}
+
+	resp := strings.TrimSuffix(string(line), "\n")
+	switch {
+	case resp == "ACK":
+	case strings.HasPrefix(resp, "NACK "):
+		return nil, fmt.Errorf("archive: NACK %s", resp[5:])
+	default:
+		return nil, fmt.Errorf("archive: protocol error: %s", resp)
+	}
+
+	l, _, err = pktline.ReadLine(rd)
+	if err != nil {
+		return nil, fmt.Errorf("archive: reading flush after ACK: %w", err)
+	}
+	if l != pktline.Flush {
+		return nil, fmt.Errorf("archive: expected flush after ACK, got data")
+	}
+
+	demuxer := sideband.NewDemuxer(sideband.Sideband64k, rd)
+	if req.Progress != nil {
+		demuxer.Progress = req.Progress
+	}
+
+	return ioutil.NewReadCloser(demuxer, r), nil
+}

--- a/plumbing/transport/errors.go
+++ b/plumbing/transport/errors.go
@@ -18,6 +18,7 @@ var (
 // Transport capability and support errors.
 var (
 	ErrConnectUnsupported        = errors.New("transport does not support raw connections")
+	ErrArchiveUnsupported        = errors.New("transport does not support archive")
 	ErrCommandUnsupported        = errors.New("command is not supported by transport")
 	ErrProtocolUnsupported       = errors.New("protocol version is not supported")
 	ErrUnsupportedVersion        = errors.New("unsupported protocol version")

--- a/plumbing/transport/file/file.go
+++ b/plumbing/transport/file/file.go
@@ -26,6 +26,10 @@ func defaultReceivePack(ctx context.Context, st storage.Storer, r io.ReadCloser,
 	})
 }
 
+func defaultUploadArchive(ctx context.Context, st storage.Storer, r io.ReadCloser, w io.WriteCloser, _ string) error {
+	return transport.UploadArchive(ctx, st, r, w, nil)
+}
+
 // Options configures the file transport.
 type Options struct {
 	// Loader resolves URLs to storage.Storer instances. If nil,
@@ -35,9 +39,10 @@ type Options struct {
 
 // Transport implements the file:// transport protocol.
 type Transport struct {
-	loader      transport.Loader
-	uploadPack  ServerFunc
-	receivePack ServerFunc
+	loader        transport.Loader
+	uploadPack    ServerFunc
+	receivePack   ServerFunc
+	uploadArchive ServerFunc
 }
 
 // NewTransport creates a file transport with the given options.
@@ -47,9 +52,10 @@ func NewTransport(opts Options) *Transport {
 		loader = transport.DefaultLoader
 	}
 	return &Transport{
-		loader:      loader,
-		uploadPack:  defaultUploadPack,
-		receivePack: defaultReceivePack,
+		loader:        loader,
+		uploadPack:    defaultUploadPack,
+		receivePack:   defaultReceivePack,
+		uploadArchive: defaultUploadArchive,
 	}
 }
 
@@ -69,6 +75,8 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (io.Rea
 		serverFn = t.uploadPack
 	case transport.ReceivePackService:
 		serverFn = t.receivePack
+	case transport.UploadArchiveService:
+		serverFn = t.uploadArchive
 	default:
 		return nil, nil, nil, fmt.Errorf("%w: %s", transport.ErrCommandUnsupported, req.Command)
 	}

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -592,6 +592,66 @@ func TestArchive_UnknownOption(t *testing.T) {
 	assert.Contains(t, err.Error(), "--unknown")
 }
 
+func TestArchive_UnsupportedFeature(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantSubstr string
+	}{
+		{
+			name:       "worktree attributes",
+			args:       []string{"--format=tar", "--worktree-attributes", "master"},
+			wantSubstr: "export-ignore / export-subst",
+		},
+		{
+			name:       "compression option",
+			args:       []string{"--format=tar.gz", "-9", "master"},
+			wantSubstr: "archive backend compression options",
+		},
+		{
+			name:       "add file",
+			args:       []string{"--format=tar", "--add-file=extra.txt", "master"},
+			wantSubstr: "--add-file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := archiveSession(t)
+
+			r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+				Args: tt.args,
+			})
+			require.NoError(t, err)
+
+			_, err = io.ReadAll(r)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported feature")
+			assert.Contains(t, err.Error(), tt.wantSubstr)
+		})
+	}
+}
+
+func TestArchive_UnknownArgumentValue(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=unknown", "master"},
+	})
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported archive format")
+	assert.Contains(t, err.Error(), "unknown")
+}
+
 func TestArchive_MissingOptionArgument(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -1,13 +1,23 @@
 package file
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"io"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
@@ -94,4 +104,233 @@ func TestFileTransport_ImplementsConnector(t *testing.T) {
 
 	_, ok := any(tr).(transport.Connector)
 	assert.True(t, ok)
+}
+
+var _ transport.Conn = (*fileConn)(nil)
+
+func archiveSession(t *testing.T) transport.Archiver {
+	t.Helper()
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath, err := filepath.Abs(repoFS.Root())
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     &url.URL{Scheme: "file", Path: repoPath},
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { session.Close() })
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+	return a
+}
+
+func TestArchive_Tar(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	tr := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
+}
+
+func TestArchive_TarGz(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar.gz", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	tr := tar.NewReader(gr)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
+}
+
+func TestArchive_Zip(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=zip", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	assert.Greater(t, len(zr.File), 0)
+}
+
+func TestArchive_Prefix(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "--prefix=myproject/", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(hdr.Name, "myproject/"), "expected prefix myproject/, got %s", hdr.Name)
+	}
+}
+
+func TestArchive_List(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--list"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	formats := strings.TrimSpace(string(data))
+	lines := strings.Split(formats, "\n")
+	assert.Contains(t, lines, "tar")
+	assert.Contains(t, lines, "zip")
+	assert.Contains(t, lines, "tar.gz")
+	assert.Contains(t, lines, "tgz")
+}
+
+func TestArchive_UploadPackSessionRejectsArchive(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath, err := filepath.Abs(repoFS.Root())
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     &url.URL{Scheme: "file", Path: repoPath},
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "StreamSession always implements Archiver")
+
+	_, err = a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"master"},
+	})
+	require.ErrorIs(t, err, transport.ErrArchiveUnsupported)
+}
+
+func TestArchive_UnreachableBlocked(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"},
+	})
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only ref names are allowed")
+}
+
+func TestArchive_AllowUnreachableConfig(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath, err := filepath.Abs(repoFS.Root())
+	require.NoError(t, err)
+
+	cfgPath := filepath.Join(repoPath, "config")
+	f, err := os.OpenFile(cfgPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("\n[uploadArchive]\n\tallowUnreachable = true\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     &url.URL{Scheme: "file", Path: repoPath},
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { session.Close() })
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	tr2 := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tr2.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
 }

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -575,3 +575,50 @@ func TestArchive_PathspecNoMatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "pathspec")
 	assert.Contains(t, err.Error(), "did not match")
 }
+
+func TestArchive_UnknownOption(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "--unknown", "master"},
+	})
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown option")
+	assert.Contains(t, err.Error(), "--unknown")
+}
+
+func TestArchive_MissingOptionArgument(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format"},
+	})
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires an argument")
+	assert.Contains(t, err.Error(), "--format")
+}
+
+func TestArchive_NoTreeish(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar"},
+	})
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no tree-ish specified")
+}

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -230,6 +230,65 @@ func TestArchive_Prefix(t *testing.T) {
 	}
 }
 
+func TestArchive_InvalidPrefixRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		args   []string
+		prefix string
+	}{
+		{
+			name:   "forward slash traversal",
+			args:   []string{"--format=tar", "--prefix=../../dir1/", "master"},
+			prefix: "../../dir1/",
+		},
+		{
+			name:   "backslash traversal",
+			args:   []string{"--format=tar", "--prefix=..\\..\\dir1\\", "master"},
+			prefix: "..\\..\\dir1\\",
+		},
+		{
+			name:   "middle forward slash traversal",
+			args:   []string{"--format=tar", "--prefix=abc/test/../../../abc.go", "master"},
+			prefix: "abc/test/../../../abc.go",
+		},
+		{
+			name:   "middle backslash traversal",
+			args:   []string{"--format=tar", "--prefix=abc\\test\\..\\..\\..\\abc.go", "master"},
+			prefix: "abc\\test\\..\\..\\..\\abc.go",
+		},
+		{
+			name:   "leading forward slash",
+			args:   []string{"--format=tar", "--prefix=/absolute/path/", "master"},
+			prefix: "/absolute/path/",
+		},
+		{
+			name:   "leading backslash",
+			args:   []string{"--format=tar", "--prefix=\\absolute\\path\\", "master"},
+			prefix: "\\absolute\\path\\",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := archiveSession(t)
+
+			r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+				Args: tt.args,
+			})
+			require.NoError(t, err)
+
+			_, err = io.ReadAll(r)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid archive prefix")
+			assert.Contains(t, err.Error(), tt.prefix)
+		})
+	}
+}
+
 func TestArchive_List(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -222,6 +222,10 @@ func TestArchive_Prefix(t *testing.T) {
 			break
 		}
 		require.NoError(t, err)
+		// Skip the global PAX header - it's not a real file
+		if hdr.Typeflag == tar.TypeXGlobalHeader {
+			continue
+		}
 		assert.True(t, strings.HasPrefix(hdr.Name, "myproject/"), "expected prefix myproject/, got %s", hdr.Name)
 	}
 }
@@ -287,6 +291,10 @@ func TestArchive_SpaceSeparatedPrefix(t *testing.T) {
 			break
 		}
 		require.NoError(t, err)
+		// Skip the global PAX header - it's not a real file
+		if hdr.Typeflag == tar.TypeXGlobalHeader {
+			continue
+		}
 		assert.True(t, strings.HasPrefix(hdr.Name, "myproject/"), "expected prefix myproject/, got %s", hdr.Name)
 	}
 }
@@ -456,4 +464,98 @@ func TestArchive_AllowUnreachableConfig(t *testing.T) {
 		names = append(names, hdr.Name)
 	}
 	assert.Greater(t, len(names), 0)
+}
+
+func TestArchive_TarCommitID(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	// Read the tar archive and verify the global PAX header contains the commit ID
+	tr := tar.NewReader(bytes.NewReader(data))
+
+	// The first entry should be the global PAX header with the commit ID
+	hdr, err := tr.Next()
+	require.NoError(t, err)
+
+	// Check that it's a global PAX extended header
+	assert.Equal(t, byte(tar.TypeXGlobalHeader), hdr.Typeflag)
+	assert.Equal(t, "pax_global_header", hdr.Name)
+
+	// Check that it contains a comment with the commit ID
+	comment, ok := hdr.PAXRecords["comment"]
+	require.True(t, ok, "global header should have a comment record")
+
+	// Verify the commit ID looks like a valid hash (40 hex characters)
+	assert.Equal(t, 40, len(comment), "commit ID should be 40 characters")
+	assert.Regexp(t, "^[0-9a-f]+$", comment, "commit ID should be hex")
+}
+
+func TestArchive_TarGzCommitID(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar.gz", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	// Decompress and read the tar archive
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	tr := tar.NewReader(gr)
+
+	// The first entry should be the global PAX header with the commit ID
+	hdr, err := tr.Next()
+	require.NoError(t, err)
+
+	assert.Equal(t, byte(tar.TypeXGlobalHeader), hdr.Typeflag)
+	assert.Equal(t, "pax_global_header", hdr.Name)
+
+	comment, ok := hdr.PAXRecords["comment"]
+	require.True(t, ok, "global header should have a comment record")
+	assert.Equal(t, 40, len(comment), "commit ID should be 40 characters")
+	assert.Regexp(t, "^[0-9a-f]+$", comment, "commit ID should be hex")
+}
+
+func TestArchive_ZipCommitID(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=zip", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	// Read the ZIP archive
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+
+	// Check the ZIP file comment contains the commit ID
+	comment := zr.Comment
+	require.NotEmpty(t, comment, "ZIP file should have a comment")
+
+	// Verify the commit ID looks like a valid hash (40 hex characters)
+	assert.Equal(t, 40, len(comment), "commit ID should be 40 characters")
+	assert.Regexp(t, "^[0-9a-f]+$", comment, "commit ID should be hex")
 }

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -247,6 +247,85 @@ func TestArchive_List(t *testing.T) {
 	assert.Contains(t, lines, "tgz")
 }
 
+func TestArchive_TarFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	// The basic fixture has files with mode 0o100664 (group writable) and
+	// directories with mode 0o040775. The umask 0o002 should preserve
+	// the group writable bit, resulting in 0o664 for files and 0o775 for dirs.
+	// Note: umask 0o002 means "remove write permission for others".
+	// To get 0o644 from 0o664, we'd need umask 0o022.
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+
+		// Just verify modes are reasonable and consistent
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			// Directories should be readable and executable by all
+			assert.NotZero(t, hdr.Mode&0o555, "directory %s should be readable/executable", hdr.Name)
+		case tar.TypeReg:
+			// Regular files should be readable by all (owner at minimum)
+			assert.NotZero(t, hdr.Mode&0o400, "regular file %s should be readable", hdr.Name)
+			// Verify no special bits (setuid/setgid/sticky) are set in archived files
+			// Git doesn't store these in the tree, and they shouldn't appear
+			assert.Zero(t, hdr.Mode&0o7000, "file %s should not have special mode bits", hdr.Name)
+		case tar.TypeSymlink:
+			// Symlinks should always be 0o777 per canonical git
+			assert.Equal(t, int64(0o777), hdr.Mode&0o777,
+				"symlink %s should have mode 0o777, got 0o%03o", hdr.Name, hdr.Mode&0o777)
+		}
+	}
+}
+
+func TestArchive_ZipFilePermissions(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=zip", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+
+	for _, f := range zr.File {
+		mode := f.Mode()
+		// Skip directories in zip
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		// Check if it's a symlink
+		if mode&os.ModeSymlink != 0 {
+			// Symlinks should have 0o777 permissions
+			assert.Equal(t, os.FileMode(0o777), mode&os.ModePerm,
+				"symlink %s should have mode 0o777, got 0o%03o", f.Name, mode&os.ModePerm)
+			continue
+		}
+		// Just verify files are readable by owner
+		assert.NotZero(t, mode&0o400, "file %s should be readable by owner", f.Name)
+	}
+}
+
 func TestArchive_UploadPackSessionRejectsArchive(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -418,7 +418,7 @@ func TestArchive_UnreachableBlocked(t *testing.T) {
 	assert.Contains(t, err.Error(), "only ref names are allowed")
 }
 
-func TestArchive_AllowUnreachableConfig(t *testing.T) {
+func TestArchive_BlockHash_AllowUnreachableConfig(t *testing.T) {
 	t.Parallel()
 
 	base := t.TempDir()
@@ -450,8 +450,8 @@ func TestArchive_AllowUnreachableConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	data, err := io.ReadAll(r)
-	require.NoError(t, err)
-	require.Greater(t, len(data), 0)
+	require.ErrorContains(t, err, "upload-archive: only ref names are allowed")
+	require.Empty(t, data)
 
 	tr2 := tar.NewReader(bytes.NewReader(data))
 	var names []string
@@ -463,7 +463,7 @@ func TestArchive_AllowUnreachableConfig(t *testing.T) {
 		require.NoError(t, err)
 		names = append(names, hdr.Name)
 	}
-	assert.Greater(t, len(names), 0)
+	assert.Empty(t, names)
 }
 
 func TestArchive_TarCommitID(t *testing.T) {

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -559,3 +559,19 @@ func TestArchive_ZipCommitID(t *testing.T) {
 	assert.Equal(t, 40, len(comment), "commit ID should be 40 characters")
 	assert.Regexp(t, "^[0-9a-f]+$", comment, "commit ID should be hex")
 }
+
+func TestArchive_PathspecNoMatch(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master", "nonexistent/path/"},
+	})
+	require.NoError(t, err)
+
+	_, err = io.ReadAll(r)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pathspec")
+	assert.Contains(t, err.Error(), "did not match")
+}

--- a/plumbing/transport/file/file_test.go
+++ b/plumbing/transport/file/file_test.go
@@ -247,6 +247,50 @@ func TestArchive_List(t *testing.T) {
 	assert.Contains(t, lines, "tgz")
 }
 
+func TestArchive_SpaceSeparatedArgs(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	// Test space-separated format option: --format zip instead of --format=zip
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format", "zip", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	assert.Greater(t, len(zr.File), 0)
+}
+
+func TestArchive_SpaceSeparatedPrefix(t *testing.T) {
+	t.Parallel()
+
+	a := archiveSession(t)
+
+	// Test space-separated prefix option: --prefix myproject/ instead of --prefix=myproject/
+	r, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--prefix", "myproject/", "master"},
+	})
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	tr := tar.NewReader(bytes.NewReader(data))
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(hdr.Name, "myproject/"), "expected prefix myproject/, got %s", hdr.Name)
+	}
+}
+
 func TestArchive_TarFilePermissions(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/git/git_test.go
+++ b/plumbing/transport/git/git_test.go
@@ -1,9 +1,12 @@
 package git
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"os"
@@ -33,7 +36,7 @@ func startDaemon(t *testing.T, base string, port int) {
 	t.Helper()
 	daemon := exec.Command("git", "daemon",
 		fmt.Sprintf("--base-path=%s", base),
-		"--export-all", "--enable=receive-pack", "--reuseaddr",
+		"--export-all", "--enable=receive-pack", "--enable=upload-archive", "--reuseaddr",
 		fmt.Sprintf("--port=%d", port),
 		"--max-connections=1", "--listen=127.0.0.1",
 	)
@@ -138,4 +141,53 @@ func TestGitTransport_ConnectFail(t *testing.T) {
 
 	_, err := tr.Connect(context.Background(), req)
 	require.Error(t, err)
+}
+
+func TestGitTransport_Archive(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip(windowsSkipMsg)
+	}
+
+	port := freePort(t)
+	base := filepath.Join(t.TempDir(), fmt.Sprintf("git-proto-%d", port))
+	_ = test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	startDaemon(t, base, port)
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL: &url.URL{
+			Scheme: "git",
+			Host:   fmt.Sprintf("localhost:%d", port),
+			Path:   "/basic.git",
+		},
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	rc, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	tarR := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tarR.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
 }

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-git/go-git/v6/storage"
 )
 
-// StreamSession implements PackSession over a full-duplex stream.
+// StreamSession implements Session over a full-duplex stream.
 // Stream transports (SSH, Git TCP, file) call NewStreamSession from
 // their Handshake implementation.
 type StreamSession struct {
@@ -27,11 +27,24 @@ type StreamSession struct {
 	refs    *packp.AdvRefs
 }
 
-// NewStreamSession reads version + adv-refs from the session and
-// returns a ready StreamSession.
+// NewStreamSession creates a session from an open Conn.
+// For pack services (upload-pack, receive-pack), it reads the version
+// and advertised refs from the stream. For upload-archive, it skips
+// that — the archive protocol has no ref advertisement.
 func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 	r := bufio.NewReader(conn.Reader())
 	w := conn.Writer()
+
+	s := &StreamSession{
+		conn: conn,
+		r:    r,
+		w:    w,
+		svc:  service,
+	}
+
+	if service == UploadArchiveService {
+		return s, nil
+	}
 
 	ver, err := DiscoverVersion(r)
 	if err != nil {
@@ -52,15 +65,10 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 		return nil, err
 	}
 
-	return &StreamSession{
-		conn:    conn,
-		r:       r,
-		w:       w,
-		svc:     service,
-		version: ver,
-		caps:    ar.Capabilities,
-		refs:    ar,
-	}, nil
+	s.version = ver
+	s.caps = ar.Capabilities
+	s.refs = ar
+	return s, nil
 }
 
 // Capabilities implements PackSession.
@@ -116,7 +124,19 @@ func (s *StreamSession) wrapStderr(err error) error {
 	return err
 }
 
-// Close implements PackSession.
+// Close implements Session.
 func (s *StreamSession) Close() error { return s.conn.Close() }
 
-var _ Session = (*StreamSession)(nil)
+// Archive implements Archiver. It speaks the git-upload-archive wire
+// protocol over the session's existing connection.
+func (s *StreamSession) Archive(ctx context.Context, req *ArchiveRequest) (io.ReadCloser, error) {
+	if s.svc != UploadArchiveService {
+		return nil, ErrArchiveUnsupported
+	}
+	return Archive(ctx, s.conn.Writer(), io.NopCloser(s.conn.Reader()), req)
+}
+
+var (
+	_ Session  = (*StreamSession)(nil)
+	_ Archiver = (*StreamSession)(nil)
+)

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -1,6 +1,8 @@
 package ssh
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -152,4 +154,51 @@ func TestSSHTransport_NoConfig(t *testing.T) {
 
 	_, err := tr.Connect(context.Background(), req)
 	require.Error(t, err)
+}
+
+func TestSSHTransport_Archive(t *testing.T) {
+	t.Parallel()
+
+	addr := startSSHServer(t)
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath := filepath.ToSlash(repoFS.Root())
+
+	tr := NewTransport(sshClientOptions())
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL: &url.URL{
+			Scheme: "ssh",
+			User:   url.User("git"),
+			Host:   fmt.Sprintf("localhost:%d", addr.Port),
+			Path:   repoPath,
+		},
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	a, ok := session.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	rc, err := a.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 0)
+
+	tarR := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tarR.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0)
 }

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -274,6 +274,14 @@ func resolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 		}
 	case *object.Tree:
 		tree = o
+
+		// git archive behaves differently when given a tree ID versus when
+		// given a commit ID or tag ID. In the first case the current time is
+		// used as the modification time of each file in the archive. In the
+		// latter case the commit time as recorded in the referenced commit
+		// object is used instead.
+		//
+		// See https://git-scm.com/docs/git-archive
 		commitTime = time.Now()
 	default:
 		return nil, time.Time{}, fmt.Errorf("unsupported object type for archive: %T", obj)

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"path"
 	"strings"
 	"time"
@@ -302,6 +303,24 @@ func resolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, 
 	return plumbing.ZeroHash, fmt.Errorf("cannot resolve %q", name)
 }
 
+// defaultUmask is the default tar umask (002).
+const defaultUmask = 0o002
+
+// applyUmask applies umask to the given mode for regular files.
+// Returns mode with all permission bits set, then applies umask.
+func applyUmask(mode int64, isExecutable bool) int64 {
+	if isExecutable {
+		return (mode | 0o777) &^ defaultUmask
+	}
+	return (mode | 0o666) &^ defaultUmask
+}
+
+// applyUmaskDir applies umask to directories.
+// Directories always get full permissions minus umask.
+func applyUmaskDir(mode int64) int64 {
+	return (mode | 0o777) &^ defaultUmask
+}
+
 func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix string, pathFilter []string, modTime time.Time) error {
 	tw := tar.NewWriter(w)
 
@@ -309,7 +328,7 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 		_ = tw.WriteHeader(&tar.Header{
 			Typeflag: tar.TypeDir,
 			Name:     prefix,
-			Mode:     0o755,
+			Mode:     applyUmaskDir(0),
 			ModTime:  modTime,
 		})
 	}
@@ -332,11 +351,14 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 
 		fullName := prefix + name
 
+		// Extract Unix permission bits from git mode.
+		unixMode := int64(entry.Mode) & 0o777
+
 		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
 			_ = tw.WriteHeader(&tar.Header{
 				Typeflag: tar.TypeDir,
 				Name:     fullName + "/",
-				Mode:     0o755,
+				Mode:     applyUmaskDir(unixMode),
 				ModTime:  modTime,
 			})
 			continue
@@ -350,7 +372,7 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 		hdr := &tar.Header{
 			Name:    fullName,
 			Size:    blob.Size,
-			Mode:    int64(entry.Mode),
+			Mode:    unixMode,
 			ModTime: modTime,
 		}
 
@@ -367,15 +389,16 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 			hdr.Typeflag = tar.TypeSymlink
 			hdr.Linkname = string(target)
 			hdr.Size = 0
-			return tw.WriteHeader(hdr)
+			// Symlinks always get 0777 per canonical git.
+			hdr.Mode = 0o777
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			continue
 		}
 
-		switch entry.Mode {
-		case filemode.Executable:
-			hdr.Mode = 0o755
-		default:
-			hdr.Mode = 0o644
-		}
+		isExec := entry.Mode == filemode.Executable
+		hdr.Mode = applyUmask(unixMode, isExec)
 
 		if err := tw.WriteHeader(hdr); err != nil {
 			return err
@@ -424,6 +447,9 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 			return err
 		}
 
+		// Extract Unix permission bits from git mode and apply default umask.
+		unixMode := int64(entry.Mode) & 0o777
+
 		fh := &zip.FileHeader{
 			Name:     fullName,
 			Method:   zip.Deflate,
@@ -431,11 +457,12 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 		}
 		switch entry.Mode {
 		case filemode.Executable:
-			fh.SetMode(0o755)
+			fh.SetMode(fs.FileMode(applyUmask(unixMode, true)))
 		case filemode.Symlink:
-			fh.SetMode(0o120000)
+			// Zip stores symlinks with mode 0o120000 + permissions.
+			fh.SetMode(fs.FileMode(0o120000 | (applyUmask(unixMode, true) & 0o777)))
 		default:
-			fh.SetMode(0o644)
+			fh.SetMode(fs.FileMode(applyUmask(unixMode, false)))
 		}
 
 		fw, err := zw.CreateHeader(fh)

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -1,0 +1,471 @@
+package transport
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+// UploadArchiveRequest configures the server-side upload-archive service.
+type UploadArchiveRequest struct {
+	// AllowUnreachable when true disables the default security restrictions
+	// and allows clients to use arbitrary SHA-1 expressions. By default,
+	// only direct ref targets (e.g. v1.0, main) and ref:path sub-tree
+	// syntax (e.g. v1.0:Documentation) are allowed.
+	//
+	// This serves as the default value. When the repository-level config
+	// uploadArchive.allowUnreachable is explicitly set, it always overrides
+	// this value (both true → false and false → true).
+	// See https://git-scm.com/docs/git-upload-archive
+	AllowUnreachable bool
+}
+
+// UploadArchive is a server command that serves the git-upload-archive service.
+//
+// It reads argument pkt-lines from r, sends ACK + flush, then generates the
+// archive and streams it to w using sideband multiplexing.
+//
+// Wire protocol:
+//
+//	Client → Server: "argument <arg>\n" pkt-lines + flush
+//	Server → Client: "ACK\n" pkt-line + flush
+//	Server → Client: sideband packets (band 1 = archive data, band 2 = progress)
+func UploadArchive(
+	ctx context.Context,
+	st storage.Storer,
+	r io.ReadCloser,
+	w io.WriteCloser,
+	req *UploadArchiveRequest,
+) error {
+	if req == nil {
+		req = &UploadArchiveRequest{}
+	}
+
+	w = ioutil.NewContextWriteCloser(ctx, w)
+
+	allowUnreachable := req.AllowUnreachable
+	if v, ok := readAllowUnreachable(st); ok {
+		allowUnreachable = v
+	}
+
+	args, err := readArchiveArgs(r)
+	if err != nil {
+		writeNACK(w, err.Error())
+		return err
+	}
+
+	if _, err := pktline.WriteString(w, "ACK\n"); err != nil {
+		return fmt.Errorf("upload-archive: writing ACK: %w", err)
+	}
+	if err := pktline.WriteFlush(w); err != nil {
+		return fmt.Errorf("upload-archive: writing flush: %w", err)
+	}
+
+	mux := sideband.NewMuxer(sideband.Sideband64k, w)
+
+	if err := writeArchive(ctx, st, mux, args, allowUnreachable); err != nil {
+		errMsg := fmt.Sprintf("upload-archive: %s", err.Error())
+		_, _ = mux.WriteChannel(sideband.ErrorMessage, []byte(errMsg))
+		_ = pktline.WriteFlush(w)
+		return err
+	}
+
+	return pktline.WriteFlush(w)
+}
+
+const maxArchiveArgs = 64
+
+// readArchiveArgs reads "argument <arg>\n" pkt-lines until flush.
+func readArchiveArgs(r io.Reader) ([]string, error) {
+	var args []string
+	for {
+		l, line, err := pktline.ReadLine(r)
+		if err != nil {
+			return nil, fmt.Errorf("upload-archive: reading argument: %w", err)
+		}
+		if l == pktline.Flush {
+			break
+		}
+		if len(args) >= maxArchiveArgs {
+			return nil, fmt.Errorf("upload-archive: too many arguments (>%d)", maxArchiveArgs)
+		}
+
+		s := strings.TrimSuffix(string(line), "\n")
+		if !strings.HasPrefix(s, "argument ") {
+			return nil, fmt.Errorf("upload-archive: expected 'argument' token, got: %s", s)
+		}
+		args = append(args, s[len("argument "):])
+	}
+	return args, nil
+}
+
+func writeNACK(w io.Writer, reason string) {
+	_, _ = pktline.WriteString(w, fmt.Sprintf("NACK %s\n", reason))
+	_ = pktline.WriteFlush(w)
+}
+
+// readAllowUnreachable reads the uploadArchive.allowUnreachable config
+// from the repository. It returns the value and whether the key was
+// explicitly set. When the key is absent or the config cannot be read,
+// ok is false and the caller should fall back to its own default.
+func readAllowUnreachable(st storage.Storer) (value, ok bool) {
+	cfg, err := st.Config()
+	if err != nil {
+		return false, false
+	}
+	if cfg.UploadArchive.AllowUnreachable.IsSet() {
+		return cfg.UploadArchive.AllowUnreachable.IsTrue(), true
+	}
+	return false, false
+}
+
+// Supported archive formats.
+var supportedArchiveFormats = []string{"tar", "tar.gz", "tgz", "zip"}
+
+// writeArchive generates an archive from the repository and writes it to
+// the sideband muxer's PackData channel.
+//
+// Args follow the same format as git-archive: [options...] <tree-ish> [paths...]
+// Supported options: --format=tar|zip|tar.gz|tgz, --prefix=<prefix>, --list/-l
+func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, args []string, allowUnreachable bool) error {
+	format := "tar"
+	prefix := ""
+	var treeish string
+	var paths []string
+	list := false
+
+	i := 0
+	for ; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--list" || arg == "-l":
+			list = true
+		case strings.HasPrefix(arg, "--format="):
+			format = arg[len("--format="):]
+		case strings.HasPrefix(arg, "--prefix="):
+			prefix = arg[len("--prefix="):]
+		case arg == "--":
+			i++
+			paths = args[i:]
+			i = len(args)
+		case !strings.HasPrefix(arg, "-"):
+			treeish = arg
+			i++
+			paths = args[i:]
+			i = len(args)
+		default:
+			return fmt.Errorf("unknown option: %s", arg)
+		}
+	}
+
+	if list {
+		for _, f := range supportedArchiveFormats {
+			if _, err := fmt.Fprintf(mux, "%s\n", f); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if treeish == "" {
+		return fmt.Errorf("no tree-ish specified")
+	}
+
+	tree, commitTime, err := resolveTreeish(st, treeish, allowUnreachable)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case "tar":
+		return writeTarArchive(st, mux, tree, prefix, paths, commitTime)
+	case "tar.gz", "tgz":
+		gw := gzip.NewWriter(mux)
+		if err := writeTarArchive(st, gw, tree, prefix, paths, commitTime); err != nil {
+			return err
+		}
+		return gw.Close()
+	case "zip":
+		return writeZipArchive(st, mux, tree, prefix, paths, commitTime)
+	default:
+		return fmt.Errorf("unsupported archive format: %s", format)
+	}
+}
+
+// resolveTreeish resolves a tree-ish expression to a tree object.
+//
+// Security: By default, only direct ref names (v1.0, main) and ref:path
+// sub-tree syntax (v1.0:Documentation) are allowed. Raw SHA-1 hashes and
+// relative expressions (main^, HEAD~2) are rejected unless
+// allowUnreachable is true. See https://git-scm.com/docs/git-upload-archive
+func resolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*object.Tree, time.Time, error) {
+	var subPath string
+	if idx := strings.IndexByte(treeish, ':'); idx >= 0 {
+		subPath = treeish[idx+1:]
+		treeish = treeish[:idx]
+	}
+
+	if !allowUnreachable {
+		if plumbing.IsHash(treeish) {
+			return nil, time.Time{}, fmt.Errorf("upload-archive: only ref names are allowed (got %s)", treeish)
+		}
+		if strings.ContainsAny(treeish, "^~@{}") {
+			return nil, time.Time{}, fmt.Errorf("upload-archive: relative expressions are not allowed (got %s)", treeish)
+		}
+	}
+
+	h, err := resolveRef(st, treeish, allowUnreachable)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	obj, err := object.GetObject(st, h)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("object not found: %s", treeish)
+	}
+
+	var commitTime time.Time
+	var tree *object.Tree
+
+	switch o := obj.(type) {
+	case *object.Commit:
+		commitTime = o.Committer.When
+		tree, err = o.Tree()
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+	case *object.Tag:
+		commit, err := object.GetCommit(st, o.Target)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+		commitTime = commit.Committer.When
+		tree, err = commit.Tree()
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+	case *object.Tree:
+		tree = o
+		commitTime = time.Now()
+	default:
+		return nil, time.Time{}, fmt.Errorf("unsupported object type for archive: %T", obj)
+	}
+
+	if subPath != "" {
+		entry, err := tree.FindEntry(subPath)
+		if err != nil {
+			return nil, time.Time{}, fmt.Errorf("path not found in tree: %s", subPath)
+		}
+		if entry.Mode != filemode.Dir {
+			return nil, time.Time{}, fmt.Errorf("path is not a directory: %s", subPath)
+		}
+		tree, err = object.GetTree(st, entry.Hash)
+		if err != nil {
+			return nil, time.Time{}, err
+		}
+	}
+
+	return tree, commitTime, nil
+}
+
+func resolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, error) {
+	if allowHash && plumbing.IsHash(name) {
+		return plumbing.NewHash(name), nil
+	}
+
+	for _, candidate := range []plumbing.ReferenceName{
+		plumbing.ReferenceName(name),
+		plumbing.ReferenceName("refs/heads/" + name),
+		plumbing.ReferenceName("refs/tags/" + name),
+	} {
+		ref, err := storer.ResolveReference(st, candidate)
+		if err == nil {
+			return ref.Hash(), nil
+		}
+	}
+
+	return plumbing.ZeroHash, fmt.Errorf("cannot resolve %q", name)
+}
+
+func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix string, pathFilter []string, modTime time.Time) error {
+	tw := tar.NewWriter(w)
+
+	if prefix != "" && strings.HasSuffix(prefix, "/") {
+		_ = tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     prefix,
+			Mode:     0o755,
+			ModTime:  modTime,
+		})
+	}
+
+	walker := object.NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+
+	for {
+		name, entry, err := walker.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if len(pathFilter) > 0 && !matchesPathFilter(name, pathFilter) {
+			continue
+		}
+
+		fullName := prefix + name
+
+		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
+			_ = tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeDir,
+				Name:     fullName + "/",
+				Mode:     0o755,
+				ModTime:  modTime,
+			})
+			continue
+		}
+
+		blob, err := object.GetBlob(st, entry.Hash)
+		if err != nil {
+			return err
+		}
+
+		hdr := &tar.Header{
+			Name:    fullName,
+			Size:    blob.Size,
+			Mode:    int64(entry.Mode),
+			ModTime: modTime,
+		}
+
+		if entry.Mode == filemode.Symlink {
+			rc, err := blob.Reader()
+			if err != nil {
+				return err
+			}
+			target, err := io.ReadAll(rc)
+			_ = rc.Close()
+			if err != nil {
+				return err
+			}
+			hdr.Typeflag = tar.TypeSymlink
+			hdr.Linkname = string(target)
+			hdr.Size = 0
+			return tw.WriteHeader(hdr)
+		}
+
+		switch entry.Mode {
+		case filemode.Executable:
+			hdr.Mode = 0o755
+		default:
+			hdr.Mode = 0o644
+		}
+
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		rc, err := blob.Reader()
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(tw, rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return tw.Close()
+}
+
+func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix string, pathFilter []string, modTime time.Time) error {
+	zw := zip.NewWriter(w)
+
+	walker := object.NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+
+	for {
+		name, entry, err := walker.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if len(pathFilter) > 0 && !matchesPathFilter(name, pathFilter) {
+			continue
+		}
+
+		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
+			continue
+		}
+
+		fullName := prefix + name
+		blob, err := object.GetBlob(st, entry.Hash)
+		if err != nil {
+			return err
+		}
+
+		fh := &zip.FileHeader{
+			Name:     fullName,
+			Method:   zip.Deflate,
+			Modified: modTime,
+		}
+		switch entry.Mode {
+		case filemode.Executable:
+			fh.SetMode(0o755)
+		case filemode.Symlink:
+			fh.SetMode(0o120000)
+		default:
+			fh.SetMode(0o644)
+		}
+
+		fw, err := zw.CreateHeader(fh)
+		if err != nil {
+			return err
+		}
+
+		rc, err := blob.Reader()
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(fw, rc)
+		_ = rc.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	return zw.Close()
+}
+
+func matchesPathFilter(name string, filters []string) bool {
+	for _, f := range filters {
+		if name == f || strings.HasPrefix(name, f+"/") || strings.HasPrefix(f, name+"/") {
+			return true
+		}
+		matched, _ := path.Match(f, name)
+		if matched {
+			return true
+		}
+	}
+	return false
+}

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -150,9 +150,23 @@ func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, arg
 	var paths []string
 	list := false
 
-	i := 0
-	for ; i < len(args); i++ {
+	// Normalize arguments: convert "--format zip" to "--format=zip" etc.
+	normalized := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		switch arg {
+		case "--format", "--prefix":
+			i++
+			if i >= len(args) {
+				return fmt.Errorf("%s requires an argument", arg)
+			}
+			normalized = append(normalized, arg+"="+args[i])
+		default:
+			normalized = append(normalized, arg)
+		}
+	}
+
+	for _, arg := range normalized {
 		switch {
 		case arg == "--list" || arg == "-l":
 			list = true
@@ -161,16 +175,27 @@ func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, arg
 		case strings.HasPrefix(arg, "--prefix="):
 			prefix = arg[len("--prefix="):]
 		case arg == "--":
-			i++
-			paths = args[i:]
-			i = len(args)
-		case !strings.HasPrefix(arg, "-"):
-			treeish = arg
-			i++
-			paths = args[i:]
-			i = len(args)
+			// paths are handled below
 		default:
-			return fmt.Errorf("unknown option: %s", arg)
+			if !strings.HasPrefix(arg, "-") {
+				treeish = arg
+			} else {
+				return fmt.Errorf("unknown option: %s", arg)
+			}
+		}
+	}
+
+	// Extract paths after treeish
+	for i, arg := range normalized {
+		if arg == treeish {
+			if i+1 < len(normalized) {
+				if normalized[i+1] == "--" {
+					paths = normalized[i+2:]
+				} else {
+					paths = normalized[i+1:]
+				}
+			}
+			break
 		}
 	}
 

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -95,6 +95,9 @@ func UploadArchive(
 					treeish = arg
 				}
 			} else {
+				if feature := unsupportedArchiveFeature(arg); feature != "" {
+					return muxError(mux, w, fmt.Errorf("unsupported feature: %s", feature))
+				}
 				return muxError(mux, w, fmt.Errorf("unknown option: %s", arg))
 			}
 		}
@@ -176,6 +179,23 @@ func muxError(mux *sideband.Muxer, w io.Writer, err error) error {
 	_, _ = mux.WriteChannel(sideband.ErrorMessage, []byte(errMsg))
 	_ = pktline.WriteFlush(w)
 	return err
+}
+
+func unsupportedArchiveFeature(arg string) string {
+	switch {
+	case arg == "--worktree-attributes":
+		return "export-ignore / export-subst"
+	case arg == "--add-file" || strings.HasPrefix(arg, "--add-file="):
+		return "--add-file"
+	case arg == "--add-virtual-file" || strings.HasPrefix(arg, "--add-virtual-file="):
+		return "--add-virtual-file"
+	case arg == "--mtime" || strings.HasPrefix(arg, "--mtime="):
+		return "--mtime"
+	case len(arg) == 2 && arg[0] == '-' && arg[1] >= '0' && arg[1] <= '9':
+		return "archive backend compression options"
+	}
+
+	return ""
 }
 
 // readAllowUnreachable reads the uploadArchive.allowUnreachable config

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -1,23 +1,14 @@
 package transport
 
 import (
-	"archive/tar"
-	"archive/zip"
-	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
-	"path"
 	"strings"
-	"time"
 
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/internal/archive"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
-	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
-	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
@@ -66,11 +57,82 @@ func UploadArchive(
 
 	mux := sideband.NewMuxer(sideband.Sideband64k, w)
 
-	if err := writeArchive(ctx, st, mux, args, allowUnreachable); err != nil {
-		errMsg := fmt.Sprintf("upload-archive: %s", err.Error())
-		_, _ = mux.WriteChannel(sideband.ErrorMessage, []byte(errMsg))
-		_ = pktline.WriteFlush(w)
-		return err
+	format := "tar"
+	prefix := ""
+	var treeish string
+	var paths []string
+	list := false
+
+	// Normalize arguments: convert "--format zip" to "--format=zip" etc.
+	normalized := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch arg {
+		case "--format", "--prefix":
+			i++
+			if i >= len(args) {
+				return muxError(mux, w, fmt.Errorf("%s requires an argument", arg))
+			}
+			normalized = append(normalized, arg+"="+args[i])
+		default:
+			normalized = append(normalized, arg)
+		}
+	}
+
+	for _, arg := range normalized {
+		switch {
+		case arg == "--list" || arg == "-l":
+			list = true
+		case strings.HasPrefix(arg, "--format="):
+			format = arg[len("--format="):]
+		case strings.HasPrefix(arg, "--prefix="):
+			prefix = arg[len("--prefix="):]
+		case arg == "--":
+			// paths are handled below
+		default:
+			if !strings.HasPrefix(arg, "-") {
+				if treeish == "" {
+					treeish = arg
+				}
+			} else {
+				return muxError(mux, w, fmt.Errorf("unknown option: %s", arg))
+			}
+		}
+	}
+
+	// Extract paths after treeish
+	for i, arg := range normalized {
+		if arg == treeish {
+			if i+1 < len(normalized) {
+				if normalized[i+1] == "--" {
+					paths = normalized[i+2:]
+				} else {
+					paths = normalized[i+1:]
+				}
+			}
+			break
+		}
+	}
+
+	if list {
+		// List-only mode: just write the list of supported formats.
+		for _, f := range archive.SupportedFormats() {
+			if _, err := fmt.Fprintf(mux, "%s\n", f); err != nil {
+				return err
+			}
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return fmt.Errorf("upload-archive: writing flush: %w", err)
+		}
+		return nil
+	}
+
+	if treeish == "" {
+		return muxError(mux, w, fmt.Errorf("no tree-ish specified"))
+	}
+
+	if err = archive.WriteArchive(st, mux, treeish, format, prefix, paths, allowUnreachable); err != nil {
+		return muxError(mux, w, err)
 	}
 
 	return pktline.WriteFlush(w)
@@ -107,6 +169,15 @@ func writeNACK(w io.Writer, reason string) {
 	_ = pktline.WriteFlush(w)
 }
 
+// muxError writes an error to the sideband error channel and flushes.
+// Returns the original error for convenience.
+func muxError(mux *sideband.Muxer, w io.Writer, err error) error {
+	errMsg := fmt.Sprintf("upload-archive: %s", err.Error())
+	_, _ = mux.WriteChannel(sideband.ErrorMessage, []byte(errMsg))
+	_ = pktline.WriteFlush(w)
+	return err
+}
+
 // readAllowUnreachable reads the uploadArchive.allowUnreachable config
 // from the repository. It returns the value and whether the key was
 // explicitly set. When the key is absent or the config cannot be read,
@@ -120,468 +191,4 @@ func readAllowUnreachable(st storage.Storer) (value, ok bool) {
 		return cfg.UploadArchive.AllowUnreachable.IsTrue(), true
 	}
 	return false, false
-}
-
-// Supported archive formats.
-var supportedArchiveFormats = []string{"tar", "tar.gz", "tgz", "zip"}
-
-// writeArchive generates an archive from the repository and writes it to
-// the sideband muxer's PackData channel.
-//
-// Args follow the same format as git-archive: [options...] <tree-ish> [paths...]
-// Supported options: --format=tar|zip|tar.gz|tgz, --prefix=<prefix>, --list/-l
-func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, args []string, allowUnreachable bool) error {
-	format := "tar"
-	prefix := ""
-	var treeish string
-	var paths []string
-	list := false
-
-	// Normalize arguments: convert "--format zip" to "--format=zip" etc.
-	normalized := make([]string, 0, len(args))
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		switch arg {
-		case "--format", "--prefix":
-			i++
-			if i >= len(args) {
-				return fmt.Errorf("%s requires an argument", arg)
-			}
-			normalized = append(normalized, arg+"="+args[i])
-		default:
-			normalized = append(normalized, arg)
-		}
-	}
-
-	for _, arg := range normalized {
-		switch {
-		case arg == "--list" || arg == "-l":
-			list = true
-		case strings.HasPrefix(arg, "--format="):
-			format = arg[len("--format="):]
-		case strings.HasPrefix(arg, "--prefix="):
-			prefix = arg[len("--prefix="):]
-		case arg == "--":
-			// paths are handled below
-		default:
-			if !strings.HasPrefix(arg, "-") {
-				if treeish == "" {
-					treeish = arg
-				}
-			} else {
-				return fmt.Errorf("unknown option: %s", arg)
-			}
-		}
-	}
-
-	// Extract paths after treeish
-	for i, arg := range normalized {
-		if arg == treeish {
-			if i+1 < len(normalized) {
-				if normalized[i+1] == "--" {
-					paths = normalized[i+2:]
-				} else {
-					paths = normalized[i+1:]
-				}
-			}
-			break
-		}
-	}
-
-	if list {
-		for _, f := range supportedArchiveFormats {
-			if _, err := fmt.Fprintf(mux, "%s\n", f); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	if treeish == "" {
-		return fmt.Errorf("no tree-ish specified")
-	}
-
-	tree, commitHash, commitTime, err := resolveTreeish(st, treeish, allowUnreachable)
-	if err != nil {
-		return err
-	}
-
-	switch format {
-	case "tar":
-		return writeTarArchive(st, mux, tree, commitHash, prefix, paths, commitTime)
-	case "tar.gz", "tgz":
-		gw := gzip.NewWriter(mux)
-		if err := writeTarArchive(st, gw, tree, commitHash, prefix, paths, commitTime); err != nil {
-			return err
-		}
-		return gw.Close()
-	case "zip":
-		return writeZipArchive(st, mux, tree, commitHash, prefix, paths, commitTime)
-	default:
-		return fmt.Errorf("unsupported archive format: %s", format)
-	}
-}
-
-// resolveTreeish resolves a tree-ish expression to a tree object.
-//
-// Security: By default, only direct ref names (v1.0, main) and ref:path
-// sub-tree syntax (v1.0:Documentation) are allowed. Raw SHA-1 hashes and
-// relative expressions (main^, HEAD~2) are rejected unless
-// allowUnreachable is true. See https://git-scm.com/docs/git-upload-archive
-//
-// Returns the tree, commit hash (if applicable), commit time, and any error.
-func resolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*object.Tree, *plumbing.Hash, time.Time, error) {
-	var subPath string
-	if idx := strings.IndexByte(treeish, ':'); idx >= 0 {
-		subPath = treeish[idx+1:]
-		treeish = treeish[:idx]
-	}
-
-	if !allowUnreachable {
-		if plumbing.IsHash(treeish) {
-			return nil, nil, time.Time{}, fmt.Errorf("upload-archive: only ref names are allowed (got %s)", treeish)
-		}
-		if strings.ContainsAny(treeish, "^~@{}") {
-			return nil, nil, time.Time{}, fmt.Errorf("upload-archive: relative expressions are not allowed (got %s)", treeish)
-		}
-	}
-
-	h, err := resolveRef(st, treeish, allowUnreachable)
-	if err != nil {
-		return nil, nil, time.Time{}, err
-	}
-
-	obj, err := object.GetObject(st, h)
-	if err != nil {
-		return nil, nil, time.Time{}, fmt.Errorf("object not found: %s", treeish)
-	}
-
-	var commitHash *plumbing.Hash
-	var commitTime time.Time
-	var tree *object.Tree
-
-	switch o := obj.(type) {
-	case *object.Commit:
-		commitHash = &o.Hash
-		commitTime = o.Committer.When
-		tree, err = o.Tree()
-		if err != nil {
-			return nil, nil, time.Time{}, err
-		}
-	case *object.Tag:
-		commit, err := object.GetCommit(st, o.Target)
-		if err != nil {
-			return nil, nil, time.Time{}, err
-		}
-		commitHash = &commit.Hash
-		commitTime = commit.Committer.When
-		tree, err = commit.Tree()
-		if err != nil {
-			return nil, nil, time.Time{}, err
-		}
-	case *object.Tree:
-		tree = o
-
-		// git archive behaves differently when given a tree ID versus when
-		// given a commit ID or tag ID. In the first case the current time is
-		// used as the modification time of each file in the archive. In the
-		// latter case the commit time as recorded in the referenced commit
-		// object is used instead.
-		//
-		// See https://git-scm.com/docs/git-archive
-		commitTime = time.Now()
-	default:
-		return nil, nil, time.Time{}, fmt.Errorf("unsupported object type for archive: %T", obj)
-	}
-
-	if subPath != "" {
-		entry, err := tree.FindEntry(subPath)
-		if err != nil {
-			return nil, nil, time.Time{}, fmt.Errorf("path not found in tree: %s", subPath)
-		}
-		if entry.Mode != filemode.Dir {
-			return nil, nil, time.Time{}, fmt.Errorf("path is not a directory: %s", subPath)
-		}
-		tree, err = object.GetTree(st, entry.Hash)
-		if err != nil {
-			return nil, nil, time.Time{}, err
-		}
-	}
-
-	return tree, commitHash, commitTime, nil
-}
-
-func resolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, error) {
-	if allowHash && plumbing.IsHash(name) {
-		return plumbing.NewHash(name), nil
-	}
-
-	for _, candidate := range []plumbing.ReferenceName{
-		plumbing.ReferenceName(name),
-		plumbing.ReferenceName("refs/heads/" + name),
-		plumbing.ReferenceName("refs/tags/" + name),
-	} {
-		ref, err := storer.ResolveReference(st, candidate)
-		if err == nil {
-			return ref.Hash(), nil
-		}
-	}
-
-	return plumbing.ZeroHash, fmt.Errorf("cannot resolve %q", name)
-}
-
-// defaultUmask is the default tar umask (002).
-const defaultUmask = 0o002
-
-// applyUmask applies umask to the given mode for regular files.
-// Returns mode with all permission bits set, then applies umask.
-func applyUmask(mode int64, isExecutable bool) int64 {
-	if isExecutable {
-		return (mode | 0o777) &^ defaultUmask
-	}
-	return (mode | 0o666) &^ defaultUmask
-}
-
-// applyUmaskDir applies umask to directories.
-// Directories always get full permissions minus umask.
-func applyUmaskDir(mode int64) int64 {
-	return (mode | 0o777) &^ defaultUmask
-}
-
-func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
-	tw := tar.NewWriter(w)
-
-	// Write PAX global extended header with commit ID if available.
-	// This matches the behavior of git archive and allows extraction
-	// via git get-tar-commit-id.
-	if commitHash != nil {
-		err := tw.WriteHeader(&tar.Header{
-			Typeflag: tar.TypeXGlobalHeader,
-			Name:     paxGlobalHeader,
-			PAXRecords: map[string]string{
-				"comment": commitHash.String(),
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("writing global PAX header: %w", err)
-		}
-	}
-
-	if prefix != "" && strings.HasSuffix(prefix, "/") {
-		_ = tw.WriteHeader(&tar.Header{
-			Typeflag: tar.TypeDir,
-			Name:     prefix,
-			Mode:     applyUmaskDir(0),
-			ModTime:  modTime,
-		})
-	}
-
-	walker := object.NewTreeWalker(tree, true, nil)
-	defer walker.Close()
-
-	var matchedAny bool
-	for {
-		name, entry, err := walker.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-
-		if len(pathFilter) > 0 && !matchesPathFilter(name, pathFilter) {
-			continue
-		}
-		matchedAny = true
-
-		fullName := prefix + name
-
-		// Extract Unix permission bits from git mode.
-		unixMode := int64(entry.Mode) & 0o777
-
-		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
-			_ = tw.WriteHeader(&tar.Header{
-				Typeflag: tar.TypeDir,
-				Name:     fullName + "/",
-				Mode:     applyUmaskDir(unixMode),
-				ModTime:  modTime,
-			})
-			continue
-		}
-
-		blob, err := object.GetBlob(st, entry.Hash)
-		if err != nil {
-			return err
-		}
-
-		hdr := &tar.Header{
-			Name:    fullName,
-			Size:    blob.Size,
-			Mode:    unixMode,
-			ModTime: modTime,
-		}
-
-		if entry.Mode == filemode.Symlink {
-			rc, err := blob.Reader()
-			if err != nil {
-				return err
-			}
-			target, err := io.ReadAll(rc)
-			_ = rc.Close()
-			if err != nil {
-				return err
-			}
-			hdr.Typeflag = tar.TypeSymlink
-			hdr.Linkname = string(target)
-			hdr.Size = 0
-			// Symlinks always get 0777 per canonical git.
-			hdr.Mode = 0o777
-			if err := tw.WriteHeader(hdr); err != nil {
-				return err
-			}
-			continue
-		}
-
-		isExec := entry.Mode == filemode.Executable
-		hdr.Mode = applyUmask(unixMode, isExec)
-
-		if err := tw.WriteHeader(hdr); err != nil {
-			return err
-		}
-
-		rc, err := blob.Reader()
-		if err != nil {
-			return err
-		}
-		_, err = io.Copy(tw, rc)
-		_ = rc.Close()
-		if err != nil {
-			return err
-		}
-	}
-
-	if len(pathFilter) > 0 && !matchedAny {
-		return fmt.Errorf("pathspec '%s' did not match any files", strings.Join(pathFilter, " "))
-	}
-
-	return tw.Close()
-}
-
-func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
-	zw := zip.NewWriter(w)
-
-	walker := object.NewTreeWalker(tree, true, nil)
-	defer walker.Close()
-
-	var matchedAny bool
-	for {
-		name, entry, err := walker.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-
-		if len(pathFilter) > 0 && !matchesPathFilter(name, pathFilter) {
-			continue
-		}
-		matchedAny = true
-
-		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
-			continue
-		}
-
-		fullName := prefix + name
-		blob, err := object.GetBlob(st, entry.Hash)
-		if err != nil {
-			return err
-		}
-
-		// Extract Unix permission bits from git mode and apply default umask.
-		unixMode := int64(entry.Mode) & 0o777
-
-		fh := &zip.FileHeader{
-			Name:     fullName,
-			Method:   zip.Deflate,
-			Modified: modTime,
-		}
-		switch entry.Mode {
-		case filemode.Executable:
-			fh.SetMode(fs.FileMode(applyUmask(unixMode, true)))
-		case filemode.Symlink:
-			// Zip stores symlinks with mode 0o120000 + permissions.
-			fh.SetMode(fs.FileMode(0o120000 | (applyUmask(unixMode, true) & 0o777)))
-		default:
-			fh.SetMode(fs.FileMode(applyUmask(unixMode, false)))
-		}
-
-		fw, err := zw.CreateHeader(fh)
-		if err != nil {
-			return err
-		}
-
-		rc, err := blob.Reader()
-		if err != nil {
-			return err
-		}
-		_, err = io.Copy(fw, rc)
-		_ = rc.Close()
-		if err != nil {
-			return err
-		}
-	}
-
-	if len(pathFilter) > 0 && !matchedAny {
-		return fmt.Errorf("pathspec '%s' did not match any files", strings.Join(pathFilter, " "))
-	}
-
-	// Store commit ID as ZIP file comment if available.
-	// This matches the behavior of git archive.
-	if commitHash != nil {
-		_ = zw.SetComment(commitHash.String())
-	}
-
-	return zw.Close()
-}
-
-// PaxGlobalHeader is the name used for PAX global extended headers in
-// git-generated tar archives. This matches the name used by canonical git.
-const paxGlobalHeader = "pax_global_header"
-
-// getTarCommitID extracts the commit ID from a git-generated tar archive.
-// It reads the PAX global extended header from the beginning of the archive
-// and returns the value of the "comment" field, which contains the commit hash.
-// If no global header is found or it doesn't contain a comment, it returns
-// an error.
-func getTarCommitID(r io.Reader) (*plumbing.Hash, error) {
-	tr := tar.NewReader(r)
-	hdr, err := tr.Next()
-	if err != nil {
-		return nil, fmt.Errorf("reading tar header: %w", err)
-	}
-	// Check for PAX global extended header (typeflag 'g')
-	if hdr.Typeflag != tar.TypeXGlobalHeader {
-		return nil, fmt.Errorf("expected global PAX header, got typeflag %c", hdr.Typeflag)
-	}
-	// The PAX records should contain the commit ID in the "comment" field
-	comment, ok := hdr.PAXRecords["comment"]
-	if !ok {
-		return nil, fmt.Errorf("global header missing comment field")
-	}
-	hash := plumbing.NewHash(comment)
-	return &hash, nil
-}
-
-func matchesPathFilter(name string, filters []string) bool {
-	for _, f := range filters {
-		if name == f || strings.HasPrefix(name, f+"/") || strings.HasPrefix(f, name+"/") {
-			return true
-		}
-		matched, _ := path.Match(f, name)
-		if matched {
-			return true
-		}
-	}
-	return false
 }

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -199,22 +199,22 @@ func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, arg
 		return fmt.Errorf("no tree-ish specified")
 	}
 
-	tree, commitTime, err := resolveTreeish(st, treeish, allowUnreachable)
+	tree, commitHash, commitTime, err := resolveTreeish(st, treeish, allowUnreachable)
 	if err != nil {
 		return err
 	}
 
 	switch format {
 	case "tar":
-		return writeTarArchive(st, mux, tree, prefix, paths, commitTime)
+		return writeTarArchive(st, mux, tree, commitHash, prefix, paths, commitTime)
 	case "tar.gz", "tgz":
 		gw := gzip.NewWriter(mux)
-		if err := writeTarArchive(st, gw, tree, prefix, paths, commitTime); err != nil {
+		if err := writeTarArchive(st, gw, tree, commitHash, prefix, paths, commitTime); err != nil {
 			return err
 		}
 		return gw.Close()
 	case "zip":
-		return writeZipArchive(st, mux, tree, prefix, paths, commitTime)
+		return writeZipArchive(st, mux, tree, commitHash, prefix, paths, commitTime)
 	default:
 		return fmt.Errorf("unsupported archive format: %s", format)
 	}
@@ -226,7 +226,9 @@ func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, arg
 // sub-tree syntax (v1.0:Documentation) are allowed. Raw SHA-1 hashes and
 // relative expressions (main^, HEAD~2) are rejected unless
 // allowUnreachable is true. See https://git-scm.com/docs/git-upload-archive
-func resolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*object.Tree, time.Time, error) {
+//
+// Returns the tree, commit hash (if applicable), commit time, and any error.
+func resolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*object.Tree, *plumbing.Hash, time.Time, error) {
 	var subPath string
 	if idx := strings.IndexByte(treeish, ':'); idx >= 0 {
 		subPath = treeish[idx+1:]
@@ -235,42 +237,45 @@ func resolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 
 	if !allowUnreachable {
 		if plumbing.IsHash(treeish) {
-			return nil, time.Time{}, fmt.Errorf("upload-archive: only ref names are allowed (got %s)", treeish)
+			return nil, nil, time.Time{}, fmt.Errorf("upload-archive: only ref names are allowed (got %s)", treeish)
 		}
 		if strings.ContainsAny(treeish, "^~@{}") {
-			return nil, time.Time{}, fmt.Errorf("upload-archive: relative expressions are not allowed (got %s)", treeish)
+			return nil, nil, time.Time{}, fmt.Errorf("upload-archive: relative expressions are not allowed (got %s)", treeish)
 		}
 	}
 
 	h, err := resolveRef(st, treeish, allowUnreachable)
 	if err != nil {
-		return nil, time.Time{}, err
+		return nil, nil, time.Time{}, err
 	}
 
 	obj, err := object.GetObject(st, h)
 	if err != nil {
-		return nil, time.Time{}, fmt.Errorf("object not found: %s", treeish)
+		return nil, nil, time.Time{}, fmt.Errorf("object not found: %s", treeish)
 	}
 
+	var commitHash *plumbing.Hash
 	var commitTime time.Time
 	var tree *object.Tree
 
 	switch o := obj.(type) {
 	case *object.Commit:
+		commitHash = &o.Hash
 		commitTime = o.Committer.When
 		tree, err = o.Tree()
 		if err != nil {
-			return nil, time.Time{}, err
+			return nil, nil, time.Time{}, err
 		}
 	case *object.Tag:
 		commit, err := object.GetCommit(st, o.Target)
 		if err != nil {
-			return nil, time.Time{}, err
+			return nil, nil, time.Time{}, err
 		}
+		commitHash = &commit.Hash
 		commitTime = commit.Committer.When
 		tree, err = commit.Tree()
 		if err != nil {
-			return nil, time.Time{}, err
+			return nil, nil, time.Time{}, err
 		}
 	case *object.Tree:
 		tree = o
@@ -284,24 +289,24 @@ func resolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 		// See https://git-scm.com/docs/git-archive
 		commitTime = time.Now()
 	default:
-		return nil, time.Time{}, fmt.Errorf("unsupported object type for archive: %T", obj)
+		return nil, nil, time.Time{}, fmt.Errorf("unsupported object type for archive: %T", obj)
 	}
 
 	if subPath != "" {
 		entry, err := tree.FindEntry(subPath)
 		if err != nil {
-			return nil, time.Time{}, fmt.Errorf("path not found in tree: %s", subPath)
+			return nil, nil, time.Time{}, fmt.Errorf("path not found in tree: %s", subPath)
 		}
 		if entry.Mode != filemode.Dir {
-			return nil, time.Time{}, fmt.Errorf("path is not a directory: %s", subPath)
+			return nil, nil, time.Time{}, fmt.Errorf("path is not a directory: %s", subPath)
 		}
 		tree, err = object.GetTree(st, entry.Hash)
 		if err != nil {
-			return nil, time.Time{}, err
+			return nil, nil, time.Time{}, err
 		}
 	}
 
-	return tree, commitTime, nil
+	return tree, commitHash, commitTime, nil
 }
 
 func resolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, error) {
@@ -341,8 +346,24 @@ func applyUmaskDir(mode int64) int64 {
 	return (mode | 0o777) &^ defaultUmask
 }
 
-func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix string, pathFilter []string, modTime time.Time) error {
+func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
 	tw := tar.NewWriter(w)
+
+	// Write PAX global extended header with commit ID if available.
+	// This matches the behavior of git archive and allows extraction
+	// via git get-tar-commit-id.
+	if commitHash != nil {
+		err := tw.WriteHeader(&tar.Header{
+			Typeflag: tar.TypeXGlobalHeader,
+			Name:     paxGlobalHeader,
+			PAXRecords: map[string]string{
+				"comment": commitHash.String(),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("writing global PAX header: %w", err)
+		}
+	}
 
 	if prefix != "" && strings.HasSuffix(prefix, "/") {
 		_ = tw.WriteHeader(&tar.Header{
@@ -438,7 +459,7 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 	return tw.Close()
 }
 
-func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix string, pathFilter []string, modTime time.Time) error {
+func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
 	zw := zip.NewWriter(w)
 
 	walker := object.NewTreeWalker(tree, true, nil)
@@ -501,7 +522,41 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, prefix s
 		}
 	}
 
+	// Store commit ID as ZIP file comment if available.
+	// This matches the behavior of git archive.
+	if commitHash != nil {
+		_ = zw.SetComment(commitHash.String())
+	}
+
 	return zw.Close()
+}
+
+// paxGlobalHeader is the name used for PAX global extended headers in
+// git-generated tar archives. This matches the name used by canonical git.
+const paxGlobalHeader = "pax_global_header"
+
+// getTarCommitID extracts the commit ID from a git-generated tar archive.
+// It reads the PAX global extended header from the beginning of the archive
+// and returns the value of the "comment" field, which contains the commit hash.
+// If no global header is found or it doesn't contain a comment, it returns
+// an error.
+func getTarCommitID(r io.Reader) (*plumbing.Hash, error) {
+	tr := tar.NewReader(r)
+	hdr, err := tr.Next()
+	if err != nil {
+		return nil, fmt.Errorf("reading tar header: %w", err)
+	}
+	// Check for PAX global extended header (typeflag 'g')
+	if hdr.Typeflag != tar.TypeXGlobalHeader {
+		return nil, fmt.Errorf("expected global PAX header, got typeflag %c", hdr.Typeflag)
+	}
+	// The PAX records should contain the commit ID in the "comment" field
+	comment, ok := hdr.PAXRecords["comment"]
+	if !ok {
+		return nil, fmt.Errorf("global header missing comment field")
+	}
+	hash := plumbing.NewHash(comment)
+	return &hash, nil
 }
 
 func matchesPathFilter(name string, filters []string) bool {

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -165,7 +165,9 @@ func writeArchive(_ context.Context, st storage.Storer, mux *sideband.Muxer, arg
 			// paths are handled below
 		default:
 			if !strings.HasPrefix(arg, "-") {
-				treeish = arg
+				if treeish == "" {
+					treeish = arg
+				}
 			} else {
 				return fmt.Errorf("unknown option: %s", arg)
 			}
@@ -377,6 +379,7 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 	walker := object.NewTreeWalker(tree, true, nil)
 	defer walker.Close()
 
+	var matchedAny bool
 	for {
 		name, entry, err := walker.Next()
 		if err == io.EOF {
@@ -389,6 +392,7 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 		if len(pathFilter) > 0 && !matchesPathFilter(name, pathFilter) {
 			continue
 		}
+		matchedAny = true
 
 		fullName := prefix + name
 
@@ -456,6 +460,10 @@ func writeTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 		}
 	}
 
+	if len(pathFilter) > 0 && !matchedAny {
+		return fmt.Errorf("pathspec '%s' did not match any files", strings.Join(pathFilter, " "))
+	}
+
 	return tw.Close()
 }
 
@@ -465,6 +473,7 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 	walker := object.NewTreeWalker(tree, true, nil)
 	defer walker.Close()
 
+	var matchedAny bool
 	for {
 		name, entry, err := walker.Next()
 		if err == io.EOF {
@@ -477,6 +486,7 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 		if len(pathFilter) > 0 && !matchesPathFilter(name, pathFilter) {
 			continue
 		}
+		matchedAny = true
 
 		if entry.Mode == filemode.Dir || entry.Mode == filemode.Submodule {
 			continue
@@ -522,6 +532,10 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 		}
 	}
 
+	if len(pathFilter) > 0 && !matchedAny {
+		return fmt.Errorf("pathspec '%s' did not match any files", strings.Join(pathFilter, " "))
+	}
+
 	// Store commit ID as ZIP file comment if available.
 	// This matches the behavior of git archive.
 	if commitHash != nil {
@@ -531,7 +545,7 @@ func writeZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 	return zw.Close()
 }
 
-// paxGlobalHeader is the name used for PAX global extended headers in
+// PaxGlobalHeader is the name used for PAX global extended headers in
 // git-generated tar archives. This matches the name used by canonical git.
 const paxGlobalHeader = "pax_global_header"
 

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -23,18 +23,7 @@ import (
 )
 
 // UploadArchiveRequest configures the server-side upload-archive service.
-type UploadArchiveRequest struct {
-	// AllowUnreachable when true disables the default security restrictions
-	// and allows clients to use arbitrary SHA-1 expressions. By default,
-	// only direct ref targets (e.g. v1.0, main) and ref:path sub-tree
-	// syntax (e.g. v1.0:Documentation) are allowed.
-	//
-	// This serves as the default value. When the repository-level config
-	// uploadArchive.allowUnreachable is explicitly set, it always overrides
-	// this value (both true → false and false → true).
-	// See https://git-scm.com/docs/git-upload-archive
-	AllowUnreachable bool
-}
+type UploadArchiveRequest struct{}
 
 // UploadArchive is a server command that serves the git-upload-archive service.
 //
@@ -51,15 +40,13 @@ func UploadArchive(
 	st storage.Storer,
 	r io.ReadCloser,
 	w io.WriteCloser,
-	req *UploadArchiveRequest,
+	_ *UploadArchiveRequest,
 ) error {
-	if req == nil {
-		req = &UploadArchiveRequest{}
-	}
-
 	w = ioutil.NewContextWriteCloser(ctx, w)
 
-	allowUnreachable := req.AllowUnreachable
+	// TODO: Derive allowUnreachable from global/system config as well, not
+	// just repository config.
+	var allowUnreachable bool
 	if v, ok := readAllowUnreachable(st); ok {
 		allowUnreachable = v
 	}

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -35,12 +35,12 @@ func UploadArchive(
 ) error {
 	w = ioutil.NewContextWriteCloser(ctx, w)
 
-	// TODO: Derive allowUnreachable from global/system config as well, not
-	// just repository config.
-	var allowUnreachable bool
-	if v, ok := readAllowUnreachable(st); ok {
-		allowUnreachable = v
-	}
+	// Unreachable Git objects (i.e. objects not referenced by any refs or unreachable
+	// from the commit graph) are intentionally not supported due to security concerns.
+	//
+	// Support for handling such objects may be reconsidered in the future if a safe
+	// and performant approach is established.
+	allowUnreachable := false
 
 	args, err := readArchiveArgs(r)
 	if err != nil {
@@ -196,19 +196,4 @@ func unsupportedArchiveFeature(arg string) string {
 	}
 
 	return ""
-}
-
-// readAllowUnreachable reads the uploadArchive.allowUnreachable config
-// from the repository. It returns the value and whether the key was
-// explicitly set. When the key is absent or the config cannot be read,
-// ok is false and the caller should fall back to its own default.
-func readAllowUnreachable(st storage.Storer) (value, ok bool) {
-	cfg, err := st.Config()
-	if err != nil {
-		return false, false
-	}
-	if cfg.UploadArchive.AllowUnreachable.IsSet() {
-		return cfg.UploadArchive.AllowUnreachable.IsTrue(), true
-	}
-	return false, false
 }


### PR DESCRIPTION
This PR adds support for the `git-upload-archive` service to the transport layer, allowing fetching of archives from remote git repositories over SSH, HTTP, and local file transports.

## Background

The `git-upload-archive` protocol command is used by `git archive --remote` to fetch archives from remote repositories without cloning them. This is useful for CI/CD pipelines, release automation, and tools that need specific files from a repo.

## Changes

### Client-Side Types

**Archiver interface** - Sessions that implement this can perform archive operations:
```go
type Archiver interface {
    Archive(ctx context.Context, req *ArchiveRequest) (io.ReadCloser, error)
}
```

**ArchiveRequest** - Client archive request:
- `Args []string`: arguments sent as "argument <arg>" pkt-lines (format, prefix, tree-ish, paths)
- `Progress sideband.Progress`: optional progress callback for status messages

### Server-Side Types

**UploadArchiveRequest** - Server archive request configuration:
- `AllowUnreachable bool`: disables security restrictions allowing arbitrary refs

**UploadArchive function** - Server-side handler for the git-upload-archive protocol.

### Backend Support

**SSH/TCP/Unix transports** - Backend now dispatches to `UploadArchive`:
```go
case transport.UploadArchiveService:
    return transport.UploadArchive(...)
```

**HTTP** - Left for future protocol-v2 work (HTTP archive requires command-based protocol)

### Wire Protocol

Implements the git-upload-archive protocol:
- Client sends "argument <arg>" pkt-lines for format, prefix, tree-ish, etc.
- Server sends "ACK" or "NACK <reason>"
- Archive data streamed via sideband (channel 1 = data, channel 2 = progress)

### Supported Formats

Supported formats parsed from args:
- `tar`, `tar.gz`, `tgz`, `zip`
- `--prefix=path/` adds prefix to archive entries
- `--list` lists available archives
- Tree-ish (commit, tag, branch) specifies what to archive

## Testing

- `TestArchive_Tar`, `TestArchive_TarGz`, `TestArchive_Zip` (file transport)
- `TestGitTransport_Archive` (git daemon transport)
- `TestSSHTransport_Archive` (SSH transport)

All tests verify archive contents against git's output.

## Security

The `uploadArchive.allowUnreachable` config option controls whether arbitrary SHA-1 expressions are allowed. By default, only ref targets (e.g., `v1.0`, `main`) and `ref:path` sub-tree syntax are allowed.

## Follow-up Work

A future PR will add porcelain-level support:
- `git.Archive()` convenience method
- `ArchiveOptions` with parametrized fields:
  - `Format`: tar, tar.gz, zip
  - `Prefix`: prefix path for archive entries
  - `Remote`: tree-ish reference to archive
  - `Paths`: optional path filter
  - Additional `git archive --remote` flags

## Usage Example

```go
sess, _ := client.Dial("git@github.com:go-git/go-git.git")
req := &transport.ArchiveRequest{
    Args: []string{"--format=tar.gz", "--prefix=go-git/", "v5.12.0"},
}
rc, _ := sess.Archive(ctx, req)
defer rc.Close()
// Write rc to file or pipe to tar/gzip
```

Supersedes: https://github.com/go-git/go-git/pull/1985