### PR TITLE
plumbing: transport/http, harden redirect handling to match canonical git

### DIFF
--- a/plumbing/client/client.go
+++ b/plumbing/client/client.go
@@ -33,6 +33,19 @@ type HTTPAuth interface {
 	Authorizer(*http.Request) error
 }
 
+// RedirectPolicy controls how HTTP transports follow redirects.
+type RedirectPolicy = xhttp.RedirectPolicy
+
+const (
+	// FollowInitialRedirects follows redirects only for the initial
+	// /info/refs discovery request.
+	FollowInitialRedirects = xhttp.FollowInitialRedirects
+	// FollowRedirects follows redirects for all requests.
+	FollowRedirects = xhttp.FollowRedirects
+	// NoFollowRedirects disables redirects for all requests.
+	NoFollowRedirects = xhttp.NoFollowRedirects
+)
+
 // Option configures a Client.
 type Option func(*options)
 
@@ -114,6 +127,14 @@ func WithDialer(fn transport.DialContextFunc) Option {
 func WithHTTPClient(c *http.Client) Option {
 	return func(o *options) {
 		o.http.Client = c
+	}
+}
+
+// WithRedirectPolicy sets the HTTP redirect policy. If unset, the HTTP
+// transport defaults to FollowInitialRedirects.
+func WithRedirectPolicy(policy RedirectPolicy) Option {
+	return func(o *options) {
+		o.http.FollowRedirects = xhttp.RedirectPolicy(policy)
 	}
 }
 

--- a/plumbing/client/client_test.go
+++ b/plumbing/client/client_test.go
@@ -136,6 +136,15 @@ func TestWithHTTPClient(t *testing.T) {
 	assert.NotNil(t, tr)
 }
 
+func TestWithRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	var o options
+	WithRedirectPolicy(NoFollowRedirects)(&o)
+
+	assert.Equal(t, xhttp.NoFollowRedirects, o.http.FollowRedirects)
+}
+
 func TestWithProxyURL(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -74,8 +74,10 @@ const infoRefsPath = "/info/refs"
 // because a mismatch could let a malicious server rewrite the base URL
 // to an unrelated repository.
 //
-// Scheme is validated to prevent SSRF via protocol downgrade (e.g. a
-// redirect to file:// or gopher://).
+// Scheme is validated to prevent SSRF via unsupported protocols (e.g.
+// a redirect to file:// or gopher://). Cross-scheme redirects only
+// permit an upgrade from http to https; downgrades must not influence
+// the session base URL used for subsequent requests.
 func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 	if resp.Request == nil {
 		return baseURL, nil
@@ -90,6 +92,13 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 
 	if final.Scheme != "http" && final.Scheme != "https" {
 		return nil, fmt.Errorf("http transport: redirect to unsupported scheme %q", final.Scheme)
+	}
+	if final.Scheme != baseURL.Scheme &&
+		!(baseURL.Scheme == "http" && final.Scheme == "https") {
+		return nil, fmt.Errorf(
+			"http transport: redirect changes scheme from %q to %q",
+			baseURL.Scheme, final.Scheme,
+		)
 	}
 
 	if !strings.HasSuffix(final.Path, infoRefsPath) {

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -84,6 +84,12 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 	}
 
 	final := resp.Request.URL
+	if !strings.HasSuffix(final.Path, infoRefsPath) {
+		return nil, fmt.Errorf(
+			"http transport: redirect target %q does not end with %s",
+			final.Path, infoRefsPath,
+		)
+	}
 	if final.Host == baseURL.Host &&
 		final.Scheme == baseURL.Scheme &&
 		strings.TrimSuffix(final.Path, infoRefsPath) == baseURL.Path {
@@ -94,17 +100,10 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 		return nil, fmt.Errorf("http transport: redirect to unsupported scheme %q", final.Scheme)
 	}
 	if final.Scheme != baseURL.Scheme &&
-		!(baseURL.Scheme == "http" && final.Scheme == "https") {
+		(baseURL.Scheme != "http" || final.Scheme != "https") {
 		return nil, fmt.Errorf(
 			"http transport: redirect changes scheme from %q to %q",
 			baseURL.Scheme, final.Scheme,
-		)
-	}
-
-	if !strings.HasSuffix(final.Path, infoRefsPath) {
-		return nil, fmt.Errorf(
-			"http transport: redirect target %q does not end with %s",
-			final.Path, infoRefsPath,
 		)
 	}
 

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -64,20 +64,46 @@ func checkError(r *http.Response) error {
 
 const infoRefsPath = "/info/refs"
 
-// applyRedirect updates the base URL if the server redirected.
-func applyRedirect(resp *http.Response, baseURL *url.URL) *url.URL {
+// applyRedirect derives a new base URL from the final request URL after
+// the HTTP client followed any redirects during the /info/refs GET.
+//
+// The logic mirrors canonical git's update_url_from_redirect(): strip
+// the request-specific tail ("/info/refs") from the final URL to recover
+// the new base. If the tail is missing, the redirect target is
+// inconsistent and we return an error — canonical git die()s here
+// because a mismatch could let a malicious server rewrite the base URL
+// to an unrelated repository.
+//
+// Scheme is validated to prevent SSRF via protocol downgrade (e.g. a
+// redirect to file:// or gopher://).
+func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 	if resp.Request == nil {
-		return baseURL
+		return baseURL, nil
 	}
-	r := resp.Request
-	if !strings.HasSuffix(r.URL.Path, infoRefsPath) {
-		return baseURL
+
+	final := resp.Request.URL
+	if final.Host == baseURL.Host &&
+		final.Scheme == baseURL.Scheme &&
+		strings.TrimSuffix(final.Path, infoRefsPath) == baseURL.Path {
+		return baseURL, nil
 	}
+
+	if final.Scheme != "http" && final.Scheme != "https" {
+		return nil, fmt.Errorf("http transport: redirect to unsupported scheme %q", final.Scheme)
+	}
+
+	if !strings.HasSuffix(final.Path, infoRefsPath) {
+		return nil, fmt.Errorf(
+			"http transport: redirect target %q does not end with %s",
+			final.Path, infoRefsPath,
+		)
+	}
+
 	redirected := *baseURL
-	redirected.Host = r.URL.Host
-	redirected.Scheme = r.URL.Scheme
-	redirected.Path = r.URL.Path[:len(r.URL.Path)-len(infoRefsPath)]
-	return &redirected
+	redirected.Host = final.Host
+	redirected.Scheme = final.Scheme
+	redirected.Path = final.Path[:len(final.Path)-len(infoRefsPath)]
+	return &redirected, nil
 }
 
 var safeHeaders = map[string]struct{}{

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -99,7 +99,8 @@ func TestApplyRedirect(t *testing.T) {
 		t.Parallel()
 		resp := &http.Response{}
 		base, _ := url.Parse("https://example.com/repo.git")
-		result := applyRedirect(resp, base)
+		result, err := applyRedirect(resp, base)
+		require.NoError(t, err)
 		assert.Equal(t, base, result)
 	})
 
@@ -108,7 +109,58 @@ func TestApplyRedirect(t *testing.T) {
 		req, _ := http.NewRequest("GET", "https://new.example.com/repo.git/info/refs", nil)
 		resp := &http.Response{Request: req}
 		base, _ := url.Parse("https://old.example.com/repo.git")
-		result := applyRedirect(resp, base)
+		result, err := applyRedirect(resp, base)
+		require.NoError(t, err)
 		assert.Equal(t, "new.example.com", result.Host)
+	})
+
+	t.Run("same host and path is no-op", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest("GET", "https://example.com/repo.git/info/refs", nil)
+		resp := &http.Response{Request: req}
+		base, _ := url.Parse("https://example.com/repo.git")
+		result, err := applyRedirect(resp, base)
+		require.NoError(t, err)
+		assert.Equal(t, base, result)
+	})
+
+	t.Run("unsupported scheme", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest("GET", "ftp://evil.com/repo.git/info/refs", nil)
+		resp := &http.Response{Request: req}
+		base, _ := url.Parse("https://example.com/repo.git")
+		_, err := applyRedirect(resp, base)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported scheme")
+	})
+
+	t.Run("tail mismatch", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest("GET", "https://evil.com/malicious-path", nil)
+		resp := &http.Response{Request: req}
+		base, _ := url.Parse("https://example.com/repo.git")
+		_, err := applyRedirect(resp, base)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not end with")
+	})
+
+	t.Run("redirect updates scheme", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest("GET", "https://example.com/repo.git/info/refs", nil)
+		resp := &http.Response{Request: req}
+		base, _ := url.Parse("http://example.com/repo.git")
+		result, err := applyRedirect(resp, base)
+		require.NoError(t, err)
+		assert.Equal(t, "https", result.Scheme)
+	})
+
+	t.Run("redirect updates path", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest("GET", "https://example.com/new-repo.git/info/refs", nil)
+		resp := &http.Response{Request: req}
+		base, _ := url.Parse("https://example.com/old-repo.git")
+		result, err := applyRedirect(resp, base)
+		require.NoError(t, err)
+		assert.Equal(t, "/new-repo.git", result.Path)
 	})
 }

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -96,12 +96,12 @@ func TestApplyRedirect(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		baseURL    string
-		finalURL   string
-		wantURL    string
-		wantErr    string
-		noRequest  bool
+		name      string
+		baseURL   string
+		finalURL  string
+		wantURL   string
+		wantErr   string
+		noRequest bool
 	}{
 		{
 			name:      "no redirect",
@@ -151,10 +151,15 @@ func TestApplyRedirect(t *testing.T) {
 			finalURL: "https://example.com/new-repo.git/info/refs",
 			wantURL:  "https://example.com/new-repo.git",
 		},
+		{
+			name:     "redirect to bare repo path errors",
+			baseURL:  "https://example.com/repo.git",
+			finalURL: "https://example.com/repo.git",
+			wantErr:  "does not end with",
+		},
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -95,72 +95,90 @@ func TestCheckError_WithReason(t *testing.T) {
 func TestApplyRedirect(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no redirect", func(t *testing.T) {
-		t.Parallel()
-		resp := &http.Response{}
-		base, _ := url.Parse("https://example.com/repo.git")
-		result, err := applyRedirect(resp, base)
-		require.NoError(t, err)
-		assert.Equal(t, base, result)
-	})
+	tests := []struct {
+		name       string
+		baseURL    string
+		finalURL   string
+		wantURL    string
+		wantErr    string
+		noRequest  bool
+	}{
+		{
+			name:      "no redirect",
+			baseURL:   "https://example.com/repo.git",
+			wantURL:   "https://example.com/repo.git",
+			noRequest: true,
+		},
+		{
+			name:     "redirect updates host",
+			baseURL:  "https://old.example.com/repo.git",
+			finalURL: "https://new.example.com/repo.git/info/refs",
+			wantURL:  "https://new.example.com/repo.git",
+		},
+		{
+			name:     "same host and path is no-op",
+			baseURL:  "https://example.com/repo.git",
+			finalURL: "https://example.com/repo.git/info/refs",
+			wantURL:  "https://example.com/repo.git",
+		},
+		{
+			name:     "unsupported scheme",
+			baseURL:  "https://example.com/repo.git",
+			finalURL: "ftp://evil.com/repo.git/info/refs",
+			wantErr:  "unsupported scheme",
+		},
+		{
+			name:     "tail mismatch",
+			baseURL:  "https://example.com/repo.git",
+			finalURL: "https://evil.com/malicious-path",
+			wantErr:  "does not end with",
+		},
+		{
+			name:     "redirect updates scheme for http to https",
+			baseURL:  "http://example.com/repo.git",
+			finalURL: "https://example.com/repo.git/info/refs",
+			wantURL:  "https://example.com/repo.git",
+		},
+		{
+			name:     "redirect rejects scheme downgrade",
+			baseURL:  "https://example.com/repo.git",
+			finalURL: "http://example.com/repo.git/info/refs",
+			wantErr:  "changes scheme",
+		},
+		{
+			name:     "redirect updates path",
+			baseURL:  "https://example.com/old-repo.git",
+			finalURL: "https://example.com/new-repo.git/info/refs",
+			wantURL:  "https://example.com/new-repo.git",
+		},
+	}
 
-	t.Run("redirect updates host", func(t *testing.T) {
-		t.Parallel()
-		req, _ := http.NewRequest("GET", "https://new.example.com/repo.git/info/refs", nil)
-		resp := &http.Response{Request: req}
-		base, _ := url.Parse("https://old.example.com/repo.git")
-		result, err := applyRedirect(resp, base)
-		require.NoError(t, err)
-		assert.Equal(t, "new.example.com", result.Host)
-	})
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	t.Run("same host and path is no-op", func(t *testing.T) {
-		t.Parallel()
-		req, _ := http.NewRequest("GET", "https://example.com/repo.git/info/refs", nil)
-		resp := &http.Response{Request: req}
-		base, _ := url.Parse("https://example.com/repo.git")
-		result, err := applyRedirect(resp, base)
-		require.NoError(t, err)
-		assert.Equal(t, base, result)
-	})
+			base, err := url.Parse(tt.baseURL)
+			require.NoError(t, err)
 
-	t.Run("unsupported scheme", func(t *testing.T) {
-		t.Parallel()
-		req, _ := http.NewRequest("GET", "ftp://evil.com/repo.git/info/refs", nil)
-		resp := &http.Response{Request: req}
-		base, _ := url.Parse("https://example.com/repo.git")
-		_, err := applyRedirect(resp, base)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unsupported scheme")
-	})
+			resp := &http.Response{}
+			if !tt.noRequest {
+				req, err := http.NewRequest("GET", tt.finalURL, nil)
+				require.NoError(t, err)
+				resp.Request = req
+			}
 
-	t.Run("tail mismatch", func(t *testing.T) {
-		t.Parallel()
-		req, _ := http.NewRequest("GET", "https://evil.com/malicious-path", nil)
-		resp := &http.Response{Request: req}
-		base, _ := url.Parse("https://example.com/repo.git")
-		_, err := applyRedirect(resp, base)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "does not end with")
-	})
+			result, err := applyRedirect(resp, base)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
 
-	t.Run("redirect updates scheme", func(t *testing.T) {
-		t.Parallel()
-		req, _ := http.NewRequest("GET", "https://example.com/repo.git/info/refs", nil)
-		resp := &http.Response{Request: req}
-		base, _ := url.Parse("http://example.com/repo.git")
-		result, err := applyRedirect(resp, base)
-		require.NoError(t, err)
-		assert.Equal(t, "https", result.Scheme)
-	})
-
-	t.Run("redirect updates path", func(t *testing.T) {
-		t.Parallel()
-		req, _ := http.NewRequest("GET", "https://example.com/new-repo.git/info/refs", nil)
-		resp := &http.Response{Request: req}
-		base, _ := url.Parse("https://example.com/old-repo.git")
-		result, err := applyRedirect(resp, base)
-		require.NoError(t, err)
-		assert.Equal(t, "/new-repo.git", result.Path)
-	})
+			require.NoError(t, err)
+			want, err := url.Parse(tt.wantURL)
+			require.NoError(t, err)
+			assert.Equal(t, want, result)
+		})
+	}
 }

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -34,7 +34,11 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 		infoURL += "?service=" + service
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, infoURL, nil)
+	// Mark this as the initial request so checkRedirect allows
+	// the HTTP client to follow redirects for this discovery request.
+	// Subsequent requests (pack POSTs, object GETs) use a plain
+	// context and will not follow redirects.
+	httpReq, err := http.NewRequestWithContext(withInitialRequest(ctx), http.MethodGet, infoURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("http transport: %w", err)
 	}
