### PR TITLE
plumbing: packp, validate push options to prevent invalid characters

### DIFF
--- a/plumbing/protocol/packp/pushopts.go
+++ b/plumbing/protocol/packp/pushopts.go
@@ -1,10 +1,19 @@
 package packp
 
 import (
+	"errors"
+	"fmt"
 	"io"
+	"slices"
+	"strings"
+	"unicode"
 
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
+
+// ErrInvalidPushOption is returned when a push option contains invalid
+// characters.
+var ErrInvalidPushOption = errors.New("invalid push option")
 
 // PushOptions represents a list of update request push-options.
 //
@@ -15,8 +24,10 @@ type PushOptions struct {
 
 // Encode encodes the push options into the given writer.
 func (opts *PushOptions) Encode(w io.Writer) error {
-	if len(opts.Options) == 0 {
-		return nil
+	if slices.ContainsFunc(opts.Options, func(opt string) bool {
+		return strings.ContainsFunc(opt, isNotGraphic) || len(opt) > pktline.MaxPayloadSize
+	}) {
+		return fmt.Errorf("%w: contains invalid character", ErrInvalidPushOption)
 	}
 
 	for _, opt := range opts.Options {
@@ -42,7 +53,12 @@ func (opts *PushOptions) Decode(r io.Reader) error {
 			break
 		}
 
-		opts.Options = append(opts.Options, s.Text())
+		opt := s.Text()
+		if strings.ContainsFunc(opt, isNotGraphic) {
+			return fmt.Errorf("%w: contains invalid character", ErrInvalidPushOption)
+		}
+
+		opts.Options = append(opts.Options, opt)
 	}
 	if err := s.Err(); err != nil {
 		return err
@@ -52,4 +68,8 @@ func (opts *PushOptions) Decode(r io.Reader) error {
 	}
 
 	return nil
+}
+
+func isNotGraphic(r rune) bool {
+	return !unicode.IsGraphic(r)
 }

--- a/plumbing/protocol/packp/pushopts.go
+++ b/plumbing/protocol/packp/pushopts.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 	"strings"
 	"unicode"
 
@@ -24,10 +23,13 @@ type PushOptions struct {
 
 // Encode encodes the push options into the given writer.
 func (opts *PushOptions) Encode(w io.Writer) error {
-	if slices.ContainsFunc(opts.Options, func(opt string) bool {
-		return strings.ContainsFunc(opt, isNotGraphic) || len(opt) > pktline.MaxPayloadSize
-	}) {
-		return fmt.Errorf("%w: contains invalid character", ErrInvalidPushOption)
+	for _, opt := range opts.Options {
+		if strings.ContainsFunc(opt, isNotGraphic) {
+			return fmt.Errorf("%w: contains invalid character", ErrInvalidPushOption)
+		}
+		if len(opt) > pktline.MaxPayloadSize {
+			return fmt.Errorf("%w: %w", ErrInvalidPushOption, pktline.ErrPayloadTooLong)
+		}
 	}
 
 	for _, opt := range opts.Options {

--- a/plumbing/protocol/packp/pushopts_test.go
+++ b/plumbing/protocol/packp/pushopts_test.go
@@ -2,6 +2,7 @@ package packp
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -34,6 +35,45 @@ func (s *PushOptionsSuite) TestPushOptionsEncode() {
 	s.Require().Equal(expected, buf.Bytes())
 }
 
+func (s *PushOptionsSuite) TestPushOptionsEncodeEmpty() {
+	var r PushOptions
+	r.Options = []string{}
+
+	expected := pktlines(s.T(), "")
+
+	var buf bytes.Buffer
+	s.Require().Nil(r.Encode(&buf))
+	s.Require().Equal(expected, buf.Bytes())
+}
+
+func (s *PushOptionsSuite) TestPushOptionsEncodeInvalidOption() {
+	cases := []struct {
+		name    string
+		options []string
+	}{
+		{
+			name:    "option with newline",
+			options: []string{"SomeKey=SomeValue\n"},
+		},
+		{
+			name:    "option with null byte",
+			options: []string{"SomeKey=SomeValue\x00"},
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			var r PushOptions
+			r.Options = c.options
+
+			var buf bytes.Buffer
+			err := r.Encode(&buf)
+			s.Require().Error(err)
+			s.Require().True(errors.Is(err, ErrInvalidPushOption))
+		})
+	}
+}
+
 func (s *PushOptionsSuite) TestPushOptionsDecode() {
 	var r PushOptions
 	r.Options = nil
@@ -52,4 +92,41 @@ func (s *PushOptionsSuite) TestPushOptionsDecode() {
 	}
 
 	s.Require().Equal(expected, r.Options)
+}
+
+func (s *PushOptionsSuite) TestPushOptionsDecodeEmpty() {
+	var r PushOptions
+	r.Options = nil
+
+	input := pktlines(s.T(), "")
+
+	s.Require().Nil(r.Decode(bytes.NewReader(input)))
+	s.Require().Empty(r.Options)
+}
+
+func (s *PushOptionsSuite) TestPushOptionsDecodeInvalidOption() {
+	cases := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "option with newline",
+			input: pktlines(s.T(), "SomeKey=SomeValue\n", ""),
+		},
+		{
+			name:  "option with null byte",
+			input: pktlines(s.T(), "SomeKey=SomeValue\x00", ""),
+		},
+	}
+
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			var r PushOptions
+			r.Options = nil
+
+			err := r.Decode(bytes.NewReader(c.input))
+			s.Require().Error(err)
+			s.Require().True(errors.Is(err, ErrInvalidPushOption))
+		})
+	}
 }

--- a/plumbing/protocol/packp/pushopts_test.go
+++ b/plumbing/protocol/packp/pushopts_test.go
@@ -3,9 +3,12 @@ package packp
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
 type PushOptionsSuite struct {
@@ -48,16 +51,24 @@ func (s *PushOptionsSuite) TestPushOptionsEncodeEmpty() {
 
 func (s *PushOptionsSuite) TestPushOptionsEncodeInvalidOption() {
 	cases := []struct {
-		name    string
-		options []string
+		name     string
+		options  []string
+		wantErrs []error
 	}{
 		{
-			name:    "option with newline",
-			options: []string{"SomeKey=SomeValue\n"},
+			name:     "option with newline",
+			options:  []string{"SomeKey=SomeValue\n"},
+			wantErrs: []error{ErrInvalidPushOption},
 		},
 		{
-			name:    "option with null byte",
-			options: []string{"SomeKey=SomeValue\x00"},
+			name:     "option with null byte",
+			options:  []string{"SomeKey=SomeValue\x00"},
+			wantErrs: []error{ErrInvalidPushOption},
+		},
+		{
+			name:     "option exceeding max payload size",
+			options:  []string{strings.Repeat("a", pktline.MaxPayloadSize+1)},
+			wantErrs: []error{ErrInvalidPushOption, pktline.ErrPayloadTooLong},
 		},
 	}
 
@@ -69,7 +80,9 @@ func (s *PushOptionsSuite) TestPushOptionsEncodeInvalidOption() {
 			var buf bytes.Buffer
 			err := r.Encode(&buf)
 			s.Require().Error(err)
-			s.Require().True(errors.Is(err, ErrInvalidPushOption))
+			for _, wantErr := range c.wantErrs {
+				s.Require().ErrorIs(err, wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Git pack push server options must not contain newlines or null bytes, as these would break the protocol.
See https://git-scm.com/docs/pack-protocol#_reference_update_request_and_packfile_transfer