### PR TITLE
plumbing: transport/http, fix multi-round pack negotiation

### DIFF
--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -177,22 +177,35 @@ func (s *smartPackSession) GetRemoteRefs(_ context.Context) ([]*plumbing.Referen
 }
 
 func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *transport.FetchRequest) error {
-	rwc := &httpRequester{session: s, ctx: ctx}
-	shallows, err := transport.NegotiatePack(ctx, st, s.caps, true, rwc, rwc, req)
+	neg := &httpNegotiator{session: s, ctx: ctx}
+
+	shallows, err := transport.NegotiatePack(ctx, st, s.caps, true, neg, neg, req)
 	if err != nil {
+		// Don't close the response body here — context-wrapper goroutines
+		// inside NegotiatePack may still be reading from it.
 		return err
 	}
-	if rwc.resp == nil {
-		if err := rwc.doPost(); err != nil {
+	if neg.current == nil || neg.current.resp == nil {
+		neg.current = &httpRequester{session: s, ctx: ctx}
+		if err := neg.current.doPost(); err != nil {
 			return err
 		}
 	}
-	return transport.FetchPack(ctx, st, s.caps, io.NopCloser(rwc), shallows, req)
+	err = transport.FetchPack(ctx, st, s.caps, io.NopCloser(neg), shallows, req)
+	neg.closeResponse()
+	return err
 }
 
 func (s *smartPackSession) Push(ctx context.Context, st storage.Storer, req *transport.PushRequest) error {
 	rwc := &httpRequester{session: s, ctx: ctx}
-	return transport.SendPack(ctx, st, s.caps, rwc, io.NopCloser(rwc), req)
+	err := transport.SendPack(ctx, st, s.caps, rwc, io.NopCloser(rwc), req)
+	// Only close the response body on success. On error (especially context
+	// cancellation), context-wrapper goroutines inside SendPack may still
+	// be reading from it.
+	if err == nil && rwc.resp != nil {
+		_ = rwc.resp.Body.Close()
+	}
+	return err
 }
 
 func (s *smartPackSession) Close() error { return nil }
@@ -253,6 +266,51 @@ func (r *httpRequester) doPost() error {
 		return fmt.Errorf("http transport: POST %s unexpected status %d", serviceURL, r.resp.StatusCode)
 	}
 	return nil
+}
+
+// httpNegotiator supports multi-round stateless RPC negotiation by
+// creating a fresh httpRequester for each round. A new round begins
+// when Write is called after the previous round's response has arrived.
+type httpNegotiator struct {
+	session *smartPackSession
+	ctx     context.Context
+	current *httpRequester
+}
+
+func (n *httpNegotiator) Write(p []byte) (int, error) {
+	if n.current != nil && n.current.resp != nil {
+		// Previous round is complete — close its response, start fresh.
+		_, _ = io.Copy(io.Discard, n.current.resp.Body)
+		_ = n.current.resp.Body.Close()
+		n.current = nil
+	}
+	if n.current == nil {
+		n.current = &httpRequester{session: n.session, ctx: n.ctx}
+	}
+	return n.current.Write(p)
+}
+
+func (n *httpNegotiator) Read(p []byte) (int, error) {
+	if n.current == nil {
+		return 0, io.ErrClosedPipe
+	}
+	return n.current.Read(p)
+}
+
+func (n *httpNegotiator) Close() error {
+	if n.current == nil {
+		return nil
+	}
+	return n.current.Close()
+}
+
+// closeResponse closes the current HTTP response body.
+// The caller (FetchPack) is expected to have already drained the body.
+func (n *httpNegotiator) closeResponse() {
+	if n.current != nil && n.current.resp != nil {
+		_ = n.current.resp.Body.Close()
+		n.current.resp = nil
+	}
 }
 
 // --- dumb HTTP pack session ---

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -1,0 +1,133 @@
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+// TestHTTPNegotiatorMultiRound verifies that httpNegotiator creates a
+// fresh HTTP POST for each negotiation round. Before the fix, only the
+// first round's data was sent because httpRequester.Close() was a no-op
+// after the first POST.
+func TestHTTPNegotiatorMultiRound(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var postBodies []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		postBodies = append(postBodies, string(body))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+		// Return a minimal pkt-line NAK response.
+		_, _ = w.Write([]byte("0008NAK\n"))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	session := &smartPackSession{
+		client:  srv.Client(),
+		baseURL: u,
+		service: transport.UploadPackService,
+	}
+
+	neg := &httpNegotiator{session: session, ctx: context.Background()}
+	defer neg.closeResponse()
+
+	// Round 1: write, close (fires POST), read response.
+	_, err = neg.Write([]byte("round1"))
+	require.NoError(t, err)
+
+	err = neg.Close()
+	require.NoError(t, err)
+
+	resp1, err := io.ReadAll(neg)
+	require.NoError(t, err)
+	assert.Equal(t, "0008NAK\n", string(resp1))
+
+	// Round 2: write triggers new requester, close fires second POST.
+	_, err = neg.Write([]byte("round2"))
+	require.NoError(t, err)
+
+	err = neg.Close()
+	require.NoError(t, err)
+
+	resp2, err := io.ReadAll(neg)
+	require.NoError(t, err)
+	assert.Equal(t, "0008NAK\n", string(resp2))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, postBodies, 2, "expected 2 POSTs (one per round)")
+	assert.Equal(t, "round1", postBodies[0])
+	assert.Equal(t, "round2", postBodies[1])
+}
+
+// TestHTTPNegotiatorCloseResponse verifies that closeResponse closes
+// the final response body without error.
+func TestHTTPNegotiatorCloseResponse(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+		_, _ = w.Write([]byte("0008NAK\n"))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	session := &smartPackSession{
+		client:  srv.Client(),
+		baseURL: u,
+		service: transport.UploadPackService,
+	}
+
+	neg := &httpNegotiator{session: session, ctx: context.Background()}
+
+	// Fire a round.
+	_, err = neg.Write([]byte("data"))
+	require.NoError(t, err)
+	err = neg.Close()
+	require.NoError(t, err)
+	_, _ = io.ReadAll(neg)
+
+	// closeResponse should not panic on a valid response.
+	assert.NotPanics(t, func() { neg.closeResponse() })
+
+	// After closeResponse, current.resp should be nil.
+	assert.Nil(t, neg.current.resp)
+
+	// closeResponse on an already-cleaned negotiator is safe.
+	assert.NotPanics(t, func() { neg.closeResponse() })
+}
+
+// TestHTTPNegotiatorNoRounds verifies that closeResponse is safe when
+// no rounds have been executed.
+func TestHTTPNegotiatorNoRounds(t *testing.T) {
+	t.Parallel()
+
+	neg := &httpNegotiator{}
+	assert.NotPanics(t, func() { neg.closeResponse() })
+
+	_, err := neg.Read(make([]byte, 1))
+	assert.ErrorIs(t, err, io.ErrClosedPipe)
+
+	err = neg.Close()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
A potential fix for https://github.com/go-git/go-git/issues/1991

I wasn't sure if I should update `httpRequester` to have the prior behaviour or make something that more clearly supports multiple http calls.

The PR adds httpNegotiator, a thin wrapper that creates a fresh httpRequester per negotiation round. The round boundary is detected in Write(): if the current requester already has a response, its body is drained and closed before a new requester is created. This keeps httpRequester as a clean single-use abstraction.

Also close HTTP response bodies in Fetch (via defer) and Push to prevent resource leaks and ensure HTTP tracing spans complete.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>