### PR TITLE
Fix gitignore negated character classes

### DIFF
--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -61,8 +61,53 @@ func ParsePattern(p string, domain []string) Pattern {
 		res.isGlob = true
 	}
 
-	res.pattern = strings.Split(p, patternDirSep)
+	res.pattern = strings.Split(normalizeGitPattern(p), patternDirSep)
 	return &res
+}
+
+func normalizeGitPattern(p string) string {
+	if !strings.Contains(p, "[!") {
+		return p
+	}
+
+	var b strings.Builder
+	b.Grow(len(p))
+	inClass := false
+	for i := 0; i < len(p); i++ {
+		c := p[i]
+		if c == '\\' && i+1 < len(p) {
+			b.WriteByte(c)
+			i++
+			b.WriteByte(p[i])
+			continue
+		}
+		if !inClass && c == '[' {
+			if i+1 < len(p) && p[i+1] == '!' && hasClosingBracket(p[i+2:]) {
+				b.WriteString("[^")
+				inClass = true
+				i++
+				continue
+			}
+			inClass = hasClosingBracket(p[i+1:])
+		} else if inClass && c == ']' {
+			inClass = false
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+func hasClosingBracket(p string) bool {
+	for i := 0; i < len(p); i++ {
+		if p[i] == '\\' && i+1 < len(p) {
+			i++
+			continue
+		}
+		if p[i] == ']' {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *pattern) Match(path []string, isDir bool) MatchResult {

--- a/plumbing/format/gitignore/pattern_test.go
+++ b/plumbing/format/gitignore/pattern_test.go
@@ -15,6 +15,44 @@ func TestPatternSuite(t *testing.T) {
 	suite.Run(t, new(PatternSuite))
 }
 
+func (s *PatternSuite) TestNormalizeGitPattern() {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "negated character class",
+			in:   "[!0-9].dat",
+			want: "[^0-9].dat",
+		},
+		{
+			name: "negated character class in glob",
+			in:   "head/[!0-9].dat",
+			want: "head/[^0-9].dat",
+		},
+		{
+			name: "escaped class opener",
+			in:   `\[!0-9].dat`,
+			want: `\[!0-9].dat`,
+		},
+		{
+			name: "unclosed class",
+			in:   "[!0-9.dat",
+			want: "[!0-9.dat",
+		},
+		{
+			name: "literal opener inside character class",
+			in:   "[[!]]",
+			want: "[[!]]",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Equal(tt.want, normalizeGitPattern(tt.in), tt.name)
+	}
+}
+
 func (s *PatternSuite) TestSimpleMatch_inclusion() {
 	p := ParsePattern("!vul?ano", nil)
 	r := p.Match([]string{"value", "vulkano", "tail"}, false)
@@ -121,6 +159,13 @@ func (s *PatternSuite) TestSimpleMatch_magicChars() {
 	p := ParsePattern("v[ou]l[kc]ano", nil)
 	r := p.Match([]string{"value", "volcano"}, false)
 	s.Equal(Exclude, r)
+}
+
+func (s *PatternSuite) TestSimpleMatch_negatedCharacterClass() {
+	p := ParsePattern("[!0-9].dat", nil)
+
+	s.Equal(Exclude, p.Match([]string{"x.dat"}, false))
+	s.Equal(NoMatch, p.Match([]string{"7.dat"}, false))
 }
 
 func (s *PatternSuite) TestSimpleMatch_wrongPattern_mismatch() {
@@ -271,6 +316,13 @@ func (s *PatternSuite) TestGlobMatch_magicChars() {
 	p := ParsePattern("**/head/v[ou]l[kc]ano", nil)
 	r := p.Match([]string{"value", "head", "volcano"}, false)
 	s.Equal(Exclude, r)
+}
+
+func (s *PatternSuite) TestGlobMatch_negatedCharacterClass() {
+	p := ParsePattern("head/[!0-9].dat", nil)
+
+	s.Equal(Exclude, p.Match([]string{"head", "x.dat"}, false))
+	s.Equal(NoMatch, p.Match([]string{"head", "7.dat"}, false))
 }
 
 func (s *PatternSuite) TestGlobMatch_wrongPattern_noTraversal_mismatch() {


### PR DESCRIPTION
Fixes #2006.

## Summary
- normalize gitignore `[!...]` character classes before matching with Go's `filepath.Match`
- avoid rewriting escaped, unclosed, or already-nested `[!` sequences
- add regression coverage for basename and slash-containing gitignore patterns

## Tests
- `go test ./plumbing/format/gitignore`