### PR TITLE
config: accept negative refspecs in RefSpec.Validate

### DIFF
--- a/config/refspec.go
+++ b/config/refspec.go
@@ -10,6 +10,7 @@ import (
 const (
 	refSpecWildcard  = "*"
 	refSpecForce     = "+"
+	refSpecNegative  = "^"
 	refSpecSeparator = ":"
 )
 
@@ -32,6 +33,13 @@ type RefSpec string
 
 // Validate validates the RefSpec
 func (s RefSpec) Validate() error {
+	// Negative refspecs ("^<pattern>") exclude matching refs from fetch/push
+	// and have no destination, so the usual "<src>:<dst>" shape does not apply.
+	// See git-fetch(1).
+	if s.IsNegative() {
+		return nil
+	}
+
 	spec := string(s)
 	if strings.Count(spec, refSpecSeparator) != 1 {
 		return ErrRefSpecMalformedSeparator
@@ -61,6 +69,12 @@ func (s RefSpec) IsDelete() bool {
 	return s[0] == refSpecSeparator[0]
 }
 
+// IsNegative returns true if the refspec excludes (rather than includes) matching
+// refs. Negative refspecs have the form "^<pattern>" and carry no destination.
+func (s RefSpec) IsNegative() bool {
+	return len(s) > 0 && s[0] == refSpecNegative[0]
+}
+
 // IsExactSHA1 returns true if the source is a SHA1 hash.
 func (s RefSpec) IsExactSHA1() bool {
 	return plumbing.IsHash(s.Src())
@@ -69,6 +83,12 @@ func (s RefSpec) IsExactSHA1() bool {
 // Src returns the src side.
 func (s RefSpec) Src() string {
 	spec := string(s)
+
+	// Negative refspecs ("^<pattern>") have no destination — the rest after the
+	// leading ^ is the exclusion pattern.
+	if s.IsNegative() {
+		return spec[1:]
+	}
 
 	var start int
 	if s.IsForceUpdate() {
@@ -117,6 +137,11 @@ func (s RefSpec) matchGlob(n plumbing.ReferenceName) bool {
 
 // Dst returns the destination for the given remote reference.
 func (s RefSpec) Dst(n plumbing.ReferenceName) plumbing.ReferenceName {
+	// Negative refspecs only exclude refs; they have no destination.
+	if s.IsNegative() {
+		return ""
+	}
+
 	spec := string(s)
 	start := strings.Index(spec, refSpecSeparator) + 1
 	dst := spec[start:]

--- a/config/refspec_test.go
+++ b/config/refspec_test.go
@@ -198,3 +198,53 @@ func (s *RefSpecSuite) TestMatchAny() {
 	s.True(MatchAny(specs, plumbing.ReferenceName("refs/heads/bar")))
 	s.False(MatchAny(specs, plumbing.ReferenceName("refs/heads/master")))
 }
+
+func (s *RefSpecSuite) TestRefSpecIsNegative() {
+	spec := RefSpec("^refs/heads/excluded")
+	s.True(spec.IsNegative())
+
+	spec = RefSpec("^refs/heads/*")
+	s.True(spec.IsNegative())
+
+	spec = RefSpec("refs/heads/*:refs/remotes/origin/*")
+	s.False(spec.IsNegative())
+
+	spec = RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	s.False(spec.IsNegative())
+
+	spec = RefSpec(":refs/heads/master")
+	s.False(spec.IsNegative())
+
+	spec = RefSpec("")
+	s.False(spec.IsNegative())
+}
+
+func (s *RefSpecSuite) TestRefSpecNegativeIsValid() {
+	// Negative refspecs carry no destination, so the "<src>:<dst>" checks
+	// must not apply to them.
+	spec := RefSpec("^refs/heads/some-excluded-branch")
+	s.NoError(spec.Validate())
+
+	spec = RefSpec("^refs/heads/*")
+	s.NoError(spec.Validate())
+
+	// Sanity: a malformed non-negative refspec still fails as before.
+	spec = RefSpec("refs/heads/*")
+	s.ErrorIs(spec.Validate(), ErrRefSpecMalformedSeparator)
+}
+
+func (s *RefSpecSuite) TestRefSpecNegativeAccessors() {
+	spec := RefSpec("^refs/heads/excluded")
+	s.Equal("refs/heads/excluded", spec.Src())
+	s.Equal("", spec.Dst(plumbing.ReferenceName("refs/heads/anything")).String())
+
+	spec = RefSpec("^refs/heads/*")
+	s.Equal("refs/heads/*", spec.Src())
+	s.Equal("", spec.Dst(plumbing.ReferenceName("refs/heads/foo")).String())
+
+	// Negative refspecs are not force updates, not deletes, and not SHA1 refs.
+	spec = RefSpec("^refs/heads/excluded")
+	s.False(spec.IsForceUpdate())
+	s.False(spec.IsDelete())
+	s.False(spec.IsExactSHA1())
+}


### PR DESCRIPTION
## What

Teaches `RefSpec.Validate` about negative refspecs (`^<pattern>`) so that repositories with exclusion rules in their fetch config can be opened without `malformed refspec, separators are wrong`. Refs #1927.

## Why

Git's refspec grammar has three shapes:

| Shape | Example |
|---|---|
| positive | `refs/heads/main:refs/remotes/origin/main` |
| force | `+refs/heads/*:refs/remotes/origin/*` |
| **negative** | `^refs/heads/some-excluded-branch` |

Only the first two have a destination, so `Validate()` insists on exactly one `:` separator. That means a repo with a perfectly normal exclusion config like

```ini
[remote "origin"]
    fetch = +refs/heads/*:refs/remotes/origin/*
    fetch = ^refs/heads/some-excluded-branch
    fetch = ^refs/heads/another-excluded-branch
```

fails on `git.PlainOpen`. This is the bug described in #1927.

## What changed

1. `refSpecNegative = "^"` constant + `RefSpec.IsNegative()` predicate.
2. `Validate()` short-circuits with `nil` for negative refspecs — they're valid by construction, no separator checks apply.
3. `Src()` strips the leading `^` so callers get the pattern in the same shape wildcard/exact refspecs produce.
4. `Dst()` returns an empty `ReferenceName` for negative refspecs (they have no destination).
5. Test coverage for `IsNegative`, `Validate`, `Src`/`Dst`, and negative-spec interaction with the existing `IsForceUpdate` / `IsDelete` / `IsExactSHA1` predicates.

I deliberately stopped here rather than also touching `Match` or the `remote.Fetch` plumbing — the issue describes that as a separate step, and I'd rather keep this PR tight so it can land first. Happy to follow up with step 2 once this is in.

## Before / after

```go
// Before
RefSpec("^refs/heads/excluded").Validate()
// → ErrRefSpecMalformedSeparator

// After
RefSpec("^refs/heads/excluded").Validate() // → nil
RefSpec("^refs/heads/*").IsNegative()      // → true
RefSpec("^refs/heads/*").Src()              // → "refs/heads/*"
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l config/refspec.go config/refspec_test.go` — clean
- [x] `go test -race ./config/...` — all pass
- [x] `go test -race -short ./...` — all pass (the SSH-transport suite wants `SSH_KNOWN_HOSTS` set locally; passes with it and CI sets it up per-platform)
- [x] `golangci-lint run ./...` — 0 issues