### PR TITLE
plumbing: transport, correct the test to use the correct receive-pack…

### DIFF
--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -139,7 +139,7 @@ func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV0() {
 }
 
 func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV2() {
-	testAdvertise(s.T(), UploadPack, "version=2", false)
+	testAdvertise(s.T(), ReceivePack, "version=2", false)
 }
 
 func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV1() {


### PR DESCRIPTION
… service name

The receive-pack test was incorrectly using the upload-pack service name. This commit corrects the test to use the receive-pack service name, ensuring that the test is validating the correct service behavior.