### PR TITLE
storage: filesystem, close packfile iterators after use

### DIFF
--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -79,6 +79,9 @@ func (o *FSObject) Reader() (io.ReadCloser, error) {
 		_, err = o.pack.Seek(o.offset, io.SeekStart)
 	}
 	if err != nil {
+		if file != nil {
+			_ = file.Close()
+		}
 		return nil, err
 	}
 
@@ -86,6 +89,10 @@ func (o *FSObject) Reader() (io.ReadCloser, error) {
 
 	zr, err := sync.GetZlibReader(br)
 	if err != nil {
+		sync.PutBufioReader(br)
+		if file != nil {
+			_ = file.Close()
+		}
 		return nil, err
 	}
 	return &zlibReadCloser{r: zr, f: file, rbuf: br}, nil

--- a/storage/filesystem/object_iter.go
+++ b/storage/filesystem/object_iter.go
@@ -43,6 +43,8 @@ func (it *lazyPackfilesIter) Next() (plumbing.EncodedObject, error) {
 			it.cur = nil
 			continue
 		} else if err != nil {
+			it.cur.Close()
+			it.cur = nil
 			return nil, err
 		}
 		return ob, nil
@@ -122,6 +124,9 @@ func newPackfileIter(
 
 	iter, err := p.GetByType(t)
 	if err != nil {
+		if !keepPack {
+			_ = f.Close()
+		}
 		return nil, err
 	}
 
@@ -149,11 +154,11 @@ func (iter *packfileIter) Next() (plumbing.EncodedObject, error) {
 }
 
 func (iter *packfileIter) ForEach(cb func(plumbing.EncodedObject) error) error {
+	defer iter.Close()
 	for {
 		o, err := iter.Next()
 		if err != nil {
 			if err == io.EOF {
-				iter.Close()
 				return nil
 			}
 			return err
@@ -198,6 +203,7 @@ func (iter *objectsIter) Next() (plumbing.EncodedObject, error) {
 }
 
 func (iter *objectsIter) ForEach(cb func(plumbing.EncodedObject) error) error {
+	defer iter.Close()
 	for {
 		o, err := iter.Next()
 		if err != nil {


### PR DESCRIPTION
This fixes some leaks of file descriptors when iterating over packfiles. The packfile iterators are now closed after use, and the file descriptor is closed if an error occurs while creating the zlib reader.

Related: https://github.com/go-git/go-git/actions/runs/24908334127/job/72949435719?pr=1987