### PR TITLE
Add gitfile support and fix loader repository detection

### DIFF
--- a/plumbing/transport/loader.go
+++ b/plumbing/transport/loader.go
@@ -1,8 +1,12 @@
 package transport
 
 import (
+	"bufio"
+	"fmt"
+	"io"
 	"net/url"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/osfs"
@@ -44,20 +48,68 @@ func (l *FilesystemLoader) load(path string, tried bool) (storage.Storer, error)
 		return nil, err
 	}
 
-	if _, err := fs.Stat("config"); err != nil {
-		if !l.strict && !tried {
+	// Check for .git first (directory or gitfile) to match git's behavior
+	// Git prefers .git/ over a bare repository in the same directory
+	if !tried && !l.strict {
+		if fi, err := fs.Lstat(".git"); err == nil {
 			tried = true
-			if fi, err := fs.Stat(".git"); err == nil && fi.IsDir() {
+			if fi.IsDir() {
+				// .git is a directory, use it
 				path = filepath.Join(path, ".git")
 			} else {
-				path += ".git"
+				// .git is a file (gitfile), read the gitdir path
+				gitdir, err := readGitfile(fs)
+				if err != nil {
+					return nil, err
+				}
+				// gitdir can be absolute or relative
+				if filepath.IsAbs(gitdir) {
+					path = gitdir
+				} else {
+					path = filepath.Join(path, gitdir)
+				}
 			}
+			return l.load(path, tried)
+		}
+	}
+
+	// Check for config file to detect bare repository
+	fi, err := fs.Lstat("config")
+	if err != nil || fi.IsDir() {
+		if !l.strict && !tried {
+			// No .git and no config, try appending .git
+			tried = true
+			path += ".git"
 			return l.load(path, tried)
 		}
 		return nil, ErrRepositoryNotFound
 	}
 
 	return filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{}), nil
+}
+
+// readGitfile reads a .git file and extracts the gitdir path.
+// The .git file should contain a single line: "gitdir: <path>"
+func readGitfile(fs billy.Filesystem) (string, error) {
+	f, err := fs.Open(".git")
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	reader := bufio.NewReader(f)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	const prefix = "gitdir: "
+	if !strings.HasPrefix(line, prefix) {
+		return "", fmt.Errorf(".git file has no %s prefix", prefix)
+	}
+
+	gitdir := strings.TrimSpace(line[len(prefix):])
+	return gitdir, nil
 }
 
 // MapLoader is a Loader that uses a lookup map keyed by URL path.

--- a/plumbing/transport/loader_test.go
+++ b/plumbing/transport/loader_test.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -84,4 +85,97 @@ func TestMapLoader_LoadNotFound(t *testing.T) {
 	sto, err := loader.Load(u)
 	assert.ErrorIs(t, err, ErrRepositoryNotFound)
 	assert.Nil(t, sto)
+}
+
+func TestFilesystemLoader_LoadWithConfigDir(t *testing.T) {
+	t.Parallel()
+	// Create a temporary directory structure that mimics a non-bare repository
+	// with a "config" directory in the working tree (which exists in go-git's own repo)
+	tmpDir := t.TempDir()
+
+	// Create repo directory
+	repoDir := filepath.Join(tmpDir, "repo")
+	require.NoError(t, os.Mkdir(repoDir, 0o755))
+
+	// Create .git directory with a config file
+	gitDir := filepath.Join(repoDir, ".git")
+	require.NoError(t, os.MkdirAll(gitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte("[core]\n"), 0o644))
+
+	// Create a "config" directory in the working tree (not in .git)
+	configDir := filepath.Join(repoDir, "config")
+	require.NoError(t, os.Mkdir(configDir, 0o755))
+
+	// The loader should find .git/config, not the config directory
+	loader := NewFilesystemLoader(osfs.New(tmpDir), false)
+	u := &url.URL{Path: "repo"}
+
+	st, err := loader.Load(u)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	// Verify it loaded the correct config
+	cfg, err := st.Config()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}
+
+func TestFilesystemLoader_LoadWithGitfile(t *testing.T) {
+	t.Parallel()
+	// Test loading a repository where .git is a file (gitfile) pointing to the real git directory
+	// This is common in worktrees and submodules
+	tmpDir := t.TempDir()
+
+	// Create the actual git directory
+	realGitDir := filepath.Join(tmpDir, "real-git")
+	require.NoError(t, os.MkdirAll(realGitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(realGitDir, "config"), []byte("[core]\n"), 0o644))
+
+	// Create working tree with .git file pointing to real git directory (absolute path)
+	workTree := filepath.Join(tmpDir, "worktree")
+	require.NoError(t, os.MkdirAll(workTree, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workTree, ".git"), []byte("gitdir: "+realGitDir+"\n"), 0o644))
+
+	// The loader should follow the gitfile and load the real git directory
+	// Use root filesystem since gitfile contains absolute path
+	loader := NewFilesystemLoader(osfs.New(""), false)
+	u := &url.URL{Path: filepath.ToSlash(workTree)}
+
+	st, err := loader.Load(u)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	// Verify it loaded the correct config
+	cfg, err := st.Config()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}
+
+func TestFilesystemLoader_LoadWithRelativeGitfile(t *testing.T) {
+	t.Parallel()
+	// Test loading a repository where .git file contains a relative path
+	tmpDir := t.TempDir()
+
+	// Create the actual git directory
+	realGitDir := filepath.Join(tmpDir, ".git-real")
+	require.NoError(t, os.MkdirAll(realGitDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(realGitDir, "config"), []byte("[core]\n"), 0o644))
+
+	// Create working tree with .git file pointing to relative git directory
+	workTree := filepath.Join(tmpDir, "repo")
+	require.NoError(t, os.MkdirAll(workTree, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workTree, ".git"), []byte("gitdir: ../.git-real\n"), 0o644))
+
+	// The loader should follow the relative gitfile path
+	loader := NewFilesystemLoader(osfs.New(tmpDir), false)
+	u := &url.URL{Path: "repo"}
+
+	st, err := loader.Load(u)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	// Verify it loaded the correct config
+	cfg, err := st.Config()
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
 }


