### PR TITLE
plumbing: transport, close storage in tests

### DIFF
--- a/plumbing/transport/serve_test.go
+++ b/plumbing/transport/serve_test.go
@@ -58,6 +58,7 @@ func testAdvertise[T UploadPackRequest | ReceivePackRequest](
 		t.Fatal(err)
 	}
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = st.Close() })
 	opts := new(T)
 	switch o := any(opts).(type) {
 	case *UploadPackRequest:

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -51,6 +51,7 @@ func (s *UploadPackServeSuite) TestUploadPackAlwaysUseSidebandWhenAvailable() {
 	dot, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	s.T().Cleanup(func() { _ = st.Close() })
 	upreq := packp.NewUploadRequest()
 	upreq.Capabilities.Add(capability.Sideband64k)
 	upreq.Capabilities.Add(capability.NoProgress)
@@ -81,6 +82,7 @@ func (s *UploadPackServeSuite) TestUploadPackSkipDeltaCompression() {
 	dot, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	s.T().Cleanup(func() { _ = st.Close() })
 
 	head, err := storer.ResolveReference(st, plumbing.HEAD)
 	require.NoError(s.T(), err)
@@ -136,6 +138,7 @@ func (s *UploadPackServeSuite) TestUploadPackStatefulMultiRoundSendsFinalACK() {
 	dot, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	s.T().Cleanup(func() { _ = st.Close() })
 
 	head, err := storer.ResolveReference(st, plumbing.HEAD)
 	s.Require().NoError(err)
@@ -232,6 +235,7 @@ func (s *UploadPackServeSuite) TestUploadPackStatelessRPCUnreachableHavesEmitsSi
 	dot, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	s.T().Cleanup(func() { _ = st.Close() })
 
 	head, err := storer.ResolveReference(st, plumbing.HEAD)
 	s.Require().NoError(err)


### PR DESCRIPTION
This ensures that the storage is closed after each test, which can help prevent resource leaks especially in Windows where tests may fail to clean up temporary directories if storage resources are still open.

Tries to fix https://github.com/go-git/go-git/actions/runs/25163782952/job/73769629975