### PR TITLE
RFC: x/config — struct-tag-based Git config marshaling

### DIFF
--- a/x/config/benchmark_test.go
+++ b/x/config/benchmark_test.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	oldconfig "github.com/go-git/go-git/v6/config"
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
+)
+
+const benchFixture = `[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	worktree = /home/user/project
+	commentchar = auto
+[user]
+	name = Test User
+	email = test@example.com
+[remote "origin"]
+	url = https://github.com/go-git/go-git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "upstream"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/upstream/*
+[branch "main"]
+	remote = origin
+	merge = refs/heads/main
+[branch "develop"]
+	remote = origin
+	merge = refs/heads/develop
+[pack]
+	window = 10
+[init]
+	defaultbranch = main
+`
+
+type benchRemote struct {
+	URL   []string `gitconfig:"url,multivalue"`
+	Fetch []string `gitconfig:"fetch,multivalue"`
+}
+
+type benchBranch struct {
+	Remote string `gitconfig:"remote"`
+	Merge  string `gitconfig:"merge"`
+}
+
+type benchCore struct {
+	RepositoryFormatVersion int    `gitconfig:"repositoryformatversion"`
+	FileMode                bool   `gitconfig:"filemode"`
+	Bare                    bool   `gitconfig:"bare"`
+	LogAllRefUpdates        bool   `gitconfig:"logallrefupdates"`
+	Worktree                string `gitconfig:"worktree"`
+	CommentChar             string `gitconfig:"commentchar"`
+}
+
+type benchUser struct {
+	Name  string `gitconfig:"name"`
+	Email string `gitconfig:"email"`
+}
+
+type benchPack struct {
+	Window int `gitconfig:"window"`
+}
+
+type benchInit struct {
+	DefaultBranch string `gitconfig:"defaultbranch"`
+}
+
+type benchConfig struct {
+	Core     benchCore               `gitconfig:"core"`
+	User     benchUser               `gitconfig:"user"`
+	Remotes  map[string]*benchRemote `gitconfig:"remote,subsection"`
+	Branches map[string]*benchBranch `gitconfig:"branch,subsection"`
+	Pack     benchPack               `gitconfig:"pack"`
+	Init     benchInit               `gitconfig:"init"`
+}
+
+func BenchmarkUnmarshal_XConfig(b *testing.B) {
+	raw := format.New()
+	if err := format.NewDecoder(bytes.NewReader([]byte(benchFixture))).Decode(raw); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		var cfg benchConfig
+		if err := Unmarshal(raw, &cfg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshal_OldConfig(b *testing.B) {
+	data := []byte(benchFixture)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		cfg := oldconfig.NewConfig()
+		if err := cfg.Unmarshal(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalWithParse_XConfig(b *testing.B) {
+	data := []byte(benchFixture)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		raw := format.New()
+		if err := format.NewDecoder(bytes.NewReader(data)).Decode(raw); err != nil {
+			b.Fatal(err)
+		}
+		var cfg benchConfig
+		if err := Unmarshal(raw, &cfg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalWithParse_OldConfig(b *testing.B) {
+	data := []byte(benchFixture)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		cfg := oldconfig.NewConfig()
+		if err := cfg.Unmarshal(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshal_XConfig(b *testing.B) {
+	raw := format.New()
+	if err := format.NewDecoder(bytes.NewReader([]byte(benchFixture))).Decode(raw); err != nil {
+		b.Fatal(err)
+	}
+	var cfg benchConfig
+	if err := Unmarshal(raw, &cfg); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		out := format.New()
+		if err := Marshal(cfg, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshal_OldConfig(b *testing.B) {
+	cfg := oldconfig.NewConfig()
+	if err := cfg.Unmarshal([]byte(benchFixture)); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := cfg.Marshal(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRoundTrip_XConfig(b *testing.B) {
+	data := []byte(benchFixture)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		raw := format.New()
+		if err := format.NewDecoder(bytes.NewReader(data)).Decode(raw); err != nil {
+			b.Fatal(err)
+		}
+		var cfg benchConfig
+		if err := Unmarshal(raw, &cfg); err != nil {
+			b.Fatal(err)
+		}
+		out := format.New()
+		if err := Marshal(cfg, out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRoundTrip_OldConfig(b *testing.B) {
+	data := []byte(benchFixture)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		cfg := oldconfig.NewConfig()
+		if err := cfg.Unmarshal(data); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := cfg.Marshal(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/x/config/config.go
+++ b/x/config/config.go
@@ -1,0 +1,1485 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// GitSize represents an integer value with optional k/M/G suffixes.
+// Suffixes multiply by 1024 (k), 1048576 (M), or 1073741824 (G).
+type GitSize struct {
+	raw string
+	n   int64
+}
+
+// NewGitSize creates a GitSize from a raw string value.
+// The string can be a plain integer or include k/M/G suffixes.
+func NewGitSize(s string) (GitSize, error) {
+	n, err := parseGitSize(s)
+	if err != nil {
+		return GitSize{}, err
+	}
+	return GitSize{raw: s, n: n}, nil
+}
+
+// NewGitSizeInt creates a GitSize from an int64 value.
+func NewGitSizeInt(n int64) GitSize {
+	return GitSize{n: n}
+}
+
+// UnmarshalGitConfig implements Unmarshaler.
+func (s *GitSize) UnmarshalGitConfig(data []byte) error {
+	s.raw = string(data)
+	n, err := parseGitSize(s.raw)
+	if err != nil {
+		return err
+	}
+	s.n = n
+	return nil
+}
+
+// MarshalGitConfig implements Marshaler.
+func (s GitSize) MarshalGitConfig() (string, error) {
+	if s.raw != "" {
+		return s.raw, nil
+	}
+	return strconv.FormatInt(s.n, 10), nil
+}
+
+func (s GitSize) Int64() int64 { return s.n }
+
+func parseGitSize(s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+	s = strings.TrimSpace(s)
+	idx := strings.IndexFunc(s, func(r rune) bool {
+		return (r < '0' || r > '9') && r != '-' && r != '+'
+	})
+	if idx == -1 {
+		return strconv.ParseInt(s, 10, 64)
+	}
+	numPart := s[:idx]
+	suffix := strings.ToLower(strings.TrimSpace(s[idx:]))
+	n, err := strconv.ParseInt(numPart, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse size %q: %w", s, err)
+	}
+	switch suffix {
+	case "k":
+		n *= 1024
+	case "m":
+		n *= 1024 * 1024
+	case "g":
+		n *= 1024 * 1024 * 1024
+	default:
+		return 0, fmt.Errorf("unknown size suffix %q in %q", suffix, s)
+	}
+	return n, nil
+}
+
+// BoolOrInt represents a value that can be either a boolean or an integer.
+type BoolOrInt struct {
+	Bool *bool
+	Int  *int64
+}
+
+// NewBoolOrIntBool creates a BoolOrInt from a bool value.
+func NewBoolOrIntBool(b bool) BoolOrInt {
+	return BoolOrInt{Bool: &b}
+}
+
+// NewBoolOrIntInt creates a BoolOrInt from an int64 value.
+func NewBoolOrIntInt(n int64) BoolOrInt {
+	return BoolOrInt{Int: &n}
+}
+
+// UnmarshalGitConfig implements Unmarshaler.
+func (b *BoolOrInt) UnmarshalGitConfig(data []byte) error {
+	s := string(data)
+	if v, err := parseBool(s); err == nil {
+		b.Bool = &v
+		b.Int = nil
+		return nil
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse %q as bool-or-int", s)
+	}
+	b.Int = &n
+	b.Bool = nil
+	return nil
+}
+
+func (b BoolOrInt) MarshalGitConfig() (string, error) {
+	if b.Bool != nil {
+		return formatBool(*b.Bool), nil
+	}
+	if b.Int != nil {
+		return strconv.FormatInt(*b.Int, 10), nil
+	}
+	return "", nil
+}
+
+// AutoBool represents a tri-state boolean: always, true, auto, false, never.
+type AutoBool string
+
+const (
+	// AutoBoolAlways always enables the feature.
+	AutoBoolAlways AutoBool = "always"
+	// AutoBoolTrue enables the feature.
+	AutoBoolTrue AutoBool = "true"
+	// AutoBoolAuto enables the feature only when output is to a terminal.
+	AutoBoolAuto AutoBool = "auto"
+	// AutoBoolFalse disables the feature.
+	AutoBoolFalse AutoBool = "false"
+	// AutoBoolNever never enables the feature.
+	AutoBoolNever AutoBool = "never"
+)
+
+// UnmarshalGitConfig implements Unmarshaler.
+func (a *AutoBool) UnmarshalGitConfig(data []byte) error {
+	*a = AutoBool(strings.ToLower(string(data)))
+	return nil
+}
+
+// MarshalGitConfig implements Marshaler.
+func (a AutoBool) MarshalGitConfig() (string, error) {
+	return string(a), nil
+}
+
+// Color represents a Git color specification with optional foreground,
+// background, and attributes.
+type Color struct {
+	Foreground string
+	Background string
+	Attributes []string
+}
+
+// NewColor creates a Color with the given foreground, background, and attributes.
+func NewColor(fg, bg string, attrs ...string) Color {
+	return Color{Foreground: fg, Background: bg, Attributes: attrs}
+}
+
+// UnmarshalGitConfig implements Unmarshaler.
+func (c *Color) UnmarshalGitConfig(data []byte) error {
+	s := strings.TrimSpace(string(data))
+	if s == "" || s == "normal" || s == "reset" {
+		if s == "reset" {
+			c.Attributes = []string{"reset"}
+		}
+		return nil
+	}
+	tokens := strings.Fields(s)
+	for _, tok := range tokens {
+		lower := strings.ToLower(tok)
+		if isColorName(lower) || isColorNumber(tok) || isColorHex(tok) {
+			if c.Foreground == "" {
+				c.Foreground = tok
+			} else if c.Background == "" {
+				c.Background = tok
+			}
+		} else {
+			c.Attributes = append(c.Attributes, tok)
+		}
+	}
+	return nil
+}
+
+// MarshalGitConfig implements Marshaler.
+func (c Color) MarshalGitConfig() (string, error) {
+	var parts []string
+	if c.Foreground != "" {
+		parts = append(parts, c.Foreground)
+	}
+	if c.Background != "" {
+		parts = append(parts, c.Background)
+	}
+	parts = append(parts, c.Attributes...)
+	return strings.Join(parts, " "), nil
+}
+
+func isColorName(s string) bool {
+	switch s {
+	case "normal", "default", "black", "red", "green", "yellow",
+		"blue", "magenta", "cyan", "white",
+		"brightblack", "brightred", "brightgreen", "brightyellow",
+		"brightblue", "brightmagenta", "brightcyan", "brightwhite":
+		return true
+	}
+	return false
+}
+
+func isColorNumber(s string) bool {
+	n, err := strconv.Atoi(s)
+	return err == nil && n >= 0 && n <= 255
+}
+
+func isColorHex(s string) bool {
+	if len(s) == 0 || s[0] != '#' {
+		return false
+	}
+	hex := s[1:]
+	return len(hex) == 3 || len(hex) == 6
+}
+
+// ExpiryDate represents a Git expiry-date value. It preserves the raw
+// string for round-trip fidelity and supports parsing relative dates
+// (e.g. "2.weeks.ago", "90.days") against a caller-supplied reference time.
+type ExpiryDate struct {
+	raw   string
+	Never bool
+	Now   bool
+}
+
+// NewExpiryDate creates an ExpiryDate from a raw git-config string.
+func NewExpiryDate(s string) ExpiryDate {
+	e := ExpiryDate{raw: s}
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "never":
+		e.Never = true
+	case "now":
+		e.Now = true
+	}
+	return e
+}
+
+// NewExpiryDateNever creates an ExpiryDate representing "never".
+func NewExpiryDateNever() ExpiryDate {
+	return ExpiryDate{Never: true}
+}
+
+// NewExpiryDateNow creates an ExpiryDate representing "now".
+func NewExpiryDateNow() ExpiryDate {
+	return ExpiryDate{Now: true}
+}
+
+// UnmarshalGitConfig implements Unmarshaler.
+func (e *ExpiryDate) UnmarshalGitConfig(data []byte) error {
+	e.raw = string(data)
+	switch strings.ToLower(strings.TrimSpace(e.raw)) {
+	case "never":
+		e.Never = true
+	case "now":
+		e.Now = true
+	}
+	return nil
+}
+
+// MarshalGitConfig implements Marshaler.
+func (e ExpiryDate) MarshalGitConfig() (string, error) {
+	if e.raw != "" {
+		return e.raw, nil
+	}
+	if e.Never {
+		return "never", nil
+	}
+	if e.Now {
+		return "now", nil
+	}
+	return "", nil
+}
+
+// Raw returns the original string value.
+func (e ExpiryDate) Raw() string { return e.raw }
+
+// Parse resolves the expiry date into an absolute time relative to now.
+// It handles "never" (zero time), "now" (the reference time), relative
+// durations like "2.weeks.ago" or "90.days", and RFC3339 timestamps.
+// Bare integers are treated as seconds in the past.
+func (e ExpiryDate) Parse(now time.Time) (time.Time, error) {
+	if e.Never {
+		return time.Time{}, nil
+	}
+	if e.Now {
+		return now, nil
+	}
+	if e.raw == "" {
+		return time.Time{}, nil
+	}
+
+	s := strings.TrimSpace(e.raw)
+
+	// Try relative date: <count>.<unit>[.ago], e.g. "2.weeks.ago", "90.days", "1.day"
+	if d, ok := parseRelativeDuration(s); ok {
+		return now.Add(-d), nil
+	}
+
+	// Try bare integer (seconds in the past).
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return now.Add(-time.Duration(n) * time.Second), nil
+	}
+
+	// Try RFC3339.
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid expiry date: %q", e.raw)
+}
+
+// parseRelativeDuration parses git's relative date format:
+// <count>.<unit>[.ago] — e.g. "2.weeks.ago", "90.days", "1.day", "3.months.ago".
+func parseRelativeDuration(s string) (time.Duration, bool) {
+	parts := strings.Split(strings.ToLower(s), ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, false
+	}
+	if len(parts) == 3 && parts[2] != "ago" {
+		return 0, false
+	}
+
+	n, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+
+	var d time.Duration
+	switch units := parts[1]; units {
+	case "second", "seconds":
+		d = time.Duration(n * float64(time.Second))
+	case "minute", "minutes":
+		d = time.Duration(n * float64(time.Minute))
+	case "hour", "hours":
+		d = time.Duration(n * float64(time.Hour))
+	case "day", "days":
+		d = time.Duration(n * float64(24*time.Hour))
+	case "week", "weeks":
+		d = time.Duration(n * float64(7*24*time.Hour))
+	case "month", "months":
+		// Approximate a month as 30 days, matching git's behaviour.
+		d = time.Duration(n * float64(30*24*time.Hour))
+	case "year", "years":
+		// Approximate a year as 365 days, matching git's behaviour.
+		d = time.Duration(n * float64(365*24*time.Hour))
+	default:
+		return 0, false
+	}
+
+	return d, true
+}
+
+// FollowRedirects controls whether Git follows HTTP redirects.
+// Valid values are "true" (follow all redirects), "false" (treat redirects
+// as errors), and "initial" (follow only the initial request, not
+// subsequent ones). The default is "initial".
+type FollowRedirects string
+
+const (
+	FollowRedirectsAll     FollowRedirects = "true"
+	FollowRedirectsNone    FollowRedirects = "false"
+	FollowRedirectsInitial FollowRedirects = "initial"
+)
+
+// UnmarshalGitConfig implements Unmarshaler.
+func (f *FollowRedirects) UnmarshalGitConfig(data []byte) error {
+	*f = FollowRedirects(strings.ToLower(string(data)))
+	return nil
+}
+
+// MarshalGitConfig implements Marshaler.
+func (f FollowRedirects) MarshalGitConfig() (string, error) {
+	return string(f), nil
+}
+
+// Pathname is a string that stores a Git config path value verbatim.
+// Tilde expansion and prefix substitution are the caller's responsibility.
+type Pathname string
+
+// UnmarshalGitConfig implements Unmarshaler.
+func (p *Pathname) UnmarshalGitConfig(data []byte) error {
+	*p = Pathname(data)
+	return nil
+}
+
+// MarshalGitConfig implements Marshaler.
+func (p Pathname) MarshalGitConfig() (string, error) {
+	return string(p), nil
+}
+
+// AdviceConfig maps the advice.* configuration variables.
+type AdviceConfig struct {
+	AddEmbeddedRepo                    *bool `gitconfig:"addembeddedrepo"`
+	AddEmptyPathspec                   *bool `gitconfig:"addemptypathspec"`
+	AddIgnoredFile                     *bool `gitconfig:"addignoredfile"`
+	AmWorkDir                          *bool `gitconfig:"amworkdir"`
+	AmbiguousFetchRefspec              *bool `gitconfig:"ambiguousfetchrefspec"`
+	CheckoutAmbiguousRemoteBranchName  *bool `gitconfig:"checkoutambiguousremotebranchname"`
+	CommitBeforeMerge                  *bool `gitconfig:"commitbeforemerge"`
+	DetachedHead                       *bool `gitconfig:"detachedhead"`
+	Diverging                          *bool `gitconfig:"diverging"`
+	FetchShowForcedUpdates             *bool `gitconfig:"fetchshowforcedupdates"`
+	ForceDeleteBranch                  *bool `gitconfig:"forcedeletebranch"`
+	IgnoredHook                        *bool `gitconfig:"ignoredhook"`
+	ImplicitIdentity                   *bool `gitconfig:"implicitidentity"`
+	MergeConflict                      *bool `gitconfig:"mergeconflict"`
+	NestedTag                          *bool `gitconfig:"nestedtag"`
+	PushAlreadyExists                  *bool `gitconfig:"pushalreadyexists"`
+	PushFetchFirst                     *bool `gitconfig:"pushfetchfirst"`
+	PushNeedsForce                     *bool `gitconfig:"pushneedsforce"`
+	PushNonFFCurrent                   *bool `gitconfig:"pushnonffcurrent"`
+	PushNonFFMatching                  *bool `gitconfig:"pushnonffmatching"`
+	PushRefNeedsUpdate                 *bool `gitconfig:"pushrefneedsupdate"`
+	PushUnqualifiedRefname             *bool `gitconfig:"pushunqualifiedrefname"`
+	PushUpdateRejected                 *bool `gitconfig:"pushupdaterejected"`
+	RebaseTodoError                    *bool `gitconfig:"rebasetodoerror"`
+	RefSyntax                          *bool `gitconfig:"refsyntax"`
+	ResetNoRefresh                     *bool `gitconfig:"resetnorefresh"`
+	ResolveConflict                    *bool `gitconfig:"resolveconflict"`
+	RmHints                            *bool `gitconfig:"rmhints"`
+	SequencerInUse                     *bool `gitconfig:"sequencerinuse"`
+	SkippedCherryPicks                 *bool `gitconfig:"skippedcherrypicks"`
+	SparseIndexExpanded                *bool `gitconfig:"sparseindexexpanded"`
+	StatusAheadBehind                  *bool `gitconfig:"statusaheadbehind"`
+	StatusHints                        *bool `gitconfig:"statushints"`
+	StatusUoption                      *bool `gitconfig:"statusuoption"`
+	SubmoduleAlternateErrorStrategyDie *bool `gitconfig:"submodulealternateerrorstrategydie"`
+	SubmoduleMergeConflict             *bool `gitconfig:"submodulemergeconflict"`
+	SubmodulesNotUpdated               *bool `gitconfig:"submodulesnotupdated"`
+	SuggestDetachingHead               *bool `gitconfig:"suggestdetachinghead"`
+	UpdateSparsePath                   *bool `gitconfig:"updatesparsepath"`
+	WaitingForEditor                   *bool `gitconfig:"waitingforeditor"`
+	WorktreeAddOrphan                  *bool `gitconfig:"worktreeaddorphan"`
+}
+
+// AliasConfig maps an alias.<name> subsection.
+type AliasConfig struct {
+	Command string `gitconfig:"command"`
+}
+
+// BranchConfig maps a branch.<name> subsection.
+type BranchConfig struct {
+	Remote       string `gitconfig:"remote"`
+	PushRemote   string `gitconfig:"pushremote"`
+	Merge        string `gitconfig:"merge"`
+	MergeOptions string `gitconfig:"mergeoptions"`
+	Rebase       string `gitconfig:"rebase"`
+	Description  string `gitconfig:"description"`
+}
+
+// BrowserConfig maps a browser.<tool> subsection.
+type BrowserConfig struct {
+	Cmd  string `gitconfig:"cmd"`
+	Path string `gitconfig:"path"`
+}
+
+// CheckoutConfig maps the checkout.* section.
+type CheckoutConfig struct {
+	DefaultRemote           string `gitconfig:"defaultremote"`
+	Guess                   *bool  `gitconfig:"guess"`
+	Workers                 int    `gitconfig:"workers"`
+	ThresholdForParallelism int    `gitconfig:"thresholdforparallelism"`
+}
+
+// CleanConfig maps the clean.* section.
+type CleanConfig struct {
+	RequireForce *bool `gitconfig:"requireforce" gitconfigDefault:"true"`
+}
+
+// CloneConfig maps the clone.* section.
+type CloneConfig struct {
+	DefaultRemoteName string `gitconfig:"defaultremotename" gitconfigDefault:"origin"`
+	RejectShallow     *bool  `gitconfig:"rejectshallow"`
+	FilterSubmodules  *bool  `gitconfig:"filtersubmodules"`
+}
+
+// ColorConfig maps the color.* section variables.
+type ColorConfig struct {
+	UI          *AutoBool `gitconfig:"ui"`
+	Advice      *AutoBool `gitconfig:"advice"`
+	Branch      *AutoBool `gitconfig:"branch"`
+	Diff        *AutoBool `gitconfig:"diff"`
+	Grep        *AutoBool `gitconfig:"grep"`
+	Interactive *AutoBool `gitconfig:"interactive"`
+	Pager       *bool     `gitconfig:"pager"`
+	Push        *AutoBool `gitconfig:"push"`
+	Remote      *AutoBool `gitconfig:"remote"`
+	ShowBranch  *AutoBool `gitconfig:"showbranch"`
+	Status      *AutoBool `gitconfig:"status"`
+	Transport   *AutoBool `gitconfig:"transport"`
+}
+
+// ColorBranchSlots maps the [color "branch"] subsection.
+type ColorBranchSlots struct {
+	Current  *Color `gitconfig:"current"`
+	Local    *Color `gitconfig:"local"`
+	Remote   *Color `gitconfig:"remote"`
+	Upstream *Color `gitconfig:"upstream"`
+	Plain    *Color `gitconfig:"plain"`
+}
+
+// ColorDiffSlots maps the [color "diff"] subsection.
+type ColorDiffSlots struct {
+	Context                   *Color `gitconfig:"context"`
+	Meta                      *Color `gitconfig:"meta"`
+	Frag                      *Color `gitconfig:"frag"`
+	Func                      *Color `gitconfig:"func"`
+	Old                       *Color `gitconfig:"old"`
+	New                       *Color `gitconfig:"new"`
+	Commit                    *Color `gitconfig:"commit"`
+	Whitespace                *Color `gitconfig:"whitespace"`
+	OldMoved                  *Color `gitconfig:"oldmoved"`
+	NewMoved                  *Color `gitconfig:"newmoved"`
+	OldMovedDimmed            *Color `gitconfig:"oldmoveddimmed"`
+	OldMovedAlternative       *Color `gitconfig:"oldmovedalternative"`
+	OldMovedAlternativeDimmed *Color `gitconfig:"oldmovedalternativedimmed"`
+	NewMovedDimmed            *Color `gitconfig:"newmoveddimmed"`
+	NewMovedAlternative       *Color `gitconfig:"newmovedalternative"`
+	NewMovedAlternativeDimmed *Color `gitconfig:"newmovedalternativedimmed"`
+	ContextDimmed             *Color `gitconfig:"contextdimmed"`
+	OldDimmed                 *Color `gitconfig:"olddimmed"`
+	NewDimmed                 *Color `gitconfig:"newdimmed"`
+	ContextBold               *Color `gitconfig:"contextbold"`
+	OldBold                   *Color `gitconfig:"oldbold"`
+	NewBold                   *Color `gitconfig:"newbold"`
+}
+
+// ColorDecorateSlots maps the [color "decorate"] subsection.
+type ColorDecorateSlots struct {
+	Branch       *Color `gitconfig:"branch"`
+	RemoteBranch *Color `gitconfig:"remotebranch"`
+	Tag          *Color `gitconfig:"tag"`
+	Stash        *Color `gitconfig:"stash"`
+	HEAD         *Color `gitconfig:"head"`
+	Grafted      *Color `gitconfig:"grafted"`
+}
+
+// ColorGrepSlots maps the [color "grep"] subsection.
+type ColorGrepSlots struct {
+	Context       *Color `gitconfig:"context"`
+	Filename      *Color `gitconfig:"filename"`
+	Function      *Color `gitconfig:"function"`
+	LineNumber    *Color `gitconfig:"linenumber"`
+	Column        *Color `gitconfig:"column"`
+	Match         *Color `gitconfig:"match"`
+	MatchContext  *Color `gitconfig:"matchcontext"`
+	MatchSelected *Color `gitconfig:"matchselected"`
+	Selected      *Color `gitconfig:"selected"`
+	Separator     *Color `gitconfig:"separator"`
+}
+
+// ColorInteractiveSlots maps the [color "interactive"] subsection.
+type ColorInteractiveSlots struct {
+	Prompt *Color `gitconfig:"prompt"`
+	Header *Color `gitconfig:"header"`
+	Help   *Color `gitconfig:"help"`
+	Error  *Color `gitconfig:"error"`
+}
+
+// ColorPushSlots maps the [color "push"] subsection.
+type ColorPushSlots struct {
+	Error *Color `gitconfig:"error"`
+}
+
+// ColorRemoteSlots maps the [color "remote"] subsection.
+type ColorRemoteSlots struct {
+	Hint    *Color `gitconfig:"hint"`
+	Warning *Color `gitconfig:"warning"`
+	Success *Color `gitconfig:"success"`
+	Error   *Color `gitconfig:"error"`
+}
+
+// ColorStatusSlots maps the [color "status"] subsection.
+type ColorStatusSlots struct {
+	Header       *Color `gitconfig:"header"`
+	Added        *Color `gitconfig:"added"`
+	Updated      *Color `gitconfig:"updated"`
+	Changed      *Color `gitconfig:"changed"`
+	Untracked    *Color `gitconfig:"untracked"`
+	Branch       *Color `gitconfig:"branch"`
+	NoBranch     *Color `gitconfig:"nobranch"`
+	LocalBranch  *Color `gitconfig:"localbranch"`
+	RemoteBranch *Color `gitconfig:"remotebranch"`
+	Unmerged     *Color `gitconfig:"unmerged"`
+}
+
+// ColorTransportSlots maps the [color "transport"] subsection.
+type ColorTransportSlots struct {
+	Rejected *Color `gitconfig:"rejected"`
+}
+
+// ColumnConfig maps the column.* section.
+type ColumnConfig struct {
+	UI     string `gitconfig:"ui"`
+	Branch string `gitconfig:"branch"`
+	Clean  string `gitconfig:"clean"`
+	Status string `gitconfig:"status"`
+	Tag    string `gitconfig:"tag"`
+}
+
+// CommitConfig maps the commit.* section.
+type CommitConfig struct {
+	Cleanup  string    `gitconfig:"cleanup"`
+	GPGSign  *bool     `gitconfig:"gpgsign"`
+	Status   *bool     `gitconfig:"status" gitconfigDefault:"true"`
+	Template Pathname  `gitconfig:"template"`
+	Verbose  BoolOrInt `gitconfig:"verbose"`
+}
+
+// CommitGraphConfig maps the commitGraph.* section.
+type CommitGraphConfig struct {
+	GenerationVersion int   `gitconfig:"generationversion" gitconfigDefault:"2"`
+	MaxNewFilters     int   `gitconfig:"maxnewfilters"`
+	ChangedPaths      *bool `gitconfig:"changedpaths"`
+	ReadChangedPaths  int   `gitconfig:"changedpathsversion" gitconfigDefault:"-1"`
+}
+
+// CoreConfig maps the core.* section.
+type CoreConfig struct {
+	RepositoryFormatVersion int      `gitconfig:"repositoryformatversion"`
+	Bare                    bool     `gitconfig:"bare"`
+	Worktree                Pathname `gitconfig:"worktree"`
+	LogAllRefUpdates        *bool    `gitconfig:"logallrefupdates"`
+	CommentChar             string   `gitconfig:"commentchar"`
+	CommentString           string   `gitconfig:"commentstring"`
+	FileMode                *bool    `gitconfig:"filemode"`
+	IgnoreCase              *bool    `gitconfig:"ignorecase"`
+	PrecomposeUnicode       *bool    `gitconfig:"precomposeunicode"`
+	ProtectHFS              *bool    `gitconfig:"protecthfs"`
+	ProtectNTFS             *bool    `gitconfig:"protectntfs"`
+	HideDotFiles            string   `gitconfig:"hidedotfiles"`
+	FSMonitor               string   `gitconfig:"fsmonitor"`
+	FSMonitorHookVersion    string   `gitconfig:"fsmonitorhookversion"`
+	TrustCTime              *bool    `gitconfig:"trustctime" gitconfigDefault:"true"`
+	SplitIndex              *bool    `gitconfig:"splitindex"`
+	UntrackedCache          string   `gitconfig:"untrackedcache"`
+	CheckStat               string   `gitconfig:"checkstat"`
+	QuotePath               *bool    `gitconfig:"quotepath" gitconfigDefault:"true"`
+	EOL                     string   `gitconfig:"eol"`
+	SafeCRLF                string   `gitconfig:"safecrlf"`
+	AutoCRLF                string   `gitconfig:"autocrlf"`
+	CheckRoundtripEncoding  string   `gitconfig:"checkroundtripencoding"`
+	Symlinks                *bool    `gitconfig:"symlinks"`
+	GitProxy                []string `gitconfig:"gitproxy,multivalue"`
+	SSHCommand              string   `gitconfig:"sshcommand"`
+	IgnoreStat              *bool    `gitconfig:"ignorestat"`
+	PreferSymlinkRefs       *bool    `gitconfig:"prefersymlinkrefs"`
+	AlternateRefsCommand    string   `gitconfig:"alternaterefscommand"`
+	AlternateRefsPrefixes   string   `gitconfig:"alternaterefsprefixes"`
+	SharedRepository        string   `gitconfig:"sharedrepository"`
+	WarnAmbiguousRefs       *bool    `gitconfig:"warnambiguousrefs" gitconfigDefault:"true"`
+	Compression             int      `gitconfig:"compression"`
+	LooseCompression        int      `gitconfig:"loosecompression"`
+	PackedGitWindowSize     GitSize  `gitconfig:"packedgitwindowsize"`
+	PackedGitLimit          GitSize  `gitconfig:"packedgitlimit"`
+	DeltaBaseCacheLimit     GitSize  `gitconfig:"deltabasecachelimit"`
+	BigFileThreshold        GitSize  `gitconfig:"bigfilethreshold" gitconfigDefault:"512m"`
+	ExcludesFile            Pathname `gitconfig:"excludesfile"`
+	AskPass                 string   `gitconfig:"askpass"`
+	AttributesFile          Pathname `gitconfig:"attributesfile"`
+	HooksPath               Pathname `gitconfig:"hookspath"`
+	Editor                  string   `gitconfig:"editor"`
+	FilesRefLockTimeout     int      `gitconfig:"filesreflocktimeout" gitconfigDefault:"100"`
+	PackedRefsTimeout       int      `gitconfig:"packedrefstimeout" gitconfigDefault:"1000"`
+	Pager                   string   `gitconfig:"pager"`
+	Whitespace              string   `gitconfig:"whitespace"`
+	Fsync                   string   `gitconfig:"fsync"`
+	FsyncMethod             string   `gitconfig:"fsyncmethod"`
+	FsyncObjectFiles        *bool    `gitconfig:"fsyncobjectfiles"`
+	PreloadIndex            *bool    `gitconfig:"preloadindex" gitconfigDefault:"true"`
+	UnsetEnvVars            string   `gitconfig:"unsetenvvars"`
+	CreateObject            string   `gitconfig:"createobject"`
+	NotesRef                string   `gitconfig:"notesref" gitconfigDefault:"refs/notes/commits"`
+	CommitGraph             *bool    `gitconfig:"commitgraph" gitconfigDefault:"true"`
+	UseReplaceRefs          *bool    `gitconfig:"usereplacerefs" gitconfigDefault:"true"`
+	MultiPackIndex          *bool    `gitconfig:"multipackindex" gitconfigDefault:"true"`
+	SparseCheckout          *bool    `gitconfig:"sparsecheckout"`
+	SparseCheckoutCone      *bool    `gitconfig:"sparsecheckoutcone"`
+	Abbrev                  string   `gitconfig:"abbrev"`
+	MaxTreeDepth            int      `gitconfig:"maxtreedepth"`
+}
+
+// CredentialConfig maps the credential.* section.
+type CredentialConfig struct {
+	Helper          []string `gitconfig:"helper,multivalue"`
+	Interactive     *bool    `gitconfig:"interactive"`
+	UseHTTPPath     *bool    `gitconfig:"usehttppath"`
+	SanitizePrompt  *bool    `gitconfig:"sanitizeprompt" gitconfigDefault:"true"`
+	ProtectProtocol *bool    `gitconfig:"protectprotocol" gitconfigDefault:"true"`
+	Username        string   `gitconfig:"username"`
+}
+
+// CredentialURLConfig maps a credential.<url>.* subsection.
+type CredentialURLConfig struct {
+	Helper      []string `gitconfig:"helper,multivalue"`
+	Interactive *bool    `gitconfig:"interactive"`
+	UseHTTPPath *bool    `gitconfig:"usehttppath"`
+	Username    string   `gitconfig:"username"`
+}
+
+// DiffConfig maps the diff.* section.
+type DiffConfig struct {
+	AutoRefreshIndex   *bool    `gitconfig:"autorefreshindex" gitconfigDefault:"true"`
+	DirStat            string   `gitconfig:"dirstat"`
+	StatNameWidth      int      `gitconfig:"statnamewidth"`
+	StatGraphWidth     int      `gitconfig:"statgraphwidth"`
+	Context            int      `gitconfig:"context" gitconfigDefault:"3"`
+	InterHunkContext   int      `gitconfig:"interhunkcontext"`
+	External           string   `gitconfig:"external"`
+	TrustExitCode      *bool    `gitconfig:"trustexitcode"`
+	IgnoreSubmodules   string   `gitconfig:"ignoresubmodules"`
+	MnemonicPrefix     *bool    `gitconfig:"mnemonicprefix"`
+	NoPrefix           *bool    `gitconfig:"noprefix"`
+	SrcPrefix          string   `gitconfig:"srcprefix"`
+	DstPrefix          string   `gitconfig:"dstprefix"`
+	Relative           *bool    `gitconfig:"relative"`
+	OrderFile          Pathname `gitconfig:"orderfile"`
+	RenameLimit        int      `gitconfig:"renamelimit"`
+	Renames            string   `gitconfig:"renames" gitconfigDefault:"true"`
+	SuppressBlankEmpty *bool    `gitconfig:"suppressblankempty"`
+	Submodule          string   `gitconfig:"submodule" gitconfigDefault:"short"`
+	WordRegex          string   `gitconfig:"wordregex"`
+	IndentHeuristic    *bool    `gitconfig:"indentheuristic" gitconfigDefault:"true"`
+	Algorithm          string   `gitconfig:"algorithm"`
+	WSErrorHighlight   string   `gitconfig:"wserrorhighlight"`
+	ColorMoved         string   `gitconfig:"colormoved"`
+	ColorMovedWS       string   `gitconfig:"colormovedws"`
+	Tool               string   `gitconfig:"tool"`
+	GUITool            string   `gitconfig:"guitool"`
+}
+
+// DiffDriverConfig maps a diff.<driver>.* subsection.
+type DiffDriverConfig struct {
+	Command       string `gitconfig:"command"`
+	TrustExitCode *bool  `gitconfig:"trustexitcode"`
+	XFuncName     string `gitconfig:"xfuncname"`
+	Binary        *bool  `gitconfig:"binary"`
+	TextConv      string `gitconfig:"textconv"`
+	WordRegex     string `gitconfig:"wordregex"`
+	CacheTextConv *bool  `gitconfig:"cachetextconv"`
+}
+
+// DifftoolConfig maps a difftool.<tool>.* subsection.
+type DifftoolConfig struct {
+	Cmd           string `gitconfig:"cmd"`
+	Path          string `gitconfig:"path"`
+	TrustExitCode *bool  `gitconfig:"trustexitcode"`
+	Prompt        *bool  `gitconfig:"prompt"`
+	GUIDefault    string `gitconfig:"guidefault"`
+}
+
+// ExtensionsConfig maps the extensions.* section.
+type ExtensionsConfig struct {
+	ObjectFormat       string `gitconfig:"objectformat"`
+	CompatObjectFormat string `gitconfig:"compatobjectformat"`
+	Noop               *bool  `gitconfig:"noop"`
+	NoopV1             *bool  `gitconfig:"noop-v1"`
+	PartialClone       string `gitconfig:"partialclone"`
+	PreciousObjects    *bool  `gitconfig:"preciousobjects"`
+	RefStorage         string `gitconfig:"refstorage"`
+	RelativeWorktrees  *bool  `gitconfig:"relativeworktrees"`
+	WorktreeConfig     *bool  `gitconfig:"worktreeconfig"`
+}
+
+// FeatureConfig maps the feature.* section.
+type FeatureConfig struct {
+	Experimental *bool `gitconfig:"experimental"`
+	ManyFiles    *bool `gitconfig:"manyfiles"`
+}
+
+// FetchConfig maps the fetch.* section.
+type FetchConfig struct {
+	RecurseSubmodules    string `gitconfig:"recursesubmodules" gitconfigDefault:"on-demand"`
+	FsckObjects          *bool  `gitconfig:"fsckobjects"`
+	UnpackLimit          int    `gitconfig:"unpacklimit"`
+	Prune                *bool  `gitconfig:"prune"`
+	PruneTags            *bool  `gitconfig:"prunetags"`
+	All                  *bool  `gitconfig:"all"`
+	Output               string `gitconfig:"output"`
+	NegotiationAlgorithm string `gitconfig:"negotiationalgorithm"`
+	ShowForcedUpdates    *bool  `gitconfig:"showforcedupdates" gitconfigDefault:"true"`
+	Parallel             int    `gitconfig:"parallel"`
+	WriteCommitGraph     *bool  `gitconfig:"writecommitgraph"`
+	BundleURI            string `gitconfig:"bundleuri"`
+	BundleCreationToken  string `gitconfig:"bundlecreationtoken"`
+}
+
+// FilterDriverConfig maps a filter.<driver>.* subsection.
+type FilterDriverConfig struct {
+	Clean  string `gitconfig:"clean"`
+	Smudge string `gitconfig:"smudge"`
+}
+
+// FormatConfig maps the format.* section.
+type FormatConfig struct {
+	Attach               string   `gitconfig:"attach"`
+	From                 string   `gitconfig:"from"`
+	ForceInBodyFrom      *bool    `gitconfig:"forceinbodyfrom"`
+	Numbered             string   `gitconfig:"numbered"`
+	Headers              []string `gitconfig:"headers,multivalue"`
+	To                   []string `gitconfig:"to,multivalue"`
+	CC                   []string `gitconfig:"cc,multivalue"`
+	SubjectPrefix        string   `gitconfig:"subjectprefix"`
+	CoverFromDescription string   `gitconfig:"coverfromdescription"`
+	Signature            string   `gitconfig:"signature"`
+	SignatureFile        Pathname `gitconfig:"signaturefile"`
+	Suffix               string   `gitconfig:"suffix" gitconfigDefault:".patch"`
+	EncodeEmailHeaders   *bool    `gitconfig:"encodeemailheaders" gitconfigDefault:"true"`
+	Pretty               string   `gitconfig:"pretty"`
+	Thread               string   `gitconfig:"thread"`
+	SignOff              *bool    `gitconfig:"signoff"`
+	CoverLetter          string   `gitconfig:"coverletter"`
+	OutputDirectory      Pathname `gitconfig:"outputdirectory"`
+	FilenameMaxLength    int      `gitconfig:"filenamemaxlength" gitconfigDefault:"64"`
+	UseAutoBase          string   `gitconfig:"useautobase"`
+	Notes                string   `gitconfig:"notes"`
+	MboxRD               *bool    `gitconfig:"mboxrd"`
+	NoPrefix             *bool    `gitconfig:"noprefix"`
+}
+
+// FsckConfig maps the fsck.* section.
+type FsckConfig struct {
+	SkipList Pathname `gitconfig:"skiplist"`
+}
+
+// FsmonitorConfig maps the fsmonitor.* section.
+type FsmonitorConfig struct {
+	AllowRemote *bool  `gitconfig:"allowremote"`
+	SocketDir   string `gitconfig:"socketdir"`
+}
+
+// GcConfig maps the gc.* section.
+type GcConfig struct {
+	AggressiveDepth         int        `gitconfig:"aggressivedepth" gitconfigDefault:"50"`
+	AggressiveWindow        int        `gitconfig:"aggressivewindow" gitconfigDefault:"250"`
+	Auto                    int        `gitconfig:"auto" gitconfigDefault:"6700"`
+	AutoPackLimit           int        `gitconfig:"autopacklimit" gitconfigDefault:"50"`
+	AutoDetach              *bool      `gitconfig:"autodetach" gitconfigDefault:"true"`
+	BigPackThreshold        GitSize    `gitconfig:"bigpackthreshold"`
+	WriteCommitGraph        *bool      `gitconfig:"writecommitgraph" gitconfigDefault:"true"`
+	LogExpiry               ExpiryDate `gitconfig:"logexpiry" gitconfigDefault:"1.day"`
+	PackRefs                string     `gitconfig:"packrefs" gitconfigDefault:"true"`
+	CruftPacks              *bool      `gitconfig:"cruftpacks" gitconfigDefault:"true"`
+	MaxCruftSize            GitSize    `gitconfig:"maxcruftsize"`
+	PruneExpire             ExpiryDate `gitconfig:"pruneexpire" gitconfigDefault:"2.weeks.ago"`
+	WorktreePruneExpire     ExpiryDate `gitconfig:"worktreepruneexpire" gitconfigDefault:"3.months.ago"`
+	ReflogExpire            ExpiryDate `gitconfig:"reflogexpire" gitconfigDefault:"90.days"`
+	ReflogExpireUnreachable ExpiryDate `gitconfig:"reflogexpireunreachable" gitconfigDefault:"30.days"`
+	RecentObjectsHook       string     `gitconfig:"recentobjectshook"`
+	RepackFilter            string     `gitconfig:"repackfilter"`
+	RepackFilterTo          string     `gitconfig:"repackfilterto"`
+	RerereResolved          ExpiryDate `gitconfig:"rerereresolved" gitconfigDefault:"60.days"`
+	RerereUnresolved        ExpiryDate `gitconfig:"rerereunresolved" gitconfigDefault:"15.days"`
+}
+
+// GPGConfig maps the gpg.* section.
+type GPGConfig struct {
+	Program       string `gitconfig:"program"`
+	Format        string `gitconfig:"format"`
+	MinTrustLevel string `gitconfig:"mintrustlevel"`
+}
+
+// GPGSSHConfig maps the [gpg "ssh"] subsection.
+type GPGSSHConfig struct {
+	Program            string   `gitconfig:"program"`
+	DefaultKeyCommand  string   `gitconfig:"defaultkeycommand"`
+	AllowedSignersFile Pathname `gitconfig:"allowedsignersfile"`
+	RevocationFile     Pathname `gitconfig:"revocationfile"`
+}
+
+// GPGFormatConfig maps a gpg.<format>.* subsection.
+type GPGFormatConfig struct {
+	Program string `gitconfig:"program"`
+}
+
+// GrepConfig maps the grep.* section.
+type GrepConfig struct {
+	LineNumber        *bool  `gitconfig:"linenumber"`
+	Column            *bool  `gitconfig:"column"`
+	PatternType       string `gitconfig:"patterntype"`
+	ExtendedRegexp    *bool  `gitconfig:"extendedregexp"`
+	Threads           int    `gitconfig:"threads"`
+	FullName          *bool  `gitconfig:"fullname"`
+	FallbackToNoIndex *bool  `gitconfig:"fallbacktonoindex"`
+}
+
+// HelpConfig maps the help.* section.
+type HelpConfig struct {
+	Browser     string `gitconfig:"browser"`
+	Format      string `gitconfig:"format"`
+	AutoCorrect string `gitconfig:"autocorrect"`
+	HTMLPath    string `gitconfig:"htmlpath"`
+}
+
+// HTTPConfig maps the http.* section.
+type HTTPConfig struct {
+	Proxy                         string          `gitconfig:"proxy"`
+	ProxyAuthMethod               string          `gitconfig:"proxyauthmethod"`
+	ProxySSLCert                  Pathname        `gitconfig:"proxysslcert"`
+	ProxySSLKey                   Pathname        `gitconfig:"proxysslkey"`
+	ProxySSLCertPasswordProtected *bool           `gitconfig:"proxysslcertpasswordprotected"`
+	ProxySSLCAInfo                Pathname        `gitconfig:"proxysslcainfo"`
+	EmptyAuth                     *bool           `gitconfig:"emptyauth"`
+	ProactiveAuth                 string          `gitconfig:"proactiveauth"`
+	Delegation                    string          `gitconfig:"delegation"`
+	ExtraHeader                   []string        `gitconfig:"extraheader,multivalue"`
+	CookieFile                    Pathname        `gitconfig:"cookiefile"`
+	SaveCookies                   *bool           `gitconfig:"savecookies"`
+	Version                       string          `gitconfig:"version"`
+	CurloptResolve                []string        `gitconfig:"curloptresolve,multivalue"`
+	SSLVersion                    string          `gitconfig:"sslversion"`
+	SSLCipherList                 string          `gitconfig:"sslcipherlist"`
+	SSLVerify                     *bool           `gitconfig:"sslverify" gitconfigDefault:"true"`
+	SSLCert                       Pathname        `gitconfig:"sslcert"`
+	SSLKey                        Pathname        `gitconfig:"sslkey"`
+	SSLCertPasswordProtected      *bool           `gitconfig:"sslcertpasswordprotected"`
+	SSLCAInfo                     Pathname        `gitconfig:"sslcainfo"`
+	SSLCAPath                     Pathname        `gitconfig:"sslcapath"`
+	SSLBackend                    string          `gitconfig:"sslbackend"`
+	SSLCertType                   string          `gitconfig:"sslcerttype"`
+	SSLKeyType                    string          `gitconfig:"sslkeytype"`
+	SchannelCheckRevoke           *bool           `gitconfig:"schannelcheckrevoke" gitconfigDefault:"true"`
+	SchannelUseSSLCAInfo          *bool           `gitconfig:"schannelusesslcainfo"`
+	PinnedPubkey                  string          `gitconfig:"pinnedpubkey"`
+	SSLTry                        *bool           `gitconfig:"ssltry"`
+	MaxRequests                   int             `gitconfig:"maxrequests" gitconfigDefault:"5"`
+	MinSessions                   int             `gitconfig:"minsessions" gitconfigDefault:"1"`
+	PostBuffer                    GitSize         `gitconfig:"postbuffer" gitconfigDefault:"1m"`
+	LowSpeedLimit                 int             `gitconfig:"lowspeedlimit"`
+	LowSpeedTime                  int             `gitconfig:"lowspeedtime"`
+	KeepAliveIdle                 int             `gitconfig:"keepaliveidle"`
+	KeepAliveInterval             int             `gitconfig:"keepaliveinterval"`
+	KeepAliveCount                int             `gitconfig:"keepalivecount"`
+	NoEPSV                        *bool           `gitconfig:"noepsv"`
+	UserAgent                     string          `gitconfig:"useragent"`
+	FollowRedirects               FollowRedirects `gitconfig:"followredirects" gitconfigDefault:"initial"`
+}
+
+// HTTPURLConfig maps an http.<url>.* subsection.
+type HTTPURLConfig struct {
+	SSLVerify   *bool    `gitconfig:"sslverify"`
+	SSLCert     Pathname `gitconfig:"sslcert"`
+	SSLKey      Pathname `gitconfig:"sslkey"`
+	SSLCAInfo   Pathname `gitconfig:"sslcainfo"`
+	SSLCAPath   Pathname `gitconfig:"sslcapath"`
+	Proxy       string   `gitconfig:"proxy"`
+	CookieFile  Pathname `gitconfig:"cookiefile"`
+	PostBuffer  GitSize  `gitconfig:"postbuffer"`
+	ExtraHeader []string `gitconfig:"extraheader,multivalue"`
+}
+
+// I18nConfig maps the i18n.* section.
+type I18nConfig struct {
+	CommitEncoding    string `gitconfig:"commitencoding" gitconfigDefault:"utf-8"`
+	LogOutputEncoding string `gitconfig:"logoutputencoding"`
+}
+
+// IndexConfig maps the index.* section.
+type IndexConfig struct {
+	RecordEndOfIndexEntries *bool  `gitconfig:"recordendofindexentries"`
+	RecordOffsetTable       *bool  `gitconfig:"recordoffsettable"`
+	Sparse                  *bool  `gitconfig:"sparse"`
+	Threads                 string `gitconfig:"threads" gitconfigDefault:"true"`
+	Version                 int    `gitconfig:"version"`
+	SkipHash                *bool  `gitconfig:"skiphash"`
+}
+
+// InitConfig maps the init.* section.
+type InitConfig struct {
+	TemplateDir         Pathname `gitconfig:"templatedir"`
+	DefaultBranch       string   `gitconfig:"defaultbranch"`
+	DefaultObjectFormat string   `gitconfig:"defaultobjectformat"`
+	DefaultRefFormat    string   `gitconfig:"defaultrefformat"`
+}
+
+// InteractiveConfig maps the interactive.* section.
+type InteractiveConfig struct {
+	SingleKey  *bool  `gitconfig:"singlekey"`
+	DiffFilter string `gitconfig:"difffilter"`
+}
+
+// LogConfig maps the log.* section.
+type LogConfig struct {
+	AbbrevCommit         *bool    `gitconfig:"abbrevcommit"`
+	Date                 string   `gitconfig:"date"`
+	Decorate             string   `gitconfig:"decorate"`
+	InitialDecorationSet string   `gitconfig:"initialdecorationset"`
+	ExcludeDecoration    []string `gitconfig:"excludedecoration,multivalue"`
+	DiffMerges           string   `gitconfig:"diffmerges" gitconfigDefault:"separate"`
+	Follow               *bool    `gitconfig:"follow"`
+	GraphColors          string   `gitconfig:"graphcolors"`
+	ShowRoot             *bool    `gitconfig:"showroot" gitconfigDefault:"true"`
+	ShowSignature        *bool    `gitconfig:"showsignature"`
+	Mailmap              *bool    `gitconfig:"mailmap" gitconfigDefault:"true"`
+}
+
+// MaintenanceConfig maps the maintenance.* section.
+type MaintenanceConfig struct {
+	Auto       *bool  `gitconfig:"auto" gitconfigDefault:"true"`
+	AutoDetach *bool  `gitconfig:"autodetach" gitconfigDefault:"true"`
+	Strategy   string `gitconfig:"strategy"`
+}
+
+// MaintenanceTaskConfig maps a maintenance.<task>.* subsection.
+type MaintenanceTaskConfig struct {
+	Enabled  *bool  `gitconfig:"enabled"`
+	Schedule string `gitconfig:"schedule"`
+}
+
+// MergeConfig maps the merge.* section.
+type MergeConfig struct {
+	ConflictStyle     string    `gitconfig:"conflictstyle"`
+	DefaultToUpstream *bool     `gitconfig:"defaulttoupstream" gitconfigDefault:"true"`
+	FF                string    `gitconfig:"ff"`
+	VerifySignatures  *bool     `gitconfig:"verifysignatures"`
+	BranchDesc        *bool     `gitconfig:"branchdesc"`
+	Log               BoolOrInt `gitconfig:"log"`
+	SuppressDest      []string  `gitconfig:"suppressdest,multivalue"`
+	RenameLimit       int       `gitconfig:"renamelimit"`
+	Renames           string    `gitconfig:"renames"`
+	DirectoryRenames  string    `gitconfig:"directoryrenames" gitconfigDefault:"conflict"`
+	Renormalize       *bool     `gitconfig:"renormalize"`
+	Stat              string    `gitconfig:"stat" gitconfigDefault:"true"`
+	AutoStash         *bool     `gitconfig:"autostash"`
+	Tool              string    `gitconfig:"tool"`
+	GUITool           string    `gitconfig:"guitool"`
+	Verbosity         int       `gitconfig:"verbosity" gitconfigDefault:"2"`
+}
+
+// MergeDriverConfig maps a merge.<driver>.* subsection.
+type MergeDriverConfig struct {
+	Name      string `gitconfig:"name"`
+	Driver    string `gitconfig:"driver"`
+	Recursive string `gitconfig:"recursive"`
+}
+
+// MergetoolConfig maps a mergetool.<tool>.* subsection.
+type MergetoolConfig struct {
+	Path          string `gitconfig:"path"`
+	Cmd           string `gitconfig:"cmd"`
+	HideResolved  *bool  `gitconfig:"hideresolved"`
+	TrustExitCode *bool  `gitconfig:"trustexitcode"`
+}
+
+// MergetoolGlobals maps the mergetool.* section-level variables.
+type MergetoolGlobals struct {
+	KeepBackup      *bool  `gitconfig:"keepbackup" gitconfigDefault:"true"`
+	KeepTemporaries *bool  `gitconfig:"keeptemporaries"`
+	WriteToTemp     *bool  `gitconfig:"writetotemp"`
+	Prompt          *bool  `gitconfig:"prompt" gitconfigDefault:"true"`
+	GUIDefault      string `gitconfig:"guidefault"`
+}
+
+// NotesConfig maps the notes.* section.
+type NotesConfig struct {
+	MergeStrategy string   `gitconfig:"mergestrategy"`
+	DisplayRef    []string `gitconfig:"displayref,multivalue"`
+	RewriteMode   string   `gitconfig:"rewritemode"`
+	RewriteRef    []string `gitconfig:"rewriteref,multivalue"`
+}
+
+// NotesNameConfig maps a notes.<name>.* subsection.
+type NotesNameConfig struct {
+	MergeStrategy string `gitconfig:"mergestrategy"`
+}
+
+// PackConfig maps the pack.* section.
+type PackConfig struct {
+	Window                     int     `gitconfig:"window" gitconfigDefault:"10"`
+	Depth                      int     `gitconfig:"depth" gitconfigDefault:"50"`
+	WindowMemory               GitSize `gitconfig:"windowmemory"`
+	Compression                int     `gitconfig:"compression"`
+	AllowPackReuse             string  `gitconfig:"allowpackreuse" gitconfigDefault:"true"`
+	Island                     string  `gitconfig:"island"`
+	IslandCore                 string  `gitconfig:"islandcore"`
+	DeltaCacheSize             GitSize `gitconfig:"deltacachesize" gitconfigDefault:"256m"`
+	DeltaCacheLimit            int     `gitconfig:"deltacachelimit" gitconfigDefault:"1000"`
+	Threads                    int     `gitconfig:"threads"`
+	IndexVersion               int     `gitconfig:"indexversion" gitconfigDefault:"2"`
+	PackSizeLimit              GitSize `gitconfig:"packsizelimit"`
+	UseBitmaps                 *bool   `gitconfig:"usebitmaps" gitconfigDefault:"true"`
+	UseBitmapBoundaryTraversal *bool   `gitconfig:"usebitmapboundarytraversal"`
+	UseSparse                  *bool   `gitconfig:"usesparse" gitconfigDefault:"true"`
+	UsePathWalk                *bool   `gitconfig:"usepathwalk"`
+	PreferBitmapTips           string  `gitconfig:"preferbitmaptips"`
+	WriteBitmapHashCache       *bool   `gitconfig:"writebitmaphashcache" gitconfigDefault:"true"`
+	WriteBitmapLookupTable     *bool   `gitconfig:"writebitmaplookuptable"`
+	ReadReverseIndex           *bool   `gitconfig:"readreverseindex" gitconfigDefault:"true"`
+	WriteReverseIndex          *bool   `gitconfig:"writereverseindex" gitconfigDefault:"true"`
+}
+
+// ProtocolConfig maps the protocol.* section.
+type ProtocolConfig struct {
+	Allow   string `gitconfig:"allow"`
+	Version int    `gitconfig:"version" gitconfigDefault:"2"`
+}
+
+// ProtocolNameConfig maps a protocol.<name>.* subsection.
+type ProtocolNameConfig struct {
+	Allow string `gitconfig:"allow"`
+}
+
+// PullConfig maps the pull.* section.
+type PullConfig struct {
+	FF        string `gitconfig:"ff"`
+	Rebase    string `gitconfig:"rebase"`
+	Octopus   string `gitconfig:"octopus"`
+	AutoStash *bool  `gitconfig:"autostash"`
+	TwoHead   string `gitconfig:"twohead"`
+}
+
+// PushConfig maps the push.* section.
+type PushConfig struct {
+	AutoSetupRemote    *bool    `gitconfig:"autosetupremote"`
+	Default            string   `gitconfig:"default" gitconfigDefault:"simple"`
+	FollowTags         *bool    `gitconfig:"followtags"`
+	GPGSign            string   `gitconfig:"gpgsign"`
+	PushOption         []string `gitconfig:"pushoption,multivalue"`
+	RecurseSubmodules  string   `gitconfig:"recursesubmodules"`
+	UseForceIfIncludes *bool    `gitconfig:"useforceifincludes"`
+	Negotiate          *bool    `gitconfig:"negotiate"`
+	UseBitmaps         *bool    `gitconfig:"usebitmaps" gitconfigDefault:"true"`
+}
+
+// RebaseConfig maps the rebase.* section.
+type RebaseConfig struct {
+	Backend              string `gitconfig:"backend"`
+	Stat                 *bool  `gitconfig:"stat"`
+	AutoSquash           *bool  `gitconfig:"autosquash"`
+	AutoStash            *bool  `gitconfig:"autostash"`
+	UpdateRefs           *bool  `gitconfig:"updaterefs"`
+	MissingCommitsCheck  string `gitconfig:"missingcommitscheck" gitconfigDefault:"ignore"`
+	InstructionFormat    string `gitconfig:"instructionformat"`
+	AbbreviateCommands   *bool  `gitconfig:"abbreviatecommands"`
+	RescheduleFailedExec *bool  `gitconfig:"reschedulefailedexec"`
+	ForkPoint            *bool  `gitconfig:"forkpoint" gitconfigDefault:"true"`
+	RebaseMerges         string `gitconfig:"rebasemerges"`
+	MaxLabelLength       int    `gitconfig:"maxlabellength"`
+}
+
+// ReceiveConfig maps the receive.* section.
+type ReceiveConfig struct {
+	AdvertiseAtomic      *bool    `gitconfig:"advertiseatomic" gitconfigDefault:"true"`
+	AdvertisePushOptions *bool    `gitconfig:"advertisepushoptions"`
+	AutoGC               *bool    `gitconfig:"autogc" gitconfigDefault:"true"`
+	CertNonceSeed        string   `gitconfig:"certnonceseed"`
+	CertNonceSlop        int      `gitconfig:"certnonceslop"`
+	FsckObjects          *bool    `gitconfig:"fsckobjects"`
+	KeepAlive            int      `gitconfig:"keepalive" gitconfigDefault:"5"`
+	UnpackLimit          int      `gitconfig:"unpacklimit"`
+	MaxInputSize         GitSize  `gitconfig:"maxinputsize"`
+	DenyDeletes          *bool    `gitconfig:"denydeletes"`
+	DenyDeleteCurrent    *bool    `gitconfig:"denydeletecurrent"`
+	DenyCurrentBranch    string   `gitconfig:"denycurrentbranch" gitconfigDefault:"refuse"`
+	DenyNonFastForwards  *bool    `gitconfig:"denynonfastforwards"`
+	HideRefs             []string `gitconfig:"hiderefs,multivalue"`
+	ProcReceiveRefs      []string `gitconfig:"procreceiverefs,multivalue"`
+	UpdateServerInfo     *bool    `gitconfig:"updateserverinfo"`
+	ShallowUpdate        *bool    `gitconfig:"shallowupdate"`
+}
+
+// RemoteConfig maps a remote.<name>.* subsection.
+type RemoteConfig struct {
+	URL                []string `gitconfig:"url,multivalue"`
+	PushURL            []string `gitconfig:"pushurl,multivalue"`
+	Proxy              string   `gitconfig:"proxy"`
+	ProxyAuthMethod    string   `gitconfig:"proxyauthmethod"`
+	Fetch              []string `gitconfig:"fetch,multivalue"`
+	Push               []string `gitconfig:"push,multivalue"`
+	Mirror             *bool    `gitconfig:"mirror"`
+	SkipFetchAll       *bool    `gitconfig:"skipfetchall"`
+	SkipDefaultUpdate  *bool    `gitconfig:"skipdefaultupdate"`
+	ReceivePack        string   `gitconfig:"receivepack"`
+	UploadPack         string   `gitconfig:"uploadpack"`
+	TagOpt             string   `gitconfig:"tagopt"`
+	VCS                string   `gitconfig:"vcs"`
+	Prune              *bool    `gitconfig:"prune"`
+	PruneTags          *bool    `gitconfig:"prunetags"`
+	Promisor           *bool    `gitconfig:"promisor"`
+	PartialCloneFilter string   `gitconfig:"partialclonefilter"`
+	ServerOption       []string `gitconfig:"serveroption,multivalue"`
+	FollowRemoteHEAD   string   `gitconfig:"followremotehead" gitconfigDefault:"create"`
+}
+
+// RepackConfig maps the repack.* section.
+type RepackConfig struct {
+	UseDeltaBaseOffset   *bool   `gitconfig:"usedeltabaseoffset" gitconfigDefault:"true"`
+	PackKeptObjects      *bool   `gitconfig:"packkeptobjects"`
+	UseDeltaIslands      *bool   `gitconfig:"usedeltaislands"`
+	WriteBitmaps         *bool   `gitconfig:"writebitmaps"`
+	UpdateServerInfo     *bool   `gitconfig:"updateserverinfo" gitconfigDefault:"true"`
+	CruftWindow          int     `gitconfig:"cruftwindow"`
+	CruftWindowMemory    GitSize `gitconfig:"cruftwindowmemory"`
+	CruftDepth           int     `gitconfig:"cruftdepth"`
+	CruftThreads         int     `gitconfig:"cruftthreads"`
+	MIDXMustContainCruft *bool   `gitconfig:"midxmustcontaincruft" gitconfigDefault:"true"`
+}
+
+// RerereConfig maps the rerere.* section.
+type RerereConfig struct {
+	AutoUpdate *bool `gitconfig:"autoupdate"`
+	Enabled    *bool `gitconfig:"enabled"`
+}
+
+// SafeConfig maps the safe.* section.
+type SafeConfig struct {
+	BareRepository string   `gitconfig:"barerepository" gitconfigDefault:"all"`
+	Directory      []string `gitconfig:"directory,multivalue"`
+}
+
+// SequenceConfig maps the sequence.* section.
+type SequenceConfig struct {
+	Editor string `gitconfig:"editor"`
+}
+
+// SplitIndexConfig maps the splitIndex.* section.
+type SplitIndexConfig struct {
+	MaxPercentChange  int        `gitconfig:"maxpercentchange" gitconfigDefault:"20"`
+	SharedIndexExpire ExpiryDate `gitconfig:"sharedindexexpire" gitconfigDefault:"2.weeks.ago"`
+}
+
+// SSHConfig maps the ssh.* section.
+type SSHConfig struct {
+	Variant string `gitconfig:"variant"`
+}
+
+// StashConfig maps the stash.* section.
+type StashConfig struct {
+	Index                *bool `gitconfig:"index"`
+	ShowIncludeUntracked *bool `gitconfig:"showincludeuntracked"`
+	ShowPatch            *bool `gitconfig:"showpatch"`
+	ShowStat             *bool `gitconfig:"showstat" gitconfigDefault:"true"`
+}
+
+// StatusConfig maps the status.* section.
+type StatusConfig struct {
+	RelativePaths        *bool     `gitconfig:"relativepaths" gitconfigDefault:"true"`
+	Short                *bool     `gitconfig:"short"`
+	Branch               *bool     `gitconfig:"branch"`
+	AheadBehind          *bool     `gitconfig:"aheadbehind" gitconfigDefault:"true"`
+	DisplayCommentPrefix *bool     `gitconfig:"displaycommentprefix"`
+	RenameLimit          int       `gitconfig:"renamelimit"`
+	Renames              string    `gitconfig:"renames"`
+	ShowStash            *bool     `gitconfig:"showstash"`
+	ShowUntrackedFiles   string    `gitconfig:"showuntrackedfiles" gitconfigDefault:"normal"`
+	SubmoduleSummary     BoolOrInt `gitconfig:"submodulesummary"`
+}
+
+// SubmoduleConfig maps a submodule.<name>.* subsection.
+type SubmoduleConfig struct {
+	URL                    string `gitconfig:"url"`
+	Update                 string `gitconfig:"update"`
+	Branch                 string `gitconfig:"branch"`
+	FetchRecurseSubmodules string `gitconfig:"fetchrecursesubmodules"`
+	Ignore                 string `gitconfig:"ignore"`
+	Active                 *bool  `gitconfig:"active"`
+}
+
+// SubmoduleGlobals maps the submodule.* section-level variables.
+type SubmoduleGlobals struct {
+	Active                 []string `gitconfig:"active,multivalue"`
+	Recurse                *bool    `gitconfig:"recurse"`
+	PropagateBranches      *bool    `gitconfig:"propagatebranches"`
+	FetchJobs              int      `gitconfig:"fetchjobs" gitconfigDefault:"1"`
+	AlternateLocation      string   `gitconfig:"alternatelocation"`
+	AlternateErrorStrategy string   `gitconfig:"alternateerrorstrategy" gitconfigDefault:"die"`
+}
+
+// TagConfig maps the tag.* section.
+type TagConfig struct {
+	ForceSignAnnotated *bool  `gitconfig:"forcesignannotated"`
+	Sort               string `gitconfig:"sort"`
+	GPGSign            *bool  `gitconfig:"gpgsign"`
+}
+
+// TrailerConfig maps the trailer.* section.
+type TrailerConfig struct {
+	Separators string `gitconfig:"separators"`
+	Where      string `gitconfig:"where" gitconfigDefault:"end"`
+	IfExists   string `gitconfig:"ifexists" gitconfigDefault:"addIfDifferentNeighbor"`
+	IfMissing  string `gitconfig:"ifmissing" gitconfigDefault:"add"`
+}
+
+// TrailerKeyConfig maps a trailer.<keyAlias>.* subsection.
+type TrailerKeyConfig struct {
+	Key       string `gitconfig:"key"`
+	Where     string `gitconfig:"where"`
+	IfExists  string `gitconfig:"ifexists"`
+	IfMissing string `gitconfig:"ifmissing"`
+	Command   string `gitconfig:"command"`
+	Cmd       string `gitconfig:"cmd"`
+}
+
+// TransferConfig maps the transfer.* section.
+type TransferConfig struct {
+	CredentialsInURL    string   `gitconfig:"credentialsinurl" gitconfigDefault:"allow"`
+	FsckObjects         *bool    `gitconfig:"fsckobjects"`
+	HideRefs            []string `gitconfig:"hiderefs,multivalue"`
+	UnpackLimit         int      `gitconfig:"unpacklimit" gitconfigDefault:"100"`
+	AdvertiseSID        *bool    `gitconfig:"advertisesid"`
+	BundleURI           *bool    `gitconfig:"bundleuri"`
+	AdvertiseObjectInfo *bool    `gitconfig:"advertiseobjectinfo"`
+}
+
+// UploadPackConfig maps the uploadpack.* section.
+type UploadPackConfig struct {
+	HideRefs                 []string `gitconfig:"hiderefs,multivalue"`
+	AllowTipSHA1InWant       *bool    `gitconfig:"allowtipsha1inwant"`
+	AllowReachableSHA1InWant *bool    `gitconfig:"allowreachablesha1inwant"`
+	AllowAnySHA1InWant       *bool    `gitconfig:"allowanysha1inwant"`
+	KeepAlive                int      `gitconfig:"keepalive" gitconfigDefault:"5"`
+	PackObjectsHook          string   `gitconfig:"packobjectshook"`
+	AllowFilter              *bool    `gitconfig:"allowfilter"`
+}
+
+// URLConfig maps a url.<base>.* subsection.
+type URLConfig struct {
+	InsteadOf     []string `gitconfig:"insteadof,multivalue"`
+	PushInsteadOf []string `gitconfig:"pushinsteadof,multivalue"`
+}
+
+// UserConfig maps the user.* section.
+type UserConfig struct {
+	Name          string `gitconfig:"name"`
+	Email         string `gitconfig:"email"`
+	SigningKey    string `gitconfig:"signingkey"`
+	UseConfigOnly *bool  `gitconfig:"useconfigonly"`
+}
+
+// AuthorConfig maps the author.* section.
+type AuthorConfig struct {
+	Name  string `gitconfig:"name"`
+	Email string `gitconfig:"email"`
+}
+
+// CommitterConfig maps the committer.* section.
+type CommitterConfig struct {
+	Name  string `gitconfig:"name"`
+	Email string `gitconfig:"email"`
+}
+
+// WorktreeConfig maps the worktree.* section.
+type WorktreeConfig struct {
+	GuessRemote      *bool `gitconfig:"guessremote"`
+	UseRelativePaths *bool `gitconfig:"userelativepaths"`
+}
+
+// IncludeConfig maps the include.* section.
+type IncludeConfig struct {
+	Path []Pathname `gitconfig:"path,multivalue"`
+}
+
+// IncludeIfConfig maps an includeIf.<condition>.* subsection.
+type IncludeIfConfig struct {
+	Path []Pathname `gitconfig:"path,multivalue"`
+}
+
+// PagerConfig maps a pager.<cmd> subsection.
+type PagerConfig struct {
+	Cmd string `gitconfig:"cmd"`
+}
+
+// PrettyConfig maps a pretty.<name> subsection.
+type PrettyConfig struct {
+	Format string `gitconfig:"format"`
+}
+
+// RefTableConfig maps the reftable.* section.
+type RefTableConfig struct {
+	BlockSize       int   `gitconfig:"blocksize" gitconfigDefault:"4096"`
+	RestartInterval int   `gitconfig:"restartinterval"`
+	IndexObjects    *bool `gitconfig:"indexobjects" gitconfigDefault:"true"`
+	GeometricFactor int   `gitconfig:"geometricfactor" gitconfigDefault:"2"`
+	LockTimeout     int   `gitconfig:"locktimeout" gitconfigDefault:"100"`
+}
+
+// RemotesConfig maps a remotes.<group> subsection.
+type RemotesConfig struct {
+	Remotes []string `gitconfig:"remotes,multivalue"`
+}
+
+// Config is the top-level struct encompassing all Git configuration variables
+// as documented in the git-config specification. It uses struct tags from
+// the x/config package to drive marshaling and unmarshaling.
+type Config struct {
+	Core             CoreConfig                        `gitconfig:"core"`
+	User             UserConfig                        `gitconfig:"user"`
+	Author           AuthorConfig                      `gitconfig:"author"`
+	Committer        CommitterConfig                   `gitconfig:"committer"`
+	Advice           AdviceConfig                      `gitconfig:"advice"`
+	Aliases          map[string]*AliasConfig           `gitconfig:"alias,subsection"`
+	Branches         map[string]*BranchConfig          `gitconfig:"branch,subsection"`
+	Browsers         map[string]*BrowserConfig         `gitconfig:"browser,subsection"`
+	Checkout         CheckoutConfig                    `gitconfig:"checkout"`
+	Clean            CleanConfig                       `gitconfig:"clean"`
+	Clone            CloneConfig                       `gitconfig:"clone"`
+	Color            ColorConfig                       `gitconfig:"color"`
+	ColorBranch      *ColorBranchSlots                 `gitconfig:"color,subsection" gitconfigSub:"branch"`
+	ColorDiff        *ColorDiffSlots                   `gitconfig:"color,subsection" gitconfigSub:"diff"`
+	ColorDecorate    *ColorDecorateSlots               `gitconfig:"color,subsection" gitconfigSub:"decorate"`
+	ColorGrep        *ColorGrepSlots                   `gitconfig:"color,subsection" gitconfigSub:"grep"`
+	ColorInteractive *ColorInteractiveSlots            `gitconfig:"color,subsection" gitconfigSub:"interactive"`
+	ColorPush        *ColorPushSlots                   `gitconfig:"color,subsection" gitconfigSub:"push"`
+	ColorRemote      *ColorRemoteSlots                 `gitconfig:"color,subsection" gitconfigSub:"remote"`
+	ColorStatus      *ColorStatusSlots                 `gitconfig:"color,subsection" gitconfigSub:"status"`
+	ColorTransport   *ColorTransportSlots              `gitconfig:"color,subsection" gitconfigSub:"transport"`
+	Column           ColumnConfig                      `gitconfig:"column"`
+	Commit           CommitConfig                      `gitconfig:"commit"`
+	CommitGraph      CommitGraphConfig                 `gitconfig:"commitgraph"`
+	Credential       CredentialConfig                  `gitconfig:"credential"`
+	Credentials      map[string]*CredentialURLConfig   `gitconfig:"credential,subsection"`
+	Diff             DiffConfig                        `gitconfig:"diff"`
+	DiffDrivers      map[string]*DiffDriverConfig      `gitconfig:"diff,subsection"`
+	Difftools        map[string]*DifftoolConfig        `gitconfig:"difftool,subsection"`
+	Extensions       ExtensionsConfig                  `gitconfig:"extensions"`
+	Feature          FeatureConfig                     `gitconfig:"feature"`
+	Fetch            FetchConfig                       `gitconfig:"fetch"`
+	FilterDrivers    map[string]*FilterDriverConfig    `gitconfig:"filter,subsection"`
+	Format           FormatConfig                      `gitconfig:"format"`
+	Fsck             FsckConfig                        `gitconfig:"fsck"`
+	Fsmonitor        FsmonitorConfig                   `gitconfig:"fsmonitor"`
+	Gc               GcConfig                          `gitconfig:"gc"`
+	GPG              GPGConfig                         `gitconfig:"gpg"`
+	GPGSSH           *GPGSSHConfig                     `gitconfig:"gpg,subsection" gitconfigSub:"ssh"`
+	GPGFormats       map[string]*GPGFormatConfig       `gitconfig:"gpg,subsection"`
+	Grep             GrepConfig                        `gitconfig:"grep"`
+	Help             HelpConfig                        `gitconfig:"help"`
+	HTTP             HTTPConfig                        `gitconfig:"http"`
+	HTTPURLs         map[string]*HTTPURLConfig         `gitconfig:"http,subsection"`
+	I18n             I18nConfig                        `gitconfig:"i18n"`
+	Index            IndexConfig                       `gitconfig:"index"`
+	Init             InitConfig                        `gitconfig:"init"`
+	Interactive      InteractiveConfig                 `gitconfig:"interactive"`
+	Log              LogConfig                         `gitconfig:"log"`
+	Maintenance      MaintenanceConfig                 `gitconfig:"maintenance"`
+	MaintenanceTasks map[string]*MaintenanceTaskConfig `gitconfig:"maintenance,subsection"`
+	Merge            MergeConfig                       `gitconfig:"merge"`
+	MergeDrivers     map[string]*MergeDriverConfig     `gitconfig:"merge,subsection"`
+	Mergetool        MergetoolGlobals                  `gitconfig:"mergetool"`
+	MergetoolTools   map[string]*MergetoolConfig       `gitconfig:"mergetool,subsection"`
+	Notes            NotesConfig                       `gitconfig:"notes"`
+	NotesNames       map[string]*NotesNameConfig       `gitconfig:"notes,subsection"`
+	Pack             PackConfig                        `gitconfig:"pack"`
+	PagerCmds        map[string]*PagerConfig           `gitconfig:"pager,subsection"`
+	PrettyNames      map[string]*PrettyConfig          `gitconfig:"pretty,subsection"`
+	Protocol         ProtocolConfig                    `gitconfig:"protocol"`
+	ProtocolNames    map[string]*ProtocolNameConfig    `gitconfig:"protocol,subsection"`
+	Pull             PullConfig                        `gitconfig:"pull"`
+	Push             PushConfig                        `gitconfig:"push"`
+	Rebase           RebaseConfig                      `gitconfig:"rebase"`
+	Receive          ReceiveConfig                     `gitconfig:"receive"`
+	RefTable         RefTableConfig                    `gitconfig:"reftable"`
+	RemoteNames      map[string]*RemoteConfig          `gitconfig:"remote,subsection"`
+	Remotes          map[string]*RemotesConfig         `gitconfig:"remotes,subsection"`
+	Repack           RepackConfig                      `gitconfig:"repack"`
+	Rerere           RerereConfig                      `gitconfig:"rerere"`
+	Safe             SafeConfig                        `gitconfig:"safe"`
+	Sequence         SequenceConfig                    `gitconfig:"sequence"`
+	SplitIndex       SplitIndexConfig                  `gitconfig:"splitindex"`
+	SSH              SSHConfig                         `gitconfig:"ssh"`
+	Stash            StashConfig                       `gitconfig:"stash"`
+	Status           StatusConfig                      `gitconfig:"status"`
+	SubmoduleGlobals SubmoduleGlobals                  `gitconfig:"submodule"`
+	Submodules       map[string]*SubmoduleConfig       `gitconfig:"submodule,subsection"`
+	Tag              TagConfig                         `gitconfig:"tag"`
+	Trailer          TrailerConfig                     `gitconfig:"trailer"`
+	Trailers         map[string]*TrailerKeyConfig      `gitconfig:"trailer,subsection"`
+	Transfer         TransferConfig                    `gitconfig:"transfer"`
+	UploadPack       UploadPackConfig                  `gitconfig:"uploadpack"`
+	URLs             map[string]*URLConfig             `gitconfig:"url,subsection"`
+	Worktree         WorktreeConfig                    `gitconfig:"worktree"`
+	Include          IncludeConfig                     `gitconfig:"include"`
+	Includes         map[string]*IncludeIfConfig       `gitconfig:"includeif,subsection"`
+}

--- a/x/config/config_test.go
+++ b/x/config/config_test.go
@@ -1,0 +1,706 @@
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
+)
+
+func parseRaw(t *testing.T, input string) *format.Config {
+	t.Helper()
+	raw := format.New()
+	if err := format.NewDecoder(bytes.NewReader([]byte(input))).Decode(raw); err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func encodeRaw(t *testing.T, raw *format.Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := format.NewEncoder(&buf).Encode(raw); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func TestUnmarshalBasicSection(t *testing.T) {
+	t.Parallel()
+	raw := parseRaw(t, "[core]\n\tbare = true\n\tworktree = /path/to/wt\n\tcommentchar = \"#\"\n")
+
+	type Core struct {
+		Bare        bool   `gitconfig:"bare"`
+		Worktree    string `gitconfig:"worktree"`
+		CommentChar string `gitconfig:"commentchar"`
+	}
+	type Config struct {
+		Core Core `gitconfig:"core"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if !cfg.Core.Bare {
+		t.Error("expected Core.Bare = true")
+	}
+	if cfg.Core.Worktree != "/path/to/wt" {
+		t.Errorf("expected Core.Worktree = /path/to/wt, got %q", cfg.Core.Worktree)
+	}
+	if cfg.Core.CommentChar != "#" {
+		t.Errorf("expected Core.CommentChar = #, got %q", cfg.Core.CommentChar)
+	}
+}
+
+func TestUnmarshalBoolVariants(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"true", true},
+		{"True", true},
+		{"TRUE", true},
+		{"yes", true},
+		{"on", true},
+		{"1", true},
+		{"false", false},
+		{"False", false},
+		{"FALSE", false},
+		{"no", false},
+		{"off", false},
+		{"0", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			raw := parseRaw(t, "[core]\n\tbare = "+tt.input+"\n")
+
+			type Core struct {
+				Bare bool `gitconfig:"bare"`
+			}
+			type Config struct {
+				Core Core `gitconfig:"core"`
+			}
+
+			var cfg Config
+			if err := Unmarshal(raw, &cfg); err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Core.Bare != tt.want {
+				t.Errorf("input %q: got %v, want %v", tt.input, cfg.Core.Bare, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnmarshalPointerBool(t *testing.T) {
+	t.Parallel()
+	type Index struct {
+		SkipHash *bool `gitconfig:"skiphash"`
+	}
+	type Config struct {
+		Index Index `gitconfig:"index"`
+	}
+
+	t.Run("absent", func(t *testing.T) {
+		t.Parallel()
+		var cfg Config
+		if err := Unmarshal(parseRaw(t, "[index]\n"), &cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Index.SkipHash != nil {
+			t.Error("expected nil for absent key")
+		}
+	})
+
+	t.Run("true", func(t *testing.T) {
+		t.Parallel()
+		var cfg Config
+		if err := Unmarshal(parseRaw(t, "[index]\n\tskiphash = true\n"), &cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Index.SkipHash == nil || !*cfg.Index.SkipHash {
+			t.Error("expected *true")
+		}
+	})
+
+	t.Run("false", func(t *testing.T) {
+		t.Parallel()
+		var cfg Config
+		if err := Unmarshal(parseRaw(t, "[index]\n\tskiphash = false\n"), &cfg); err != nil {
+			t.Fatal(err)
+		}
+		if cfg.Index.SkipHash == nil || *cfg.Index.SkipHash {
+			t.Error("expected *false")
+		}
+	})
+}
+
+func TestUnmarshalIntegers(t *testing.T) {
+	t.Parallel()
+	raw := parseRaw(t, "[pack]\n\twindow = 15\n\tdepth = 50\n")
+
+	type Pack struct {
+		Window uint `gitconfig:"window"`
+		Depth  int  `gitconfig:"depth"`
+	}
+	type Config struct {
+		Pack Pack `gitconfig:"pack"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Pack.Window != 15 {
+		t.Errorf("expected window=15, got %d", cfg.Pack.Window)
+	}
+	if cfg.Pack.Depth != 50 {
+		t.Errorf("expected depth=50, got %d", cfg.Pack.Depth)
+	}
+}
+
+func TestUnmarshalDefault(t *testing.T) {
+	t.Parallel()
+	type Core struct {
+		CommentChar string `gitconfig:"commentchar" gitconfigDefault:"#"`
+		Window      int    `gitconfig:"window" gitconfigDefault:"10"`
+	}
+	type Config struct {
+		Core Core `gitconfig:"core"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(parseRaw(t, "[core]\n"), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Core.CommentChar != "#" {
+		t.Errorf("expected default #, got %q", cfg.Core.CommentChar)
+	}
+	if cfg.Core.Window != 10 {
+		t.Errorf("expected default 10, got %d", cfg.Core.Window)
+	}
+}
+
+func TestUnmarshalSubsectionMap(t *testing.T) {
+	t.Parallel()
+	raw := parseRaw(t, `[remote "origin"]
+	url = https://github.com/go-git/go-git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "upstream"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/upstream/*
+`)
+
+	type Remote struct {
+		URL   []string `gitconfig:"url,multivalue"`
+		Fetch []string `gitconfig:"fetch,multivalue"`
+	}
+	type Config struct {
+		Remotes map[string]*Remote `gitconfig:"remote,subsection"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.Remotes) != 2 {
+		t.Fatalf("expected 2 remotes, got %d", len(cfg.Remotes))
+	}
+
+	origin := cfg.Remotes["origin"]
+	if origin == nil {
+		t.Fatal("missing remote origin")
+	}
+	if len(origin.URL) != 1 || origin.URL[0] != "https://github.com/go-git/go-git" {
+		t.Errorf("unexpected origin URL: %v", origin.URL)
+	}
+
+	upstream := cfg.Remotes["upstream"]
+	if upstream == nil {
+		t.Fatal("missing remote upstream")
+	}
+}
+
+func TestUnmarshalMultipleURLs(t *testing.T) {
+	t.Parallel()
+	raw := parseRaw(t, `[remote "origin"]
+	url = https://github.com/go-git/go-git
+	url = git@github.com:go-git/go-git.git
+`)
+
+	type Remote struct {
+		URL []string `gitconfig:"url,multivalue"`
+	}
+	type Config struct {
+		Remotes map[string]*Remote `gitconfig:"remote,subsection"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	origin := cfg.Remotes["origin"]
+	if origin == nil {
+		t.Fatal("missing remote origin")
+	}
+	if len(origin.URL) != 2 {
+		t.Fatalf("expected 2 URLs, got %d", len(origin.URL))
+	}
+	if origin.URL[0] != "https://github.com/go-git/go-git" {
+		t.Errorf("unexpected URL[0]: %s", origin.URL[0])
+	}
+	if origin.URL[1] != "git@github.com:go-git/go-git.git" {
+		t.Errorf("unexpected URL[1]: %s", origin.URL[1])
+	}
+}
+
+func TestUnmarshalSingleSubsection(t *testing.T) {
+	t.Parallel()
+	raw := parseRaw(t, `[gpg]
+	format = ssh
+[gpg "ssh"]
+	program = /usr/bin/ssh-keygen
+	allowedsignersfile = ~/.ssh/allowed_signers
+`)
+
+	type SSHConfig struct {
+		Program            string `gitconfig:"program"`
+		AllowedSignersFile string `gitconfig:"allowedsignersfile"`
+	}
+	type GPGConfig struct {
+		Format string `gitconfig:"format"`
+	}
+	type Config struct {
+		GPG    GPGConfig  `gitconfig:"gpg"`
+		GPGSSH *SSHConfig `gitconfig:"gpg,subsection" gitconfigSub:"ssh"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.GPG.Format != "ssh" {
+		t.Errorf("expected format=ssh, got %q", cfg.GPG.Format)
+	}
+	if cfg.GPGSSH == nil {
+		t.Fatal("expected GPGSSH to be set")
+	}
+	if cfg.GPGSSH.Program != "/usr/bin/ssh-keygen" {
+		t.Errorf("unexpected program: %q", cfg.GPGSSH.Program)
+	}
+	if cfg.GPGSSH.AllowedSignersFile != "~/.ssh/allowed_signers" {
+		t.Errorf("unexpected allowedSignersFile: %q", cfg.GPGSSH.AllowedSignersFile)
+	}
+}
+
+func TestUnmarshalCustomType(t *testing.T) {
+	t.Parallel()
+	raw := parseRaw(t, "[http]\n\tfollowredirects = initial\n")
+
+	type HTTP struct {
+		FollowRedirects *customEnum `gitconfig:"followredirects"`
+	}
+	type Config struct {
+		HTTP HTTP `gitconfig:"http"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.HTTP.FollowRedirects == nil {
+		t.Fatal("expected non-nil")
+	}
+	if string(*cfg.HTTP.FollowRedirects) != "initial" {
+		t.Errorf("expected initial, got %q", *cfg.HTTP.FollowRedirects)
+	}
+}
+
+type customEnum string
+
+func (c *customEnum) UnmarshalGitConfig(data []byte) error {
+	*c = customEnum(data)
+	return nil
+}
+
+func (c customEnum) MarshalGitConfig() (string, error) {
+	return string(c), nil
+}
+
+func TestUnmarshalCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	raw := parseRaw(t, "[Core]\n\tBare = true\n")
+
+	type Core struct {
+		Bare bool `gitconfig:"bare"`
+	}
+	type Config struct {
+		Core Core `gitconfig:"core"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Core.Bare {
+		t.Error("expected case-insensitive match for section and key")
+	}
+}
+
+func TestMarshalBasic(t *testing.T) {
+	t.Parallel()
+	type Core struct {
+		Bare     bool   `gitconfig:"bare"`
+		Worktree string `gitconfig:"worktree"`
+	}
+	type Config struct {
+		Core Core `gitconfig:"core"`
+	}
+
+	cfg := Config{Core: Core{Bare: true, Worktree: "/path"}}
+	raw := format.New()
+	if err := Marshal(cfg, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	s := encodeRaw(t, raw)
+	if !contains(s, "bare = true") {
+		t.Errorf("expected bare = true in output:\n%s", s)
+	}
+	if !contains(s, "worktree = /path") {
+		t.Errorf("expected worktree = /path in output:\n%s", s)
+	}
+}
+
+func TestMarshalOmitempty(t *testing.T) {
+	t.Parallel()
+	type Core struct {
+		Bare     bool   `gitconfig:"bare,omitempty"`
+		Worktree string `gitconfig:"worktree,omitempty"`
+	}
+	type Config struct {
+		Core Core `gitconfig:"core"`
+	}
+
+	cfg := Config{Core: Core{Bare: false, Worktree: ""}}
+	raw := format.New()
+	if err := Marshal(cfg, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	s := encodeRaw(t, raw)
+	if contains(s, "bare") {
+		t.Error("expected bare to be omitted")
+	}
+	if contains(s, "worktree") {
+		t.Error("expected worktree to be omitted")
+	}
+}
+
+func TestMarshalPointerBool(t *testing.T) {
+	t.Parallel()
+	type Index struct {
+		SkipHash *bool `gitconfig:"skiphash"`
+	}
+	type Config struct {
+		Index Index `gitconfig:"index"`
+	}
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		raw := format.New()
+		if err := Marshal(Config{}, raw); err != nil {
+			t.Fatal(err)
+		}
+		if contains(encodeRaw(t, raw), "skiphash") {
+			t.Error("expected nil pointer to be omitted")
+		}
+	})
+
+	t.Run("true", func(t *testing.T) {
+		t.Parallel()
+		v := true
+		raw := format.New()
+		if err := Marshal(Config{Index: Index{SkipHash: &v}}, raw); err != nil {
+			t.Fatal(err)
+		}
+		if !contains(encodeRaw(t, raw), "skiphash = true") {
+			t.Error("expected skiphash = true")
+		}
+	})
+
+	t.Run("false", func(t *testing.T) {
+		t.Parallel()
+		v := false
+		raw := format.New()
+		if err := Marshal(Config{Index: Index{SkipHash: &v}}, raw); err != nil {
+			t.Fatal(err)
+		}
+		if !contains(encodeRaw(t, raw), "skiphash = false") {
+			t.Error("expected skiphash = false")
+		}
+	})
+}
+
+func TestMarshalSubsectionMap(t *testing.T) {
+	t.Parallel()
+	type Remote struct {
+		URL   []string `gitconfig:"url,multivalue"`
+		Fetch []string `gitconfig:"fetch,multivalue"`
+	}
+	type Config struct {
+		Remotes map[string]*Remote `gitconfig:"remote,subsection"`
+	}
+
+	cfg := Config{
+		Remotes: map[string]*Remote{
+			"origin": {
+				URL:   []string{"https://github.com/go-git/go-git"},
+				Fetch: []string{"+refs/heads/*:refs/remotes/origin/*"},
+			},
+		},
+	}
+
+	raw := format.New()
+	if err := Marshal(cfg, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	s := encodeRaw(t, raw)
+	if !contains(s, `[remote "origin"]`) {
+		t.Errorf("expected remote origin section:\n%s", s)
+	}
+	if !contains(s, "url = https://github.com/go-git/go-git") {
+		t.Errorf("expected url:\n%s", s)
+	}
+}
+
+func TestMarshalSingleSubsection(t *testing.T) {
+	t.Parallel()
+	type SSHConfig struct {
+		Program string `gitconfig:"program"`
+	}
+	type GPGConfig struct {
+		Format string `gitconfig:"format"`
+	}
+	type Config struct {
+		GPG    GPGConfig  `gitconfig:"gpg"`
+		GPGSSH *SSHConfig `gitconfig:"gpg,subsection" gitconfigSub:"ssh"`
+	}
+
+	cfg := Config{
+		GPG:    GPGConfig{Format: "ssh"},
+		GPGSSH: &SSHConfig{Program: "/usr/bin/ssh-keygen"},
+	}
+
+	raw := format.New()
+	if err := Marshal(cfg, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	s := encodeRaw(t, raw)
+	if !contains(s, "format = ssh") {
+		t.Errorf("expected format:\n%s", s)
+	}
+	if !contains(s, `[gpg "ssh"]`) {
+		t.Errorf("expected gpg ssh subsection:\n%s", s)
+	}
+	if !contains(s, "program = /usr/bin/ssh-keygen") {
+		t.Errorf("expected program:\n%s", s)
+	}
+}
+
+func TestMarshalCustomType(t *testing.T) {
+	t.Parallel()
+	type HTTP struct {
+		FollowRedirects customEnum `gitconfig:"followredirects"`
+	}
+	type Config struct {
+		HTTP HTTP `gitconfig:"http"`
+	}
+
+	cfg := Config{HTTP: HTTP{FollowRedirects: "initial"}}
+	raw := format.New()
+	if err := Marshal(cfg, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	if !contains(encodeRaw(t, raw), "followredirects = initial") {
+		t.Error("unexpected output")
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	t.Parallel()
+	input := `[core]
+	bare = true
+	worktree = /path/to/wt
+[remote "origin"]
+	url = https://github.com/go-git/go-git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "upstream"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/upstream/*
+`
+	type Remote struct {
+		URL   []string `gitconfig:"url,multivalue"`
+		Fetch []string `gitconfig:"fetch,multivalue"`
+	}
+	type Core struct {
+		Bare     bool   `gitconfig:"bare"`
+		Worktree string `gitconfig:"worktree"`
+	}
+	type Config struct {
+		Core    Core               `gitconfig:"core"`
+		Remotes map[string]*Remote `gitconfig:"remote,subsection"`
+	}
+
+	raw := parseRaw(t, input)
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	raw2 := format.New()
+	if err := Marshal(cfg, raw2); err != nil {
+		t.Fatal(err)
+	}
+
+	var cfg2 Config
+	if err := Unmarshal(raw2, &cfg2); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg2.Core.Bare != cfg.Core.Bare {
+		t.Error("round-trip: bare mismatch")
+	}
+	if cfg2.Core.Worktree != cfg.Core.Worktree {
+		t.Error("round-trip: worktree mismatch")
+	}
+	if len(cfg2.Remotes) != len(cfg.Remotes) {
+		t.Errorf("round-trip: remotes count mismatch: %d vs %d", len(cfg2.Remotes), len(cfg.Remotes))
+	}
+	for name, r := range cfg.Remotes {
+		r2 := cfg2.Remotes[name]
+		if r2 == nil {
+			t.Errorf("round-trip: missing remote %s", name)
+			continue
+		}
+		if len(r2.URL) != len(r.URL) {
+			t.Errorf("round-trip: remote %s URL count mismatch", name)
+		}
+	}
+}
+
+func TestRoundTripPreservesUnknown(t *testing.T) {
+	t.Parallel()
+	input := `[core]
+	bare = true
+[custom]
+	key = value
+`
+	type Core struct {
+		Bare bool `gitconfig:"bare"`
+	}
+	type Config struct {
+		Core Core `gitconfig:"core"`
+	}
+
+	raw := parseRaw(t, input)
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Marshal(cfg, raw); err != nil {
+		t.Fatal(err)
+	}
+
+	s := encodeRaw(t, raw)
+	if !contains(s, "[custom]") {
+		t.Errorf("expected unknown section preserved:\n%s", s)
+	}
+	if !contains(s, "key = value") {
+		t.Errorf("expected unknown key preserved:\n%s", s)
+	}
+}
+
+func TestUnmarshalInvalidInput(t *testing.T) {
+	t.Parallel()
+	var cfg struct {
+		Core struct {
+			Bare bool `gitconfig:"bare"`
+		} `gitconfig:"core"`
+	}
+
+	err := Unmarshal(parseRaw(t, "[core]\n\tbare = notabool\n"), &cfg)
+	if err == nil {
+		t.Error("expected error for invalid bool")
+	}
+}
+
+func TestUnmarshalNonPointerError(t *testing.T) {
+	t.Parallel()
+	type Config struct{}
+	err := Unmarshal(format.New(), Config{})
+	if err == nil {
+		t.Error("expected error for non-pointer")
+	}
+}
+
+func TestUnmarshalEmptyConfig(t *testing.T) {
+	t.Parallel()
+	type Core struct {
+		Bare bool `gitconfig:"bare"`
+	}
+	type Config struct {
+		Core Core `gitconfig:"core"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(format.New(), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Core.Bare {
+		t.Error("expected false for missing section")
+	}
+}
+
+func TestUnmarshalSkipField(t *testing.T) {
+	t.Parallel()
+	raw := parseRaw(t, "[core]\n\tbare = true\n")
+
+	type Core struct {
+		Bare    bool   `gitconfig:"bare"`
+		Ignored string `gitconfig:"-"`
+	}
+	type Config struct {
+		Core Core `gitconfig:"core"`
+	}
+
+	var cfg Config
+	if err := Unmarshal(raw, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Core.Ignored != "" {
+		t.Error("expected skipped field to be empty")
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/x/config/decode.go
+++ b/x/config/decode.go
@@ -1,0 +1,241 @@
+package config
+
+import (
+	"encoding"
+	"fmt"
+	"reflect"
+
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
+)
+
+// Unmarshal reads fields from a parsed Git config into a struct.
+// v must be a non-nil pointer to a struct.
+//
+// The raw *format.Config is not modified. Unknown sections and keys
+// remain in raw for round-trip fidelity — the caller owns the
+// raw config lifecycle.
+func Unmarshal(raw *format.Config, v any) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return fmt.Errorf("gitconfig: Unmarshal requires a non-nil pointer, got %T", v)
+	}
+	rv = rv.Elem()
+	if rv.Kind() != reflect.Struct {
+		return fmt.Errorf("gitconfig: Unmarshal requires a pointer to a struct, got pointer to %s", rv.Kind())
+	}
+
+	return decodeStruct(rv, raw)
+}
+
+func decodeStruct(rv reflect.Value, raw *format.Config) error {
+	info := getStructInfo(rv.Type())
+
+	for i := range info.fields {
+		sf := &info.fields[i]
+		fv := rv.FieldByIndex(sf.index)
+		sectionName := sf.tag.key
+
+		if sf.tag.subsection && isMapOfPtrStruct(sf.typ) {
+			if err := decodeSubsectionMap(fv, raw, sectionName); err != nil {
+				return fmt.Errorf("gitconfig: %s: %w", sectionName, err)
+			}
+			continue
+		}
+
+		if sf.tag.subsection && sf.isPtr && sf.elemType.Kind() == reflect.Struct {
+			if err := decodeSingleSubsection(fv, raw, sectionName, sf.subName); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sf.elemType.Kind() == reflect.Struct && !implementsUnmarshaler(sf.typ) {
+			if err := decodeSectionFields(fv, raw, sectionName); err != nil {
+				return err
+			}
+			continue
+		}
+	}
+
+	return nil
+}
+
+func decodeSectionFields(fv reflect.Value, raw *format.Config, sectionName string) error {
+	if !raw.HasSection(sectionName) {
+		return nil
+	}
+
+	section := raw.Section(sectionName)
+
+	if fv.Kind() == reflect.Pointer {
+		if fv.IsNil() {
+			fv.Set(reflect.New(fv.Type().Elem()))
+		}
+		fv = fv.Elem()
+	}
+
+	return decodeOptionsInto(fv, section.Options, sectionName)
+}
+
+func decodeOptionsInto(rv reflect.Value, opts format.Options, path string) error {
+	info := getStructInfo(rv.Type())
+
+	for i := range info.fields {
+		sf := &info.fields[i]
+		fv := rv.FieldByIndex(sf.index)
+		if err := decodeOption(fv, opts, sf, path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func decodeOption(fv reflect.Value, opts format.Options, sf *structField, sectionName string) error {
+	key := sf.tag.key
+	path := sectionName + "." + key
+
+	if sf.tag.multivalue {
+		return decodeMultivalue(fv, opts, sf, path)
+	}
+
+	if !opts.Has(key) {
+		if sf.hasDefault {
+			return setFromString(fv, sf.defaultValue, sf, path)
+		}
+		return nil
+	}
+
+	value := opts.Get(key)
+	return setFromString(fv, value, sf, path)
+}
+
+func decodeMultivalue(fv reflect.Value, opts format.Options, sf *structField, path string) error {
+	values := opts.GetAll(sf.tag.key)
+	if len(values) == 0 {
+		return nil
+	}
+
+	sliceType := fv.Type()
+	if sliceType.Kind() != reflect.Slice {
+		return fmt.Errorf("gitconfig: %s: multivalue requires a slice type, got %s", path, sliceType)
+	}
+	elemType := sliceType.Elem()
+	slice := reflect.MakeSlice(sliceType, 0, len(values))
+
+	for _, val := range values {
+		elem := reflect.New(elemType).Elem()
+		if err := setScalar(elem, val, path); err != nil {
+			return err
+		}
+		slice = reflect.Append(slice, elem)
+	}
+
+	fv.Set(slice)
+	return nil
+}
+
+func setFromString(fv reflect.Value, s string, sf *structField, path string) error {
+	if sf.isPtr {
+		ptr := reflect.New(sf.elemType)
+		if err := setScalar(ptr.Elem(), s, path); err != nil {
+			return err
+		}
+		fv.Set(ptr)
+		return nil
+	}
+	return setScalar(fv, s, path)
+}
+
+func setScalar(fv reflect.Value, s, path string) error {
+	addr := fv
+	if fv.CanAddr() {
+		addr = fv.Addr()
+	}
+
+	if addr.CanInterface() {
+		if u, ok := addr.Interface().(Unmarshaler); ok {
+			if err := u.UnmarshalGitConfig([]byte(s)); err != nil {
+				return fmt.Errorf("gitconfig: %s: %w", path, err)
+			}
+			return nil
+		}
+		if u, ok := addr.Interface().(encoding.TextUnmarshaler); ok {
+			if err := u.UnmarshalText([]byte(s)); err != nil {
+				return fmt.Errorf("gitconfig: %s: %w", path, err)
+			}
+			return nil
+		}
+	}
+
+	v, err := stringToValue(s, fv.Type())
+	if err != nil {
+		return fmt.Errorf("gitconfig: %s: %w", path, err)
+	}
+	fv.Set(v)
+	return nil
+}
+
+func decodeSubsectionMap(fv reflect.Value, raw *format.Config, sectionName string) error {
+	if !raw.HasSection(sectionName) {
+		return nil
+	}
+
+	section := raw.Section(sectionName)
+	if len(section.Subsections) == 0 {
+		return nil
+	}
+
+	mapType := fv.Type()
+	elemType := mapType.Elem().Elem()
+
+	if fv.IsNil() {
+		fv.Set(reflect.MakeMap(mapType))
+	}
+
+	for _, sub := range section.Subsections {
+		newVal := reflect.New(elemType)
+		if err := decodeOptionsInto(newVal.Elem(), sub.Options, sectionName+"."+sub.Name); err != nil {
+			return err
+		}
+		fv.SetMapIndex(reflect.ValueOf(sub.Name), newVal)
+	}
+
+	return nil
+}
+
+func decodeSingleSubsection(fv reflect.Value, raw *format.Config, sectionName, subName string) error {
+	if !raw.HasSection(sectionName) {
+		return nil
+	}
+
+	section := raw.Section(sectionName)
+	if !section.HasSubsection(subName) {
+		return nil
+	}
+
+	sub := section.Subsection(subName)
+	newVal := reflect.New(fv.Type().Elem())
+	if err := decodeOptionsInto(newVal.Elem(), sub.Options, sectionName+"."+subName); err != nil {
+		return err
+	}
+	fv.Set(newVal)
+	return nil
+}
+
+func isMapOfPtrStruct(t reflect.Type) bool {
+	return t.Kind() == reflect.Map &&
+		t.Key().Kind() == reflect.String &&
+		t.Elem().Kind() == reflect.Pointer &&
+		t.Elem().Elem().Kind() == reflect.Struct
+}
+
+func implementsUnmarshaler(t reflect.Type) bool {
+	unmarshalerType := reflect.TypeFor[Unmarshaler]()
+	textUnmarshalerType := reflect.TypeFor[encoding.TextUnmarshaler]()
+
+	return t.Implements(unmarshalerType) ||
+		reflect.PointerTo(t).Implements(unmarshalerType) ||
+		t.Implements(textUnmarshalerType) ||
+		reflect.PointerTo(t).Implements(textUnmarshalerType)
+}

--- a/x/config/doc.go
+++ b/x/config/doc.go
@@ -1,0 +1,47 @@
+// Package config provides struct-tag-based marshaling and unmarshaling of
+// Git INI-style configuration files.
+//
+// It works similarly to encoding/json: define a Go struct with `gitconfig`
+// tags and call [Unmarshal] or [Marshal] to convert between the struct and
+// a parsed Git config ([github.com/go-git/go-git/v6/plumbing/format/config.Config]).
+//
+// # Struct Tags
+//
+// The `gitconfig` struct tag controls how fields are mapped:
+//
+//	type Core struct {
+//	    IsBare   bool   `gitconfig:"bare"`
+//	    Worktree string `gitconfig:"worktree"`
+//	}
+//
+// Tag options are comma-separated after the key name:
+//
+//   - omitempty: skip zero-value fields on marshal
+//   - multivalue: collect all occurrences into a slice
+//   - subsection: this field maps to Git subsections
+//   - -: skip this field entirely
+//
+// Additional tag keys provide parameterized values:
+//
+//   - gitconfigDefault: literal default value when key is absent
+//   - gitconfigSub: fixed subsection name for single named subsections
+//
+// # Sections and Subsections
+//
+// All fields are declared at the root struct level. The `gitconfig` tag key
+// is always the section name. Both section-key fields and subsection fields
+// can share the same section name:
+//
+//	type Config struct {
+//	    Core    CoreConfig               `gitconfig:"core"`
+//	    Remotes map[string]*RemoteConfig `gitconfig:"remote,subsection"`
+//	    GPG     GPGConfig                `gitconfig:"gpg"`
+//	    GPGSSH  *SSHConfig               `gitconfig:"gpg,subsection" gitconfigSub:"ssh"`
+//	}
+//
+// # Custom Types
+//
+// Types implementing [Marshaler] or [Unmarshaler] control their own
+// serialization. The package also checks for [encoding.TextMarshaler]
+// and [encoding.TextUnmarshaler] as fallbacks.
+package config

--- a/x/config/encode.go
+++ b/x/config/encode.go
@@ -1,0 +1,280 @@
+package config
+
+import (
+	"encoding"
+	"fmt"
+	"reflect"
+	"sort"
+
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
+)
+
+// Marshal writes struct fields into a parsed Git config.
+// Existing keys in raw are updated; new keys are added.
+// Unknown keys already in raw are preserved.
+func Marshal(v any, raw *format.Config) error {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Pointer {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return fmt.Errorf("gitconfig: Marshal requires a struct, got %s", rv.Kind())
+	}
+
+	return encodeStruct(rv, raw)
+}
+
+func encodeStruct(rv reflect.Value, raw *format.Config) error {
+	info := getStructInfo(rv.Type())
+
+	for i := range info.fields {
+		sf := &info.fields[i]
+		fv := rv.FieldByIndex(sf.index)
+		sectionName := sf.tag.key
+
+		if sf.tag.subsection && isMapOfPtrStruct(sf.typ) {
+			if err := encodeSubsectionMap(fv, raw, sectionName); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sf.tag.subsection && sf.isPtr && sf.elemType.Kind() == reflect.Struct {
+			if err := encodeSingleSubsection(fv, raw, sectionName, sf.subName); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sf.elemType.Kind() == reflect.Struct && !implementsMarshaler(sf.typ) {
+			if err := encodeSectionFields(fv, raw, sectionName); err != nil {
+				return err
+			}
+			continue
+		}
+	}
+
+	return nil
+}
+
+func encodeSectionFields(fv reflect.Value, raw *format.Config, sectionName string) error {
+	if fv.Kind() == reflect.Pointer {
+		if fv.IsNil() {
+			return nil
+		}
+		fv = fv.Elem()
+	}
+
+	section := raw.Section(sectionName)
+	return encodeOptionsFrom(fv, section, sectionName)
+}
+
+func encodeOptionsFrom(rv reflect.Value, section *format.Section, sectionName string) error {
+	info := getStructInfo(rv.Type())
+
+	for i := range info.fields {
+		sf := &info.fields[i]
+		fv := rv.FieldByIndex(sf.index)
+		if err := encodeOption(section, fv, sf, sectionName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func encodeOption(section *format.Section, fv reflect.Value, sf *structField, sectionName string) error {
+	key := sf.tag.key
+
+	if sf.tag.multivalue {
+		return encodeMultivalue(section, fv, sf, sectionName)
+	}
+
+	if sf.isPtr {
+		if fv.IsNil() {
+			return nil
+		}
+		fv = fv.Elem()
+	}
+
+	if sf.tag.omitempty && isZero(fv) {
+		return nil
+	}
+
+	s, err := marshalValue(fv)
+	if err != nil {
+		return fmt.Errorf("gitconfig: %s.%s: %w", sectionName, key, err)
+	}
+
+	section.SetOption(key, s)
+	return nil
+}
+
+func encodeMultivalue(section *format.Section, fv reflect.Value, sf *structField, sectionName string) error {
+	key := sf.tag.key
+
+	if fv.Kind() != reflect.Slice || fv.Len() == 0 {
+		return nil
+	}
+
+	section.RemoveOption(key)
+	for i := range fv.Len() {
+		s, err := marshalValue(fv.Index(i))
+		if err != nil {
+			return fmt.Errorf("gitconfig: %s.%s[%d]: %w", sectionName, key, i, err)
+		}
+		section.AddOption(key, s)
+	}
+	return nil
+}
+
+func encodeSubsectionMap(fv reflect.Value, raw *format.Config, sectionName string) error {
+	if fv.IsNil() || fv.Len() == 0 {
+		return nil
+	}
+
+	section := raw.Section(sectionName)
+	keys := sortedMapKeys(fv)
+
+	for _, name := range keys {
+		val := fv.MapIndex(reflect.ValueOf(name))
+		if val.IsNil() {
+			continue
+		}
+
+		sub := section.Subsection(name)
+		if err := encodeSubsectionOptionsFrom(val.Elem(), sub, sectionName+"."+name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func encodeSingleSubsection(fv reflect.Value, raw *format.Config, sectionName, subName string) error {
+	if fv.IsNil() {
+		return nil
+	}
+
+	section := raw.Section(sectionName)
+	sub := section.Subsection(subName)
+	return encodeSubsectionOptionsFrom(fv.Elem(), sub, sectionName+"."+subName)
+}
+
+func encodeSubsectionOptionsFrom(rv reflect.Value, sub *format.Subsection, path string) error {
+	info := getStructInfo(rv.Type())
+
+	for i := range info.fields {
+		sf := &info.fields[i]
+		fv := rv.FieldByIndex(sf.index)
+		key := sf.tag.key
+
+		if sf.tag.multivalue {
+			if fv.Kind() != reflect.Slice || fv.Len() == 0 {
+				continue
+			}
+			values := make([]string, 0, fv.Len())
+			for j := range fv.Len() {
+				s, err := marshalValue(fv.Index(j))
+				if err != nil {
+					return fmt.Errorf("gitconfig: %s.%s[%d]: %w", path, key, j, err)
+				}
+				values = append(values, s)
+			}
+			sub.SetOption(key, values...)
+			continue
+		}
+
+		if sf.isPtr {
+			if fv.IsNil() {
+				continue
+			}
+			fv = fv.Elem()
+		}
+
+		if sf.tag.omitempty && isZero(fv) {
+			continue
+		}
+
+		s, err := marshalValue(fv)
+		if err != nil {
+			return fmt.Errorf("gitconfig: %s.%s: %w", path, key, err)
+		}
+		sub.SetOption(key, s)
+	}
+
+	return nil
+}
+
+func marshalValue(fv reflect.Value) (string, error) {
+	if fv.CanInterface() {
+		if m, ok := fv.Interface().(Marshaler); ok {
+			return m.MarshalGitConfig()
+		}
+		if m, ok := fv.Interface().(encoding.TextMarshaler); ok {
+			b, err := m.MarshalText()
+			if err != nil {
+				return "", err
+			}
+			return string(b), nil
+		}
+	}
+
+	if fv.CanAddr() {
+		addr := fv.Addr()
+		if m, ok := addr.Interface().(Marshaler); ok {
+			return m.MarshalGitConfig()
+		}
+		if m, ok := addr.Interface().(encoding.TextMarshaler); ok {
+			b, err := m.MarshalText()
+			if err != nil {
+				return "", err
+			}
+			return string(b), nil
+		}
+	}
+
+	return valueToString(fv)
+}
+
+func isZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.String:
+		return v.String() == ""
+	case reflect.Slice, reflect.Map:
+		return v.IsNil() || v.Len() == 0
+	case reflect.Pointer, reflect.Interface:
+		return v.IsNil()
+	case reflect.Struct:
+		return v.IsZero()
+	default:
+		return false
+	}
+}
+
+func implementsMarshaler(t reflect.Type) bool {
+	marshalerType := reflect.TypeFor[Marshaler]()
+	textMarshalerType := reflect.TypeFor[encoding.TextMarshaler]()
+
+	return t.Implements(marshalerType) ||
+		reflect.PointerTo(t).Implements(marshalerType) ||
+		t.Implements(textMarshalerType) ||
+		reflect.PointerTo(t).Implements(textMarshalerType)
+}
+
+func sortedMapKeys(m reflect.Value) []string {
+	keys := make([]string, 0, m.Len())
+	for _, k := range m.MapKeys() {
+		keys = append(keys, k.String())
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/x/config/gitconfig_test.go
+++ b/x/config/gitconfig_test.go
@@ -1,0 +1,726 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGitSizeUnmarshal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  int64
+	}{
+		{"0", 0},
+		{"1024", 1024},
+		{"1k", 1024},
+		{"1K", 1024},
+		{"512k", 512 * 1024},
+		{"1m", 1024 * 1024},
+		{"2M", 2 * 1024 * 1024},
+		{"1g", 1024 * 1024 * 1024},
+		{"4G", 4 * 1024 * 1024 * 1024},
+		{"256m", 256 * 1024 * 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			var s GitSize
+			if err := s.UnmarshalGitConfig([]byte(tt.input)); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if s.Int64() != tt.want {
+				t.Errorf("NewGitSize(%q).Int64() = %d, want %d", tt.input, s.Int64(), tt.want)
+			}
+		})
+	}
+}
+
+func TestGitSizeUnmarshalPlainInt(t *testing.T) {
+	t.Parallel()
+	var s GitSize
+	if err := s.UnmarshalGitConfig([]byte("4096")); err != nil {
+		t.Fatal(err)
+	}
+	if s.Int64() != 4096 {
+		t.Errorf("got %d, want 4096", s.Int64())
+	}
+}
+
+func TestGitSizeUnmarshalInvalidSuffix(t *testing.T) {
+	t.Parallel()
+	var s GitSize
+	err := s.UnmarshalGitConfig([]byte("1x"))
+	if err == nil {
+		t.Error("expected error for unknown suffix")
+	}
+}
+
+func TestGitSizeUnmarshalEmpty(t *testing.T) {
+	t.Parallel()
+	var s GitSize
+	if err := s.UnmarshalGitConfig([]byte("")); err != nil {
+		t.Fatal(err)
+	}
+	if s.Int64() != 0 {
+		t.Errorf("got %d, want 0", s.Int64())
+	}
+}
+
+func TestGitSizeMarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+	tests := []string{"1k", "512m", "2G", "100"}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			var s GitSize
+			if err := s.UnmarshalGitConfig([]byte(input)); err != nil {
+				t.Fatal(err)
+			}
+			got, err := s.MarshalGitConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != input {
+				t.Errorf("round-trip: got %q, want %q", got, input)
+			}
+		})
+	}
+}
+
+func TestGitSizeMarshalFromInt(t *testing.T) {
+	t.Parallel()
+	s := NewGitSizeInt(4096)
+	got, err := s.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "4096" {
+		t.Errorf("got %q, want %q", got, "4096")
+	}
+}
+
+func TestNewGitSize(t *testing.T) {
+	t.Parallel()
+	s, err := NewGitSize("10m")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Int64() != 10*1024*1024 {
+		t.Errorf("got %d, want %d", s.Int64(), 10*1024*1024)
+	}
+	got, _ := s.MarshalGitConfig()
+	if got != "10m" {
+		t.Errorf("round-trip: got %q, want %q", got, "10m")
+	}
+}
+
+func TestNewGitSizeInvalid(t *testing.T) {
+	t.Parallel()
+	_, err := NewGitSize("abc")
+	if err == nil {
+		t.Error("expected error for invalid size")
+	}
+}
+
+func TestBoolOrIntBool(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		isBool bool
+		boolVal bool
+	}{
+		{"true", true, true},
+		{"false", true, false},
+		{"yes", true, true},
+		{"no", true, false},
+		{"1", true, true},
+		{"0", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			var b BoolOrInt
+			if err := b.UnmarshalGitConfig([]byte(tt.input)); err != nil {
+				t.Fatal(err)
+			}
+			if tt.isBool {
+				if b.Bool == nil {
+					t.Fatal("expected Bool to be set")
+				}
+				if *b.Bool != tt.boolVal {
+					t.Errorf("Bool = %v, want %v", *b.Bool, tt.boolVal)
+				}
+				if b.Int != nil {
+					t.Error("expected Int to be nil")
+				}
+			}
+		})
+	}
+}
+
+func TestBoolOrIntInt(t *testing.T) {
+	t.Parallel()
+	var b BoolOrInt
+	if err := b.UnmarshalGitConfig([]byte("42")); err != nil {
+		t.Fatal(err)
+	}
+	if b.Int == nil {
+		t.Fatal("expected Int to be set")
+	}
+	if *b.Int != 42 {
+		t.Errorf("Int = %d, want 42", *b.Int)
+	}
+	if b.Bool != nil {
+		t.Error("expected Bool to be nil")
+	}
+}
+
+func TestBoolOrIntInvalid(t *testing.T) {
+	t.Parallel()
+	var b BoolOrInt
+	err := b.UnmarshalGitConfig([]byte("notaboolorint"))
+	if err == nil {
+		t.Error("expected error for invalid bool-or-int")
+	}
+}
+
+func TestBoolOrIntMarshalBool(t *testing.T) {
+	t.Parallel()
+	b := NewBoolOrIntBool(true)
+	got, err := b.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "true" {
+		t.Errorf("got %q, want %q", got, "true")
+	}
+}
+
+func TestBoolOrIntMarshalInt(t *testing.T) {
+	t.Parallel()
+	b := NewBoolOrIntInt(7)
+	got, err := b.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "7" {
+		t.Errorf("got %q, want %q", got, "7")
+	}
+}
+
+func TestBoolOrIntMarshalEmpty(t *testing.T) {
+	t.Parallel()
+	var b BoolOrInt
+	got, err := b.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestAutoBoolUnmarshal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  AutoBool
+	}{
+		{"always", AutoBoolAlways},
+		{"true", AutoBoolTrue},
+		{"auto", AutoBoolAuto},
+		{"false", AutoBoolFalse},
+		{"never", AutoBoolNever},
+		{"ALWAYS", AutoBoolAlways},
+		{"True", AutoBoolTrue},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			var a AutoBool
+			if err := a.UnmarshalGitConfig([]byte(tt.input)); err != nil {
+				t.Fatal(err)
+			}
+			if a != tt.want {
+				t.Errorf("got %q, want %q", a, tt.want)
+			}
+		})
+	}
+}
+
+func TestAutoBoolMarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, v := range []AutoBool{AutoBoolAlways, AutoBoolTrue, AutoBoolAuto, AutoBoolFalse, AutoBoolNever} {
+		got, err := v.MarshalGitConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != string(v) {
+			t.Errorf("round-trip: got %q, want %q", got, string(v))
+		}
+	}
+}
+
+func TestColorUnmarshal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		input  string
+		fg     string
+		bg     string
+		attrs  []string
+	}{
+		{"foreground only", "red", "red", "", nil},
+		{"fg and bg", "red green", "red", "green", nil},
+		{"fg bg attr", "red blue bold", "red", "blue", []string{"bold"}},
+		{"fg bg multi-attr", "red blue bold ul", "red", "blue", []string{"bold", "ul"}},
+		{"numeric color", "196", "196", "", nil},
+		{"hex color", "#ff0000", "#ff0000", "", nil},
+		{"empty", "", "", "", nil},
+		{"normal", "normal", "", "", nil},
+		{"reset", "reset", "", "", []string{"reset"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var c Color
+			if err := c.UnmarshalGitConfig([]byte(tt.input)); err != nil {
+				t.Fatal(err)
+			}
+			if c.Foreground != tt.fg {
+				t.Errorf("Foreground = %q, want %q", c.Foreground, tt.fg)
+			}
+			if c.Background != tt.bg {
+				t.Errorf("Background = %q, want %q", c.Background, tt.bg)
+			}
+			if len(c.Attributes) != len(tt.attrs) {
+				t.Errorf("Attributes = %v, want %v", c.Attributes, tt.attrs)
+			} else {
+				for i := range tt.attrs {
+					if c.Attributes[i] != tt.attrs[i] {
+						t.Errorf("Attributes[%d] = %q, want %q", i, c.Attributes[i], tt.attrs[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestColorMarshal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		c    Color
+		want string
+	}{
+		{"fg only", Color{Foreground: "red"}, "red"},
+		{"fg and bg", Color{Foreground: "red", Background: "green"}, "red green"},
+		{"fg bg attrs", NewColor("red", "blue", "bold"), "red blue bold"},
+		{"empty", Color{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tt.c.MarshalGitConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestColorRoundTrip(t *testing.T) {
+	t.Parallel()
+	inputs := []string{"red", "red green", "red blue bold ul", "196", "#ff0000"}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			var c Color
+			if err := c.UnmarshalGitConfig([]byte(input)); err != nil {
+				t.Fatal(err)
+			}
+			got, err := c.MarshalGitConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != input {
+				t.Errorf("round-trip: got %q, want %q", got, input)
+			}
+		})
+	}
+}
+
+func TestNewColor(t *testing.T) {
+	t.Parallel()
+	c := NewColor("red", "green", "bold", "ul")
+	if c.Foreground != "red" {
+		t.Errorf("Foreground = %q, want %q", c.Foreground, "red")
+	}
+	if c.Background != "green" {
+		t.Errorf("Background = %q, want %q", c.Background, "green")
+	}
+	if len(c.Attributes) != 2 {
+		t.Fatalf("Attributes = %v, want 2 items", c.Attributes)
+	}
+	if c.Attributes[0] != "bold" || c.Attributes[1] != "ul" {
+		t.Errorf("Attributes = %v, want [bold ul]", c.Attributes)
+	}
+}
+
+func TestExpiryDateNever(t *testing.T) {
+	t.Parallel()
+	e := NewExpiryDateNever()
+	if !e.Never {
+		t.Error("expected Never = true")
+	}
+	if e.Now {
+		t.Error("expected Now = false")
+	}
+	got, err := e.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "never" {
+		t.Errorf("got %q, want %q", got, "never")
+	}
+	ref := time.Now()
+	parsed, err := e.Parse(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !parsed.IsZero() {
+		t.Error("expected zero time for never")
+	}
+}
+
+func TestExpiryDateNow(t *testing.T) {
+	t.Parallel()
+	e := NewExpiryDateNow()
+	if e.Never {
+		t.Error("expected Never = false")
+	}
+	if !e.Now {
+		t.Error("expected Now = true")
+	}
+	got, err := e.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "now" {
+		t.Errorf("got %q, want %q", got, "now")
+	}
+	ref := time.Now()
+	parsed, err := e.Parse(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !parsed.Equal(ref) {
+		t.Errorf("Parse(now) = %v, want %v", parsed, ref)
+	}
+}
+
+func TestExpiryDateRaw(t *testing.T) {
+	t.Parallel()
+	e := NewExpiryDate("2.weeks.ago")
+	if e.Never || e.Now {
+		t.Error("expected Never and Now to be false")
+	}
+	if e.Raw() != "2.weeks.ago" {
+		t.Errorf("Raw() = %q, want %q", e.Raw(), "2.weeks.ago")
+	}
+}
+
+func TestExpiryDateUnmarshal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		never bool
+		now   bool
+	}{
+		{"never", true, false},
+		{"NEVER", true, false},
+		{"now", false, true},
+		{"Now", false, true},
+		{"2.weeks.ago", false, false},
+		{"90.days", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			var e ExpiryDate
+			if err := e.UnmarshalGitConfig([]byte(tt.input)); err != nil {
+				t.Fatal(err)
+			}
+			if e.Never != tt.never {
+				t.Errorf("Never = %v, want %v", e.Never, tt.never)
+			}
+			if e.Now != tt.now {
+				t.Errorf("Now = %v, want %v", e.Now, tt.now)
+			}
+		})
+	}
+}
+
+func TestExpiryDateMarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+	inputs := []string{"never", "now", "2.weeks.ago", "90.days", "1.day"}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			var e ExpiryDate
+			if err := e.UnmarshalGitConfig([]byte(input)); err != nil {
+				t.Fatal(err)
+			}
+			got, err := e.MarshalGitConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != input {
+				t.Errorf("round-trip: got %q, want %q", got, input)
+			}
+		})
+	}
+}
+
+func TestExpiryDateMarshalFromNever(t *testing.T) {
+	t.Parallel()
+	e := ExpiryDate{Never: true}
+	got, err := e.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "never" {
+		t.Errorf("got %q, want %q", got, "never")
+	}
+}
+
+func TestExpiryDateMarshalFromNow(t *testing.T) {
+	t.Parallel()
+	e := ExpiryDate{Now: true}
+	got, err := e.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "now" {
+		t.Errorf("got %q, want %q", got, "now")
+	}
+}
+
+func TestExpiryDateMarshalEmpty(t *testing.T) {
+	t.Parallel()
+	var e ExpiryDate
+	got, err := e.MarshalGitConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestExpiryDateParseRelative(t *testing.T) {
+	t.Parallel()
+	ref := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		input string
+		want  time.Duration
+	}{
+		{"2.weeks.ago", 2 * 7 * 24 * time.Hour},
+		{"90.days", 90 * 24 * time.Hour},
+		{"1.day", 24 * time.Hour},
+		{"3.months.ago", 3 * 30 * 24 * time.Hour},
+		{"1.hour", time.Hour},
+		{"5.minutes.ago", 5 * time.Minute},
+		{"1.year", 365 * 24 * time.Hour},
+		{"30.seconds", 30 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			e := NewExpiryDate(tt.input)
+			parsed, err := e.Parse(ref)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected := ref.Add(-tt.want)
+			if !parsed.Equal(expected) {
+				t.Errorf("Parse(%q) = %v, want %v", tt.input, parsed, expected)
+			}
+		})
+	}
+}
+
+func TestExpiryDateParseBareInt(t *testing.T) {
+	t.Parallel()
+	ref := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	e := NewExpiryDate("3600")
+	parsed, err := e.Parse(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := ref.Add(-3600 * time.Second)
+	if !parsed.Equal(expected) {
+		t.Errorf("Parse(3600) = %v, want %v", parsed, expected)
+	}
+}
+
+func TestExpiryDateParseRFC3339(t *testing.T) {
+	t.Parallel()
+	ts := "2024-06-01T00:00:00Z"
+	e := NewExpiryDate(ts)
+	ref := time.Now()
+	parsed, err := e.Parse(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, _ := time.Parse(time.RFC3339, ts)
+	if !parsed.Equal(expected) {
+		t.Errorf("Parse(%q) = %v, want %v", ts, parsed, expected)
+	}
+}
+
+func TestExpiryDateParseInvalid(t *testing.T) {
+	t.Parallel()
+	e := NewExpiryDate("not-a-date")
+	_, err := e.Parse(time.Now())
+	if err == nil {
+		t.Error("expected error for invalid expiry date")
+	}
+}
+
+func TestExpiryDateParseEmpty(t *testing.T) {
+	t.Parallel()
+	var e ExpiryDate
+	parsed, err := e.Parse(time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !parsed.IsZero() {
+		t.Error("expected zero time for empty ExpiryDate")
+	}
+}
+
+func TestParseRelativeDuration(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  time.Duration
+		ok    bool
+	}{
+		{"2.weeks.ago", 2 * 7 * 24 * time.Hour, true},
+		{"1.day", 24 * time.Hour, true},
+		{"90.days", 90 * 24 * time.Hour, true},
+		{"3.months.ago", 3 * 30 * 24 * time.Hour, true},
+		{"1.second", time.Second, true},
+		{"5.minutes.ago", 5 * time.Minute, true},
+		{"1.hour", time.Hour, true},
+		{"1.year", 365 * 24 * time.Hour, true},
+		{"0.days", 0, false},
+		{"-1.days", 0, false},
+		{"1.fortnight", 0, false},
+		{"1.day.ago.extra", 0, false},
+		{"1.day.notago", 0, false},
+		{"plain", 0, false},
+		{"2", 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseRelativeDuration(tt.input)
+			if ok != tt.ok {
+				t.Errorf("parseRelativeDuration(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+			if ok && got != tt.want {
+				t.Errorf("parseRelativeDuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPathnameRoundTrip(t *testing.T) {
+	t.Parallel()
+	inputs := []string{"/usr/bin/git", "~/.gitconfig", "relative/path", ""}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			var p Pathname
+			if err := p.UnmarshalGitConfig([]byte(input)); err != nil {
+				t.Fatal(err)
+			}
+			got, err := p.MarshalGitConfig()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != input {
+				t.Errorf("round-trip: got %q, want %q", got, input)
+			}
+		})
+	}
+}
+
+func TestPathnameString(t *testing.T) {
+	t.Parallel()
+	p := Pathname("/some/path")
+	if string(p) != "/some/path" {
+		t.Errorf("string conversion: got %q, want %q", string(p), "/some/path")
+	}
+}
+
+func TestFollowRedirectsUnmarshal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  FollowRedirects
+	}{
+		{"true", FollowRedirectsAll},
+		{"false", FollowRedirectsNone},
+		{"initial", FollowRedirectsInitial},
+		{"True", FollowRedirectsAll},
+		{"INITIAL", FollowRedirectsInitial},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			var f FollowRedirects
+			if err := f.UnmarshalGitConfig([]byte(tt.input)); err != nil {
+				t.Fatal(err)
+			}
+			if f != tt.want {
+				t.Errorf("got %q, want %q", f, tt.want)
+			}
+		})
+	}
+}
+
+func TestFollowRedirectsMarshalRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, v := range []FollowRedirects{FollowRedirectsAll, FollowRedirectsNone, FollowRedirectsInitial} {
+		got, err := v.MarshalGitConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != string(v) {
+			t.Errorf("round-trip: got %q, want %q", got, string(v))
+		}
+	}
+}
+
+func TestFollowRedirectsConstants(t *testing.T) {
+	t.Parallel()
+	if FollowRedirectsAll != "true" {
+		t.Errorf("FollowRedirectsAll = %q, want %q", FollowRedirectsAll, "true")
+	}
+	if FollowRedirectsNone != "false" {
+		t.Errorf("FollowRedirectsNone = %q, want %q", FollowRedirectsNone, "false")
+	}
+	if FollowRedirectsInitial != "initial" {
+		t.Errorf("FollowRedirectsInitial = %q, want %q", FollowRedirectsInitial, "initial")
+	}
+}

--- a/x/config/interfaces.go
+++ b/x/config/interfaces.go
@@ -1,0 +1,13 @@
+package config
+
+// Marshaler is implemented by types that can marshal themselves into a
+// Git config string value.
+type Marshaler interface {
+	MarshalGitConfig() (string, error)
+}
+
+// Unmarshaler is implemented by types that can unmarshal a Git config
+// string value into themselves.
+type Unmarshaler interface {
+	UnmarshalGitConfig([]byte) error
+}

--- a/x/config/tags.go
+++ b/x/config/tags.go
@@ -1,0 +1,134 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+)
+
+const (
+	tagName       = "gitconfig"
+	tagDefault    = "gitconfigDefault"
+	tagSubsection = "gitconfigSub"
+)
+
+type fieldTag struct {
+	key        string
+	omitempty  bool
+	multivalue bool
+	subsection bool
+	skip       bool
+}
+
+func parseTag(tag string) fieldTag {
+	if tag == "-" {
+		return fieldTag{skip: true}
+	}
+
+	var ft fieldTag
+	parts := strings.Split(tag, ",")
+
+	if len(parts) > 0 {
+		ft.key = parts[0]
+	}
+
+	for _, opt := range parts[1:] {
+		switch opt {
+		case "omitempty":
+			ft.omitempty = true
+		case "multivalue":
+			ft.multivalue = true
+		case "subsection":
+			ft.subsection = true
+		}
+	}
+
+	return ft
+}
+
+type structField struct {
+	index        []int
+	tag          fieldTag
+	typ          reflect.Type
+	isPtr        bool
+	elemType     reflect.Type
+	defaultValue string
+	hasDefault   bool
+	subName      string
+}
+
+type structInfo struct {
+	fields []structField
+}
+
+var (
+	structCacheMu sync.RWMutex
+	structCache   = map[reflect.Type]*structInfo{}
+)
+
+func getStructInfo(t reflect.Type) *structInfo {
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	structCacheMu.RLock()
+	if info, ok := structCache[t]; ok {
+		structCacheMu.RUnlock()
+		return info
+	}
+	structCacheMu.RUnlock()
+
+	info := buildStructInfo(t)
+
+	structCacheMu.Lock()
+	structCache[t] = info
+	structCacheMu.Unlock()
+
+	return info
+}
+
+func buildStructInfo(t reflect.Type) *structInfo {
+	info := &structInfo{}
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+
+		tag := f.Tag.Get(tagName)
+		if tag == "" {
+			continue
+		}
+
+		ft := parseTag(tag)
+		if ft.skip {
+			continue
+		}
+
+		sf := structField{
+			index: f.Index,
+			tag:   ft,
+			typ:   f.Type,
+		}
+
+		if f.Type.Kind() == reflect.Pointer {
+			sf.isPtr = true
+			sf.elemType = f.Type.Elem()
+		} else {
+			sf.elemType = f.Type
+		}
+
+		if dv, ok := f.Tag.Lookup(tagDefault); ok {
+			sf.defaultValue = dv
+			sf.hasDefault = true
+		}
+
+		if sn := f.Tag.Get(tagSubsection); sn != "" {
+			sf.subName = sn
+		}
+
+		info.fields = append(info.fields, sf)
+	}
+
+	return info
+}

--- a/x/config/types.go
+++ b/x/config/types.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+func parseBool(s string) (bool, error) {
+	switch strings.ToLower(s) {
+	case "true", "yes", "on", "1":
+		return true, nil
+	case "false", "no", "off", "0", "":
+		return false, nil
+	default:
+		return false, fmt.Errorf("cannot parse %q as bool", s)
+	}
+}
+
+func formatBool(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
+func stringToValue(s string, t reflect.Type) (reflect.Value, error) {
+	switch t.Kind() {
+	case reflect.String:
+		return reflect.ValueOf(s).Convert(t), nil
+
+	case reflect.Bool:
+		v, err := parseBool(s)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		return reflect.ValueOf(v).Convert(t), nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v, err := strconv.ParseInt(s, 10, t.Bits())
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf("cannot parse %q as %s: %w", s, t, err)
+		}
+		return reflect.ValueOf(v).Convert(t), nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v, err := strconv.ParseUint(s, 10, t.Bits())
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf("cannot parse %q as %s: %w", s, t, err)
+		}
+		return reflect.ValueOf(v).Convert(t), nil
+
+	case reflect.Float32, reflect.Float64:
+		v, err := strconv.ParseFloat(s, t.Bits())
+		if err != nil {
+			return reflect.Value{}, fmt.Errorf("cannot parse %q as %s: %w", s, t, err)
+		}
+		return reflect.ValueOf(v).Convert(t), nil
+
+	default:
+		return reflect.Value{}, fmt.Errorf("unsupported type %s", t)
+	}
+}
+
+func valueToString(v reflect.Value) (string, error) {
+	switch v.Kind() {
+	case reflect.String:
+		return v.String(), nil
+
+	case reflect.Bool:
+		return formatBool(v.Bool()), nil
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(v.Int(), 10), nil
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return strconv.FormatUint(v.Uint(), 10), nil
+
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'f', -1, v.Type().Bits()), nil
+
+	default:
+		return "", fmt.Errorf("unsupported type %s", v.Type())
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces a new `x/config` package that uses Go struct tags to marshal and unmarshal Git INI-style configuration files, similar to how `encoding/json` works for JSON.

The package sits on top of the existing low-level INI parser (`plumbing/format/config`) and is designed to eventually replace the hand-written mapping layer in `config/config.go`.

## Motivation

Today, every section in `config/config.go` has a hand-written `marshalFoo()` / `unmarshalFoo()` pair — **~500 lines** of repetitive code. Adding a new config key requires touching multiple functions, manually converting types, and keeping marshal and unmarshal logic in sync.

The current implementation also has **inconsistent boolean parsing** across different sections:
- `core.bare` only accepts literal `"true"` (not `"yes"`, `"on"`, `"1"`)
- `core.filemode` only checks for `"false"`
- `gpg.gpgSign` uses `strconv.ParseBool`
- `pack.readReverseIndex` uses `!= "false"`

A struct-tag approach gives us:
- **Declarative schema** — the struct definition _is_ the documentation
- **Uniform type conversion** — one Git-spec-compliant bool parser everywhere
- **Reduced boilerplate** — adding a new key is one struct field + tag
- **Familiar API** — Go developers already know this pattern from `encoding/json`

## Design

### API

The package operates on `*format.Config` — the caller owns the parse/encode lifecycle:

```go
func Unmarshal(raw *format.Config, v any) error
func Marshal(v any, raw *format.Config) error
```

This means unknown sections and keys are automatically preserved in `raw` for round-trip fidelity — no overflow mechanism needed.

### Struct Tags

Three tag keys, each with a clear purpose:

| Tag | Contains | Example |
|---|---|---|
| `gitconfig` | Key name + boolean flags | `gitconfig:"bare,omitempty"` |
| `gitconfigDefault` | Literal default value | `gitconfigDefault:"#"` |
| `gitconfigSub` | Fixed subsection name | `gitconfigSub:"ssh"` |

Separating parameterized values into their own tags avoids escaping issues (default values can contain commas and equals signs) and keeps the main tag trivially parseable.

### Flat Subsection Model

All fields are declared at the root level. Section keys and subsections are peers:

```go
type Config struct {
    // [core] section keys
    Core CoreConfig `gitconfig:"core"`

    // [remote "name"] subsection collection
    Remotes map[string]*RemoteConfig `gitconfig:"remote,subsection"`

    // [gpg] section keys
    GPG GPGConfig `gitconfig:"gpg"`

    // [gpg "ssh"] single named subsection
    GPGSSH *SSHConfig `gitconfig:"gpg,subsection" gitconfigSub:"ssh"`
}
```

The `subsection` tag is **mandatory** for both maps and single pointers — one concept, one tag. No implicit type-driven behavior.

### Custom Types

Types implementing `Marshaler` / `Unmarshaler` control their own serialization. The package also checks `encoding.TextMarshaler` / `TextUnmarshaler` as fallbacks:

```go
type Marshaler interface {
    MarshalGitConfig() (string, error)
}

type Unmarshaler interface {
    UnmarshalGitConfig([]byte) error
}
```

### Features

- **Git-spec-compliant bool parsing**: `true`/`yes`/`on`/`1` and inverses (case-insensitive)
- **Pointer nil semantics**: `*bool` — nil=absent, `*false`=explicit false (replaces `OptBool`)
- **Multi-value keys**: `[]string` with `multivalue` tag collects all occurrences
- **Defaults**: `gitconfigDefault:"value"` tag for absent keys
- **Thread-safe**: struct info cache uses `sync.RWMutex`

## Benchmarks

Compared against the current hand-written `config.Config` on a realistic fixture (6 sections, 2 remotes, 2 branches, ~35 lines):

```
goos: darwin
goarch: arm64
cpu: Apple M3 Max

                                      x/config             old config
Unmarshal (pre-parsed)          2,668 ns/op   66 allocs    8,776 ns/op  185 allocs  ← 3.3× faster
Unmarshal (including parse)     9,107 ns/op  214 allocs    8,880 ns/op  185 allocs  ← ~parity
Marshal                         2,476 ns/op  104 allocs    3,963 ns/op   99 allocs  ← 1.6× faster
Round-trip (parse+unmarshal+   11,674 ns/op  318 allocs   13,341 ns/op  284 allocs  ← 1.15× faster
            marshal+encode)
```

### Interpretation

- **Unmarshal without parsing is 3.3× faster** because the old config re-scans raw sections, creates fresh maps, and does ad-hoc string comparisons. The reflection overhead is undetectable at this scale.
- **With parsing, it's parity** — the `gcfg` parser dominates both paths.
- **Marshal is 1.6× faster** despite reflection.
- **Alloc count is slightly higher** (318 vs 284 round-trip) due to `reflect.Value` interface boxing, `reflect.MakeSlice/Map`, and map key sorting. But **alloc bytes are lower** (10.4KB vs 12.1KB) — our allocations are smaller individually.
- For config files parsed once at startup, the difference is ~1.7µs — immeasurable in practice.

## What's in the PR

### New files

| File | Purpose | Lines |
|---|---|---|
| `x/config/doc.go` | Package documentation | 44 |
| `x/config/interfaces.go` | `Marshaler` / `Unmarshaler` interfaces | 13 |
| `x/config/tags.go` | Multi-tag parser + thread-safe struct cache | 131 |
| `x/config/types.go` | Built-in type converters (bool, int, string) | 88 |
| `x/config/decode.go` | `Unmarshal` — reflection-based decoder | 241 |
| `x/config/encode.go` | `Marshal` — reflection-based encoder | 269 |
| `x/config/config_test.go` | 24 functional tests | 668 |
| `x/config/benchmark_test.go` | Comparative benchmarks | 186 |

### No existing code changed

This is purely additive — zero modifications to the existing `config` package or any other package.

## Migration Path (not in this PR)

A 4-phase migration is planned:

1. **Phase 0** (this PR): Build `x/config` as a standalone package
2. **Phase 1**: Rewire `config.Config.Marshal/Unmarshal` to use `x/config` internally
3. **Phase 2**: Replace `OptBool` with `*bool`
4. **Phase 3**: Move `RefSpec` to `plumbing/`, reduce `config` surface area

## Differences from `git config`

The package is a struct mapper, not a `git config` reimplementation. Intentionally out of scope:
- Scope/precedence (system → global → local) — caller merges multiple files
- Integer suffix parsing (`1G`, `10k`) — delegated to custom `Marshaler`/`Unmarshaler` types
- Color/pathname/date types — delegated to custom types
- Conditional includes (`includeIf`) — handled by the layer that reads config files from disk
- Comment preservation — the low-level parser discards comments (existing limitation)
- Bare key output — always writes `key = true` (unambiguous, matches `git config set` behavior)