### PR TITLE
git: worktree, fix treeContainsDirs test to build a new tree for each…

### DIFF
--- a/worktree_test.go
+++ b/worktree_test.go
@@ -3760,13 +3760,15 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 
 func TestTreeContainsDirs(t *testing.T) {
 	t.Parallel()
-	tree := &object.Tree{
-		Entries: []object.TreeEntry{
-			{Name: "foo", Mode: filemode.Dir},
-			{Name: "bar", Mode: filemode.Dir},
-			{Name: "baz", Mode: filemode.Dir},
-			{Name: "this-is-regular", Mode: filemode.Regular},
-		},
+	buildTree := func() *object.Tree {
+		return &object.Tree{
+			Entries: []object.TreeEntry{
+				{Name: "foo", Mode: filemode.Dir},
+				{Name: "bar", Mode: filemode.Dir},
+				{Name: "baz", Mode: filemode.Dir},
+				{Name: "this-is-regular", Mode: filemode.Regular},
+			},
+		}
 	}
 
 	tests := []struct {
@@ -3799,7 +3801,7 @@ func TestTreeContainsDirs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, test.expected, treeContainsDirs(tree, test.dirs))
+			assert.Equal(t, test.expected, treeContainsDirs(buildTree(), test.dirs))
 		})
 	}
 }


### PR DESCRIPTION
… test case

This makes the TestTreeContainsDirs test more robust by ensuring that each test case operates on a fresh tree instance. This prevents any unintended side effects from previous test cases.

The treeContainsDirs function may write to the tree and cause a race condition when a single tree is shared across multiple test cases. By building a new tree for each test case, we ensure that the tests are isolated and can be run in parallel without interference.

See tree.go:185-189:
```go
  func (t *Tree) entry(baseName string) (*TreeEntry, error) {
      if t.m == nil {       // read t.m
          t.buildMap()      // write t.m
      }
      entry, ok := t.m[baseName]  // read t.m
```

Fixes: https://github.com/go-git/go-git/actions/runs/25163491857/job/73763612343?pr=2014