@@ -66,21 +70,42 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 		return nil, err
 	}
 
-	// Update base URL if the server redirected.
+	// Update base URL from the final redirect target.
+	redirectedURL, err := applyRedirect(resp, baseURL)
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, err
+	}
 	sessReq := *req
-	sessReq.URL = applyRedirect(resp, baseURL)
+	sessReq.URL = redirectedURL
+	authorizer := t.opts.Authorizer
+
+	// Clear credentials when the redirect landed on a different host.
+	// The session stores baseURL and re-applies its User field and the
+	// Authorizer callback on every subsequent POST — without this, the
+	// original host's credentials would be sent to the new host.
+	// Go's http.Client already strips the Authorization header on
+	// cross-host redirects during the initial GET, but User and
+	// Authorizer are carried in the session and applied explicitly by
+	// doPost/applyAuth. In canonical git, credential_from_url()
+	// re-derives credentials from the new URL, effectively wiping the
+	// old ones.
+	if redirectedURL.Host != baseURL.Host {
+		sessReq.URL.User = nil
+		authorizer = nil
+	}
 
 	if forceDumb {
-		return handshakeDumb(resp, &sessReq, client, t.opts.Authorizer)
+		return handshakeDumb(resp, &sessReq, client, authorizer)
 	}
 
 	expected := fmt.Sprintf("application/x-%s-advertisement", service)
 	isSmart := resp.Header.Get("Content-Type") == expected
 
 	if isSmart {
-		return handshakeSmart(resp, &sessReq, client, t.opts.Authorizer)
+		return handshakeSmart(resp, &sessReq, client, authorizer)
 	}
