### PR TITLE
utils: sync, Make zlib compression pluggable via x/plugin

### DIFF
--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -104,7 +104,7 @@ func (klauspostProvider) NewReader(r io.Reader) (plugin.ZlibReader, error) {
     }
     zlr, ok := zr.(plugin.ZlibReader)
     if !ok {
-        return nil, fmt.Errorf("klauspost reader %T does not implement Resetter", zr)
+        return nil, fmt.Errorf("klauspost reader %T does not implement plugin.ZlibReader", zr)
     }
     return zlr, nil
 }
@@ -114,9 +114,12 @@ func (klauspostProvider) NewWriter(w io.Writer) plugin.ZlibWriter {
 }
 
 func init() {
-    plugin.Register(plugin.Zlib(), func() plugin.ZlibProvider {
+    err := plugin.Register(plugin.Zlib(), func() plugin.ZlibProvider {
         return klauspostProvider{}
     })
+    if err != nil {
+        panic(err)
+    }
 }
 ```
 

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -85,7 +85,10 @@ Install a provider during program init, before any `go-git` operation runs:
 
 ```go
 import (
+    "io"
+
     kpzlib "github.com/klauspost/compress/zlib"
+
     gogitsync "github.com/go-git/go-git/v6/utils/sync"
 )
 

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -77,6 +77,41 @@ The default hash functions can be changed by calling `hash.RegisterHash`.
 
 New `SHA1` or `SHA256` hash functions that implement the `hash.RegisterHash` interface can be registered by calling `RegisterHash`.
 
+## Compression
+
+`go-git` uses zlib compression for loose objects and packfile entries. By default it uses the Go standard library's `compress/zlib`. The implementation is pluggable via the [`utils/sync.ZlibProvider`](utils/sync/zlib.go) interface, which lets you swap in a drop-in alternative — for example [`github.com/klauspost/compress/zlib`](https://github.com/klauspost/compress) — without `go-git` taking a direct dependency on it.
+
+Install a provider during program init, before any `go-git` operation runs:
+
+```go
+import (
+    kpzlib "github.com/klauspost/compress/zlib"
+    gogitsync "github.com/go-git/go-git/v6/utils/sync"
+)
+
+type klauspostProvider struct{}
+
+func (klauspostProvider) NewReader(r io.Reader) (gogitsync.ZlibReader, error) {
+    zr, err := kpzlib.NewReader(r)
+    if err != nil {
+        return nil, err
+    }
+    return zr.(gogitsync.ZlibReader), nil
+}
+
+func (klauspostProvider) NewWriter(w io.Writer) gogitsync.ZlibWriter {
+    return kpzlib.NewWriter(w)
+}
+
+func init() {
+    gogitsync.SetZlibProvider(klauspostProvider{})
+}
+```
+
+`SetZlibProvider` returns the previously installed provider, which is useful for save-and-restore patterns in tests. Installing a provider after `go-git` has begun compressing or decompressing data is undefined — see the `SetZlibProvider` godoc for the full contract.
+
+> **Breaking change in v6.** `utils/sync.GetZlibWriter` now returns `sync.ZlibWriter` (an interface) instead of `*zlib.Writer`, and `PutZlibWriter` accepts the same interface. Callers that previously relied on the concrete `*zlib.Writer` return type will need to update to the interface, whose method set is `Write`, `Close`, `Reset(io.Writer)`, and `Flush`.
+
 ## Plugin System (Experimental)
 
 > **Note:** The plugin system is experimental and its API may change in future releases.

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -81,8 +81,6 @@ New `SHA1` or `SHA256` hash functions that implement the `hash.RegisterHash` int
 
 `go-git` uses zlib compression for loose objects and packfile entries. By default it uses the Go standard library's `compress/zlib`, registered at init time as the [`plugin.Zlib()`](x/plugin/plugin_zlib.go) provider. Register an alternative `plugin.ZlibProvider` — for example [`github.com/klauspost/compress/zlib`](https://github.com/klauspost/compress) — to swap the implementation without `go-git` taking a direct dependency on it.
 
-> **Breaking change in v6.** `utils/sync.GetZlibWriter` now returns `sync.ZlibWriter` (an interface aliased to `plugin.ZlibWriter`) instead of `*zlib.Writer`, and `PutZlibWriter` accepts the same interface. Callers that previously relied on the concrete `*zlib.Writer` return type will need to update to the interface, whose method set is `Write`, `Close`, `Reset(io.Writer)`, and `Flush`.
-
 Register a provider during program init, before any `go-git` operation runs. Registration uses the [plugin system](#plugin-system-experimental) so it follows the same freeze-on-first-use lifecycle as other plugins:
 
 ```go

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -81,10 +81,13 @@ New `SHA1` or `SHA256` hash functions that implement the `hash.RegisterHash` int
 
 `go-git` uses zlib compression for loose objects and packfile entries. By default it uses the Go standard library's `compress/zlib`. The implementation is pluggable via the [`utils/sync.ZlibProvider`](utils/sync/zlib.go) interface, which lets you swap in a drop-in alternative — for example [`github.com/klauspost/compress/zlib`](https://github.com/klauspost/compress) — without `go-git` taking a direct dependency on it.
 
+> **Breaking change in v6.** `utils/sync.GetZlibWriter` now returns `sync.ZlibWriter` (an interface) instead of `*zlib.Writer`, and `PutZlibWriter` accepts the same interface. Callers that previously relied on the concrete `*zlib.Writer` return type will need to update to the interface, whose method set is `Write`, `Close`, `Reset(io.Writer)`, and `Flush`.
+
 Install a provider during program init, before any `go-git` operation runs:
 
 ```go
 import (
+    "fmt"
     "io"
 
     kpzlib "github.com/klauspost/compress/zlib"
@@ -99,7 +102,11 @@ func (klauspostProvider) NewReader(r io.Reader) (gogitsync.ZlibReader, error) {
     if err != nil {
         return nil, err
     }
-    return zr.(gogitsync.ZlibReader), nil
+    zlr, ok := zr.(gogitsync.ZlibReader)
+    if !ok {
+        return nil, fmt.Errorf("klauspost reader %T does not implement Resetter", zr)
+    }
+    return zlr, nil
 }
 
 func (klauspostProvider) NewWriter(w io.Writer) gogitsync.ZlibWriter {
@@ -112,8 +119,6 @@ func init() {
 ```
 
 `SetZlibProvider` returns the previously installed provider, which is useful for save-and-restore patterns in tests. Installing a provider after `go-git` has begun compressing or decompressing data is undefined — see the `SetZlibProvider` godoc for the full contract.
-
-> **Breaking change in v6.** `utils/sync.GetZlibWriter` now returns `sync.ZlibWriter` (an interface) instead of `*zlib.Writer`, and `PutZlibWriter` accepts the same interface. Callers that previously relied on the concrete `*zlib.Writer` return type will need to update to the interface, whose method set is `Write`, `Close`, `Reset(io.Writer)`, and `Flush`.
 
 ## Plugin System (Experimental)
 

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -79,11 +79,11 @@ New `SHA1` or `SHA256` hash functions that implement the `hash.RegisterHash` int
 
 ## Compression
 
-`go-git` uses zlib compression for loose objects and packfile entries. By default it uses the Go standard library's `compress/zlib`. The implementation is pluggable via the [`utils/sync.ZlibProvider`](utils/sync/zlib.go) interface, which lets you swap in a drop-in alternative — for example [`github.com/klauspost/compress/zlib`](https://github.com/klauspost/compress) — without `go-git` taking a direct dependency on it.
+`go-git` uses zlib compression for loose objects and packfile entries. By default it uses the Go standard library's `compress/zlib`, registered at init time as the [`plugin.Zlib()`](x/plugin/plugin_zlib.go) provider. Register an alternative `plugin.ZlibProvider` — for example [`github.com/klauspost/compress/zlib`](https://github.com/klauspost/compress) — to swap the implementation without `go-git` taking a direct dependency on it.
 
-> **Breaking change in v6.** `utils/sync.GetZlibWriter` now returns `sync.ZlibWriter` (an interface) instead of `*zlib.Writer`, and `PutZlibWriter` accepts the same interface. Callers that previously relied on the concrete `*zlib.Writer` return type will need to update to the interface, whose method set is `Write`, `Close`, `Reset(io.Writer)`, and `Flush`.
+> **Breaking change in v6.** `utils/sync.GetZlibWriter` now returns `sync.ZlibWriter` (an interface aliased to `plugin.ZlibWriter`) instead of `*zlib.Writer`, and `PutZlibWriter` accepts the same interface. Callers that previously relied on the concrete `*zlib.Writer` return type will need to update to the interface, whose method set is `Write`, `Close`, `Reset(io.Writer)`, and `Flush`.
 
-Install a provider during program init, before any `go-git` operation runs:
+Register a provider during program init, before any `go-git` operation runs. Registration uses the [plugin system](#plugin-system-experimental) so it follows the same freeze-on-first-use lifecycle as other plugins:
 
 ```go
 import (
@@ -92,33 +92,35 @@ import (
 
     kpzlib "github.com/klauspost/compress/zlib"
 
-    gogitsync "github.com/go-git/go-git/v6/utils/sync"
+    "github.com/go-git/go-git/v6/x/plugin"
 )
 
 type klauspostProvider struct{}
 
-func (klauspostProvider) NewReader(r io.Reader) (gogitsync.ZlibReader, error) {
+func (klauspostProvider) NewReader(r io.Reader) (plugin.ZlibReader, error) {
     zr, err := kpzlib.NewReader(r)
     if err != nil {
         return nil, err
     }
-    zlr, ok := zr.(gogitsync.ZlibReader)
+    zlr, ok := zr.(plugin.ZlibReader)
     if !ok {
         return nil, fmt.Errorf("klauspost reader %T does not implement Resetter", zr)
     }
     return zlr, nil
 }
 
-func (klauspostProvider) NewWriter(w io.Writer) gogitsync.ZlibWriter {
+func (klauspostProvider) NewWriter(w io.Writer) plugin.ZlibWriter {
     return kpzlib.NewWriter(w)
 }
 
 func init() {
-    gogitsync.SetZlibProvider(klauspostProvider{})
+    plugin.Register(plugin.Zlib(), func() plugin.ZlibProvider {
+        return klauspostProvider{}
+    })
 }
 ```
 
-`SetZlibProvider` returns the previously installed provider, which is useful for save-and-restore patterns in tests. Installing a provider after `go-git` has begun compressing or decompressing data is undefined — see the `SetZlibProvider` godoc for the full contract.
+Registering after `go-git` has already resolved the zlib provider (on the first pool miss or `sync.NewZlibWriter` call) returns `plugin.ErrFrozen` and the existing provider stays in effect.
 
 ## Plugin System (Experimental)
 

--- a/plumbing/format/objfile/writer.go
+++ b/plumbing/format/objfile/writer.go
@@ -1,7 +1,6 @@
 package objfile
 
 import (
-	"compress/zlib"
 	"errors"
 	"io"
 	"strconv"
@@ -21,7 +20,7 @@ type Writer struct {
 	raw    io.Writer
 	hasher plumbing.Hasher
 	multi  io.Writer
-	zlib   *zlib.Writer
+	zlib   sync.ZlibWriter
 
 	closed  bool
 	pending int64 // number of unwritten bytes

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -48,7 +48,7 @@ func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool) *E
 
 	mw := io.MultiWriter(w, h)
 	ow := newOffsetWriter(mw)
-	zw := sync.NewZlibWriter(mw)
+	zw := sync.GetZlibWriter(mw)
 	return &Encoder{
 		selector:     newDeltaSelector(s),
 		w:            ow,

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -1,7 +1,6 @@
 package packfile
 
 import (
-	"compress/zlib"
 	"crypto"
 	"errors"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/utils/binary"
 	"github.com/go-git/go-git/v6/utils/ioutil"
+	"github.com/go-git/go-git/v6/utils/sync"
 )
 
 // Encoder gets the data from the storage and write it into the writer in PACK
@@ -21,7 +21,7 @@ import (
 type Encoder struct {
 	selector *deltaSelector
 	w        *offsetWriter
-	zw       *zlib.Writer
+	zw       sync.ZlibWriter
 	hasher   hash.Hash
 
 	useRefDeltas bool
@@ -48,7 +48,7 @@ func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool) *E
 
 	mw := io.MultiWriter(w, h)
 	ow := newOffsetWriter(mw)
-	zw := zlib.NewWriter(mw)
+	zw := sync.NewZlibWriter(mw)
 	return &Encoder{
 		selector:     newDeltaSelector(s),
 		w:            ow,

--- a/utils/sync/reset_zlib_test.go
+++ b/utils/sync/reset_zlib_test.go
@@ -1,0 +1,33 @@
+package sync
+
+import (
+	"sync"
+
+	_ "unsafe"
+
+	"github.com/go-git/go-git/v6/x/plugin"
+)
+
+//go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
+func resetPluginEntry(name plugin.Name)
+
+// ResetZlibForTest unfreezes the zlib plugin entry, reseeds the
+// provider-resolution cache, and replaces the reader and writer pools
+// so previously-pooled instances (built against the old provider) are
+// dropped. Tests call this before installing a custom provider and
+// during t.Cleanup so later tests see a fresh state.
+//
+// This function lives in a _test.go file and is only accessible to
+// test binaries; production builds never see it.
+func ResetZlibForTest() {
+	resetPluginEntry("zlib")
+	resolvedProvider = sync.OnceValue(func() plugin.ZlibProvider {
+		p, err := plugin.Get(plugin.Zlib())
+		if err != nil {
+			panic("utils/sync: no zlib provider registered in x/plugin: " + err.Error())
+		}
+		return p
+	})
+	zlibReader = sync.Pool{New: newPooledZlibReader}
+	zlibWriter = sync.Pool{New: newPooledZlibWriter}
+}

--- a/utils/sync/reset_zlib_test.go
+++ b/utils/sync/reset_zlib_test.go
@@ -11,23 +11,12 @@ import (
 //go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
 func resetPluginEntry(name plugin.Name)
 
-// ResetZlibForTest unfreezes the zlib plugin entry, reseeds the
-// provider-resolution cache, and replaces the reader and writer pools
-// so previously-pooled instances (built against the old provider) are
-// dropped. Tests call this before installing a custom provider and
-// during t.Cleanup so later tests see a fresh state.
-//
-// This function lives in a _test.go file and is only accessible to
-// test binaries; production builds never see it.
+// ResetZlibForTest resets the zlib plugin registration and local cached
+// provider/pools so tests can control initialization deterministically.
 func ResetZlibForTest() {
 	resetPluginEntry("zlib")
-	resolvedProvider = sync.OnceValue(func() plugin.ZlibProvider {
-		p, err := plugin.Get(plugin.Zlib())
-		if err != nil {
-			panic("utils/sync: no zlib provider registered in x/plugin: " + err.Error())
-		}
-		return p
-	})
+	zlibProviderOnce = sync.Once{}
+	zlibProvider = nil
 	zlibReader = sync.Pool{New: newPooledZlibReader}
 	zlibWriter = sync.Pool{New: newPooledZlibWriter}
 }

--- a/utils/sync/zlib.go
+++ b/utils/sync/zlib.go
@@ -2,153 +2,50 @@ package sync
 
 import (
 	"bytes"
-	"compress/zlib"
-	"fmt"
 	"io"
 	"sync"
-	"sync/atomic"
+
+	"github.com/go-git/go-git/v6/x/plugin"
 )
+
+// ZlibReader is an alias of plugin.ZlibReader.
+type ZlibReader = plugin.ZlibReader
+
+// ZlibWriter is an alias of plugin.ZlibWriter.
+type ZlibWriter = plugin.ZlibWriter
 
 var (
 	zlibInitBytes = []byte{0x78, 0x9c, 0x01, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01}
 
-	zlibProvider atomic.Pointer[ZlibProvider]
+	resolvedProvider = sync.OnceValue(func() plugin.ZlibProvider {
+		p, err := plugin.Get(plugin.Zlib())
+		if err != nil {
+			// Unreachable in normal builds: x/plugin registers a
+			// stdlib default in init.
+			panic("utils/sync: no zlib provider registered in x/plugin: " + err.Error())
+		}
+		return p
+	})
 
-	zlibReader = sync.Pool{
-		New: func() any {
-			r, err := activeZlibProvider().NewReader(bytes.NewReader(zlibInitBytes))
-			if err != nil {
-				// Unreachable for any conforming zlib implementation:
-				// zlibInitBytes is a minimal valid zlib stream used to
-				// seed the pool. A provider returning an error here is
-				// non-compliant; fail loudly rather than stash a nil
-				// reader that would panic with no context on first use.
-				panic("utils/sync: zlib provider failed to initialize pooled reader: " + err.Error())
-			}
-			return &ZLibReader{
-				reader: r,
-				dict:   nil,
-			}
-		},
-	}
-	zlibWriter = sync.Pool{
-		New: func() any {
-			return activeZlibProvider().NewWriter(nil)
-		},
-	}
+	zlibReader = sync.Pool{New: newPooledZlibReader}
+	zlibWriter = sync.Pool{New: newPooledZlibWriter}
 )
 
-func init() {
-	var p ZlibProvider = StdlibZlibProvider{}
-	zlibProvider.Store(&p)
-}
-
-// ZlibReader is the method set required of a zlib decompression reader.
-// It matches the value returned by compress/zlib.NewReader, which
-// implements both io.ReadCloser and zlib.Resetter.
-//
-// Implementations must support Reset being called on a reader after
-// Close so that pooled readers can be re-seeded with a new source and
-// dictionary, matching zlib.Resetter semantics. Reset runs once per
-// packfile object during scan, so it should be O(1) and avoid
-// reallocating decompressor state.
-type ZlibReader interface {
-	io.ReadCloser
-	Reset(r io.Reader, dict []byte) error
-}
-
-// ZlibWriter is the method set required of a zlib compression writer.
-// It matches the stdlib *zlib.Writer.
-//
-// Implementations must preserve the following behavioral contract
-// that go-git relies on:
-//
-//   - Close flushes pending data and writes the zlib stream footer,
-//     but must not close the underlying io.Writer. Both objfile and
-//     packfile keep using the wrapped writer after the ZlibWriter
-//     closes.
-//   - Reset after Close is supported: packfile.Encoder closes the
-//     writer once per object entry and then calls Reset to reuse it
-//     for the next entry within the same encode. Reset is on the
-//     per-object hot path during encode, so it should be O(1) and
-//     avoid reallocating compressor state.
-//   - Flush writes any pending compressed data to the underlying
-//     writer without ending the stream; the writer remains usable
-//     after Flush.
-type ZlibWriter interface {
-	io.WriteCloser
-	Reset(w io.Writer)
-	Flush() error
-}
-
-// ZlibProvider constructs zlib implementations. Go-git calls its
-// factory methods (often via internal sync.Pool instances) whenever it
-// needs to read or write zlib-compressed data. Install a non-default
-// provider with SetZlibProvider — for example to swap in
-// github.com/klauspost/compress/zlib without go-git taking a direct
-// dependency on it.
-//
-// Implementations must be safe for concurrent calls to NewReader and
-// NewWriter. Returned readers and writers need not be concurrency-safe
-// themselves; each caller gets its own instance.
-type ZlibProvider interface {
-	NewReader(r io.Reader) (ZlibReader, error)
-	NewWriter(w io.Writer) ZlibWriter
-}
-
-// SetZlibProvider installs p as the zlib implementation used by go-git
-// and returns the provider that was previously active. The returned
-// value is useful for save-and-restore patterns in tests.
-//
-// Call SetZlibProvider during program init, before any go-git
-// operation runs. Installing a provider after go-git has begun
-// compressing or decompressing data is undefined: existing sync.Pool
-// entries remain on the old provider until the garbage collector
-// evicts them, and callers that have already acquired a reader or
-// writer continue to use the old one.
-//
-// SetZlibProvider panics if p is nil. A typed-nil provider (a non-nil
-// interface wrapping a nil concrete value) cannot be detected here
-// and will panic on first use.
-func SetZlibProvider(p ZlibProvider) ZlibProvider {
-	if p == nil {
-		panic("utils/sync: SetZlibProvider called with nil provider")
-	}
-	prev := zlibProvider.Swap(&p)
-	if prev == nil {
-		return nil
-	}
-	return *prev
-}
-
-func activeZlibProvider() ZlibProvider {
-	return *zlibProvider.Load()
-}
-
-// StdlibZlibProvider produces readers and writers from the Go
-// standard library's compress/zlib package. It is the default
-// provider registered in init, and is exported so custom providers
-// can delegate to it (for example, to wrap stdlib with instrumentation
-// or a partial klauspost migration).
-type StdlibZlibProvider struct{}
-
-// NewReader returns a zlib decompression reader backed by
-// compress/zlib.
-func (StdlibZlibProvider) NewReader(r io.Reader) (ZlibReader, error) {
-	zr, err := zlib.NewReader(r)
+func newPooledZlibReader() any {
+	r, err := resolvedProvider().NewReader(bytes.NewReader(zlibInitBytes))
 	if err != nil {
-		return nil, err
+		// Unreachable for any conforming zlib implementation:
+		// zlibInitBytes is a minimal valid zlib stream used to seed
+		// the pool. A provider returning an error here is
+		// non-compliant; fail loudly rather than stash a nil reader
+		// that would panic with no context on first use.
+		panic("utils/sync: zlib provider failed to initialize pooled reader: " + err.Error())
 	}
-	zlr, ok := zr.(ZlibReader)
-	if !ok {
-		return nil, fmt.Errorf("utils/sync: compress/zlib reader %T does not implement zlib.Resetter", zr)
-	}
-	return zlr, nil
+	return &ZLibReader{reader: r, dict: nil}
 }
 
-// NewWriter returns a zlib compression writer backed by compress/zlib.
-func (StdlibZlibProvider) NewWriter(w io.Writer) ZlibWriter {
-	return zlib.NewWriter(w)
+func newPooledZlibWriter() any {
+	return resolvedProvider().NewWriter(nil)
 }
 
 // NewZlibWriter returns a ZlibWriter built by the active provider. The
@@ -157,7 +54,7 @@ func (StdlibZlibProvider) NewWriter(w io.Writer) ZlibWriter {
 // held per encoder across many Reset calls) where pool rental offers
 // no benefit.
 func NewZlibWriter(w io.Writer) ZlibWriter {
-	return activeZlibProvider().NewWriter(w)
+	return resolvedProvider().NewWriter(w)
 }
 
 // ZLibReader is a poolable zlib reader.

--- a/utils/sync/zlib.go
+++ b/utils/sync/zlib.go
@@ -2,10 +2,13 @@ package sync
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"sync"
 
+	"github.com/go-git/go-git/v6/utils/trace"
 	"github.com/go-git/go-git/v6/x/plugin"
+	"github.com/go-git/go-git/v6/x/plugin/zlib"
 )
 
 // ZlibReader is an alias of plugin.ZlibReader.
@@ -14,47 +17,48 @@ type ZlibReader = plugin.ZlibReader
 // ZlibWriter is an alias of plugin.ZlibWriter.
 type ZlibWriter = plugin.ZlibWriter
 
+var errNilZlibReader = errors.New("utils/sync: zlib reader source is nil")
+
 var (
 	zlibInitBytes = []byte{0x78, 0x9c, 0x01, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01}
 
-	resolvedProvider = sync.OnceValue(func() plugin.ZlibProvider {
-		p, err := plugin.Get(plugin.Zlib())
-		if err != nil {
-			// Unreachable in normal builds: x/plugin registers a
-			// stdlib default in init.
-			panic("utils/sync: no zlib provider registered in x/plugin: " + err.Error())
-		}
-		return p
-	})
+	zlibProviderOnce sync.Once
+	zlibProvider     plugin.ZlibProvider
 
 	zlibReader = sync.Pool{New: newPooledZlibReader}
 	zlibWriter = sync.Pool{New: newPooledZlibWriter}
 )
 
+func getZlibProvider() plugin.ZlibProvider {
+	zlibProviderOnce.Do(func() {
+		p, err := plugin.Get(plugin.Zlib())
+		if err != nil {
+			// This code path should be unreachable, as the zlib plugin
+			// is registered with a built-in implementation, and invalid
+			// registrations are rejected.
+			//
+			// If for some reason a plugin is not found, fallback to
+			// default implementation.
+			zlibProvider = zlib.NewStdlib()
+			trace.Internal.Print("zlib plugin not registered: fall back to built-in version")
+			return
+		}
+		zlibProvider = p
+	})
+
+	return zlibProvider
+}
+
 func newPooledZlibReader() any {
-	r, err := resolvedProvider().NewReader(bytes.NewReader(zlibInitBytes))
+	r, err := getZlibProvider().NewReader(bytes.NewReader(zlibInitBytes))
 	if err != nil {
-		// Unreachable for any conforming zlib implementation:
-		// zlibInitBytes is a minimal valid zlib stream used to seed
-		// the pool. A provider returning an error here is
-		// non-compliant; fail loudly rather than stash a nil reader
-		// that would panic with no context on first use.
-		panic("utils/sync: zlib provider failed to initialize pooled reader: " + err.Error())
+		panic("zlib provider failed to initialize pooled reader: " + err.Error())
 	}
 	return &ZLibReader{reader: r, dict: nil}
 }
 
 func newPooledZlibWriter() any {
-	return resolvedProvider().NewWriter(nil)
-}
-
-// NewZlibWriter returns a ZlibWriter built by the active provider. The
-// writer is not managed by a sync.Pool; the caller owns it for its
-// full lifetime. Use this for long-lived writers (for example, one
-// held per encoder across many Reset calls) where pool rental offers
-// no benefit.
-func NewZlibWriter(w io.Writer) ZlibWriter {
-	return resolvedProvider().NewWriter(w)
+	return getZlibProvider().NewWriter(nil)
 }
 
 // ZLibReader is a poolable zlib reader.
@@ -73,13 +77,22 @@ func (r *ZLibReader) Close() error {
 	return r.reader.Close()
 }
 
-// GetZlibReader returns a ZLibReader that is managed by a sync.Pool.
-// Returns a ZLibReader that is reset using a dictionary that is
+// Reset resets the pooled zlib reader.
+func (r *ZLibReader) Reset(in io.Reader, dict []byte) error {
+	return r.reader.Reset(in, dict)
+}
+
+// GetZlibReader returns a ZlibReader that is managed by a sync.Pool.
+// Returns a ZlibReader that is reset using a dictionary that is
 // also managed by a sync.Pool.
 //
 // After use, the ZLibReader should be put back into the sync.Pool
 // by calling PutZlibReader.
 func GetZlibReader(r io.Reader) (*ZLibReader, error) {
+	if r == nil {
+		return nil, errNilZlibReader
+	}
+
 	z := zlibReader.Get().(*ZLibReader)
 	z.dict = GetByteSlice()
 
@@ -104,6 +117,10 @@ func PutZlibReader(z *ZLibReader) {
 // After use, the writer should be put back into the sync.Pool by
 // calling PutZlibWriter.
 func GetZlibWriter(w io.Writer) ZlibWriter {
+	if w == nil {
+		w = io.Discard
+	}
+
 	z := zlibWriter.Get().(ZlibWriter)
 	z.Reset(w)
 	return z

--- a/utils/sync/zlib.go
+++ b/utils/sync/zlib.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"bytes"
 	"compress/zlib"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -38,7 +39,7 @@ var (
 )
 
 func init() {
-	var p ZlibProvider = stdlibZlibProvider{}
+	var p ZlibProvider = StdlibZlibProvider{}
 	zlibProvider.Store(&p)
 }
 
@@ -48,11 +49,11 @@ func init() {
 //
 // Implementations must support Reset being called on a reader after
 // Close so that pooled readers can be re-seeded with a new source and
-// dictionary, matching zlib.Resetter semantics.
+// dictionary, matching zlib.Resetter semantics. Reset runs once per
+// packfile object during scan, so it should be O(1) and avoid
+// reallocating decompressor state.
 type ZlibReader interface {
 	io.ReadCloser
-	// Reset swaps the source and an optional preset dictionary without
-	// reallocating, matching zlib.Resetter.
 	Reset(r io.Reader, dict []byte) error
 }
 
@@ -68,16 +69,15 @@ type ZlibReader interface {
 //     closes.
 //   - Reset after Close is supported: packfile.Encoder closes the
 //     writer once per object entry and then calls Reset to reuse it
-//     for the next entry within the same encode.
+//     for the next entry within the same encode. Reset is on the
+//     per-object hot path during encode, so it should be O(1) and
+//     avoid reallocating compressor state.
 //   - Flush writes any pending compressed data to the underlying
 //     writer without ending the stream; the writer remains usable
 //     after Flush.
 type ZlibWriter interface {
 	io.WriteCloser
-	// Reset swaps the destination writer, matching *zlib.Writer.Reset.
 	Reset(w io.Writer)
-	// Flush writes any pending compressed data to the underlying
-	// writer, matching *zlib.Writer.Flush.
 	Flush() error
 }
 
@@ -125,21 +125,29 @@ func activeZlibProvider() ZlibProvider {
 	return *zlibProvider.Load()
 }
 
-// stdlibZlibProvider produces compress/zlib readers and writers and is
-// the default provider registered in init.
-type stdlibZlibProvider struct{}
+// StdlibZlibProvider produces readers and writers from the Go
+// standard library's compress/zlib package. It is the default
+// provider registered in init, and is exported so custom providers
+// can delegate to it (for example, to wrap stdlib with instrumentation
+// or a partial klauspost migration).
+type StdlibZlibProvider struct{}
 
-func (stdlibZlibProvider) NewReader(r io.Reader) (ZlibReader, error) {
+// NewReader returns a zlib decompression reader backed by
+// compress/zlib.
+func (StdlibZlibProvider) NewReader(r io.Reader) (ZlibReader, error) {
 	zr, err := zlib.NewReader(r)
 	if err != nil {
 		return nil, err
 	}
-	// compress/zlib's reader value implements zlib.Resetter, so its
-	// concrete type satisfies ZlibReader.
-	return zr.(ZlibReader), nil
+	zlr, ok := zr.(ZlibReader)
+	if !ok {
+		return nil, fmt.Errorf("utils/sync: compress/zlib reader %T does not implement zlib.Resetter", zr)
+	}
+	return zlr, nil
 }
 
-func (stdlibZlibProvider) NewWriter(w io.Writer) ZlibWriter {
+// NewWriter returns a zlib compression writer backed by compress/zlib.
+func (StdlibZlibProvider) NewWriter(w io.Writer) ZlibWriter {
 	return zlib.NewWriter(w)
 }
 

--- a/utils/sync/zlib.go
+++ b/utils/sync/zlib.go
@@ -5,35 +5,124 @@ import (
 	"compress/zlib"
 	"io"
 	"sync"
+	"sync/atomic"
 )
 
 var (
 	zlibInitBytes = []byte{0x78, 0x9c, 0x01, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01}
-	zlibReader    = sync.Pool{
+
+	zlibProvider atomic.Pointer[ZlibProvider]
+
+	zlibReader = sync.Pool{
 		New: func() any {
-			r, _ := zlib.NewReader(bytes.NewReader(zlibInitBytes))
+			r, _ := activeZlibProvider().NewReader(bytes.NewReader(zlibInitBytes))
 			return &ZLibReader{
-				reader: r.(zlibReadCloser),
+				reader: r,
 				dict:   nil,
 			}
 		},
 	}
 	zlibWriter = sync.Pool{
 		New: func() any {
-			return zlib.NewWriter(nil)
+			return activeZlibProvider().NewWriter(nil)
 		},
 	}
 )
 
-type zlibReadCloser interface {
+func init() {
+	var p ZlibProvider = stdlibZlibProvider{}
+	zlibProvider.Store(&p)
+}
+
+// ZlibReader is the method set required of a zlib decompression reader.
+// It matches the value returned by compress/zlib.NewReader, which
+// implements both io.ReadCloser and zlib.Resetter.
+type ZlibReader interface {
 	io.ReadCloser
-	zlib.Resetter
+	// Reset swaps the source and an optional preset dictionary without
+	// reallocating, matching zlib.Resetter.
+	Reset(r io.Reader, dict []byte) error
+}
+
+// ZlibWriter is the method set required of a zlib compression writer.
+// It matches the stdlib *zlib.Writer.
+type ZlibWriter interface {
+	io.WriteCloser
+	// Reset swaps the destination writer, matching *zlib.Writer.Reset.
+	Reset(w io.Writer)
+	// Flush writes any pending compressed data to the underlying
+	// writer, matching *zlib.Writer.Flush.
+	Flush() error
+}
+
+// ZlibProvider constructs zlib implementations. Go-git calls its
+// factory methods (often via internal sync.Pool instances) whenever it
+// needs to read or write zlib-compressed data. Install a non-default
+// provider with SetZlibProvider — for example to swap in
+// github.com/klauspost/compress/zlib without go-git taking a direct
+// dependency on it.
+//
+// Implementations must be safe for concurrent calls to NewReader and
+// NewWriter. Returned readers and writers need not be concurrency-safe
+// themselves; each caller gets its own instance.
+type ZlibProvider interface {
+	NewReader(r io.Reader) (ZlibReader, error)
+	NewWriter(w io.Writer) ZlibWriter
+}
+
+// SetZlibProvider installs p as the zlib implementation used by go-git
+// and returns the provider that was previously active. The returned
+// value is useful for save-and-restore patterns in tests.
+//
+// Call SetZlibProvider during program init, before any go-git
+// operation runs. Installing a provider after go-git has begun
+// compressing or decompressing data is undefined: existing sync.Pool
+// entries remain on the old provider until the garbage collector
+// evicts them, and callers that have already acquired a reader or
+// writer continue to use the old one.
+func SetZlibProvider(p ZlibProvider) ZlibProvider {
+	prev := zlibProvider.Swap(&p)
+	if prev == nil {
+		return nil
+	}
+	return *prev
+}
+
+func activeZlibProvider() ZlibProvider {
+	return *zlibProvider.Load()
+}
+
+// stdlibZlibProvider produces compress/zlib readers and writers and is
+// the default provider registered in init.
+type stdlibZlibProvider struct{}
+
+func (stdlibZlibProvider) NewReader(r io.Reader) (ZlibReader, error) {
+	zr, err := zlib.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	// compress/zlib's reader value implements zlib.Resetter, so its
+	// concrete type satisfies ZlibReader.
+	return zr.(ZlibReader), nil
+}
+
+func (stdlibZlibProvider) NewWriter(w io.Writer) ZlibWriter {
+	return zlib.NewWriter(w)
+}
+
+// NewZlibWriter returns a ZlibWriter built by the active provider. The
+// writer is not managed by a sync.Pool; the caller owns it for its
+// full lifetime. Use this for long-lived writers (for example, one
+// held per encoder across many Reset calls) where pool rental offers
+// no benefit.
+func NewZlibWriter(w io.Writer) ZlibWriter {
+	return activeZlibProvider().NewWriter(w)
 }
 
 // ZLibReader is a poolable zlib reader.
 type ZLibReader struct {
 	dict   *[]byte
-	reader zlibReadCloser
+	reader ZlibReader
 }
 
 // Read reads data from the zlib reader.
@@ -71,19 +160,19 @@ func PutZlibReader(z *ZLibReader) {
 	zlibReader.Put(z)
 }
 
-// GetZlibWriter returns a *zlib.Writer that is managed by a sync.Pool.
+// GetZlibWriter returns a ZlibWriter that is managed by a sync.Pool.
 // Returns a writer that is reset with w and ready for use.
 //
-// After use, the *zlib.Writer should be put back into the sync.Pool
-// by calling PutZlibWriter.
-func GetZlibWriter(w io.Writer) *zlib.Writer {
-	z := zlibWriter.Get().(*zlib.Writer)
+// After use, the writer should be put back into the sync.Pool by
+// calling PutZlibWriter.
+func GetZlibWriter(w io.Writer) ZlibWriter {
+	z := zlibWriter.Get().(ZlibWriter)
 	z.Reset(w)
 	return z
 }
 
 // PutZlibWriter puts w back into its sync.Pool.
-func PutZlibWriter(w *zlib.Writer) {
+func PutZlibWriter(w ZlibWriter) {
 	if w == nil {
 		return
 	}

--- a/utils/sync/zlib.go
+++ b/utils/sync/zlib.go
@@ -15,7 +15,15 @@ var (
 
 	zlibReader = sync.Pool{
 		New: func() any {
-			r, _ := activeZlibProvider().NewReader(bytes.NewReader(zlibInitBytes))
+			r, err := activeZlibProvider().NewReader(bytes.NewReader(zlibInitBytes))
+			if err != nil {
+				// Unreachable for any conforming zlib implementation:
+				// zlibInitBytes is a minimal valid zlib stream used to
+				// seed the pool. A provider returning an error here is
+				// non-compliant; fail loudly rather than stash a nil
+				// reader that would panic with no context on first use.
+				panic("utils/sync: zlib provider failed to initialize pooled reader: " + err.Error())
+			}
 			return &ZLibReader{
 				reader: r,
 				dict:   nil,
@@ -37,6 +45,10 @@ func init() {
 // ZlibReader is the method set required of a zlib decompression reader.
 // It matches the value returned by compress/zlib.NewReader, which
 // implements both io.ReadCloser and zlib.Resetter.
+//
+// Implementations must support Reset being called on a reader after
+// Close so that pooled readers can be re-seeded with a new source and
+// dictionary, matching zlib.Resetter semantics.
 type ZlibReader interface {
 	io.ReadCloser
 	// Reset swaps the source and an optional preset dictionary without
@@ -46,6 +58,20 @@ type ZlibReader interface {
 
 // ZlibWriter is the method set required of a zlib compression writer.
 // It matches the stdlib *zlib.Writer.
+//
+// Implementations must preserve the following behavioral contract
+// that go-git relies on:
+//
+//   - Close flushes pending data and writes the zlib stream footer,
+//     but must not close the underlying io.Writer. Both objfile and
+//     packfile keep using the wrapped writer after the ZlibWriter
+//     closes.
+//   - Reset after Close is supported: packfile.Encoder closes the
+//     writer once per object entry and then calls Reset to reuse it
+//     for the next entry within the same encode.
+//   - Flush writes any pending compressed data to the underlying
+//     writer without ending the stream; the writer remains usable
+//     after Flush.
 type ZlibWriter interface {
 	io.WriteCloser
 	// Reset swaps the destination writer, matching *zlib.Writer.Reset.
@@ -80,7 +106,14 @@ type ZlibProvider interface {
 // entries remain on the old provider until the garbage collector
 // evicts them, and callers that have already acquired a reader or
 // writer continue to use the old one.
+//
+// SetZlibProvider panics if p is nil. A typed-nil provider (a non-nil
+// interface wrapping a nil concrete value) cannot be detected here
+// and will panic on first use.
 func SetZlibProvider(p ZlibProvider) ZlibProvider {
+	if p == nil {
+		panic("utils/sync: SetZlibProvider called with nil provider")
+	}
 	prev := zlibProvider.Swap(&p)
 	if prev == nil {
 		return nil

--- a/utils/sync/zlib_test.go
+++ b/utils/sync/zlib_test.go
@@ -1,0 +1,172 @@
+package sync_test
+
+import (
+	"bytes"
+	"compress/zlib"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/objfile"
+	gogitsync "github.com/go-git/go-git/v6/utils/sync"
+)
+
+// stdlibWrapper mirrors the package-internal default provider. It lets
+// test code construct a tracking provider that delegates to the stdlib
+// without coupling to unexported types.
+type stdlibWrapper struct{}
+
+func (stdlibWrapper) NewReader(r io.Reader) (gogitsync.ZlibReader, error) {
+	zr, err := zlib.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	return zr.(gogitsync.ZlibReader), nil
+}
+
+func (stdlibWrapper) NewWriter(w io.Writer) gogitsync.ZlibWriter {
+	return zlib.NewWriter(w)
+}
+
+// trackingProvider wraps another provider and counts factory calls and
+// bytes flowing through returned readers/writers.
+type trackingProvider struct {
+	inner       gogitsync.ZlibProvider
+	readerCalls atomic.Int64
+	writerCalls atomic.Int64
+	readBytes   atomic.Int64
+	writeBytes  atomic.Int64
+}
+
+func (t *trackingProvider) NewReader(r io.Reader) (gogitsync.ZlibReader, error) {
+	t.readerCalls.Add(1)
+	inner, err := t.inner.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	return &trackingReader{ZlibReader: inner, parent: t}, nil
+}
+
+func (t *trackingProvider) NewWriter(w io.Writer) gogitsync.ZlibWriter {
+	t.writerCalls.Add(1)
+	return &trackingWriter{ZlibWriter: t.inner.NewWriter(w), parent: t}
+}
+
+type trackingReader struct {
+	gogitsync.ZlibReader
+	parent *trackingProvider
+}
+
+func (r *trackingReader) Read(p []byte) (int, error) {
+	n, err := r.ZlibReader.Read(p)
+	r.parent.readBytes.Add(int64(n))
+	return n, err
+}
+
+type trackingWriter struct {
+	gogitsync.ZlibWriter
+	parent *trackingProvider
+}
+
+func (w *trackingWriter) Write(p []byte) (int, error) {
+	n, err := w.ZlibWriter.Write(p)
+	w.parent.writeBytes.Add(int64(n))
+	return n, err
+}
+
+func TestSetZlibProviderReturnsPrevious(t *testing.T) {
+	p1 := &trackingProvider{inner: stdlibWrapper{}}
+	prev := gogitsync.SetZlibProvider(p1)
+	defer gogitsync.SetZlibProvider(prev)
+	require.NotNil(t, prev, "default provider must not be nil")
+
+	p2 := &trackingProvider{inner: stdlibWrapper{}}
+	fromSwap := gogitsync.SetZlibProvider(p2)
+	assert.Same(t, p1, fromSwap)
+
+	restored := gogitsync.SetZlibProvider(prev)
+	assert.Same(t, p2, restored)
+}
+
+func TestNewZlibWriterUsesActiveProvider(t *testing.T) {
+	tracker := &trackingProvider{inner: stdlibWrapper{}}
+	prev := gogitsync.SetZlibProvider(tracker)
+	defer gogitsync.SetZlibProvider(prev)
+
+	payload := []byte("hello world")
+
+	var buf bytes.Buffer
+	w := gogitsync.NewZlibWriter(&buf)
+	_, err := w.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	assert.Equal(t, int64(1), tracker.writerCalls.Load())
+	assert.Equal(t, int64(len(payload)), tracker.writeBytes.Load())
+
+	zr, err := zlib.NewReader(&buf)
+	require.NoError(t, err)
+	got, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close())
+	assert.Equal(t, payload, got)
+}
+
+// TestObjfileRoundTripUsesActiveProvider exercises the pooled
+// GetZlibReader / GetZlibWriter paths through their intended caller
+// (objfile) and verifies a round-trip works with a custom provider
+// installed. This is the first test to touch the sync.Pool in this
+// binary, so New is guaranteed to fire through the tracker.
+func TestObjfileRoundTripUsesActiveProvider(t *testing.T) {
+	tracker := &trackingProvider{inner: stdlibWrapper{}}
+	prev := gogitsync.SetZlibProvider(tracker)
+	defer gogitsync.SetZlibProvider(prev)
+
+	payload := []byte("pluggable compression smoke test")
+
+	var buf bytes.Buffer
+	w := objfile.NewWriter(&buf)
+	require.NoError(t, w.WriteHeader(plumbing.BlobObject, int64(len(payload))))
+	n, err := w.Write(payload)
+	require.NoError(t, err)
+	assert.Equal(t, len(payload), n)
+	require.NoError(t, w.Close())
+
+	r, err := objfile.NewReader(&buf)
+	require.NoError(t, err)
+	typ, size, err := r.Header()
+	require.NoError(t, err)
+	assert.Equal(t, plumbing.BlobObject, typ)
+	assert.Equal(t, int64(len(payload)), size)
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Equal(t, payload, got)
+
+	assert.Positive(t, tracker.writerCalls.Load(), "writer factory should have been invoked via the pool")
+	assert.Positive(t, tracker.readerCalls.Load(), "reader factory should have been invoked via the pool")
+	assert.Positive(t, tracker.writeBytes.Load(), "bytes should have flowed through the tracker writer")
+	assert.Positive(t, tracker.readBytes.Load(), "bytes should have flowed through the tracker reader")
+}
+
+func TestDefaultProviderRoundTripWithStdlib(t *testing.T) {
+	payload := []byte("default provider check")
+
+	var buf bytes.Buffer
+	w := gogitsync.NewZlibWriter(&buf)
+	_, err := w.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	zr, err := zlib.NewReader(&buf)
+	require.NoError(t, err)
+	got, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	require.NoError(t, zr.Close())
+	assert.Equal(t, payload, got)
+}

--- a/utils/sync/zlib_test.go
+++ b/utils/sync/zlib_test.go
@@ -15,23 +15,6 @@ import (
 	gogitsync "github.com/go-git/go-git/v6/utils/sync"
 )
 
-// stdlibWrapper mirrors the package-internal default provider. It lets
-// test code construct a tracking provider that delegates to the stdlib
-// without coupling to unexported types.
-type stdlibWrapper struct{}
-
-func (stdlibWrapper) NewReader(r io.Reader) (gogitsync.ZlibReader, error) {
-	zr, err := zlib.NewReader(r)
-	if err != nil {
-		return nil, err
-	}
-	return zr.(gogitsync.ZlibReader), nil
-}
-
-func (stdlibWrapper) NewWriter(w io.Writer) gogitsync.ZlibWriter {
-	return zlib.NewWriter(w)
-}
-
 // trackingProvider wraps another provider and counts factory calls and
 // bytes flowing through returned readers/writers.
 type trackingProvider struct {
@@ -78,13 +61,13 @@ func (w *trackingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func TestSetZlibProviderReturnsPrevious(t *testing.T) {
-	p1 := &trackingProvider{inner: stdlibWrapper{}}
+func TestSetZlibProviderReturnsPrevious(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
+	p1 := &trackingProvider{inner: gogitsync.StdlibZlibProvider{}}
 	prev := gogitsync.SetZlibProvider(p1)
 	defer gogitsync.SetZlibProvider(prev)
 	require.NotNil(t, prev, "default provider must not be nil")
 
-	p2 := &trackingProvider{inner: stdlibWrapper{}}
+	p2 := &trackingProvider{inner: gogitsync.StdlibZlibProvider{}}
 	fromSwap := gogitsync.SetZlibProvider(p2)
 	assert.Same(t, p1, fromSwap)
 
@@ -93,14 +76,15 @@ func TestSetZlibProviderReturnsPrevious(t *testing.T) {
 }
 
 func TestSetZlibProviderPanicsOnNil(t *testing.T) {
+	t.Parallel()
 	assert.PanicsWithValue(t,
 		"utils/sync: SetZlibProvider called with nil provider",
 		func() { gogitsync.SetZlibProvider(nil) },
 	)
 }
 
-func TestNewZlibWriterUsesActiveProvider(t *testing.T) {
-	tracker := &trackingProvider{inner: stdlibWrapper{}}
+func TestNewZlibWriterUsesActiveProvider(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
+	tracker := &trackingProvider{inner: gogitsync.StdlibZlibProvider{}}
 	prev := gogitsync.SetZlibProvider(tracker)
 	defer gogitsync.SetZlibProvider(prev)
 
@@ -128,8 +112,8 @@ func TestNewZlibWriterUsesActiveProvider(t *testing.T) {
 // (objfile) and verifies a round-trip works with a custom provider
 // installed. This is the first test to touch the sync.Pool in this
 // binary, so New is guaranteed to fire through the tracker.
-func TestObjfileRoundTripUsesActiveProvider(t *testing.T) {
-	tracker := &trackingProvider{inner: stdlibWrapper{}}
+func TestObjfileRoundTripUsesActiveProvider(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
+	tracker := &trackingProvider{inner: gogitsync.StdlibZlibProvider{}}
 	prev := gogitsync.SetZlibProvider(tracker)
 	defer gogitsync.SetZlibProvider(prev)
 
@@ -162,6 +146,7 @@ func TestObjfileRoundTripUsesActiveProvider(t *testing.T) {
 }
 
 func TestDefaultProviderRoundTripWithStdlib(t *testing.T) {
+	t.Parallel()
 	payload := []byte("default provider check")
 
 	var buf bytes.Buffer

--- a/utils/sync/zlib_test.go
+++ b/utils/sync/zlib_test.go
@@ -3,91 +3,69 @@ package sync_test
 import (
 	"bytes"
 	"io"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/format/objfile"
 	gogitsync "github.com/go-git/go-git/v6/utils/sync"
 	"github.com/go-git/go-git/v6/x/plugin"
-	xzlib "github.com/go-git/go-git/v6/x/plugin/zlib"
+	xpluginzlib "github.com/go-git/go-git/v6/x/plugin/zlib"
 )
 
-// trackingProvider wraps another provider and counts factory calls and
-// bytes flowing through returned readers/writers.
-type trackingProvider struct {
-	inner       plugin.ZlibProvider
-	readerCalls atomic.Int64
-	writerCalls atomic.Int64
-	readBytes   atomic.Int64
-	writeBytes  atomic.Int64
-}
+func TestZlib_WriteRead(t *testing.T) {
+	t.Parallel()
 
-func (t *trackingProvider) NewReader(r io.Reader) (plugin.ZlibReader, error) {
-	t.readerCalls.Add(1)
-	inner, err := t.inner.NewReader(r)
-	if err != nil {
-		return nil, err
+	write := func(p []byte) []byte {
+		var buf bytes.Buffer
+
+		zw := gogitsync.GetZlibWriter(&buf)
+		l, err := zw.Write(p)
+		require.NoError(t, err)
+		require.NoError(t, zw.Close())
+		assert.Len(t, p, l)
+
+		gogitsync.PutZlibWriter(zw)
+		return buf.Bytes()
 	}
-	return &trackingReader{ZlibReader: inner, parent: t}, nil
+
+	read := func(stream []byte) []byte {
+		zr, err := gogitsync.GetZlibReader(bytes.NewReader(stream))
+		require.NoError(t, err)
+
+		got, err := io.ReadAll(zr)
+		require.NoError(t, err)
+		require.NoError(t, zr.Close())
+		gogitsync.PutZlibReader(zr)
+		return got
+	}
+
+	payload1 := []byte("default provider check")
+	assert.Equal(t, payload1, read(write(payload1)))
+
+	payload2 := []byte("second payload to exercise reset")
+	assert.Equal(t, payload2, read(write(payload2)))
 }
 
-func (t *trackingProvider) NewWriter(w io.Writer) plugin.ZlibWriter {
-	t.writerCalls.Add(1)
-	return &trackingWriter{ZlibWriter: t.inner.NewWriter(w), parent: t}
-}
-
-type trackingReader struct {
-	plugin.ZlibReader
-	parent *trackingProvider
-}
-
-func (r *trackingReader) Read(p []byte) (int, error) {
-	n, err := r.ZlibReader.Read(p)
-	r.parent.readBytes.Add(int64(n))
-	return n, err
-}
-
-type trackingWriter struct {
-	plugin.ZlibWriter
-	parent *trackingProvider
-}
-
-func (w *trackingWriter) Write(p []byte) (int, error) {
-	n, err := w.ZlibWriter.Write(p)
-	w.parent.writeBytes.Add(int64(n))
-	return n, err
-}
-
-// installProvider resets the zlib plugin entry, registers provider as
-// the active provider for the test, and schedules cleanup that
-// restores the built-in stdlib default.
-func installProvider(t *testing.T, provider plugin.ZlibProvider) {
-	t.Helper()
+func TestZlib_NoPluginRegistered_UsesStdlib(t *testing.T) { //nolint:paralleltest // mutates global plugin/cache state
 	gogitsync.ResetZlibForTest()
-	require.NoError(t, plugin.Register(plugin.Zlib(), func() plugin.ZlibProvider { return provider }))
-	t.Cleanup(gogitsync.ResetZlibForTest)
-}
+	t.Cleanup(func() {
+		gogitsync.ResetZlibForTest()
+		require.NoError(t, plugin.Register(plugin.Zlib(), func() plugin.ZlibProvider {
+			return xpluginzlib.NewStdlib()
+		}))
+	})
 
-func TestNewZlibWriterUsesActiveProvider(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
-	tracker := &trackingProvider{inner: xzlib.NewStdlib()}
-	installProvider(t, tracker)
-
-	payload := []byte("hello world")
-
+	payload := []byte("fallback to stdlib")
 	var buf bytes.Buffer
-	w := gogitsync.NewZlibWriter(&buf)
+
+	w := gogitsync.GetZlibWriter(&buf)
 	_, err := w.Write(payload)
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
+	gogitsync.PutZlibWriter(w)
 
-	assert.Equal(t, int64(1), tracker.writerCalls.Load())
-	assert.Equal(t, int64(len(payload)), tracker.writeBytes.Load())
-
-	zr, err := xzlib.NewStdlib().NewReader(&buf)
+	zr, err := xpluginzlib.NewStdlib().NewReader(&buf)
 	require.NoError(t, err)
 	got, err := io.ReadAll(zr)
 	require.NoError(t, err)
@@ -95,69 +73,23 @@ func TestNewZlibWriterUsesActiveProvider(t *testing.T) { //nolint:paralleltest /
 	assert.Equal(t, payload, got)
 }
 
-// TestObjfileRoundTripUsesActiveProvider exercises the pooled
-// GetZlibReader / GetZlibWriter paths through their intended caller
-// (objfile) and verifies a round-trip works with a custom provider
-// installed. ResetZlibForTest replaces the sync.Pools, so the pools
-// are guaranteed to miss and resolve through the tracker.
-func TestObjfileRoundTripUsesActiveProvider(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
-	tracker := &trackingProvider{inner: xzlib.NewStdlib()}
-	installProvider(t, tracker)
+func TestZlib_GetZlibReaderNilDoesNotPanic(t *testing.T) {
+	t.Parallel()
 
-	payload := []byte("pluggable compression smoke test")
-
-	var buf bytes.Buffer
-	w := objfile.NewWriter(&buf)
-	require.NoError(t, w.WriteHeader(plumbing.BlobObject, int64(len(payload))))
-	n, err := w.Write(payload)
-	require.NoError(t, err)
-	assert.Equal(t, len(payload), n)
-	require.NoError(t, w.Close())
-
-	r, err := objfile.NewReader(&buf)
-	require.NoError(t, err)
-	typ, size, err := r.Header()
-	require.NoError(t, err)
-	assert.Equal(t, plumbing.BlobObject, typ)
-	assert.Equal(t, int64(len(payload)), size)
-
-	got, err := io.ReadAll(r)
-	require.NoError(t, err)
-	require.NoError(t, r.Close())
-	assert.Equal(t, payload, got)
-
-	assert.Positive(t, tracker.writerCalls.Load(), "writer factory should have been invoked via the pool")
-	assert.Positive(t, tracker.readerCalls.Load(), "reader factory should have been invoked via the pool")
-	assert.Positive(t, tracker.writeBytes.Load(), "bytes should have flowed through the tracker writer")
-	assert.Positive(t, tracker.readBytes.Load(), "bytes should have flowed through the tracker reader")
+	assert.NotPanics(t, func() {
+		zr, err := gogitsync.GetZlibReader(nil)
+		assert.Error(t, err)
+		assert.Nil(t, zr)
+	})
 }
 
-func TestDefaultProviderRoundTripWithStdlib(t *testing.T) { //nolint:paralleltest // pins the zlib provider to stdlib for the duration
-	installProvider(t, xzlib.NewStdlib())
+func TestZlib_GetZlibWriterNilDoesNotPanic(t *testing.T) {
+	t.Parallel()
 
-	payload := []byte("default provider check")
-
-	var buf bytes.Buffer
-	w := gogitsync.NewZlibWriter(&buf)
-	_, err := w.Write(payload)
-	require.NoError(t, err)
-	require.NoError(t, w.Close())
-
-	zr, err := xzlib.NewStdlib().NewReader(&buf)
-	require.NoError(t, err)
-	got, err := io.ReadAll(zr)
-	require.NoError(t, err)
-	require.NoError(t, zr.Close())
-	assert.Equal(t, payload, got)
-}
-
-func TestRegisterAfterGetIsFrozen(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
-	installProvider(t, xzlib.NewStdlib())
-
-	// Force resolution so the plugin entry freezes.
-	w := gogitsync.NewZlibWriter(io.Discard)
-	require.NoError(t, w.Close())
-
-	err := plugin.Register(plugin.Zlib(), func() plugin.ZlibProvider { return xzlib.NewStdlib() })
-	assert.ErrorIs(t, err, plugin.ErrFrozen)
+	assert.NotPanics(t, func() {
+		zw := gogitsync.GetZlibWriter(nil)
+		assert.NotNil(t, zw)
+		assert.NoError(t, zw.Close())
+		gogitsync.PutZlibWriter(zw)
+	})
 }

--- a/utils/sync/zlib_test.go
+++ b/utils/sync/zlib_test.go
@@ -145,8 +145,13 @@ func TestObjfileRoundTripUsesActiveProvider(t *testing.T) { //nolint:paralleltes
 	assert.Positive(t, tracker.readBytes.Load(), "bytes should have flowed through the tracker reader")
 }
 
-func TestDefaultProviderRoundTripWithStdlib(t *testing.T) {
-	t.Parallel()
+func TestDefaultProviderRoundTripWithStdlib(t *testing.T) { //nolint:paralleltest // pins the zlib provider to Stdlib for the duration
+	// Force the stdlib provider for the duration so the assertion is
+	// about the default behavior, not about whatever provider a
+	// concurrent test has installed.
+	prev := gogitsync.SetZlibProvider(gogitsync.StdlibZlibProvider{})
+	defer gogitsync.SetZlibProvider(prev)
+
 	payload := []byte("default provider check")
 
 	var buf bytes.Buffer

--- a/utils/sync/zlib_test.go
+++ b/utils/sync/zlib_test.go
@@ -92,6 +92,13 @@ func TestSetZlibProviderReturnsPrevious(t *testing.T) {
 	assert.Same(t, p2, restored)
 }
 
+func TestSetZlibProviderPanicsOnNil(t *testing.T) {
+	assert.PanicsWithValue(t,
+		"utils/sync: SetZlibProvider called with nil provider",
+		func() { gogitsync.SetZlibProvider(nil) },
+	)
+}
+
 func TestNewZlibWriterUsesActiveProvider(t *testing.T) {
 	tracker := &trackingProvider{inner: stdlibWrapper{}}
 	prev := gogitsync.SetZlibProvider(tracker)

--- a/utils/sync/zlib_test.go
+++ b/utils/sync/zlib_test.go
@@ -2,7 +2,6 @@ package sync_test
 
 import (
 	"bytes"
-	"compress/zlib"
 	"io"
 	"sync/atomic"
 	"testing"
@@ -13,19 +12,21 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/objfile"
 	gogitsync "github.com/go-git/go-git/v6/utils/sync"
+	"github.com/go-git/go-git/v6/x/plugin"
+	xzlib "github.com/go-git/go-git/v6/x/plugin/zlib"
 )
 
 // trackingProvider wraps another provider and counts factory calls and
 // bytes flowing through returned readers/writers.
 type trackingProvider struct {
-	inner       gogitsync.ZlibProvider
+	inner       plugin.ZlibProvider
 	readerCalls atomic.Int64
 	writerCalls atomic.Int64
 	readBytes   atomic.Int64
 	writeBytes  atomic.Int64
 }
 
-func (t *trackingProvider) NewReader(r io.Reader) (gogitsync.ZlibReader, error) {
+func (t *trackingProvider) NewReader(r io.Reader) (plugin.ZlibReader, error) {
 	t.readerCalls.Add(1)
 	inner, err := t.inner.NewReader(r)
 	if err != nil {
@@ -34,13 +35,13 @@ func (t *trackingProvider) NewReader(r io.Reader) (gogitsync.ZlibReader, error) 
 	return &trackingReader{ZlibReader: inner, parent: t}, nil
 }
 
-func (t *trackingProvider) NewWriter(w io.Writer) gogitsync.ZlibWriter {
+func (t *trackingProvider) NewWriter(w io.Writer) plugin.ZlibWriter {
 	t.writerCalls.Add(1)
 	return &trackingWriter{ZlibWriter: t.inner.NewWriter(w), parent: t}
 }
 
 type trackingReader struct {
-	gogitsync.ZlibReader
+	plugin.ZlibReader
 	parent *trackingProvider
 }
 
@@ -51,7 +52,7 @@ func (r *trackingReader) Read(p []byte) (int, error) {
 }
 
 type trackingWriter struct {
-	gogitsync.ZlibWriter
+	plugin.ZlibWriter
 	parent *trackingProvider
 }
 
@@ -61,32 +62,19 @@ func (w *trackingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func TestSetZlibProviderReturnsPrevious(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
-	p1 := &trackingProvider{inner: gogitsync.StdlibZlibProvider{}}
-	prev := gogitsync.SetZlibProvider(p1)
-	defer gogitsync.SetZlibProvider(prev)
-	require.NotNil(t, prev, "default provider must not be nil")
-
-	p2 := &trackingProvider{inner: gogitsync.StdlibZlibProvider{}}
-	fromSwap := gogitsync.SetZlibProvider(p2)
-	assert.Same(t, p1, fromSwap)
-
-	restored := gogitsync.SetZlibProvider(prev)
-	assert.Same(t, p2, restored)
-}
-
-func TestSetZlibProviderPanicsOnNil(t *testing.T) {
-	t.Parallel()
-	assert.PanicsWithValue(t,
-		"utils/sync: SetZlibProvider called with nil provider",
-		func() { gogitsync.SetZlibProvider(nil) },
-	)
+// installProvider resets the zlib plugin entry, registers provider as
+// the active provider for the test, and schedules cleanup that
+// restores the built-in stdlib default.
+func installProvider(t *testing.T, provider plugin.ZlibProvider) {
+	t.Helper()
+	gogitsync.ResetZlibForTest()
+	require.NoError(t, plugin.Register(plugin.Zlib(), func() plugin.ZlibProvider { return provider }))
+	t.Cleanup(gogitsync.ResetZlibForTest)
 }
 
 func TestNewZlibWriterUsesActiveProvider(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
-	tracker := &trackingProvider{inner: gogitsync.StdlibZlibProvider{}}
-	prev := gogitsync.SetZlibProvider(tracker)
-	defer gogitsync.SetZlibProvider(prev)
+	tracker := &trackingProvider{inner: xzlib.NewStdlib()}
+	installProvider(t, tracker)
 
 	payload := []byte("hello world")
 
@@ -99,7 +87,7 @@ func TestNewZlibWriterUsesActiveProvider(t *testing.T) { //nolint:paralleltest /
 	assert.Equal(t, int64(1), tracker.writerCalls.Load())
 	assert.Equal(t, int64(len(payload)), tracker.writeBytes.Load())
 
-	zr, err := zlib.NewReader(&buf)
+	zr, err := xzlib.NewStdlib().NewReader(&buf)
 	require.NoError(t, err)
 	got, err := io.ReadAll(zr)
 	require.NoError(t, err)
@@ -110,12 +98,11 @@ func TestNewZlibWriterUsesActiveProvider(t *testing.T) { //nolint:paralleltest /
 // TestObjfileRoundTripUsesActiveProvider exercises the pooled
 // GetZlibReader / GetZlibWriter paths through their intended caller
 // (objfile) and verifies a round-trip works with a custom provider
-// installed. This is the first test to touch the sync.Pool in this
-// binary, so New is guaranteed to fire through the tracker.
+// installed. ResetZlibForTest replaces the sync.Pools, so the pools
+// are guaranteed to miss and resolve through the tracker.
 func TestObjfileRoundTripUsesActiveProvider(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
-	tracker := &trackingProvider{inner: gogitsync.StdlibZlibProvider{}}
-	prev := gogitsync.SetZlibProvider(tracker)
-	defer gogitsync.SetZlibProvider(prev)
+	tracker := &trackingProvider{inner: xzlib.NewStdlib()}
+	installProvider(t, tracker)
 
 	payload := []byte("pluggable compression smoke test")
 
@@ -145,12 +132,8 @@ func TestObjfileRoundTripUsesActiveProvider(t *testing.T) { //nolint:paralleltes
 	assert.Positive(t, tracker.readBytes.Load(), "bytes should have flowed through the tracker reader")
 }
 
-func TestDefaultProviderRoundTripWithStdlib(t *testing.T) { //nolint:paralleltest // pins the zlib provider to Stdlib for the duration
-	// Force the stdlib provider for the duration so the assertion is
-	// about the default behavior, not about whatever provider a
-	// concurrent test has installed.
-	prev := gogitsync.SetZlibProvider(gogitsync.StdlibZlibProvider{})
-	defer gogitsync.SetZlibProvider(prev)
+func TestDefaultProviderRoundTripWithStdlib(t *testing.T) { //nolint:paralleltest // pins the zlib provider to stdlib for the duration
+	installProvider(t, xzlib.NewStdlib())
 
 	payload := []byte("default provider check")
 
@@ -160,10 +143,21 @@ func TestDefaultProviderRoundTripWithStdlib(t *testing.T) { //nolint:paralleltes
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
-	zr, err := zlib.NewReader(&buf)
+	zr, err := xzlib.NewStdlib().NewReader(&buf)
 	require.NoError(t, err)
 	got, err := io.ReadAll(zr)
 	require.NoError(t, err)
 	require.NoError(t, zr.Close())
 	assert.Equal(t, payload, got)
+}
+
+func TestRegisterAfterGetIsFrozen(t *testing.T) { //nolint:paralleltest // modifies global zlib provider state
+	installProvider(t, xzlib.NewStdlib())
+
+	// Force resolution so the plugin entry freezes.
+	w := gogitsync.NewZlibWriter(io.Discard)
+	require.NoError(t, w.Close())
+
+	err := plugin.Register(plugin.Zlib(), func() plugin.ZlibProvider { return xzlib.NewStdlib() })
+	assert.ErrorIs(t, err, plugin.ErrFrozen)
 }

--- a/x/plugin/plugin.go
+++ b/x/plugin/plugin.go
@@ -58,6 +58,12 @@ func Register[T any](key key[T], factory func() T) error {
 		return ErrNilFactory
 	}
 
+	if e.validate != nil {
+		if err := e.validate(factory()); err != nil {
+			return err
+		}
+	}
+
 	e.factory = factory
 	return nil
 }
@@ -104,20 +110,33 @@ type key[T any] struct {
 // newKey creates a new plugin entry key with the given name.
 // It panics if a key with the same name has already been created.
 func newKey[T any](name Name) key[T] {
+	return newKeyWithValidator[T](name, nil)
+}
+
+// newKeyWithValidator creates a new plugin entry key with the given name
+// and optional registration-time validator.
+func newKeyWithValidator[T any](name Name, validate func(T) error) key[T] {
 	mu.Lock()
 	defer mu.Unlock()
 
 	if _, exists := entries[name]; exists {
 		panic("plugin: duplicate key name: " + name)
 	}
-	entries[name] = &entry{}
+	var wrapped func(any) error
+	if validate != nil {
+		wrapped = func(v any) error {
+			return validate(v.(T))
+		}
+	}
+	entries[name] = &entry{validate: wrapped}
 	return key[T]{name: name}
 }
 
 // entry holds the internal state for a single plugin entry.
 type entry struct {
-	frozen  bool
-	factory any // func() T stored as any; nil means not registered
+	frozen   bool
+	factory  any // func() T stored as any; nil means not registered
+	validate func(any) error
 }
 
 // resetEntry clears the factory and unfreezes the plugin entry identified by

--- a/x/plugin/plugin_test.go
+++ b/x/plugin/plugin_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -158,4 +159,19 @@ func TestPerKeyFreezeIsolation(t *testing.T) { //nolint:paralleltest // modifies
 
 	assert.ErrorIs(t, Register(a, func() string { return "ay" }), ErrFrozen)
 	assert.NoError(t, Register(b, func() string { return "by" }))
+}
+
+func TestRegisterRunsValidator(t *testing.T) { //nolint:paralleltest // modifies global plugin state
+	resetGlobal()
+
+	wantErr := errors.New("invalid plugin")
+	key := newKeyWithValidator("validated", func(v string) error {
+		if v == "bad" {
+			return wantErr
+		}
+		return nil
+	})
+
+	assert.ErrorIs(t, Register(key, func() string { return "bad" }), wantErr)
+	assert.NoError(t, Register(key, func() string { return "good" }))
 }

--- a/x/plugin/plugin_zlib.go
+++ b/x/plugin/plugin_zlib.go
@@ -31,6 +31,6 @@ type ZlibProvider = xzlib.Provider
 // Zlib returns the key used to register a zlib provider plugin. When
 // set, go-git uses this plugin to construct zlib readers and writers
 // instead of the built-in stdlib provider.
-func Zlib() key[ZlibProvider] { //nolint:revive // intentional unexported return type
+func Zlib() key[ZlibProvider] {
 	return zlibKey
 }

--- a/x/plugin/plugin_zlib.go
+++ b/x/plugin/plugin_zlib.go
@@ -14,7 +14,7 @@ func init() {
 
 const zlibPlugin Name = "zlib"
 
-var zlibKey = newKey[ZlibProvider](zlibPlugin)
+var zlibKey = newKeyWithValidator(zlibPlugin, xzlib.ValidateProvider)
 
 // ZlibReader is the method set required of a zlib decompression reader.
 // See [xzlib.Reader] for the full contract.

--- a/x/plugin/plugin_zlib.go
+++ b/x/plugin/plugin_zlib.go
@@ -1,0 +1,36 @@
+package plugin
+
+import (
+	xzlib "github.com/go-git/go-git/v6/x/plugin/zlib"
+)
+
+func init() {
+	// Registers the stdlib-backed zlib provider by default, aligning
+	// go-git's behaviour with its historical use of compress/zlib.
+	_ = Register(Zlib(), func() ZlibProvider {
+		return xzlib.NewStdlib()
+	})
+}
+
+const zlibPlugin Name = "zlib"
+
+var zlibKey = newKey[ZlibProvider](zlibPlugin)
+
+// ZlibReader is the method set required of a zlib decompression reader.
+// See [xzlib.Reader] for the full contract.
+type ZlibReader = xzlib.Reader
+
+// ZlibWriter is the method set required of a zlib compression writer.
+// See [xzlib.Writer] for the full contract.
+type ZlibWriter = xzlib.Writer
+
+// ZlibProvider constructs zlib readers and writers. See
+// [xzlib.Provider] for the full contract.
+type ZlibProvider = xzlib.Provider
+
+// Zlib returns the key used to register a zlib provider plugin. When
+// set, go-git uses this plugin to construct zlib readers and writers
+// instead of the built-in stdlib provider.
+func Zlib() key[ZlibProvider] { //nolint:revive // intentional unexported return type
+	return zlibKey
+}

--- a/x/plugin/zlib/stdlib.go
+++ b/x/plugin/zlib/stdlib.go
@@ -1,7 +1,5 @@
 // Package zlib provides the zlib provider interfaces and the built-in
-// Stdlib implementation backing go-git's default compression. The
-// interfaces live here — rather than in x/plugin — so x/plugin can
-// alias them without creating an import cycle back to this subpackage.
+// Stdlib implementation backing go-git's default compression.
 package zlib
 
 import (
@@ -12,20 +10,18 @@ import (
 
 // Reader is the method set required of a zlib decompression reader.
 // It matches the value returned by compress/zlib.NewReader, which
-// implements both io.ReadCloser and zlib.Resetter.
+// implements both io.ReadCloser and zlib.Reader.
 //
 // Implementations must support Reset being called on a reader after
 // Close so that pooled readers can be re-seeded with a new source and
-// dictionary, matching zlib.Resetter semantics. Reset runs once per
-// packfile object during scan, so it should be O(1) and avoid
-// reallocating decompressor state.
+// dictionary, matching zlib.Reader semantics. During a packfile scan,
+// the Reset will be called once per object.
 type Reader interface {
 	io.ReadCloser
 	Reset(r io.Reader, dict []byte) error
 }
 
-// Writer is the method set required of a zlib compression writer.
-// It matches the stdlib *zlib.Writer.
+// Writer defines the interface for a zlib compression writer.
 //
 // Implementations must preserve the following behavioral contract
 // that go-git relies on:
@@ -37,8 +33,7 @@ type Reader interface {
 //   - Reset after Close is supported: packfile.Encoder closes the
 //     writer once per object entry and then calls Reset to reuse it
 //     for the next entry within the same encode. Reset is on the
-//     per-object hot path during encode, so it should be O(1) and
-//     avoid reallocating compressor state.
+//     per-object hot path during encode.
 //   - Flush writes any pending compressed data to the underlying
 //     writer without ending the stream; the writer remains usable
 //     after Flush.
@@ -49,11 +44,7 @@ type Writer interface {
 }
 
 // Provider constructs zlib implementations. go-git calls its factory
-// methods (often via internal sync.Pool instances) whenever it needs
-// to read or write zlib-compressed data. Register a non-default
-// provider with plugin.Register(plugin.Zlib(), factory) — for example
-// to swap in github.com/klauspost/compress/zlib without go-git taking
-// a direct dependency on it.
+// methods whenever it needs to read or write zlib-compressed data.
 //
 // Implementations must be safe for concurrent calls to NewReader and
 // NewWriter. Returned readers and writers need not be concurrency-safe
@@ -64,8 +55,7 @@ type Provider interface {
 }
 
 // Stdlib is a zlib provider backed by the Go standard library's
-// compress/zlib package. It is the default provider registered with
-// x/plugin during package init.
+// compress/zlib package. It is the default provider used in go-git.
 type Stdlib struct{}
 
 // NewStdlib returns a new Stdlib provider.
@@ -79,10 +69,12 @@ func (*Stdlib) NewReader(r io.Reader) (Reader, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	zlr, ok := zr.(Reader)
 	if !ok {
-		return nil, fmt.Errorf("compress/zlib reader %T does not implement zlib.Resetter", zr)
+		return nil, fmt.Errorf("compress/zlib reader %T does not implement Reader", zr)
 	}
+
 	return zlr, nil
 }
 

--- a/x/plugin/zlib/stdlib.go
+++ b/x/plugin/zlib/stdlib.go
@@ -1,0 +1,92 @@
+// Package zlib provides the zlib provider interfaces and the built-in
+// Stdlib implementation backing go-git's default compression. The
+// interfaces live here — rather than in x/plugin — so x/plugin can
+// alias them without creating an import cycle back to this subpackage.
+package zlib
+
+import (
+	"compress/zlib"
+	"fmt"
+	"io"
+)
+
+// Reader is the method set required of a zlib decompression reader.
+// It matches the value returned by compress/zlib.NewReader, which
+// implements both io.ReadCloser and zlib.Resetter.
+//
+// Implementations must support Reset being called on a reader after
+// Close so that pooled readers can be re-seeded with a new source and
+// dictionary, matching zlib.Resetter semantics. Reset runs once per
+// packfile object during scan, so it should be O(1) and avoid
+// reallocating decompressor state.
+type Reader interface {
+	io.ReadCloser
+	Reset(r io.Reader, dict []byte) error
+}
+
+// Writer is the method set required of a zlib compression writer.
+// It matches the stdlib *zlib.Writer.
+//
+// Implementations must preserve the following behavioral contract
+// that go-git relies on:
+//
+//   - Close flushes pending data and writes the zlib stream footer,
+//     but must not close the underlying io.Writer. Both objfile and
+//     packfile keep using the wrapped writer after the ZlibWriter
+//     closes.
+//   - Reset after Close is supported: packfile.Encoder closes the
+//     writer once per object entry and then calls Reset to reuse it
+//     for the next entry within the same encode. Reset is on the
+//     per-object hot path during encode, so it should be O(1) and
+//     avoid reallocating compressor state.
+//   - Flush writes any pending compressed data to the underlying
+//     writer without ending the stream; the writer remains usable
+//     after Flush.
+type Writer interface {
+	io.WriteCloser
+	Reset(w io.Writer)
+	Flush() error
+}
+
+// Provider constructs zlib implementations. go-git calls its factory
+// methods (often via internal sync.Pool instances) whenever it needs
+// to read or write zlib-compressed data. Register a non-default
+// provider with plugin.Register(plugin.Zlib(), factory) — for example
+// to swap in github.com/klauspost/compress/zlib without go-git taking
+// a direct dependency on it.
+//
+// Implementations must be safe for concurrent calls to NewReader and
+// NewWriter. Returned readers and writers need not be concurrency-safe
+// themselves; each caller gets its own instance.
+type Provider interface {
+	NewReader(r io.Reader) (Reader, error)
+	NewWriter(w io.Writer) Writer
+}
+
+// Stdlib is a zlib provider backed by the Go standard library's
+// compress/zlib package. It is the default provider registered with
+// x/plugin during package init.
+type Stdlib struct{}
+
+// NewStdlib returns a new Stdlib provider.
+func NewStdlib() *Stdlib {
+	return &Stdlib{}
+}
+
+// NewReader returns a zlib decompression reader backed by compress/zlib.
+func (*Stdlib) NewReader(r io.Reader) (Reader, error) {
+	zr, err := zlib.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	zlr, ok := zr.(Reader)
+	if !ok {
+		return nil, fmt.Errorf("compress/zlib reader %T does not implement zlib.Resetter", zr)
+	}
+	return zlr, nil
+}
+
+// NewWriter returns a zlib compression writer backed by compress/zlib.
+func (*Stdlib) NewWriter(w io.Writer) Writer {
+	return zlib.NewWriter(w)
+}

--- a/x/plugin/zlib/validate.go
+++ b/x/plugin/zlib/validate.go
@@ -1,0 +1,61 @@
+package zlib
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+)
+
+var (
+	// ErrNilProvider is returned when a nil Provider is validated.
+	ErrNilProvider = errors.New("zlib provider must not be nil")
+	// ErrNilReader is returned when Provider.NewReader reports success but
+	// returns a nil Reader.
+	ErrNilReader = errors.New("zlib provider returned nil reader")
+	// ErrNilWriter is returned when Provider.NewWriter returns a nil Writer.
+	ErrNilWriter = errors.New("zlib provider returned nil writer")
+)
+
+var validateInitBytes = []byte{0x78, 0x9c, 0x01, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00, 0x00, 0x01}
+
+// ValidateProvider checks the minimal behavioral contract go-git needs
+// from a zlib Provider during initialization.
+func ValidateProvider(provider Provider) error {
+	if isNil(provider) {
+		return ErrNilProvider
+	}
+
+	reader, err := provider.NewReader(bytes.NewReader(validateInitBytes))
+	if err != nil {
+		return fmt.Errorf("provider.NewReader: %w", err)
+	}
+	if isNil(reader) {
+		return ErrNilReader
+	}
+	if err := reader.Close(); err != nil {
+		return fmt.Errorf("provider.NewReader.Close: %w", err)
+	}
+
+	writer := provider.NewWriter(io.Discard)
+	if isNil(writer) {
+		return ErrNilWriter
+	}
+
+	return nil
+}
+
+func isNil(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}

--- a/x/plugin/zlib/validate_test.go
+++ b/x/plugin/zlib/validate_test.go
@@ -1,0 +1,106 @@
+package zlib
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		provider     Provider
+		wantErr      error
+		wantContains []string
+	}{
+		{
+			name:     "accepts conforming provider",
+			provider: validProvider{},
+		},
+		{
+			name:     "rejects nil provider",
+			provider: nil,
+			wantErr:  ErrNilProvider,
+		},
+		{
+			name:         "rejects reader initialization errors",
+			provider:     readerErrorProvider{},
+			wantContains: []string{"provider.NewReader", "boom"},
+		},
+		{
+			name:     "rejects nil reader",
+			provider: nilReaderProvider{},
+			wantErr:  ErrNilReader,
+		},
+		{
+			name:     "rejects nil writer",
+			provider: nilWriterProvider{},
+			wantErr:  ErrNilWriter,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateProvider(tt.provider)
+			if tt.wantErr == nil && len(tt.wantContains) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			}
+			for _, want := range tt.wantContains {
+				assert.ErrorContains(t, err, want)
+			}
+		})
+	}
+}
+
+type validProvider struct{}
+
+func (validProvider) NewReader(r io.Reader) (Reader, error) {
+	return NewStdlib().NewReader(r)
+}
+
+func (validProvider) NewWriter(w io.Writer) Writer {
+	return NewStdlib().NewWriter(w)
+}
+
+type readerErrorProvider struct{}
+
+func (readerErrorProvider) NewReader(io.Reader) (Reader, error) {
+	return nil, errors.New("boom")
+}
+
+func (readerErrorProvider) NewWriter(io.Writer) Writer {
+	return NewStdlib().NewWriter(io.Discard)
+}
+
+type nilReaderProvider struct{}
+
+func (nilReaderProvider) NewReader(io.Reader) (Reader, error) {
+	return nil, nil
+}
+
+func (nilReaderProvider) NewWriter(io.Writer) Writer {
+	return NewStdlib().NewWriter(io.Discard)
+}
+
+type nilWriterProvider struct{}
+
+func (nilWriterProvider) NewReader(r io.Reader) (Reader, error) {
+	return NewStdlib().NewReader(r)
+}
+
+func (nilWriterProvider) NewWriter(io.Writer) Writer {
+	return nil
+}


### PR DESCRIPTION
Adds a pluggable zlib compression path to go-git by wiring it into the existing `x/plugin` registry. The stdlib `compress/zlib` is registered as the default provider during `x/plugin`'s init, so existing behaviour is unchanged — but applications can now register an alternative (for example `github.com/klauspost/compress/zlib`) without go-git taking a direct dependency on it.

See EXTENDING.md for the full example.

Registration follows the same freeze-on-first-use lifecycle as other plugins: once go-git has resolved the provider (on the first pool miss or NewZlibWriter call) subsequent plugin.Register calls return plugin.ErrFrozen and the active provider is kept.