### PR TITLE
git: add repository and remote archive support

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -1,0 +1,67 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+// ArchiveRemote creates an archive from a remote repository.
+// It returns an io.ReadCloser that yields the archive data.
+// The caller must close the returned ReadCloser.
+func ArchiveRemote(url string, o *ArchiveOptions) (io.ReadCloser, error) {
+	return ArchiveRemoteContext(context.Background(), url, o)
+}
+
+// ArchiveRemoteContext creates an archive from a remote repository.
+// The provided Context can be used to cancel the operation.
+func ArchiveRemoteContext(ctx context.Context, url string, o *ArchiveOptions) (io.ReadCloser, error) {
+	if o == nil {
+		o = &ArchiveOptions{}
+	}
+	if err := o.Validate(); err != nil {
+		return nil, err
+	}
+	if url == "" {
+		return nil, errors.New("remote URL is required")
+	}
+
+	cl, req, err := newClient(url, o.ClientOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Command = transport.UploadArchiveService
+	sess, err := cl.Handshake(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if session implements Archiver
+	arch, ok := sess.(transport.Archiver)
+	if !ok {
+		_ = sess.Close()
+		return nil, transport.ErrArchiveUnsupported
+	}
+
+	// Build arguments
+	var args []string
+	if o.Format != "" {
+		args = append(args, "--format="+o.Format)
+	}
+	if o.Prefix != "" {
+		args = append(args, "--prefix="+o.Prefix)
+	}
+	args = append(args, o.Treeish)
+	if len(o.Paths) > 0 {
+		args = append(args, "--")
+		args = append(args, o.Paths...)
+	}
+
+	return arch.Archive(ctx, &transport.ArchiveRequest{
+		Args:     args,
+		Progress: o.Progress,
+	})
+}

--- a/archive_test.go
+++ b/archive_test.go
@@ -1,0 +1,239 @@
+package git
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/internal/transport/test"
+)
+
+func TestArchiveOptionsValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    *ArchiveOptions
+		wantErr string
+	}{
+		{
+			name:    "valid hash treeish",
+			opts:    &ArchiveOptions{Format: "tar", Treeish: "8ab686eafeb1f44702738c8b0f24f2567c36da6d"},
+			wantErr: "",
+		},
+		{
+			name:    "valid branch treeish",
+			opts:    &ArchiveOptions{Format: "zip", Treeish: "master"},
+			wantErr: "",
+		},
+		{
+			name:    "valid revision expression with caret",
+			opts:    &ArchiveOptions{Treeish: "v1.0^{tree}"},
+			wantErr: "",
+		},
+		{
+			name:    "valid revision expression with tilde",
+			opts:    &ArchiveOptions{Treeish: "HEAD~3"},
+			wantErr: "",
+		},
+		{
+			name:    "valid colon subpath syntax",
+			opts:    &ArchiveOptions{Treeish: "HEAD:Documentation/"},
+			wantErr: "",
+		},
+		{
+			name:    "prefix with path traversal",
+			opts:    &ArchiveOptions{Format: "tar", Treeish: "HEAD", Prefix: "../escape/"},
+			wantErr: "invalid archive prefix",
+		},
+		{
+			name:    "absolute prefix",
+			opts:    &ArchiveOptions{Format: "tar", Treeish: "HEAD", Prefix: "/opt/build/"},
+			wantErr: "invalid archive prefix",
+		},
+		{
+			name:    "valid relative prefix",
+			opts:    &ArchiveOptions{Format: "tar", Treeish: "HEAD", Prefix: "myproject/"},
+			wantErr: "",
+		},
+		{
+			name:    "valid paths with dot-dot",
+			opts:    &ArchiveOptions{Format: "tar", Treeish: "HEAD", Paths: []string{"a/../b"}},
+			wantErr: "",
+		},
+		{
+			name:    "empty format defaults to tar",
+			opts:    &ArchiveOptions{Treeish: "main"},
+			wantErr: "",
+		},
+		{
+			name:    "empty tree-ish",
+			opts:    &ArchiveOptions{Format: "tar", Treeish: ""},
+			wantErr: "tree-ish is required",
+		},
+		{
+			// Validation happens during either Archive or ArchiveRemote.
+			name:    "unsupported format",
+			opts:    &ArchiveOptions{Format: "rar", Treeish: "HEAD"},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.opts.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestArchiveRemote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		opts    *ArchiveOptions
+		wantErr string
+	}{
+		{
+			name:    "empty tree-ish",
+			url:     "file:///tmp/repo.git",
+			opts:    &ArchiveOptions{Format: "tar", Treeish: ""},
+			wantErr: "tree-ish is required",
+		},
+		{
+			name:    "empty URL",
+			url:     "",
+			opts:    &ArchiveOptions{Format: "tar", Treeish: "master"},
+			wantErr: "remote URL is required",
+		},
+		{
+			name:    "remote allows custom format",
+			url:     "file:///tmp/repo.git",
+			opts:    &ArchiveOptions{Format: "tar.xz", Treeish: "master"},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := ArchiveRemote(tt.url, tt.opts)
+			if tt.wantErr == "" {
+				if err != nil {
+					assert.NotContains(t, err.Error(), "unsupported format")
+				}
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestArchiveRemoteIntegration(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath, err := filepath.Abs(repoFS.Root())
+	require.NoError(t, err)
+	repoURL := "file://" + repoPath
+
+	tests := []struct {
+		name      string
+		opts      *ArchiveOptions
+		wantFiles bool
+		wantCheck func(t *testing.T, data []byte)
+	}{
+		{
+			name:      "tar format",
+			opts:      &ArchiveOptions{Format: "tar", Treeish: "master"},
+			wantFiles: true,
+		},
+		{
+			name: "tar with prefix",
+			opts: &ArchiveOptions{Format: "tar", Treeish: "master", Prefix: "myproject/"},
+			wantCheck: func(t *testing.T, data []byte) {
+				tr := tar.NewReader(bytes.NewReader(data))
+				for {
+					hdr, err := tr.Next()
+					if err == io.EOF {
+						break
+					}
+					require.NoError(t, err)
+					if hdr.Typeflag == tar.TypeXGlobalHeader {
+						continue
+					}
+					assert.True(t, strings.HasPrefix(hdr.Name, "myproject/"),
+						"expected prefix myproject/, got %s", hdr.Name)
+				}
+			},
+		},
+		{
+			name: "tar with path filter",
+			opts: &ArchiveOptions{Format: "tar", Treeish: "master", Paths: []string{".gitignore"}},
+			wantCheck: func(t *testing.T, data []byte) {
+				tr := tar.NewReader(bytes.NewReader(data))
+				var names []string
+				for {
+					hdr, err := tr.Next()
+					if err == io.EOF {
+						break
+					}
+					require.NoError(t, err)
+					if hdr.Typeflag != tar.TypeXGlobalHeader {
+						names = append(names, hdr.Name)
+					}
+				}
+				assert.Equal(t, []string{".gitignore"}, names)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rc, err := ArchiveRemote(repoURL, tt.opts)
+			require.NoError(t, err)
+			t.Cleanup(func() { rc.Close() })
+
+			data, err := io.ReadAll(rc)
+			require.NoError(t, err)
+
+			if tt.wantCheck != nil {
+				tt.wantCheck(t, data)
+				return
+			}
+
+			if tt.wantFiles {
+				tr := tar.NewReader(bytes.NewReader(data))
+				var count int
+				for {
+					_, err := tr.Next()
+					if err == io.EOF {
+						break
+					}
+					require.NoError(t, err)
+					count++
+				}
+				assert.Greater(t, count, 0, "archive should contain entries")
+			}
+		})
+	}
+}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -61,6 +61,10 @@ var (
 	// ErrInvalidPrefix is returned when the requested archive prefix contains
 	// path traversal sequences.
 	ErrInvalidPrefix = errors.New("invalid archive prefix")
+
+	// ErrUnsupportedFormat is returned when the requested archive format is
+	// not supported.
+	ErrUnsupportedFormat = errors.New("unsupported archive format")
 )
 
 const maxTarSymlinkTargetSize = 64 * 1024
@@ -461,26 +465,14 @@ func GetTarCommitID(r io.Reader) (*plumbing.Hash, error) {
 	return &hash, nil
 }
 
-// WriteArchive generates an archive from the repository and writes it to w.
+// WriteArchive generates an archive from a resolved tree and writes it to w.
 //
-// Args follow the same format as git-archive: [options...] <tree-ish> [paths...]
 // Supported formats: tar, zip, tar.gz, tgz.
 // The prefix is prepended to all file paths in the archive.
 // The paths slice can be used to filter which files are included.
-// If allowUnreachable is false, only ref names are allowed (no raw hashes).
-func WriteArchive(st storage.Storer, w io.Writer, treeish, format, prefix string,
-	paths []string, allowUnreachable bool,
-) error {
-	if treeish == "" {
-		return fmt.Errorf("no tree-ish specified")
-	}
-	if hasInvalidArchivePrefix(prefix) {
+func WriteArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, commitTime time.Time, format, prefix string, paths []string) error {
+	if HasInvalidPrefix(prefix) {
 		return fmt.Errorf("%w: %s", ErrInvalidPrefix, prefix)
-	}
-
-	tree, commitHash, commitTime, err := ResolveTreeish(st, treeish, allowUnreachable)
-	if err != nil {
-		return err
 	}
 
 	switch format {
@@ -495,11 +487,15 @@ func WriteArchive(st storage.Storer, w io.Writer, treeish, format, prefix string
 	case "zip":
 		return WriteZipArchive(st, w, tree, commitHash, prefix, paths, commitTime)
 	default:
-		return fmt.Errorf("unsupported archive format: %s", format)
+		return fmt.Errorf("%w: %s", ErrUnsupportedFormat, format)
 	}
 }
 
-func hasInvalidArchivePrefix(prefix string) bool {
+// HasInvalidPrefix reports whether prefix contains path traversal
+// sequences ("..") or starts with an absolute path separator ("/" or "\").
+// Both local and remote archive paths should call this before accepting a
+// user-supplied prefix.
+func HasInvalidPrefix(prefix string) bool {
 	if strings.HasPrefix(prefix, "/") || strings.HasPrefix(prefix, "\\") {
 		return true
 	}

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
 // StreamSession implements Session over a full-duplex stream.
@@ -145,7 +146,15 @@ func (s *StreamSession) Archive(ctx context.Context, req *ArchiveRequest) (io.Re
 	if s.svc != UploadArchiveService {
 		return nil, ErrArchiveUnsupported
 	}
-	return Archive(ctx, s.conn.Writer(), io.NopCloser(s.conn.Reader()), req)
+
+	rc := ioutil.NewReadCloser(s.conn.Reader(), s.conn)
+	archive, err := Archive(ctx, s.conn.Writer(), rc, req)
+	if err != nil {
+		_ = rc.Close()
+		return nil, err
+	}
+
+	return archive, nil
 }
 
 var (

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -134,7 +134,12 @@ func UploadArchive(
 		return muxError(mux, w, fmt.Errorf("no tree-ish specified"))
 	}
 
-	if err = archive.WriteArchive(st, mux, treeish, format, prefix, paths, allowUnreachable); err != nil {
+	tree, commitHash, commitTime, err := archive.ResolveTreeish(st, treeish, allowUnreachable)
+	if err != nil {
+		return muxError(mux, w, err)
+	}
+
+	if err = archive.WriteArchive(st, mux, tree, commitHash, commitTime, format, prefix, paths); err != nil {
 		return muxError(mux, w, err)
 	}
 

--- a/repository.go
+++ b/repository.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -16,14 +17,17 @@ import (
 	"github.com/go-git/go-billy/v6/osfs"
 
 	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/internal/archive"
 	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/internal/revision"
 	"github.com/go-git/go-git/v6/internal/url"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/client"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
@@ -1430,6 +1434,86 @@ func (r *Repository) PushContext(ctx context.Context, o *PushOptions) error {
 	}
 
 	return remote.PushContext(ctx, o)
+}
+
+// ArchiveOptions stores the options for the Archive operation.
+type ArchiveOptions struct {
+	// Format is the archive format.
+	// Archive supports tar, tar.gz, tgz, and zip locally.
+	// ArchiveRemote passes the format through to the remote server, so
+	// supported values are server-dependent.
+	// Defaults to tar.
+	Format string
+	// Prefix is an optional prefix to prepend to each pathname.
+	Prefix string
+	// Treeish is the tree-ish object to archive (commit, tag, or tree).
+	Treeish string
+	// Paths is an optional list of paths to include in the archive.
+	// If empty, all paths are included.
+	Paths []string
+	// ClientOptions are options for the transport client (used by ArchiveRemote).
+	ClientOptions []client.Option
+	// Progress receives human-readable status from the remote server.
+	// Only used by ArchiveRemote, ignored by Archive.
+	Progress sideband.Progress
+}
+
+// Validate validates the ArchiveOptions.
+func (o *ArchiveOptions) Validate() error {
+	if o.Treeish == "" {
+		return errors.New("tree-ish is required")
+	}
+
+	if o.Prefix != "" && archive.HasInvalidPrefix(o.Prefix) {
+		return fmt.Errorf("%w: %s", archive.ErrInvalidPrefix, o.Prefix)
+	}
+
+	return nil
+}
+
+// Archive creates an archive from the local repository.
+// It returns an io.ReadCloser that yields the archive data.
+// The caller must close the returned ReadCloser.
+func (r *Repository) Archive(o *ArchiveOptions) (io.ReadCloser, error) {
+	return r.ArchiveContext(context.Background(), o)
+}
+
+// ArchiveContext creates an archive from the local repository.
+// The provided Context can be used to cancel the operation.
+func (r *Repository) ArchiveContext(ctx context.Context, o *ArchiveOptions) (io.ReadCloser, error) {
+	if o == nil {
+		o = &ArchiveOptions{}
+	}
+	if err := o.Validate(); err != nil {
+		return nil, err
+	}
+
+	format := o.Format
+	if format == "" {
+		format = "tar"
+	}
+
+	if !slices.Contains(archive.SupportedFormats(), format) {
+		return nil, fmt.Errorf("%w: %s", archive.ErrUnsupportedFormat, format)
+	}
+
+	// Always allow unreachable refs for local archives.
+	tree, commitHash, commitTime, err := archive.ResolveTreeish(r.Storer, o.Treeish, true)
+	if err != nil {
+		return nil, err
+	}
+
+	prefix := o.Prefix
+	paths := slices.Clone(o.Paths)
+
+	pr, pw := io.Pipe()
+	cw := ioutil.NewContextWriter(ctx, pw)
+	go func() {
+		err := archive.WriteArchive(r.Storer, cw, tree, commitHash, commitTime, format, prefix, paths)
+		_ = pw.CloseWithError(err)
+	}()
+
+	return pr, nil
 }
 
 // Log returns the commit history from the given LogOptions.

--- a/repository_test.go
+++ b/repository_test.go
@@ -1,7 +1,10 @@
 package git
 
 import (
+	"archive/tar"
+	"archive/zip"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -27,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/config"
+	archivePkg "github.com/go-git/go-git/v6/internal/archive"
 	"github.com/go-git/go-git/v6/internal/server"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
@@ -4075,4 +4079,225 @@ func TestCreateTagSignerSelection(t *testing.T) { //nolint:paralleltest // modif
 			}
 		})
 	}
+}
+
+func TestRepository_Archive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		opts      ArchiveOptions
+		wantErr   string
+		wantRead  string // if non-empty, reading stream should fail containing this substring
+		wantFiles bool   // if true, archive should contain at least one file
+		wantCheck func(t *testing.T, data []byte)
+	}{
+		{
+			name:      "tar format",
+			opts:      ArchiveOptions{Format: "tar", Treeish: "master"},
+			wantFiles: true,
+		},
+		{
+			name:      "tar.gz format",
+			opts:      ArchiveOptions{Format: "tar.gz", Treeish: "master"},
+			wantFiles: true,
+		},
+		{
+			name:      "tgz format",
+			opts:      ArchiveOptions{Format: "tgz", Treeish: "master"},
+			wantFiles: true,
+		},
+		{
+			name:      "zip format",
+			opts:      ArchiveOptions{Format: "zip", Treeish: "master"},
+			wantFiles: true,
+		},
+		{
+			name: "tar with prefix",
+			opts: ArchiveOptions{Format: "tar", Treeish: "master", Prefix: "myproject/"},
+			wantCheck: func(t *testing.T, data []byte) {
+				tr := tar.NewReader(bytes.NewReader(data))
+				for {
+					hdr, err := tr.Next()
+					if err == io.EOF {
+						break
+					}
+					require.NoError(t, err)
+					if hdr.Typeflag == tar.TypeXGlobalHeader {
+						continue
+					}
+					assert.True(t, strings.HasPrefix(hdr.Name, "myproject/"),
+						"expected prefix myproject/, got %s", hdr.Name)
+				}
+			},
+		},
+		{
+			name:      "tar with path filter",
+			opts:      ArchiveOptions{Format: "tar", Treeish: "master", Paths: []string{".gitignore"}},
+			wantFiles: true,
+		},
+		{
+			name:      "tar from tag",
+			opts:      ArchiveOptions{Format: "tar", Treeish: "v1.0.0"},
+			wantFiles: true,
+		},
+		{
+			name: "tar contains commit ID in PAX header",
+			opts: ArchiveOptions{Format: "tar", Treeish: "master"},
+			wantCheck: func(t *testing.T, data []byte) {
+				commitID, err := archivePkg.GetTarCommitID(bytes.NewReader(data))
+				require.NoError(t, err)
+				assert.NotNil(t, commitID)
+			},
+		},
+		{
+			name: "zip contains commit ID as comment",
+			opts: ArchiveOptions{Format: "zip", Treeish: "master"},
+			wantCheck: func(t *testing.T, data []byte) {
+				zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+				require.NoError(t, err)
+				assert.NotEmpty(t, zr.Comment)
+			},
+		},
+		{
+			name:    "invalid format",
+			opts:    ArchiveOptions{Format: "rar", Treeish: "master"},
+			wantErr: "unsupported archive format",
+		},
+		{
+			name:    "empty tree-ish",
+			opts:    ArchiveOptions{Format: "tar", Treeish: ""},
+			wantErr: "tree-ish is required",
+		},
+		{
+			name:    "invalid prefix",
+			opts:    ArchiveOptions{Format: "tar", Treeish: "master", Prefix: "../../etc/"},
+			wantErr: "invalid archive prefix",
+		},
+		{
+			name:    "nonexistent ref",
+			opts:    ArchiveOptions{Format: "tar", Treeish: "nonexistent-branch"},
+			wantErr: "cannot resolve",
+		},
+		{
+			name:     "pathspec no match",
+			opts:     ArchiveOptions{Format: "tar", Treeish: "master", Paths: []string{"nonexistent/path/xyzzy"}},
+			wantRead: "pathspec",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := setupArchiveRepo(t)
+
+			rc, err := r.Archive(&tt.opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			t.Cleanup(func() { rc.Close() })
+
+			data, err := io.ReadAll(rc)
+			if tt.wantRead != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantRead)
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.wantCheck != nil {
+				tt.wantCheck(t, data)
+				return
+			}
+
+			if tt.wantFiles {
+				names := archiveFileNames(t, tt.opts.Format, data)
+				assert.Greater(t, len(names), 0, "archive should contain files")
+			}
+		})
+	}
+}
+
+func TestRepository_ArchiveContext_Cancelled(t *testing.T) {
+	t.Parallel()
+
+	r := setupArchiveRepo(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	ar, err := r.ArchiveContext(ctx, &ArchiveOptions{
+		Format:  "tar",
+		Treeish: "master",
+	})
+	assert.NoError(t, err)
+	t.Cleanup(func() { ar.Close() })
+	_, err = io.Copy(io.Discard, ar)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// archiveFileNames extracts file names from an archive based on format.
+func archiveFileNames(t *testing.T, format string, data []byte) []string {
+	t.Helper()
+
+	var names []string
+
+	switch format {
+	case "zip":
+		zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+		require.NoError(t, err)
+		for _, f := range zr.File {
+			names = append(names, f.Name)
+		}
+
+	case "tar":
+		tr := tar.NewReader(bytes.NewReader(data))
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			if hdr.Typeflag == tar.TypeXGlobalHeader {
+				continue
+			}
+			names = append(names, hdr.Name)
+		}
+
+	default: // tar.gz, tgz
+		gr, err := gzip.NewReader(bytes.NewReader(data))
+		require.NoError(t, err)
+		tr := tar.NewReader(gr)
+		defer gr.Close()
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			if hdr.Typeflag == tar.TypeXGlobalHeader {
+				continue
+			}
+			names = append(names, hdr.Name)
+		}
+	}
+
+	return names
+}
+
+// setupArchiveRepo creates a repository from the basic fixture suitable for
+// archive tests. It returns an opened *Repository.
+func setupArchiveRepo(t *testing.T) *Repository {
+	t.Helper()
+	f := fixtures.Basic().One()
+	dotgit, err := f.DotGit()
+	require.NoError(t, err)
+	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	r, err := Open(st, memfs.New())
+	require.NoError(t, err)
+	return r
 }


### PR DESCRIPTION
This implements the high level porcelain end of `git-upload-archive` and the `git archive` equivalent APIs. It adds a `repo.Archive(opts)` and `git.ArchiveRemote(url, opts)` methods to create archives of local and remote repositories.

This continues the work that was introduced in https://github.com/go-git/go-git/pull/1986