-	return handshakeDumb(resp, &sessReq, client, t.opts.Authorizer)
+	return handshakeDumb(resp, &sessReq, client, authorizer)
 }
 
 func handshakeSmart(resp *http.Response, req *transport.Request, client *http.Client, authorizer func(*http.Request) error) (transport.Session, error) {

--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -2,12 +2,31 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/url"
 
 	"github.com/go-git/go-git/v6/plumbing/transport"
 )
+
+// contextKey is an unexported type for context keys in this package.
+type contextKey int
+
+const initialRequestKey contextKey = iota
+
+// withInitialRequest marks a context so that checkRedirect allows
+// the HTTP client to follow redirects. Only the /info/refs discovery
+// request should carry this flag.
+func withInitialRequest(ctx context.Context) context.Context {
+	return context.WithValue(ctx, initialRequestKey, true)
+}
+
+func isInitialRequest(req *http.Request) bool {
+	v, _ := req.Context().Value(initialRequestKey).(bool)
+	return v
+}
 
 // Options configures the HTTP transport.
 type Options struct {
@@ -63,5 +82,32 @@ func (t *Transport) resolveClient() *http.Client {
 		tr.TLSClientConfig = t.opts.TLS
 	}
 
-	return &http.Client{Transport: tr}
+	return &http.Client{
+		Transport:     tr,
+		CheckRedirect: checkRedirect,
+	}
+}
+
+// checkRedirect implements the "initial" redirect policy from canonical
+// git (http.followRedirects = initial). Only the first request in a
+// session — the GET /info/refs discovery — is allowed to follow
+// redirects. All subsequent requests (pack-data POSTs, dumb-HTTP object
+// GETs) treat a 3xx response as an error.
+//
+// Credential handling on redirect is left to Go's http.Client, which
+// already strips the Authorization header when a redirect crosses to a
+// different host (since Go 1.8) and preserves it for same-host
+// redirects — matching the expected behavior for scheme upgrades and
+// path-only redirects on the same server.
+func checkRedirect(req *http.Request, via []*http.Request) error {
+	if !isInitialRequest(req) {
+		return fmt.Errorf("http transport: redirect on non-initial request to %s", req.URL)
+	}
+	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+		return fmt.Errorf("http transport: redirect to unsupported scheme %q", req.URL.Scheme)
+	}
+	if len(via) >= 10 {
+		return fmt.Errorf("http transport: too many redirects")
+	}
+	return nil
 }

