### PR TITLE
Remove use of `ChrootOS`

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-git/go-billy/v6/osfs"
-	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -328,11 +326,9 @@ func (s *ConfigSuite) TestLoadConfigXDG() {
 	cfg.User.Name = "foo"
 	cfg.User.Email = "foo@foo.com"
 
-	tmp, err := util.TempDir(osfs.Default, "", "test-commit-options")
-	s.NoError(err)
-	defer util.RemoveAll(osfs.Default, tmp)
+	tmp := s.T().TempDir()
 
-	err = osfs.Default.MkdirAll(filepath.Join(tmp, "git"), 0o777)
+	err := os.MkdirAll(filepath.Join(tmp, "git"), 0o777)
 	s.NoError(err)
 
 	os.Setenv("XDG_CONFIG_HOME", tmp)
@@ -344,7 +340,7 @@ func (s *ConfigSuite) TestLoadConfigXDG() {
 	s.NoError(err)
 
 	cfgFile := filepath.Join(tmp, "git/config")
-	err = util.WriteFile(osfs.Default, cfgFile, content, 0o777)
+	err = os.WriteFile(cfgFile, content, 0o777)
 	s.NoError(err)
 
 	cfg, err = LoadConfig(GlobalScope)

--- a/plumbing/transport/ssh/auth_extended_test.go
+++ b/plumbing/transport/ssh/auth_extended_test.go
@@ -8,8 +8,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/go-git/go-billy/v6/osfs"
-	"github.com/go-git/go-billy/v6/util"
 	"github.com/kevinburke/ssh_config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,14 +39,10 @@ func TestNewPublicKeysFromFile(t *testing.T) {
 	}
 	t.Parallel()
 
-	f, err := util.TempFile(osfs.Default, "", "ssh-test-key")
-	require.NoError(t, err)
-	_, err = f.Write(testdata.PEMBytes["rsa"])
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-	defer util.RemoveAll(osfs.Default, f.Name())
+	path := filepath.Join(t.TempDir(), "ssh-test-key")
+	require.NoError(t, os.WriteFile(path, testdata.PEMBytes["rsa"], 0o600))
 
-	auth, err := NewPublicKeysFromFile("git", f.Name(), "")
+	auth, err := NewPublicKeysFromFile("git", path, "")
 	require.NoError(t, err)
 	require.NotNil(t, auth)
 }
@@ -82,14 +76,10 @@ func TestNewKnownHostsCallback(t *testing.T) {
 	}
 	t.Parallel()
 
-	f, err := util.TempFile(osfs.Default, "", "known-hosts")
-	require.NoError(t, err)
-	_, err = f.Write([]byte(`github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==`))
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-	defer util.RemoveAll(osfs.Default, f.Name())
+	path := filepath.Join(t.TempDir(), "known-hosts")
+	require.NoError(t, os.WriteFile(path, []byte(`github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==`), 0o600))
 
-	clb, err := NewKnownHostsCallback(f.Name())
+	clb, err := NewKnownHostsCallback(path)
 	require.NoError(t, err)
 	require.NotNil(t, clb)
 }

