### PR TITLE
Fix file handle leaks in worktree tests on Windows

### DIFF
--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -259,6 +259,7 @@ func checkWorktree(t *testing.T, storage, wt billy.Filesystem, path string) {
 
 	f, err := wt.Open(fn)
 	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
 
 	data, err := io.ReadAll(f)
 	require.NoError(t, err)
@@ -307,6 +308,7 @@ func checkFiles(t *testing.T, expected []expectedFile, storage, wt billy.Filesys
 
 		f, err := storage.Open(fn)
 		require.NoError(t, err)
+		defer func() { _ = f.Close() }()
 
 		data, err := io.ReadAll(f)
 		require.NoError(t, err)


### PR DESCRIPTION
This PR fixes intermittent test failures on Windows CI by ensuring file handles are explicitly closed.

## Problem

TestAdd was intermittently failing on Windows with:
```
--- FAIL: TestAdd (1.65s)
    testing.go:1369: TempDir RemoveAll cleanup: unlinkat C:\Users\RUNNER~1\AppData\Local\Temp\TestAdd1970882492\001\worktrees\test-work-tree\commondir: The process cannot access the file because it is being used by another process.
```

## Root Cause

Two helper functions (`checkWorktree()` and `checkFiles()`) opened files without explicitly closing them:
- Line 260: `f, err := wt.Open(fn)` 
- Line 309: `f, err := storage.Open(fn)`

This created a race condition:
- **Most of the time:** Go's finalizer closes handles before cleanup → test passes ✅
- **Occasionally:** Test cleanup runs before finalizer → Windows can't delete open files → test fails ❌

Windows is stricter than Unix about deleting files with open handles, so this only manifested on Windows CI.

## Solution

Added explicit `defer func() { _ = f.Close() }()` after each `Open()` call, eliminating the race condition by ensuring handles are closed deterministically.

## Testing

All tests pass locally:
```bash
go test ./x/plumbing/worktree/... -v -run TestAdd
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)