### PR TITLE
git: worktree, hoist Config() calls out of per-file loops

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -320,8 +320,13 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		return err
 	}
 
+	cfg, err := w.r.Config()
+	if err != nil {
+		return err
+	}
+
 	if opts.Mode == MergeReset {
-		unstaged, err := w.containsUnstagedChanges()
+		unstaged, err := w.containsUnstagedChanges(cfg)
 		if err != nil {
 			return err
 		}
@@ -376,13 +381,13 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	}
 
 	if opts.Mode == MergeReset && len(removedFiles) > 0 {
-		if err := w.resetWorktree(t, removedFiles); err != nil {
+		if err := w.resetWorktree(cfg, t, removedFiles); err != nil {
 			return err
 		}
 	}
 
 	if opts.Mode == HardReset || opts.Mode == KeepReset {
-		if err := w.resetWorktreeToTree(prevTree, t, opts.Files); err != nil {
+		if err := w.resetWorktreeToTree(cfg, prevTree, t, opts.Files); err != nil {
 			return err
 		}
 	}
@@ -659,7 +664,7 @@ func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparse
 //     file with SkipWorktree=true must not exist in the worktree.
 //
 // files optionally restricts the operation to a specific subset of paths.
-func (w *Worktree) resetWorktreeToTree(fromTree, toTree *object.Tree, files []string) error {
+func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *object.Tree, files []string) error {
 	filesMap := buildFilePathMap(files)
 
 	// Step 1: delete files removed from the tracked tree.
@@ -697,7 +702,7 @@ func (w *Worktree) resetWorktreeToTree(fromTree, toTree *object.Tree, files []st
 	// Delete actions. The observable result is unchanged because Delete
 	// actions are skipped by the loop below; the matcher only avoids the
 	// pointless lstat of every file under directories like node_modules.
-	worktreeChanges, err := w.diffStagingWithWorktree(true, true)
+	worktreeChanges, err := w.diffStagingWithWorktree(cfg, true, true)
 	if err != nil {
 		return err
 	}
@@ -729,7 +734,7 @@ func (w *Worktree) resetWorktreeToTree(fromTree, toTree *object.Tree, files []st
 			}
 		}
 
-		if err := w.checkoutChange(ch, toTree, b); err != nil {
+		if err := w.checkoutChange(cfg, ch, toTree, b); err != nil {
 			return err
 		}
 	}
@@ -766,8 +771,8 @@ func (w *Worktree) resetWorktreeToTree(fromTree, toTree *object.Tree, files []st
 // from the index in this same Reset is no longer in idxMap, so the
 // noder's IgnoreMatcher would prune it from the walk and the Delete
 // action needed to remove it from disk would never be emitted.
-func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
-	changes, err := w.diffStagingWithWorktree(true, false)
+func (w *Worktree) resetWorktree(cfg *config.Config, t *object.Tree, files []string) error {
+	changes, err := w.diffStagingWithWorktree(cfg, true, false)
 	if err != nil {
 		return err
 	}
@@ -798,7 +803,7 @@ func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
 			}
 		}
 
-		if err := w.checkoutChange(ch, t, b); err != nil {
+		if err := w.checkoutChange(cfg, ch, t, b); err != nil {
 			return err
 		}
 	}
@@ -807,7 +812,7 @@ func (w *Worktree) resetWorktree(t *object.Tree, files []string) error {
 	return w.r.Storer.SetIndex(idx)
 }
 
-func (w *Worktree) checkoutChange(ch merkletrie.Change, t *object.Tree, idx *indexBuilder) error {
+func (w *Worktree) checkoutChange(cfg *config.Config, ch merkletrie.Change, t *object.Tree, idx *indexBuilder) error {
 	a, err := ch.Action()
 	if err != nil {
 		return err
@@ -845,11 +850,11 @@ func (w *Worktree) checkoutChange(ch merkletrie.Change, t *object.Tree, idx *ind
 		return w.checkoutChangeSubmodule(name, a, e, idx)
 	}
 
-	return w.checkoutChangeRegularFile(name, a, t, e, idx)
+	return w.checkoutChangeRegularFile(cfg, name, a, t, e, idx)
 }
 
-func (w *Worktree) containsUnstagedChanges() (bool, error) {
-	ch, err := w.diffStagingWithWorktree(false, true)
+func (w *Worktree) containsUnstagedChanges(cfg *config.Config) (bool, error) {
+	ch, err := w.diffStagingWithWorktree(cfg, false, true)
 	if err != nil {
 		return false, err
 	}
@@ -927,7 +932,8 @@ func (w *Worktree) checkoutChangeSubmodule(name string,
 	return nil
 }
 
-func (w *Worktree) checkoutChangeRegularFile(name string,
+func (w *Worktree) checkoutChangeRegularFile(cfg *config.Config,
+	name string,
 	a merkletrie.Action,
 	t *object.Tree,
 	e *object.TreeEntry,
@@ -950,7 +956,7 @@ func (w *Worktree) checkoutChangeRegularFile(name string,
 			return err
 		}
 
-		if err := w.checkoutFile(f); err != nil {
+		if err := w.checkoutFile(cfg, f); err != nil {
 			return err
 		}
 
@@ -960,7 +966,7 @@ func (w *Worktree) checkoutChangeRegularFile(name string,
 	return nil
 }
 
-func (w *Worktree) checkoutFile(f *object.File) (err error) {
+func (w *Worktree) checkoutFile(cfg *config.Config, f *object.File) (err error) {
 	mode, err := f.Mode.ToOSFileMode()
 	if err != nil {
 		return err
@@ -976,15 +982,10 @@ func (w *Worktree) checkoutFile(f *object.File) (err error) {
 	}
 	defer ioutil.CheckClose(dstFile, &err)
 
-	return w.copyObjectToWorktree(f, dstFile)
+	return w.copyObjectToWorktree(cfg, f, dstFile)
 }
 
-func (w *Worktree) copyObjectToWorktree(object *object.File, file billy.File) (err error) {
-	cfg, err := w.r.Config()
-	if err != nil {
-		return err
-	}
-
+func (w *Worktree) copyObjectToWorktree(cfg *config.Config, object *object.File, file billy.File) (err error) {
 	var src io.ReadCloser
 	var dst io.Writer = file
 
@@ -1151,15 +1152,20 @@ func resolveModuleURL(originURL, moduleURL string) (string, error) {
 
 // Submodules returns all the available submodules
 func (w *Worktree) Submodules() (Submodules, error) {
+	cfg, err := w.r.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	return w.submodulesWithConfig(cfg)
+}
+
+// submodulesWithConfig returns all the available submodules using an already-loaded config.
+func (w *Worktree) submodulesWithConfig(cfg *config.Config) (Submodules, error) {
 	l := make(Submodules, 0)
 	m, err := w.readGitmodulesFile()
 	if err != nil || m == nil {
 		return l, err
-	}
-
-	c, err := w.r.Config()
-	if err != nil {
-		return nil, err
 	}
 
 	var originURL string
@@ -1170,13 +1176,13 @@ func (w *Worktree) Submodules() (Submodules, error) {
 	}
 
 	for _, s := range m.Submodules {
-		sub := w.newSubmodule(s, c.Submodules[s.Name])
-		cfg := sub.Config()
-		resolvedURL, err := resolveModuleURL(originURL, cfg.URL)
+		sub := w.newSubmodule(s, cfg.Submodules[s.Name])
+		subCfg := sub.Config()
+		resolvedURL, err := resolveModuleURL(originURL, subCfg.URL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve submodule URL %q: %w", s.URL, err)
 		}
-		cfg.URL = resolvedURL
+		subCfg.URL = resolvedURL
 		l = append(l, sub)
 	}
 

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -197,6 +197,11 @@ func (w *Worktree) CherryPick(commitOpts *CommitOptions, ortStrategyOption OrtMe
 }
 
 func (w *Worktree) autoAddModifiedAndDeleted() error {
+	cfg, err := w.r.Config()
+	if err != nil {
+		return err
+	}
+
 	s, err := w.Status()
 	if err != nil {
 		return err
@@ -212,7 +217,7 @@ func (w *Worktree) autoAddModifiedAndDeleted() error {
 			continue
 		}
 
-		if _, _, err := w.doAddFile(idx, s, path, nil); err != nil {
+		if _, _, err := w.doAddFile(cfg, idx, s, path, nil); err != nil {
 			return err
 		}
 	}

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-git/go-billy/v6/util"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/format/gitignore"
@@ -63,10 +64,15 @@ func (w *Worktree) StatusWithOptions(o StatusOptions) (Status, error) {
 		hash = ref.Hash()
 	}
 
-	return w.status(o.Strategy, hash)
+	cfg, err := w.r.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	return w.status(cfg, o.Strategy, hash)
 }
 
-func (w *Worktree) status(ss StatusStrategy, commit plumbing.Hash) (Status, error) {
+func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing.Hash) (Status, error) {
 	s, err := ss.new(w)
 	if err != nil {
 		return nil, err
@@ -96,7 +102,7 @@ func (w *Worktree) status(ss StatusStrategy, commit plumbing.Hash) (Status, erro
 		}
 	}
 
-	right, err := w.diffStagingWithWorktree(false, true)
+	right, err := w.diffStagingWithWorktree(cfg, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -135,13 +141,8 @@ func nameFromAction(ch *merkletrie.Change) string {
 	return name
 }
 
-func (w *Worktree) diffStagingWithWorktree(reverse, excludeIgnoredChanges bool) (merkletrie.Changes, error) {
+func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeIgnoredChanges bool) (merkletrie.Changes, error) {
 	idx, err := w.r.Storer.Index()
-	if err != nil {
-		return nil, err
-	}
-
-	cfg, err := w.r.Config()
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +150,7 @@ func (w *Worktree) diffStagingWithWorktree(reverse, excludeIgnoredChanges bool) 
 	from := mindex.NewRootNodeWithOptions(idx, mindex.RootNodeOptions{
 		UpholdExecutableBit: cfg.Core.FileMode,
 	})
-	submodules, err := w.getSubmodulesStatus()
+	submodules, err := w.getSubmodulesStatus(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -188,10 +189,10 @@ func (w *Worktree) collectIgnorePatterns() []gitignore.Pattern {
 	return append(patterns, w.Excludes...)
 }
 
-func (w *Worktree) getSubmodulesStatus() (map[string]plumbing.Hash, error) {
+func (w *Worktree) getSubmodulesStatus(cfg *config.Config) (map[string]plumbing.Hash, error) {
 	o := map[string]plumbing.Hash{}
 
-	sub, err := w.Submodules()
+	sub, err := w.submodulesWithConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +294,7 @@ func (w *Worktree) Add(path string) (plumbing.Hash, error) {
 	return w.doAdd(path, make([]gitignore.Pattern, 0), false)
 }
 
-func (w *Worktree) doAddDirectory(idx *index.Index, s Status, directory string, ignorePattern []gitignore.Pattern) (added bool, err error) {
+func (w *Worktree) doAddDirectory(cfg *config.Config, idx *index.Index, s Status, directory string, ignorePattern []gitignore.Pattern) (added bool, err error) {
 	if len(ignorePattern) > 0 {
 		m := gitignore.NewMatcher(ignorePattern)
 		matchPath := strings.Split(directory, string(os.PathSeparator))
@@ -311,7 +312,7 @@ func (w *Worktree) doAddDirectory(idx *index.Index, s Status, directory string, 
 		}
 
 		var a bool
-		a, _, err = w.doAddFile(idx, s, name, ignorePattern)
+		a, _, err = w.doAddFile(cfg, idx, s, name, ignorePattern)
 		if err != nil {
 			return added, err
 		}
@@ -360,6 +361,11 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 		}()
 	}
 
+	cfg, err := w.r.Config()
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
 	idx, err := w.r.Storer.Index()
 	if err != nil {
 		return plumbing.ZeroHash, err
@@ -394,9 +400,9 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 	}
 
 	if err != nil || !fi.IsDir() {
-		added, h, err = w.doAddFile(idx, s, path, ignorePattern)
+		added, h, err = w.doAddFile(cfg, idx, s, path, ignorePattern)
 	} else {
-		added, err = w.doAddDirectory(idx, s, path, ignorePattern)
+		added, err = w.doAddDirectory(cfg, idx, s, path, ignorePattern)
 	}
 
 	if err != nil {
@@ -431,6 +437,11 @@ func (w *Worktree) AddGlob(pattern string) error {
 		return ErrGlobNoMatches
 	}
 
+	cfg, err := w.r.Config()
+	if err != nil {
+		return err
+	}
+
 	s, err := w.Status()
 	if err != nil {
 		return err
@@ -450,9 +461,9 @@ func (w *Worktree) AddGlob(pattern string) error {
 
 		var added bool
 		if fi.IsDir() {
-			added, err = w.doAddDirectory(idx, s, file, make([]gitignore.Pattern, 0))
+			added, err = w.doAddDirectory(cfg, idx, s, file, make([]gitignore.Pattern, 0))
 		} else {
-			added, _, err = w.doAddFile(idx, s, file, make([]gitignore.Pattern, 0))
+			added, _, err = w.doAddFile(cfg, idx, s, file, make([]gitignore.Pattern, 0))
 		}
 
 		if err != nil {
@@ -474,7 +485,7 @@ func (w *Worktree) AddGlob(pattern string) error {
 // doAddFile create a new blob from path and update the index, added is true if
 // the file added is different from the index.
 // if s status is nil will skip the status check and update the index anyway
-func (w *Worktree) doAddFile(idx *index.Index, s Status, path string, ignorePattern []gitignore.Pattern) (added bool, h plumbing.Hash, err error) {
+func (w *Worktree) doAddFile(cfg *config.Config, idx *index.Index, s Status, path string, ignorePattern []gitignore.Pattern) (added bool, h plumbing.Hash, err error) {
 	if s != nil && s.File(path).Worktree == Unmodified {
 		return false, h, nil
 	}
@@ -487,7 +498,7 @@ func (w *Worktree) doAddFile(idx *index.Index, s Status, path string, ignorePatt
 		}
 	}
 
-	h, err = w.copyFileToStorage(path)
+	h, err = w.copyFileToStorage(cfg, path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			added = true
@@ -504,7 +515,7 @@ func (w *Worktree) doAddFile(idx *index.Index, s Status, path string, ignorePatt
 	return true, h, err
 }
 
-func (w *Worktree) copyFileToStorage(path string) (hash plumbing.Hash, err error) {
+func (w *Worktree) copyFileToStorage(cfg *config.Config, path string) (hash plumbing.Hash, err error) {
 	fi, err := w.filesystem.Lstat(path)
 	if err != nil {
 		return plumbing.ZeroHash, err
@@ -524,7 +535,7 @@ func (w *Worktree) copyFileToStorage(path string) (hash plumbing.Hash, err error
 	if fi.Mode()&os.ModeSymlink != 0 {
 		err = w.fillEncodedObjectFromSymlink(writer, path, fi)
 	} else {
-		err = w.fillEncodedObjectFromFile(writer, path, fi)
+		err = w.fillEncodedObjectFromFile(cfg, writer, path, fi)
 	}
 
 	if err != nil {
@@ -534,17 +545,12 @@ func (w *Worktree) copyFileToStorage(path string) (hash plumbing.Hash, err error
 	return w.r.Storer.SetEncodedObject(obj)
 }
 
-func (w *Worktree) fillEncodedObjectFromFile(dst io.Writer, path string, _ os.FileInfo) (err error) {
+func (w *Worktree) fillEncodedObjectFromFile(cfg *config.Config, dst io.Writer, path string, _ os.FileInfo) (err error) {
 	file, err := w.filesystem.Open(path)
 	if err != nil {
 		return err
 	}
 	defer ioutil.CheckClose(file, &err)
-
-	cfg, err := w.r.Config()
-	if err != nil {
-		return err
-	}
 
 	switch cfg.Core.AutoCRLF {
 	case "true", "input":


### PR DESCRIPTION
## Summary

Cache the `*config.Config` result at each public entry point and thread it
through internal functions instead of repeatedly calling `w.r.Config()` for
each file during checkout, reset, status, and add operations.

Addresses Tier 1 item 1 from #1956: *"Cache r.Config() result outside the
checkout file loop, pass it through as a parameter."*

## Problem

On the filesystem storage backend, each `w.r.Config()` call does:
file open, full file read, INI parse, struct alloc. During checkout,
`Config()` was called **N+4 times** (once per file in `copyObjectToWorktree`
plus overhead), where N is the number of files being checked out. The config
cannot change mid-operation, so all but the first call are wasted work.

## Solution

Call `w.r.Config()` once at each public entry point (`Reset`,
`StatusWithOptions`, `doAdd`, `AddGlob`), then pass the resulting
`*config.Config` through all private functions in the call chain.

- `Reset()` threads cfg through `containsUnstagedChanges`, `resetWorktree`,
  `resetWorktreeToTree`, `checkoutChange`, `checkoutChangeRegularFile`,
  `checkoutFile`, `copyObjectToWorktree`
- `StatusWithOptions()` threads cfg through `status`, `diffStagingWithWorktree`,
  `getSubmodulesStatus`
- `doAdd()` / `AddGlob()` threads cfg through `doAddFile`, `doAddDirectory`,
  `copyFileToStorage`, `fillEncodedObjectFromFile`
- `autoAddModifiedAndDeleted()` threads cfg through `doAddFile`

The public `Submodules()` method keeps its existing signature and delegates
to a new private `submodulesWithConfig(cfg)` that internal callers use
directly.

**No public API changes. No new struct fields. No cached state.**

## Config() calls per operation

| Operation | Before | After |
|---|---|---|
| `Reset(MergeReset)` on N files | N + 4 | 1 |
| `Reset(HardReset)` on N files | N + 2 | 1 |
| `Status()` | 2 | 1 |
| `Add` on N files | N | 1 |
| `Submodules()` (public, standalone) | 1 | 1 |

## Benchmark results

```
goos: darwin
goarch: arm64
cpu: Apple M4 Pro

                     | bench-before.txt |           bench-after.txt            |
                     |      sec/op      |    sec/op     vs base                |
CloneLargeRepo-12           6.093 +- 38%    1.946 +- 15%  -68.06% (p=0.000 n=10)
CloneDeepRepo-12            3.878 +- 72%    2.143 +-  7%  -44.75% (p=0.000 n=10)
Status/Clean-12            59.96m +-  3%   63.43m +-  7%        ~ (p=0.075 n=10)
Status/Modified-12         63.30m +-  4%   62.86m +-  4%        ~ (p=0.796 n=10)
StatusLarge/Clean-12       148.1m +-  2%   142.8m +-  3%   -3.53% (p=0.015 n=10)
geomean                    421.3m         298.6m        -29.12%

                     | bench-before.txt |           bench-after.txt           |
                     |       B/op       |     B/op      vs base               |
CloneLargeRepo-12          151.1Mi +- 0%   137.5Mi +- 0%  -9.02% (p=0.000 n=10)
CloneDeepRepo-12           163.7Mi +- 0%   150.1Mi +- 0%  -8.35% (p=0.000 n=10)
Status/Clean-12            5.497Mi +- 0%   5.497Mi +- 0%  -0.01% (p=0.043 n=10)
Status/Modified-12         5.581Mi +- 0%   5.574Mi +- 0%  -0.12% (p=0.015 n=10)
StatusLarge/Clean-12       12.68Mi +- 0%   12.68Mi +- 0%       ~ (p=0.118 n=10)
geomean                    24.93Mi        24.03Mi       -3.60%

                     | bench-before.txt |           bench-after.txt           |
                     |    allocs/op     |  allocs/op   vs base                |
CloneLargeRepo-12          1013.4k +- 0%   805.3k +- 0%  -20.54% (p=0.000 n=10)
CloneDeepRepo-12           1113.7k +- 0%   905.6k +- 0%  -18.69% (p=0.000 n=10)
Status/Clean-12             83.84k +- 0%   83.84k +- 0%        ~ (p=0.195 n=10)
Status/Modified-12          84.62k +- 0%   84.62k +- 0%        ~ (p=0.237 n=10)
StatusLarge/Clean-12        207.1k +- 0%   207.1k +- 0%        ~ (p=0.337 n=10)
geomean                     277.9k        254.7k        -8.37%
```

## Known follow-up opportunities

A few internal paths still double-read Config because they call the public
`w.Status()` method (which has its own `w.r.Config()` call):

- `doAdd` / `AddGlob` / `autoAddModifiedAndDeleted` call `w.Status()`
  internally
- `checkoutChangeSubmodule` calls `w.Submodule()` which calls `w.Submodules()`
- `preloadStatus` in `status.go` has its own Config() call

These are pre-existing and not regressions. Addressing them requires a
`statusWithConfig` private variant — a good candidate for a follow-up PR.