--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -16,6 +16,19 @@ type contextKey int
 
 const initialRequestKey contextKey = iota
 
+// RedirectPolicy controls how the HTTP transport follows redirects.
+type RedirectPolicy string
+
+const (
+	// FollowInitialRedirects follows redirects only for the initial
+	// /info/refs discovery request.
+	FollowInitialRedirects RedirectPolicy = "initial"
+	// FollowRedirects follows redirects for all requests.
+	FollowRedirects RedirectPolicy = "true"
+	// NoFollowRedirects disables redirects for all requests.
+	NoFollowRedirects RedirectPolicy = "false"
+)
+
 // withInitialRequest marks a context so that checkRedirect allows
 // the HTTP client to follow redirects. Only the /info/refs discovery
 // request should carry this flag.
@@ -34,6 +47,10 @@ type Options struct {
 	// created. When Client is set, TLS and HTTPProxy are ignored —
 	// configure them on the provided Client directly.
 	Client *http.Client
+
+	// FollowRedirects controls redirect handling. The zero value defaults
+	// to "initial", matching Git's default behavior.
+	FollowRedirects RedirectPolicy
 
 	// Authorizer mutates outgoing HTTP requests to add authentication.
 	Authorizer func(*http.Request) error
@@ -70,7 +87,7 @@ func NewTransport(opts Options) *Transport {
 func (t *Transport) resolveClient() *http.Client {
 	if t.opts.Client != nil {
 		client := *t.opts.Client
-		client.CheckRedirect = wrapCheckRedirect(t.opts.Client.CheckRedirect)
+		client.CheckRedirect = wrapCheckRedirect(t.opts.redirectPolicy(), t.opts.Client.CheckRedirect)
 		return &client
 	}
 
@@ -86,13 +103,20 @@ func (t *Transport) resolveClient() *http.Client {
 
 	return &http.Client{
 		Transport:     tr,
-		CheckRedirect: checkRedirect,
+		CheckRedirect: wrapCheckRedirect(t.opts.redirectPolicy(), nil),
 	}
 }
 
-func wrapCheckRedirect(next func(*http.Request, []*http.Request) error) func(*http.Request, []*http.Request) error {
+func (o Options) redirectPolicy() RedirectPolicy {
+	if o.FollowRedirects == "" {
+		return FollowInitialRedirects
+	}
+	return o.FollowRedirects
+}
+
+func wrapCheckRedirect(policy RedirectPolicy, next func(*http.Request, []*http.Request) error) func(*http.Request, []*http.Request) error {
 	return func(req *http.Request, via []*http.Request) error {
-		if err := checkRedirect(req, via); err != nil {
+		if err := checkRedirect(req, via, policy); err != nil {
 			return err
 		}
 		if next != nil {
@@ -102,20 +126,33 @@ func wrapCheckRedirect(next func(*http.Request, []*http.Request) error) func(*ht
 	}
 }
 
-// checkRedirect implements the "initial" redirect policy from canonical
-// git (http.followRedirects = initial). Only the first request in a
-// session — the GET /info/refs discovery — is allowed to follow
-// redirects. All subsequent requests (pack-data POSTs, dumb-HTTP object
-// GETs) treat a 3xx response as an error.
+// checkRedirect implements Git's http.followRedirects policies. The
+// default policy is "initial", where only the GET /info/refs discovery
+// request is allowed to follow redirects.
 //
 // Credential handling on redirect is left to Go's http.Client, which
 // already strips the Authorization header when a redirect crosses to a
 // different host (since Go 1.8) and preserves it for same-host
 // redirects — matching the expected behavior for scheme upgrades and
 // path-only redirects on the same server.
-func checkRedirect(req *http.Request, via []*http.Request) error {
-	if !isInitialRequest(req) {
-		return fmt.Errorf("http transport: redirect on non-initial request to %s", req.URL)
+func checkRedirect(req *http.Request, via []*http.Request, policy RedirectPolicy) error {
+	if len(via) != 0 {
+		prev := via[len(via)-1]
+		if prev.URL != nil && prev.URL.Scheme == "https" && req.URL.Scheme == "http" {
+			return fmt.Errorf("http transport: redirect downgrades scheme to %s", redactedURL(req.URL))
+		}
+	}
+
+	switch policy {
+	case FollowRedirects:
+	case NoFollowRedirects:
+		return fmt.Errorf("http transport: redirects disabled to %s", redactedURL(req.URL))
+	case FollowInitialRedirects:
+		if !isInitialRequest(req) {
+			return fmt.Errorf("http transport: redirect on non-initial request to %s", redactedURL(req.URL))
+		}
+	default:
+		return fmt.Errorf("http transport: invalid redirect policy %q", policy)
 	}
 	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
 		return fmt.Errorf("http transport: redirect to unsupported scheme %q", req.URL.Scheme)

--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -69,7 +69,9 @@ func NewTransport(opts Options) *Transport {
 
 func (t *Transport) resolveClient() *http.Client {
 	if t.opts.Client != nil {
-		return t.opts.Client
+		client := *t.opts.Client
+		client.CheckRedirect = wrapCheckRedirect(t.opts.Client.CheckRedirect)
+		return &client
 	}
 
 	tr := http.DefaultTransport.(*http.Transport).Clone()
@@ -85,6 +87,18 @@ func (t *Transport) resolveClient() *http.Client {
 	return &http.Client{
 		Transport:     tr,
 		CheckRedirect: checkRedirect,
+	}
+}
+
+func wrapCheckRedirect(next func(*http.Request, []*http.Request) error) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if err := checkRedirect(req, via); err != nil {
+			return err
+		}
+		if next != nil {
+			return next(req, via)
+		}
+		return nil
 	}
 }
 

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -180,134 +180,21 @@ func TestRedirectPathWithFetch(t *testing.T) {
 
 func TestRedirectPostBlocked(t *testing.T) {
 	t.Parallel()
-
-	base, backend := setupSmartServer(t)
-	prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
-
-	rl := test.ListenTCP(t)
-	raddr := rl.Addr().(*net.TCPAddr)
-
-	backendURL := fmt.Sprintf("http://localhost:%d", backend.Port)
-	proxyServer := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost {
-				http.Redirect(w, r, backendURL+r.URL.Path, http.StatusTemporaryRedirect)
-				return
-			}
-			resp, err := http.Get(backendURL + r.URL.Path + "?" + r.URL.RawQuery)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadGateway)
-				return
-			}
-			defer resp.Body.Close()
-			maps.Copy(w.Header(), resp.Header)
-			w.WriteHeader(resp.StatusCode)
-			io.Copy(w, resp.Body)
-		}),
-	}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		require.ErrorIs(t, proxyServer.Serve(rl), http.ErrServerClosed)
-	}()
-	t.Cleanup(func() {
-		require.NoError(t, proxyServer.Close())
-		<-done
-	})
-
-	tr := NewTransport(Options{})
-	endpoint := &url.URL{
-		Scheme: "http",
-		Host:   fmt.Sprintf("localhost:%d", raddr.Port),
-		Path:   "/basic.git",
-	}
-
-	session, err := tr.Handshake(context.Background(), &transport.Request{
-		URL:     endpoint,
-		Command: transport.UploadPackService,
-	})
-	require.NoError(t, err)
-	defer session.Close()
-
-	refs, err := session.GetRemoteRefs(context.Background())
-	require.NoError(t, err)
-	require.NotNil(t, refs)
-
-	st := memory.NewStorage()
-	req := &transport.FetchRequest{}
-	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-
-	err = session.Fetch(context.Background(), st, req)
+	err := fetchWithRedirectedPost(t, Options{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "non-initial request")
 }
 
 func TestRedirectPostBlockedWithCustomClient(t *testing.T) {
 	t.Parallel()
-
-	base, backend := setupSmartServer(t)
-	prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
-
-	rl := test.ListenTCP(t)
-	raddr := rl.Addr().(*net.TCPAddr)
-
-	backendURL := fmt.Sprintf("http://localhost:%d", backend.Port)
-	proxyServer := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost {
-				http.Redirect(w, r, backendURL+r.URL.Path, http.StatusTemporaryRedirect)
-				return
-			}
-			resp, err := http.Get(backendURL + r.URL.Path + "?" + r.URL.RawQuery)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadGateway)
-				return
-			}
-			defer resp.Body.Close()
-			maps.Copy(w.Header(), resp.Header)
-			w.WriteHeader(resp.StatusCode)
-			io.Copy(w, resp.Body)
-		}),
-	}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		require.ErrorIs(t, proxyServer.Serve(rl), http.ErrServerClosed)
-	}()
-	t.Cleanup(func() {
-		require.NoError(t, proxyServer.Close())
-		<-done
-	})
-
-	tr := NewTransport(Options{
-		Client: &http.Client{},
-	})
-	endpoint := &url.URL{
-		Scheme: "http",
-		Host:   fmt.Sprintf("localhost:%d", raddr.Port),
-		Path:   "/basic.git",
-	}
-
-	session, err := tr.Handshake(context.Background(), &transport.Request{
-		URL:     endpoint,
-		Command: transport.UploadPackService,
-	})
-	require.NoError(t, err)
-	defer session.Close()
-
-	refs, err := session.GetRemoteRefs(context.Background())
-	require.NoError(t, err)
-	require.NotNil(t, refs)
-
-	st := memory.NewStorage()
-	req := &transport.FetchRequest{}
-	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-
-	err = session.Fetch(context.Background(), st, req)
+	err := fetchWithRedirectedPost(t, Options{Client: &http.Client{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "non-initial request")
+}
+
+func TestRedirectPostAllowedWithFollowRedirects(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, fetchWithRedirectedPost(t, Options{FollowRedirects: FollowRedirects}))
 }
 
 func TestRedirectStripsCredentials(t *testing.T) {
@@ -363,46 +250,209 @@ func TestRedirectStripsCredentials(t *testing.T) {
 func TestCheckRedirectPolicy(t *testing.T) {
 	t.Parallel()
 
-	t.Run("blocks non-initial request", func(t *testing.T) {
-		t.Parallel()
-		target, _ := url.Parse("http://example.com/repo.git")
-		req := &http.Request{URL: target}
-		req = req.WithContext(context.Background())
-		err := checkRedirect(req, []*http.Request{{}})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "non-initial request")
+	tests := []struct {
+		name          string
+		policy        RedirectPolicy
+		targetURL     string
+		initial       bool
+		redirectCount int
+		via           []string
+		wantErr       string
+	}{
+		{
+			name:      "initial blocks non-initial request",
+			policy:    FollowInitialRedirects,
+			targetURL: "http://example.com/repo.git",
+			wantErr:   "non-initial request",
+		},
+		{
+			name:      "initial allows initial request",
+			policy:    FollowInitialRedirects,
+			targetURL: "http://example.com/repo.git",
+			initial:   true,
+		},
+		{
+			name:      "true allows non-initial request",
+			policy:    FollowRedirects,
+			targetURL: "http://example.com/repo.git",
+		},
+		{
+			name:      "false blocks redirects",
+			policy:    NoFollowRedirects,
+			targetURL: "http://example.com/repo.git",
+			initial:   true,
+			wantErr:   "redirects disabled",
+		},
+		{
+			name:      "blocks unsupported scheme",
+			policy:    FollowRedirects,
+			targetURL: "file:///etc/passwd",
+			initial:   true,
+			wantErr:   "unsupported scheme",
+		},
+		{
+			name:          "blocks too many redirects",
+			policy:        FollowRedirects,
+			targetURL:     "http://example.com/repo.git",
+			initial:       true,
+			redirectCount: 10,
+			wantErr:       "too many redirects",
+		},
+		{
+			name:      "blocks https to http downgrade",
+			policy:    FollowRedirects,
+			targetURL: "http://example.com/repo.git",
+			initial:   true,
+			via:       []string{"https://example.com/repo.git"},
+			wantErr:   "downgrades scheme",
+		},
+		{
+			name:      "redacts credentials in redirect errors",
+			policy:    NoFollowRedirects,
+			targetURL: "https://user:pass@example.com/repo.git",
+			initial:   true,
+			wantErr:   "https://user:REDACTED@example.com/repo.git",
+		},
+		{
+			name:      "rejects invalid policy",
+			policy:    RedirectPolicy("bogus"),
+			targetURL: "http://example.com/repo.git",
+			initial:   true,
+			wantErr:   "invalid redirect policy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			target, err := url.Parse(tt.targetURL)
+			require.NoError(t, err)
+
+			req := &http.Request{URL: target, Header: http.Header{}}
+			if tt.initial {
+				req = req.WithContext(withInitialRequest(context.Background()))
+			} else {
+				req = req.WithContext(context.Background())
+			}
+
+			via := make([]*http.Request, tt.redirectCount)
+			for i := range via {
+				via[i] = &http.Request{}
+			}
+			if len(tt.via) != 0 {
+				via = make([]*http.Request, 0, len(tt.via))
+				for _, rawURL := range tt.via {
+					u, err := url.Parse(rawURL)
+					require.NoError(t, err)
+					via = append(via, &http.Request{URL: u})
+				}
+			}
+
+			err = checkRedirect(req, via, tt.policy)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestOptionsRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		option Options
+		want   RedirectPolicy
+	}{
+		{
+			name: "nil config defaults to initial",
+			want: FollowInitialRedirects,
+		},
+		{
+			name:   "true is preserved",
+			option: Options{FollowRedirects: FollowRedirects},
+			want:   FollowRedirects,
+		},
+		{
+			name:   "false is preserved",
+			option: Options{FollowRedirects: NoFollowRedirects},
+			want:   NoFollowRedirects,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.option.redirectPolicy())
+		})
+	}
+}
+
+func fetchWithRedirectedPost(t *testing.T, opts Options) error {
+	t.Helper()
+
+	base, backend := setupSmartServer(t)
+	prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
+
+	rl := test.ListenTCP(t)
+	raddr := rl.Addr().(*net.TCPAddr)
+
+	backendURL := fmt.Sprintf("http://localhost:%d", backend.Port)
+	proxyServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				http.Redirect(w, r, backendURL+r.URL.Path, http.StatusTemporaryRedirect)
+				return
+			}
+			resp, err := http.Get(backendURL + r.URL.Path + "?" + r.URL.RawQuery)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			defer resp.Body.Close()
+			maps.Copy(w.Header(), resp.Header)
+			w.WriteHeader(resp.StatusCode)
+			_, _ = io.Copy(w, resp.Body)
+		}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.ErrorIs(t, proxyServer.Serve(rl), http.ErrServerClosed)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, proxyServer.Close())
+		<-done
 	})
 
