### PR TITLE
fix: convert gitignore [!...] negation to [^...] for Go filepath.Match

### DIFF
--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -88,9 +88,21 @@ func (p *pattern) Match(path []string, isDir bool) MatchResult {
 	return Exclude
 }
 
+// convertGitignoreNegation converts gitignore-style negation [!...] to
+// Go's filepath.Match compatible syntax [^...].
+// Git's gitignore uses [!...] for negated character classes, but Go's
+// filepath.Match uses [^...] for the same purpose.
+func convertGitignoreNegation(pattern string) string {
+	if strings.Contains(pattern, "[!") {
+		pattern = strings.ReplaceAll(pattern, "[!", "[^")
+	}
+	return pattern
+}
+
 func (p *pattern) simpleNameMatch(path []string, isDir bool) bool {
 	for i, name := range path {
-		if match, err := filepath.Match(p.pattern[0], name); err != nil {
+		convertedPattern := convertGitignoreNegation(p.pattern[0])
+		if match, err := filepath.Match(convertedPattern, name); err != nil {
 			return false
 		} else if !match {
 			continue
@@ -129,7 +141,8 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 			for len(path) > 0 {
 				e := path[0]
 				path = path[1:]
-				if match, err := filepath.Match(pattern, e); err != nil {
+				convertedPattern := convertGitignoreNegation(pattern)
+				if match, err := filepath.Match(convertedPattern, e); err != nil {
 					return false
 				} else if match {
 					matched = true
@@ -140,7 +153,8 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 				}
 			}
 		} else {
-			if match, err := filepath.Match(pattern, path[0]); err != nil || !match {
+			convertedPattern := convertGitignoreNegation(pattern)
+			if match, err := filepath.Match(convertedPattern, path[0]); err != nil || !match {
 				return false
 			}
 			matched = true

--- a/plumbing/format/gitignore/pattern_test.go
+++ b/plumbing/format/gitignore/pattern_test.go
@@ -302,3 +302,35 @@ func (s *PatternSuite) TestGlobMatch_folderVersusFileAgain() {
 	r := p.Match([]string{"ab", "ab"}, false)
 	s.Equal(Exclude, r)
 }
+
+func (s *PatternSuite) TestNegationPattern() {
+	// Test [!...] negation pattern - issue #2006
+	// [!cc] should match anything EXCEPT cc (not just starting with !)
+	p := ParsePattern("[!cc]", nil)
+	r := p.Match([]string{"a"}, false)
+	s.Equal(Exclude, r) // 'a' does not start with 'c', so it should be excluded
+	r = p.Match([]string{"cc"}, false)
+	s.Equal(NoMatch, r) // 'cc' is exactly 'cc', should NOT be matched (excluded)
+	r = p.Match([]string{"cx"}, false)
+	s.Equal(NoMatch, r) // 'cx' starts with 'c', should NOT be matched
+}
+
+func (s *PatternSuite) TestNegationPatternInSubdir() {
+	// Test [!...] in subdirectory patterns
+	p := ParsePattern("subdir/[!cc]", nil)
+	r := p.Match([]string{"subdir", "a"}, false)
+	s.Equal(Exclude, r)
+	r = p.Match([]string{"subdir", "cc"}, false)
+	s.Equal(NoMatch, r)
+}
+
+func (s *PatternSuite) TestNegationPatternMultipleChars() {
+	// Test [!abc] - should exclude any char in [abc]
+	p := ParsePattern("[!abc]", nil)
+	r := p.Match([]string{"d"}, false)
+	s.Equal(Exclude, r) // 'd' is not a, b, or c, should be excluded
+	r = p.Match([]string{"a"}, false)
+	s.Equal(NoMatch, r)
+	r = p.Match([]string{"b"}, false)
+	s.Equal(NoMatch, r)
+}


### PR DESCRIPTION
Fixes go-git/go-git#2006

The gitignore format uses [!c] to mean "exclude any character except c", but Go's filepath.Match uses [^c] for the same purpose. This fix converts [!...] patterns to [^...] before matching.

## Changes
- Add convertGitignoreNegation() helper that converts [!...] → [^...]
- Apply conversion in both simpleNameMatch() and globMatch()
- Add comprehensive tests for negation patterns

## Testing
All existing tests pass, plus new tests for:
- Basic [!cc] pattern (should match anything except starting with c)
- [!...] in subdirectory patterns
- [!abc] multi-char negation

Note: This replaces the previously submitted PR #2021 which was badly diverged from main.