### PR TITLE
fix: match [!...] gitignore negation like Git does (fixes #2006)

### DIFF
--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -88,9 +88,21 @@ func (p *pattern) Match(path []string, isDir bool) MatchResult {
 	return Exclude
 }
 
+// convertGitignoreNegation converts gitignore-style negation [!...] to
+// Go's filepath.Match compatible syntax [^...].
+// Git's gitignore uses [!...] for negated character classes, but Go's
+// filepath.Match uses [^...] for the same purpose.
+func convertGitignoreNegation(pattern string) string {
+	if strings.Contains(pattern, "[!") {
+		pattern = strings.ReplaceAll(pattern, "[!", "[^")
+	}
+	return pattern
+}
+
 func (p *pattern) simpleNameMatch(path []string, isDir bool) bool {
 	for i, name := range path {
-		if match, err := filepath.Match(p.pattern[0], name); err != nil {
+		convertedPattern := convertGitignoreNegation(p.pattern[0])
+		if match, err := filepath.Match(convertedPattern, name); err != nil {
 			return false
 		} else if !match {
 			continue
@@ -124,12 +136,13 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 		if len(path) == 0 {
 			return false
 		}
+		convertedPattern := convertGitignoreNegation(pattern)
 		if canTraverse {
 			canTraverse = false
 			for len(path) > 0 {
 				e := path[0]
 				path = path[1:]
-				if match, err := filepath.Match(pattern, e); err != nil {
+				if match, err := filepath.Match(convertedPattern, e); err != nil {
 					return false
 				} else if match {
 					matched = true
@@ -140,7 +153,7 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 				}
 			}
 		} else {
-			if match, err := filepath.Match(pattern, path[0]); err != nil || !match {
+			if match, err := filepath.Match(convertedPattern, path[0]); err != nil || !match {
 				return false
 			}
 			matched = true

--- a/plumbing/format/gitignore/pattern_test.go
+++ b/plumbing/format/gitignore/pattern_test.go
@@ -302,3 +302,44 @@ func (s *PatternSuite) TestGlobMatch_folderVersusFileAgain() {
 	r := p.Match([]string{"ab", "ab"}, false)
 	s.Equal(Exclude, r)
 }
+
+func (s *PatternSuite) TestGitignoreNegation_simpleMatch() {
+	// [!0-9] should match any character NOT in 0-9
+	p := ParsePattern("[!0-9].dat", nil)
+	r := p.Match([]string{"x.dat"}, false)
+	s.Equal(Exclude, r)
+}
+
+func (s *PatternSuite) TestGitignoreNegation_simpleMatch_numericExcluded() {
+	// [!0-9] should NOT match digits
+	p := ParsePattern("[!0-9].dat", nil)
+	r := p.Match([]string{"7.dat"}, false)
+	s.Equal(NoMatch, r)
+}
+
+func (s *PatternSuite) TestGitignoreNegation_globMatch() {
+	// [!abc] should match any character NOT in a,b,c
+	p := ParsePattern("dir/[!abc].dat", nil)
+	r := p.Match([]string{"dir", "x.dat"}, false)
+	s.Equal(Exclude, r)
+}
+
+func (s *PatternSuite) TestGitignoreNegation_globMatch_excluded() {
+	// [!abc] should NOT match a, b, or c
+	p := ParsePattern("dir/[!abc].dat", nil)
+	r := p.Match([]string{"dir", "a.dat"}, false)
+	s.Equal(NoMatch, r)
+}
+
+func (s *PatternSuite) TestGitignoreNegation_withQuestionMark() {
+	// Combinations with other glob metacharacters
+	p := ParsePattern("[!0-9]?.dat", nil)
+	r := p.Match([]string{"ab.dat"}, false)
+	s.Equal(Exclude, r)
+}
+
+func (s *PatternSuite) TestGitignoreNegation_doubleAsterisk() {
+	p := ParsePattern("dir/**/[!0-9]*.dat", nil)
+	r := p.Match([]string{"dir", "subdir", "x.dat"}, false)
+	s.Equal(Exclude, r)
+}


### PR DESCRIPTION
fix: match [!...] gitignore negation like Git does (fixes #2006)

## Summary

Git's .gitignore syntax uses `[!...]` for negated character classes (match any character NOT in the set), but Go's `filepath.Match` uses `[^...]` for the same purpose.

go-git v5.18.0 was passing gitignore patterns directly to `filepath.Match`, causing `[!0-9].dat` to match digits (opposite of Git's behavior).

## Fix

Added `convertGitignoreNegation()` that converts `[!...]` to `[^...]` before passing to `filepath.Match` in both `simpleNameMatch` and `globMatch`.

## Test Cases

Added 6 test cases covering:
- `[!0-9].dat` matching non-digits (x.dat matches, 7.dat no match)
- `dir/[!abc].dat` glob matching
- `[!0-9]?.dat` with question mark
- `dir/**/[!0-9]*.dat` with double asterisks

## Issue
Fixes https://github.com/go-git/go-git/issues/2006