### PR TITLE
plumbing: transport, Align flush size with upstream git

### DIFF
--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -39,6 +39,7 @@ func TestSmartMultiRoundFetch(t *testing.T) {
 	remoteFS := prepareRepo(t, fixture, base, "packfile.git")
 	remotePath := remoteFS.Root()
 	remoteStorage := filesystem.NewStorage(osfs.New(remotePath), cache.NewObjectLRUDefault())
+	defer func() { _ = remoteStorage.Close() }()
 
 	oldCommit := nthCommitFromHead(t, remoteStorage, plumbing.NewHash(fixture.Head), 96)
 
@@ -46,6 +47,8 @@ func TestSmartMultiRoundFetch(t *testing.T) {
 	require.NoError(t, remoteStorage.SetReference(plumbing.NewHashReference(seedRef, oldCommit)))
 	seedPath := filepath.Join(t.TempDir(), "seed.git")
 	seedStorage := initBareStorage(t, seedPath)
+	defer func() { _ = seedStorage.Close() }()
+
 	fetchToStorage(t, remotePath, seedStorage, oldCommit)
 	require.NoError(t, seedStorage.SetReference(plumbing.NewHashReference(plumbing.Master, oldCommit)))
 	require.NoError(t, seedStorage.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))
@@ -53,6 +56,8 @@ func TestSmartMultiRoundFetch(t *testing.T) {
 
 	clientPath := filepath.Join(t.TempDir(), "client.git")
 	clientStorage := initBareStorage(t, clientPath)
+	defer func() { _ = clientStorage.Close() }()
+
 	fetchToStorage(t, seedPath, clientStorage, oldCommit)
 	require.NoError(t, clientStorage.SetReference(plumbing.NewHashReference(plumbing.Master, oldCommit)))
 	require.NoError(t, clientStorage.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -1,80 +1,90 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
+	"github.com/go-git/go-billy/v6/osfs"
+	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/plumbing/transport"
+	filetransport "github.com/go-git/go-git/v6/plumbing/transport/file"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
-// TestHTTPNegotiatorMultiRound verifies that httpNegotiator creates a
-// fresh HTTP POST for each negotiation round. Before the fix, only the
-// first round's data was sent because httpRequester.Close() was a no-op
-// after the first POST.
-func TestHTTPNegotiatorMultiRound(t *testing.T) {
+func TestSmartMultiRoundFetch(t *testing.T) {
 	t.Parallel()
 
-	var mu sync.Mutex
-	var postBodies []string
+	fixture := fixtures.ByURL("https://github.com/src-d/go-git.git").One()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		mu.Lock()
-		postBodies = append(postBodies, string(body))
-		mu.Unlock()
-		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
-		// Return a minimal pkt-line NAK response.
-		_, _ = w.Write([]byte("0008NAK\n"))
-	}))
-	defer srv.Close()
+	base, backend := setupSmartServer(t)
+	remoteFS := prepareRepo(t, fixture, base, "packfile.git")
+	remotePath := remoteFS.Root()
+	remoteStorage := filesystem.NewStorage(osfs.New(remotePath), cache.NewObjectLRUDefault())
 
-	u, err := url.Parse(srv.URL)
+	oldCommit := nthCommitFromHead(t, remoteStorage, plumbing.NewHash(fixture.Head), 96)
+
+	seedRef := plumbing.ReferenceName("refs/heads/seed-old")
+	require.NoError(t, remoteStorage.SetReference(plumbing.NewHashReference(seedRef, oldCommit)))
+	seedPath := filepath.Join(t.TempDir(), "seed.git")
+	seedStorage := initBareStorage(t, seedPath)
+	fetchToStorage(t, remotePath, seedStorage, oldCommit)
+	require.NoError(t, seedStorage.SetReference(plumbing.NewHashReference(plumbing.Master, oldCommit)))
+	require.NoError(t, seedStorage.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))
+	require.NoError(t, remoteStorage.RemoveReference(seedRef))
+
+	clientPath := filepath.Join(t.TempDir(), "client.git")
+	clientStorage := initBareStorage(t, clientPath)
+	fetchToStorage(t, seedPath, clientStorage, oldCommit)
+	require.NoError(t, clientStorage.SetReference(plumbing.NewHashReference(plumbing.Master, oldCommit)))
+	require.NoError(t, clientStorage.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))
+	haves := commitHaves(t, clientStorage, oldCommit, 80)
+	require.Greater(t, len(haves), 32, "test setup must force multiple have rounds")
+
+	want := plumbing.NewHash(fixture.Head)
+	require.Error(t, clientStorage.HasEncodedObject(want), "seed client should not already have the remote tip")
+
+	proxyURL, requests := setupCountingProxy(t, backend)
+
+	tr := NewTransport(Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     proxyURL,
+		Command: transport.UploadPackService,
+	})
 	require.NoError(t, err)
+	defer session.Close()
 
-	session := &smartPackSession{
-		client:  srv.Client(),
-		baseURL: u,
-		service: transport.UploadPackService,
+	req := &transport.FetchRequest{
+		Wants: []plumbing.Hash{want},
+		Haves: haves,
 	}
 
-	neg := &httpNegotiator{session: session, ctx: context.Background()}
-	defer neg.closeResponse()
-
-	// Round 1: write, close (fires POST), read response.
-	_, err = neg.Write([]byte("round1"))
+	err = session.Fetch(context.Background(), clientStorage, req)
 	require.NoError(t, err)
+	require.NoError(t, clientStorage.HasEncodedObject(want))
 
-	err = neg.Close()
-	require.NoError(t, err)
-
-	resp1, err := io.ReadAll(neg)
-	require.NoError(t, err)
-	assert.Equal(t, "0008NAK\n", string(resp1))
-
-	// Round 2: write triggers new requester, close fires second POST.
-	_, err = neg.Write([]byte("round2"))
-	require.NoError(t, err)
-
-	err = neg.Close()
-	require.NoError(t, err)
-
-	resp2, err := io.ReadAll(neg)
-	require.NoError(t, err)
-	assert.Equal(t, "0008NAK\n", string(resp2))
-
-	mu.Lock()
-	defer mu.Unlock()
-	require.Len(t, postBodies, 2, "expected 2 POSTs (one per round)")
-	assert.Equal(t, "round1", postBodies[0])
-	assert.Equal(t, "round2", postBodies[1])
+	requests.mu.Lock()
+	defer requests.mu.Unlock()
+	require.GreaterOrEqual(t, len(requests.bodies), 2, "expected multiple stateless RPC rounds")
+	assert.NotEqual(t, string(requests.bodies[0]), string(requests.bodies[1]), "subsequent rounds should send different negotiation payloads")
 }
 
 // TestHTTPNegotiatorCloseResponse verifies that closeResponse closes
