### PR TITLE
storage: filesystem, dedupe object iteration

### DIFF
--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/capability"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/memory"
 )
 
 // UploadPackSuite is a test suite for upload-pack over the new transport API.
@@ -122,15 +124,15 @@ func (s *UploadPackSuite) TestUploadPack() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	beforeCount := s.countObjects(s.Storer)
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	err = conn.Fetch(context.Background(), s.Storer, req)
+	clientStorer := memory.NewStorage(memory.WithObjectFormat(config.SHA1))
+	err = conn.Fetch(context.Background(), clientStorer, req)
 	s.Require().NoError(err)
 
-	afterCount := s.countObjects(s.Storer)
-	s.Require().Equal(28, afterCount-beforeCount)
+	afterCount := s.countObjects(clientStorer)
+	s.Require().Equal(28, afterCount)
 }
 
 // TestUploadPackWithContext tests upload-pack with a cancelled context.
@@ -150,8 +152,9 @@ func (s *UploadPackSuite) TestUploadPackWithContext() {
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	err = conn.Fetch(ctx, s.Storer, req)
-	s.Require().NotNil(err)
+	clientStorer := memory.NewStorage(memory.WithObjectFormat(config.SHA1))
+	err = conn.Fetch(ctx, clientStorer, req)
+	s.Require().Error(err)
 }
 
 // TestUploadPackWithContextOnRead tests upload-pack with context cancelled during read.
@@ -172,7 +175,7 @@ func (s *UploadPackSuite) TestUploadPackWithContextOnRead() {
 
 	cancel()
 	err = conn.Fetch(ctx, s.Storer, req)
-	s.Require().NotNil(err)
+	s.Require().Error(err)
 }
 
 // TestUploadPackFull tests a full upload-pack fetch with advertised references.
@@ -186,15 +189,15 @@ func (s *UploadPackSuite) TestUploadPackFull() {
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 
-	beforeCount := s.countObjects(s.Storer)
 	req := &transport.FetchRequest{}
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	err = conn.Fetch(context.Background(), s.Storer, req)
+	clientStorer := memory.NewStorage(memory.WithObjectFormat(config.SHA1))
+	err = conn.Fetch(context.Background(), clientStorer, req)
 	s.Require().NoError(err)
 
-	afterCount := s.countObjects(s.Storer)
-	s.Require().Equal(28, afterCount-beforeCount)
+	afterCount := s.countObjects(clientStorer)
+	s.Require().Equal(28, afterCount)
 }
 
 // TestUploadPackInvalidReq tests upload-pack with an invalid request.
@@ -248,12 +251,14 @@ func (s *UploadPackSuite) testUploadPackFetch(req *transport.FetchRequest, expec
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	beforeCount := s.countObjects(s.Storer)
-	err = conn.Fetch(context.Background(), s.Storer, req)
+	beforeCount := s.countObjects(s.EmptyStorer)
+	s.Zero(beforeCount)
+
+	err = conn.Fetch(context.Background(), s.EmptyStorer, req)
 	s.Require().NoError(err)
 
-	afterCount := s.countObjects(s.Storer)
-	s.Require().Equal(expectedObjects, afterCount-beforeCount)
+	afterCount := s.countObjects(s.EmptyStorer)
+	s.Require().Equal(expectedObjects, afterCount)
 }
 
 // TestFetchError tests that fetching a non-existent object returns an error.
@@ -267,7 +272,7 @@ func (s *UploadPackSuite) TestFetchError() {
 	req.Wants = append(req.Wants, plumbing.NewHash("1111111111111111111111111111111111111111"))
 
 	err = conn.Fetch(context.Background(), s.Storer, req)
-	s.Require().NotNil(err)
+	s.Require().Error(err)
 }
 
 func (s *UploadPackSuite) countObjects(st storage.Storer) int {

--- a/storage/filesystem/object_iter.go
+++ b/storage/filesystem/object_iter.go
@@ -149,6 +149,7 @@ func (iter *packfileIter) Next() (plumbing.EncodedObject, error) {
 			continue
 		}
 
+		iter.seen[obj.Hash()] = struct{}{}
 		return obj, nil
 	}
 }