--- a/storage/filesystem/config_test.go
+++ b/storage/filesystem/config_test.go
@@ -30,9 +30,7 @@ func TestConfigSuite(t *testing.T) {
 }
 
 func (s *ConfigSuite) SetupTest() {
-	tmp, err := util.TempDir(osfs.Default, "", "go-git-filestystem-config")
-	s.Require().NoError(err)
-
+	tmp := s.T().TempDir()
 	s.dir = dotgit.New(osfs.New(tmp))
 	s.path = tmp
 }

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -13,14 +13,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/go-git/go-billy/v6"
-	"github.com/go-git/go-billy/v6/helper/chroot"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
@@ -1332,24 +1330,8 @@ func (d *DotGit) Alternates() ([]*DotGit, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		path := scanner.Text()
-
-		// Avoid creating multiple dotgits for the same alternative path.
-		if _, ok := seen[path]; ok {
-			continue
-		}
-
-		seen[path] = struct{}{}
-
-		if filepath.IsAbs(path) {
-			// Handling absolute paths should be straight-forward. However, the default osfs (Chroot)
-			// tries to concatenate an abs path with the root path in some operations (e.g. Stat),
-			// which leads to unexpected errors. Therefore, make the path relative to the current FS instead.
-			if reflect.TypeOf(fs) == reflect.TypeFor[*chroot.ChrootHelper]() {
-				path, err = filepath.Rel(fs.Root(), path)
-				if err != nil {
-					return nil, fmt.Errorf("cannot make path %q relative: %w", path, err)
-				}
-			}
+		if filepath.IsAbs(path) || filepath.VolumeName(path) != "" {
+			path = filepath.Clean(path)
 		} else {
 			// By Git conventions, relative paths should be based on the object database (.git/objects/info)
 			// location as per: https://www.kernel.org/pub/software/scm/git/docs/gitrepository-layout.html
@@ -1359,6 +1341,15 @@ func (d *DotGit) Alternates() ([]*DotGit, error) {
 			abs := filepath.Join(string(filepath.Separator), filepath.ToSlash(path))
 			path = filepath.FromSlash(abs)
 		}
+
+		path = alternatePathForFS(path, fs.Root())
+
+		// Avoid creating multiple dotgits for the same alternative path.
+		if _, ok := seen[path]; ok {
+			continue
+		}
+
+		seen[path] = struct{}{}
 
 		// Aligns with upstream behavior: exit if target path is not a valid directory.
 		if fi, err := fs.Stat(path); err != nil || !fi.IsDir() {
@@ -1376,6 +1367,29 @@ func (d *DotGit) Alternates() ([]*DotGit, error) {
 	}
 
 	return alternates, nil
+}
+
+func alternatePathForFS(path, root string) string {
+	if root == "" {
+		return path
+	}
+
+	root = filepath.Clean(root)
+	if root == "." || root == string(filepath.Separator) {
+		return path
+	}
+
+	rel, err := filepath.Rel(root, path)
+	if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return rel
+	}
+
+	vol := filepath.VolumeName(path)
+	if vol != "" {
+		return strings.TrimLeft(path[len(vol):], `\/`)
+	}
+
+	return strings.TrimPrefix(path, root+string(filepath.Separator))
 }
 
 // Fs returns the underlying filesystem of the DotGit folder.

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -1151,6 +1151,66 @@ func TestAlternatesDupes(t *testing.T) {
 	assert.Len(t, dotgits, 1)
 }
 
+func TestAlternatesAbsolutePathOutsideAlternatesFSRoot(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	altRoot := filepath.Join(base, "alt-root")
+	outsideObjects := filepath.Join(base, "outside", ".git", "objects")
+
+	require.NoError(t, os.MkdirAll(altRoot, 0o700))
+	require.NoError(t, os.MkdirAll(outsideObjects, 0o700))
+
+	altFS := osfs.New(altRoot)
+	dotFS, err := altFS.Chroot("repo")
+	require.NoError(t, err)
+
+	dir := NewWithOptions(dotFS, Options{AlternatesFS: altFS})
+	require.NoError(t, dir.Initialize())
+
+	require.NoError(t, altFS.MkdirAll(filepath.Join("outside", ".git", "objects"), 0o700))
+
+	altpath := dotFS.Join("objects", "info", "alternates")
+	f, err := dotFS.Create(altpath)
+	require.NoError(t, err)
+	_, err = f.Write([]byte(outsideObjects + "\n"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	dotgits, err := dir.Alternates()
+	require.Error(t, err)
+	assert.Nil(t, dotgits)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestAlternatesDefaultAbsolutePathOutsideDotGitRoot(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	dotRoot := filepath.Join(base, "repo", ".git")
+	alternateRoot := filepath.Join(base, "alternate", ".git")
+	alternateObjects := filepath.Join(alternateRoot, "objects")
+
+	require.NoError(t, os.MkdirAll(dotRoot, 0o700))
+	require.NoError(t, os.MkdirAll(alternateObjects, 0o700))
+
+	dotFS := osfs.New(dotRoot)
+	dir := NewWithOptions(dotFS, Options{AlternatesFS: osfs.New(alternateRoot)})
+	require.NoError(t, dir.Initialize())
+
+	altpath := dotFS.Join("objects", "info", "alternates")
+	f, err := dotFS.Create(altpath)
+	require.NoError(t, err)
+	_, err = f.Write([]byte(alternateObjects + "\n"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	dotgits, err := dir.Alternates()
+	require.NoError(t, err)
+	require.Len(t, dotgits, 1)
+	assert.Equal(t, alternateRoot, dotgits[0].fs.Root())
+}
+
 type norwfs struct {
 	billy.Filesystem
 }

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -1328,7 +1328,6 @@ func TestIssue55(t *testing.T) {
 		fs   billy.Filesystem
 	}{
 		{"BoundOS", osfs.New(t.TempDir(), osfs.WithBoundOS())},
-		{"ChrootOS", osfs.New(t.TempDir(), osfs.WithChrootOS())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -177,7 +177,6 @@ func TestPackWriterPermissions(t *testing.T) {
 		fs   billy.Filesystem
 	}{
 		{"BoundOS", osfs.New(t.TempDir(), osfs.WithBoundOS())},
-		{"ChrootOS", osfs.New(t.TempDir(), osfs.WithChrootOS())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -220,9 +219,7 @@ func TestPackWriterExistingReadOnly(t *testing.T) {
 		writeRev bool
 	}{
 		{"BoundOS", osfs.New(t.TempDir(), osfs.WithBoundOS()), false},
-		{"ChrootOS", osfs.New(t.TempDir(), osfs.WithChrootOS()), false},
 		{"BoundOS_Rev", osfs.New(t.TempDir(), osfs.WithBoundOS()), true},
-		{"ChrootOS_Rev", osfs.New(t.TempDir(), osfs.WithChrootOS()), true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -338,7 +335,6 @@ func TestObjectWriterPermissions(t *testing.T) {
 		fs   billy.Filesystem
 	}{
 		{"BoundOS", osfs.New(t.TempDir(), osfs.WithBoundOS())},
-		{"ChrootOS", osfs.New(t.TempDir(), osfs.WithChrootOS())},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
The `ChrootOS` implementation from `go-billy` has been deprecated in `v5` and completely removed from `v6`. This change removes that dependency.