@@ -130,4 +140,119 @@ func TestHTTPNegotiatorNoRounds(t *testing.T) {
 
 	err = neg.Close()
 	assert.NoError(t, err)
+}
+
+type uploadPackRequests struct {
+	mu     sync.Mutex
+	bodies [][]byte
+}
+
+func setupCountingProxy(t testing.TB, backendAddr *net.TCPAddr) (*url.URL, *uploadPackRequests) {
+	t.Helper()
+
+	backendURL, err := url.Parse("http://" + backendAddr.String())
+	require.NoError(t, err)
+
+	requests := &uploadPackRequests{}
+	proxy := httputil.NewSingleHostReverseProxy(backendURL)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/git-upload-pack") {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_ = r.Body.Close()
+
+			requests.mu.Lock()
+			requests.bodies = append(requests.bodies, body)
+			requests.mu.Unlock()
+
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			r.ContentLength = int64(len(body))
+		}
+
+		proxy.ServeHTTP(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL + "/packfile.git")
+	require.NoError(t, err)
+	return u, requests
+}
+
+func nthCommitFromHead(t testing.TB, storage storer.EncodedObjectStorer, head plumbing.Hash, n int) plumbing.Hash {
+	t.Helper()
+
+	commit, err := object.GetCommit(storage, head)
+	require.NoError(t, err)
+
+	iter := object.NewCommitPostorderIterFirstParent(commit, nil)
+	defer iter.Close()
+
+	var (
+		hash  plumbing.Hash
+		count int
+	)
+	err = iter.ForEach(func(c *object.Commit) error {
+		hash = c.Hash
+		count++
+		if count == n {
+			return storer.ErrStop
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, n, count)
+	return hash
+}
+
+func commitHaves(t testing.TB, storage storer.EncodedObjectStorer, head plumbing.Hash, n int) []plumbing.Hash {
+	t.Helper()
+
+	commit, err := object.GetCommit(storage, head)
+	require.NoError(t, err)
+
+	iter := object.NewCommitPostorderIterFirstParent(commit, nil)
+	defer iter.Close()
+
+	haves := make([]plumbing.Hash, 0, n)
+	err = iter.ForEach(func(c *object.Commit) error {
+		haves = append(haves, c.Hash)
+		if len(haves) == n {
+			return storer.ErrStop
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return haves
+}
+
+func initBareStorage(t testing.TB, path string) *filesystem.Storage {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(path, 0o755))
+	st := filesystem.NewStorage(osfs.New(path), cache.NewObjectLRUDefault())
+	cfg := config.NewConfig()
+	cfg.Core.IsBare = true
+	require.NoError(t, st.SetConfig(cfg))
+	return st
+}
+
+func fetchToStorage(t testing.TB, repoPath string, storage *filesystem.Storage, want plumbing.Hash) {
+	t.Helper()
+
+	tr := filetransport.NewTransport(filetransport.Options{})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     &url.URL{Scheme: "file", Path: repoPath},
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, session.Close()) }()
+
+	err = session.Fetch(context.Background(), storage, &transport.FetchRequest{
+		Wants: []plumbing.Hash{want},
+	})
+	require.NoError(t, err)
 }

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -17,6 +17,28 @@ import (
 	xstorage "github.com/go-git/go-git/v6/x/storage"
 )
 
+const (
+	initialFlush  = 16
+	pipeSafeFlush = 32
+	largeFlush    = 16384
+	maxInVein     = 256
+)
+
+func nextFlush(statelessRPC bool, count int) int {
+	if statelessRPC {
+		if count < largeFlush {
+			return count << 1
+		}
+		return count * 11 / 10
+	}
+
+	if count < pipeSafeFlush {
+		return count << 1
+	}
+
+	return count + pipeSafeFlush
+}
+
 // NegotiatePack performs the pack negotiation phase of the fetch operation.
 func NegotiatePack(
 	ctx context.Context,
@@ -137,16 +159,16 @@ func NegotiatePack(
 	var done bool
 	var gotContinue bool
 	firstRound := true
+	flushAt := initialFlush
 
 	for !done {
 		var uphav packp.UploadHaves
-		for i := 0; i < 32 && len(req.Haves) > 0; i++ {
+		for i := 0; i < flushAt && len(req.Haves) > 0; i++ {
 			uphav.Haves = append(uphav.Haves, req.Haves[len(req.Haves)-1])
 			req.Haves = req.Haves[:len(req.Haves)-1]
 			inVein++
 		}
 
-		const maxInVein = 256
 		done = len(req.Haves) == 0 || (gotContinue && inVein >= maxInVein)
 		uphav.Done = done
 
@@ -213,6 +235,7 @@ func NegotiatePack(
 		}
 
 		firstRound = false
+		flushAt = nextFlush(statelessRPC, flushAt)
 	}
 
 	if !statelessRPC {

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -39,6 +39,37 @@ func nextFlush(statelessRPC bool, count int) int {
 	return count + pipeSafeFlush
 }
 
+func applyServerACKs(
+	statelessRPC bool,
+	acks []packp.ACK,
+	common map[plumbing.Hash]struct{},
+	statelessCommon *[]plumbing.Hash,
+	gotContinue *bool,
+	gotReady *bool,
+	inVein *int,
+) {
+	for _, ack := range acks {
+		if !*gotContinue && ack.Status > 0 {
+			*gotContinue = true
+		}
+
+		switch ack.Status {
+		case packp.ACKContinue:
+			*inVein = 0
+		case packp.ACKReady:
+			*gotReady = true
+			*inVein = 0
+		case packp.ACKCommon:
+			_, alreadyCommon := common[ack.Hash]
+			common[ack.Hash] = struct{}{}
+			if statelessRPC && !alreadyCommon {
+				*statelessCommon = append(*statelessCommon, ack.Hash)
+				*inVein = 0
+			}
+		}
+	}
+}
+
 // NegotiatePack performs the pack negotiation phase of the fetch operation.
 func NegotiatePack(
 	ctx context.Context,
@@ -155,21 +186,41 @@ func NegotiatePack(
 	}
 
 	common := map[plumbing.Hash]struct{}{}
+	var statelessCommon []plumbing.Hash
 	var inVein int
 	var done bool
 	var gotContinue bool
+	var gotReady bool
+	var sendDoneAfterReady bool
 	firstRound := true
 	flushAt := initialFlush
 
 	for !done {
 		var uphav packp.UploadHaves
-		for i := 0; i < flushAt && len(req.Haves) > 0; i++ {
+		if statelessRPC && !sendDoneAfterReady {
+			uphav.Haves = append(uphav.Haves, statelessCommon...)
+		}
+
+		batchSize := 0
+		if !sendDoneAfterReady {
+			batchSize = flushAt
+			if gotContinue {
+				remaining := maxInVein - inVein
+				if remaining <= 0 {
+					batchSize = 0
+				} else if batchSize > remaining {
+					batchSize = remaining
+				}
+			}
+		}
+
+		for i := 0; i < batchSize && len(req.Haves) > 0; i++ {
 			uphav.Haves = append(uphav.Haves, req.Haves[len(req.Haves)-1])
 			req.Haves = req.Haves[:len(req.Haves)-1]
 			inVein++
 		}
 
-		done = len(req.Haves) == 0 || (gotContinue && inVein >= maxInVein)
+		done = sendDoneAfterReady || len(req.Haves) == 0 || (gotContinue && inVein >= maxInVein)
 		uphav.Done = done
 
 		if isSubset(req.Wants, uphav.Haves) && len(upreq.Shallows) == 0 {
@@ -218,20 +269,19 @@ func NegotiatePack(
 					readc <- fmt.Errorf("decoding server-response: %w", err)
 					return
 				}
-				for _, ack := range srvrs.ACKs {
-					if !gotContinue && ack.Status > 0 {
-						gotContinue = true
-					}
-					if ack.Status == packp.ACKCommon {
-						common[ack.Hash] = struct{}{}
-					}
-				}
+				applyServerACKs(statelessRPC, srvrs.ACKs, common, &statelessCommon, &gotContinue, &gotReady, &inVein)
 			}
 			readc <- nil
 		}()
 
 		if err := <-readc; err != nil {
 			return nil, err
+		}
+		if sendDoneAfterReady {
+			break
+		}
+		if gotReady {
+			sendDoneAfterReady = true
 		}
 
 		firstRound = false

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -39,6 +39,37 @@ func nextFlush(statelessRPC bool, count int) int {
 	return count + pipeSafeFlush
 }
 
+func applyServerACKs(
+	statelessRPC bool,
+	acks []packp.ACK,
+	common map[plumbing.Hash]struct{},
+	statelessCommon *[]plumbing.Hash,
+	gotContinue *bool,
+	gotReady *bool,
+	inVein *int,
+) {
+	for _, ack := range acks {
+		if !*gotContinue && ack.Status > 0 {
+			*gotContinue = true
+		}
+
+		switch ack.Status {
+		case packp.ACKContinue:
+			*inVein = 0
+		case packp.ACKReady:
+			*gotReady = true
+			*inVein = 0
+		case packp.ACKCommon:
+			_, alreadyCommon := common[ack.Hash]
+			common[ack.Hash] = struct{}{}
+			if statelessRPC && !alreadyCommon {
+				*statelessCommon = append(*statelessCommon, ack.Hash)
+				*inVein = 0
+			}
+		}
+	}
+}
+
 // NegotiatePack performs the pack negotiation phase of the fetch operation.
 func NegotiatePack(
 	ctx context.Context,
@@ -157,21 +188,41 @@ func NegotiatePack(
 	}
 
 	common := map[plumbing.Hash]struct{}{}
+	var statelessCommon []plumbing.Hash
 	var inVein int
 	var done bool
 	var gotContinue bool
+	var gotReady bool
+	var sendDoneAfterReady bool
 	firstRound := true
 	flushAt := initialFlush
 
 	for !done {
 		var uphav packp.UploadHaves
-		for i := 0; i < flushAt && len(req.Haves) > 0; i++ {
+		if statelessRPC && !sendDoneAfterReady {
+			uphav.Haves = append(uphav.Haves, statelessCommon...)
+		}
+
+		batchSize := 0
+		if !sendDoneAfterReady {
+			batchSize = flushAt
+			if gotContinue {
+				remaining := maxInVein - inVein
+				if remaining <= 0 {
+					batchSize = 0
+				} else if batchSize > remaining {
+					batchSize = remaining
+				}
+			}
+		}
+
+		for i := 0; i < batchSize && len(req.Haves) > 0; i++ {
 			uphav.Haves = append(uphav.Haves, req.Haves[len(req.Haves)-1])
 			req.Haves = req.Haves[:len(req.Haves)-1]
 			inVein++
 		}
 
-		done = len(req.Haves) == 0 || (gotContinue && inVein >= maxInVein)
+		done = sendDoneAfterReady || len(req.Haves) == 0 || (gotContinue && inVein >= maxInVein)
 		uphav.Done = done
 
 		if isSubset(req.Wants, uphav.Haves) && len(upreq.Shallows) == 0 {
@@ -220,20 +271,19 @@ func NegotiatePack(
 					readc <- fmt.Errorf("decoding server-response: %w", err)
 					return
 				}
-				for _, ack := range srvrs.ACKs {
-					if !gotContinue && ack.Status > 0 {
-						gotContinue = true
-					}
-					if ack.Status == packp.ACKCommon {
-						common[ack.Hash] = struct{}{}
-					}
-				}
+				applyServerACKs(statelessRPC, srvrs.ACKs, common, &statelessCommon, &gotContinue, &gotReady, &inVein)
 			}
 			readc <- nil
 		}()
 
 		if err := <-readc; err != nil {
 			return nil, err
+		}
+		if sendDoneAfterReady {
+			break
+		}
+		if gotReady {
+			sendDoneAfterReady = true
 		}
 
 		firstRound = false

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -17,6 +17,28 @@ import (
 	xstorage "github.com/go-git/go-git/v6/x/storage"
 )
 
+const (
+	initialFlush  = 16
+	pipeSafeFlush = 32
+	largeFlush    = 16384
+	maxInVein     = 256
+)
+
+func nextFlush(statelessRPC bool, count int) int {
+	if statelessRPC {
+		if count < largeFlush {
+			return count << 1
+		}
+		return count * 11 / 10
+	}
+
+	if count < pipeSafeFlush {
+		return count << 1
+	}
+
+	return count + pipeSafeFlush
+}
+
 // NegotiatePack performs the pack negotiation phase of the fetch operation.
 func NegotiatePack(
 	ctx context.Context,
@@ -139,16 +161,16 @@ func NegotiatePack(
 	var done bool
 	var gotContinue bool
 	firstRound := true
+	flushAt := initialFlush
 
 	for !done {
 		var uphav packp.UploadHaves
-		for i := 0; i < 32 && len(req.Haves) > 0; i++ {
+		for i := 0; i < flushAt && len(req.Haves) > 0; i++ {
 			uphav.Haves = append(uphav.Haves, req.Haves[len(req.Haves)-1])
 			req.Haves = req.Haves[:len(req.Haves)-1]
 			inVein++
 		}
 
-		const maxInVein = 256
 		done = len(req.Haves) == 0 || (gotContinue && inVein >= maxInVein)
 		uphav.Done = done
 
@@ -215,6 +237,7 @@ func NegotiatePack(
 		}
 
 		firstRound = false
+		flushAt = nextFlush(statelessRPC, flushAt)
 	}
 
 	if !statelessRPC {

--- a/plumbing/transport/negotiate_test.go
+++ b/plumbing/transport/negotiate_test.go
@@ -99,6 +99,24 @@ func TestNegotiatePackCompleteWithNonEOFCloseError(t *testing.T) {
 	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
+func TestNextFlushStatelessRPC(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 32, nextFlush(true, 16))
+	assert.Equal(t, 64, nextFlush(true, 32))
+	assert.Equal(t, 18022, nextFlush(true, 16384))
+	assert.Equal(t, 36044, nextFlush(true, 32768))
+}
+
+func TestNextFlushStateful(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 32, nextFlush(false, 16))
+	assert.Equal(t, 64, nextFlush(false, 32))
+	assert.Equal(t, 96, nextFlush(false, 64))
+	assert.Equal(t, 128, nextFlush(false, 96))
+}
+
 // mockWriteCloser implements io.WriteCloser for testing.
 type mockWriteCloser struct {
 	writeBuf *bytes.Buffer

--- a/plumbing/transport/negotiate_test.go
+++ b/plumbing/transport/negotiate_test.go
@@ -3,118 +3,372 @@ package transport
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"maps"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
 
-func TestNegotiatePackNoChangeWithEOFOnClose(t *testing.T) {
+func TestNegotiatePackCloseBehavior(t *testing.T) {
 	t.Parallel()
-
-	caps := capability.List{}
-	reader := bytes.NewReader(nil)
-	writer := newMockWriteCloser(nil)
-	writer.closeErr = io.EOF
-
-	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	req := &FetchRequest{
-		Wants: []plumbing.Hash{hash},
-		Haves: []plumbing.Hash{hash},
-	}
-
-	storer := memory.NewStorage()
-	_, err := NegotiatePack(context.TODO(), storer, caps, false, reader, writer, req)
-	require.ErrorIs(t, err, ErrNoChange)
-	assert.Equal(t, "0000", writer.writeBuf.String())
-}
-
-func TestNegotiatePackNoChangeWithNonEOFCloseError(t *testing.T) {
-	t.Parallel()
-
-	caps := capability.List{}
-	reader := bytes.NewReader(nil)
-	writer := newMockWriteCloser(nil)
-	writer.closeErr = io.ErrUnexpectedEOF
-
-	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	req := &FetchRequest{
-		Wants: []plumbing.Hash{hash},
-		Haves: []plumbing.Hash{hash},
-	}
-
-	storer := memory.NewStorage()
-	_, err := NegotiatePack(context.TODO(), storer, caps, false, reader, writer, req)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, ErrNoChange)
-	assert.Contains(t, err.Error(), "closing writer")
-	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
-}
-
-func TestNegotiatePackCompleteWithEOFOnClose(t *testing.T) {
-	t.Parallel()
-
-	caps := capability.List{}
-	reader := bytes.NewReader([]byte("0008NAK\n"))
-	writer := newMockWriteCloser(nil)
-	writer.closeErr = io.EOF
 
 	hashA := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 	hashB := plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")
-	req := &FetchRequest{
-		Wants: []plumbing.Hash{hashA},
-		Haves: []plumbing.Hash{hashB},
+
+	tests := []struct {
+		name            string
+		reader          []byte
+		closeErr        error
+		req             *FetchRequest
+		wantErrIs       error
+		wantErrText     string
+		wantFlush       string
+		wantNoErr       bool
+		wantShallowsNil bool
+	}{
+		{
+			name:      "no_change_eof_on_close",
+			closeErr:  io.EOF,
+			req:       &FetchRequest{Wants: []plumbing.Hash{hashA}, Haves: []plumbing.Hash{hashA}},
+			wantErrIs: ErrNoChange,
+			wantFlush: "0000",
+		},
+		{
+			name:        "no_change_non_eof_on_close",
+			closeErr:    io.ErrUnexpectedEOF,
+			req:         &FetchRequest{Wants: []plumbing.Hash{hashA}, Haves: []plumbing.Hash{hashA}},
+			wantErrText: "closing writer",
+			wantFlush:   "0000",
+		},
+		{
+			name:            "complete_eof_on_close",
+			reader:          []byte("0008NAK\n"),
+			closeErr:        io.EOF,
+			req:             &FetchRequest{Wants: []plumbing.Hash{hashA}, Haves: []plumbing.Hash{hashB}},
+			wantNoErr:       true,
+			wantShallowsNil: true,
+		},
+		{
+			name:            "complete_non_eof_on_close",
+			reader:          []byte("0008NAK\n"),
+			closeErr:        io.ErrUnexpectedEOF,
+			req:             &FetchRequest{Wants: []plumbing.Hash{hashA}, Haves: []plumbing.Hash{hashB}},
+			wantErrText:     "closing writer",
+			wantShallowsNil: true,
+		},
 	}
 
-	storer := memory.NewStorage()
-	shallows, err := NegotiatePack(context.TODO(), storer, caps, false, reader, writer, req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			writer := newMockWriteCloser(nil)
+			writer.closeErr = tt.closeErr
+
+			shallows, err := NegotiatePack(
+				context.TODO(),
+				memory.NewStorage(),
+				capability.List{},
+				false,
+				bytes.NewReader(tt.reader),
+				writer,
+				tt.req,
+			)
+
+			switch {
+			case tt.wantNoErr:
+				require.NoError(t, err)
+			case tt.wantErrIs != nil:
+				require.ErrorIs(t, err, tt.wantErrIs)
+			default:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrText)
+				assert.ErrorIs(t, err, tt.closeErr)
+			}
+
+			if tt.wantFlush != "" {
+				assert.Equal(t, tt.wantFlush, writer.writeBuf.String())
+			}
+			if tt.wantShallowsNil {
+				assert.Nil(t, shallows)
+			}
+		})
+	}
+}
+
+func TestNextFlush(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statelessRPC bool
+		in           int
+		want         int
+	}{
+		{name: "stateless_initial", statelessRPC: true, in: 16, want: 32},
+		{name: "stateless_growth", statelessRPC: true, in: 32, want: 64},
+		{name: "stateless_large_boundary", statelessRPC: true, in: 16384, want: 18022},
+		{name: "stateless_large_growth", statelessRPC: true, in: 32768, want: 36044},
+		{name: "stateful_initial", statelessRPC: false, in: 16, want: 32},
+		{name: "stateful_pipe_safe_boundary", statelessRPC: false, in: 32, want: 64},
+		{name: "stateful_linear_growth_64", statelessRPC: false, in: 64, want: 96},
+		{name: "stateful_linear_growth_96", statelessRPC: false, in: 96, want: 128},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, nextFlush(tt.statelessRPC, tt.in))
+		})
+	}
+}
+
+func TestNegotiatePackMultiRound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statelessRPC bool
+		wantCount    int
+		haveCount    int
+		flushCount   int
+	}{
+		{
+			name:         "stateful",
+			statelessRPC: false,
+			wantCount:    1,
+			haveCount:    17,
+			flushCount:   2,
+		},
+		{
+			name:         "stateless",
+			statelessRPC: true,
+			wantCount:    2,
+			haveCount:    17,
+			flushCount:   3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			writer := negotiatePackMultiRound(t, tt.statelessRPC)
+			out := writer.writeBuf.String()
+
+			assert.Equal(t, tt.wantCount, strings.Count(out, "want "))
+			assert.Equal(t, tt.haveCount, strings.Count(out, "have "))
+			assert.Equal(t, tt.flushCount, strings.Count(out, "0000"))
+		})
+	}
+}
+
+func TestNegotiatePackStatelessRequeuesACKCommon(t *testing.T) {
+	t.Parallel()
+
+	commonHash := plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	reader := bytes.NewBuffer(nil)
+	_, err := pktline.WriteString(reader, "ACK "+commonHash.String()+" common\n")
 	require.NoError(t, err)
-	assert.Nil(t, shallows)
+	_, err = pktline.WriteString(reader, "NAK\n")
+	require.NoError(t, err)
+	_, err = pktline.WriteString(reader, "NAK\n")
+	require.NoError(t, err)
+
+	writer := newMockWriteCloser(nil)
+	haves := append([]plumbing.Hash{plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")}, makeSyntheticHaves(15)...)
+	haves = append(haves, commonHash)
+	req := &FetchRequest{
+		Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+		Haves: haves,
+	}
+
+	_, err = NegotiatePack(context.TODO(), memory.NewStorage(), capability.List{}, true, reader, writer, req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, strings.Count(writer.writeBuf.String(), "have "+commonHash.String()), "ACK_common haves should be re-sent on subsequent stateless rounds")
 }
 
-func TestNegotiatePackCompleteWithNonEOFCloseError(t *testing.T) {
+func TestApplyServerACKs(t *testing.T) {
 	t.Parallel()
 
-	caps := capability.List{}
-	reader := bytes.NewReader([]byte("0008NAK\n"))
-	writer := newMockWriteCloser(nil)
-	writer.closeErr = io.ErrUnexpectedEOF
+	commonHash := plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 
-	hashA := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	hashB := plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")
+	tests := []struct {
+		name                   string
+		statelessRPC           bool
+		acks                   []packp.ACK
+		initialCommon          map[plumbing.Hash]struct{}
+		initialStatelessCommon []plumbing.Hash
+		initialGotContinue     bool
+		initialGotReady        bool
+		initialInVein          int
+		wantGotContinue        bool
+		wantGotReady           bool
+		wantInVein             int
+		wantStatelessCommon    []plumbing.Hash
+		wantCommonContains     []plumbing.Hash
+	}{
+		{
+			name:                "ack_continue_resets_in_vein",
+			acks:                []packp.ACK{{Status: packp.ACKContinue}},
+			initialCommon:       map[plumbing.Hash]struct{}{},
+			initialInVein:       123,
+			wantGotContinue:     true,
+			wantGotReady:        false,
+			wantInVein:          0,
+			wantStatelessCommon: nil,
+		},
+		{
+			name:                "stateless_ack_common_requeues_and_resets",
+			statelessRPC:        true,
+			acks:                []packp.ACK{{Hash: commonHash, Status: packp.ACKCommon}},
+			initialCommon:       map[plumbing.Hash]struct{}{},
+			initialInVein:       77,
+			wantGotContinue:     true,
+			wantGotReady:        false,
+			wantInVein:          0,
+			wantStatelessCommon: []plumbing.Hash{commonHash},
+			wantCommonContains:  []plumbing.Hash{commonHash},
+		},
+		{
+			name:                   "duplicate_stateless_ack_common_does_not_duplicate",
+			statelessRPC:           true,
+			acks:                   []packp.ACK{{Hash: commonHash, Status: packp.ACKCommon}, {Hash: commonHash, Status: packp.ACKCommon}},
+			initialCommon:          map[plumbing.Hash]struct{}{commonHash: {}},
+			initialStatelessCommon: []plumbing.Hash{commonHash},
+			initialGotContinue:     true,
+			initialInVein:          55,
+			wantGotContinue:        true,
+			wantGotReady:           false,
+			wantInVein:             55,
+			wantStatelessCommon:    []plumbing.Hash{commonHash},
+			wantCommonContains:     []plumbing.Hash{commonHash},
+		},
+		{
+			name:                "ack_ready_sets_ready_and_resets",
+			acks:                []packp.ACK{{Status: packp.ACKReady}},
+			initialCommon:       map[plumbing.Hash]struct{}{},
+			initialInVein:       42,
+			wantGotContinue:     true,
+			wantGotReady:        true,
+			wantInVein:          0,
+			wantStatelessCommon: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			common := mapsClone(tt.initialCommon)
+			statelessCommon := append([]plumbing.Hash(nil), tt.initialStatelessCommon...)
+			gotContinue := tt.initialGotContinue
+			gotReady := tt.initialGotReady
+			inVein := tt.initialInVein
+
+			applyServerACKs(tt.statelessRPC, tt.acks, common, &statelessCommon, &gotContinue, &gotReady, &inVein)
+
+			assert.Equal(t, tt.wantGotContinue, gotContinue)
+			assert.Equal(t, tt.wantGotReady, gotReady)
+			assert.Equal(t, tt.wantInVein, inVein)
+			assert.Equal(t, tt.wantStatelessCommon, statelessCommon)
+			for _, h := range tt.wantCommonContains {
+				assert.Contains(t, common, h)
+			}
+		})
+	}
+}
+
+func TestNegotiatePackStatelessClampsAfterGotContinue(t *testing.T) {
+	t.Parallel()
+
+	reader := bytes.NewBuffer(nil)
+	continueHash := plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	var err error
+	_, err = pktline.WriteString(reader, "ACK "+continueHash.String()+" continue\n")
+	require.NoError(t, err)
+	for range 4 {
+		_, err = pktline.WriteString(reader, "NAK\n")
+		require.NoError(t, err)
+	}
+
+	writer := newMockWriteCloser(nil)
 	req := &FetchRequest{
-		Wants: []plumbing.Hash{hashA},
-		Haves: []plumbing.Hash{hashB},
+		Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+		Haves: makeSyntheticHaves(600),
+	}
+
+	_, err = NegotiatePack(context.TODO(), memory.NewStorage(), capability.List{}, true, reader, writer, req)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, strings.Count(writer.writeBuf.String(), "have "), initialFlush+maxInVein, "post-continue stateless negotiation should clamp new haves to the remaining in-vein budget")
+}
+
+func TestNegotiatePackStopsImmediatelyOnACKReady(t *testing.T) {
+	t.Parallel()
+
+	readyHash := plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	reader := bytes.NewBuffer(nil)
+	_, err := pktline.WriteString(reader, "ACK "+readyHash.String()+" ready\n")
+	require.NoError(t, err)
+
+	writer := newMockWriteCloser(nil)
+	req := &FetchRequest{
+		Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+		Haves: makeSyntheticHaves(40),
+	}
+
+	_, err = NegotiatePack(context.TODO(), memory.NewStorage(), capability.List{}, true, reader, writer, req)
+	require.NoError(t, err)
+
+	out := writer.writeBuf.String()
+	assert.Equal(t, 2, strings.Count(out, "want "), "ACK_ready should send only the terminal done request after the first round")
+	assert.Equal(t, initialFlush, strings.Count(out, "have "), "ACK_ready should stop after the first batch")
+}
+
+func negotiatePackMultiRound(t *testing.T, statelessRPC bool) *mockWriteCloser {
+	t.Helper()
+
+	caps := capability.List{}
+	reader := bytes.NewReader([]byte("0008NAK\n0008NAK\n"))
+	writer := newMockWriteCloser(nil)
+
+	req := &FetchRequest{
+		Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+		Haves: makeSyntheticHaves(17),
 	}
 
 	storer := memory.NewStorage()
-	_, err := NegotiatePack(context.TODO(), storer, caps, false, reader, writer, req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "closing writer")
-	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	_, err := NegotiatePack(context.TODO(), storer, caps, statelessRPC, reader, writer, req)
+	require.NoError(t, err)
+	return writer
 }
 
-func TestNextFlushStatelessRPC(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, 32, nextFlush(true, 16))
-	assert.Equal(t, 64, nextFlush(true, 32))
-	assert.Equal(t, 18022, nextFlush(true, 16384))
-	assert.Equal(t, 36044, nextFlush(true, 32768))
+func makeSyntheticHaves(n int, keep ...plumbing.Hash) []plumbing.Hash {
+	haves := make([]plumbing.Hash, 0, n)
+	haves = append(haves, keep...)
+	for i := len(haves); i < n; i++ {
+		hash := fmt.Sprintf("%040x", i+1)
+		haves = append(haves, plumbing.NewHash(strings.ReplaceAll(hash, "0", "a")))
+	}
+	return haves
 }
 
-func TestNextFlushStateful(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, 32, nextFlush(false, 16))
-	assert.Equal(t, 64, nextFlush(false, 32))
-	assert.Equal(t, 96, nextFlush(false, 64))
-	assert.Equal(t, 128, nextFlush(false, 96))
+func mapsClone(in map[plumbing.Hash]struct{}) map[plumbing.Hash]struct{} {
+	out := make(map[plumbing.Hash]struct{}, len(in))
+	maps.Copy(out, in)
+	return out
 }
 
 // mockWriteCloser implements io.WriteCloser for testing.

--- a/plumbing/transport/negotiate_test.go
+++ b/plumbing/transport/negotiate_test.go
@@ -3,118 +3,372 @@ package transport
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
+	"maps"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
 
-func TestNegotiatePackNoChangeWithEOFOnClose(t *testing.T) {
+func TestNegotiatePackCloseBehavior(t *testing.T) {
 	t.Parallel()
-
-	caps := capability.NewList()
-	reader := bytes.NewReader(nil)
-	writer := newMockWriteCloser(nil)
-	writer.closeErr = io.EOF
-
-	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	req := &FetchRequest{
-		Wants: []plumbing.Hash{hash},
-		Haves: []plumbing.Hash{hash},
-	}
-
-	storer := memory.NewStorage()
-	_, err := NegotiatePack(context.TODO(), storer, caps, false, reader, writer, req)
-	require.ErrorIs(t, err, ErrNoChange)
-	assert.Equal(t, "0000", writer.writeBuf.String())
-}
-
-func TestNegotiatePackNoChangeWithNonEOFCloseError(t *testing.T) {
-	t.Parallel()
-
-	caps := capability.NewList()
-	reader := bytes.NewReader(nil)
-	writer := newMockWriteCloser(nil)
-	writer.closeErr = io.ErrUnexpectedEOF
-
-	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	req := &FetchRequest{
-		Wants: []plumbing.Hash{hash},
-		Haves: []plumbing.Hash{hash},
-	}
-
-	storer := memory.NewStorage()
-	_, err := NegotiatePack(context.TODO(), storer, caps, false, reader, writer, req)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, ErrNoChange)
-	assert.Contains(t, err.Error(), "closing writer")
-	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
-}
-
-func TestNegotiatePackCompleteWithEOFOnClose(t *testing.T) {
-	t.Parallel()
-
-	caps := capability.NewList()
-	reader := bytes.NewReader([]byte("0008NAK\n"))
-	writer := newMockWriteCloser(nil)
-	writer.closeErr = io.EOF
 
 	hashA := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 	hashB := plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")
-	req := &FetchRequest{
-		Wants: []plumbing.Hash{hashA},
-		Haves: []plumbing.Hash{hashB},
+
+	tests := []struct {
+		name            string
+		reader          []byte
+		closeErr        error
+		req             *FetchRequest
+		wantErrIs       error
+		wantErrText     string
+		wantFlush       string
+		wantNoErr       bool
+		wantShallowsNil bool
+	}{
+		{
+			name:      "no_change_eof_on_close",
+			closeErr:  io.EOF,
+			req:       &FetchRequest{Wants: []plumbing.Hash{hashA}, Haves: []plumbing.Hash{hashA}},
+			wantErrIs: ErrNoChange,
+			wantFlush: "0000",
+		},
+		{
+			name:        "no_change_non_eof_on_close",
+			closeErr:    io.ErrUnexpectedEOF,
+			req:         &FetchRequest{Wants: []plumbing.Hash{hashA}, Haves: []plumbing.Hash{hashA}},
+			wantErrText: "closing writer",
+			wantFlush:   "0000",
+		},
+		{
+			name:            "complete_eof_on_close",
+			reader:          []byte("0008NAK\n"),
+			closeErr:        io.EOF,
+			req:             &FetchRequest{Wants: []plumbing.Hash{hashA}, Haves: []plumbing.Hash{hashB}},
+			wantNoErr:       true,
+			wantShallowsNil: true,
+		},
+		{
+			name:            "complete_non_eof_on_close",
+			reader:          []byte("0008NAK\n"),
+			closeErr:        io.ErrUnexpectedEOF,
+			req:             &FetchRequest{Wants: []plumbing.Hash{hashA}, Haves: []plumbing.Hash{hashB}},
+			wantErrText:     "closing writer",
+			wantShallowsNil: true,
+		},
 	}
 
-	storer := memory.NewStorage()
-	shallows, err := NegotiatePack(context.TODO(), storer, caps, false, reader, writer, req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			writer := newMockWriteCloser(nil)
+			writer.closeErr = tt.closeErr
+
+			shallows, err := NegotiatePack(
+				context.TODO(),
+				memory.NewStorage(),
+				capability.NewList(),
+				false,
+				bytes.NewReader(tt.reader),
+				writer,
+				tt.req,
+			)
+
+			switch {
+			case tt.wantNoErr:
+				require.NoError(t, err)
+			case tt.wantErrIs != nil:
+				require.ErrorIs(t, err, tt.wantErrIs)
+			default:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrText)
+				assert.ErrorIs(t, err, tt.closeErr)
+			}
+
+			if tt.wantFlush != "" {
+				assert.Equal(t, tt.wantFlush, writer.writeBuf.String())
+			}
+			if tt.wantShallowsNil {
+				assert.Nil(t, shallows)
+			}
+		})
+	}
+}
+
+func TestNextFlush(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statelessRPC bool
+		in           int
+		want         int
+	}{
+		{name: "stateless_initial", statelessRPC: true, in: 16, want: 32},
+		{name: "stateless_growth", statelessRPC: true, in: 32, want: 64},
+		{name: "stateless_large_boundary", statelessRPC: true, in: 16384, want: 18022},
+		{name: "stateless_large_growth", statelessRPC: true, in: 32768, want: 36044},
+		{name: "stateful_initial", statelessRPC: false, in: 16, want: 32},
+		{name: "stateful_pipe_safe_boundary", statelessRPC: false, in: 32, want: 64},
+		{name: "stateful_linear_growth_64", statelessRPC: false, in: 64, want: 96},
+		{name: "stateful_linear_growth_96", statelessRPC: false, in: 96, want: 128},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, nextFlush(tt.statelessRPC, tt.in))
+		})
+	}
+}
+
+func TestNegotiatePackMultiRound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statelessRPC bool
+		wantCount    int
+		haveCount    int
+		flushCount   int
+	}{
+		{
+			name:         "stateful",
+			statelessRPC: false,
+			wantCount:    1,
+			haveCount:    17,
+			flushCount:   2,
+		},
+		{
+			name:         "stateless",
+			statelessRPC: true,
+			wantCount:    2,
+			haveCount:    17,
+			flushCount:   3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			writer := negotiatePackMultiRound(t, tt.statelessRPC)
+			out := writer.writeBuf.String()
+
+			assert.Equal(t, tt.wantCount, strings.Count(out, "want "))
+			assert.Equal(t, tt.haveCount, strings.Count(out, "have "))
+			assert.Equal(t, tt.flushCount, strings.Count(out, "0000"))
+		})
+	}
+}
+
+func TestNegotiatePackStatelessRequeuesACKCommon(t *testing.T) {
+	t.Parallel()
+
+	commonHash := plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	reader := bytes.NewBuffer(nil)
+	_, err := pktline.WriteString(reader, "ACK "+commonHash.String()+" common\n")
 	require.NoError(t, err)
-	assert.Nil(t, shallows)
+	_, err = pktline.WriteString(reader, "NAK\n")
+	require.NoError(t, err)
+	_, err = pktline.WriteString(reader, "NAK\n")
+	require.NoError(t, err)
+
+	writer := newMockWriteCloser(nil)
+	haves := append([]plumbing.Hash{plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")}, makeSyntheticHaves(15)...)
+	haves = append(haves, commonHash)
+	req := &FetchRequest{
+		Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+		Haves: haves,
+	}
+
+	_, err = NegotiatePack(context.TODO(), memory.NewStorage(), capability.NewList(), true, reader, writer, req)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, strings.Count(writer.writeBuf.String(), "have "+commonHash.String()), "ACK_common haves should be re-sent on subsequent stateless rounds")
 }
 
-func TestNegotiatePackCompleteWithNonEOFCloseError(t *testing.T) {
+func TestApplyServerACKs(t *testing.T) {
 	t.Parallel()
 
-	caps := capability.NewList()
-	reader := bytes.NewReader([]byte("0008NAK\n"))
-	writer := newMockWriteCloser(nil)
-	writer.closeErr = io.ErrUnexpectedEOF
+	commonHash := plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 
-	hashA := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	hashB := plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")
+	tests := []struct {
+		name                   string
+		statelessRPC           bool
+		acks                   []packp.ACK
+		initialCommon          map[plumbing.Hash]struct{}
+		initialStatelessCommon []plumbing.Hash
+		initialGotContinue     bool
+		initialGotReady        bool
+		initialInVein          int
+		wantGotContinue        bool
+		wantGotReady           bool
+		wantInVein             int
+		wantStatelessCommon    []plumbing.Hash
+		wantCommonContains     []plumbing.Hash
+	}{
+		{
+			name:                "ack_continue_resets_in_vein",
+			acks:                []packp.ACK{{Status: packp.ACKContinue}},
+			initialCommon:       map[plumbing.Hash]struct{}{},
+			initialInVein:       123,
+			wantGotContinue:     true,
+			wantGotReady:        false,
+			wantInVein:          0,
+			wantStatelessCommon: nil,
+		},
+		{
+			name:                "stateless_ack_common_requeues_and_resets",
+			statelessRPC:        true,
+			acks:                []packp.ACK{{Hash: commonHash, Status: packp.ACKCommon}},
+			initialCommon:       map[plumbing.Hash]struct{}{},
+			initialInVein:       77,
+			wantGotContinue:     true,
+			wantGotReady:        false,
+			wantInVein:          0,
+			wantStatelessCommon: []plumbing.Hash{commonHash},
+			wantCommonContains:  []plumbing.Hash{commonHash},
+		},
+		{
+			name:                   "duplicate_stateless_ack_common_does_not_duplicate",
+			statelessRPC:           true,
+			acks:                   []packp.ACK{{Hash: commonHash, Status: packp.ACKCommon}, {Hash: commonHash, Status: packp.ACKCommon}},
+			initialCommon:          map[plumbing.Hash]struct{}{commonHash: {}},
+			initialStatelessCommon: []plumbing.Hash{commonHash},
+			initialGotContinue:     true,
+			initialInVein:          55,
+			wantGotContinue:        true,
+			wantGotReady:           false,
+			wantInVein:             55,
+			wantStatelessCommon:    []plumbing.Hash{commonHash},
+			wantCommonContains:     []plumbing.Hash{commonHash},
+		},
+		{
+			name:                "ack_ready_sets_ready_and_resets",
+			acks:                []packp.ACK{{Status: packp.ACKReady}},
+			initialCommon:       map[plumbing.Hash]struct{}{},
+			initialInVein:       42,
+			wantGotContinue:     true,
+			wantGotReady:        true,
+			wantInVein:          0,
+			wantStatelessCommon: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			common := mapsClone(tt.initialCommon)
+			statelessCommon := append([]plumbing.Hash(nil), tt.initialStatelessCommon...)
+			gotContinue := tt.initialGotContinue
+			gotReady := tt.initialGotReady
+			inVein := tt.initialInVein
+
+			applyServerACKs(tt.statelessRPC, tt.acks, common, &statelessCommon, &gotContinue, &gotReady, &inVein)
+
+			assert.Equal(t, tt.wantGotContinue, gotContinue)
+			assert.Equal(t, tt.wantGotReady, gotReady)
+			assert.Equal(t, tt.wantInVein, inVein)
+			assert.Equal(t, tt.wantStatelessCommon, statelessCommon)
+			for _, h := range tt.wantCommonContains {
+				assert.Contains(t, common, h)
+			}
+		})
+	}
+}
+
+func TestNegotiatePackStatelessClampsAfterGotContinue(t *testing.T) {
+	t.Parallel()
+
+	reader := bytes.NewBuffer(nil)
+	continueHash := plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	var err error
+	_, err = pktline.WriteString(reader, "ACK "+continueHash.String()+" continue\n")
+	require.NoError(t, err)
+	for range 4 {
+		_, err = pktline.WriteString(reader, "NAK\n")
+		require.NoError(t, err)
+	}
+
+	writer := newMockWriteCloser(nil)
 	req := &FetchRequest{
-		Wants: []plumbing.Hash{hashA},
-		Haves: []plumbing.Hash{hashB},
+		Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+		Haves: makeSyntheticHaves(600),
+	}
+
+	_, err = NegotiatePack(context.TODO(), memory.NewStorage(), capability.NewList(), true, reader, writer, req)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, strings.Count(writer.writeBuf.String(), "have "), initialFlush+maxInVein, "post-continue stateless negotiation should clamp new haves to the remaining in-vein budget")
+}
+
+func TestNegotiatePackStopsImmediatelyOnACKReady(t *testing.T) {
+	t.Parallel()
+
+	readyHash := plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	reader := bytes.NewBuffer(nil)
+	_, err := pktline.WriteString(reader, "ACK "+readyHash.String()+" ready\n")
+	require.NoError(t, err)
+
+	writer := newMockWriteCloser(nil)
+	req := &FetchRequest{
+		Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+		Haves: makeSyntheticHaves(40),
+	}
+
+	_, err = NegotiatePack(context.TODO(), memory.NewStorage(), capability.NewList(), true, reader, writer, req)
+	require.NoError(t, err)
+
+	out := writer.writeBuf.String()
+	assert.Equal(t, 2, strings.Count(out, "want "), "ACK_ready should send only the terminal done request after the first round")
+	assert.Equal(t, initialFlush, strings.Count(out, "have "), "ACK_ready should stop after the first batch")
+}
+
+func negotiatePackMultiRound(t *testing.T, statelessRPC bool) *mockWriteCloser {
+	t.Helper()
+
+	caps := capability.NewList()
+	reader := bytes.NewReader([]byte("0008NAK\n0008NAK\n"))
+	writer := newMockWriteCloser(nil)
+
+	req := &FetchRequest{
+		Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+		Haves: makeSyntheticHaves(17),
 	}
 
 	storer := memory.NewStorage()
-	_, err := NegotiatePack(context.TODO(), storer, caps, false, reader, writer, req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "closing writer")
-	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	_, err := NegotiatePack(context.TODO(), storer, caps, statelessRPC, reader, writer, req)
+	require.NoError(t, err)
+	return writer
 }
 
