### PR TITLE
Add support for negative refspecs

### DIFF
--- a/config/refspec.go
+++ b/config/refspec.go
@@ -11,6 +11,7 @@ const (
 	refSpecWildcard  = "*"
 	refSpecForce     = "+"
 	refSpecSeparator = ":"
+	refSpecNegative  = "^"
 )
 
 var (
@@ -30,8 +31,32 @@ var (
 // https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
 type RefSpec string
 
+// IsNegative returns true if the refspec is a negative refspec (starts with ^).
+func (s RefSpec) IsNegative() bool {
+	return len(s) > 0 && s[0] == refSpecNegative[0]
+}
+
+// MatchNegative reports whether n is excluded by this negative refspec.
+func (s RefSpec) MatchNegative(n plumbing.ReferenceName) bool {
+	if !s.IsNegative() {
+		return false
+	}
+	pattern := string(s[1:])
+	name := n.String()
+	prefix, suffix, isWild := strings.Cut(pattern, refSpecWildcard)
+	if !isWild {
+		return pattern == name
+	}
+	return len(name) >= len(prefix)+len(suffix) &&
+		strings.HasPrefix(name, prefix) &&
+		strings.HasSuffix(name, suffix)
+}
+
 // Validate validates the RefSpec
 func (s RefSpec) Validate() error {
+	if s.IsNegative() {
+		return nil
+	}
 	spec := string(s)
 	if strings.Count(spec, refSpecSeparator) != 1 {
 		return ErrRefSpecMalformedSeparator

--- a/config/refspec_test.go
+++ b/config/refspec_test.go
@@ -18,6 +18,27 @@ func TestRefSpecSuite(t *testing.T) {
 	suite.Run(t, new(RefSpecSuite))
 }
 
+func (s *RefSpecSuite) TestRefSpecIsNegative() {
+	s.True(RefSpec("^refs/heads/main").IsNegative())
+	s.True(RefSpec("^refs/heads/*").IsNegative())
+	s.False(RefSpec("+refs/heads/*:refs/remotes/origin/*").IsNegative())
+	s.False(RefSpec("refs/heads/*:refs/remotes/origin/*").IsNegative())
+}
+
+func (s *RefSpecSuite) TestRefSpecMatchNegative() {
+	spec := RefSpec("^refs/heads/main")
+	s.True(spec.MatchNegative(plumbing.ReferenceName("refs/heads/main")))
+	s.False(spec.MatchNegative(plumbing.ReferenceName("refs/heads/other")))
+
+	spec = RefSpec("^refs/heads/*")
+	s.True(spec.MatchNegative(plumbing.ReferenceName("refs/heads/main")))
+	s.True(spec.MatchNegative(plumbing.ReferenceName("refs/heads/feature")))
+	s.False(spec.MatchNegative(plumbing.ReferenceName("refs/tags/v1.0")))
+
+	spec = RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	s.False(spec.MatchNegative(plumbing.ReferenceName("refs/heads/main")))
+}
+
 func (s *RefSpecSuite) TestRefSpecIsValid() {
 	spec := RefSpec("+refs/heads/*:refs/remotes/origin/*")
 	s.NoError(spec.Validate())
@@ -48,6 +69,12 @@ func (s *RefSpecSuite) TestRefSpecIsValid() {
 
 	spec = RefSpec("12039e008f9a4e3394f3f94f8ea897785cb09448:refs/heads/*")
 	s.ErrorIs(spec.Validate(), ErrRefSpecMalformedWildcard)
+
+	spec = RefSpec("^refs/heads/some-excluded-branch")
+	s.NoError(spec.Validate())
+
+	spec = RefSpec("^refs/heads/*")
+	s.NoError(spec.Validate())
 }
 
 func (s *RefSpecSuite) TestRefSpecIsForceUpdate() {

--- a/remote.go
+++ b/remote.go
@@ -411,6 +411,9 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 
 	isWildcard := true
 	for _, s := range o.RefSpecs {
+		if s.IsNegative() {
+			continue
+		}
 		if !s.IsWildcard() {
 			isWildcard = false
 			break
@@ -552,6 +555,9 @@ func newClient(rawURL string, opts []client.Option) (*client.Client, *transport.
 func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer) (bool, error) {
 	var updatedPrune bool
 	for _, spec := range specs {
+		if spec.IsNegative() {
+			continue
+		}
 		rev := spec.Reverse()
 		for _, ref := range localRefs {
 			if !rev.Match(ref.Name()) {
@@ -908,14 +914,49 @@ func calculateRefs(
 		spec = append(spec, refspecAllTags)
 	}
 
+	var negSpecs []config.RefSpec
 	refs := make(memory.ReferenceStorage)
 	// list of references matched for each spec
 	specToRefs := make([][]*plumbing.Reference, len(spec))
 	for i := range spec {
+		if spec[i].IsNegative() {
+			negSpecs = append(negSpecs, spec[i])
+			continue
+		}
 		var err error
 		specToRefs[i], err = doCalculateRefs(spec[i], remoteRefs, refs)
 		if err != nil {
 			return nil, nil, err
+		}
+	}
+
+	if len(negSpecs) > 0 {
+		for i, refList := range specToRefs {
+			if spec[i].IsNegative() {
+				continue
+			}
+			filtered := refList[:0]
+			for _, ref := range refList {
+				excluded := false
+				for _, neg := range negSpecs {
+					if neg.MatchNegative(ref.Name()) {
+						excluded = true
+						break
+					}
+				}
+				if !excluded {
+					filtered = append(filtered, ref)
+				}
+			}
+			specToRefs[i] = filtered
+		}
+		for name, ref := range refs {
+			for _, neg := range negSpecs {
+				if neg.MatchNegative(ref.Name()) {
+					delete(refs, name)
+					break
+				}
+			}
 		}
 	}
 
@@ -1125,6 +1166,9 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, sha
 func (r *Remote) isSupportedRefSpec(refs []config.RefSpec, caps *capability.List) error {
 	var containsIsExact bool
 	for _, ref := range refs {
+		if ref.IsNegative() {
+			continue
+		}
 		if ref.IsExactSHA1() {
 			containsIsExact = true
 		}
@@ -1155,6 +1199,9 @@ func (r *Remote) updateLocalReferenceStorage(
 	shallows, _ := r.s.Shallow()
 
 	for i, spec := range specs {
+		if spec.IsNegative() {
+			continue
+		}
 		if !spec.IsWildcard() {
 			isWildcard = false
 		}

--- a/remote_test.go
+++ b/remote_test.go
@@ -66,7 +66,7 @@ func (s *RemoteSuite) TestFetchOverriddenEndpoint() {
 
 func (s *RemoteSuite) TestFetchInvalidFetchOptions() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
-	invalid := config.RefSpec("^*$ñ")
+	invalid := config.RefSpec("*$ñ")
 	err := r.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{invalid}})
 	s.ErrorIs(err, config.ErrRefSpecMalformedSeparator)
 }
@@ -1314,7 +1314,7 @@ func (s *RemoteSuite) TestPushInvalidSchemaEndpoint() {
 
 func (s *RemoteSuite) TestPushInvalidFetchOptions() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
-	invalid := config.RefSpec("^*$ñ")
+	invalid := config.RefSpec("*$ñ")
 	err := r.Push(&PushOptions{RefSpecs: []config.RefSpec{invalid}})
 	s.ErrorIs(err, config.ErrRefSpecMalformedSeparator)
 }
@@ -1325,7 +1325,7 @@ func (s *RemoteSuite) TestPushInvalidRefSpec() {
 		URLs: []string{"some-url"},
 	})
 
-	rs := config.RefSpec("^*$**")
+	rs := config.RefSpec("*$**")
 	err := r.Push(&PushOptions{
 		RefSpecs: []config.RefSpec{rs},
 	})


### PR DESCRIPTION
Adds support for negative refspecs, which use the `^` prefix to exclude certain refs from fetch operations. Go-git wasn't handling these, so opening repos with them in the config would fail. Added IsNegative() and MatchNegative() methods to detect and match them properly, plus skipped validation for negative specs.