### PR TITLE
storage/filesystem/dotgit: clean up empty parent dirs after RemoveRef

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -949,7 +949,25 @@ func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
 		return err
 	}
 
+	if err == nil || os.IsNotExist(err) {
+		d.removeEmptyParentDirs(path)
+	}
+
 	return d.rewritePackedRefsWithoutRef(name)
+}
+
+// removeEmptyParentDirs walks up the directory tree from the removed ref file
+// and removes any empty parent directories, stopping at the DotGit root.
+func (d *DotGit) removeEmptyParentDirs(refPath string) {
+	dir := filepath.Dir(refPath)
+	root := d.fs.Join(".")
+
+	for dir != "." && dir != root {
+		if err := d.fs.Remove(dir); err != nil {
+			break
+		}
+		dir = filepath.Dir(dir)
+	}
 }
 
 func refsRecvFunc(refs *[]*plumbing.Reference, seen map[plumbing.ReferenceName]bool) refsRecv {


### PR DESCRIPTION
When RemoveRef deletes a reference file like `refs/heads/bugfix/1`, it now also removes empty parent directories (e.g. `refs/heads/bugfix/`) that were created for the nested reference.

This matches Git's behavior where deleting a branch cleans up empty parent directories.

Fixes go-git/go-git#1822