### PR TITLE
internal: servers, add git server implementation

### DIFF
--- a/internal/server/git/git.go
+++ b/internal/server/git/git.go
@@ -26,6 +26,8 @@ import (
 
 const defaultAddr = "127.0.0.1:0"
 
+var errAlreadyStarted = errors.New("git: server already started")
+
 // Server is a git:// protocol server.
 type Server struct {
 	// Loader resolves repository URLs to storage. If nil,
@@ -61,10 +63,12 @@ type Server struct {
 	ln  net.Listener
 	srv *backend.Backend
 
-	mu    sync.Mutex
+	mu    sync.RWMutex
 	conns map[net.Conn]context.CancelFunc
 	wg    sync.WaitGroup
 	done  chan struct{}
+
+	started bool
 }
 
 // FromLoader creates a git:// server backed by the given loader.
@@ -78,31 +82,46 @@ func FromLoader(loader transport.Loader) *Server {
 // It returns the endpoint URL (e.g. "git://127.0.0.1:XXXXX") that
 // clients can use to connect.
 func (s *Server) Start() (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.started {
+		return "", errAlreadyStarted
+	}
+
 	if s.Loader == nil {
 		s.Loader = transport.DefaultLoader
+	}
+
+	ln, err := net.Listen("tcp", defaultAddr)
+	if err != nil {
+		return "", fmt.Errorf("git: listen: %w", err)
 	}
 
 	s.srv = backend.New(s.Loader)
 	s.conns = make(map[net.Conn]context.CancelFunc)
 	s.done = make(chan struct{})
-
-	var err error
-	s.ln, err = net.Listen("tcp", defaultAddr)
-	if err != nil {
-		return "", fmt.Errorf("git: listen: %w", err)
-	}
+	s.ln = ln
+	s.started = true
 
 	go s.serve()
 
-	return s.Endpoint()
+	return endpoint(ln)
 }
 
 // Endpoint returns the git:// URL clients should connect to.
 func (s *Server) Endpoint() (string, error) {
-	if s.ln == nil {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return endpoint(s.ln)
+}
+
+func endpoint(ln net.Listener) (string, error) {
+	if ln == nil {
 		return "", errors.New("git: server not started")
 	}
-	return "git://" + s.ln.Addr().String(), nil
+	return "git://" + ln.Addr().String(), nil
 }
 
 // Close immediately closes the listener and all active connections.
@@ -120,11 +139,12 @@ func (s *Server) Close() error {
 		cancel()
 	}
 	s.conns = make(map[net.Conn]context.CancelFunc)
+	ln := s.ln
 	s.mu.Unlock()
 
 	var err error
-	if s.ln != nil {
-		err = s.ln.Close()
+	if ln != nil {
+		err = ln.Close()
 	}
 	s.wg.Wait()
 	return err
@@ -189,9 +209,9 @@ func (s *Server) handleConn(conn net.Conn) {
 	defer func() { _ = conn.Close() }()
 
 	// Retrieve the per-connection context created by trackConn.
-	s.mu.Lock()
+	s.mu.RLock()
 	cancel, ok := s.conns[conn]
-	s.mu.Unlock()
+	s.mu.RUnlock()
 	if !ok {
 		return
 	}

--- a/internal/server/git/git.go
+++ b/internal/server/git/git.go
@@ -1,0 +1,142 @@
+// Package git provides an in-process git:// protocol server for testing.
+//
+// It listens on a random TCP port and handles the git:// wire protocol
+// (git-upload-pack, git-receive-pack, git-upload-archive) using the
+// [backend.Backend] handler. This allows integration tests to exercise
+// the full git:// transport stack without requiring an external git
+// daemon.
+package git
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+
+	"github.com/go-git/go-git/v6/backend"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+const defaultAddr = "127.0.0.1:0"
+
+// Server is a git:// protocol server.
+type Server struct {
+	// Loader resolves repository URLs to storage. If nil,
+	// [transport.DefaultLoader] is used.
+	Loader transport.Loader
+
+	// ErrorLog is used to log errors. If nil, errors are not logged.
+	ErrorLog *log.Logger
+
+	ln  net.Listener
+	srv *backend.Backend
+}
+
+// FromLoader creates a git:// server backed by the given loader.
+func FromLoader(loader transport.Loader) *Server {
+	return &Server{
+		Loader: loader,
+	}
+}
+
+// Start starts the git:// server on a random port.
+// It returns the endpoint URL (e.g. "git://127.0.0.1:XXXXX") that
+// clients can use to connect.
+func (s *Server) Start() (string, error) {
+	if s.Loader == nil {
+		s.Loader = transport.DefaultLoader
+	}
+
+	s.srv = backend.New(s.Loader)
+
+	var err error
+	s.ln, err = net.Listen("tcp", defaultAddr)
+	if err != nil {
+		return "", fmt.Errorf("git: listen: %w", err)
+	}
+
+	go s.serve()
+
+	return s.Endpoint()
+}
+
+// Endpoint returns the git:// URL clients should connect to.
+func (s *Server) Endpoint() (string, error) {
+	if s.ln == nil {
+		return "", errors.New("git: server not started")
+	}
+	return "git://" + s.ln.Addr().String(), nil
+}
+
+// Close shuts down the server and closes the listener.
+func (s *Server) Close() error {
+	if s.ln != nil {
+		return s.ln.Close()
+	}
+	return nil
+}
+
+// serve accepts connections and handles each in a goroutine.
+func (s *Server) serve() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			// Listener closed — normal shutdown.
+			return
+		}
+		go s.handleConn(conn)
+	}
+}
+
+// handleConn processes a single git:// connection.
+//
+// Wire protocol:
+//
+//	Client sends: <command> <path>\0host=<host>\0\n  (pkt-line)
+//	Server reads the GitProtoRequest, resolves the repository, and
+//	dispatches to the appropriate backend handler.
+func (s *Server) handleConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Read the git protocol request line.
+	br := bufio.NewReader(conn)
+	var proto packp.GitProtoRequest
+	if err := proto.Decode(br); err != nil {
+		s.logf("git: decode request: %v", err)
+		return
+	}
+
+	req := backend.RequestFromProto(&proto)
+	if !s.validService(req.Service) {
+		s.logf("git: unsupported service: %s", req.Service)
+		return
+	}
+
+	if err := s.srv.Serve(ctx, io.NopCloser(conn), ioutil.WriteNopCloser(conn), req); err != nil {
+		s.logf("git: serve %s %s: %v", req.Service, req.URL.Path, err)
+	}
+}
+
+func (s *Server) logf(format string, v ...any) {
+	if s.ErrorLog != nil {
+		s.ErrorLog.Printf(format, v...)
+	}
+}
+
+// validService returns true if the service is one we handle.
+func (*Server) validService(svc string) bool {
+	switch svc {
+	case transport.UploadPackService, transport.ReceivePackService, transport.UploadArchiveService:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/server/git/git.go
+++ b/internal/server/git/git.go
@@ -1,10 +1,9 @@
-// Package git provides an in-process git:// protocol server for testing.
+// Package git provides an in-process git:// protocol server.
 //
-// It listens on a random TCP port and handles the git:// wire protocol
+// It listens on a TCP port and handles the git:// wire protocol
 // (git-upload-pack, git-receive-pack, git-upload-archive) using the
-// [backend.Backend] handler. This allows integration tests to exercise
-// the full git:// transport stack without requiring an external git
-// daemon.
+// [backend.Backend] handler. The server supports configurable timeouts
+// and maximum connections, similar to git-daemon.
 package git
 
 import (
@@ -15,6 +14,9 @@ import (
 	"io"
 	"log"
 	"net"
+	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/go-git/go-git/v6/backend"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
@@ -33,8 +35,36 @@ type Server struct {
 	// ErrorLog is used to log errors. If nil, errors are not logged.
 	ErrorLog *log.Logger
 
+	// Timeout is the idle timeout for each connection. If a connection
+	// has no read or write activity for this duration, it is closed.
+	// If zero, there is no idle timeout. Corresponds to git-daemon's
+	// --timeout.
+	Timeout time.Duration
+
+	// InitTimeout is the timeout for the initial protocol handshake
+	// (reading the GitProtoRequest). If zero, there is no handshake
+	// timeout. Corresponds to git-daemon's --init-timeout.
+	InitTimeout time.Duration
+
+	// MaxTimeout is the absolute maximum duration a connection is
+	// allowed to live, regardless of activity. If zero, there is no
+	// maximum. This is useful to prevent long-lived connections from
+	// consuming server resources indefinitely.
+	MaxTimeout time.Duration
+
+	// MaxConnections is the maximum number of simultaneous connections.
+	// If zero, there is no limit. Corresponds to git-daemon's
+	// --max-connections. Connections beyond the limit are immediately
+	// closed.
+	MaxConnections int
+
 	ln  net.Listener
 	srv *backend.Backend
+
+	mu    sync.Mutex
+	conns map[net.Conn]context.CancelFunc
+	wg    sync.WaitGroup
+	done  chan struct{}
 }
 
 // FromLoader creates a git:// server backed by the given loader.
@@ -53,6 +83,8 @@ func (s *Server) Start() (string, error) {
 	}
 
 	s.srv = backend.New(s.Loader)
+	s.conns = make(map[net.Conn]context.CancelFunc)
+	s.done = make(chan struct{})
 
 	var err error
 	s.ln, err = net.Listen("tcp", defaultAddr)
@@ -73,12 +105,29 @@ func (s *Server) Endpoint() (string, error) {
 	return "git://" + s.ln.Addr().String(), nil
 }
 
-// Close shuts down the server and closes the listener.
+// Close immediately closes the listener and all active connections.
 func (s *Server) Close() error {
-	if s.ln != nil {
-		return s.ln.Close()
+	s.mu.Lock()
+	if s.done != nil {
+		select {
+		case <-s.done:
+		default:
+			close(s.done)
+		}
 	}
-	return nil
+	for conn, cancel := range s.conns {
+		_ = conn.Close()
+		cancel()
+	}
+	s.conns = make(map[net.Conn]context.CancelFunc)
+	s.mu.Unlock()
+
+	var err error
+	if s.ln != nil {
+		err = s.ln.Close()
+	}
+	s.wg.Wait()
+	return err
 }
 
 // serve accepts connections and handles each in a goroutine.
@@ -86,11 +135,47 @@ func (s *Server) serve() {
 	for {
 		conn, err := s.ln.Accept()
 		if err != nil {
-			// Listener closed — normal shutdown.
-			return
+			select {
+			case <-s.done:
+				return
+			default:
+				s.logf("git: accept: %v", err)
+				return
+			}
 		}
-		go s.handleConn(conn)
+
+		if !s.trackConn(conn, true) {
+			_ = conn.Close()
+			continue
+		}
+
+		s.wg.Go(func() {
+			s.handleConn(conn)
+			s.trackConn(conn, false)
+		})
 	}
+}
+
+// trackConn registers or unregisters a connection. Returns false if
+// the connection exceeds MaxConnections and should be rejected.
+func (s *Server) trackConn(conn net.Conn, add bool) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if add {
+		if s.MaxConnections > 0 && len(s.conns) >= s.MaxConnections {
+			return false
+		}
+		_, cancel := context.WithCancel(context.Background())
+		s.conns[conn] = cancel
+		return true
+	}
+
+	if cancel, ok := s.conns[conn]; ok {
+		cancel()
+		delete(s.conns, conn)
+	}
+	return true
 }
 
 // handleConn processes a single git:// connection.
@@ -103,16 +188,48 @@ func (s *Server) serve() {
 func (s *Server) handleConn(conn net.Conn) {
 	defer func() { _ = conn.Close() }()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	// Retrieve the per-connection context created by trackConn.
+	s.mu.Lock()
+	cancel, ok := s.conns[conn]
+	s.mu.Unlock()
+	if !ok {
+		return
+	}
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	// When the connection times out, cancel the per-connection context
+	// so backend.Serve can abort gracefully.
+	closeCanceler := func() {
+		cancel()
+		ctxCancel()
+	}
+
+	maxDeadline := time.Time{}
+	if s.MaxTimeout > 0 {
+		maxDeadline = time.Now().Add(s.MaxTimeout)
+	}
+
+	sc := &serverConn{
+		Conn:          conn,
+		idleTimeout:   s.Timeout,
+		initTimeout:   s.InitTimeout,
+		maxDeadline:   maxDeadline,
+		closeCanceler: closeCanceler,
+	}
+	sc.updateDeadline()
 
 	// Read the git protocol request line.
-	br := bufio.NewReader(conn)
+	br := bufio.NewReader(sc)
 	var proto packp.GitProtoRequest
 	if err := proto.Decode(br); err != nil {
 		s.logf("git: decode request: %v", err)
 		return
 	}
+
+	// Handshake complete — clear init deadline so only idle + max
+	// remain in effect.
+	sc.clearInitDeadline()
 
 	req := backend.RequestFromProto(&proto)
 	if !s.validService(req.Service) {
@@ -120,7 +237,7 @@ func (s *Server) handleConn(conn net.Conn) {
 		return
 	}
 
-	if err := s.srv.Serve(ctx, io.NopCloser(conn), ioutil.WriteNopCloser(conn), req); err != nil {
+	if err := s.srv.Serve(ctx, io.NopCloser(br), ioutil.WriteNopCloser(sc), req); err != nil {
 		s.logf("git: serve %s %s: %v", req.Service, req.URL.Path, err)
 	}
 }
@@ -139,4 +256,94 @@ func (*Server) validService(svc string) bool {
 	default:
 		return false
 	}
+}
+
+// serverConn wraps a net.Conn with deadline management, inspired by
+// gliderlabs/ssh. Every Read and Write resets the idle deadline.
+// Three deadlines are computed:
+//
+//   - initTimeout: applied only during the initial handshake phase
+//     (reading the GitProtoRequest). Cleared once the handshake
+//     completes.
+//   - idleTimeout: resets on each Read/Write. If no I/O occurs
+//     within this duration, the connection times out.
+//   - maxDeadline: absolute deadline for the connection lifetime,
+//     set once when the connection is accepted.
+//
+// When a timeout net.Error is returned from Read or Write, the
+// connection's context is cancelled via closeCanceler so the
+// backend handler can abort gracefully.
+type serverConn struct {
+	net.Conn
+
+	idleTimeout   time.Duration
+	initTimeout   time.Duration
+	maxDeadline   time.Time
+	initCleared   atomic.Bool
+	closeCanceler func()
+}
+
+func (c *serverConn) Read(b []byte) (n int, err error) {
+	if c.idleTimeout > 0 {
+		c.updateDeadline()
+	}
+	n, err = c.Conn.Read(b)
+	if ne, ok := err.(net.Error); ok && ne.Timeout() && c.closeCanceler != nil {
+		c.closeCanceler()
+	}
+	return n, err
+}
+
+func (c *serverConn) Write(p []byte) (n int, err error) {
+	if c.idleTimeout > 0 {
+		c.updateDeadline()
+	}
+	n, err = c.Conn.Write(p)
+	if ne, ok := err.(net.Error); ok && ne.Timeout() && c.closeCanceler != nil {
+		c.closeCanceler()
+	}
+	return n, err
+}
+
+func (c *serverConn) Close() (err error) {
+	err = c.Conn.Close()
+	if c.closeCanceler != nil {
+		c.closeCanceler()
+	}
+	return err
+}
+
+// clearInitDeadline clears the handshake deadline so only idle +
+// max remain in effect.
+func (c *serverConn) clearInitDeadline() {
+	c.initCleared.Store(true)
+	if c.idleTimeout > 0 || !c.maxDeadline.IsZero() {
+		c.updateDeadline()
+	}
+}
+
+// updateDeadline recomputes and sets the connection deadline from the
+// three configured timeouts. The earliest non-zero deadline wins.
+func (c *serverConn) updateDeadline() {
+	var deadline time.Time
+
+	if !c.maxDeadline.IsZero() {
+		deadline = c.maxDeadline
+	}
+
+	if !c.initCleared.Load() && c.initTimeout > 0 {
+		initDeadline := time.Now().Add(c.initTimeout)
+		if deadline.IsZero() || initDeadline.Before(deadline) {
+			deadline = initDeadline
+		}
+	}
+
+	if c.idleTimeout > 0 {
+		idleDeadline := time.Now().Add(c.idleTimeout)
+		if deadline.IsZero() || idleDeadline.Before(deadline) {
+			deadline = idleDeadline
+		}
+	}
+
+	_ = c.SetDeadline(deadline)
 }

--- a/internal/server/git/git.go
+++ b/internal/server/git/git.go
@@ -164,38 +164,56 @@ func (s *Server) serve() {
 			}
 		}
 
-		if !s.trackConn(conn, true) {
+		ctx, ok := s.addConn(conn)
+		if !ok {
 			_ = conn.Close()
 			continue
 		}
 
 		s.wg.Go(func() {
-			s.handleConn(conn)
-			s.trackConn(conn, false)
+			s.handleConn(ctx, conn)
+			s.removeConn(conn)
 		})
 	}
 }
 
-// trackConn registers or unregisters a connection. Returns false if
-// the connection exceeds MaxConnections and should be rejected.
-func (s *Server) trackConn(conn net.Conn, add bool) bool {
+// addConn registers a new connection with a fresh per-connection context.
+// Returns false (and a nil context) if the connection exceeds
+// MaxConnections and should be rejected.
+func (s *Server) addConn(conn net.Conn) (context.Context, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if add {
-		if s.MaxConnections > 0 && len(s.conns) >= s.MaxConnections {
-			return false
-		}
-		_, cancel := context.WithCancel(context.Background())
-		s.conns[conn] = cancel
-		return true
+	if s.MaxConnections > 0 && len(s.conns) >= s.MaxConnections {
+		return nil, false
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.conns[conn] = cancel
+	return ctx, true
+}
+
+// removeConn unregisters a connection, cancelling its per-connection
+// context.
+func (s *Server) removeConn(conn net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if cancel, ok := s.conns[conn]; ok {
 		cancel()
 		delete(s.conns, conn)
 	}
-	return true
+}
+
+// cancelConn cancels the per-connection context if still registered.
+// Used to abort an in-flight backend.Serve when the connection times
+// out.
+func (s *Server) cancelConn(conn net.Conn) {
+	s.mu.RLock()
+	cancel, ok := s.conns[conn]
+	s.mu.RUnlock()
+	if ok {
+		cancel()
+	}
 }
 
 // handleConn processes a single git:// connection.
@@ -205,35 +223,27 @@ func (s *Server) trackConn(conn net.Conn, add bool) bool {
 //	Client sends: <command> <path>\0host=<host>\0\n  (pkt-line)
 //	Server reads the GitProtoRequest, resolves the repository, and
 //	dispatches to the appropriate backend handler.
-func (s *Server) handleConn(conn net.Conn) {
+func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 	defer func() { _ = conn.Close() }()
-
-	// Retrieve the per-connection context created by trackConn.
-	s.mu.RLock()
-	cancel, ok := s.conns[conn]
-	s.mu.RUnlock()
-	if !ok {
-		return
-	}
-	ctx, ctxCancel := context.WithCancel(context.Background())
-	defer ctxCancel()
 
 	// When the connection times out, cancel the per-connection context
 	// so backend.Serve can abort gracefully.
-	closeCanceler := func() {
-		cancel()
-		ctxCancel()
-	}
+	closeCanceler := func() { s.cancelConn(conn) }
 
+	now := time.Now()
 	maxDeadline := time.Time{}
 	if s.MaxTimeout > 0 {
-		maxDeadline = time.Now().Add(s.MaxTimeout)
+		maxDeadline = now.Add(s.MaxTimeout)
+	}
+	initDeadline := time.Time{}
+	if s.InitTimeout > 0 {
+		initDeadline = now.Add(s.InitTimeout)
 	}
 
 	sc := &serverConn{
 		Conn:          conn,
 		idleTimeout:   s.Timeout,
-		initTimeout:   s.InitTimeout,
+		initDeadline:  initDeadline,
 		maxDeadline:   maxDeadline,
 		closeCanceler: closeCanceler,
 	}
@@ -282,9 +292,10 @@ func (*Server) validService(svc string) bool {
 // gliderlabs/ssh. Every Read and Write resets the idle deadline.
 // Three deadlines are computed:
 //
-//   - initTimeout: applied only during the initial handshake phase
-//     (reading the GitProtoRequest). Cleared once the handshake
-//     completes.
+//   - initDeadline: absolute deadline for the initial handshake phase
+//     (reading the GitProtoRequest). Fixed at connection accept time
+//     so that a slow client trickling bytes cannot keep extending it.
+//     Cleared once the handshake completes.
 //   - idleTimeout: resets on each Read/Write. If no I/O occurs
 //     within this duration, the connection times out.
 //   - maxDeadline: absolute deadline for the connection lifetime,
@@ -297,7 +308,7 @@ type serverConn struct {
 	net.Conn
 
 	idleTimeout   time.Duration
-	initTimeout   time.Duration
+	initDeadline  time.Time
 	maxDeadline   time.Time
 	initCleared   atomic.Bool
 	closeCanceler func()
@@ -351,10 +362,9 @@ func (c *serverConn) updateDeadline() {
 		deadline = c.maxDeadline
 	}
 
-	if !c.initCleared.Load() && c.initTimeout > 0 {
-		initDeadline := time.Now().Add(c.initTimeout)
-		if deadline.IsZero() || initDeadline.Before(deadline) {
-			deadline = initDeadline
+	if !c.initCleared.Load() && !c.initDeadline.IsZero() {
+		if deadline.IsZero() || c.initDeadline.Before(deadline) {
+			deadline = c.initDeadline
 		}
 	}
 

--- a/internal/server/git/git_test.go
+++ b/internal/server/git/git_test.go
@@ -1,0 +1,188 @@
+package git_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/url"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	servergit "github.com/go-git/go-git/v6/internal/server"
+	servergitdaemon "github.com/go-git/go-git/v6/internal/server/git"
+	transportgit "github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/plumbing/transport/git"
+)
+
+func TestGitServer_UploadPack(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitServer(t, fixtures.Basic().One())
+
+	tr := git.NewTransport(git.Options{})
+	req := &transportgit.Request{
+		URL:     srv.url("/basic.git"),
+		Command: transportgit.UploadPackService,
+	}
+
+	sess, err := tr.Handshake(context.Background(), req)
+	require.NoError(t, err)
+	t.Cleanup(func() { sess.Close() })
+
+	refs, err := sess.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	assert.Greater(t, len(refs), 0, "server should advertise refs")
+}
+
+func TestGitServer_Archive(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitServer(t, fixtures.Basic().One())
+
+	tr := git.NewTransport(git.Options{})
+	req := &transportgit.Request{
+		URL:     srv.url("/basic.git"),
+		Command: transportgit.UploadArchiveService,
+	}
+
+	sess, err := tr.Handshake(context.Background(), req)
+	require.NoError(t, err)
+	t.Cleanup(func() { sess.Close() })
+
+	arch, ok := sess.(transportgit.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	rc, err := arch.Archive(context.Background(), &transportgit.ArchiveRequest{
+		Args: []string{"--format=tar", "master"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { rc.Close() })
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	tarReader := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if hdr.Typeflag == tar.TypeXGlobalHeader {
+			continue
+		}
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0, "archive should contain files")
+}
+
+func TestGitServer_ArchiveTarGz(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitServer(t, fixtures.Basic().One())
+
+	tr := git.NewTransport(git.Options{})
+	req := &transportgit.Request{
+		URL:     srv.url("/basic.git"),
+		Command: transportgit.UploadArchiveService,
+	}
+
+	sess, err := tr.Handshake(context.Background(), req)
+	require.NoError(t, err)
+	t.Cleanup(func() { sess.Close() })
+
+	arch, ok := sess.(transportgit.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	rc, err := arch.Archive(context.Background(), &transportgit.ArchiveRequest{
+		Args: []string{"--format=tar.gz", "master"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { rc.Close() })
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	require.NoError(t, err)
+
+	tarReader := tar.NewReader(gr)
+	var names []string
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if hdr.Typeflag == tar.TypeXGlobalHeader {
+			continue
+		}
+		names = append(names, hdr.Name)
+	}
+	assert.Greater(t, len(names), 0, "archive should contain files")
+}
+
+func TestGitServer_UnsupportedService(t *testing.T) {
+	t.Parallel()
+
+	srv := startGitServer(t, fixtures.Basic().One())
+
+	tr := git.NewTransport(git.Options{})
+	req := &transportgit.Request{
+		URL:     srv.url("/basic.git"),
+		Command: "git-unsupported-service",
+	}
+
+	// The server silently drops connections for unsupported services.
+	// Connect may succeed (it's just TCP + request write), but
+	// Handshake will fail because the server closes the connection.
+	conn, err := tr.Connect(context.Background(), req)
+	if err != nil {
+		// Connection failed — acceptable outcome.
+		return
+	}
+	defer conn.Close()
+
+	// If Connect succeeded, reading from the connection should fail
+	// because the server closes it immediately.
+	buf := make([]byte, 1)
+	_, err = conn.Reader().Read(buf)
+	assert.Error(t, err, "reading from unsupported service should fail")
+}
+
+// gitServer is a helper that holds a running git:// server and its endpoint.
+type gitServer struct {
+	server   *servergitdaemon.Server
+	endpoint string
+}
+
+func (g *gitServer) url(path string) *url.URL {
+	u, err := url.Parse(g.endpoint + path)
+	if err != nil {
+		panic("invalid URL: " + err.Error())
+	}
+	return u
+}
+
+// startGitServer starts a git:// server backed by the given fixture.
+func startGitServer(t *testing.T, f *fixtures.Fixture) *gitServer {
+	t.Helper()
+
+	loader := servergit.Loader(t, f)
+	srv := servergitdaemon.FromLoader(loader)
+
+	endpoint, err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
+
+	return &gitServer{
+		server:   srv,
+		endpoint: endpoint,
+	}
+}

--- a/internal/server/git/git_test.go
+++ b/internal/server/git/git_test.go
@@ -20,26 +20,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/transport/git"
 )
 
-func TestGitServer_UploadPack(t *testing.T) {
-	t.Parallel()
-
-	srv := startGitServer(t, fixtures.Basic().One())
-
-	tr := git.NewTransport(git.Options{})
-	req := &transportgit.Request{
-		URL:     srv.url("/basic.git"),
-		Command: transportgit.UploadPackService,
-	}
-
-	sess, err := tr.Handshake(context.Background(), req)
-	require.NoError(t, err)
-	t.Cleanup(func() { sess.Close() })
-
-	refs, err := sess.GetRemoteRefs(context.Background())
-	require.NoError(t, err)
-	assert.Greater(t, len(refs), 0, "server should advertise refs")
-}
-
 func TestGitServer_Archive(t *testing.T) {
 	t.Parallel()
 
@@ -127,31 +107,6 @@ func TestGitServer_ArchiveTarGz(t *testing.T) {
 		names = append(names, hdr.Name)
 	}
 	assert.Greater(t, len(names), 0, "archive should contain files")
-}
-
-func TestGitServer_UnsupportedService(t *testing.T) {
-	t.Parallel()
-
-	srv := startGitServer(t, fixtures.Basic().One())
-
-	tr := git.NewTransport(git.Options{})
-	req := &transportgit.Request{
-		URL:     srv.url("/basic.git"),
-		Command: "git-unsupported-service",
-	}
-
-	// The server silently drops connections for unsupported services.
-	// Connect may succeed (it's just TCP + request write), but
-	// Handshake will fail because the server closes the connection.
-	conn, err := tr.Connect(context.Background(), req)
-	if err != nil {
-		return
-	}
-	defer conn.Close()
-
-	buf := make([]byte, 1)
-	_, err = conn.Reader().Read(buf)
-	assert.Error(t, err, "reading from unsupported service should fail")
 }
 
 func TestGitServer_MaxConnections(t *testing.T) {

--- a/internal/server/git/git_test.go
+++ b/internal/server/git/git_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/url"
 	"testing"
+	"time"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/assert"
@@ -144,16 +145,94 @@ func TestGitServer_UnsupportedService(t *testing.T) {
 	// Handshake will fail because the server closes the connection.
 	conn, err := tr.Connect(context.Background(), req)
 	if err != nil {
-		// Connection failed — acceptable outcome.
 		return
 	}
 	defer conn.Close()
 
-	// If Connect succeeded, reading from the connection should fail
-	// because the server closes it immediately.
 	buf := make([]byte, 1)
 	_, err = conn.Reader().Read(buf)
 	assert.Error(t, err, "reading from unsupported service should fail")
+}
+
+func TestGitServer_MaxConnections(t *testing.T) {
+	t.Parallel()
+
+	loader := servergit.Loader(t, fixtures.Basic().One())
+	srv := servergitdaemon.FromLoader(loader)
+	srv.MaxConnections = 1
+
+	endpoint, err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
+
+	u, err := url.Parse(endpoint + "/basic.git")
+	require.NoError(t, err)
+
+	// Hold one connection open.
+	tr1 := git.NewTransport(git.Options{})
+	conn1, err := tr1.Connect(context.Background(), &transportgit.Request{
+		URL: u, Command: transportgit.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer conn1.Close()
+
+	// Second connection should be rejected (server closes it).
+	tr2 := git.NewTransport(git.Options{})
+	conn2, err := tr2.Connect(context.Background(), &transportgit.Request{
+		URL: u, Command: transportgit.UploadPackService,
+	})
+	if err != nil {
+		return
+	}
+	defer conn2.Close()
+
+	buf := make([]byte, 1)
+	_, err = conn2.Reader().Read(buf)
+	assert.Error(t, err, "second connection should be rejected due to max connections")
+}
+
+func TestGitServer_InitTimeout(t *testing.T) {
+	t.Parallel()
+
+	loader := servergit.Loader(t, fixtures.Basic().One())
+	srv := servergitdaemon.FromLoader(loader)
+	srv.InitTimeout = 50 * time.Millisecond
+
+	endpoint, err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
+
+	// The init timeout configuration is accepted without error.
+	// Exercising it requires a raw TCP connection that stalls after
+	// connect, which is difficult from the client transport layer.
+	_ = endpoint
+}
+
+func TestGitServer_Timeout(t *testing.T) {
+	t.Parallel()
+
+	loader := servergit.Loader(t, fixtures.Basic().One())
+	srv := servergitdaemon.FromLoader(loader)
+	srv.Timeout = 100 * time.Millisecond
+
+	endpoint, err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { srv.Close() })
+
+	u, err := url.Parse(endpoint + "/basic.git")
+	require.NoError(t, err)
+
+	// Normal operation should still work within the idle timeout.
+	tr := git.NewTransport(git.Options{})
+	sess, err := tr.Handshake(context.Background(), &transportgit.Request{
+		URL: u, Command: transportgit.UploadPackService,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { sess.Close() })
+
+	refs, err := sess.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	assert.Greater(t, len(refs), 0, "should still get refs within idle timeout")
 }
 
 // gitServer is a helper that holds a running git:// server and its endpoint.

--- a/internal/server/git/git_test.go
+++ b/internal/server/git/git_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
+	"net"
 	"net/url"
 	"testing"
 	"time"
@@ -123,7 +124,6 @@ func TestGitServer_MaxConnections(t *testing.T) {
 	u, err := url.Parse(endpoint + "/basic.git")
 	require.NoError(t, err)
 
-	// Hold one connection open.
 	tr1 := git.NewTransport(git.Options{})
 	conn1, err := tr1.Connect(context.Background(), &transportgit.Request{
 		URL: u, Command: transportgit.UploadPackService,
@@ -131,19 +131,14 @@ func TestGitServer_MaxConnections(t *testing.T) {
 	require.NoError(t, err)
 	defer conn1.Close()
 
-	// Second connection should be rejected (server closes it).
-	tr2 := git.NewTransport(git.Options{})
-	conn2, err := tr2.Connect(context.Background(), &transportgit.Request{
-		URL: u, Command: transportgit.UploadPackService,
-	})
-	if err != nil {
-		return
-	}
+	conn2, err := net.Dial("tcp", u.Host)
+	require.NoError(t, err, "TCP accept should succeed before server checks MaxConnections")
 	defer conn2.Close()
 
+	require.NoError(t, conn2.SetReadDeadline(time.Now().Add(2*time.Second)))
 	buf := make([]byte, 1)
-	_, err = conn2.Reader().Read(buf)
-	assert.Error(t, err, "second connection should be rejected due to max connections")
+	_, err = conn2.Read(buf)
+	assert.ErrorIs(t, err, io.EOF, "second connection should be closed by server due to MaxConnections")
 }
 
 func TestGitServer_InitTimeout(t *testing.T) {
@@ -168,26 +163,28 @@ func TestGitServer_Timeout(t *testing.T) {
 
 	loader := servergit.Loader(t, fixtures.Basic().One())
 	srv := servergitdaemon.FromLoader(loader)
-	srv.Timeout = 100 * time.Millisecond
+	srv.Timeout = 200 * time.Millisecond
 
 	endpoint, err := srv.Start()
 	require.NoError(t, err)
 	t.Cleanup(func() { srv.Close() })
 
-	u, err := url.Parse(endpoint + "/basic.git")
+	u, err := url.Parse(endpoint)
 	require.NoError(t, err)
 
-	// Normal operation should still work within the idle timeout.
-	tr := git.NewTransport(git.Options{})
-	sess, err := tr.Handshake(context.Background(), &transportgit.Request{
-		URL: u, Command: transportgit.UploadPackService,
-	})
+	conn, err := net.Dial("tcp", u.Host)
 	require.NoError(t, err)
-	t.Cleanup(func() { sess.Close() })
+	defer conn.Close()
 
-	refs, err := sess.GetRemoteRefs(context.Background())
-	require.NoError(t, err)
-	assert.Greater(t, len(refs), 0, "should still get refs within idle timeout")
+	// Stay idle past the configured Timeout; the server must close
+	// the connection, surfacing as a Read error.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	buf := make([]byte, 1)
+	start := time.Now()
+	_, err = conn.Read(buf)
+	elapsed := time.Since(start)
+	assert.Error(t, err, "server should close idle connection past Timeout")
+	assert.GreaterOrEqual(t, elapsed, srv.Timeout, "server should not close before Timeout elapses")
 }
 
 // gitServer is a helper that holds a running git:// server and its endpoint.

--- a/internal/server/http/http.go
+++ b/internal/server/http/http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	gohttp "net/http"
+	"sync"
 	"time"
 
 	"github.com/go-git/go-git/v6/backend"
@@ -16,11 +17,16 @@ const (
 	addr = "127.0.0.1:0"
 )
 
+var errAlreadyStarted = errors.New("http: server already started")
+
 type server struct {
 	l transport.Loader
 
 	ln  net.Listener
 	srv *gohttp.Server
+
+	mu      sync.RWMutex
+	started bool
 }
 
 // FromLoader creates an HTTP git server backed by the given loader.
@@ -32,15 +38,20 @@ func FromLoader(l transport.Loader) (*server, error) { //nolint:revive // unexpo
 }
 
 func (s *server) Start() (string, error) {
-	h := backend.New(s.l)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-	var err error
-	s.ln, err = net.Listen("tcp", addr)
+	if s.started {
+		return "", errAlreadyStarted
+	}
+
+	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return "", fmt.Errorf("cannot listen to TCP: %w", err)
 	}
 
-	s.srv = &gohttp.Server{
+	h := backend.New(s.l)
+	srv := &gohttp.Server{
 		Addr:         addr,
 		Handler:      h,
 		ReadTimeout:  10 * time.Second,
@@ -48,24 +59,43 @@ func (s *server) Start() (string, error) {
 		IdleTimeout:  60 * time.Second,
 	}
 
+	s.ln = ln
+	s.srv = srv
+	s.started = true
+
 	go func() {
-		_ = s.srv.Serve(s.ln)
+		_ = srv.Serve(ln)
 	}()
 
-	return s.Endpoint()
+	return endpoint(ln, srv)
 }
 
 func (s *server) Endpoint() (string, error) {
-	if s.ln != nil && s.srv != nil {
-		return "http://" + s.ln.Addr().String(), nil
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return endpoint(s.ln, s.srv)
+}
+
+func endpoint(ln net.Listener, srv *gohttp.Server) (string, error) {
+	if ln != nil && srv != nil {
+		return "http://" + ln.Addr().String(), nil
 	}
 
 	return "", errors.New("failed to get endpoint: server not started")
 }
 
 func (s *server) Close() error {
+	s.mu.RLock()
+	srv := s.srv
+	s.mu.RUnlock()
+
+	if srv == nil {
+		return nil
+	}
+
 	// s.srv.Close() closes the listener internally; calling s.ln.Close()
 	// separately would close it twice and return "use of closed network
 	// connection" from the second close.
-	return s.srv.Close()
+	return srv.Close()
 }

--- a/internal/server/servers.go
+++ b/internal/server/servers.go
@@ -3,6 +3,7 @@ package server
 import (
 	"io"
 
+	"github.com/go-git/go-git/v6/internal/server/git"
 	"github.com/go-git/go-git/v6/internal/server/http"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 )
@@ -17,6 +18,9 @@ type GitServer interface {
 func All(l transport.Loader) []GitServer {
 	servers := []GitServer{}
 	if srv, err := http.FromLoader(l); err == nil {
+		servers = append(servers, srv)
+	}
+	if srv := git.FromLoader(l); srv != nil {
 		servers = append(servers, srv)
 	}
 

--- a/internal/server/servers.go
+++ b/internal/server/servers.go
@@ -20,9 +20,7 @@ func All(l transport.Loader) []GitServer {
 	if srv, err := http.FromLoader(l); err == nil {
 		servers = append(servers, srv)
 	}
-	if srv := git.FromLoader(l); srv != nil {
-		servers = append(servers, srv)
-	}
+	servers = append(servers, git.FromLoader(l))
 
 	return servers
 }

--- a/internal/server/servers_test.go
+++ b/internal/server/servers_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/suite"
+
+	servergit "github.com/go-git/go-git/v6/internal/server/git"
+	serverhttp "github.com/go-git/go-git/v6/internal/server/http"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	transportgit "github.com/go-git/go-git/v6/plumbing/transport/git"
+	transporthttp "github.com/go-git/go-git/v6/plumbing/transport/http"
+)
+
+type serverImplementation struct {
+	name         string
+	newServer    func(transport.Loader) (GitServer, error)
+	newTransport func() transport.Transport
+}
+
+var serverImplementations = []serverImplementation{
+	{
+		name: "git",
+		newServer: func(l transport.Loader) (GitServer, error) {
+			return servergit.FromLoader(l), nil
+		},
+		newTransport: func() transport.Transport {
+			return transportgit.NewTransport(transportgit.Options{})
+		},
+	},
+	{
+		name: "http",
+		newServer: func(l transport.Loader) (GitServer, error) {
+			return serverhttp.FromLoader(l)
+		},
+		newTransport: func() transport.Transport {
+			return transporthttp.NewTransport(transporthttp.Options{})
+		},
+	},
+}
+
+type ServerSuite struct {
+	suite.Suite
+
+	impl serverImplementation
+}
+
+func TestServerSuite(t *testing.T) {
+	t.Parallel()
+
+	for _, impl := range serverImplementations {
+		t.Run(impl.name, func(t *testing.T) {
+			t.Parallel()
+
+			suite.Run(t, &ServerSuite{impl: impl})
+		})
+	}
+}
+
+func (s *ServerSuite) TestUploadPack() {
+	endpoint := s.startServer(fixtures.Basic().One())
+
+	sess, err := s.impl.newTransport().Handshake(context.Background(), &transport.Request{
+		URL:     endpoint.url("/basic.git"),
+		Command: transport.UploadPackService,
+	})
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { s.Require().NoError(sess.Close()) })
+
+	refs, err := sess.GetRemoteRefs(context.Background())
+	s.Require().NoError(err)
+	s.Greater(len(refs), 0, "server should advertise refs")
+}
+
+func (s *ServerSuite) TestUnsupportedService() {
+	endpoint := s.startServer(fixtures.Basic().One())
+
+	sess, err := s.impl.newTransport().Handshake(context.Background(), &transport.Request{
+		URL:     endpoint.url("/basic.git"),
+		Command: "git-unsupported-service",
+	})
+	if err == nil {
+		s.Require().NotNil(sess)
+		s.T().Cleanup(func() { s.Require().NoError(sess.Close()) })
+	}
+	s.Require().Error(err)
+}
+
+func (s *ServerSuite) TestStartAlreadyStarted() {
+	srv, err := s.impl.newServer(nil)
+	s.Require().NoError(err)
+
+	endpoint, err := srv.Start()
+	s.Require().NoError(err)
+	s.NotEmpty(endpoint)
+	s.T().Cleanup(func() { s.Require().NoError(srv.Close()) })
+
+	endpoint, err = srv.Start()
+	s.Require().Error(err, "Start() after Start() succeeded with endpoint %q", endpoint)
+	s.Empty(endpoint)
+	s.Contains(err.Error(), "server already started")
+}
+
+func (s *ServerSuite) TestStartAfterClose() {
+	srv, err := s.impl.newServer(nil)
+	s.Require().NoError(err)
+
+	endpoint, err := srv.Start()
+	s.Require().NoError(err)
+	s.NotEmpty(endpoint)
+	s.Require().NoError(srv.Close())
+
+	endpoint, err = srv.Start()
+	if err == nil {
+		_ = srv.Close()
+	}
+	s.Require().Error(err, "Start() after Close() succeeded with endpoint %q", endpoint)
+	s.Empty(endpoint)
+	s.Contains(err.Error(), "server already started")
+}
+
+type runningServer struct {
+	endpoint string
+}
+
+func (s *ServerSuite) startServer(f *fixtures.Fixture) runningServer {
+	s.T().Helper()
+
+	srv, err := s.impl.newServer(Loader(s.T(), f))
+	s.Require().NoError(err)
+
+	endpoint, err := srv.Start()
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { s.Require().NoError(srv.Close()) })
+
+	return runningServer{endpoint: endpoint}
+}
+
+func (s runningServer) url(path string) *url.URL {
+	u, err := url.Parse(s.endpoint + path)
+	if err != nil {
+		panic(fmt.Sprintf("invalid URL %q: %v", s.endpoint+path, err))
+	}
+	return u
+}

--- a/plumbing/protocol/packp/gitproto.go
+++ b/plumbing/protocol/packp/gitproto.go
@@ -34,10 +34,6 @@ func (g *GitProtoRequest) validate() error {
 		return fmt.Errorf("%w: empty request command", ErrInvalidGitProtoRequest)
 	}
 
-	if g.Pathname == "" {
-		return fmt.Errorf("%w: empty pathname", ErrInvalidGitProtoRequest)
-	}
-
 	return nil
 }
 

--- a/plumbing/protocol/packp/gitproto_test.go
+++ b/plumbing/protocol/packp/gitproto_test.go
@@ -37,9 +37,7 @@ func TestEncodeGitProtoRequest(t *testing.T) {
 func TestEncodeInvalidGitProtoRequest(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	p := GitProtoRequest{
-		RequestCommand: "command",
-	}
+	p := GitProtoRequest{}
 	err := p.Encode(&buf)
 	if err == nil {
 		t.Fatal("expected error")


### PR DESCRIPTION
This adds a new Git TCP server implementation based on the existing backend package. All the tests that use the `internal/server.All()` for testing now will also use a git daemon `git://` TCP server in addition to the existing HTTP server.

I assume this can eventually grow to offer a full `git-daemon` implementation that can replace [go-git/cli/server/git](https://github.com/go-git/cli/tree/main/server/git)