--- a/storage/filesystem/object_iter_test.go
+++ b/storage/filesystem/object_iter_test.go
@@ -1,0 +1,280 @@
+package filesystem
+
+import (
+	"crypto"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/go-git/go-billy/v6"
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
+	"github.com/go-git/go-git/v6/plumbing/hash"
+	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
+)
+
+func TestPackfileIter_SeenSkips(t *testing.T) {
+	t.Parallel()
+	pf := loadPackFixture(t)
+	total := len(pf.hashes)
+
+	tests := []struct {
+		name      string
+		preSeen   func(hashes []plumbing.Hash) []plumbing.Hash
+		wantCount int
+	}{
+		{"no preseed returns all", func(_ []plumbing.Hash) []plumbing.Hash { return nil }, total},
+		{"preseed one skips one", func(h []plumbing.Hash) []plumbing.Hash { return h[:1] }, total - 1},
+		{"preseed half skips half", func(h []plumbing.Hash) []plumbing.Hash { return h[:total/2] }, total - total/2},
+		{"preseed all returns none", func(h []plumbing.Hash) []plumbing.Hash { return h }, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pack := pf.openPack(t)
+			seen := make(map[plumbing.Hash]struct{})
+			for _, h := range tc.preSeen(pf.hashes) {
+				seen[h] = struct{}{}
+			}
+
+			iter, err := newPackfileIter(pf.fs, pack, plumbing.AnyObject, seen, pf.idx,
+				cache.NewObjectLRUDefault(), false, crypto.SHA1.Size())
+			require.NoError(t, err)
+
+			var got int
+			require.NoError(t, iter.ForEach(func(plumbing.EncodedObject) error {
+				got++
+				return nil
+			}))
+			require.Equal(t, tc.wantCount, got)
+		})
+	}
+}
+
+func TestPackfileIter_SharedSeenDedupsAcrossIterators(t *testing.T) {
+	t.Parallel()
+	pf := loadPackFixture(t)
+	seen := make(map[plumbing.Hash]struct{})
+	cch := cache.NewObjectLRUDefault()
+
+	count := func() int {
+		pack := pf.openPack(t)
+		iter, err := newPackfileIter(pf.fs, pack, plumbing.AnyObject, seen, pf.idx,
+			cch, false, crypto.SHA1.Size())
+		require.NoError(t, err)
+
+		var n int
+		require.NoError(t, iter.ForEach(func(plumbing.EncodedObject) error {
+			n++
+			return nil
+		}))
+		return n
+	}
+
+	first := count()
+	second := count()
+
+	require.Equal(t, len(pf.hashes), first)
+	require.Zero(t, second, "shared seen map should suppress duplicates from second iteration")
+	require.Len(t, seen, len(pf.hashes))
+}
+
+func TestPackfileIter_ForEachClosesPack(t *testing.T) {
+	t.Parallel()
+	pf := loadPackFixture(t)
+	stopAt := len(pf.hashes) / 2
+	cbErr := errors.New("stop")
+
+	tests := []struct {
+		name    string
+		cb      func(int) error
+		wantErr error
+	}{
+		{
+			name:    "callback returns nil completes",
+			cb:      func(int) error { return nil },
+			wantErr: nil,
+		},
+		{
+			name:    "callback returns error aborts",
+			cb:      func(_ int) error { return cbErr },
+			wantErr: cbErr,
+		},
+		{
+			name: "callback errors midway",
+			cb: func(i int) error {
+				if i >= stopAt {
+					return cbErr
+				}
+				return nil
+			},
+			wantErr: cbErr,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pack := &closeCounter{File: pf.openPack(t)}
+			iter, err := newPackfileIter(pf.fs, pack, plumbing.AnyObject,
+				make(map[plumbing.Hash]struct{}), pf.idx,
+				cache.NewObjectLRUDefault(), false, crypto.SHA1.Size())
+			require.NoError(t, err)
+
+			var i int
+			err = iter.ForEach(func(plumbing.EncodedObject) error {
+				defer func() { i++ }()
+				return tc.cb(i)
+			})
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+			require.Equal(t, 1, pack.closed, "pack must be closed after ForEach returns")
+		})
+	}
+}
+
+func TestPackfileIter_ForEachKeepsPackOpen(t *testing.T) {
+	t.Parallel()
+	pf := loadPackFixture(t)
+	pack := &closeCounter{File: pf.openPack(t)}
+
+	iter, err := newPackfileIter(pf.fs, pack, plumbing.AnyObject,
+		make(map[plumbing.Hash]struct{}), pf.idx,
+		cache.NewObjectLRUDefault(), true, crypto.SHA1.Size())
+	require.NoError(t, err)
+
+	require.NoError(t, iter.ForEach(func(plumbing.EncodedObject) error { return nil }))
+	require.Zero(t, pack.closed, "keepPack=true must not close the underlying file")
+}
+
+func TestNewPackfileIter_ClosesPackOnGetByTypeError(t *testing.T) {
+	t.Parallel()
+	pf := loadPackFixture(t)
+
+	tests := []struct {
+		name        string
+		keepPack    bool
+		wantClosed  int
+		wantClosedR string
+	}{
+		{"keepPack false closes on error", false, 1, "must close when keepPack is false"},
+		{"keepPack true leaves it open", true, 0, "must not close when keepPack is true"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pack := &closeCounter{File: pf.openPack(t)}
+			iter, err := newPackfileIter(pf.fs, pack, plumbing.OFSDeltaObject,
+				make(map[plumbing.Hash]struct{}), pf.idx,
+				cache.NewObjectLRUDefault(), tc.keepPack, crypto.SHA1.Size())
+			require.Error(t, err)
+			require.Nil(t, iter)
+			require.Equal(t, tc.wantClosed, pack.closed, tc.wantClosedR)
+		})
+	}
+}
+
+func TestObjectsIter_ForEachClosesOnError(t *testing.T) {
+	t.Parallel()
+	fs, err := fixtures.ByTag(".git").ByTag("unpacked").One().DotGit()
+	require.NoError(t, err)
+	o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
+
+	cbErr := errors.New("stop")
+
+	tests := []struct {
+		name    string
+		cb      func(plumbing.EncodedObject) error
+		wantErr error
+	}{
+		{"cb returns nil completes", func(plumbing.EncodedObject) error { return nil }, nil},
+		{"cb returns error propagates", func(plumbing.EncodedObject) error { return cbErr }, cbErr},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			objects, err := o.dir.Objects()
+			require.NoError(t, err)
+			require.NotEmpty(t, objects)
+
+			iter := &objectsIter{s: o, t: plumbing.AnyObject, h: append([]plumbing.Hash{}, objects...)}
+			err = iter.ForEach(tc.cb)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+			require.Empty(t, iter.h, "iter.h must be drained by Close after ForEach returns")
+		})
+	}
+}
+
+type packFixture struct {
+	fs       billy.Filesystem
+	dg       *dotgit.DotGit
+	packHash plumbing.Hash
+	idx      idxfile.Index
+	hashes   []plumbing.Hash
+}
+
+func loadPackFixture(t *testing.T) packFixture {
+	t.Helper()
+
+	fs, err := fixtures.Basic().ByTag(".git").One().DotGit()
+	require.NoError(t, err)
+	dg := dotgit.New(fs)
+
+	packs, err := dg.ObjectPacks()
+	require.NoError(t, err)
+	require.NotEmpty(t, packs)
+
+	idxFile, err := dg.ObjectPackIdx(packs[0])
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = idxFile.Close() })
+
+	idx := idxfile.NewMemoryIndex(crypto.SHA1.Size())
+	require.NoError(t, idxfile.NewDecoder(idxFile, hash.New(crypto.SHA1)).Decode(idx))
+
+	entries, err := idx.Entries()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = entries.Close() })
+
+	var hashes []plumbing.Hash
+	for {
+		e, err := entries.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		hashes = append(hashes, e.Hash)
+	}
+
+	return packFixture{fs: fs, dg: dg, packHash: packs[0], idx: idx, hashes: hashes}
+}
+
+func (p packFixture) openPack(t *testing.T) billy.File {
+	t.Helper()
+	f, err := p.dg.ObjectPack(p.packHash)
+	require.NoError(t, err)
+	return f
+}
+
+type closeCounter struct {
+	billy.File
+	closed int
+}
+
+func (c *closeCounter) Close() error {
+	c.closed++
+	return c.File.Close()
+}


### PR DESCRIPTION
The shared seen map in lazyPackfilesIter was never written to by packfileIter.Next, so the same object hash could be returned once per packfile it appeared in. Mark each returned hash as seen so cross-pack iteration over IterEncodedObjects no longer double-counts.

Also tighten resource handling on iterator error paths: defer Close in ForEach for both packfileIter and objectsIter, close the inner iter and clear cur in lazyPackfilesIter on Next errors, and close the pack file in newPackfileIter when GetByType fails (when keepPack is false).

Update the upload-pack test suite to fetch into s.EmptyStorer with absolute pre/post counts. The previous before/after diff against s.Storer relied on the duplicate-counting bug, since s.Storer aliased the server-side fixture filesystem.

Add table-driven tests for the iterator behaviour: seen-map skipping, shared-seen dedupe across iterators, ForEach closing the pack on every return path (including callback error), and newPackfileIter closing the pack file when GetByType returns an error.