-	t.Run("allows initial request", func(t *testing.T) {
-		t.Parallel()
-		target, _ := url.Parse("http://example.com/repo.git")
-		req := &http.Request{URL: target, Header: http.Header{}}
-		req = req.WithContext(withInitialRequest(context.Background()))
-		err := checkRedirect(req, []*http.Request{{}})
-		require.NoError(t, err)
-	})
+	tr := NewTransport(opts)
+	endpoint := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("localhost:%d", raddr.Port),
+		Path:   "/basic.git",
+	}
 
-	t.Run("blocks unsupported scheme", func(t *testing.T) {
-		t.Parallel()
-		target, _ := url.Parse("file:///etc/passwd")
-		req := &http.Request{URL: target, Header: http.Header{}}
-		req = req.WithContext(withInitialRequest(context.Background()))
-		err := checkRedirect(req, []*http.Request{{}})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unsupported scheme")
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     endpoint,
+		Command: transport.UploadPackService,
 	})
+	require.NoError(t, err)
+	defer session.Close()
 
-	t.Run("blocks too many redirects", func(t *testing.T) {
-		t.Parallel()
-		target, _ := url.Parse("http://example.com/repo.git")
-		req := &http.Request{URL: target, Header: http.Header{}}
-		req = req.WithContext(withInitialRequest(context.Background()))
-		via := make([]*http.Request, 10)
-		for i := range via {
-			via[i] = &http.Request{}
-		}
-		err := checkRedirect(req, via)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "too many redirects")
-	})
+	refs, err := session.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, refs)
+
+	st := memory.NewStorage()
+	req := &transport.FetchRequest{}
+	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+
+	return session.Fetch(context.Background(), st, req)
 }

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -243,6 +243,73 @@ func TestRedirectPostBlocked(t *testing.T) {
 	assert.Contains(t, err.Error(), "non-initial request")
 }
 