### PR DESCRIPTION
## Summary

Fixes #1993 - Multiple issues in `FilesystemLoader` repository detection:
1. "remote repository is empty" when cloning from local repos with `config/` directory
2. Gitfiles (worktrees/submodules) not supported
3. Priority mismatch with git when both bare repo and `.git/` exist

## Problems

### 1. Config Directory Confusion

The `FilesystemLoader.load()` method checks for a `config` file to detect git repositories:

```go
if _, err := fs.Stat("config"); err != nil {
```

However, this only verified that `config` *exists*, not that it's a **file**. When cloning from a local non-bare repository that has a `config/` **directory** in its working tree (like go-git's own repository), the loader would incorrectly treat the working directory as a bare repository.

**Result:**
- Loader creates storage pointing to wrong path (working tree instead of `.git/`)
- No references found in storage
- Empty repository advertised (zero hash with `capabilities^{}`)
- Client receives "remote repository is empty" error

### 2. Gitfile Not Supported

Git worktrees and submodules use a `.git` **file** (gitfile) containing `gitdir: <path>` pointing to the actual git directory. The loader only checked if `.git` was a directory, failing to handle this common case.

**Example:**
```bash
# Common in worktrees/submodules
$ cat .git
gitdir: /path/to/real/git/dir
```

### 3. Priority Mismatch

When both a bare repository and `.git/` subdirectory existed, the loader would find the bare repo's `config` first, while git prefers `.git/` subdirectory.

## Solutions

### 1. Distinguish Files from Directories

```go
fi, err := fs.Stat("config")
if err != nil || fi.IsDir() {
    // Not a git repository, check for .git
}
```

### 2. Support Gitfiles

Added `readGitfile()` function to parse gitdir paths:
- Reads `.git` file
- Extracts `gitdir:` path
- Supports both absolute and relative paths

```go
if fi.IsDir() {
    path = filepath.Join(path, ".git")
} else {
    // .git is a file (gitfile), read the gitdir path
    gitdir, err := readGitfile(fs)
    // Handle absolute or relative paths
}
```

### 3. Check `.git` First

Reorganized logic to check for `.git` before checking for `config`, matching git's preference order:

1. Check for `.git` (directory or gitfile) ✓
2. Check for `config` file (bare repository)
3. Try appending `.git` to path

## Test Coverage

- [x] `TestFilesystemLoader_LoadWithConfigDir` - Repo with config/ directory in working tree
- [x] `TestFilesystemLoader_LoadWithGitfile` - Absolute gitfile path (worktree case)
- [x] `TestFilesystemLoader_LoadWithRelativeGitfile` - Relative gitfile path (submodule case)
- [x] All existing loader tests still pass
- [x] Linting passes

## Compatibility with Git

Verified behavior matches git CLI:
- ✅ Config directory doesn't confuse detection
- ✅ Gitfiles work (worktrees/submodules)
- ✅ `.git/` preferred over bare repo in same location

🤖 Generated with [Claude Code](https://claude.com/claude-code)