-func TestNextFlushStatelessRPC(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, 32, nextFlush(true, 16))
-	assert.Equal(t, 64, nextFlush(true, 32))
-	assert.Equal(t, 18022, nextFlush(true, 16384))
-	assert.Equal(t, 36044, nextFlush(true, 32768))
+func makeSyntheticHaves(n int, keep ...plumbing.Hash) []plumbing.Hash {
+	haves := make([]plumbing.Hash, 0, n)
+	haves = append(haves, keep...)
+	for i := len(haves); i < n; i++ {
+		hash := fmt.Sprintf("%040x", i+1)
+		haves = append(haves, plumbing.NewHash(strings.ReplaceAll(hash, "0", "a")))
+	}
+	return haves
 }
 
-func TestNextFlushStateful(t *testing.T) {
-	t.Parallel()
-
-	assert.Equal(t, 32, nextFlush(false, 16))
-	assert.Equal(t, 64, nextFlush(false, 32))
-	assert.Equal(t, 96, nextFlush(false, 64))
-	assert.Equal(t, 128, nextFlush(false, 96))
+func mapsClone(in map[plumbing.Hash]struct{}) map[plumbing.Hash]struct{} {
+	out := make(map[plumbing.Hash]struct{}, len(in))
+	maps.Copy(out, in)
+	return out
 }
 
 // mockWriteCloser implements io.WriteCloser for testing.


### PR DESCRIPTION
Previously go-git flush size was hard-coded to `32`, which could be rather inefficient for very
large negotiations. This change aligns the behaviour with upstream, growing exponentially that
number when it is safe to do so, as per [next_flush()](https://github.com/git/git/blob/9f223ef1c026d91c7ac68cc0211bde255dda6199/fetch-pack.c#L276).

The initial flush size is now `16` - which is also aligned with upstream.