### PR TITLE
plumbing: gitignore, Fix loading of deeper ignored files

### DIFF
--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/go-git/go-billy/v6"
@@ -50,23 +51,32 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 // recursively traversing through the directory structure. The result is in
 // the ascending order of priority (last higher).
 func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) {
-	return extendPatterns(fs, nil, path)
-}
-
-func extendPatterns(fs billy.Filesystem, start []Pattern, path []string) (ps []Pattern, err error) {
-	gitignore, err := readIgnoreFile(fs, path, gitignoreFile)
-	if err != nil && !os.IsNotExist(err) {
+	patternSets, err := extendPatterns(fs, nil, path)
+	if err != nil {
 		return nil, err
 	}
+
+	ps = slices.Concat(patternSets...)
+
+	return ps, nil
+}
+
+func extendPatterns(fs billy.Filesystem, matchers []Matcher, path []string) (found [][]Pattern, err error) {
+	// Read current directory's ignore patterns.
 	infoExclude, err := readIgnoreFile(fs, path, infoExcludeFile)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
+	gitignore, err := readIgnoreFile(fs, path, gitignoreFile)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
 
-	foundPatterns := append(gitignore, infoExclude...)
-
-	ignorePatterns := append(start, foundPatterns...)
-	ignoreMatcher := NewMatcher(ignorePatterns)
+	dirPatterns := slices.Concat(infoExclude, gitignore)
+	if len(dirPatterns) > 0 {
+		found = [][]Pattern{dirPatterns}
+		matchers = append(matchers, NewMatcher(dirPatterns))
+	}
 
 	fis, err := fs.ReadDir(fs.Join(path...))
 	if err != nil {
@@ -74,23 +84,34 @@ func extendPatterns(fs billy.Filesystem, start []Pattern, path []string) (ps []P
 	}
 
 	for _, fi := range fis {
-		if fi.IsDir() && fi.Name() != gitDir {
-			if ignoreMatcher.Match(append(path, fi.Name()), true) {
-				continue
-			}
+		if !fi.IsDir() || fi.Name() == gitDir {
+			continue
+		}
 
-			subPatterns, err := extendPatterns(fs, ignorePatterns, append(path, fi.Name()))
-			if err != nil {
-				return nil, err
-			}
+		fiPath := append(path, fi.Name()) //nolint:gocritic
 
-			if len(subPatterns) > 0 {
-				foundPatterns = append(foundPatterns, subPatterns...)
+		match := false
+		for _, matcher := range matchers {
+			if matcher.Match(fiPath, true) {
+				match = true
+				break
 			}
+		}
+		if match {
+			continue
+		}
+
+		subPatterns, err := extendPatterns(fs, matchers, fiPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(subPatterns) > 0 {
+			found = append(found, subPatterns...)
 		}
 	}
 
-	return foundPatterns, err
+	return found, err
 }
 
 func loadPatterns(fs billy.Filesystem, path string) (ps []Pattern, err error) {

--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	gofs "io/fs"
 	"os"
 	"strings"
 
@@ -12,7 +11,7 @@ import (
 
 	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/plumbing/format/config"
-	gioutil "github.com/go-git/go-git/v6/utils/ioutil"
+	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
 const (
@@ -31,57 +30,67 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 	ignoreFile, _ = pathutil.ReplaceTildeWithHome(ignoreFile)
 
 	f, err := fs.Open(fs.Join(append(path, ignoreFile)...))
-	if err == nil {
-		defer func() { _ = f.Close() }()
-
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			s := scanner.Text()
-			if !strings.HasPrefix(s, commentPrefix) && len(strings.TrimSpace(s)) > 0 {
-				ps = append(ps, ParsePattern(s, path))
-			}
-		}
-	} else if !os.IsNotExist(err) {
+	if err != nil {
 		return nil, err
 	}
 
-	return ps, err
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		s := scanner.Text()
+		if !strings.HasPrefix(s, commentPrefix) && len(strings.TrimSpace(s)) > 0 {
+			ps = append(ps, ParsePattern(s, path))
+		}
+	}
+	return ps, scanner.Err()
 }
 
 // ReadPatterns reads the .git/info/exclude and then the gitignore patterns
 // recursively traversing through the directory structure. The result is in
 // the ascending order of priority (last higher).
 func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) {
-	ps, _ = readIgnoreFile(fs, path, infoExcludeFile)
+	return extendPatterns(fs, nil, path)
+}
 
-	subps, _ := readIgnoreFile(fs, path, gitignoreFile)
-	ps = append(ps, subps...)
+func extendPatterns(fs billy.Filesystem, start []Pattern, path []string) (ps []Pattern, err error) {
+	gitignore, err := readIgnoreFile(fs, path, gitignoreFile)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	infoExclude, err := readIgnoreFile(fs, path, infoExcludeFile)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
 
-	var fis []gofs.DirEntry
-	fis, err = fs.ReadDir(fs.Join(path...))
+	foundPatterns := append(gitignore, infoExclude...)
+
+	ignorePatterns := append(start, foundPatterns...)
+	ignoreMatcher := NewMatcher(ignorePatterns)
+
+	fis, err := fs.ReadDir(fs.Join(path...))
 	if err != nil {
-		return ps, err
+		return nil, err
 	}
 
 	for _, fi := range fis {
 		if fi.IsDir() && fi.Name() != gitDir {
-			if NewMatcher(ps).Match(append(path, fi.Name()), true) {
+			if ignoreMatcher.Match(append(path, fi.Name()), true) {
 				continue
 			}
 
-			var subps []Pattern
-			subps, err = ReadPatterns(fs, append(path, fi.Name()))
+			subPatterns, err := extendPatterns(fs, ignorePatterns, append(path, fi.Name()))
 			if err != nil {
-				return ps, err
+				return nil, err
 			}
 
-			if len(subps) > 0 {
-				ps = append(ps, subps...)
+			if len(subPatterns) > 0 {
+				foundPatterns = append(foundPatterns, subPatterns...)
 			}
 		}
 	}
 
-	return ps, err
+	return foundPatterns, err
 }
 
 func loadPatterns(fs billy.Filesystem, path string) (ps []Pattern, err error) {
@@ -93,7 +102,7 @@ func loadPatterns(fs billy.Filesystem, path string) (ps []Pattern, err error) {
 		return nil, err
 	}
 
-	defer gioutil.CheckClose(f, &err)
+	defer ioutil.CheckClose(f, &err)
 
 	b, err := io.ReadAll(f)
 	if err != nil {

--- a/plumbing/format/gitignore/dir_test.go
+++ b/plumbing/format/gitignore/dir_test.go
@@ -49,7 +49,9 @@ func (s *MatcherSuite) SetupTest() {
 	s.NoError(err)
 	_, err = f.Write([]byte("ignore.crlf\r\n"))
 	s.NoError(err)
-	_, err = f.Write([]byte("ignore_dir\n"))
+	_, err = f.Write([]byte("/ignore_dir\n"))
+	s.NoError(err)
+	_, err = f.Write([]byte("nested/ignore_dir\n"))
 	s.NoError(err)
 	err = f.Close()
 	s.NoError(err)
@@ -72,6 +74,17 @@ func (s *MatcherSuite) SetupTest() {
 	_, err = fs.Create("ignore_dir/file")
 	s.NoError(err)
 	err = f.Close()
+	s.NoError(err)
+
+	err = fs.MkdirAll("nested/ignore_dir", os.ModePerm)
+	s.NoError(err)
+	f, err = fs.Create("nested/ignore_dir/.gitignore")
+	s.NoError(err)
+	_, err = f.Write([]byte("!file\n"))
+	s.NoError(err)
+	err = f.Close()
+	s.NoError(err)
+	_, err = fs.Create("nested/ignore_dir/file")
 	s.NoError(err)
 
 	err = fs.MkdirAll("another", os.ModePerm)
@@ -285,13 +298,14 @@ func (s *MatcherSuite) SetupTest() {
 
 func (s *MatcherSuite) TestDir_ReadPatterns() {
 	checkPatterns := func(ps []Pattern) {
-		s.Len(ps, 7)
+		s.Len(ps, 8)
 		m := NewMatcher(ps)
 
 		s.True(m.Match([]string{"exclude.crlf"}, true))
 		s.True(m.Match([]string{"ignore.crlf"}, true))
 		s.True(m.Match([]string{"vendor", "gopkg.in"}, true))
 		s.True(m.Match([]string{"ignore_dir", "file"}, false))
+		s.True(m.Match([]string{"nested", "ignore_dir", "file"}, false))
 		s.False(m.Match([]string{"vendor", "github.com"}, true))
 		s.True(m.Match([]string{"multiple", "sub", "ignores", "first", "ignore_dir"}, true))
 		s.True(m.Match([]string{"multiple", "sub", "ignores", "second", "ignore_dir"}, true))


### PR DESCRIPTION
This PR contains a cherry pick of commit in #1379 which fixes behavior of reading ignore patterns of nested directories. After this, `ReadPatterns` checks parent directory's ignore patterns while determining which directories to read from.