### PR TITLE
Add storage leak detection, fix leaks, and remove Repository.Close()

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,3 +39,15 @@ When reviewing pull requests in this repository, focus on correctness, maintaina
 - Any new encoding or decoding feature must include fuzz tests.
 - Flag encoding/decoding changes that lack fuzz coverage, especially when they parse untrusted, malformed, or external input.
 - Check that fuzz tests cover malformed input, boundary cases, round-trip behavior, and compatibility expectations where relevant.
+
+## Resource management
+
+- **Storage cleanup**: Storage instances must be closed by whoever creates them. The general rule: if a function creates Storage internally, the caller must close it.
+  - **Functions that create storage internally** (`PlainClone`, `PlainInit`, `PlainOpen`, `PlainOpenWithOptions`, `worktree.Worktree.Open()`): These create storage internally, so the returned repository's storage must be closed with `defer func() { _ = git.CloseStorage(r) }()` immediately after error checking.
+  - **Direct storage creation** (`filesystem.NewStorage`, `transactional.NewStorage`): If you create a storage, you must close it with `defer func() { _ = sto.Close() }()`.
+  - **Functions that receive storage** (`Init(storage)`, `Open(storage, worktree)`, `Clone(storage, ...)`): Do NOT close the repository's storage, since the caller owns it.
+  - Flag any repository creation where the instance is discarded with `_`. These must assign to a variable and close the storage.
+  - Rationale: Prevents file handle leaks that cause intermittent Windows test failures.
+  - Leak detection is available via `-tags leakcheck` which will panic with a clear message if storages are garbage collected without calling `Close()`.
+- **File handle cleanup**: All file `Open()` calls should have corresponding `defer Close()` calls, using `defer func() { _ = f.Close() }()` to avoid errcheck violations.
+- **Other closeable resources**: Flag leaked connections, file descriptors, and other resources that implement `io.Closer`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,34 @@ In order for a PR to be accepted it needs to pass a list of requirements:
 - If the PR is a new feature, it has to come with a suite of unit tests, that tests the new functionality.
 - In any case, all the PRs have to pass the personal evaluation of at least one of the maintainers of go-git.
 
+## Code Review Checklist
+
+When reviewing code (whether you're a human reviewer or using AI tools to assist), please verify:
+
+### Resource Management
+- **Storage cleanup**: Storage instances must be closed by whoever creates them. Repository doesn't own storage (it's passed in), so it's the caller's responsibility:
+  - **Plain\* functions** (`PlainClone`, `PlainInit`, `PlainOpen`, `PlainOpenWithOptions`): These create storage internally, so the returned repository's storage must be closed with `defer func() { if closer, ok := r.Storer.(io.Closer); ok { _ = closer.Close() } }()` immediately after error checking.
+  - **Direct storage creation** (`filesystem.NewStorage`, `transactional.NewStorage`): If you create a storage, you must close it with `defer func() { _ = sto.Close() }()`.
+  - **Do not discard repositories** with `_`. If you see `_, err := PlainClone(...)`, assign it to a variable and close its storage.
+  - Rationale: Prevents file handle leaks that cause intermittent Windows test failures.
+  - **Leak detection**: Run tests with `-tags leakcheck` to enable automatic detection of unclosed storages:
+    ```bash
+    go test -tags leakcheck ./...
+    ```
+    This will panic with a clear message if any storage is garbage collected without calling `Close()`.
+- **File handle cleanup**: All file `Open()` calls should have corresponding `defer Close()` calls, using `defer func() { _ = f.Close() }()` to avoid errcheck violations.
+- **Other closeable resources**: Check for leaked connections, file descriptors, and other resources that implement `io.Closer`.
+
+### Git Compatibility
+- Changes must match the behavior of the reference `git` implementation.
+- When possible, contributors should link to relevant upstream Git source code or documentation.
+- Test cases should verify compatibility with real Git repositories.
+
+### Test Quality
+- New code must include tests that actually exercise the feature or bug fix.
+- Tests should not rely on timing or race conditions for correctness.
+- Resource cleanup in tests is mandatory (see Resource Management above).
+
 ### Branches
 
 The development branch is `main`, where all development takes place.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,23 @@ In order for a PR to be accepted it needs to pass a list of requirements:
 - If the PR is a new feature, it has to come with a suite of unit tests that cover the new functionality.
 - In any case, all the PRs have to pass the personal evaluation of at least one of the maintainers of go-git.
 
+## Code Review Checklist
+
+When reviewing code (whether you're a human reviewer or using AI tools to assist), please verify:
+
+### Resource Management
+- **Storage cleanup**: Close storage after creating it or using functions that create storage internally:
+  - **Functions that create storage internally**: `PlainClone`, `PlainInit`, `PlainOpen`, `PlainOpenWithOptions`, `worktree.Worktree.Open()` → Use `defer func() { _ = git.CloseStorage(r) }()`
+  - **Direct storage creation**: `filesystem.NewStorage()`, `transactional.NewStorage()` → Use `defer func() { _ = sto.Close() }()`
+  - **Functions that receive storage**: `Init(storage)`, `Open(storage, worktree)`, `Clone(storage, ...)` → Do NOT close (caller owns the storage)
+- **File handles**: All file `Open()` calls must have `defer func() { _ = f.Close() }()`.
+- **Leak detection**: Run tests with `-tags leakcheck` to detect unclosed resources:
+  ```bash
+  go test -tags leakcheck ./...
+  ```
+
+For detailed review guidelines, see [.github/copilot-instructions.md](.github/copilot-instructions.md).
+
 ### Branches
 
 The development branch is `main`, where all development takes place.

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ build-git:
 
 test:
 	@echo "running against `git version`"; \
-	$(GOTEST) -race ./...
-	$(GOTEST) -v _examples/common_test.go _examples/common.go --examples
+	$(GOTEST) -race -tags leakcheck ./...
+	$(GOTEST) -tags leakcheck -v _examples/common_test.go _examples/common.go --examples
 
 test-coverage:
 	@echo "running against `git version`"; \

--- a/_examples/blame/main.go
+++ b/_examples/blame/main.go
@@ -18,6 +18,7 @@ func main() {
 	Info("git open %s", url)
 	r, err := git.PlainOpen(url)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Retrieve the branch's HEAD, to then get the HEAD commit.
 	ref, err := r.Head()

--- a/_examples/branch/main.go
+++ b/_examples/branch/main.go
@@ -19,6 +19,7 @@ func main() {
 		URL: url,
 	})
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Create a new branch to the current HEAD
 	Info("git branch my-branch")

--- a/_examples/checkout-branch/main.go
+++ b/_examples/checkout-branch/main.go
@@ -22,6 +22,7 @@ func main() {
 		URL: url,
 	})
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// ... retrieving the commit being pointed by HEAD
 	Info("git show-ref --head HEAD")

--- a/_examples/checkout/main.go
+++ b/_examples/checkout/main.go
@@ -21,6 +21,7 @@ func main() {
 	})
 
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// ... retrieving the commit being pointed by HEAD
 	Info("git show-ref --head HEAD")

--- a/_examples/clone/auth/basic/access_token/main.go
+++ b/_examples/clone/auth/basic/access_token/main.go
@@ -27,6 +27,7 @@ func main() {
 		},
 	})
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	ref, err := r.Head()
 	CheckIfError(err)

--- a/_examples/clone/auth/basic/username_password/main.go
+++ b/_examples/clone/auth/basic/username_password/main.go
@@ -27,6 +27,7 @@ func main() {
 		},
 	})
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	ref, err := r.Head()
 	CheckIfError(err)

--- a/_examples/clone/auth/ssh/private_key/main.go
+++ b/_examples/clone/auth/ssh/private_key/main.go
@@ -39,6 +39,7 @@ func main() {
 		},
 	})
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	ref, err := r.Head()
 	CheckIfError(err)

--- a/_examples/clone/auth/ssh/ssh_agent/main.go
+++ b/_examples/clone/auth/ssh/ssh_agent/main.go
@@ -27,6 +27,7 @@ func main() {
 		},
 	})
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	ref, err := r.Head()
 	CheckIfError(err)

--- a/_examples/clone/main.go
+++ b/_examples/clone/main.go
@@ -23,6 +23,7 @@ func main() {
 	})
 
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// ... retrieving the branch being pointed by HEAD
 	ref, err := r.Head()

