### PR TITLE
storage: filesystem/mmap, Surface error getting object by delta offset

### DIFF
--- a/storage/filesystem/mmap/fsobject.go
+++ b/storage/filesystem/mmap/fsobject.go
@@ -176,7 +176,8 @@ func (o *ondemandObject) resolveMetadata() error {
 	var err error
 	if o.diskType == plumbing.OFSDeltaObject {
 		reader := bytes.NewReader(o.scanner.packMmap[pos:])
-		negativeOffset, err := binary.ReadVariableWidthInt(reader)
+		var negativeOffset int64
+		negativeOffset, err = binary.ReadVariableWidthInt(reader)
 		if err != nil {
 			return fmt.Errorf("failed to read OFS delta offset: %w", err)
 		}
@@ -184,8 +185,7 @@ func (o *ondemandObject) resolveMetadata() error {
 		consumed := len(o.scanner.packMmap[pos:]) - reader.Len()
 		pos += int64(consumed)
 
-		//nolint:staticcheck
-		base, err = o.scanner.GetByOffset(baseOffset) //nolint:ineffassign
+		base, err = o.scanner.GetByOffset(baseOffset)
 	} else {
 		hashSize := o.scanner.hashSize
 		end := pos + int64(hashSize)


### PR DESCRIPTION
I noticed in #1776 that the linter complained about an ineffectual assignment, which was [dismissed as a false positive](https://github.com/go-git/go-git/pull/1776/changes/BASE..508651306e3e3ebc7e08ddeac106a70fd3f6fec0#r2592500800).

The linter was actually correct here. The outer `err` is shadowed by one defined when calling `binary.ReadVariableWidthInt`, so the assignment is indeed ineffectual. Consequently, the outer `err` is always nil for this code path, even if `scanner.GetByOffset` fails.

This PR avoids shadowing `err` so that the error is surfaced correctly.