### PR TITLE
docs: update comment to reflect support for the last 2 stable Go versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-git/go-git/v6
 
-// go-git supports the last 3 stable Go versions.
+// go-git supports the last 2 stable Go versions.
 go 1.25.0
 
 require (


### PR DESCRIPTION
As per [rfc-0001](https://github.com/go-git/go-git/blob/main/rfcs/0001-supported-go-versions.md), go-git supports only the last two stable Go versions.

Currently, the stable Go versions are 1.25 and 1.26.