### PR TITLE
internal: git, add server timeout test small tolerance

### DIFF
--- a/internal/server/git/git_test.go
+++ b/internal/server/git/git_test.go
@@ -184,7 +184,8 @@ func TestGitServer_Timeout(t *testing.T) {
 	_, err = conn.Read(buf)
 	elapsed := time.Since(start)
 	assert.Error(t, err, "server should close idle connection past Timeout")
-	assert.GreaterOrEqual(t, elapsed, srv.Timeout, "server should not close before Timeout elapses")
+	// Allow a small tolerance for timer/scheduling jitter.
+	assert.GreaterOrEqual(t, elapsed, srv.Timeout-5*time.Millisecond, "server should not close before Timeout elapses")
 }
 
 // gitServer is a helper that holds a running git:// server and its endpoint.


### PR DESCRIPTION
This adds a small tolerance to workaround OS related time precision jitter. Without this, time-based tests might fail with really small deltas like 199.3ms < 200ms.