### PR TITLE
plumbing: format/packfile, use ReadAt in FSObject.Reader() for concurrency safety.

### DIFF
--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"io"
+	"math"
 	"os"
 
 	billy "github.com/go-git/go-billy/v6"
@@ -54,6 +55,10 @@ func NewFSObject(
 }
 
 // Reader implements the plumbing.EncodedObject interface.
+//
+// Reader is safe for concurrent use: it uses ReadAt (which does not modify the
+// file's seek cursor) instead of Seek+Read, so multiple goroutines can call
+// Reader on FSObjects that share the same underlying packfile handle.
 func (o *FSObject) Reader() (io.ReadCloser, error) {
 	obj, ok := o.cache.Get(o.hash)
 	if ok && obj != o {
@@ -65,27 +70,32 @@ func (o *FSObject) Reader() (io.ReadCloser, error) {
 		return reader, nil
 	}
 
+	pack := o.pack
 	var file io.Closer
-	_, err := o.pack.Seek(o.offset, io.SeekStart)
-	// fsobject aims to reuse an existing file descriptor to the packfile.
-	// In some cases that descriptor would already be closed, in such cases,
-	// open the packfile again and close it when the reader is closed.
+
+	// Probe with a 1-byte ReadAt to detect a closed file descriptor without
+	// modifying any shared state. A zero-length read cannot be used because
+	// some implementations (e.g. os.File) return (0, nil) for empty reads
+	// even on closed files.
+	_, err := pack.ReadAt(make([]byte, 1), o.offset)
 	if err != nil && errors.Is(err, os.ErrClosed) {
-		o.pack, err = o.fs.Open(o.packPath)
+		pack, err = o.fs.Open(o.packPath)
 		if err != nil {
 			return nil, err
 		}
-		file = o.pack
-		_, err = o.pack.Seek(o.offset, io.SeekStart)
-	}
-	if err != nil {
-		if file != nil {
-			_ = file.Close()
-		}
+		file = pack
+	} else if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 
-	br := sync.GetBufioReader(o.pack)
+	// SectionReader provides a standalone io.Reader backed by ReadAt. Each
+	// SectionReader maintains its own read position, so concurrent calls
+	// to Reader do not interfere with each other or with the packfile's
+	// Scanner. The upper bound is set to math.MaxInt64 because zlib
+	// streams are self-terminating — the decompressor stops at the DEFLATE
+	// end marker regardless of how many bytes remain available.
+	sr := io.NewSectionReader(pack, o.offset, math.MaxInt64-o.offset)
+	br := sync.GetBufioReader(sr)
 
 	zr, err := sync.GetZlibReader(br)
 	if err != nil {

--- a/plumbing/format/packfile/fsobject_test.go
+++ b/plumbing/format/packfile/fsobject_test.go
@@ -1,0 +1,62 @@
+package packfile_test
+
+import (
+	"io"
+	"testing"
+	"testing/synctest"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/internal/fixtureutil"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+)
+
+// TestFSObjectConcurrentReader verifies that multiple goroutines can call
+// Reader() on FSObjects backed by the same packfile handle without racing.
+// Before the ReadAt fix, FSObject.Reader() used Seek+Read on a shared file
+// descriptor, causing data races under concurrent access.
+func TestFSObjectConcurrentReader(t *testing.T) {
+	t.Parallel()
+
+	f := fixtures.Basic().One()
+	index := getIndexFromFixture(t, f)
+
+	pf, pfErr := f.Packfile()
+	require.NoError(t, pfErr)
+	p := packfile.NewPackfile(pf,
+		packfile.WithIdx(index),
+		packfile.WithFs(osfs.New(t.TempDir())),
+	)
+
+	entries := fixtureutil.Entries(f)
+	objects := make([]plumbing.EncodedObject, 0, len(entries))
+	for h := range entries {
+		obj, err := p.Get(h)
+		require.NoError(t, err)
+		objects = append(objects, obj)
+	}
+	require.NotEmpty(t, objects)
+
+	const iterations = 5
+	synctest.Test(t, func(t *testing.T) {
+		for range iterations {
+			for _, obj := range objects {
+				go func() {
+					reader, err := obj.Reader()
+					if err != nil {
+						t.Errorf("Reader(): %v", err)
+						return
+					}
+					defer reader.Close()
+
+					if _, err = io.ReadAll(reader); err != nil {
+						t.Errorf("ReadAll(): %v", err)
+					}
+				}()
+			}
+		}
+	})
+}


### PR DESCRIPTION
Replace Seek+Read with io.SectionReader backed by ReadAt in FSObject.Reader(). ReadAt does not modify the file's seek cursor (it maps to pread(2) on POSIX), so multiple goroutines can safely call Reader() on FSObjects that share the same packfile handle. The billy.File interface already requires io.ReaderAt, and both osfs (via os.File) and memfs implementations are documented as safe for concurrent ReadAt calls.

The closed-file recovery path now uses a 1-byte ReadAt probe instead of Seek to detect stale descriptors without mutating shared state.

A zero-length ReadAt is insufficient because os.File returns (0, nil) for empty reads even on closed files.

This PR is necessary to enable parallel checkout from PR #1749 which will help resolving #1956

Assisted-by: OpenCode with Claude Opus 4.6 <noreply@anthropic.com>