### PR TITLE
Read sha1 elimination

### DIFF
--- a/bench_blob_read_test.go
+++ b/bench_blob_read_test.go
@@ -1,0 +1,57 @@
+package git
+
+import (
+	"io"
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+// BenchmarkBlobRead opens the current repo, resolves commit 9d0f15c4,
+// walks its tree, and reads every blob.
+func BenchmarkBlobRead(b *testing.B) {
+	// v5.0.0 tag. This is now 6 years ago, so reconstructing this
+	// will follow a lot delta chains.
+	const commitSHA = "9d0f15c4fa712cdacfa3887e9baac918f093fbf6"
+
+	for b.Loop() {
+		commitHash := plumbing.NewHash(commitSHA)
+
+		repo, err := PlainOpen(".")
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		commit, err := repo.CommitObject(commitHash)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		tree, err := commit.Tree()
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		iter := object.NewFileIter(repo.Storer, tree)
+		for {
+			f, err := iter.Next()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			r, err := f.Reader()
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, err := io.Copy(io.Discard, r); err != nil {
+				r.Close()
+				b.Fatal(err)
+			}
+			r.Close()
+		}
+	}
+}

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -2,6 +2,7 @@ package packfile
 
 import (
 	"bufio"
+	"container/list"
 	"crypto"
 	"fmt"
 	"io"
@@ -29,6 +30,64 @@ var (
 	ErrZLib = NewError("zlib reading error")
 )
 
+// deltaBaseCacheMemLimit and deltaBaseCacheObjLimit mirror the limits used by
+// libgit2 (pack.h: GIT_PACK_CACHE_MEMORY_LIMIT / GIT_PACK_CACHE_SIZE_LIMIT).
+const (
+	deltaBaseCacheMemLimit = 16 * 1024 * 1024 // 16 MiB total
+	deltaBaseCacheObjLimit = 1024 * 1024       // skip objects larger than 1 MiB
+)
+
+// deltaBaseCache is an LRU cache keyed by pack offset, used for delta base
+// resolution. Using offsets as keys avoids calling obj.Hash() (which triggers
+// a SHA recomputation) just to populate the cache. The cache is bounded by
+// total byte size, not entry count, matching libgit2's design.
+type deltaBaseCache struct {
+	memUsed int64
+	ll      *list.List
+	items   map[int64]*list.Element
+}
+
+type deltaCacheEntry struct {
+	offset int64
+	size   int64
+	obj    plumbing.EncodedObject
+}
+
+func newDeltaBaseCache() *deltaBaseCache {
+	return &deltaBaseCache{
+		ll:    list.New(),
+		items: make(map[int64]*list.Element),
+	}
+}
+
+func (c *deltaBaseCache) get(offset int64) (plumbing.EncodedObject, bool) {
+	if e, ok := c.items[offset]; ok {
+		c.ll.MoveToFront(e)
+		return e.Value.(*deltaCacheEntry).obj, true
+	}
+	return nil, false
+}
+
+func (c *deltaBaseCache) put(offset int64, obj plumbing.EncodedObject) {
+	if _, ok := c.items[offset]; ok {
+		return
+	}
+	sz := obj.Size()
+	if sz > deltaBaseCacheObjLimit {
+		return
+	}
+	e := c.ll.PushFront(&deltaCacheEntry{offset: offset, size: sz, obj: obj})
+	c.items[offset] = e
+	c.memUsed += sz
+	for c.memUsed > deltaBaseCacheMemLimit && c.ll.Len() > 0 {
+		back := c.ll.Back()
+		entry := back.Value.(*deltaCacheEntry)
+		c.memUsed -= entry.size
+		delete(c.items, entry.offset)
+		c.ll.Remove(back)
+	}
+}
+
 // Packfile allows retrieving information from inside a packfile.
 type Packfile struct {
 	idxfile.Index
@@ -43,8 +102,9 @@ type Packfile struct {
 	scanReader io.ReadSeekCloser
 	scanner    *Scanner
 
-	cache cache.Object
-	rbuf  *bufio.Reader
+	cache      cache.Object
+	deltaCache *deltaBaseCache
+	rbuf       *bufio.Reader
 
 	id           plumbing.Hash
 	m            sync.Mutex
@@ -220,7 +280,19 @@ func (p *Packfile) get(h plumbing.Hash) (plumbing.EncodedObject, error) {
 		return nil, err
 	}
 
-	return p.objectFromHeader(oh)
+	obj, err := p.objectFromHeader(oh)
+	if err != nil {
+		return nil, err
+	}
+
+	// The hash is already known here; pre-set it so ObjectLRU.Put does not
+	// trigger a SHA recomputation on delta-reconstructed MemoryObjects.
+	if mo, ok := obj.(*plumbing.MemoryObject); ok {
+		mo.SetHash(h)
+	}
+	p.cache.Put(obj)
+
+	return obj, nil
 }
 
 // getByOffset is not threat-safe, and should only be called within packfile.go.
@@ -239,7 +311,19 @@ func (p *Packfile) getByOffset(offset int64) (plumbing.EncodedObject, error) {
 		return nil, err
 	}
 
-	return p.objectFromHeader(oh)
+	obj, err := p.objectFromHeader(oh)
+	if err != nil {
+		return nil, err
+	}
+
+	// The hash is already known here; pre-set it so ObjectLRU.Put does not
+	// trigger a SHA recomputation on delta-reconstructed MemoryObjects.
+	if mo, ok := obj.(*plumbing.MemoryObject); ok {
+		mo.SetHash(h)
+	}
+	p.cache.Put(obj)
+
+	return obj, nil
 }
 
 func (p *Packfile) init() error {
@@ -314,6 +398,8 @@ func (p *Packfile) init() error {
 		if p.cache == nil {
 			p.cache = cache.NewObjectLRUDefault()
 		}
+
+		p.deltaCache = newDeltaBaseCache()
 	})
 
 	return p.onceErr
@@ -418,6 +504,13 @@ func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, er
 	obj.SetSize(oh.Size)
 	obj.SetType(oh.Type)
 
+	// Pre-populate from the scanner-computed hash for non-delta objects.
+	// For delta objects the hash is unknown here; callers (get/getByOffset)
+	// set it after reconstruction using the index-provided hash.
+	if !oh.Hash.IsZero() {
+		obj.SetHash(oh.Hash)
+	}
+
 	w, err := obj.Writer()
 	if err != nil {
 		return nil, err
@@ -433,13 +526,21 @@ func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, er
 
 		switch oh.Type {
 		case plumbing.REFDeltaObject:
+			// REFDelta bases are looked up by hash (already known from the pack
+			// stream), so the hash-keyed cache is appropriate here.
 			var ok bool
 			parent, ok = p.cache.Get(oh.Reference)
 			if !ok {
 				parent, err = p.get(oh.Reference)
 			}
 		case plumbing.OFSDeltaObject:
-			parent, err = p.getByOffset(oh.OffsetReference)
+			// OFSDelta bases are looked up by offset. Use the offset-keyed
+			// deltaCache to avoid triggering a SHA recomputation on the base.
+			var ok bool
+			parent, ok = p.deltaCache.get(oh.OffsetReference)
+			if !ok {
+				parent, err = p.getByOffset(oh.OffsetReference)
+			}
 		}
 
 		if err != nil {
@@ -469,7 +570,9 @@ func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, er
 		return nil, err
 	}
 
-	p.cache.Put(obj)
+	// Store in the offset-keyed delta cache so that subsequent OFSDelta
+	// objects can use this as a base without triggering a SHA recomputation.
+	p.deltaCache.put(oh.Offset, obj)
 
 	return obj, nil
 }

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -265,7 +265,7 @@ func (p *Packfile) init() error {
 
 		p.rbuf = gogitsync.GetBufioReader(nil)
 
-		opts := []ScannerOption{WithBufioReader(p.rbuf)}
+		opts := []ScannerOption{WithBufioReader(p.rbuf), WithoutPackChecksum(), WithoutObjectChecksum()}
 
 		if p.objectIDSize == format.SHA256Size {
 			opts = append(opts, WithSHA256())

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -186,7 +186,9 @@ type Scanner struct {
 	*scannerReader
 	rbuf *bufio.Reader
 
-	lowMemoryMode bool
+	lowMemoryMode  bool
+	packChecksum   bool
+	objectChecksum bool
 }
 
 // NewScanner creates a new instance of Scanner.
@@ -195,11 +197,13 @@ func NewScanner(rs io.Reader, opts ...ScannerOption) *Scanner {
 	packhash := gogithash.New(crypto.SHA1)
 
 	r := &Scanner{
-		objIndex: -1,
-		hasher:   plumbing.NewHasher(format.SHA1, plumbing.AnyObject, 0),
-		crc:      crc,
-		packhash: packhash,
-		nextFn:   packHeaderSignature,
+		objIndex:       -1,
+		hasher:         plumbing.NewHasher(format.SHA1, plumbing.AnyObject, 0),
+		crc:            crc,
+		packhash:       packhash,
+		nextFn:         packHeaderSignature,
+		packChecksum:   true,
+		objectChecksum: true,
 		// Set the default size, which can be overridden by opts.
 		objectIDSize: packhash.Size(),
 	}
@@ -208,7 +212,18 @@ func NewScanner(rs io.Reader, opts ...ScannerOption) *Scanner {
 		opt(r)
 	}
 
-	r.scannerReader = newScannerReader(rs, io.MultiWriter(crc, r.packhash), r.rbuf)
+	var hashWriter io.Writer
+	switch {
+	case r.objectChecksum && r.packChecksum:
+		hashWriter = io.MultiWriter(crc, r.packhash)
+	case r.objectChecksum:
+		hashWriter = crc
+	case r.packChecksum:
+		hashWriter = r.packhash
+	default:
+		hashWriter = io.Discard
+	}
+	r.scannerReader = newScannerReader(rs, hashWriter, r.rbuf)
 
 	return r
 }

--- a/plumbing/format/packfile/scanner_options.go
+++ b/plumbing/format/packfile/scanner_options.go
@@ -29,3 +29,20 @@ func WithBufioReader(buf *bufio.Reader) ScannerOption {
 		s.rbuf = buf
 	}
 }
+
+// WithoutPackChecksum disables the pack-level SHA checksum in the
+// scanner. The pack checksum can only verified when processing the
+// pack sequentially.
+func WithoutPackChecksum() ScannerOption {
+	return func(s *Scanner) {
+		s.packChecksum = false
+	}
+}
+
+// WithoutObjectChecksum disables the per-object CRC32 checksum in the scanner.
+// oh.Crc32 on ObjectHeader will be zero when this option is set.
+func WithoutObjectChecksum() ScannerOption {
+	return func(s *Scanner) {
+		s.objectChecksum = false
+	}
+}

--- a/plumbing/memory.go
+++ b/plumbing/memory.go
@@ -45,6 +45,9 @@ func (o *MemoryObject) Hash() Hash {
 	return o.h
 }
 
+// SetHash pre-populates the object hash, avoiding recomputation on Hash().
+func (o *MemoryObject) SetHash(h Hash) { o.h = h }
+
 // Type returns the ObjectType
 func (o *MemoryObject) Type() ObjectType { return o.t }
 


### PR DESCRIPTION
I noticed sha1 computations while doing reads. These commits should fix it, yielding a 15% overall speedup.