+func TestRedirectPostBlockedWithCustomClient(t *testing.T) {
+	t.Parallel()
+
+	base, backend := setupSmartServer(t)
+	prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
+
+	rl := test.ListenTCP(t)
+	raddr := rl.Addr().(*net.TCPAddr)
+
+	backendURL := fmt.Sprintf("http://localhost:%d", backend.Port)
+	proxyServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				http.Redirect(w, r, backendURL+r.URL.Path, http.StatusTemporaryRedirect)
+				return
+			}
+			resp, err := http.Get(backendURL + r.URL.Path + "?" + r.URL.RawQuery)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			defer resp.Body.Close()
+			maps.Copy(w.Header(), resp.Header)
+			w.WriteHeader(resp.StatusCode)
+			io.Copy(w, resp.Body)
+		}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.ErrorIs(t, proxyServer.Serve(rl), http.ErrServerClosed)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, proxyServer.Close())
+		<-done
+	})
+
+	tr := NewTransport(Options{
+		Client: &http.Client{},
+	})
+	endpoint := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("localhost:%d", raddr.Port),
+		Path:   "/basic.git",
+	}
+
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     endpoint,
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	refs, err := session.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, refs)
+
+	st := memory.NewStorage()
+	req := &transport.FetchRequest{}
+	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+
+	err = session.Fetch(context.Background(), st, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-initial request")
+}
+
 func TestRedirectStripsCredentials(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -3,12 +3,15 @@ package http
 import (
 	"context"
 	"fmt"
+	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/internal/transport/test"
@@ -173,4 +176,166 @@ func TestRedirectPathWithFetch(t *testing.T) {
 
 	err = session.Fetch(context.Background(), st, req)
 	require.NoError(t, err)
+}
+
+func TestRedirectPostBlocked(t *testing.T) {
+	t.Parallel()
+
+	base, backend := setupSmartServer(t)
+	prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
+
+	rl := test.ListenTCP(t)
+	raddr := rl.Addr().(*net.TCPAddr)
+
+	backendURL := fmt.Sprintf("http://localhost:%d", backend.Port)
+	proxyServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPost {
+				http.Redirect(w, r, backendURL+r.URL.Path, http.StatusTemporaryRedirect)
+				return
+			}
+			resp, err := http.Get(backendURL + r.URL.Path + "?" + r.URL.RawQuery)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadGateway)
+				return
+			}
+			defer resp.Body.Close()
+			maps.Copy(w.Header(), resp.Header)
+			w.WriteHeader(resp.StatusCode)
+			io.Copy(w, resp.Body)
+		}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.ErrorIs(t, proxyServer.Serve(rl), http.ErrServerClosed)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, proxyServer.Close())
+		<-done
+	})
+
+	tr := NewTransport(Options{})
+	endpoint := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("localhost:%d", raddr.Port),
+		Path:   "/basic.git",
+	}
+
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     endpoint,
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	refs, err := session.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, refs)
+
+	st := memory.NewStorage()
+	req := &transport.FetchRequest{}
+	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+
+	err = session.Fetch(context.Background(), st, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-initial request")
+}
+
+func TestRedirectStripsCredentials(t *testing.T) {
+	t.Parallel()
+
+	base, backend := setupSmartServer(t)
+	prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
+
+	rl := test.ListenTCP(t)
+	raddr := rl.Addr().(*net.TCPAddr)
+
+	backendURL := fmt.Sprintf("http://localhost:%d", backend.Port)
+	redirectServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			target := backendURL + r.URL.Path
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusMovedPermanently)
+		}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.ErrorIs(t, redirectServer.Serve(rl), http.ErrServerClosed)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, redirectServer.Close())
+		<-done
+	})
+
+	tr := NewTransport(Options{})
+	endpoint := &url.URL{
+		Scheme: "http",
+		User:   url.UserPassword("testuser", "testpass"),
+		Host:   fmt.Sprintf("localhost:%d", raddr.Port),
+		Path:   "/basic.git",
+	}
+
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     endpoint,
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	sps, ok := session.(*smartPackSession)
+	require.True(t, ok)
+	assert.Nil(t, sps.baseURL.User)
+}
+
+func TestCheckRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("blocks non-initial request", func(t *testing.T) {
+		t.Parallel()
+		target, _ := url.Parse("http://example.com/repo.git")
+		req := &http.Request{URL: target}
+		req = req.WithContext(context.Background())
+		err := checkRedirect(req, []*http.Request{{}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-initial request")
+	})
+
+	t.Run("allows initial request", func(t *testing.T) {
+		t.Parallel()
+		target, _ := url.Parse("http://example.com/repo.git")
+		req := &http.Request{URL: target, Header: http.Header{}}
+		req = req.WithContext(withInitialRequest(context.Background()))
+		err := checkRedirect(req, []*http.Request{{}})
+		require.NoError(t, err)
+	})
+
+	t.Run("blocks unsupported scheme", func(t *testing.T) {
+		t.Parallel()
+		target, _ := url.Parse("file:///etc/passwd")
+		req := &http.Request{URL: target, Header: http.Header{}}
+		req = req.WithContext(withInitialRequest(context.Background()))
+		err := checkRedirect(req, []*http.Request{{}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported scheme")
+	})
+
+	t.Run("blocks too many redirects", func(t *testing.T) {
+		t.Parallel()
+		target, _ := url.Parse("http://example.com/repo.git")
+		req := &http.Request{URL: target, Header: http.Header{}}
+		req = req.WithContext(withInitialRequest(context.Background()))
+		via := make([]*http.Request, 10)
+		for i := range via {
+			via[i] = &http.Request{}
+		}
+		err := checkRedirect(req, via)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too many redirects")
+	})
 }

--- a/plumbing/transport/http/tls_test.go
+++ b/plumbing/transport/http/tls_test.go
@@ -99,7 +99,7 @@ func TestResolveClient_CustomClientWrapsRedirectPolicy(t *testing.T) {
 
 	called := false
 	custom := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			called = true
 			return nil
 		},

--- a/plumbing/transport/http/tls_test.go
+++ b/plumbing/transport/http/tls_test.go
@@ -1,9 +1,11 @@
 package http
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,14 +80,45 @@ func TestResolveClient_InsecureAndCABundle(t *testing.T) {
 func TestResolveClient_CustomClient_IgnoresTLS(t *testing.T) {
 	t.Parallel()
 
-	custom := &http.Client{}
+	customTransport := &http.Transport{}
+	custom := &http.Client{Transport: customTransport}
 	tr := NewTransport(Options{
 		Client: custom,
 		TLS:    &tls.Config{InsecureSkipVerify: true},
 	})
 	client := tr.resolveClient()
 
-	assert.Equal(t, custom, client)
+	assert.NotSame(t, custom, client)
+	assert.Same(t, customTransport, client.Transport)
+	require.NotNil(t, client.CheckRedirect)
+	assert.Nil(t, custom.CheckRedirect)
+}
+
+func TestResolveClient_CustomClientWrapsRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	custom := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			called = true
+			return nil
+		},
+	}
+	tr := NewTransport(Options{Client: custom})
+	client := tr.resolveClient()
+
+	target, _ := url.Parse("http://example.com/repo.git")
+	req := &http.Request{URL: target, Header: http.Header{}}
+	req = req.WithContext(withInitialRequest(context.Background()))
+
+	err := client.CheckRedirect(req, []*http.Request{{}})
+	require.NoError(t, err)
+	assert.True(t, called)
+
+	req = req.WithContext(context.Background())
+	err = client.CheckRedirect(req, []*http.Request{{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-initial request")
 }
 
 func TestResolveClient_NilTLS(t *testing.T) {


### PR DESCRIPTION
## Summary

The HTTP transport's redirect handling had several security gaps compared to canonical git's default `http.followRedirects = initial` policy. This PR closes them.

### Problem

When go-git's HTTP transport follows server redirects during `Handshake` (the `GET /info/refs` discovery request), several things could go wrong:

1. **No redirect policy** — Go's default `http.Client` follows redirects on *every* request (GET, POST, etc.). A malicious server could redirect a pack-data POST to an attacker-controlled host and the client would silently follow it. Canonical git only follows redirects on the initial `/info/refs` request and treats 3xx on subsequent requests as errors.

2. **No protocol/scheme restriction** — A redirect to `file://`, `gopher://`, or any other scheme was accepted. This is an SSRF vector in server-side environments. Canonical git restricts redirect targets to `http`/`https`/`ftp`/`ftps` via `CURLOPT_REDIR_PROTOCOLS`.

3. **Silent fallback on path mismatch** — If the redirect target's path didn't end with `/info/refs`, `applyRedirect` silently returned the original base URL instead of erroring. Canonical git's `update_url_from_redirect()` calls `die()` here because a tail mismatch could indicate a malicious redirect attempting to rewrite the base URL to an unrelated repository.

4. **Credential leakage to redirect target** — Both the URL-embedded `Userinfo` credentials and the `Authorizer` callback were stored in the session and re-applied on every subsequent POST. After a cross-host redirect, the original host's credentials would be sent to the new host. Canonical git re-derives credentials from the new URL via `credential_from_url()`, effectively wiping the old ones.

### Changes

- **`common.go`** — `applyRedirect` now returns `(*url.URL, error)`. Validates the redirect target's scheme is `http` or `https`. Returns a hard error when the redirected path doesn't end with `/info/refs` (matching canonical git's `die()` behavior).

- **`http.go`** — Adds a `CheckRedirect` policy (`checkRedirect`) implementing canonical git's `initial` mode: only the `/info/refs` GET (tagged via context key) is allowed to follow redirects. Non-initial requests, unsupported schemes, and >10 hops are rejected. Go's stdlib already strips `Authorization` on cross-host redirects and preserves it for same-host redirects, so no manual header manipulation is needed.

- **`handshake.go`** — Tags the `/info/refs` request with `withInitialRequest(ctx)`. After `applyRedirect`, clears both `URL.User` and the `Authorizer` callback when the host changed — both are credential sources that would otherwise leak to the redirect target.

### Canonical git reference

- Redirect policy: `http.c:130` (`HTTP_FOLLOW_INITIAL` default), `http.c:1583-1591` (CURLOPT_FOLLOWLOCATION per-request)
- Protocol whitelist: `http.c:991-1013` (`get_curl_allowed_protocols`)
- Tail validation: `http.c:2243-2293` (`update_url_from_redirect`)
- Credential wipe: `http.c:2354-2360` (`credential_from_url` after redirect)

## Test plan

- [x] `TestCheckRedirectPolicy` — unit tests for the `checkRedirect` function: blocks non-initial requests, allows initial requests, blocks unsupported schemes, blocks >10 redirects
- [x] `TestApplyRedirect` — unit tests for `applyRedirect`: no-op detection, host/scheme/path updates, scheme rejection, tail mismatch error
- [x] `TestRedirectPostBlocked` — integration test: server proxies GET but 307-redirects POST; verifies fetch fails with "non-initial request"
- [x] `TestRedirectStripsCredentials` — integration test: cross-host redirect clears `URL.User` from the session's base URL
- [x] `TestRedirectPath`, `TestRedirectSchema`, `TestRedirectPathWithFetch` — existing integration tests still pass (legitimate redirects during handshake continue to work)
- [x] Full `go test ./plumbing/transport/http/...` passes