--- a/_examples/commit/main.go
+++ b/_examples/commit/main.go
@@ -20,6 +20,7 @@ func main() {
 	// Opens an already existing repository.
 	r, err := git.PlainOpen(directory)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	w, err := r.Worktree()
 	CheckIfError(err)

--- a/_examples/config/main.go
+++ b/_examples/config/main.go
@@ -20,6 +20,7 @@ func main() {
 	Info("git init")
 	r, err := git.PlainInit(tmp, false)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Load the configuration
 	cfg, err := r.Config()

--- a/_examples/context/main.go
+++ b/_examples/context/main.go
@@ -36,11 +36,12 @@ func main() {
 
 	// Using PlainCloneContext we can provide to a context, if the context
 	// is cancelled, the clone operation stops gracefully.
-	_, err := git.PlainCloneContext(ctx, directory, &git.CloneOptions{
+	r, err := git.PlainCloneContext(ctx, directory, &git.CloneOptions{
 		URL:      url,
 		Progress: os.Stdout,
 	})
 
 	// If the context was cancelled, an error is returned.
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 }

--- a/_examples/find-if-any-tag-point-head/main.go
+++ b/_examples/find-if-any-tag-point-head/main.go
@@ -17,6 +17,7 @@ func main() {
 	// We instantiate a new repository targeting the given path (the .git folder)
 	r, err := git.PlainOpen(path)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Get HEAD reference to use for comparison later on.
 	ref, err := r.Head()

--- a/_examples/merge_base/main.go
+++ b/_examples/merge_base/main.go
@@ -80,6 +80,7 @@ func main() {
 	// Open a git repository from current directory
 	repo, err := git.PlainOpen(path)
 	checkIfError(err, exitCodeCouldNotOpenRepository, "not in a git repository")
+	defer func() { _ = git.CloseStorage(repo) }()
 
 	// Get the hashes of the passed revisions
 	var hashes []*plumbing.Hash

--- a/_examples/open/main.go
+++ b/_examples/open/main.go
@@ -17,6 +17,7 @@ func main() {
 	// We instantiate a new repository targeting the given path (the .git folder)
 	r, err := git.PlainOpen(path)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Length of the HEAD history
 	Info("git rev-list HEAD --count")

--- a/_examples/progress/main.go
+++ b/_examples/progress/main.go
@@ -16,7 +16,7 @@ func main() {
 	// Clone the given repository to the given directory
 	Info("git clone %s %s", url, directory)
 
-	_, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(directory, &git.CloneOptions{
 		URL:   url,
 		Depth: 1,
 
@@ -27,4 +27,5 @@ func main() {
 	})
 
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 }

--- a/_examples/pull/main.go
+++ b/_examples/pull/main.go
@@ -16,6 +16,7 @@ func main() {
 	// We instantiate a new repository targeting the given path (the .git folder)
 	r, err := git.PlainOpen(path)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Get the working directory for the repository
 	w, err := r.Worktree()

--- a/_examples/push/main.go
+++ b/_examples/push/main.go
@@ -15,6 +15,7 @@ func main() {
 
 	r, err := git.PlainOpen(path)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	Info("git push")
 	// push using default options

--- a/_examples/restore/main.go
+++ b/_examples/restore/main.go
@@ -47,6 +47,7 @@ func main() {
 	// Opens an already existing repository.
 	r, err := git.PlainOpen(directory)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	w, err := r.Worktree()
 	CheckIfError(err)

--- a/_examples/revision/main.go
+++ b/_examples/revision/main.go
@@ -19,6 +19,7 @@ func main() {
 	// We instantiate a new repository targeting the given path (the .git folder)
 	r, err := git.PlainOpen(path)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Resolve revision into a sha1 commit, only some revisions are resolved
 	// look at the doc to get more details

--- a/_examples/sha256/main.go
+++ b/_examples/sha256/main.go
@@ -25,6 +25,7 @@ func main() {
 	// Init a new repository using the ObjectFormat SHA256.
 	r, err := git.PlainInit(directory, false, git.WithObjectFormat(config.SHA256))
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	w, err := r.Worktree()
 	CheckIfError(err)

--- a/_examples/showcase/main.go
+++ b/_examples/showcase/main.go
@@ -29,6 +29,7 @@ func main() {
 
 	r, err := git.PlainClone(path, &git.CloneOptions{URL: url})
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Getting the latest commit on the current branch
 	Info("git log -1")

--- a/_examples/sparse-checkout/main.go
+++ b/_examples/sparse-checkout/main.go
@@ -20,6 +20,7 @@ func main() {
 		NoCheckout: true,
 	})
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	w, err := r.Worktree()
 	CheckIfError(err)

--- a/_examples/submodule/main.go
+++ b/_examples/submodule/main.go
@@ -24,6 +24,7 @@ func main() {
 	})
 
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	w, err := r.Worktree()
 	if err != nil {

--- a/_examples/tag-create-push/main.go
+++ b/_examples/tag-create-push/main.go
@@ -26,6 +26,7 @@ func main() {
 		log.Printf("clone repo error: %s", err)
 		return
 	}
+	defer func() { _ = git.CloseStorage(r) }()
 
 	created, err := setTag(r, tag)
 	if err != nil {

--- a/_examples/tag/main.go
+++ b/_examples/tag/main.go
@@ -18,6 +18,7 @@ func main() {
 	// We instantiate a new repository targeting the given path (the .git folder)
 	r, err := git.PlainOpen(path)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// List all tag references, both lightweight tags and annotated tags
 	Info("git show-ref --tag")

--- a/_examples/update-server-info/main.go
+++ b/_examples/update-server-info/main.go
@@ -21,6 +21,7 @@ func main() {
 	// We instantiate a new repository targeting the given path (the .git folder)
 	r, err := git.PlainOpen(path)
 	CheckIfError(err)
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Update the server info files & save them to the file-system.
 	fs := r.Storer.(*filesystem.Storage).Filesystem()

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -88,6 +88,11 @@ func (b *Backend) Serve(ctx context.Context, r io.ReadCloser, w io.WriteCloser, 
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if closer, ok := st.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	switch req.Service {
 	case transport.UploadPackService:

--- a/backend/http.go
+++ b/backend/http.go
@@ -198,6 +198,11 @@ func (b *Backend) handleDumbSendFile(w http.ResponseWriter, _ *http.Request, rep
 		renderStatusError(w, http.StatusNotFound)
 		return
 	}
+	defer func() {
+		if closer, ok := st.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fss, ok := st.(storer.FilesystemStorer)
 	if !ok {

--- a/common_test.go
+++ b/common_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"testing"
 	"time"
@@ -36,6 +37,19 @@ func (s *BaseSuite) SetupSuite() {
 	s.buildBasicRepository()
 
 	s.cache = make(map[string]*Repository)
+}
+
+func (s *BaseSuite) TearDownSuite() {
+	if s.Repository != nil {
+		if closer, ok := s.Repository.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}
+	for _, r := range s.cache {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}
 }
 
 // registerTestConfigLoader registers a static ConfigSource plugin with

--- a/common_test.go
+++ b/common_test.go
@@ -38,6 +38,15 @@ func (s *BaseSuite) SetupSuite() {
 	s.cache = make(map[string]*Repository)
 }
 
+func (s *BaseSuite) TearDownSuite() {
+	if s.Repository != nil {
+		_ = CloseStorage(s.Repository)
+	}
+	for _, r := range s.cache {
+		_ = CloseStorage(r)
+	}
+}
+
 // registerTestConfigLoader registers a static ConfigSource plugin with
 // default test user data. Tests that need specific config values should
 // register their own ConfigSource.

--- a/example_test.go
+++ b/example_test.go
@@ -52,13 +52,14 @@ func ExamplePlainClone() {
 	defer os.RemoveAll(dir) // clean up
 
 	// Clones the repository into the given dir, just as a normal git clone does
-	_, err = git.PlainClone(dir, &git.CloneOptions{
+	r, err := git.PlainClone(dir, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 	})
 	if err != nil {
 		log.Print(err)
 		return
 	}
+	defer func() { _ = git.CloseStorage(r) }()
 
 	// Prints the content of the CHANGELOG file from the cloned repository
 	changelog, err := os.Open(filepath.Join(dir, "CHANGELOG"))
@@ -81,7 +82,7 @@ func ExamplePlainClone_usernamePassword() {
 	defer os.RemoveAll(dir) // clean up
 
 	// Clones the repository into the given dir, just as a normal git clone does
-	_, err = git.PlainClone(dir, &git.CloneOptions{
+	r, err := git.PlainClone(dir, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 		ClientOptions: []client.Option{
 			client.WithHTTPAuth(&http.BasicAuth{
@@ -92,7 +93,9 @@ func ExamplePlainClone_usernamePassword() {
 	})
 	if err != nil {
 		log.Print(err)
+		return
 	}
+	defer func() { _ = git.CloseStorage(r) }()
 }
 
 func ExamplePlainClone_accessToken() {
@@ -105,7 +108,7 @@ func ExamplePlainClone_accessToken() {
 	defer os.RemoveAll(dir) // clean up
 
 	// Clones the repository into the given dir, just as a normal git clone does
-	_, err = git.PlainClone(dir, &git.CloneOptions{
+	r, err := git.PlainClone(dir, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 		ClientOptions: []client.Option{
 			client.WithHTTPAuth(&http.BasicAuth{
@@ -116,7 +119,9 @@ func ExamplePlainClone_accessToken() {
 	})
 	if err != nil {
 		log.Print(err)
+		return
 	}
+	defer func() { _ = git.CloseStorage(r) }()
 }
 
 func ExampleRepository_References() {

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -119,6 +119,7 @@ func TestResolveRef(t *testing.T) {
 	dotGit, err := fixture.DotGit()
 	require.NoError(t, err)
 	storer := filesystem.NewStorage(dotGit, nil)
+	defer func() { _ = storer.Close() }()
 
 	// Get expected hashes from the fixture
 	masterRef, err := storer.Reference(plumbing.ReferenceName("refs/heads/master"))
@@ -205,6 +206,7 @@ func TestResolveTreeish_Errors(t *testing.T) {
 	dotGit, err := fixture.DotGit()
 	require.NoError(t, err)
 	storer := filesystem.NewStorage(dotGit, nil)
+	defer func() { _ = storer.Close() }()
 
 	tests := []struct {
 		name             string
@@ -263,6 +265,7 @@ func TestResolveTreeish_AllowUnreachable(t *testing.T) {
 	dotGit, err := fixture.DotGit()
 	require.NoError(t, err)
 	storer := filesystem.NewStorage(dotGit, nil)
+	defer func() { _ = storer.Close() }()
 
 	// Get the master commit hash for testing
 	masterRef, err := storer.Reference(plumbing.ReferenceName("refs/heads/master"))
@@ -392,6 +395,7 @@ func TestResolveTreeish_AnnotatedTags(t *testing.T) {
 	dotGit, err := fixture.DotGit()
 	require.NoError(t, err)
 	storer := filesystem.NewStorage(dotGit, nil)
+	defer func() { _ = storer.Close() }()
 
 	tests := []struct {
 		name    string

--- a/plumbing/format/commitgraph/commitgraph_test.go
+++ b/plumbing/format/commitgraph/commitgraph_test.go
@@ -91,6 +91,7 @@ func (s *CommitgraphSuite) TestDecodeMultiChain() {
 		dotgit2, err := f.DotGit()
 		s.Require().NoError(err)
 		storer := filesystem.NewStorage(dotgit2, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 		p, err := f.Packfile()
 		s.Require().NoError(err)
 		defer p.Close()

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -55,6 +55,9 @@ func TestParserHashes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			if closer, ok := tc.storage.(io.Closer); ok {
+				defer func() { _ = closer.Close() }()
+			}
 			f := fixtures.Basic().One()
 
 			obs := new(testObserver)
@@ -142,8 +145,16 @@ func TestThinPack(t *testing.T) {
 	assert.ErrorIs(t, err, packfile.ErrReferenceDeltaNotFound)
 
 	// start over with a clean repo
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 	r, err = git.PlainInit(t.TempDir(), true)
 	assert.NoError(t, err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// Now unpack a base packfile into our empty repo:
 	f := fixtures.ByURL("https://github.com/spinnaker/spinnaker.git").One()

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -77,6 +77,9 @@ func TestParserStorageModes(t *testing.T) {
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
+				if closer, ok := tc.storage.(io.Closer); ok {
+					defer func() { _ = closer.Close() }()
+				}
 
 				obs := new(testObserver)
 				pf, pfErr := f.Packfile()
@@ -171,8 +174,12 @@ func TestThinPack(t *testing.T) {
 	assert.ErrorIs(t, err, packfile.ErrReferenceDeltaNotFound)
 
 	// start over with a clean repo
+	_ = git.CloseStorage(r)
 	r, err = git.PlainInit(t.TempDir(), true)
 	assert.NoError(t, err)
+	defer func() {
+		_ = git.CloseStorage(r)
+	}()
 
 	// Now unpack a base packfile into our empty repo:
 	f := fixtures.ByURL("https://github.com/spinnaker/spinnaker.git").One()

--- a/plumbing/object/change_test.go
+++ b/plumbing/object/change_test.go
@@ -260,6 +260,7 @@ func (s *ChangeSuite) TestNoFileFilemodes() {
 	dotgit, err := f.DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	iter, err := sto.IterEncodedObjects(plumbing.AnyObject)
 	s.NoError(err)

--- a/plumbing/object/commitgraph/commitnode_test.go
+++ b/plumbing/object/commitgraph/commitnode_test.go
@@ -108,6 +108,7 @@ func testCommitAndTree(s *CommitNodeSuite, nodeIndex CommitNodeIndex) {
 func (s *CommitNodeSuite) TestObjectGraph() {
 	f := fixtures.ByTag("commit-graph").One()
 	storer := unpackRepository(f)
+	defer func() { _ = storer.Close() }()
 
 	nodeIndex := NewObjectCommitNodeIndex(storer)
 	testWalker(s, nodeIndex)
@@ -118,6 +119,7 @@ func (s *CommitNodeSuite) TestObjectGraph() {
 func (s *CommitNodeSuite) TestCommitGraph() {
 	f := fixtures.ByTag("commit-graph").One()
 	storer := unpackRepository(f)
+	defer func() { _ = storer.Close() }()
 	reader, err := storer.Filesystem().Open(path.Join("objects", "info", "commit-graph"))
 	s.NoError(err)
 	defer reader.Close()
@@ -134,6 +136,7 @@ func (s *CommitNodeSuite) TestCommitGraph() {
 func (s *CommitNodeSuite) TestMixedGraph() {
 	f := fixtures.ByTag("commit-graph").One()
 	storer := unpackRepository(f)
+	defer func() { _ = storer.Close() }()
 
 	// Take the commit-graph file and copy it to memory index without the last commit
 	reader, err := storer.Filesystem().Open(path.Join("objects", "info", "commit-graph"))

--- a/plumbing/object/commitgraph/commitnode_walker_test.go
+++ b/plumbing/object/commitgraph/commitnode_walker_test.go
@@ -20,6 +20,7 @@ func TestCommitNodeIter(t *testing.T) {
 	f := fixtures.ByTag("commit-graph-chain-2").One()
 
 	storer := newUnpackRepository(f)
+	defer func() { _ = storer.Close() }()
 
 	index, err := commitgraph.OpenChainOrFileIndex(storer.Filesystem())
 	assert.NoError(t, err)

--- a/plumbing/object/difftree_test.go
+++ b/plumbing/object/difftree_test.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"testing"
 
@@ -32,6 +33,12 @@ func (s *DiffTreeSuite) SetupSuite() {
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 	s.Storer = sto
 	s.cache = make(map[string]storer.EncodedObjectStorer)
+}
+
+func (s *DiffTreeSuite) TearDownSuite() {
+	if closer, ok := s.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 func (s *DiffTreeSuite) commitFromStorer(sto storer.EncodedObjectStorer,

--- a/plumbing/object/file_test.go
+++ b/plumbing/object/file_test.go
@@ -212,6 +212,7 @@ func (s *FileSuite) TestIgnoreEmptyDirEntries() {
 		dotgit, err := f.DotGit()
 		s.Require().NoError(err)
 		sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+		defer func() { _ = sto.Close() }()
 
 		h := plumbing.NewHash(t.commit)
 		commit, err := GetCommit(sto, h)
@@ -268,6 +269,7 @@ func (s *FileSuite) TestFileIterSubmodule() {
 	dotgit, err := fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit()
 	s.Require().NoError(err)
 	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
 
 	hash := plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4")
 	commit, err := GetCommit(st, hash)

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -34,6 +34,12 @@ func (s *BaseObjectsSuite) SetupSuite(t *testing.T) {
 	s.t = t
 }
 
+func (s *BaseObjectsSuite) TearDownSuite() {
+	if closer, ok := s.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
+}
+
 func (s *BaseObjectsSuite) tag(h plumbing.Hash) *Tag {
 	t, err := GetTag(s.Storer, h)
 	assert.NoError(s.t, err)

--- a/plumbing/object/patch_test.go
+++ b/plumbing/object/patch_test.go
@@ -25,6 +25,7 @@ func (s *PatchSuite) TestStatsWithSubmodules() {
 	subDotgit, err := fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit()
 	s.Require().NoError(err)
 	storer := filesystem.NewStorage(subDotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = storer.Close() }()
 
 	commit, err := GetCommit(storer, plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4"))
 	s.NoError(err)

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -28,10 +28,20 @@ func TestTagSuite(t *testing.T) {
 
 func (s *TagSuite) SetupSuite() {
 	s.BaseObjectsSuite.SetupSuite(s.T())
+	// Close the base storer before overwriting it
+	if closer, ok := s.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 	tagsDotgit, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
 	storer := filesystem.NewStorage(tagsDotgit, cache.NewObjectLRUDefault())
 	s.Storer = storer
+}
+
+func (s *TagSuite) TearDownSuite() {
+	if closer, ok := s.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 func (s *TagSuite) TestNameIDAndType() {

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -505,6 +505,7 @@ func (s *TreeSuite) TestTreeWalkerNextSubmodule() {
 	dotgit2, err := fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit()
 	s.Require().NoError(err)
 	st := filesystem.NewStorage(dotgit2, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
 
 	hash := plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4")
 	commit, err := GetCommit(st, hash)

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -2,6 +2,7 @@ package revlist
 
 import (
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"testing"
@@ -82,6 +83,12 @@ func (s *RevListSuite) SetupTest() {
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 	s.Storer = sto
+}
+
+func (s *RevListSuite) TearDownTest() {
+	if closer, ok := s.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 func (s *RevListSuite) TestRevListObjects_Submodules() {
@@ -531,6 +538,7 @@ func (s *RevListSuite) TestRevListObjects_ReintroducedBlobInHaveAncestor() {
 	dotgit, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	t := s.T()
 	license := plumbing.NewHash("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88")
@@ -610,6 +618,7 @@ func (s *RevListSuite) TestRevListObjects_MissingHaveAncestorIsTolerated() {
 	dotgit, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 	t := s.T()
 
 	haveTree := testMakeTree(t, sto, []object.TreeEntry{

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing"
 	transport "github.com/go-git/go-git/v6/plumbing/transport"
-	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
 
@@ -74,8 +73,7 @@ func TestRedirectSchema(t *testing.T) {
 	t.Parallel()
 
 	base, backend := setupSmartServer(t)
-	basicFS := prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
-	_ = filesystem.NewStorage(basicFS, nil)
+	_ = prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
 
 	rl := test.ListenTCP(t)
 	raddr := rl.Addr().(*net.TCPAddr)

--- a/plumbing/transport/loader_test.go
+++ b/plumbing/transport/loader_test.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -20,6 +21,7 @@ func TestFilesystemLoader_Load(t *testing.T) {
 
 	repoPath := filepath.Join(dir, "repo.git")
 	st := filesystem.NewStorage(osfs.New(repoPath), nil)
+	defer func() { _ = st.Close() }()
 	require.NoError(t, st.Init())
 	cfg, err := st.Config()
 	require.NoError(t, err)
@@ -31,6 +33,11 @@ func TestFilesystemLoader_Load(t *testing.T) {
 	u := &url.URL{Path: "repo"}
 	sto, err := loader.Load(u)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := sto.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	assert.NotNil(t, sto)
 }
 
@@ -39,6 +46,7 @@ func TestFilesystemLoader_LoadBare(t *testing.T) {
 	dir := t.TempDir()
 
 	st := filesystem.NewStorage(osfs.New(filepath.Join(dir, "bare.git")), nil)
+	defer func() { _ = st.Close() }()
 	require.NoError(t, st.Init())
 	cfg, err := st.Config()
 	require.NoError(t, err)
@@ -50,6 +58,11 @@ func TestFilesystemLoader_LoadBare(t *testing.T) {
 	u := &url.URL{Path: "bare.git"}
 	sto, err := loader.Load(u)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := sto.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	assert.NotNil(t, sto)
 }
 
@@ -112,6 +125,11 @@ func TestFilesystemLoader_LoadWithConfigDir(t *testing.T) {
 
 	st, err := loader.Load(u)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := st.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	require.NotNil(t, st)
 
 	// Verify it loaded the correct config
@@ -143,6 +161,11 @@ func TestFilesystemLoader_LoadWithGitfile(t *testing.T) {
 
 	st, err := loader.Load(u)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := st.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	require.NotNil(t, st)
 
 	// Verify it loaded the correct config
@@ -172,6 +195,11 @@ func TestFilesystemLoader_LoadWithRelativeGitfile(t *testing.T) {
 
 	st, err := loader.Load(u)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := st.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	require.NotNil(t, st)
 
 	// Verify it loaded the correct config

--- a/prune_test.go
+++ b/prune_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"io"
 	"testing"
 	"time"
 
@@ -27,6 +28,11 @@ func (s *PruneSuite) testPrune(deleteTime time.Time) {
 	srcFs, err := fixtures.ByTag("unpacked").One().DotGit()
 	s.Require().NoError(err)
 	var sto storage.Storer = filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	defer func() {
+		if closer, ok := sto.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	los := sto.(storer.LooseObjectStorer)
 	s.NotNil(los)

--- a/remote.go
+++ b/remote.go
@@ -128,7 +128,15 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		return err
 	}
 
-	return r.sendPack(ctx, sess, remoteRefs, o)
+	if err := r.sendPack(ctx, sess, remoteRefs, o); err != nil {
+		return err
+	}
+
+	if err := sess.Close(); err != nil {
+		return fmt.Errorf("error closing connection: %w", err)
+	}
+
+	return nil
 }
 
 func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRefs storer.ReferenceStorer, o *PushOptions) error {

--- a/remote_test.go
+++ b/remote_test.go
@@ -365,6 +365,7 @@ func (s *RemoteSuite) TestFetchOfMissingObjects() {
 	s.Require().NoError(util.RemoveAll(dotgit, "objects/pack"))
 
 	storage := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = storage.Close() }()
 
 	r, err := Open(storage, nil)
 	s.Require().NoError(err)
@@ -420,6 +421,7 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter() {
 	fs := s.TemporalFilesystem()
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = fss.Close() }()
 	mock := &mockPackfileWriter{Storer: fss}
 
 	url := s.GetBasicLocalRepositoryURL()
@@ -552,6 +554,7 @@ func (s *RemoteSuite) TestFetchFastForwardFS() {
 	fs := s.TemporalFilesystem()
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = fss.Close() }()
 
 	// This exercises `storage.filesystem.Storage.CheckAndSetReference()`.
 	s.testFetchFastForward(fss)
@@ -574,6 +577,11 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	srcFs, err := fixtures.Basic().One().DotGit()
 	s.Require().NoError(err)
@@ -609,8 +617,13 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 
 func (s *RemoteSuite) TestPushContext() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
@@ -638,8 +651,13 @@ func (s *RemoteSuite) TestPushContext() {
 
 func (s *RemoteSuite) TestPushPushOptions() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs, err := fixtures.Basic().One().DotGit()
 	s.Require().NoError(err)
@@ -675,12 +693,18 @@ func eventually(s *RemoteSuite, condition func() bool) {
 
 func (s *RemoteSuite) TestPushContextCanceled() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -706,6 +730,11 @@ func (s *RemoteSuite) TestPushTags() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
@@ -735,6 +764,11 @@ func (s *RemoteSuite) TestPushTagsByOID() {
 
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
@@ -766,11 +800,16 @@ func (s *RemoteSuite) TestPushTagsByOID() {
 	})
 }
 
-func (s *RemoteSuite) TestPushBlobByOID() {
+func (s *RemoteSuite) testPushObjectByOID(oid, refName string) {
 	url := s.T().TempDir()
 
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
@@ -783,49 +822,34 @@ func (s *RemoteSuite) TestPushBlobByOID() {
 
 	err = r.Push(&PushOptions{
 		RefSpecs: []config.RefSpec{
-			"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391:refs/misc/myblob",
+			config.RefSpec(oid + ":" + refName),
 		},
 		FollowTags: false,
 	})
 	s.NoError(err)
 
 	AssertReferences(s.T(), server, map[string]string{
-		"refs/misc/myblob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+		refName: oid,
 	})
 }
 
+func (s *RemoteSuite) TestPushBlobByOID() {
+	s.testPushObjectByOID("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "refs/misc/myblob")
+}
+
 func (s *RemoteSuite) TestPushTreeByOID() {
-	url := s.T().TempDir()
-
-	server, err := PlainInit(url, true)
-	s.NoError(err)
-
-	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
-	s.Require().NoError(err)
-	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-
-	r := NewRemote(sto, &config.RemoteConfig{
-		Name: DefaultRemoteName,
-		URLs: []string{url},
-	})
-
-	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{
-			"70846e9a10ef7b41064b40f07713d5b8b9a8fc73:refs/misc/mytree",
-		},
-		FollowTags: false,
-	})
-	s.NoError(err)
-
-	AssertReferences(s.T(), server, map[string]string{
-		"refs/misc/mytree": "70846e9a10ef7b41064b40f07713d5b8b9a8fc73",
-	})
+	s.testPushObjectByOID("70846e9a10ef7b41064b40f07713d5b8b9a8fc73", "refs/misc/mytree")
 }
 
 func (s *RemoteSuite) TestPushFollowTags() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/basic.git").One().DotGit()
 	s.Require().NoError(err)
@@ -837,6 +861,11 @@ func (s *RemoteSuite) TestPushFollowTags() {
 	})
 
 	localRepo := newRepository(sto, fs)
+	defer func() {
+		if closer, ok := localRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	tipTag, err := localRepo.CreateTag(
 		"tip",
 		plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
@@ -885,6 +914,7 @@ func (s *RemoteSuite) TestPushNoErrAlreadyUpToDate() {
 	fs, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -901,12 +931,18 @@ func (s *RemoteSuite) TestPushDeleteReference() {
 	fs, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  fs.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -928,12 +964,18 @@ func (s *RemoteSuite) TestForcePushDeleteReference() {
 	s.Require().NoError(err)
 
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  fs.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -956,9 +998,15 @@ func (s *RemoteSuite) TestPushRejectNonFastForward() {
 	s.Require().NoError(err)
 
 	server := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = server.Close() }()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: fs.Root(), Bare: true})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.Require().NoError(err)
@@ -983,10 +1031,12 @@ func (s *RemoteSuite) TestPushForce() {
 	dotgit, dotgitErr := f.DotGit()
 	s.Require().NoError(dotgitErr)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(dstErr)
 	dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+	defer func() { _ = dstSto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -1012,10 +1062,12 @@ func (s *RemoteSuite) TestPushForceWithOption() {
 	dotgit, dotgitErr := f.DotGit()
 	s.Require().NoError(dotgitErr)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(dstErr)
 	dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+	defer func() { _ = dstSto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -1068,10 +1120,12 @@ func (s *RemoteSuite) TestPushForceWithLease_success() {
 		dotgit, dotgitErr := f.DotGit()
 		s.Require().NoError(dotgitErr)
 		sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+		defer func() { _ = sto.Close() }()
 
 		dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 		s.Require().NoError(dstErr)
 		dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+		defer func() { _ = dstSto.Close() }()
 
 		newCommit := plumbing.NewHashReference(
 			"refs/heads/branch", plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
@@ -1133,6 +1187,7 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 		dotgit, dotgitErr := f.DotGit()
 		s.Require().NoError(dotgitErr)
 		sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+		defer func() { _ = sto.Close() }()
 		s.NoError(sto.SetReference(
 			plumbing.NewHashReference(
 				"refs/heads/branch", plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
@@ -1142,6 +1197,7 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 		dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 		s.Require().NoError(dstErr)
 		dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+		defer func() { _ = dstSto.Close() }()
 		s.NoError(dstSto.SetReference(
 			plumbing.NewHashReference(
 				"refs/heads/branch", plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"),
@@ -1173,12 +1229,22 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 func (s *RemoteSuite) TestPushPrune() {
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	tag, err := r.Reference(plumbing.ReferenceName("refs/tags/v1.0.0"), true)
 	s.NoError(err)
@@ -1227,12 +1293,22 @@ func (s *RemoteSuite) TestPushPrune() {
 func (s *RemoteSuite) TestPushNewReference() {
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -1257,12 +1333,22 @@ func (s *RemoteSuite) TestPushNewReference() {
 func (s *RemoteSuite) TestPushNewReferenceAndDeleteInBatch() {
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -1514,12 +1600,18 @@ func (s *RemoteSuite) TestUpdateShallows() {
 
 func (s *RemoteSuite) TestUseRefDeltas() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -1540,10 +1632,12 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 	dotgit, dotgitErr := f.DotGit()
 	s.Require().NoError(dotgitErr)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(dstErr)
 	dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+	defer func() { _ = dstSto.Close() }()
 
 	url := dstFs.Root()
 	r := NewRemote(sto, &config.RemoteConfig{
@@ -1593,11 +1687,16 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 
 func (s *RemoteSuite) TestFetchPrune() {
 	url := s.T().TempDir()
-	_, err := PlainClone(url, &CloneOptions{
+	urlRepo, err := PlainClone(url, &CloneOptions{
 		URL:  s.GetBasicLocalRepositoryURL(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := urlRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	dir := s.T().TempDir()
 	r, err := PlainClone(dir, &CloneOptions{
@@ -1605,6 +1704,11 @@ func (s *RemoteSuite) TestFetchPrune() {
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -1623,6 +1727,11 @@ func (s *RemoteSuite) TestFetchPrune() {
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := rSave.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	AssertReferences(s.T(), rSave, map[string]string{
 		"refs/remotes/origin/branch": ref.Hash().String(),
@@ -1646,11 +1755,16 @@ func (s *RemoteSuite) TestFetchPrune() {
 
 func (s *RemoteSuite) TestFetchPruneTags() {
 	url := s.T().TempDir()
-	_, err := PlainClone(url, &CloneOptions{
+	urlRepo, err := PlainClone(url, &CloneOptions{
 		URL:  s.GetBasicLocalRepositoryURL(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := urlRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	dir := s.T().TempDir()
 	r, err := PlainClone(dir, &CloneOptions{
@@ -1658,6 +1772,11 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -1676,6 +1795,11 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := rSave.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	AssertReferences(s.T(), rSave, map[string]string{
 		"refs/tags/v1": ref.Hash().String(),
@@ -1706,10 +1830,20 @@ func (s *RemoteSuite) TestCanPushShasToReference() {
 	remote, err := PlainInit(filepath.Join(d, "remote"), true)
 	s.NoError(err)
 	s.NotNil(remote)
+	defer func() {
+		if closer, ok := remote.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	repo, err := PlainInit(filepath.Join(d, "repo"), false)
 	s.NoError(err)
 	s.NotNil(repo)
+	defer func() {
+		if closer, ok := repo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	sha := CommitNewFile(s.T(), repo, "README.md")
 
@@ -1751,6 +1885,11 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 	remote, err := PlainInit(remoteURL, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(remote)
+	defer func() {
+		if closer, ok := remote.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	_ = CommitNewFile(s.T(), remote, "File1")
 	_ = CommitNewFile(s.T(), remote, "File2")
@@ -1764,6 +1903,11 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 		ReferenceName: "master",
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := repo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// Add new commits to the origin (more than 1 so that our next test hits a missing commit)
 	_ = CommitNewFile(s.T(), remote, "File3")
@@ -1825,6 +1969,11 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 	// Build a remote with two commits so we can take a shallow clone.
 	remoteRepo, err := PlainInit(remoteURL, false)
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := remoteRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	_ = CommitNewFile(s.T(), remoteRepo, "File1")
 	_ = CommitNewFile(s.T(), remoteRepo, "File2")
 
@@ -1837,6 +1986,11 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 		ReferenceName: "master",
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := repo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// Push two more commits to the remote while the local clone is still shallow.
 	_ = CommitNewFile(s.T(), remoteRepo, "File3")
@@ -1875,6 +2029,11 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if closer, ok := remoteRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// 2. Add a commit with an empty tree to master and custom ref, also set HEAD
 	emptyTreeID := writeEmptyTree(t, remoteRepo)
@@ -1892,6 +2051,11 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if closer, ok := localRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	if err := localRepo.Fetch(&FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec(fmt.Sprintf("%s:%s", customRef, customRef)),

--- a/remote_test.go
+++ b/remote_test.go
@@ -365,6 +365,7 @@ func (s *RemoteSuite) TestFetchOfMissingObjects() {
 	s.Require().NoError(util.RemoveAll(dotgit, "objects/pack"))
 
 	storage := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = storage.Close() }()
 
 	r, err := Open(storage, nil)
 	s.Require().NoError(err)
@@ -420,6 +421,7 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter() {
 	fs := s.TemporalFilesystem()
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = fss.Close() }()
 	mock := &mockPackfileWriter{Storer: fss}
 
 	url := s.GetBasicLocalRepositoryURL()
@@ -552,6 +554,7 @@ func (s *RemoteSuite) TestFetchFastForwardFS() {
 	fs := s.TemporalFilesystem()
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = fss.Close() }()
 
 	// This exercises `storage.filesystem.Storage.CheckAndSetReference()`.
 	s.testFetchFastForward(fss)
@@ -574,6 +577,9 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	srcFs, err := fixtures.Basic().One().DotGit()
 	s.Require().NoError(err)
@@ -609,8 +615,11 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 
 func (s *RemoteSuite) TestPushContext() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
@@ -638,8 +647,11 @@ func (s *RemoteSuite) TestPushContext() {
 
 func (s *RemoteSuite) TestPushPushOptions() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	fs, err := fixtures.Basic().One().DotGit()
 	s.Require().NoError(err)
@@ -675,12 +687,16 @@ func eventually(s *RemoteSuite, condition func() bool) {
 
 func (s *RemoteSuite) TestPushContextCanceled() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -706,6 +722,9 @@ func (s *RemoteSuite) TestPushTags() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
@@ -735,6 +754,9 @@ func (s *RemoteSuite) TestPushTagsByOID() {
 
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
@@ -766,11 +788,14 @@ func (s *RemoteSuite) TestPushTagsByOID() {
 	})
 }
 
-func (s *RemoteSuite) TestPushBlobByOID() {
+func (s *RemoteSuite) testPushObjectByOID(oid, refName string) {
 	url := s.T().TempDir()
 
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
@@ -783,49 +808,32 @@ func (s *RemoteSuite) TestPushBlobByOID() {
 
 	err = r.Push(&PushOptions{
 		RefSpecs: []config.RefSpec{
-			"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391:refs/misc/myblob",
+			config.RefSpec(oid + ":" + refName),
 		},
 		FollowTags: false,
 	})
 	s.NoError(err)
 
 	AssertReferences(s.T(), server, map[string]string{
-		"refs/misc/myblob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+		refName: oid,
 	})
 }
 
+func (s *RemoteSuite) TestPushBlobByOID() {
+	s.testPushObjectByOID("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", "refs/misc/myblob")
+}
+
 func (s *RemoteSuite) TestPushTreeByOID() {
-	url := s.T().TempDir()
-
-	server, err := PlainInit(url, true)
-	s.NoError(err)
-
-	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
-	s.Require().NoError(err)
-	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-
-	r := NewRemote(sto, &config.RemoteConfig{
-		Name: DefaultRemoteName,
-		URLs: []string{url},
-	})
-
-	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{
-			"70846e9a10ef7b41064b40f07713d5b8b9a8fc73:refs/misc/mytree",
-		},
-		FollowTags: false,
-	})
-	s.NoError(err)
-
-	AssertReferences(s.T(), server, map[string]string{
-		"refs/misc/mytree": "70846e9a10ef7b41064b40f07713d5b8b9a8fc73",
-	})
+	s.testPushObjectByOID("70846e9a10ef7b41064b40f07713d5b8b9a8fc73", "refs/misc/mytree")
 }
 
 func (s *RemoteSuite) TestPushFollowTags() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/basic.git").One().DotGit()
 	s.Require().NoError(err)
@@ -837,6 +845,9 @@ func (s *RemoteSuite) TestPushFollowTags() {
 	})
 
 	localRepo := newRepository(sto, fs)
+	defer func() {
+		_ = CloseStorage(localRepo)
+	}()
 	tipTag, err := localRepo.CreateTag(
 		"tip",
 		plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
@@ -885,6 +896,7 @@ func (s *RemoteSuite) TestPushNoErrAlreadyUpToDate() {
 	fs, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -901,12 +913,16 @@ func (s *RemoteSuite) TestPushDeleteReference() {
 	fs, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  fs.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -928,12 +944,16 @@ func (s *RemoteSuite) TestForcePushDeleteReference() {
 	s.Require().NoError(err)
 
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  fs.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -956,9 +976,13 @@ func (s *RemoteSuite) TestPushRejectNonFastForward() {
 	s.Require().NoError(err)
 
 	server := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = server.Close() }()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: fs.Root(), Bare: true})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.Require().NoError(err)
@@ -983,10 +1007,12 @@ func (s *RemoteSuite) TestPushForce() {
 	dotgit, dotgitErr := f.DotGit()
 	s.Require().NoError(dotgitErr)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(dstErr)
 	dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+	defer func() { _ = dstSto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -1012,10 +1038,12 @@ func (s *RemoteSuite) TestPushForceWithOption() {
 	dotgit, dotgitErr := f.DotGit()
 	s.Require().NoError(dotgitErr)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(dstErr)
 	dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+	defer func() { _ = dstSto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -1068,10 +1096,12 @@ func (s *RemoteSuite) TestPushForceWithLease_success() {
 		dotgit, dotgitErr := f.DotGit()
 		s.Require().NoError(dotgitErr)
 		sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+		defer func() { _ = sto.Close() }()
 
 		dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 		s.Require().NoError(dstErr)
 		dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+		defer func() { _ = dstSto.Close() }()
 
 		newCommit := plumbing.NewHashReference(
 			"refs/heads/branch", plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
@@ -1133,6 +1163,7 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 		dotgit, dotgitErr := f.DotGit()
 		s.Require().NoError(dotgitErr)
 		sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+		defer func() { _ = sto.Close() }()
 		s.NoError(sto.SetReference(
 			plumbing.NewHashReference(
 				"refs/heads/branch", plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
@@ -1142,6 +1173,7 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 		dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 		s.Require().NoError(dstErr)
 		dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+		defer func() { _ = dstSto.Close() }()
 		s.NoError(dstSto.SetReference(
 			plumbing.NewHashReference(
 				"refs/heads/branch", plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"),
@@ -1173,12 +1205,18 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 func (s *RemoteSuite) TestPushPrune() {
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	tag, err := r.Reference(plumbing.ReferenceName("refs/tags/v1.0.0"), true)
 	s.NoError(err)
@@ -1227,12 +1265,18 @@ func (s *RemoteSuite) TestPushPrune() {
 func (s *RemoteSuite) TestPushNewReference() {
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -1257,12 +1301,18 @@ func (s *RemoteSuite) TestPushNewReference() {
 func (s *RemoteSuite) TestPushNewReferenceAndDeleteInBatch() {
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -1514,12 +1564,16 @@ func (s *RemoteSuite) TestUpdateShallows() {
 
 func (s *RemoteSuite) TestUseRefDeltas() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	fs, err := fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -1540,10 +1594,12 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 	dotgit, dotgitErr := f.DotGit()
 	s.Require().NoError(dotgitErr)
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	dstFs, dstErr := f.DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(dstErr)
 	dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
+	defer func() { _ = dstSto.Close() }()
 
 	url := dstFs.Root()
 	r := NewRemote(sto, &config.RemoteConfig{
@@ -1593,11 +1649,14 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 
 func (s *RemoteSuite) TestFetchPrune() {
 	url := s.T().TempDir()
-	_, err := PlainClone(url, &CloneOptions{
+	urlRepo, err := PlainClone(url, &CloneOptions{
 		URL:  s.GetBasicLocalRepositoryURL(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(urlRepo)
+	}()
 
 	dir := s.T().TempDir()
 	r, err := PlainClone(dir, &CloneOptions{
@@ -1605,6 +1664,9 @@ func (s *RemoteSuite) TestFetchPrune() {
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -1623,6 +1685,9 @@ func (s *RemoteSuite) TestFetchPrune() {
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(rSave)
+	}()
 
 	AssertReferences(s.T(), rSave, map[string]string{
 		"refs/remotes/origin/branch": ref.Hash().String(),
@@ -1646,11 +1711,14 @@ func (s *RemoteSuite) TestFetchPrune() {
 
 func (s *RemoteSuite) TestFetchPruneTags() {
 	url := s.T().TempDir()
-	_, err := PlainClone(url, &CloneOptions{
+	urlRepo, err := PlainClone(url, &CloneOptions{
 		URL:  s.GetBasicLocalRepositoryURL(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(urlRepo)
+	}()
 
 	dir := s.T().TempDir()
 	r, err := PlainClone(dir, &CloneOptions{
@@ -1658,6 +1726,9 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remote, err := r.Remote(DefaultRemoteName)
 	s.NoError(err)
@@ -1676,6 +1747,9 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 		Bare: true,
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(rSave)
+	}()
 
 	AssertReferences(s.T(), rSave, map[string]string{
 		"refs/tags/v1": ref.Hash().String(),
@@ -1706,10 +1780,16 @@ func (s *RemoteSuite) TestCanPushShasToReference() {
 	remote, err := PlainInit(filepath.Join(d, "remote"), true)
 	s.NoError(err)
 	s.NotNil(remote)
+	defer func() {
+		_ = CloseStorage(remote)
+	}()
 
 	repo, err := PlainInit(filepath.Join(d, "repo"), false)
 	s.NoError(err)
 	s.NotNil(repo)
+	defer func() {
+		_ = CloseStorage(repo)
+	}()
 
 	sha := CommitNewFile(s.T(), repo, "README.md")
 
@@ -1751,6 +1831,9 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 	remote, err := PlainInit(remoteURL, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(remote)
+	defer func() {
+		_ = CloseStorage(remote)
+	}()
 
 	_ = CommitNewFile(s.T(), remote, "File1")
 	_ = CommitNewFile(s.T(), remote, "File2")
@@ -1764,6 +1847,9 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 		ReferenceName: "master",
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(repo)
+	}()
 
 	// Add new commits to the origin (more than 1 so that our next test hits a missing commit)
 	_ = CommitNewFile(s.T(), remote, "File3")
@@ -1825,6 +1911,9 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 	// Build a remote with two commits so we can take a shallow clone.
 	remoteRepo, err := PlainInit(remoteURL, false)
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(remoteRepo)
+	}()
 	_ = CommitNewFile(s.T(), remoteRepo, "File1")
 	_ = CommitNewFile(s.T(), remoteRepo, "File2")
 
@@ -1837,6 +1926,9 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 		ReferenceName: "master",
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(repo)
+	}()
 
 	// Push two more commits to the remote while the local clone is still shallow.
 	_ = CommitNewFile(s.T(), remoteRepo, "File3")
@@ -1875,6 +1967,9 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		_ = CloseStorage(remoteRepo)
+	}()
 
 	// 2. Add a commit with an empty tree to master and custom ref, also set HEAD
 	emptyTreeID := writeEmptyTree(t, remoteRepo)
@@ -1892,6 +1987,9 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		_ = CloseStorage(localRepo)
+	}()
 	if err := localRepo.Fetch(&FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec(fmt.Sprintf("%s:%s", customRef, customRef)),

--- a/repository.go
+++ b/repository.go
@@ -364,6 +364,7 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 	})
 	r, err := initFn(s)
 	if err != nil {
+		_ = s.Close()
 		return nil, err
 	}
 
@@ -373,11 +374,13 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 
 	cfg, err := r.Config()
 	if err != nil {
+		_ = s.Close()
 		return nil, err
 	}
 
 	err = r.Storer.SetConfig(cfg)
 	if err != nil {
+		_ = s.Close()
 		return nil, err
 	}
 
@@ -441,7 +444,12 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 
 	s := filesystem.NewStorage(repositoryFs, cache.NewObjectLRUDefault())
 
-	return Open(s, wt)
+	r, err := Open(s, wt)
+	if err != nil {
+		_ = s.Close()
+		return nil, err
+	}
+	return r, nil
 }
 
 func dotGitToOSFilesystems(path string, detect bool) (dot, wt billy.Filesystem, err error) {
@@ -619,6 +627,10 @@ func PlainCloneContext(ctx context.Context, path string, o *CloneOptions) (*Repo
 			// We created the directory; remove it entirely.
 			_ = os.RemoveAll(path)
 		}
+		// Close the storage that PlainInit created
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
 		return r, err
 	}
 
@@ -657,16 +669,6 @@ func checkTargetDirIsEmpty(path string) (empty bool, err error) {
 	}
 
 	return false, nil
-}
-
-// Close releases any open resources held by the repository. It must be called
-// when the repository is no longer needed. It is safe to call Close on a
-// repository backed by memory storage, where it is a no-op.
-func (r *Repository) Close() error {
-	if c, ok := r.Storer.(io.Closer); ok {
-		return c.Close()
-	}
-	return nil
 }
 
 // Config return the repository config. In a filesystem backed repository this
@@ -1093,6 +1095,11 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		if err != nil {
 			return fmt.Errorf("failed to open remote repository: %w", err)
 		}
+		defer func() {
+			if closer, ok := remoteRepo.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 		conf, err := remoteRepo.Config()
 		if err != nil {
 			return fmt.Errorf("failed to read remote repository configuration: %w", err)

--- a/repository.go
+++ b/repository.go
@@ -87,6 +87,27 @@ type Repository struct {
 	wt billy.Filesystem
 }
 
+// CloseStorage safely closes a repository's storage if it implements io.Closer.
+// It returns any error from Close() for explicit error handling, or can be used with defer.
+//
+// This is only needed when using Plain* functions (PlainClone, PlainInit, PlainOpen,
+// PlainOpenWithOptions) which create storage internally. When you create storage directly
+// (e.g., filesystem.NewStorage), close it directly instead.
+//
+// Usage:
+//
+//	r, err := git.PlainClone("/tmp/repo", false, &git.CloneOptions{...})
+//	if err != nil {
+//	    return err
+//	}
+//	defer func() { _ = git.CloseStorage(r) }()
+func CloseStorage(r *Repository) error {
+	if closer, ok := r.Storer.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
 type initOptions struct {
 	defaultBranch plumbing.ReferenceName
 	workTree      billy.Filesystem
@@ -364,6 +385,7 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 	})
 	r, err := initFn(s)
 	if err != nil {
+		_ = s.Close()
 		return nil, err
 	}
 
@@ -373,11 +395,13 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 
 	cfg, err := r.Config()
 	if err != nil {
+		_ = s.Close()
 		return nil, err
 	}
 
 	err = r.Storer.SetConfig(cfg)
 	if err != nil {
+		_ = s.Close()
 		return nil, err
 	}
 
@@ -441,7 +465,12 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 
 	s := filesystem.NewStorage(repositoryFs, cache.NewObjectLRUDefault())
 
-	return Open(s, wt)
+	r, err := Open(s, wt)
+	if err != nil {
+		_ = s.Close()
+		return nil, err
+	}
+	return r, nil
 }
 
 func dotGitToOSFilesystems(path string, detect bool) (dot, wt billy.Filesystem, err error) {
@@ -619,6 +648,8 @@ func PlainCloneContext(ctx context.Context, path string, o *CloneOptions) (*Repo
 			// We created the directory; remove it entirely.
 			_ = os.RemoveAll(path)
 		}
+		// Close the storage that PlainInit created
+		_ = CloseStorage(r)
 		return r, err
 	}
 
@@ -657,16 +688,6 @@ func checkTargetDirIsEmpty(path string) (empty bool, err error) {
 	}
 
 	return false, nil
-}
-
-// Close releases any open resources held by the repository. It must be called
-// when the repository is no longer needed. It is safe to call Close on a
-// repository backed by memory storage, where it is a no-op.
-func (r *Repository) Close() error {
-	if c, ok := r.Storer.(io.Closer); ok {
-		return c.Close()
-	}
-	return nil
 }
 
 // Config return the repository config. In a filesystem backed repository this
@@ -1093,6 +1114,9 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		if err != nil {
 			return fmt.Errorf("failed to open remote repository: %w", err)
 		}
+		defer func() {
+			_ = CloseStorage(remoteRepo)
+		}()
 		conf, err := remoteRepo.Config()
 		if err != nil {
 			return fmt.Errorf("failed to read remote repository configuration: %w", err)

--- a/repository_test.go
+++ b/repository_test.go
@@ -150,6 +150,11 @@ func TestPlainInitAndPlainOpen(t *testing.T) {
 				r, err := PlainInit(rdir, tc.wantBare, opts...)
 				require.NotNil(t, r)
 				require.NoError(t, err)
+				defer func() {
+					if closer, ok := r.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				cfg, err := r.Config()
 				require.NoError(t, err)
@@ -172,6 +177,11 @@ func TestPlainInitAndPlainOpen(t *testing.T) {
 				ro, err := PlainOpen(rdir)
 				require.NotNil(t, ro)
 				require.NoError(t, err)
+				defer func() {
+					if closer, ok := ro.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				if !tc.wantBare {
 					ref, err := ro.Head()
@@ -204,6 +214,7 @@ func (s *RepositorySuite) TestInitNonStandardDotGit() {
 	fs := osfs.New(dir)
 	dot, _ := fs.Chroot("storage")
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
 
 	wt, _ := fs.Chroot("worktree")
 	r, err := Init(st, WithWorkTree(wt))
@@ -228,6 +239,7 @@ func (s *RepositorySuite) TestInitStandardDotGit() {
 	fs := osfs.New(dir)
 	dot, _ := fs.Chroot(".git")
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
 
 	r, err := Init(st, WithWorkTree(fs))
 	s.NoError(err)
@@ -248,6 +260,9 @@ func (s *RepositorySuite) TestInitAlreadyExists() {
 	r, err := Init(st)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	r, err = Init(st)
 	s.ErrorIs(err, ErrTargetDirNotEmpty)
@@ -260,10 +275,16 @@ func (s *RepositorySuite) TestOpen() {
 	r, err := Init(st, WithWorkTree(memfs.New()))
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	r, err = Open(st, memfs.New())
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 func (s *RepositorySuite) TestOpenBare() {
@@ -272,10 +293,16 @@ func (s *RepositorySuite) TestOpenBare() {
 	r, err := Init(st)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	r, err = Open(st, nil)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 func (s *RepositorySuite) TestOpenBareMissingWorktree() {
@@ -284,10 +311,16 @@ func (s *RepositorySuite) TestOpenBareMissingWorktree() {
 	r, err := Init(st, WithWorkTree(memfs.New()))
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	r, err = Open(st, nil)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 func (s *RepositorySuite) TestOpenNotExists() {
@@ -345,6 +378,11 @@ func TestCloneAll(t *testing.T) {
 				}
 				require.NoError(t, err)
 				require.NotNil(t, r, "repository must not be nil")
+				defer func() {
+					if closer, ok := r.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				remotes, err := r.Remotes()
 				require.NoError(t, err)
@@ -500,6 +538,11 @@ func TestFetchByHashThenResolveRevision(t *testing.T) {
 		Tags:  NoTags,
 	})
 	require.NoError(t, err, "clone should succeed")
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// Confirm the target commit is not yet available.
 	_, err = r.CommitObject(plumbing.NewHash(commitSHA))
@@ -605,8 +648,11 @@ func TestPlainCloneContext_EmptyRemoteReturnsError(t *testing.T) {
 	t.Parallel()
 
 	remote := filepath.Join(t.TempDir(), "remote.git")
-	_, err := PlainInit(remote, true)
+	remoteRepo, err := PlainInit(remote, true)
 	require.NoError(t, err)
+	if closer, ok := remoteRepo.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	dest := filepath.Join(t.TempDir(), "clone")
 	_, err = PlainCloneContext(context.Background(), dest, &CloneOptions{
@@ -622,8 +668,13 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 
 	// Create a bare empty repository to use as the remote.
 	remote := filepath.Join(t.TempDir(), "remote.git")
-	_, err := PlainInit(remote, true)
+	remoteRepo, err := PlainInit(remote, true)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := remoteRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	dest := filepath.Join(t.TempDir(), "clone")
 	r, err := PlainCloneContext(context.Background(), dest, &CloneOptions{
@@ -632,6 +683,11 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, r)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// The cloned repo should have the "origin" remote configured.
 	remotes, err := r.Remotes()
@@ -656,6 +712,11 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 	// its config persisted (unlike a partialInit repo).
 	reopened, err := PlainOpen(dest)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := reopened.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	reopenedRemotes, err := reopened.Remotes()
 	require.NoError(t, err)
 	require.Len(t, reopenedRemotes, 1)
@@ -678,6 +739,11 @@ func TestPlainCloneContext_DetachedHeadSource(t *testing.T) {
 	srcDir := t.TempDir()
 	src, err := PlainInit(srcDir, false)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := src.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	wt, err := src.Worktree()
 	require.NoError(t, err)
@@ -723,6 +789,11 @@ func TestPlainCloneContext_DetachedHeadSource(t *testing.T) {
 	// git clone creates a symbolic HEAD (→ refs/heads/<branch>) in the clone
 	// even when the source has a detached HEAD; the resolved commit must match.
 	require.NotNil(t, dst, "cloned repository must not be nil")
+	defer func() {
+		if closer, ok := dst.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	rawClonedHead, err := dst.Storer.Reference(plumbing.HEAD)
 	require.NoError(t, err)
@@ -778,6 +849,7 @@ func TestFailSafeUnsupportedStorage(t *testing.T) {
 		dotgit, dotgitErr := f.DotGit(fixtures.WithMemFS())
 		require.NoError(t, dotgitErr)
 		st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+		defer func() { _ = st.Close() }()
 
 		wrapped := &sha1OnlyStorage{st}
 		_, okGetter := storage.Storer(wrapped).(xstorage.ExtensionChecker)
@@ -798,6 +870,9 @@ func (s *RepositorySuite) TestCloneContext() {
 	})
 
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 	s.ErrorIs(err, context.Canceled)
 }
 
@@ -1215,6 +1290,9 @@ func (s *RepositorySuite) TestPlainInitAlreadyExists() {
 	r, err := PlainInit(dir, true)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	r, err = PlainInit(dir, true)
 	s.ErrorIs(err, ErrTargetDirNotEmpty)
@@ -1228,6 +1306,9 @@ func (s *RepositorySuite) TestPlainOpenTildePath() {
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	currentUser, err := user.Current()
 	s.NoError(err)
@@ -1241,6 +1322,9 @@ func (s *RepositorySuite) TestPlainOpenTildePath() {
 		r, err = PlainOpen(path)
 		s.NoError(err)
 		s.NotNil(r)
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
 	}
 }
 
@@ -1253,6 +1337,9 @@ func (s *RepositorySuite) testPlainOpenGitFile(f func(string, string) string) {
 	r, err := PlainInit(fs.Join(fs.Root(), dir), true)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	altDir, err := util.TempDir(fs, "", "plain-open")
 	s.NoError(err)
@@ -1267,6 +1354,9 @@ func (s *RepositorySuite) testPlainOpenGitFile(f func(string, string) string) {
 	r, err = PlainOpen(fs.Join(fs.Root(), altDir))
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 }
 
 func (s *RepositorySuite) TestPlainOpenBareAbsoluteGitDirFile() {
@@ -1306,6 +1396,9 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage() {
 	r, err := PlainInit(dir, true)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	altDir, err := util.TempDir(fs, "", "")
 	s.NoError(err)
@@ -1316,9 +1409,9 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage() {
 	)
 	s.NoError(err)
 
-	r, err = PlainOpen(altDir)
+	r2, err := PlainOpen(altDir)
 	s.ErrorIs(err, ErrRepositoryNotExists)
-	s.Nil(r)
+	s.Nil(r2)
 }
 
 func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileBadPrefix() {
@@ -1330,6 +1423,9 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileBadPrefix() {
 	r, err := PlainInit(fs.Join(fs.Root(), dir), true)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	altDir, err := util.TempDir(fs, "", "")
 	s.NoError(err)
@@ -1369,15 +1465,24 @@ func (s *RepositorySuite) TestPlainOpenDetectDotGit() {
 	r, err := PlainInit(fs.Join(fs.Root(), dir), false)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	opt := &PlainOpenOptions{DetectDotGit: true}
 	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), subdir), opt)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), file), opt)
 	s.NoError(err)
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	optnodetect := &PlainOpenOptions{DetectDotGit: false}
 	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), file), optnodetect)
@@ -1407,6 +1512,11 @@ func (s *RepositorySuite) TestPlainClone() {
 	})
 
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remotes, err := r.Remotes()
 	s.NoError(err)
@@ -1427,6 +1537,11 @@ func (s *RepositorySuite) TestPlainCloneBareAndShared() {
 		Bare:   true,
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	altpath := path.Join(dir, "objects", "info", "alternates")
 	_, err = os.Stat(altpath)
@@ -1453,6 +1568,11 @@ func (s *RepositorySuite) TestPlainCloneShared() {
 		Shared: true,
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	altpath := path.Join(dir, GitDirName, "objects", "info", "alternates")
 	_, err = os.Stat(altpath)
@@ -1511,6 +1631,11 @@ func (s *RepositorySuite) TestPlainCloneWithRemoteName() {
 	})
 
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	remote, err := r.Remote("test")
 	s.NoError(err)
@@ -1522,6 +1647,9 @@ func (s *RepositorySuite) TestPlainCloneOverExistingGitDirectory() {
 	r, err := PlainInit(dir, false)
 	s.NotNil(r)
 	s.NoError(err)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	r, err = PlainClone(dir, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -1540,6 +1668,9 @@ func (s *RepositorySuite) TestPlainCloneContextCancel() {
 	})
 
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 	s.ErrorIs(err, context.Canceled)
 }
 
@@ -1556,6 +1687,9 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithExistentDir() {
 		URL: "incorrectOnPurpose",
 	})
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 	s.ErrorIs(err, transport.ErrRepositoryNotFound)
 
 	_, err = fs.Stat(dir)
@@ -1581,6 +1715,9 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNonExistentDir() {
 		URL: "incorrectOnPurpose",
 	})
 	s.NotNil(r)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 	s.ErrorIs(err, transport.ErrRepositoryNotFound)
 
 	_, err = fs.Stat(repoDir)
@@ -1648,6 +1785,9 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistingOverExistingGitDirecto
 	r, err := PlainInit(dir, false)
 	s.NotNil(r)
 	s.NoError(err)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	r, err = PlainCloneContext(ctx, dir, &CloneOptions{
 		URL: "incorrectOnPurpose",
@@ -1666,6 +1806,11 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules() {
 		RecurseSubmodules: DefaultSubmoduleRecursionDepth,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	cfg, err := r.Config()
 	s.NoError(err)
@@ -1695,6 +1840,11 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules() {
 		ShallowSubmodules: true,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := mainRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	mainWorktree, err := mainRepo.Worktree()
 	s.Require().NoError(err)
@@ -1704,7 +1854,11 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules() {
 
 	subRepo, err := submodule.Repository()
 	s.Require().NoError(err)
-	defer subRepo.Close()
+	defer func() {
+		if closer, ok := subRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	lr, err := subRepo.Log(&LogOptions{})
 	s.Require().NoError(err)
@@ -1726,6 +1880,11 @@ func (s *RepositorySuite) TestPlainCloneNoCheckout() {
 		RecurseSubmodules: DefaultSubmoduleRecursionDepth,
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	h, err := r.Head()
 	s.NoError(err)
@@ -2165,6 +2324,11 @@ func (s *RepositorySuite) TestPush() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
 		Name: "test",
@@ -2190,8 +2354,11 @@ func (s *RepositorySuite) TestPush() {
 
 func (s *RepositorySuite) TestPushContext() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.NoError(err)
+	if closer, ok := server.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
 		Name: "foo",
@@ -2233,6 +2400,11 @@ func (s *RepositorySuite) TestPushWithProgress() {
 
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	m := "Receiving..."
 	installPreReceiveHook(s, fs, path, m)
@@ -2263,6 +2435,11 @@ func (s *RepositorySuite) TestPushDepth() {
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
 		URL:   server.wt.Root(),
@@ -2301,6 +2478,7 @@ func (s *RepositorySuite) TestPushNonExistentRemote() {
 	srcFs, err := fixtures.Basic().One().DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r, err := Open(sto, srcFs)
 	s.NoError(err)
@@ -3273,6 +3451,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotated() {
 	fs := s.TemporalFilesystem()
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = fss.Close() }()
 
 	r, _ := Init(fss)
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
@@ -3302,6 +3481,9 @@ func (s *RepositorySuite) TestDeleteTagAnnotated() {
 	err = r.RepackObjects(&RepackConfig{})
 	s.NoError(err)
 
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 	r, err = PlainOpen(fs.Root())
 	s.NotNil(r)
 	s.NoError(err)
@@ -3320,6 +3502,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotatedUnpacked() {
 	fs := s.TemporalFilesystem()
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = fss.Close() }()
 
 	r, _ := Init(fss)
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
@@ -3383,6 +3566,7 @@ func (s *RepositorySuite) TestBranches() {
 	dotgit1, err := f.DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(dotgit1, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 	dotgit2, err := f.DotGit()
 	s.Require().NoError(err)
 	r, err := Open(sto, dotgit2)
@@ -3608,6 +3792,9 @@ func (s *RepositorySuite) TestResolveRevision() {
 	s.Require().NoError(err)
 	r, err := Open(sto, dotgit2)
 	s.NoError(err)
+	if closer, ok := r.Storer.(io.Closer); ok {
+		_ = closer.Close()
+	}
 
 	datas := map[string]string{
 		"HEAD":                       "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",

--- a/repository_test.go
+++ b/repository_test.go
@@ -150,6 +150,9 @@ func TestPlainInitAndPlainOpen(t *testing.T) {
 				r, err := PlainInit(rdir, tc.wantBare, opts...)
 				require.NotNil(t, r)
 				require.NoError(t, err)
+				defer func() {
+					_ = CloseStorage(r)
+				}()
 
 				cfg, err := r.Config()
 				require.NoError(t, err)
@@ -172,6 +175,9 @@ func TestPlainInitAndPlainOpen(t *testing.T) {
 				ro, err := PlainOpen(rdir)
 				require.NotNil(t, ro)
 				require.NoError(t, err)
+				defer func() {
+					_ = CloseStorage(ro)
+				}()
 
 				if !tc.wantBare {
 					ref, err := ro.Head()
@@ -204,6 +210,7 @@ func (s *RepositorySuite) TestInitNonStandardDotGit() {
 	fs := osfs.New(dir)
 	dot, _ := fs.Chroot("storage")
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
 
 	wt, _ := fs.Chroot("worktree")
 	r, err := Init(st, WithWorkTree(wt))
@@ -228,6 +235,7 @@ func (s *RepositorySuite) TestInitStandardDotGit() {
 	fs := osfs.New(dir)
 	dot, _ := fs.Chroot(".git")
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
 
 	r, err := Init(st, WithWorkTree(fs))
 	s.NoError(err)
@@ -347,6 +355,9 @@ func TestCloneAll(t *testing.T) {
 				}
 				require.NoError(t, err)
 				require.NotNil(t, r, "repository must not be nil")
+				defer func() {
+					_ = CloseStorage(r)
+				}()
 
 				remotes, err := r.Remotes()
 				require.NoError(t, err)
@@ -506,6 +517,9 @@ func TestFetchByHashThenResolveRevision(t *testing.T) {
 		Tags:  NoTags,
 	})
 	require.NoError(t, err, "clone should succeed")
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	// Confirm the target commit is not yet available.
 	_, err = r.CommitObject(plumbing.NewHash(commitSHA))
@@ -611,8 +625,11 @@ func TestPlainCloneContext_EmptyRemoteReturnsError(t *testing.T) {
 	t.Parallel()
 
 	remote := filepath.Join(t.TempDir(), "remote.git")
-	_, err := PlainInit(remote, true)
+	remoteRepo, err := PlainInit(remote, true)
 	require.NoError(t, err)
+	defer func() {
+		_ = CloseStorage(remoteRepo)
+	}()
 
 	dest := filepath.Join(t.TempDir(), "clone")
 	_, err = PlainCloneContext(context.Background(), dest, &CloneOptions{
@@ -628,8 +645,11 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 
 	// Create a bare empty repository to use as the remote.
 	remote := filepath.Join(t.TempDir(), "remote.git")
-	_, err := PlainInit(remote, true)
+	remoteRepo, err := PlainInit(remote, true)
 	require.NoError(t, err)
+	defer func() {
+		_ = CloseStorage(remoteRepo)
+	}()
 
 	dest := filepath.Join(t.TempDir(), "clone")
 	r, err := PlainCloneContext(context.Background(), dest, &CloneOptions{
@@ -638,6 +658,9 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotNil(t, r)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	// The cloned repo should have the "origin" remote configured.
 	remotes, err := r.Remotes()
@@ -662,6 +685,9 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 	// its config persisted (unlike a partialInit repo).
 	reopened, err := PlainOpen(dest)
 	require.NoError(t, err)
+	defer func() {
+		_ = CloseStorage(reopened)
+	}()
 	reopenedRemotes, err := reopened.Remotes()
 	require.NoError(t, err)
 	require.Len(t, reopenedRemotes, 1)
@@ -684,6 +710,9 @@ func TestPlainCloneContext_DetachedHeadSource(t *testing.T) {
 	srcDir := t.TempDir()
 	src, err := PlainInit(srcDir, false)
 	require.NoError(t, err)
+	defer func() {
+		_ = CloseStorage(src)
+	}()
 
 	wt, err := src.Worktree()
 	require.NoError(t, err)
@@ -729,6 +758,9 @@ func TestPlainCloneContext_DetachedHeadSource(t *testing.T) {
 	// git clone creates a symbolic HEAD (→ refs/heads/<branch>) in the clone
 	// even when the source has a detached HEAD; the resolved commit must match.
 	require.NotNil(t, dst, "cloned repository must not be nil")
+	defer func() {
+		_ = CloseStorage(dst)
+	}()
 
 	rawClonedHead, err := dst.Storer.Reference(plumbing.HEAD)
 	require.NoError(t, err)
@@ -784,6 +816,7 @@ func TestFailSafeUnsupportedStorage(t *testing.T) {
 		dotgit, dotgitErr := f.DotGit(fixtures.WithMemFS())
 		require.NoError(t, dotgitErr)
 		st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+		defer func() { _ = st.Close() }()
 
 		wrapped := &sha1OnlyStorage{st}
 		_, okGetter := storage.Storer(wrapped).(xstorage.ExtensionChecker)
@@ -1221,6 +1254,7 @@ func (s *RepositorySuite) TestPlainInitAlreadyExists() {
 	r, err := PlainInit(dir, true)
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 
 	r, err = PlainInit(dir, true)
 	s.ErrorIs(err, ErrTargetDirNotEmpty)
@@ -1234,6 +1268,7 @@ func (s *RepositorySuite) TestPlainOpenTildePath() {
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 
 	currentUser, err := user.Current()
 	s.NoError(err)
@@ -1247,6 +1282,7 @@ func (s *RepositorySuite) TestPlainOpenTildePath() {
 		r, err = PlainOpen(path)
 		s.NoError(err)
 		s.NotNil(r)
+		_ = CloseStorage(r)
 	}
 }
 
@@ -1259,6 +1295,7 @@ func (s *RepositorySuite) testPlainOpenGitFile(f func(string, string) string) {
 	r, err := PlainInit(fs.Join(fs.Root(), dir), true)
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 
 	altDir, err := util.TempDir(fs, "", "plain-open")
 	s.NoError(err)
@@ -1273,6 +1310,7 @@ func (s *RepositorySuite) testPlainOpenGitFile(f func(string, string) string) {
 	r, err = PlainOpen(fs.Join(fs.Root(), altDir))
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 }
 
 func (s *RepositorySuite) TestPlainOpenBareAbsoluteGitDirFile() {
@@ -1312,6 +1350,7 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage() {
 	r, err := PlainInit(dir, true)
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 
 	altDir, err := util.TempDir(fs, "", "")
 	s.NoError(err)
@@ -1322,9 +1361,9 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage() {
 	)
 	s.NoError(err)
 
-	r, err = PlainOpen(altDir)
+	r2, err := PlainOpen(altDir)
 	s.ErrorIs(err, ErrRepositoryNotExists)
-	s.Nil(r)
+	s.Nil(r2)
 }
 
 func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileBadPrefix() {
@@ -1336,6 +1375,7 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileBadPrefix() {
 	r, err := PlainInit(fs.Join(fs.Root(), dir), true)
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 
 	altDir, err := util.TempDir(fs, "", "")
 	s.NoError(err)
@@ -1375,15 +1415,18 @@ func (s *RepositorySuite) TestPlainOpenDetectDotGit() {
 	r, err := PlainInit(fs.Join(fs.Root(), dir), false)
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 
 	opt := &PlainOpenOptions{DetectDotGit: true}
 	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), subdir), opt)
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 
 	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), file), opt)
 	s.NoError(err)
 	s.NotNil(r)
+	_ = CloseStorage(r)
 
 	optnodetect := &PlainOpenOptions{DetectDotGit: false}
 	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), file), optnodetect)
@@ -1413,6 +1456,9 @@ func (s *RepositorySuite) TestPlainClone() {
 	})
 
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remotes, err := r.Remotes()
 	s.NoError(err)
@@ -1433,6 +1479,9 @@ func (s *RepositorySuite) TestPlainCloneBareAndShared() {
 		Bare:   true,
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	altpath := path.Join(dir, "objects", "info", "alternates")
 	_, err = os.Stat(altpath)
@@ -1459,6 +1508,9 @@ func (s *RepositorySuite) TestPlainCloneShared() {
 		Shared: true,
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	altpath := path.Join(dir, GitDirName, "objects", "info", "alternates")
 	_, err = os.Stat(altpath)
@@ -1517,6 +1569,9 @@ func (s *RepositorySuite) TestPlainCloneWithRemoteName() {
 	})
 
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	remote, err := r.Remote("test")
 	s.NoError(err)
@@ -1528,6 +1583,7 @@ func (s *RepositorySuite) TestPlainCloneOverExistingGitDirectory() {
 	r, err := PlainInit(dir, false)
 	s.NotNil(r)
 	s.NoError(err)
+	_ = CloseStorage(r)
 
 	r, err = PlainClone(dir, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -1654,6 +1710,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistingOverExistingGitDirecto
 	r, err := PlainInit(dir, false)
 	s.NotNil(r)
 	s.NoError(err)
+	_ = CloseStorage(r)
 
 	r, err = PlainCloneContext(ctx, dir, &CloneOptions{
 		URL: "incorrectOnPurpose",
@@ -1675,6 +1732,9 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules() {
 			RecurseSubmodules: DefaultSubmoduleRecursionDepth,
 		})
 		require.NoError(t, err)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
@@ -1704,6 +1764,9 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules() {
 			ShallowSubmodules: true,
 		})
 		require.NoError(t, err)
+		defer func() {
+			_ = CloseStorage(mainRepo)
+		}()
 
 		mainWorktree, err := mainRepo.Worktree()
 		require.NoError(t, err)
@@ -1713,7 +1776,6 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules() {
 
 		subRepo, err := submodule.Repository()
 		require.NoError(t, err)
-		defer subRepo.Close()
 
 		lr, err := subRepo.Log(&LogOptions{})
 		require.NoError(t, err)
@@ -1739,6 +1801,9 @@ func (s *RepositorySuite) TestPlainCloneNoCheckout() {
 			RecurseSubmodules: DefaultSubmoduleRecursionDepth,
 		})
 		require.NoError(t, err)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		h, err := r.Head()
 		require.NoError(t, err)
@@ -2183,6 +2248,9 @@ func (s *RepositorySuite) TestPush() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
 		Name: "test",
@@ -2208,8 +2276,11 @@ func (s *RepositorySuite) TestPush() {
 
 func (s *RepositorySuite) TestPushContext() {
 	url := s.T().TempDir()
-	_, err := PlainInit(url, true)
+	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
 		Name: "foo",
@@ -2251,6 +2322,9 @@ func (s *RepositorySuite) TestPushWithProgress() {
 
 	server, err := PlainInit(url, true)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	m := "Receiving..."
 	installPreReceiveHook(s, fs, path, m)
@@ -2281,6 +2355,9 @@ func (s *RepositorySuite) TestPushDepth() {
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
 		URL:   server.wt.Root(),
@@ -2319,6 +2396,7 @@ func (s *RepositorySuite) TestPushNonExistentRemote() {
 	srcFs, err := fixtures.Basic().One().DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	r, err := Open(sto, srcFs)
 	s.NoError(err)
@@ -3291,6 +3369,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotated() {
 	fs := s.TemporalFilesystem()
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = fss.Close() }()
 
 	r, _ := Init(fss)
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
@@ -3323,6 +3402,9 @@ func (s *RepositorySuite) TestDeleteTagAnnotated() {
 	r, err = PlainOpen(fs.Root())
 	s.NotNil(r)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	// Now check to see if the GC was effective in removing the tag object.
 	obj, err = r.TagObject(ref.Hash())
@@ -3338,6 +3420,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotatedUnpacked() {
 	fs := s.TemporalFilesystem()
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = fss.Close() }()
 
 	r, _ := Init(fss)
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
@@ -3401,6 +3484,7 @@ func (s *RepositorySuite) TestBranches() {
 	dotgit1, err := f.DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(dotgit1, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 	dotgit2, err := f.DotGit()
 	s.Require().NoError(err)
 	r, err := Open(sto, dotgit2)
@@ -3622,6 +3706,7 @@ func (s *RepositorySuite) TestResolveRevision() {
 	dotgit1, err := f.DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(dotgit1, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 	dotgit2, err := f.DotGit()
 	s.Require().NoError(err)
 	r, err := Open(sto, dotgit2)
@@ -3664,6 +3749,7 @@ func (s *RepositorySuite) TestResolveRevisionAnnotated() {
 	dotgit1, err := f.DotGit()
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(dotgit1, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 	dotgit2, err := f.DotGit()
 	s.Require().NoError(err)
 	r, err := Open(sto, dotgit2)

--- a/repository_unix_test.go
+++ b/repository_unix_test.go
@@ -4,6 +4,7 @@ package git
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,11 @@ func TestPlainInitFileMode(t *testing.T) {
 	dir := t.TempDir()
 	r, err := PlainInit(dir, false)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	cfg, err := r.Config()
 	require.NoError(t, err)

--- a/repository_unix_test.go
+++ b/repository_unix_test.go
@@ -21,6 +21,9 @@ func TestPlainInitFileMode(t *testing.T) {
 	dir := t.TempDir()
 	r, err := PlainInit(dir, false)
 	require.NoError(t, err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	cfg, err := r.Config()
 	require.NoError(t, err)

--- a/repository_windows_test.go
+++ b/repository_windows_test.go
@@ -4,6 +4,7 @@ package git
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -28,6 +29,11 @@ func TestCloneFileUrlWindows(t *testing.T) {
 
 	r, err := PlainInit(dir, false)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	err = util.WriteFile(r.wt, "foo", nil, 0o755)
 	require.NoError(t, err)
@@ -60,7 +66,7 @@ func TestCloneFileUrlWindows(t *testing.T) {
 
 	for _, tc := range tests {
 		assert.Regexp(t, regexp.MustCompile(tc.pattern), tc.url)
-		_, err = Clone(memory.NewStorage(), nil, &CloneOptions{
+		_, err := Clone(memory.NewStorage(), nil, &CloneOptions{
 			URL: tc.url,
 		})
 

--- a/repository_windows_test.go
+++ b/repository_windows_test.go
@@ -28,6 +28,9 @@ func TestCloneFileUrlWindows(t *testing.T) {
 
 	r, err := PlainInit(dir, false)
 	require.NoError(t, err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	err = util.WriteFile(r.wt, "foo", nil, 0o755)
 	require.NoError(t, err)
@@ -60,7 +63,7 @@ func TestCloneFileUrlWindows(t *testing.T) {
 
 	for _, tc := range tests {
 		assert.Regexp(t, regexp.MustCompile(tc.pattern), tc.url)
-		_, err = Clone(memory.NewStorage(), nil, &CloneOptions{
+		_, err := Clone(memory.NewStorage(), nil, &CloneOptions{
 			URL: tc.url,
 		})
 

--- a/storage/filesystem/index_test.go
+++ b/storage/filesystem/index_test.go
@@ -19,6 +19,7 @@ import (
 func TestIndexCacheHit(t *testing.T) {
 	t.Parallel()
 	sto, spy := newIndexStorageWithSpy(t)
+	defer func() { _ = sto.Close() }()
 
 	orig := &index.Index{
 		Version: 2,
@@ -49,6 +50,7 @@ func TestIndexCacheHit(t *testing.T) {
 func TestIndexCacheReturnsCopy(t *testing.T) {
 	t.Parallel()
 	sto, spy := newIndexStorageWithSpy(t)
+	defer func() { _ = sto.Close() }()
 
 	require.NoError(t, sto.SetIndex(&index.Index{
 		Version: 2,
@@ -72,6 +74,7 @@ func TestIndexCacheReturnsCopy(t *testing.T) {
 func TestIndexCacheIsolatesEntrySliceMutation(t *testing.T) {
 	t.Parallel()
 	sto, spy := newIndexStorageWithSpy(t)
+	defer func() { _ = sto.Close() }()
 
 	require.NoError(t, sto.SetIndex(&index.Index{
 		Version: 2,
@@ -100,6 +103,7 @@ func TestIndexCacheIsolatesEntrySliceMutation(t *testing.T) {
 func TestIndexCacheIsolatesSetIndexCallerMutation(t *testing.T) {
 	t.Parallel()
 	sto, spy := newIndexStorageWithSpy(t)
+	defer func() { _ = sto.Close() }()
 
 	idx := &index.Index{
 		Version: 2,
@@ -129,6 +133,7 @@ func TestIndexCacheIsolatesSetIndexCallerMutation(t *testing.T) {
 func TestIndexCacheInvalidatedByExternalChange(t *testing.T) {
 	t.Parallel()
 	sto, spy := newIndexStorageWithSpy(t)
+	defer func() { _ = sto.Close() }()
 
 	require.NoError(t, sto.SetIndex(&index.Index{
 		Version: 2,
@@ -155,6 +160,7 @@ func TestIndexCacheInvalidatedByExternalChange(t *testing.T) {
 func TestIndexCacheWriteThrough(t *testing.T) {
 	t.Parallel()
 	sto, spy := newIndexStorageWithSpy(t)
+	defer func() { _ = sto.Close() }()
 
 	require.NoError(t, sto.SetIndex(&index.Index{
 		Version: 2,
@@ -175,6 +181,7 @@ func TestIndexCacheWriteThrough(t *testing.T) {
 func TestIndexCacheMissingFile(t *testing.T) {
 	t.Parallel()
 	sto, spy := newIndexStorageWithSpy(t)
+	defer func() { _ = sto.Close() }()
 
 	idx, err := sto.Index()
 	require.NoError(t, err)
@@ -192,6 +199,7 @@ func TestIndexCacheClearedWhenFileDeleted(t *testing.T) {
 	fs := osfs.New(tmp)
 	spy := newSpyIndexCache()
 	sto := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{IndexCache: spy})
+	defer func() { _ = sto.Close() }()
 	require.NoError(t, sto.Init())
 
 	require.NoError(t, sto.SetIndex(&index.Index{

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -50,6 +50,9 @@ type ObjectStorage struct {
 	alternatesInit bool
 	alternatesErr  error
 	muA            sync.RWMutex
+
+	// closed tracks whether Close() has been called (used by leak detection)
+	closed bool
 }
 
 // NewObjectStorage creates a new ObjectStorage with the given .git directory and cache.
@@ -831,6 +834,9 @@ func (s *ObjectStorage) buildPackfileIters(
 
 // Close closes all opened files including cached alternate storages.
 func (s *ObjectStorage) Close() error {
+	// Mark as closed for leak detection (used by finalizer when compiled with -tags leakcheck)
+	s.closed = true
+
 	var firstError error
 
 	s.muA.RLock()

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -144,9 +144,6 @@ func (s *FsSuite) TestGetFromPackfileKeepDescriptors() {
 		offset, err := pack2.Seek(0, io.SeekCurrent)
 		s.Require().NoError(err)
 		s.Equal(int64(0), offset)
-
-		err = o.Close()
-		s.Require().NoError(err)
 	}
 }
 
@@ -307,19 +304,22 @@ func (s *FsSuite) TestIterLargeObjectThreshold() {
 func (s *FsSuite) TestIterWithType() {
 	for _, f := range fixtures.ByTag(".git") {
 		for _, t := range objectTypes {
-			fs, err := f.DotGit()
-			s.Require().NoError(err)
-			o := NewStorage(fs, cache.NewObjectLRUDefault())
+			func() {
+				fs, err := f.DotGit()
+				s.Require().NoError(err)
+				o := NewStorage(fs, cache.NewObjectLRUDefault())
+				defer func() { _ = o.Close() }()
 
-			iter, err := o.IterEncodedObjects(t)
-			s.Require().NoError(err)
+				iter, err := o.IterEncodedObjects(t)
+				s.Require().NoError(err)
 
-			err = iter.ForEach(func(o plumbing.EncodedObject) error {
-				s.Equal(t, o.Type())
-				return nil
-			})
+				err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+					s.Equal(t, obj.Type())
+					return nil
+				})
 
-			s.Require().NoError(err)
+				s.Require().NoError(err)
+			}()
 		}
 	}
 }

--- a/storage/filesystem/reflog_test.go
+++ b/storage/filesystem/reflog_test.go
@@ -17,6 +17,7 @@ import (
 func TestReflogReadNonExistent(t *testing.T) {
 	t.Parallel()
 	sto := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	entries, err := sto.Reflog(plumbing.ReferenceName("refs/heads/no-such-ref"))
 	require.NoError(t, err)
@@ -26,6 +27,7 @@ func TestReflogReadNonExistent(t *testing.T) {
 func TestReflogAppendAndRead(t *testing.T) {
 	t.Parallel()
 	sto := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 	ref := plumbing.ReferenceName("refs/heads/main")
 
 	e1 := &reflog.Entry{
@@ -65,6 +67,7 @@ func TestReflogAppendAndRead(t *testing.T) {
 func TestReflogDelete(t *testing.T) {
 	t.Parallel()
 	sto := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 	ref := plumbing.ReferenceName("refs/heads/main")
 
 	require.NoError(t, sto.AppendReflog(ref, &reflog.Entry{
@@ -88,6 +91,7 @@ func TestReflogDelete(t *testing.T) {
 func TestReflogDeleteNonExistent(t *testing.T) {
 	t.Parallel()
 	sto := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
 
 	err := sto.DeleteReflog(plumbing.ReferenceName("refs/heads/no-such-ref"))
 	assert.NoError(t, err)

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -132,6 +132,8 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 		ReflogStorage:    ReflogStorage{dir: dir},
 	}
 
+	setupLeakCheck(s)
+
 	return s
 }
 

--- a/storage/filesystem/storage_leakcheck.go
+++ b/storage/filesystem/storage_leakcheck.go
@@ -1,0 +1,49 @@
+//go:build leakcheck
+
+package filesystem
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// setupLeakCheck sets up leak detection for a storage
+func setupLeakCheck(s *Storage) {
+	// Capture stack trace at storage creation time
+	buf := make([]byte, 4096)
+	n := runtime.Stack(buf, false)
+	stack := string(buf[:n])
+
+	runtime.SetFinalizer(s, func(storage *Storage) {
+		if !storage.closed {
+			// Extract just the relevant part of the stack (skip runtime internals)
+			// Stack trace format: goroutine header\nfunction\n\tfile:line\nfunction\n\tfile:line...
+			lines := strings.Split(stack, "\n")
+			relevantStack := []string{}
+			// Skip line 0 (goroutine header), then process pairs starting from line 1
+			for i := 1; i < len(lines)-1; i += 2 {
+				funcLine := lines[i]
+				fileLine := ""
+				if i+1 < len(lines) {
+					fileLine = lines[i+1]
+				}
+				// Check if this stack frame is relevant (contains go-git or testing)
+				if strings.Contains(funcLine, "go-git") || strings.Contains(fileLine, "go-git") ||
+					strings.Contains(funcLine, "testing.") {
+					relevantStack = append(relevantStack, funcLine)
+					if fileLine != "" {
+						relevantStack = append(relevantStack, fileLine)
+					}
+				}
+			}
+
+			panic(fmt.Sprintf("\n\n=== STORAGE LEAK DETECTED ===\n"+
+				"Storage was garbage collected without Close() being called!\n"+
+				"This will cause file handle leaks on Windows.\n"+
+				"Always call defer func() { _ = storage.Close() }() after creating a storage.\n\n"+
+				"Storage was created at:\n%s\n"+
+				"=====================\n\n", strings.Join(relevantStack, "\n")))
+		}
+	})
+}

--- a/storage/filesystem/storage_leakcheck.go
+++ b/storage/filesystem/storage_leakcheck.go
@@ -1,0 +1,32 @@
+//go:build leakcheck
+
+package filesystem
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// setupLeakCheck sets up leak detection for a storage
+func setupLeakCheck(s *Storage) {
+	// Capture stack trace at storage creation time
+	buf := make([]byte, 4096)
+	n := runtime.Stack(buf, false)
+	stack := string(buf[:n])
+
+	runtime.SetFinalizer(s, func(storage *Storage) {
+		if !storage.closed {
+			panic(fmt.Sprintf(`
+=== STORAGE LEAK DETECTED ===
+Storage was garbage collected without Close() being called!
+This will cause file handle leaks on Windows.
+Always call defer func() { _ = storage.Close() }() after creating a storage.
+
+Storage was created at:
+
+%s
+=====================
+`, stack))
+		}
+	})
+}

--- a/storage/filesystem/storage_noleakcheck.go
+++ b/storage/filesystem/storage_noleakcheck.go
@@ -1,0 +1,8 @@
+//go:build !leakcheck
+
+package filesystem
+
+// setupLeakCheck is a no-op when leak checking is disabled
+func setupLeakCheck(_ *Storage) {
+	// No-op
+}

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -51,6 +51,7 @@ func TestNewStorageShouldNotAddAnyContentsToDir(t *testing.T) {
 		fs,
 		cache.NewObjectLRUDefault(),
 		filesystem.Options{ExclusiveAccess: true})
+	defer func() { _ = sto.Close() }()
 	assert.NotNil(t, sto)
 
 	fis, err := fs.ReadDir("/")
@@ -130,6 +131,7 @@ func TestSetObjectFormat(t *testing.T) {
 				cache.NewObjectLRUDefault(),
 				filesystem.Options{ObjectFormat: tt.initialFormat},
 			)
+			defer func() { _ = sto.Close() }()
 			require.NoError(t, sto.Init())
 
 			err := sto.SetObjectFormat(tt.targetFormat)
@@ -232,6 +234,7 @@ func TestNewStorageWithOptions(t *testing.T) {
 				cache.NewObjectLRUDefault(),
 				filesystem.Options{ObjectFormat: tt.inObjectFormat},
 			)
+			defer func() { _ = sto.Close() }()
 
 			cfg, err := sto.Config()
 			require.NoError(t, err)
@@ -278,6 +281,7 @@ func TestSetObjectFormatWithExistingPackfiles(t *testing.T) {
 			fs, err := fixtures.ByTag(tt.tag).One().DotGit()
 			require.NoError(t, err)
 			sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+			defer func() { _ = sto.Close() }()
 
 			packs, err := sto.ObjectPacks()
 			require.NoError(t, err)
@@ -337,6 +341,7 @@ func TestSupportsExtension(t *testing.T) {
 			t.Parallel()
 
 			sto := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+			defer func() { _ = sto.Close() }()
 			got := sto.SupportsExtension(tt.ext, tt.value)
 			assert.Equal(t, tt.want, got)
 		})
@@ -354,5 +359,6 @@ func getExplicitSHA1(t testing.TB) billy.Filesystem {
 	err = st.SetConfig(cfg)
 	require.NoError(t, err)
 
+	_ = st.Close()
 	return fs
 }

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -51,6 +51,7 @@ func TestNewStorageShouldNotAddAnyContentsToDir(t *testing.T) {
 		fs,
 		cache.NewObjectLRUDefault(),
 		filesystem.Options{ExclusiveAccess: true})
+	defer func() { _ = sto.Close() }()
 	assert.NotNil(t, sto)
 
 	fis, err := fs.ReadDir("/")
@@ -130,6 +131,7 @@ func TestSetObjectFormat(t *testing.T) {
 				cache.NewObjectLRUDefault(),
 				filesystem.Options{ObjectFormat: tt.initialFormat},
 			)
+			defer func() { _ = sto.Close() }()
 			require.NoError(t, sto.Init())
 
 			err := sto.SetObjectFormat(tt.targetFormat)
@@ -232,6 +234,7 @@ func TestNewStorageWithOptions(t *testing.T) {
 				cache.NewObjectLRUDefault(),
 				filesystem.Options{ObjectFormat: tt.inObjectFormat},
 			)
+			defer func() { _ = sto.Close() }()
 
 			cfg, err := sto.Config()
 			require.NoError(t, err)
@@ -283,6 +286,7 @@ func TestSetObjectFormatWithExistingPackfiles(t *testing.T) {
 			fs, err := fixtures.ByTag(tt.tag).ByObjectFormat(tt.fixOF).One().DotGit()
 			require.NoError(t, err)
 			sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+			defer func() { _ = sto.Close() }()
 
 			packs, err := sto.ObjectPacks()
 			require.NoError(t, err)
@@ -342,6 +346,7 @@ func TestSupportsExtension(t *testing.T) {
 			t.Parallel()
 
 			sto := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+			defer func() { _ = sto.Close() }()
 			got := sto.SupportsExtension(tt.ext, tt.value)
 			assert.Equal(t, tt.want, got)
 		})
@@ -359,5 +364,6 @@ func getExplicitSHA1(t testing.TB) billy.Filesystem {
 	err = st.SetConfig(cfg)
 	require.NoError(t, err)
 
+	_ = st.Close()
 	return fs
 }

--- a/storage/tests/storage_test.go
+++ b/storage/tests/storage_test.go
@@ -82,6 +82,11 @@ func forEachStorage(t *testing.T, tc func(sto Storer, t *testing.T)) {
 		sto, name := factory(t)
 
 		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if closer, ok := sto.(io.Closer); ok {
+					_ = closer.Close()
+				}
+			}()
 			tc(sto, t)
 		})
 	}
@@ -598,10 +603,20 @@ func TestModule(t *testing.T) {
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		storer, err := sto.Module("foo")
 		require.NoError(t, err)
+		defer func() {
+			if closer, ok := storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 		assert.NotNil(t, storer)
 
-		storer, err = sto.Module("foo")
+		storer2, err := sto.Module("foo")
 		require.NoError(t, err)
-		assert.NotNil(t, storer)
+		defer func() {
+			if closer, ok := storer2.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
+		assert.NotNil(t, storer2)
 	})
 }

--- a/storage/transactional/storage.go
+++ b/storage/transactional/storage.go
@@ -30,6 +30,7 @@ type basic struct {
 	*ShallowStorage
 	*ConfigStorage
 	reflog *ReflogStorage
+	closed bool
 }
 
 // packageWriter implements storer.PackfileWriter interface over
@@ -68,6 +69,8 @@ func NewStorage(base, temporal storage.Storer) Storage {
 			st.reflog = NewReflogStorage(baseReflog, tempReflog)
 		}
 	}
+
+	setupLeakCheck(st)
 
 	pw, ok := temporal.(storer.PackfileWriter)
 	if ok {
@@ -127,6 +130,23 @@ func (s *basic) Commit() error {
 	}
 
 	return nil
+}
+
+// Close closes both the base and temporal storages if they implement io.Closer.
+func (s *basic) Close() error {
+	// Mark as closed for leak detection (used by finalizer when compiled with -tags leakcheck)
+	s.closed = true
+
+	var err error
+	if closer, ok := s.temporal.(io.Closer); ok {
+		err = closer.Close()
+	}
+	if closer, ok := s.s.(io.Closer); ok {
+		if closeErr := closer.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}
+	return err
 }
 
 // PackfileWriter honors storage.PackfileWriter.

--- a/storage/transactional/storage_leakcheck.go
+++ b/storage/transactional/storage_leakcheck.go
@@ -1,0 +1,49 @@
+//go:build leakcheck
+
+package transactional
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// setupLeakCheck sets up leak detection for a transactional storage
+func setupLeakCheck(s *basic) {
+	// Capture stack trace at storage creation time
+	buf := make([]byte, 4096)
+	n := runtime.Stack(buf, false)
+	stack := string(buf[:n])
+
+	runtime.SetFinalizer(s, func(storage *basic) {
+		if !storage.closed {
+			// Extract just the relevant part of the stack (skip runtime internals)
+			// Stack trace format: goroutine header\nfunction\n\tfile:line\nfunction\n\tfile:line...
+			lines := strings.Split(stack, "\n")
+			relevantStack := []string{}
+			// Skip line 0 (goroutine header), then process pairs starting from line 1
+			for i := 1; i < len(lines)-1; i += 2 {
+				funcLine := lines[i]
+				fileLine := ""
+				if i+1 < len(lines) {
+					fileLine = lines[i+1]
+				}
+				// Check if this stack frame is relevant (contains go-git or testing)
+				if strings.Contains(funcLine, "go-git") || strings.Contains(fileLine, "go-git") ||
+					strings.Contains(funcLine, "testing.") {
+					relevantStack = append(relevantStack, funcLine)
+					if fileLine != "" {
+						relevantStack = append(relevantStack, fileLine)
+					}
+				}
+			}
+
+			panic(fmt.Sprintf("\n\n=== TRANSACTIONAL STORAGE LEAK DETECTED ===\n"+
+				"Transactional storage was garbage collected without Close() being called!\n"+
+				"This will cause file handle leaks on Windows if wrapping filesystem storage.\n"+
+				"Always call defer func() { _ = storage.Close() }() after creating a transactional storage.\n\n"+
+				"Storage was created at:\n%s\n"+
+				"=====================\n\n", strings.Join(relevantStack, "\n")))
+		}
+	})
+}

--- a/storage/transactional/storage_leakcheck.go
+++ b/storage/transactional/storage_leakcheck.go
@@ -1,0 +1,33 @@
+//go:build leakcheck
+
+package transactional
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// setupLeakCheck sets up leak detection for a transactional storage
+func setupLeakCheck(s *basic) {
+	// Capture stack trace at storage creation time
+	buf := make([]byte, 4096)
+	n := runtime.Stack(buf, false)
+	stack := string(buf[:n])
+
+	runtime.SetFinalizer(s, func(storage *basic) {
+		if !storage.closed {
+			panic(fmt.Sprintf(`
+
+=== TRANSACTIONAL STORAGE LEAK DETECTED ===
+Transactional storage was garbage collected without Close() being called!
+This will cause file handle leaks on Windows if wrapping filesystem storage.
+Always call defer func() { _ = storage.Close() }() after creating a transactional storage.
+
+Storage was created at:
+%s
+=====================
+
+`, stack))
+		}
+	})
+}

--- a/storage/transactional/storage_noleakcheck.go
+++ b/storage/transactional/storage_noleakcheck.go
@@ -1,0 +1,6 @@
+//go:build !leakcheck
+
+package transactional
+
+// setupLeakCheck is a no-op when leak checking is disabled
+func setupLeakCheck(*basic) {}

--- a/storage/transactional/storage_test.go
+++ b/storage/transactional/storage_test.go
@@ -1,6 +1,7 @@
 package transactional
 
 import (
+	"io"
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
@@ -20,6 +21,11 @@ func TestCommit(t *testing.T) {
 	base := memory.NewStorage()
 	temporal := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
 	st := NewStorage(base, temporal)
+	defer func() {
+		if closer, ok := st.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	commit := base.NewEncodedObject()
 	commit.SetType(plumbing.CommitObject)
@@ -45,11 +51,13 @@ func TestCommit(t *testing.T) {
 func TestTransactionalPackfileWriter(t *testing.T) {
 	t.Parallel()
 	base := memory.NewStorage()
-	var temporal storage.Storer
-
-	store := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
-	temporal = store
+	temporal := storage.Storer(filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault()))
 	st := NewStorage(base, temporal)
+	defer func() {
+		if closer, ok := st.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	_, tmpOK := temporal.(storer.PackfileWriter)
 	_, ok := st.(storer.PackfileWriter)

--- a/submodule.go
+++ b/submodule.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path"
 
 	"github.com/go-git/go-billy/v6"
@@ -87,6 +88,11 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	head, err := r.Head()
 	if err == nil {
@@ -211,6 +217,11 @@ func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, force
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	if err := s.fetchAndCheckout(ctx, r, o, hash); err != nil {
 		return err

--- a/submodule.go
+++ b/submodule.go
@@ -87,6 +87,9 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	head, err := r.Head()
 	if err == nil {
@@ -211,6 +214,9 @@ func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, force
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	if err := s.fetchAndCheckout(ctx, r, o, hash); err != nil {
 		return err

--- a/submodule_config_test.go
+++ b/submodule_config_test.go
@@ -19,6 +19,9 @@ func TestSubmoduleRepositoryConfigIsIndependentFromParent(t *testing.T) {
 		t.Parallel()
 
 		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
@@ -31,7 +34,9 @@ func TestSubmoduleRepositoryConfigIsIndependentFromParent(t *testing.T) {
 
 		subRepo, err := sm.Repository()
 		require.NoError(t, err)
-		defer subRepo.Close()
+		defer func() {
+			_ = CloseStorage(subRepo)
+		}()
 
 		subCfg, err := subRepo.Config()
 		require.NoError(t, err)
@@ -46,7 +51,10 @@ func TestSubmoduleRepositoryConfigPersistsObjectFormatOnReopen(t *testing.T) {
 	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
 		t.Parallel()
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 		require.NoError(t, sm.Init())
@@ -56,11 +64,13 @@ func TestSubmoduleRepositoryConfigPersistsObjectFormatOnReopen(t *testing.T) {
 
 		cfg, err := subRepo.Config()
 		require.NoError(t, err)
-		require.NoError(t, subRepo.Close())
+		require.NoError(t, CloseStorage(subRepo))
 
 		reopened, err := sm.Repository()
 		require.NoError(t, err)
-		defer reopened.Close()
+		defer func() {
+			_ = CloseStorage(reopened)
+		}()
 
 		reopenedCfg, err := reopened.Config()
 		require.NoError(t, err)
@@ -76,13 +86,18 @@ func TestSubmoduleRepositoryCreateRemoteWritesModuleConfig(t *testing.T) {
 		t.Parallel()
 
 		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 		require.NoError(t, sm.Init())
 
 		subRepo, err := sm.Repository()
 		require.NoError(t, err)
-		defer subRepo.Close()
+		defer func() {
+			_ = CloseStorage(subRepo)
+		}()
 
 		_, err = subRepo.CreateRemote(&config.RemoteConfig{
 			Name: "module-only",

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
@@ -23,6 +24,14 @@ func TestSubmoduleSuite(t *testing.T) {
 	suite.Run(t, new(SubmoduleSuite))
 }
 
+func (s *SubmoduleSuite) SetupSuite() {
+	// SubmoduleSuite creates its own repository in SetupTest,
+	// so we don't call buildBasicRepository() here to avoid creating
+	// storage that will be immediately overwritten (and leaked).
+	// We only initialize the cache.
+	s.cache = make(map[string]*Repository)
+}
+
 func (s *SubmoduleSuite) SetupTest() {
 	url := s.GetLocalRepositoryURL(fixtures.ByTag("submodule").One())
 
@@ -32,6 +41,14 @@ func (s *SubmoduleSuite) SetupTest() {
 	s.Repository = r
 	s.Worktree, err = r.Worktree()
 	s.Require().NoError(err)
+}
+
+func (s *SubmoduleSuite) TearDownTest() {
+	if s.Repository != nil {
+		if closer, ok := s.Repository.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}
 }
 
 func (s *SubmoduleSuite) TestInit() {
@@ -71,7 +88,11 @@ func (s *SubmoduleSuite) TestUpdate() {
 
 	r, err := sm.Repository()
 	s.Require().NoError(err)
-	defer r.Close()
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	ref, err := r.Reference(plumbing.HEAD, true)
 	s.Require().NoError(err)
@@ -164,7 +185,11 @@ func (s *SubmoduleSuite) TestUpdateWithInitAndUpdate() {
 
 	r, err := sm.Repository()
 	s.Require().NoError(err)
-	defer r.Close()
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	ref, err := r.Reference(plumbing.HEAD, true)
 	s.Require().NoError(err)
@@ -241,7 +266,11 @@ func (s *SubmoduleSuite) TestSubmodulesFetchDepth() {
 
 	r, err := sm.Repository()
 	s.Require().NoError(err)
-	defer r.Close()
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	lr, err := r.Log(&LogOptions{})
 	s.Require().NoError(err)

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -20,6 +20,9 @@ func TestSubmoduleInit(t *testing.T) {
 		t.Parallel()
 
 		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 
@@ -50,13 +53,18 @@ func TestSubmoduleUpdate(t *testing.T) {
 		}
 
 		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 		require.NoError(t, sm.Update(&SubmoduleUpdateOptions{Init: true}))
 
 		subRepo, err := sm.Repository()
 		require.NoError(t, err)
-		defer subRepo.Close()
+		defer func() {
+			_ = CloseStorage(subRepo)
+		}()
 
 		ref, err := subRepo.Reference(plumbing.HEAD, true)
 		require.NoError(t, err)
@@ -74,13 +82,16 @@ func TestSubmoduleRepositoryWithoutInit(t *testing.T) {
 	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
 		t.Parallel()
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 
-		r, err := sm.Repository()
+		subRepo, err := sm.Repository()
 		require.ErrorIs(t, err, ErrSubmoduleNotInitialized)
-		require.Nil(t, r)
+		require.Nil(t, subRepo)
 	})
 }
 
@@ -90,7 +101,10 @@ func TestSubmoduleUpdateWithoutInit(t *testing.T) {
 	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
 		t.Parallel()
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 		err := sm.Update(&SubmoduleUpdateOptions{})
@@ -104,7 +118,10 @@ func TestSubmoduleUpdateWithNotFetch(t *testing.T) {
 	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
 		t.Parallel()
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 		err := sm.Update(&SubmoduleUpdateOptions{
@@ -126,7 +143,10 @@ func TestSubmoduleUpdateWithRecursion(t *testing.T) {
 			t.Skip("skipping test in short mode.")
 		}
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, "itself")
 		err := sm.Update(&SubmoduleUpdateOptions{
@@ -152,13 +172,18 @@ func TestSubmoduleUpdateWithInitAndUpdate(t *testing.T) {
 		}
 
 		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 		require.NoError(t, sm.Update(&SubmoduleUpdateOptions{Init: true}))
 
 		subRepo, err := sm.Repository()
 		require.NoError(t, err)
-		defer subRepo.Close()
+		defer func() {
+			_ = CloseStorage(subRepo)
+		}()
 
 		log, err := subRepo.Log(&LogOptions{})
 		require.NoError(t, err)
@@ -199,7 +224,10 @@ func TestSubmodulesInit(t *testing.T) {
 	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
 		t.Parallel()
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm, err := wt.Submodules()
 		require.NoError(t, err)
@@ -220,7 +248,10 @@ func TestGitSubmodulesSymlink(t *testing.T) {
 	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
 		t.Parallel()
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		file, err := wt.Filesystem.Create("badfile")
 		require.NoError(t, err)
@@ -240,7 +271,10 @@ func TestSubmodulesStatus(t *testing.T) {
 	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
 		t.Parallel()
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm, err := wt.Submodules()
 		require.NoError(t, err)
@@ -261,7 +295,10 @@ func TestSubmodulesUpdateContext(t *testing.T) {
 			t.Skip("skipping test in short mode.")
 		}
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm, err := wt.Submodules()
 		require.NoError(t, err)
@@ -288,7 +325,10 @@ func TestSubmodulesFetchDepth(t *testing.T) {
 			t.Skip("shallow submodule updates do not yet support SHA-256 shallow-update parsing")
 		}
 
-		_, wt := cloneFixture(t, f)
+		r, wt := cloneFixture(t, f)
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 		require.NoError(t, sm.Update(&SubmoduleUpdateOptions{
@@ -298,7 +338,9 @@ func TestSubmodulesFetchDepth(t *testing.T) {
 
 		subRepo, err := sm.Repository()
 		require.NoError(t, err)
-		defer subRepo.Close()
+		defer func() {
+			_ = CloseStorage(subRepo)
+		}()
 
 		lr, err := subRepo.Log(&LogOptions{})
 		require.NoError(t, err)

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -681,6 +681,7 @@ func (s *WorktreeSuite) TestCommitTreeSort() {
 	fs := s.TemporalFilesystem()
 
 	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
 	_, err := Init(st)
 	s.Require().NoError(err)
 
@@ -730,6 +731,7 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 	fsDotgit, err := fs.Chroot(".git") // real fs to get modified timestamps
 	s.Require().NoError(err)
 	storage := filesystem.NewStorage(fsDotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = storage.Close() }()
 
 	r, err := Init(storage, WithWorkTree(fs))
 	s.Require().NoError(err)
@@ -784,6 +786,11 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 
 func (s *WorktreeSuite) TestCommitInvalidCharactersInAuthorInfos() {
 	f := fixtures.Basic().One()
+	if s.Repository != nil {
+		if closer, ok := s.Repository.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}
 	s.Repository = NewRepositoryWithEmptyWorktree(f)
 
 	expected := plumbing.NewHash("e8eecef2524c3a37cf0f0996603162f81e0373f1")

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -681,6 +681,7 @@ func (s *WorktreeSuite) TestCommitTreeSort() {
 	fs := s.TemporalFilesystem()
 
 	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
 	_, err := Init(st)
 	s.Require().NoError(err)
 
@@ -730,6 +731,7 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 	fsDotgit, err := fs.Chroot(".git") // real fs to get modified timestamps
 	s.Require().NoError(err)
 	storage := filesystem.NewStorage(fsDotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = storage.Close() }()
 
 	r, err := Init(storage, WithWorkTree(fs))
 	s.Require().NoError(err)
@@ -784,6 +786,9 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 
 func (s *WorktreeSuite) TestCommitInvalidCharactersInAuthorInfos() {
 	f := fixtures.Basic().One()
+	if s.Repository != nil {
+		_ = CloseStorage(s.Repository)
+	}
 	s.Repository = NewRepositoryWithEmptyWorktree(f)
 
 	expected := plumbing.NewHash("e8eecef2524c3a37cf0f0996603162f81e0373f1")

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -24,6 +24,7 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	defer func() { _ = s.Close() }()
 	r, err := Init(s, WithWorkTree(w))
 	require.NoError(t, err)
 	require.NotNil(t, r)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -51,9 +51,25 @@ func TestWorktreeSuite(t *testing.T) {
 	suite.Run(t, new(WorktreeSuite))
 }
 
+func (s *WorktreeSuite) SetupSuite() {
+	// WorktreeSuite creates its own repository in SetupTest,
+	// so we don't call buildBasicRepository() here to avoid creating
+	// storage that will be immediately overwritten (and leaked).
+	// We only initialize the cache.
+	s.cache = make(map[string]*Repository)
+}
+
 func (s *WorktreeSuite) SetupTest() {
 	f := fixtures.Basic().One()
 	s.Repository = NewRepositoryWithEmptyWorktree(f)
+}
+
+func (s *WorktreeSuite) TearDownTest() {
+	if s.Repository != nil {
+		if closer, ok := s.Repository.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}
 }
 
 func (s *WorktreeSuite) TestPullCheckout() {
@@ -80,6 +96,11 @@ func (s *WorktreeSuite) TestPullFastForward() {
 
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
@@ -107,6 +128,11 @@ func (s *WorktreeSuite) TestPullNonFastForward() {
 
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
@@ -241,6 +267,11 @@ func (s *RepositorySuite) TestPullAdd() {
 
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
@@ -316,6 +347,11 @@ func (s *WorktreeSuite) TestPullAfterShallowClone() {
 
 	remote, err := PlainInit(remoteURL, false)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := remote.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	s.NotNil(remote)
 
 	_ = CommitNewFile(s.T(), remote, "File1")
@@ -329,6 +365,11 @@ func (s *WorktreeSuite) TestPullAfterShallowClone() {
 		ReferenceName: "master",
 	})
 	s.NoError(err)
+	defer func() {
+		if closer, ok := repo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	_ = CommitNewFile(s.T(), remote, "File3")
 	_ = CommitNewFile(s.T(), remote, "File4")
@@ -354,6 +395,11 @@ func (s *WorktreeSuite) TestPullAfterShallowClone_UntrackedFilesPreserved() {
 
 	remote, err := PlainInit(remoteURL, false)
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := remote.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	_ = CommitNewFile(s.T(), remote, "File1")
 	_ = CommitNewFile(s.T(), remote, "File2")
@@ -366,6 +412,11 @@ func (s *WorktreeSuite) TestPullAfterShallowClone_UntrackedFilesPreserved() {
 		ReferenceName: "master",
 	})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := repo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// Create an untracked file in the cloned worktree.
 	untrackedPath := filepath.Join(repoDir, "untracked.txt")
@@ -503,6 +554,11 @@ func (s *WorktreeSuite) TestCheckoutSymlink() {
 
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -561,6 +617,11 @@ func (s *WorktreeSuite) TestCheckoutSparse() {
 func (s *WorktreeSuite) TestCheckoutCRLF() {
 	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
 		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())
+		defer func() {
+			if closer, ok := r.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
@@ -605,6 +666,11 @@ func (s *WorktreeSuite) TestFilenameNormalization() {
 
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	filename := "페"
 
@@ -671,6 +737,11 @@ func (s *WorktreeSuite) TestFilenameNormalization() {
 func (s *WorktreeSuite) TestCheckoutSubmodule() {
 	url := "https://github.com/git-fixtures/submodule.git"
 	r := NewRepositoryWithEmptyWorktree(fixtures.ByURL(url).One())
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -686,6 +757,11 @@ func (s *WorktreeSuite) TestCheckoutSubmodule() {
 func (s *WorktreeSuite) TestCheckoutSubmoduleInitialized() {
 	url := "https://github.com/git-fixtures/submodule.git"
 	r := s.NewRepository(fixtures.ByURL(url).One())
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -704,6 +780,11 @@ func (s *WorktreeSuite) TestCheckoutSubmoduleInitialized() {
 func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized() {
 	url := "https://github.com/git-fixtures/submodule.git"
 	r := s.NewRepository(fixtures.ByURL(url).One())
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// modify the .gitmodules from original one
 	file, err := r.wt.OpenFile(".gitmodules", os.O_WRONLY|os.O_TRUNC, 0o666)
@@ -735,7 +816,11 @@ func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized() {
 	s.NoError(err)
 	basicRepo, err := basicSubmodule.Repository()
 	s.NoError(err)
-	defer basicRepo.Close()
+	defer func() {
+		if closer, ok := basicRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	basicRemotes, err := basicRepo.Remotes()
 	s.NoError(err)
 	s.Equal("https://github.com/git-fixtures/basic.git", basicRemotes[0].Config().URLs[0])
@@ -744,7 +829,11 @@ func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized() {
 	s.NoError(err)
 	itselfRepo, err := itselfSubmodule.Repository()
 	s.NoError(err)
-	defer itselfRepo.Close()
+	defer func() {
+		if closer, ok := itselfRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	itselfRemotes, err := itselfRepo.Remotes()
 	s.NoError(err)
 	s.Equal("https://github.com/git-fixtures/submodule.git", itselfRemotes[0].Config().URLs[0])
@@ -1053,6 +1142,11 @@ func (s *WorktreeSuite) TestCheckoutCreateInvalidBranch() {
 func (s *WorktreeSuite) TestCheckoutTag() {
 	f := fixtures.ByTag("tags").One()
 	r := NewRepositoryWithEmptyWorktree(f)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	w, err := r.Worktree()
 	s.NoError(err)
 
@@ -1090,6 +1184,11 @@ func (s *WorktreeSuite) TestCheckoutTag() {
 func (s *WorktreeSuite) TestCheckoutTagHash() {
 	f := fixtures.ByTag("tags").One()
 	r := NewRepositoryWithEmptyWorktree(f)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	w, err := r.Worktree()
 	s.NoError(err)
 
@@ -1139,6 +1238,11 @@ func (s *WorktreeSuite) TestCheckoutBisectSubmodules() {
 func (s *WorktreeSuite) testCheckoutBisect(url string) {
 	f := fixtures.ByURL(url).One()
 	r := NewRepositoryWithEmptyWorktree(f)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -1460,6 +1564,11 @@ func (s *WorktreeSuite) TestResetKeepConflict() {
 	// Build a repo with two commits that both touch "tracked.txt".
 	r, err := PlainInit(repoDir, false)
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	w, err := r.Worktree()
 	s.Require().NoError(err)
 
@@ -1565,6 +1674,11 @@ func (s *WorktreeSuite) TestResetKeepConflictNotOnSparseExcluded() {
 
 	r, err := PlainInit(repoDir, false)
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	w, err := r.Worktree()
 	s.Require().NoError(err)
 
@@ -1642,6 +1756,11 @@ func (s *WorktreeSuite) TestResetKeepUntrackedOverwrite() {
 
 	r, err := PlainInit(repoDir, false)
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	w, err := r.Worktree()
 	s.Require().NoError(err)
 
@@ -2045,6 +2164,11 @@ func (s *WorktreeSuite) TestSubmodule() {
 
 	r, err := Open(filesystem.NewStorage(gitdir, cache.NewObjectLRUDefault()), fs)
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := r.Worktree()
 	s.Require().NoError(err)
@@ -2057,6 +2181,11 @@ func (s *WorktreeSuite) TestSubmodule() {
 
 func (s *WorktreeSuite) TestSubmodules() {
 	r := s.NewRepository(fixtures.ByTag("submodule").One())
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := r.Worktree()
 	s.Require().NoError(err)
@@ -2289,6 +2418,11 @@ func (s *WorktreeSuite) TestAddAbsolutePath() {
 
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -2320,6 +2454,11 @@ func (s *WorktreeSuite) TestAddAbsolutePath() {
 func (s *WorktreeSuite) TestAddCRLF() {
 	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
 		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())
+		defer func() {
+			if closer, ok := r.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
@@ -2392,6 +2531,11 @@ func (s *WorktreeSuite) TestIgnored() {
 func (s *WorktreeSuite) TestExcludedNoGitignore() {
 	f := fixtures.ByTag("empty").One()
 	r := s.NewRepository(f)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	fs := memfs.New()
 	w := &Worktree{
@@ -2567,6 +2711,11 @@ func (s *WorktreeSuite) TestAddSymlink() {
 
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 	err = util.WriteFile(r.wt, "foo", []byte("qux"), 0o644)
 	s.NoError(err)
 	err = r.wt.Symlink("foo", "bar")
@@ -3260,6 +3409,11 @@ func TestAlternatesRepo(t *testing.T) {
 	d, _ := rep1fs.Chroot(GitDirName)
 	rep1, err := Open(filesystem.NewStorage(d, cache.NewObjectLRUDefault()), nil)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := rep1.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// Open 2nd repo.
 	rep2fs, err := fs.Chroot("rep2")
@@ -3271,6 +3425,11 @@ func TestAlternatesRepo(t *testing.T) {
 		})
 	rep2, err := Open(storer, rep2fs)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := rep2.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	// Get the HEAD commit from the main repo.
 	h, err := rep1.Head()
@@ -3477,6 +3636,11 @@ func (s *WorktreeSuite) TestGrep() {
 
 	server, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		if closer, ok := server.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := server.Worktree()
 	s.Require().NoError(err)
@@ -3580,6 +3744,11 @@ func (s *WorktreeSuite) TestResetLingeringDirectories() {
 
 	repo, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := repo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := repo.Worktree()
 	s.NoError(err)
@@ -3625,6 +3794,11 @@ func (s *WorktreeSuite) TestAddAndCommit() {
 
 	repo, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := repo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := repo.Worktree()
 	s.NoError(err)
@@ -3667,6 +3841,11 @@ func (s *WorktreeSuite) TestAddAndCommitEmpty() {
 
 	repo, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		if closer, ok := repo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	w, err := repo.Worktree()
 	s.NoError(err)
@@ -3692,6 +3871,11 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 		s.Require().NoError(err)
 		repo, err := PlainOpenWithOptions(fs.Root(), nil)
 		s.Require().NoError(err)
+		defer func() {
+			if closer, ok := repo.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		wt, err := repo.Worktree()
 		s.NoError(err)
@@ -3711,6 +3895,11 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 		s.Require().NoError(err)
 		repo, err := PlainOpenWithOptions(fs.Root(), nil)
 		s.Require().NoError(err)
+		defer func() {
+			if closer, ok := repo.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		wt, err := repo.Worktree()
 		s.NoError(err)
@@ -3733,6 +3922,11 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 		s.Require().NoError(err)
 		repo, err := PlainOpenWithOptions(fs.Root(), nil)
 		s.Require().NoError(err)
+		defer func() {
+			if closer, ok := repo.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		wt, err := repo.Worktree()
 		s.NoError(err)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -51,9 +51,24 @@ func TestWorktreeSuite(t *testing.T) {
 	suite.Run(t, new(WorktreeSuite))
 }
 
+func (s *WorktreeSuite) SetupSuite() {
+	// WorktreeSuite creates its own repository in SetupTest,
+	// so we don't call buildBasicRepository() here to avoid creating
+	// storage that will be immediately overwritten (and leaked).
+	// We only initialize the cache.
+	s.cache = make(map[string]*Repository)
+}
+
 func (s *WorktreeSuite) SetupTest() {
 	f := fixtures.Basic().One()
 	s.Repository = NewRepositoryWithEmptyWorktree(f)
+}
+
+func (s *WorktreeSuite) TearDownTest() {
+	if s.Repository != nil {
+		_ = CloseStorage(s.Repository)
+		s.Repository = nil
+	}
 }
 
 func (s *WorktreeSuite) TestPullCheckout() {
@@ -80,6 +95,9 @@ func (s *WorktreeSuite) TestPullFastForward() {
 
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
@@ -107,6 +125,9 @@ func (s *WorktreeSuite) TestPullNonFastForward() {
 
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
@@ -241,6 +262,9 @@ func (s *RepositorySuite) TestPullAdd() {
 
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
@@ -316,6 +340,9 @@ func (s *WorktreeSuite) TestPullAfterShallowClone() {
 
 	remote, err := PlainInit(remoteURL, false)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(remote)
+	}()
 	s.NotNil(remote)
 
 	_ = CommitNewFile(s.T(), remote, "File1")
@@ -329,6 +356,9 @@ func (s *WorktreeSuite) TestPullAfterShallowClone() {
 		ReferenceName: "master",
 	})
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(repo)
+	}()
 
 	_ = CommitNewFile(s.T(), remote, "File3")
 	_ = CommitNewFile(s.T(), remote, "File4")
@@ -354,6 +384,9 @@ func (s *WorktreeSuite) TestPullAfterShallowClone_UntrackedFilesPreserved() {
 
 	remote, err := PlainInit(remoteURL, false)
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(remote)
+	}()
 
 	_ = CommitNewFile(s.T(), remote, "File1")
 	_ = CommitNewFile(s.T(), remote, "File2")
@@ -366,6 +399,9 @@ func (s *WorktreeSuite) TestPullAfterShallowClone_UntrackedFilesPreserved() {
 		ReferenceName: "master",
 	})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(repo)
+	}()
 
 	// Create an untracked file in the cloned worktree.
 	untrackedPath := filepath.Join(repoDir, "untracked.txt")
@@ -503,6 +539,9 @@ func (s *WorktreeSuite) TestCheckoutSymlink() {
 
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -561,6 +600,9 @@ func (s *WorktreeSuite) TestCheckoutSparse() {
 func (s *WorktreeSuite) TestCheckoutCRLF() {
 	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
 		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
@@ -605,6 +647,9 @@ func (s *WorktreeSuite) TestFilenameNormalization() {
 
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	filename := "페"
 
@@ -671,6 +716,9 @@ func (s *WorktreeSuite) TestFilenameNormalization() {
 func (s *WorktreeSuite) TestCheckoutSubmodule() {
 	url := "https://github.com/git-fixtures/submodule.git"
 	r := NewRepositoryWithEmptyWorktree(fixtures.ByURL(url).One())
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -686,6 +734,9 @@ func (s *WorktreeSuite) TestCheckoutSubmodule() {
 func (s *WorktreeSuite) TestCheckoutSubmoduleInitialized() {
 	url := "https://github.com/git-fixtures/submodule.git"
 	r := s.NewRepository(fixtures.ByURL(url).One())
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -704,6 +755,9 @@ func (s *WorktreeSuite) TestCheckoutSubmoduleInitialized() {
 func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized() {
 	url := "https://github.com/git-fixtures/submodule.git"
 	r := s.NewRepository(fixtures.ByURL(url).One())
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	// modify the .gitmodules from original one
 	file, err := r.wt.OpenFile(".gitmodules", os.O_WRONLY|os.O_TRUNC, 0o666)
@@ -735,7 +789,9 @@ func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized() {
 	s.NoError(err)
 	basicRepo, err := basicSubmodule.Repository()
 	s.NoError(err)
-	defer basicRepo.Close()
+	defer func() {
+		_ = CloseStorage(basicRepo)
+	}()
 	basicRemotes, err := basicRepo.Remotes()
 	s.NoError(err)
 	s.Equal("https://github.com/git-fixtures/basic.git", basicRemotes[0].Config().URLs[0])
@@ -744,7 +800,9 @@ func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized() {
 	s.NoError(err)
 	itselfRepo, err := itselfSubmodule.Repository()
 	s.NoError(err)
-	defer itselfRepo.Close()
+	defer func() {
+		_ = CloseStorage(itselfRepo)
+	}()
 	itselfRemotes, err := itselfRepo.Remotes()
 	s.NoError(err)
 	s.Equal("https://github.com/git-fixtures/submodule.git", itselfRemotes[0].Config().URLs[0])
@@ -1053,6 +1111,9 @@ func (s *WorktreeSuite) TestCheckoutCreateInvalidBranch() {
 func (s *WorktreeSuite) TestCheckoutTag() {
 	f := fixtures.ByTag("tags").One()
 	r := NewRepositoryWithEmptyWorktree(f)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 	w, err := r.Worktree()
 	s.NoError(err)
 
@@ -1090,6 +1151,9 @@ func (s *WorktreeSuite) TestCheckoutTag() {
 func (s *WorktreeSuite) TestCheckoutTagHash() {
 	f := fixtures.ByTag("tags").One()
 	r := NewRepositoryWithEmptyWorktree(f)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 	w, err := r.Worktree()
 	s.NoError(err)
 
@@ -1139,6 +1203,9 @@ func (s *WorktreeSuite) TestCheckoutBisectSubmodules() {
 func (s *WorktreeSuite) testCheckoutBisect(url string) {
 	f := fixtures.ByURL(url).One()
 	r := NewRepositoryWithEmptyWorktree(f)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -1460,6 +1527,9 @@ func (s *WorktreeSuite) TestResetKeepConflict() {
 	// Build a repo with two commits that both touch "tracked.txt".
 	r, err := PlainInit(repoDir, false)
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 	w, err := r.Worktree()
 	s.Require().NoError(err)
 
@@ -1565,6 +1635,9 @@ func (s *WorktreeSuite) TestResetKeepConflictNotOnSparseExcluded() {
 
 	r, err := PlainInit(repoDir, false)
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 	w, err := r.Worktree()
 	s.Require().NoError(err)
 
@@ -1642,6 +1715,9 @@ func (s *WorktreeSuite) TestResetKeepUntrackedOverwrite() {
 
 	r, err := PlainInit(repoDir, false)
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 	w, err := r.Worktree()
 	s.Require().NoError(err)
 
@@ -2045,6 +2121,9 @@ func (s *WorktreeSuite) TestSubmodule() {
 
 	r, err := Open(filesystem.NewStorage(gitdir, cache.NewObjectLRUDefault()), fs)
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	w, err := r.Worktree()
 	s.Require().NoError(err)
@@ -2057,6 +2136,9 @@ func (s *WorktreeSuite) TestSubmodule() {
 
 func (s *WorktreeSuite) TestSubmodules() {
 	r := s.NewRepository(fixtures.ByTag("submodule").One())
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	w, err := r.Worktree()
 	s.Require().NoError(err)
@@ -2289,6 +2371,9 @@ func (s *WorktreeSuite) TestAddAbsolutePath() {
 
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	w, err := r.Worktree()
 	s.NoError(err)
@@ -2320,6 +2405,9 @@ func (s *WorktreeSuite) TestAddAbsolutePath() {
 func (s *WorktreeSuite) TestAddCRLF() {
 	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
 		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())
+		defer func() {
+			_ = CloseStorage(r)
+		}()
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
@@ -2392,6 +2480,9 @@ func (s *WorktreeSuite) TestIgnored() {
 func (s *WorktreeSuite) TestExcludedNoGitignore() {
 	f := fixtures.ByTag("empty").One()
 	r := s.NewRepository(f)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 
 	fs := memfs.New()
 	w := &Worktree{
@@ -2567,6 +2658,9 @@ func (s *WorktreeSuite) TestAddSymlink() {
 
 	r, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(r)
+	}()
 	err = util.WriteFile(r.wt, "foo", []byte("qux"), 0o644)
 	s.NoError(err)
 	err = r.wt.Symlink("foo", "bar")
@@ -3260,6 +3354,9 @@ func TestAlternatesRepo(t *testing.T) {
 	d, _ := rep1fs.Chroot(GitDirName)
 	rep1, err := Open(filesystem.NewStorage(d, cache.NewObjectLRUDefault()), nil)
 	require.NoError(t, err)
+	defer func() {
+		_ = CloseStorage(rep1)
+	}()
 
 	// Open 2nd repo.
 	rep2fs, err := fs.Chroot("rep2")
@@ -3271,6 +3368,9 @@ func TestAlternatesRepo(t *testing.T) {
 		})
 	rep2, err := Open(storer, rep2fs)
 	require.NoError(t, err)
+	defer func() {
+		_ = CloseStorage(rep2)
+	}()
 
 	// Get the HEAD commit from the main repo.
 	h, err := rep1.Head()
@@ -3477,6 +3577,9 @@ func (s *WorktreeSuite) TestGrep() {
 
 	server, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
+	defer func() {
+		_ = CloseStorage(server)
+	}()
 
 	w, err := server.Worktree()
 	s.Require().NoError(err)
@@ -3580,6 +3683,9 @@ func (s *WorktreeSuite) TestResetLingeringDirectories() {
 
 	repo, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(repo)
+	}()
 
 	w, err := repo.Worktree()
 	s.NoError(err)
@@ -3625,6 +3731,9 @@ func (s *WorktreeSuite) TestAddAndCommit() {
 
 	repo, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(repo)
+	}()
 
 	w, err := repo.Worktree()
 	s.NoError(err)
@@ -3667,6 +3776,9 @@ func (s *WorktreeSuite) TestAddAndCommitEmpty() {
 
 	repo, err := PlainInit(dir, false)
 	s.NoError(err)
+	defer func() {
+		_ = CloseStorage(repo)
+	}()
 
 	w, err := repo.Worktree()
 	s.NoError(err)
@@ -3692,6 +3804,9 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 		s.Require().NoError(err)
 		repo, err := PlainOpenWithOptions(fs.Root(), nil)
 		s.Require().NoError(err)
+		defer func() {
+			_ = CloseStorage(repo)
+		}()
 
 		wt, err := repo.Worktree()
 		s.NoError(err)
@@ -3711,6 +3826,9 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 		s.Require().NoError(err)
 		repo, err := PlainOpenWithOptions(fs.Root(), nil)
 		s.Require().NoError(err)
+		defer func() {
+			_ = CloseStorage(repo)
+		}()
 
 		wt, err := repo.Worktree()
 		s.NoError(err)
@@ -3733,6 +3851,9 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 		s.Require().NoError(err)
 		repo, err := PlainOpenWithOptions(fs.Root(), nil)
 		s.Require().NoError(err)
+		defer func() {
+			_ = CloseStorage(repo)
+		}()
 
 		wt, err := repo.Worktree()
 		s.NoError(err)

--- a/x/plumbing/worktree/worktree.go
+++ b/x/plumbing/worktree/worktree.go
@@ -102,6 +102,11 @@ func (w *Worktree) Add(wt billy.Filesystem, name string, opts ...Option) error {
 		if err != nil {
 			return fmt.Errorf("unable to open repository: %w", err)
 		}
+		defer func() {
+			if closer, ok := r.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		ref, err := r.Head()
 		if err != nil {
@@ -142,6 +147,11 @@ func (w *Worktree) Add(wt billy.Filesystem, name string, opts ...Option) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if closer, ok := r.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	work, err := r.Worktree()
 	if err != nil {
@@ -229,7 +239,12 @@ func (w *Worktree) Open(wt billy.Filesystem) (*git.Repository, error) {
 	}
 
 	stor := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-	return git.Open(stor, wt)
+	repo, err := git.Open(stor, wt)
+	if err != nil {
+		_ = stor.Close()
+		return nil, err
+	}
+	return repo, nil
 }
 
 // Init initialises a worktree filesystem, connecting it to an existing

--- a/x/plumbing/worktree/worktree.go
+++ b/x/plumbing/worktree/worktree.go
@@ -142,6 +142,9 @@ func (w *Worktree) Add(wt billy.Filesystem, name string, opts ...Option) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_ = git.CloseStorage(r)
+	}()
 
 	work, err := r.Worktree()
 	if err != nil {
@@ -229,7 +232,12 @@ func (w *Worktree) Open(wt billy.Filesystem) (*git.Repository, error) {
 	}
 
 	stor := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-	return git.Open(stor, wt)
+	repo, err := git.Open(stor, wt)
+	if err != nil {
+		_ = stor.Close()
+		return nil, err
+	}
+	return repo, nil
 }
 
 // Init initialises a worktree filesystem, connecting it to an existing

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -145,11 +145,18 @@ func TestAdd(t *testing.T) {
 				})
 				checkFiles(t, expected, storage, wt, name)
 
-				w, err := New(filesystem.NewStorage(storage, cache.NewObjectLRUDefault()))
+				st := filesystem.NewStorage(storage, cache.NewObjectLRUDefault())
+				defer func() { _ = st.Close() }()
+				w, err := New(st)
 				require.NoError(t, err)
 
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
+				defer func() {
+					if closer, ok := repo.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				// Verify HEAD points to the commit (detached).
 				head, err := repo.Head()
@@ -171,11 +178,18 @@ func TestAdd(t *testing.T) {
 			name:    "branch-worktree",
 			wantErr: false,
 			checkFiles: func(t *testing.T, storage, wt billy.Filesystem, _ string) {
-				w, err := New(filesystem.NewStorage(storage, cache.NewObjectLRUDefault()))
+				st := filesystem.NewStorage(storage, cache.NewObjectLRUDefault())
+				defer func() { _ = st.Close() }()
+				w, err := New(st)
 				require.NoError(t, err)
 
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
+				defer func() {
+					if closer, ok := repo.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				// Verify HEAD points to the branch.
 				head, err := repo.Head()
@@ -216,6 +230,7 @@ func TestAdd(t *testing.T) {
 			t.Parallel()
 
 			storer := tt.setupStorer()
+			defer func() { _ = storer.Close() }()
 			wt := tt.setupWorktree()
 
 			w, err := New(storer)
@@ -460,6 +475,7 @@ func TestRemove(t *testing.T) {
 			t.Parallel()
 
 			storer := tt.setupStorer()
+			defer func() { _ = storer.Close() }()
 			w, err := New(storer)
 			require.NoError(t, err, "Unable to create worktree")
 
@@ -593,6 +609,7 @@ func TestList(t *testing.T) {
 			t.Parallel()
 
 			storer := tt.setup()
+			defer func() { _ = storer.Close() }()
 			w, err := New(storer)
 			require.NoError(t, err)
 
@@ -793,6 +810,7 @@ func TestOpen(t *testing.T) {
 			t.Parallel()
 
 			storer, wtFS := tt.setup()
+			defer func() { _ = storer.Close() }()
 			w, err := New(storer)
 			require.NoError(t, err)
 
@@ -806,6 +824,11 @@ func TestOpen(t *testing.T) {
 			}
 
 			require.NoError(t, err, "Open() should not return an error")
+			defer func() {
+				if closer, ok := repo.Storer.(io.Closer); ok {
+					_ = closer.Close()
+				}
+			}()
 
 			if tt.checkRepo != nil {
 				tt.checkRepo(t, repo, wtFS)
@@ -853,6 +876,11 @@ func TestInit(t *testing.T) {
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
 				require.NotNil(t, repo)
+				defer func() {
+					if closer, ok := repo.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				fi, err := wt.Stat(".git")
 				require.NoError(t, err)
@@ -886,6 +914,11 @@ func TestInit(t *testing.T) {
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
 				require.NotNil(t, repo)
+				defer func() {
+					if closer, ok := repo.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				fi, err := wt.Stat(".git")
 				require.NoError(t, err)
@@ -923,6 +956,11 @@ func TestInit(t *testing.T) {
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
 				require.NotNil(t, repo)
+				defer func() {
+					if closer, ok := repo.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				fi, err := wt.Stat(".git")
 				require.NoError(t, err)
@@ -980,6 +1018,11 @@ func TestInit(t *testing.T) {
 
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
+				defer func() {
+					if closer, ok := repo.Storer.(io.Closer); ok {
+						_ = closer.Close()
+					}
+				}()
 
 				head, err := repo.Head()
 				require.NoError(t, err)
@@ -1000,6 +1043,7 @@ func TestInit(t *testing.T) {
 			t.Parallel()
 
 			storer, name := tt.setup()
+			defer func() { _ = storer.Close() }()
 			w, err := New(storer)
 			require.NoError(t, err)
 
@@ -1030,6 +1074,11 @@ func TestWorktreeIsolation(t *testing.T) {
 
 	mainRepo, err := git.PlainInit(mainRepoDir, false)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := mainRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	mainWt, err := mainRepo.Worktree()
 	require.NoError(t, err)
@@ -1053,6 +1102,11 @@ func TestWorktreeIsolation(t *testing.T) {
 	remoteDir := t.TempDir()
 	remoteRepo, err := git.PlainInit(remoteDir, true)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := remoteRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	_, err = mainRepo.CreateRemote(&config.RemoteConfig{
 		Name: "origin",
@@ -1078,6 +1132,11 @@ func TestWorktreeIsolation(t *testing.T) {
 
 	wtRepo, err := w.Open(worktreeFS)
 	require.NoError(t, err)
+	defer func() {
+		if closer, ok := wtRepo.Storer.(io.Closer); ok {
+			_ = closer.Close()
+		}
+	}()
 
 	wtWorkTree, err := wtRepo.Worktree()
 	require.NoError(t, err)
@@ -1158,6 +1217,7 @@ func TestWorktreeConfig(t *testing.T) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 
 		cfg, err := storer.Config()
 		require.NoError(t, err)
@@ -1180,6 +1240,11 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repo, err := w.Open(wtFS)
 		require.NoError(t, err)
+		defer func() {
+			if closer, ok := repo.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
@@ -1194,6 +1259,7 @@ func TestWorktreeConfig(t *testing.T) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 
 		cfg, err := storer.Config()
 		require.NoError(t, err)
@@ -1211,6 +1277,11 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repo, err := w.Open(wtFS)
 		require.NoError(t, err)
+		defer func() {
+			if closer, ok := repo.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
@@ -1223,6 +1294,7 @@ func TestWorktreeConfig(t *testing.T) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 
 		w, err := New(storer)
 		require.NoError(t, err)
@@ -1238,6 +1310,11 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repo, err := w.Open(wtFS)
 		require.NoError(t, err)
+		defer func() {
+			if closer, ok := repo.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
@@ -1250,6 +1327,7 @@ func TestWorktreeConfig(t *testing.T) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(t.TempDir, osfs.WithBoundOS()))
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 
 		cfg, err := storer.Config()
 		require.NoError(t, err)
@@ -1271,6 +1349,11 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repo, err := w.Open(wtFS)
 		require.NoError(t, err)
+		defer func() {
+			if closer, ok := repo.Storer.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}()
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
@@ -1300,6 +1383,7 @@ func FuzzAdd(f *testing.F) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 		w, err := New(storer)
 		require.NoError(t, err, "failed to create worktree manager")
 		require.NotNil(t, w)
@@ -1334,6 +1418,7 @@ func FuzzOpen(f *testing.F) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 		w, err := New(storer)
 		require.NoError(t, err, "failed to create worktree manager")
 		require.NotNil(t, w)
@@ -1343,6 +1428,13 @@ func FuzzOpen(f *testing.F) {
 		require.NoError(t, err, "failed to write .git file")
 
 		repo, err := w.Open(wtFS)
+		if repo != nil {
+			defer func() {
+				if closer, ok := repo.Storer.(io.Closer); ok {
+					_ = closer.Close()
+				}
+			}()
+		}
 
 		if err == nil && repo == nil {
 			assert.Fail(t, "invalid state: repository and error is nil")
@@ -1354,6 +1446,7 @@ func ExampleWorktree_Open() {
 	// Setup repository storage pointing to existing dotgit.
 	fs := osfs.New("/path/to/repo/.git")
 	storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = storer.Close() }()
 	w, err := New(storer)
 	if err != nil {
 		panic(err)
@@ -1386,6 +1479,7 @@ func ExampleWorktree_Remove() {
 	// Setup repository storage pointing to existing dotgit.
 	fs := osfs.New("/path/to/repo/.git")
 	storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = storer.Close() }()
 	w, err := New(storer)
 	if err != nil {
 		panic(err)
@@ -1404,6 +1498,7 @@ func ExampleWorktree_Init() {
 	// Setup repository storage on osfs pointing to existing dotgit.
 	storerFS := osfs.New("/path/to/repo/.git")
 	storer := filesystem.NewStorage(storerFS, cache.NewObjectLRUDefault())
+	defer func() { _ = storer.Close() }()
 	w, err := New(storer)
 	if err != nil {
 		panic(err)

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -145,11 +145,16 @@ func TestAdd(t *testing.T) {
 				})
 				checkFiles(t, expected, storage, wt, name)
 
-				w, err := New(filesystem.NewStorage(storage, cache.NewObjectLRUDefault()))
+				st := filesystem.NewStorage(storage, cache.NewObjectLRUDefault())
+				defer func() { _ = st.Close() }()
+				w, err := New(st)
 				require.NoError(t, err)
 
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
+				defer func() {
+					_ = git.CloseStorage(repo)
+				}()
 
 				// Verify HEAD points to the commit (detached).
 				head, err := repo.Head()
@@ -171,11 +176,16 @@ func TestAdd(t *testing.T) {
 			name:    "branch-worktree",
 			wantErr: false,
 			checkFiles: func(t *testing.T, storage, wt billy.Filesystem, _ string) {
-				w, err := New(filesystem.NewStorage(storage, cache.NewObjectLRUDefault()))
+				st := filesystem.NewStorage(storage, cache.NewObjectLRUDefault())
+				defer func() { _ = st.Close() }()
+				w, err := New(st)
 				require.NoError(t, err)
 
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
+				defer func() {
+					_ = git.CloseStorage(repo)
+				}()
 
 				// Verify HEAD points to the branch.
 				head, err := repo.Head()
@@ -216,6 +226,7 @@ func TestAdd(t *testing.T) {
 			t.Parallel()
 
 			storer := tt.setupStorer()
+			defer func() { _ = storer.Close() }()
 			wt := tt.setupWorktree()
 
 			w, err := New(storer)
@@ -460,6 +471,7 @@ func TestRemove(t *testing.T) {
 			t.Parallel()
 
 			storer := tt.setupStorer()
+			defer func() { _ = storer.Close() }()
 			w, err := New(storer)
 			require.NoError(t, err, "Unable to create worktree")
 
@@ -593,6 +605,7 @@ func TestList(t *testing.T) {
 			t.Parallel()
 
 			storer := tt.setup()
+			defer func() { _ = storer.Close() }()
 			w, err := New(storer)
 			require.NoError(t, err)
 
@@ -793,6 +806,7 @@ func TestOpen(t *testing.T) {
 			t.Parallel()
 
 			storer, wtFS := tt.setup()
+			defer func() { _ = storer.Close() }()
 			w, err := New(storer)
 			require.NoError(t, err)
 
@@ -806,6 +820,9 @@ func TestOpen(t *testing.T) {
 			}
 
 			require.NoError(t, err, "Open() should not return an error")
+			defer func() {
+				_ = git.CloseStorage(repo)
+			}()
 
 			if tt.checkRepo != nil {
 				tt.checkRepo(t, repo, wtFS)
@@ -853,6 +870,9 @@ func TestInit(t *testing.T) {
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
 				require.NotNil(t, repo)
+				defer func() {
+					_ = git.CloseStorage(repo)
+				}()
 
 				fi, err := wt.Stat(".git")
 				require.NoError(t, err)
@@ -886,6 +906,9 @@ func TestInit(t *testing.T) {
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
 				require.NotNil(t, repo)
+				defer func() {
+					_ = git.CloseStorage(repo)
+				}()
 
 				fi, err := wt.Stat(".git")
 				require.NoError(t, err)
@@ -923,6 +946,9 @@ func TestInit(t *testing.T) {
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
 				require.NotNil(t, repo)
+				defer func() {
+					_ = git.CloseStorage(repo)
+				}()
 
 				fi, err := wt.Stat(".git")
 				require.NoError(t, err)
@@ -980,6 +1006,9 @@ func TestInit(t *testing.T) {
 
 				repo, err := w.Open(wt)
 				require.NoError(t, err)
+				defer func() {
+					_ = git.CloseStorage(repo)
+				}()
 
 				head, err := repo.Head()
 				require.NoError(t, err)
@@ -1000,6 +1029,7 @@ func TestInit(t *testing.T) {
 			t.Parallel()
 
 			storer, name := tt.setup()
+			defer func() { _ = storer.Close() }()
 			w, err := New(storer)
 			require.NoError(t, err)
 
@@ -1030,6 +1060,9 @@ func TestWorktreeIsolation(t *testing.T) {
 
 	mainRepo, err := git.PlainInit(mainRepoDir, false)
 	require.NoError(t, err)
+	defer func() {
+		_ = git.CloseStorage(mainRepo)
+	}()
 
 	mainWt, err := mainRepo.Worktree()
 	require.NoError(t, err)
@@ -1053,6 +1086,9 @@ func TestWorktreeIsolation(t *testing.T) {
 	remoteDir := t.TempDir()
 	remoteRepo, err := git.PlainInit(remoteDir, true)
 	require.NoError(t, err)
+	defer func() {
+		_ = git.CloseStorage(remoteRepo)
+	}()
 
 	_, err = mainRepo.CreateRemote(&config.RemoteConfig{
 		Name: "origin",
@@ -1078,6 +1114,9 @@ func TestWorktreeIsolation(t *testing.T) {
 
 	wtRepo, err := w.Open(worktreeFS)
 	require.NoError(t, err)
+	defer func() {
+		_ = git.CloseStorage(wtRepo)
+	}()
 
 	wtWorkTree, err := wtRepo.Worktree()
 	require.NoError(t, err)
@@ -1158,6 +1197,7 @@ func TestWorktreeConfig(t *testing.T) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 
 		cfg, err := storer.Config()
 		require.NoError(t, err)
@@ -1180,6 +1220,9 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repo, err := w.Open(wtFS)
 		require.NoError(t, err)
+		defer func() {
+			_ = git.CloseStorage(repo)
+		}()
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
@@ -1194,6 +1237,7 @@ func TestWorktreeConfig(t *testing.T) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 
 		cfg, err := storer.Config()
 		require.NoError(t, err)
@@ -1211,6 +1255,9 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repo, err := w.Open(wtFS)
 		require.NoError(t, err)
+		defer func() {
+			_ = git.CloseStorage(repo)
+		}()
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
@@ -1223,6 +1270,7 @@ func TestWorktreeConfig(t *testing.T) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 
 		w, err := New(storer)
 		require.NoError(t, err)
@@ -1238,6 +1286,9 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repo, err := w.Open(wtFS)
 		require.NoError(t, err)
+		defer func() {
+			_ = git.CloseStorage(repo)
+		}()
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
@@ -1250,6 +1301,7 @@ func TestWorktreeConfig(t *testing.T) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(t.TempDir, osfs.WithBoundOS()))
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 
 		cfg, err := storer.Config()
 		require.NoError(t, err)
@@ -1271,6 +1323,9 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repo, err := w.Open(wtFS)
 		require.NoError(t, err)
+		defer func() {
+			_ = git.CloseStorage(repo)
+		}()
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
@@ -1300,6 +1355,7 @@ func FuzzAdd(f *testing.F) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 		w, err := New(storer)
 		require.NoError(t, err, "failed to create worktree manager")
 		require.NotNil(t, w)
@@ -1329,6 +1385,7 @@ func FuzzOpen(f *testing.F) {
 		fs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
 		require.NoError(t, err)
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+		defer func() { _ = storer.Close() }()
 		w, err := New(storer)
 		require.NoError(t, err, "failed to create worktree manager")
 		require.NotNil(t, w)
@@ -1338,6 +1395,11 @@ func FuzzOpen(f *testing.F) {
 		require.NoError(t, err, "failed to write .git file")
 
 		repo, err := w.Open(wtFS)
+		if repo != nil {
+			defer func() {
+				_ = git.CloseStorage(repo)
+			}()
+		}
 
 		if err == nil && repo == nil {
 			assert.Fail(t, "invalid state: repository and error is nil")
@@ -1349,6 +1411,7 @@ func ExampleWorktree_Open() {
 	// Setup repository storage pointing to existing dotgit.
 	fs := osfs.New("/path/to/repo/.git")
 	storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = storer.Close() }()
 	w, err := New(storer)
 	if err != nil {
 		panic(err)
@@ -1381,6 +1444,7 @@ func ExampleWorktree_Remove() {
 	// Setup repository storage pointing to existing dotgit.
 	fs := osfs.New("/path/to/repo/.git")
 	storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = storer.Close() }()
 	w, err := New(storer)
 	if err != nil {
 		panic(err)
@@ -1399,6 +1463,7 @@ func ExampleWorktree_Init() {
 	// Setup repository storage on osfs pointing to existing dotgit.
 	storerFS := osfs.New("/path/to/repo/.git")
 	storer := filesystem.NewStorage(storerFS, cache.NewObjectLRUDefault())
+	defer func() { _ = storer.Close() }()
 	w, err := New(storer)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary

This PR adds storage leak detection and fixes all file handle leaks by enforcing a storage ownership model.

Repository doesn't own storage (it's passed in via Init/Open/Clone), so it shouldn't close it. Only Plain* functions (PlainInit, PlainOpen, PlainClone, PlainOpenWithOptions) and `worktree.Worktree.Open()` create storage internally.

**Note:** This PR is an alternative to #1999. Both fix the file handle leaks, but take different architectural approaches. We will choose one or the other.

## Changes

### Core Changes
- **Adds storage leak detection** in `storage/filesystem` and `storage/transactional` (enabled with `-tags leakcheck`)
- **Removes `repository.Close()` method** and `closed` field from Repository struct
- **Adds `CloseStorage(r *Repository)` helper function** to simplify closing storage created by Plain* functions
- **Updates all examples** to demonstrate the storage ownership model
- Shifts to a storage ownership model where the creator of storage is responsible for closing it

### Storage Ownership Model
1. **Functions that create storage internally** (PlainClone, PlainInit, PlainOpen, PlainOpenWithOptions, worktree.Worktree.Open()):
   - Return repositories whose storage must be closed by the caller
   - Use: `defer func() { _ = git.CloseStorage(r) }()`

2. **Functions that receive storage** (Clone, Init, Open):
   - Return repositories where storage is managed externally
   - Do not close storage via the repository

3. **Direct storage creation** (filesystem.NewStorage):
   - Close storage directly, not via CloseStorage

### Example Updates
- Updated 27 _examples files to use `git.CloseStorage(r)` for Plain* functions
- Updated example_test.go to demonstrate proper storage ownership patterns
- Examples correctly demonstrate when to close storage vs. when caller owns it

### Code Quality Improvements
- Replaced 50+ instances of verbose close patterns with the cleaner `CloseStorage` helper
- Fixed 40+ storage leaks across test files by adding proper `defer` close statements
- Updated error handling in PlainInit and PlainClone to close storage on error paths
- Removed unused `io` imports after pattern refactoring

### Documentation
- Updated `CONTRIBUTING.md` with detailed storage ownership rules and examples
- Updated `.github/copilot-instructions.md` with storage cleanup guidelines

## Test Plan

All tests pass with leak detection enabled:
```bash
go test -tags leakcheck -count=1 ./...
```

The leak detection will panic with a clear message if any storage is garbage collected without calling `Close()`, making it easy to catch leaks in the future.

## Files Changed
50 files changed: 937 insertions(+), 106 deletions(-)

Key files:
- `repository.go`: Added CloseStorage helper, removed Close method
- `storage/filesystem/storage_leakcheck.go`: New leak detection implementation
- `storage/transactional/storage_leakcheck.go`: New leak detection implementation
- `CONTRIBUTING.md`: Documented storage ownership model
- `_examples/`: Updated 27 examples to demonstrate storage ownership
- `example_test.go`: Updated to use git.CloseStorage()
- Test files: Fixed leaks and replaced verbose patterns throughout

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)