### PR TITLE
plumbing/transport: don't emit a second NAK after encoding empty ACKs

### DIFF
--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -228,8 +228,17 @@ func UploadPack(
 					writec <- fmt.Errorf("sending final ack server-response: %w", err)
 					return
 				}
-			case ack.Hash.IsZero():
-				// We don't have multi-ack and there are no haves. Encode a NAK.
+			case ack.Hash.IsZero() && len(haves) == 0:
+				// We don't have multi-ack and no haves were sent. Emit the
+				// single terminal NAK.
+				//
+				// When haves *were* sent, the ServerResponse{ACKs: acks}
+				// write above already emitted a NAK (encodeServerResponse
+				// writes NAK when ACKs is empty). Emitting another one here
+				// would produce two consecutive "0008NAK\n" pktlines;
+				// ServerResponse.Decode consumes only the first, and the
+				// second would then be misread by the sideband demuxer as
+				// a frame with channel byte 'N' ("unknown channel NAK").
 				srvrsp := packp.ServerResponse{}
 				if err := srvrsp.Encode(w); err != nil {
 					writec <- fmt.Errorf("sending final nak server-response: %w", err)

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -229,8 +229,7 @@ func UploadPack(
 					return
 				}
 			case ack.Hash.IsZero() && len(haves) == 0:
-				// We don't have multi-ack and no haves were sent. Emit the
-				// single terminal NAK.
+				// No haves were sent. Emit the single terminal NAK.
 				//
 				// When haves *were* sent, the ServerResponse{ACKs: acks}
 				// write above already emitted a NAK (encodeServerResponse

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -153,17 +153,17 @@ func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV1() {
 // the client sends haves that are not reachable from any want, the server
 // emits exactly one NAK pktline before the sideband-wrapped pack, not two.
 //
-// The upload-pack writer currently emits an extra NAK in this case. It first
-// calls ServerResponse{ACKs: nil}.Encode, which writes a NAK, and then falls
-// through to the "ack.Hash.IsZero()" branch, which writes a second NAK.
-// packp.ServerResponse.Decode consumes only the first NAK, leaving the second
+// Previously, the upload-pack writer emitted an extra NAK in this case. It
+// first called ServerResponse{ACKs: nil}.Encode, which wrote a NAK, and then
+// fell through to the "ack.Hash.IsZero()" branch, which wrote a second NAK.
+// packp.ServerResponse.Decode consumed only the first NAK, leaving the second
 // "0008NAK\n" pktline in front of the sideband frames. The sideband demuxer
-// then reads "NAK\n" as a frame with channel byte 'N' (0x4E) and fails with
+// then read "NAK\n" as a frame with channel byte 'N' (0x4E) and failed with
 // "unknown channel NAK".
 //
 // A caller consuming the response with the standard go-git client pipeline
 // (ServerResponse.Decode + sideband.Demuxer) cannot recover.
-func (s *UploadPackSuite) TestUploadPackStatelessRPCUnreachableHavesEmitsSingleNAK() {
+func (s *UploadPackServeSuite) TestUploadPackStatelessRPCUnreachableHavesEmitsSingleNAK() {
 	dot, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
@@ -189,7 +189,7 @@ func (s *UploadPackSuite) TestUploadPackStatelessRPCUnreachableHavesEmitsSingleN
 	s.Require().NoError(upreq.Encode(&reqW))
 	s.Require().NoError(uphav.Encode(&reqW))
 
-	buf := testServe(s.T(), st, UploadPack, io.NopCloser(&reqW), &UploadPackOptions{
+	buf := testServe(s.T(), st, UploadPack, io.NopCloser(&reqW), &UploadPackRequest{
 		GitProtocol:   "version=1",
 		AdvertiseRefs: false,
 		StatelessRPC:  true,

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
@@ -14,6 +15,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 )
@@ -145,4 +147,90 @@ func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV2() {
 func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV1() {
 	buf := testAdvertise(s.T(), ReceivePack, "version=1", false)
 	s.Contains(buf.String(), "version 1")
+}
+
+// TestUploadPackStatelessRPCUnreachableHavesEmitsSingleNAK verifies that when
+// the client sends haves that are not reachable from any want, the server
+// emits exactly one NAK pktline before the sideband-wrapped pack, not two.
+//
+// The upload-pack writer currently emits an extra NAK in this case. It first
+// calls ServerResponse{ACKs: nil}.Encode, which writes a NAK, and then falls
+// through to the "ack.Hash.IsZero()" branch, which writes a second NAK.
+// packp.ServerResponse.Decode consumes only the first NAK, leaving the second
+// "0008NAK\n" pktline in front of the sideband frames. The sideband demuxer
+// then reads "NAK\n" as a frame with channel byte 'N' (0x4E) and fails with
+// "unknown channel NAK".
+//
+// A caller consuming the response with the standard go-git client pipeline
+// (ServerResponse.Decode + sideband.Demuxer) cannot recover.
+func (s *UploadPackSuite) TestUploadPackStatelessRPCUnreachableHavesEmitsSingleNAK() {
+	dot, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+	s.Require().NoError(err)
+	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	s.Require().NoError(err)
+
+	upreq := packp.NewUploadRequest()
+	upreq.Capabilities.Add(capability.Sideband64k)
+	upreq.Capabilities.Add(capability.NoProgress)
+	upreq.Wants = append(upreq.Wants, head.Hash())
+
+	// A hash the server definitely does not have and that is not reachable
+	// from the want. This is the rewind / divergent-overwrite case: client
+	// sends a "have" the server cannot match against the wants.
+	unreachable := plumbing.NewHash("0123456789abcdef0123456789abcdef01234567")
+
+	var uphav packp.UploadHaves
+	uphav.Haves = []plumbing.Hash{unreachable}
+	uphav.Done = true
+
+	var reqW bytes.Buffer
+	s.Require().NoError(upreq.Encode(&reqW))
+	s.Require().NoError(uphav.Encode(&reqW))
+
+	buf := testServe(s.T(), st, UploadPack, io.NopCloser(&reqW), &UploadPackOptions{
+		GitProtocol:   "version=1",
+		AdvertiseRefs: false,
+		StatelessRPC:  true,
+	})
+	raw := buf.Bytes()
+
+	// First: byte-level assertion. The response must not begin with two
+	// consecutive NAK pktlines.
+	const doubleNAK = "0008NAK\n0008NAK\n"
+	s.Falsef(bytes.HasPrefix(raw, []byte(doubleNAK)),
+		"response begins with two NAK pktlines, client-side sideband demux will fail:\n%s",
+		prefixHex(raw, 64),
+	)
+
+	// Second: end-to-end assertion using the standard client pipeline.
+	// ServerResponse.Decode + sideband.Demuxer + PACK signature read.
+	rd := bytes.NewReader(raw)
+	var srv packp.ServerResponse
+	s.Require().NoError(srv.Decode(rd), "decode server response")
+
+	demux := sideband.NewDemuxer(sideband.Sideband64k, rd)
+	var signature [4]byte
+	_, err = io.ReadFull(demux, signature[:])
+	s.Require().NoError(err, "read PACK signature through sideband demuxer")
+	s.Equal("PACK", string(signature[:]), "expected PACK magic after the NAK preamble")
+}
+
+func prefixHex(b []byte, n int) string {
+	if len(b) < n {
+		n = len(b)
+	}
+	var sb strings.Builder
+	for _, c := range b[:n] {
+		if c >= 0x20 && c < 0x7f {
+			sb.WriteByte(c)
+		} else {
+			sb.WriteString("\\x")
+			const hexchars = "0123456789abcdef"
+			sb.WriteByte(hexchars[c>>4])
+			sb.WriteByte(hexchars[c&0x0f])
+		}
+	}
+	return sb.String()
 }


### PR DESCRIPTION
## Summary

`UploadPack` wrote **two** NAK pktlines in front of the sideband-wrapped pack when a stateless-RPC client sent `haves` that weren't reachable from any `want`:

```
0008NAK\n        ← ServerResponse{ACKs: nil}.Encode  (len(haves) > 0 branch)
0008NAK\n        ← ServerResponse{}.Encode           (ack.Hash.IsZero() branch)
0009\x01PACK…    ← sideband-wrapped pack
```

`ServerResponse.Decode` only consumes the first NAK. The standard go-git client pipeline (`Decode` + `sideband.Demuxer`) then reads the trailing `"NAK\n"` as a sideband frame, sees channel byte `'N'` (0x4E), and fails with `unknown channel NAK`. This reliably breaks fetches where the target's advertised ref isn't an ancestor of the want — rewinds, divergent overwrites, force-push retargets — even between a go-git client and a go-git server.

## Fix

Only emit the terminal NAK in the `ack.Hash.IsZero()` branch when no haves were sent. When haves were sent with no common found, the `len(haves) > 0` branch already wrote the NAK via `ServerResponse{ACKs: empty}.Encode`.

## Behavior matrix

| haves | common found? | multi-ack? | Output (before → after) |
|---|---|---|---|
| empty | — | — | 1 NAK → 1 NAK |
| present | yes | no | 1 ACK → 1 ACK |
| present | yes | yes | ACKs-with-status + final ACK → same |
| **present** | **no** | **no** | **2 NAKs → 1 NAK** |
| present | no | yes | ACKs + 1 NAK → same |

## Test

Adds `TestUploadPackStatelessRPCUnreachableHavesEmitsSingleNAK` in the new `ReceivePackServeSuite` file, asserting both:

1. Response does not begin with `0008NAK\n0008NAK\n`.
2. `ServerResponse.Decode` + `sideband.NewDemuxer(Sideband64k)` can read the `PACK` signature end-to-end.

## Verification

- New test: FAIL before, PASS after.
- `./plumbing/transport/...`: all green.
- `./...` full module: all green.