### PR TITLE
v5: Align object encoding with upstream

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check Package Prefix
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^(\*|docs|git|plumbing|utils|config|_examples|internal|storage|cli|build): .+'
+          pattern: '^(\*|docs|git|plumbing|utils|config|_examples|internal|storage|cli|build|tests): .+'
           error: |
             Commit message(s) does not align with contribution acceptance criteria.
 

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -20,6 +20,7 @@ const (
 	beginpgp       string = "-----BEGIN PGP SIGNATURE-----"
 	endpgp         string = "-----END PGP SIGNATURE-----"
 	headerpgp      string = "gpgsig"
+	headerpgp256   string = "gpgsig-sha256"
 	headerencoding string = "encoding"
 
 	// https://github.com/git/git/blob/bcb6cae2966cc407ca1afc77413b3ef11103c175/Documentation/gitformat-signature.txt#L153
@@ -98,8 +99,8 @@ func (h ExtraHeader) Format(f fmt.State, verb rune) {
 func parseExtraHeader(line []byte) (ExtraHeader, bool) {
 	split := bytes.SplitN(line, []byte{' '}, 2)
 
-	out := ExtraHeader {
-		Key: string(bytes.TrimRight(split[0], "\n")),
+	out := ExtraHeader{
+		Key:   string(bytes.TrimRight(split[0], "\n")),
 		Value: "",
 	}
 
@@ -248,6 +249,7 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	var message bool
 	var mergetag bool
 	var pgpsig bool
+	var pgpsig256 bool
 	var msgbuf bytes.Buffer
 	var extraheader *ExtraHeader = nil
 	for {
@@ -274,6 +276,13 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 			} else {
 				pgpsig = false
 			}
+		}
+
+		if pgpsig256 {
+			if len(line) > 0 && line[0] == ' ' {
+				continue
+			}
+			pgpsig256 = false
 		}
 
 		if extraheader != nil {
@@ -319,6 +328,8 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 			case headerpgp:
 				c.PGPSignature += string(data) + "\n"
 				pgpsig = true
+			case headerpgp256:
+				pgpsig256 = true
 			default:
 				h, maybecontinued := parseExtraHeader(original_line)
 				if maybecontinued {
@@ -407,7 +418,7 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	}
 
 	for _, header := range c.ExtraHeaders {
-		
+
 		if _, err = fmt.Fprintf(w, "\n%s", header); err != nil {
 			return err
 		}

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -486,6 +486,15 @@ func isSignatureHeader(line []byte) bool {
 		bytes.HasPrefix(line, []byte(headerpgp256+" "))
 }
 
+func isStandardHeader(key string) bool {
+	switch key {
+	case "tree", "parent", "author", "committer",
+		headerencoding, headermergetag, headerpgp, headerpgp256:
+		return true
+	}
+	return false
+}
+
 func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	o.SetType(plumbing.CommitObject)
 	w, err := o.Writer()
@@ -544,7 +553,9 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	}
 
 	for _, header := range c.ExtraHeaders {
-
+		if isStandardHeader(header.Key) {
+			continue
+		}
 		if _, err = fmt.Fprintf(w, "\n%s", header); err != nil {
 			return err
 		}

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -191,6 +191,11 @@ func (c *Commit) NumParents() int {
 
 var ErrParentNotFound = errors.New("commit parent not found")
 
+// ErrMalformedCommit is returned when a commit object cannot be decoded
+// because its standard headers (tree, parent, author, committer) are missing,
+// duplicated, or out of order.
+var ErrMalformedCommit = errors.New("malformed commit")
+
 // Parent returns the ith parent of a commit.
 func (c *Commit) Parent(i int) (*Commit, error) {
 	if len(c.ParentHashes) == 0 || i > len(c.ParentHashes)-1 {
@@ -256,107 +261,17 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
-	var message bool
-	var mergetag bool
-	var pgpsig bool
-	var pgpsig256 bool
-	var msgbuf bytes.Buffer
-	var extraheader *ExtraHeader = nil
-	for {
-		line, err := r.ReadBytes('\n')
-		if err != nil && err != io.EOF {
+	s := &commitScanner{r: r, c: c}
+	for state := scanTree; state != nil; {
+		state, err = state(s)
+		if err != nil {
 			return err
 		}
-
-		if mergetag {
-			if len(line) > 0 && line[0] == ' ' {
-				line = bytes.TrimLeft(line, " ")
-				c.MergeTag += string(line)
-				continue
-			} else {
-				mergetag = false
-			}
-		}
-
-		if pgpsig {
-			if len(line) > 0 && line[0] == ' ' {
-				line = bytes.TrimLeft(line, " ")
-				c.PGPSignature += string(line)
-				continue
-			} else {
-				pgpsig = false
-			}
-		}
-
-		if pgpsig256 {
-			if len(line) > 0 && line[0] == ' ' {
-				continue
-			}
-			pgpsig256 = false
-		}
-
-		if extraheader != nil {
-			if len(line) > 0 && line[0] == ' ' {
-				extraheader.Value += string(line[1:])
-				continue
-			} else {
-				extraheader.Value = strings.TrimRight(extraheader.Value, "\n")
-				c.ExtraHeaders = append(c.ExtraHeaders, *extraheader)
-				extraheader = nil
-			}
-		}
-
-		if !message {
-			original_line := line
-			line = bytes.TrimSpace(line)
-			if len(line) == 0 {
-				message = true
-				continue
-			}
-
-			split := bytes.SplitN(line, []byte{' '}, 2)
-
-			var data []byte
-			if len(split) == 2 {
-				data = split[1]
-			}
-
-			switch string(split[0]) {
-			case "tree":
-				c.TreeHash = plumbing.NewHash(string(data))
-			case "parent":
-				c.ParentHashes = append(c.ParentHashes, plumbing.NewHash(string(data)))
-			case "author":
-				c.Author.Decode(data)
-			case "committer":
-				c.Committer.Decode(data)
-			case headermergetag:
-				c.MergeTag += string(data) + "\n"
-				mergetag = true
-			case headerencoding:
-				c.Encoding = MessageEncoding(data)
-			case headerpgp:
-				c.PGPSignature += string(data) + "\n"
-				pgpsig = true
-			case headerpgp256:
-				pgpsig256 = true
-			default:
-				h, maybecontinued := parseExtraHeader(original_line)
-				if maybecontinued {
-					extraheader = &h
-				} else {
-					c.ExtraHeaders = append(c.ExtraHeaders, h)
-				}
-			}
-		} else {
-			msgbuf.Write(line)
-		}
-
-		if err == io.EOF {
-			break
-		}
 	}
-	c.Message = msgbuf.String()
+	if !s.sawTree {
+		return fmt.Errorf("%w: missing tree header", ErrMalformedCommit)
+	}
+	c.Message = s.msgbuf.String()
 	return nil
 }
 

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"slices"
 	"strings"
 
@@ -299,7 +298,7 @@ func (c *Commit) Encode(o plumbing.EncodedObject) error {
 //     representation prevails.
 func (c *Commit) EncodeWithoutSignature(o plumbing.EncodedObject) error {
 	if c.matchesSource() {
-		return stripSignaturesFromRaw(o, c.src)
+		return stripObjectSignatures(o, c.src, plumbing.CommitObject)
 	}
 	return c.encode(o, false)
 }
@@ -336,69 +335,6 @@ func signatureEqual(a, b Signature) bool {
 		a.Email == b.Email &&
 		a.When.Unix() == b.When.Unix() &&
 		a.When.Format("-0700") == b.When.Format("-0700")
-}
-
-// stripSignaturesFromRaw streams src into dst, dropping the canonical commit
-// signature headers ("gpgsig " and "gpgsig-sha256 ") together with their
-// continuation lines (those starting with a space). Everything past the
-// blank line that ends the header block is copied verbatim, as is any other
-// "gpgsig"-prefixed extra header (for example a user-defined "gpgsig-key-id")
-// that does not match one of the canonical signature headers.
-func stripSignaturesFromRaw(dst, src plumbing.EncodedObject) (err error) {
-	dst.SetType(plumbing.CommitObject)
-
-	r, err := src.Reader()
-	if err != nil {
-		return err
-	}
-	defer ioutil.CheckClose(r, &err)
-
-	w, err := dst.Writer()
-	if err != nil {
-		return err
-	}
-	defer ioutil.CheckClose(w, &err)
-
-	br := sync.GetBufioReader(r)
-	defer sync.PutBufioReader(br)
-
-	var inBody, skipping bool
-	for {
-		line, rerr := br.ReadBytes('\n')
-		if rerr != nil && rerr != io.EOF {
-			return rerr
-		}
-
-		write := true
-		if !inBody {
-			switch {
-			case skipping && len(line) > 0 && line[0] == ' ':
-				write = false
-			case isSignatureHeader(line):
-				skipping = true
-				write = false
-			case len(line) == 1 && line[0] == '\n':
-				skipping = false
-				inBody = true
-			default:
-				skipping = false
-			}
-		}
-
-		if write && len(line) > 0 {
-			if _, werr := w.Write(line); werr != nil {
-				return werr
-			}
-		}
-		if rerr == io.EOF {
-			return nil
-		}
-	}
-}
-
-func isSignatureHeader(line []byte) bool {
-	return bytes.HasPrefix(line, []byte(headerpgp+" ")) ||
-		bytes.HasPrefix(line, []byte(headerpgp256+" "))
 }
 
 func isStandardHeader(key string) bool {

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -42,6 +43,11 @@ type MessageEncoding string
 // in time, such as a timestamp, the author of the changes since the last
 // commit, a pointer to the previous commit(s), etc.
 // http://shafiulazam.com/gitbook/1_the_git_object_model.html
+//
+// When a Commit is populated by Decode it retains a reference to the source
+// plumbing.EncodedObject so that EncodeWithoutSignature can reproduce the
+// exact bytes the signature was computed over. Refer to EncodeWithoutSignature
+// for more information.
 type Commit struct {
 	// Hash of the commit object.
 	Hash plumbing.Hash
@@ -67,6 +73,9 @@ type Commit struct {
 	ExtraHeaders []ExtraHeader
 
 	s storer.EncodedObjectStorer
+	// src holds the encoded object this Commit was decoded from, used by
+	// EncodeWithoutSignature to recover the canonical signed bytes.
+	src plumbing.EncodedObject
 }
 
 // ExtraHeader holds any non-standard header
@@ -236,6 +245,7 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 
 	c.Hash = o.Hash()
 	c.Encoding = defaultUtf8CommitMessageEncoding
+	c.src = o
 
 	reader, err := o.Reader()
 	if err != nil {
@@ -355,9 +365,125 @@ func (c *Commit) Encode(o plumbing.EncodedObject) error {
 	return c.encode(o, true)
 }
 
-// EncodeWithoutSignature export a Commit into a plumbing.EncodedObject without the signature (correspond to the payload of the PGP signature).
+// EncodeWithoutSignature exports a Commit into a plumbing.EncodedObject
+// without any signature headers, producing the payload that PGP/GPG
+// signatures are computed over.
+//
+// Behaviour depends on how the Commit was created:
+//
+//   - For Commits populated by Decode whose exported fields still match the
+//     source object, the payload is streamed from the raw source bytes with
+//     gpgsig and gpgsig-sha256 headers (and their continuation lines)
+//     stripped verbatim. This preserves the exact bytes the signature was
+//     computed over, regardless of any normalization performed by Decode.
+//
+//   - For Commits constructed in memory, or for decoded Commits whose
+//     exported fields have been mutated, the payload is derived from the
+//     current struct fields. Mutation is detected by re-decoding the source
+//     object and comparing exported fields; if any differ, the in-memory
+//     representation prevails.
 func (c *Commit) EncodeWithoutSignature(o plumbing.EncodedObject) error {
+	if c.matchesSource() {
+		return stripSignaturesFromRaw(o, c.src)
+	}
 	return c.encode(o, false)
+}
+
+// matchesSource reports whether c.src is set and re-decoding it produces a
+// Commit whose payload-affecting exported fields are identical to those of
+// c. It is the auto-detection used by EncodeWithoutSignature to decide
+// between the raw bytes and the struct-encoded payload.
+//
+// PGPSignature is intentionally excluded from the comparison: neither path
+// emits it, so mutating it must not trigger a switch to struct-encode (which
+// would change the byte layout the caller is trying to verify against).
+func (c *Commit) matchesSource() bool {
+	if c.src == nil {
+		return false
+	}
+	fresh := &Commit{}
+	if err := fresh.Decode(c.src); err != nil {
+		return false
+	}
+	return c.Hash == fresh.Hash &&
+		signatureEqual(c.Author, fresh.Author) &&
+		signatureEqual(c.Committer, fresh.Committer) &&
+		c.MergeTag == fresh.MergeTag &&
+		c.Message == fresh.Message &&
+		c.TreeHash == fresh.TreeHash &&
+		c.Encoding == fresh.Encoding &&
+		slices.Equal(c.ParentHashes, fresh.ParentHashes) &&
+		slices.Equal(c.ExtraHeaders, fresh.ExtraHeaders)
+}
+
+func signatureEqual(a, b Signature) bool {
+	return a.Name == b.Name &&
+		a.Email == b.Email &&
+		a.When.Unix() == b.When.Unix() &&
+		a.When.Format("-0700") == b.When.Format("-0700")
+}
+
+// stripSignaturesFromRaw streams src into dst, dropping the canonical commit
+// signature headers ("gpgsig " and "gpgsig-sha256 ") together with their
+// continuation lines (those starting with a space). Everything past the
+// blank line that ends the header block is copied verbatim, as is any other
+// "gpgsig"-prefixed extra header (for example a user-defined "gpgsig-key-id")
+// that does not match one of the canonical signature headers.
+func stripSignaturesFromRaw(dst, src plumbing.EncodedObject) (err error) {
+	dst.SetType(plumbing.CommitObject)
+
+	r, err := src.Reader()
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(r, &err)
+
+	w, err := dst.Writer()
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(w, &err)
+
+	br := sync.GetBufioReader(r)
+	defer sync.PutBufioReader(br)
+
+	var inBody, skipping bool
+	for {
+		line, rerr := br.ReadBytes('\n')
+		if rerr != nil && rerr != io.EOF {
+			return rerr
+		}
+
+		write := true
+		if !inBody {
+			switch {
+			case skipping && len(line) > 0 && line[0] == ' ':
+				write = false
+			case isSignatureHeader(line):
+				skipping = true
+				write = false
+			case len(line) == 1 && line[0] == '\n':
+				skipping = false
+				inBody = true
+			default:
+				skipping = false
+			}
+		}
+
+		if write && len(line) > 0 {
+			if _, werr := w.Write(line); werr != nil {
+				return werr
+			}
+		}
+		if rerr == io.EOF {
+			return nil
+		}
+	}
+}
+
+func isSignatureHeader(line []byte) bool {
+	return bytes.HasPrefix(line, []byte(headerpgp+" ")) ||
+		bytes.HasPrefix(line, []byte(headerpgp256+" "))
 }
 
 func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -241,14 +241,22 @@ func (c *Commit) Type() plumbing.ObjectType {
 	return plumbing.CommitObject
 }
 
+func (c *Commit) reset() {
+	storer := c.s
+	*c = Commit{
+		Encoding: defaultUtf8CommitMessageEncoding,
+		s:        storer,
+	}
+}
+
 // Decode transforms a plumbing.EncodedObject into a Commit struct.
 func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	if o.Type() != plumbing.CommitObject {
 		return ErrUnsupportedObject
 	}
 
+	c.reset()
 	c.Hash = o.Hash()
-	c.Encoding = defaultUtf8CommitMessageEncoding
 	c.src = o
 
 	reader, err := o.Reader()

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -477,9 +477,21 @@ func (c *Commit) String() string {
 	)
 }
 
+// ErrMultipleSignatures is returned by Verify when the commit carries more
+// than one armored signature block. Mirrors upstream's parse_gpg_output
+// rejection of GOODSIG/BADSIG status lines after the first
+// (gpg-interface.c:257-269): multi-signature commits are intentionally
+// unsupported because their provenance cannot be reduced to a single
+// authoritative signer.
+var ErrMultipleSignatures = errors.New("commit has multiple signatures")
+
 // Verify performs PGP verification of the commit with a provided armored
 // keyring and returns openpgp.Entity associated with verifying key on success.
 func (c *Commit) Verify(armoredKeyRing string) (*openpgp.Entity, error) {
+	if countSignatureBlocks([]byte(c.PGPSignature)) > 1 {
+		return nil, ErrMultipleSignatures
+	}
+
 	keyRingReader := strings.NewReader(armoredKeyRing)
 	keyring, err := openpgp.ReadArmoredKeyRing(keyRingReader)
 	if err != nil {

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -28,9 +28,14 @@ type commitScanner struct {
 	// First-occurrence tracking: once the corresponding field has been
 	// decoded, subsequent occurrences are silently dropped (matches
 	// upstream's find_commit_header / first-wins semantics).
+	//
+	// gpgsig is not tracked here: upstream's parse_buffer_signed_by_header
+	// (commit.c:1186) accumulates every occurrence into one signature buffer,
+	// so we do the same on the scanner side to keep verification payloads
+	// byte-aligned. gpgsig-sha256 is recognized and skipped without exposing a
+	// new field in v5.
 	sawTree, sawAuthor, sawCommitter bool
 	sawEncoding, sawMergetag         bool
-	sawPgp                           bool
 
 	// extra is the multi-line ExtraHeader currently being assembled.
 	extra *ExtraHeader
@@ -216,13 +221,8 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 			next = scanMergetagCont
 		}
 	case headerpgp:
-		if s.sawPgp {
-			next = scanSkipCont
-		} else {
-			s.c.PGPSignature += string(data) + "\n"
-			s.sawPgp = true
-			next = scanPgpCont
-		}
+		s.c.PGPSignature += string(data) + "\n"
+		next = scanPgpCont
 	case headerpgp256:
 		next = scanSkipCont
 	default:
@@ -241,14 +241,20 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 	return next, nil
 }
 
-// scanMergetagCont and scanPgpCont accumulate continuation
-// lines for the matching first-wins header. Continuations strip exactly one
-// leading space, mirroring upstream's `line + 1` (commit.c:1509). The first
-// non-continuation line is pushed back so scanHeaders can dispatch it.
+// scanMergetagCont accumulates continuation lines for the first mergetag
+// header. Continuations strip exactly one leading space, mirroring upstream's
+// `line + 1` (commit.c:1509). The first non-continuation line is pushed back
+// so scanHeaders can dispatch it.
 func scanMergetagCont(s *commitScanner) (commitState, error) {
 	return continuationCont(s, &s.c.MergeTag, scanMergetagCont)
 }
 
+// scanPgpCont accumulates continuation lines for a signature header.
+// Continuations strip exactly one leading space, mirroring upstream's
+// `line + 1` (commit.c:1509). The first non-continuation line is pushed back
+// so scanHeaders can dispatch it. Repeat occurrences of the same signature
+// header land back here and concatenate, matching upstream's
+// parse_buffer_signed_by_header (commit.c:1186).
 func scanPgpCont(s *commitScanner) (commitState, error) {
 	return continuationCont(s, &s.c.PGPSignature, scanPgpCont)
 }
@@ -271,8 +277,8 @@ func continuationCont(s *commitScanner, dst *string, self commitState) (commitSt
 	return scanHeaders, nil
 }
 
-// scanSkipCont discards continuation lines that belong to a duplicate
-// mergetag / gpgsig / gpgsig-sha256 header that scanHeaders chose to drop.
+// scanSkipCont discards continuation lines that belong to a header scanHeaders
+// chose to drop.
 func scanSkipCont(s *commitScanner) (commitState, error) {
 	line, err := s.readLine()
 	if err != nil && err != io.EOF {

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -85,7 +85,11 @@ func scanTree(s *commitScanner) (commitState, error) {
 	if key != "tree" {
 		return nil, fmt.Errorf("%w: tree header must be first", ErrMalformedCommit)
 	}
-	s.c.TreeHash = plumbing.NewHash(string(data))
+	h, herr := parseObjectIDHex(data, ErrMalformedCommit, "tree")
+	if herr != nil {
+		return nil, herr
+	}
+	s.c.TreeHash = h
 	s.sawTree = true
 	if err == io.EOF {
 		return nil, nil
@@ -112,7 +116,11 @@ func scanParents(s *commitScanner) (commitState, error) {
 
 	key, data := splitHeader(line)
 	if key == "parent" {
-		s.c.ParentHashes = append(s.c.ParentHashes, plumbing.NewHash(string(data)))
+		h, herr := parseObjectIDHex(data, ErrMalformedCommit, "parent")
+		if herr != nil {
+			return nil, herr
+		}
+		s.c.ParentHashes = append(s.c.ParentHashes, h)
 		if err == io.EOF {
 			return nil, nil
 		}
@@ -358,4 +366,12 @@ func splitHeader(line []byte) (string, []byte) {
 		return string(trimmed), nil
 	}
 	return string(key), value
+}
+
+func parseObjectIDHex(data []byte, malformedErr error, header string) (plumbing.Hash, error) {
+	id := string(data)
+	if !plumbing.IsHash(id) {
+		return plumbing.ZeroHash, fmt.Errorf("%w: bad %s hash", malformedErr, header)
+	}
+	return plumbing.NewHash(id), nil
 }

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -1,0 +1,355 @@
+package object
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// commitScanner holds the working state of the commit decoder driven by the
+// stateFn loop in (*Commit).Decode. Each commitState reads one or more lines
+// from r, updates the in-progress *Commit and the scanner's bookkeeping, and
+// returns the state that should run next (or nil to stop).
+type commitScanner struct {
+	r      *bufio.Reader
+	c      *Commit
+	msgbuf bytes.Buffer
+
+	// pending holds a line that was read but the current state decided to
+	// hand back to the next state, paired with the io.EOF flag that was
+	// returned when the line was originally read.
+	pending    []byte
+	pendingErr error
+
+	// First-occurrence tracking: once the corresponding field has been
+	// decoded, subsequent occurrences are silently dropped (matches
+	// upstream's find_commit_header / first-wins semantics).
+	sawTree, sawAuthor, sawCommitter bool
+	sawEncoding, sawMergetag         bool
+	sawPgp                           bool
+
+	// extra is the multi-line ExtraHeader currently being assembled.
+	extra *ExtraHeader
+}
+
+// commitState is one step of the decoder state machine. Each function reads
+// the lines it needs, mutates *Commit via s.c, and returns the next state to
+// run (or nil to terminate the loop).
+type commitState func(*commitScanner) (commitState, error)
+
+// readLine returns the next line from the buffer, transparently consuming any
+// line that was previously pushed back by a state that decided not to handle
+// it.
+func (s *commitScanner) readLine() ([]byte, error) {
+	if s.pending != nil {
+		line, err := s.pending, s.pendingErr
+		s.pending, s.pendingErr = nil, nil
+		return line, err
+	}
+	line, err := s.r.ReadBytes('\n')
+	if err != nil && err != io.EOF {
+		return line, err
+	}
+	return line, err
+}
+
+// pushBack stashes an unconsumed line so the next state's readLine call sees
+// it. Only one line can be pushed back at a time.
+func (s *commitScanner) pushBack(line []byte, err error) {
+	s.pending = line
+	s.pendingErr = err
+}
+
+// scanTree expects the first non-empty header to be `tree HASH`. Anything
+// else (or an empty buffer) is rejected with ErrMalformedCommit, matching
+// upstream's `bogus commit object` check.
+func scanTree(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 || isBlankLine(line) {
+		return nil, fmt.Errorf("%w: missing tree header", ErrMalformedCommit)
+	}
+
+	key, data := splitHeader(line)
+	if key != "tree" {
+		return nil, fmt.Errorf("%w: tree header must be first", ErrMalformedCommit)
+	}
+	s.c.TreeHash = plumbing.NewHash(string(data))
+	s.sawTree = true
+	if err == io.EOF {
+		return nil, nil
+	}
+	return scanParents, nil
+}
+
+// scanParents consumes contiguous `parent HASH` lines. The first non-parent
+// line ends the parent block and is handed off to scanAuthor; any later
+// `parent` line is silently dropped (matches upstream's parse_commit_buffer
+// exiting its parent loop at the first non-parent line and
+// read_commit_extra_header_lines filtering `parent` out of extras).
+func scanParents(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "parent" {
+		s.c.ParentHashes = append(s.c.ParentHashes, plumbing.NewHash(string(data)))
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanParents, nil
+	}
+	s.pushBack(line, err)
+	return scanAuthor, nil
+}
+
+// scanAuthor accepts an `author` line at its canonical position immediately
+// after the parent block. Any other header here is pushed back for
+// scanCommitter; an out-of-place author is therefore silently dropped.
+// Mirrors upstream's parse_commit_date func.
+func scanAuthor(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "author" {
+		s.c.Author.Decode(data)
+		s.sawAuthor = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanCommitter, nil
+	}
+	s.pushBack(line, err)
+	return scanCommitter, nil
+}
+
+// scanCommitter accepts a `committer` line at its canonical position
+// immediately after the author. Any other header is pushed back for
+// scanHeaders. Same upstream rationale as scanAuthor.
+func scanCommitter(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "committer" {
+		s.c.Committer.Decode(data)
+		s.sawCommitter = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanHeaders, nil
+	}
+	s.pushBack(line, err)
+	return scanHeaders, nil
+}
+
+// scanHeaders dispatches one header line. Continuation-bearing headers
+// (mergetag, gpgsig, gpgsig-sha256, and unknown extras whose value is
+// continued on subsequent lines) hand off to a dedicated continuation state
+// that handles the `<space>...` lines and then returns here.
+func scanHeaders(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanMessage, nil
+	}
+
+	originalLine := line
+	key, data := splitHeader(line)
+
+	var next commitState = scanHeaders
+	switch key {
+	case "tree", "parent", "author", "committer":
+		// Anything reaching scanHeaders with one of these keys is out of
+		// canonical position: duplicate tree, parent past the contiguous
+		// block, or author/committer not at their expected slot. Drop them
+		// the same way upstream's standard_header_field filter excludes
+		// them from the extras list (read_commit_extra_header_lines,
+		// commit.c:1520-1522).
+	case headerencoding:
+		if !s.sawEncoding {
+			s.c.Encoding = MessageEncoding(data)
+			s.sawEncoding = true
+		}
+	case headermergetag:
+		if s.sawMergetag {
+			next = scanSkipCont
+		} else {
+			s.c.MergeTag += string(data) + "\n"
+			s.sawMergetag = true
+			next = scanMergetagCont
+		}
+	case headerpgp:
+		if s.sawPgp {
+			next = scanSkipCont
+		} else {
+			s.c.PGPSignature += string(data) + "\n"
+			s.sawPgp = true
+			next = scanPgpCont
+		}
+	case headerpgp256:
+		next = scanSkipCont
+	default:
+		h, multiline := parseExtraHeader(originalLine)
+		if multiline {
+			s.extra = &h
+			next = scanExtraCont
+		} else {
+			s.c.ExtraHeaders = append(s.c.ExtraHeaders, h)
+		}
+	}
+
+	if err == io.EOF {
+		return nil, nil
+	}
+	return next, nil
+}
+
+// scanMergetagCont and scanPgpCont accumulate continuation
+// lines for the matching first-wins header. Continuations strip exactly one
+// leading space, mirroring upstream's `line + 1` (commit.c:1509). The first
+// non-continuation line is pushed back so scanHeaders can dispatch it.
+func scanMergetagCont(s *commitScanner) (commitState, error) {
+	return continuationCont(s, &s.c.MergeTag, scanMergetagCont)
+}
+
+func scanPgpCont(s *commitScanner) (commitState, error) {
+	return continuationCont(s, &s.c.PGPSignature, scanPgpCont)
+}
+
+func continuationCont(s *commitScanner, dst *string, self commitState) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) > 0 && line[0] == ' ' {
+		*dst += string(line[1:])
+		if err == io.EOF {
+			return nil, nil
+		}
+		return self, nil
+	}
+	if len(line) > 0 {
+		s.pushBack(line, err)
+	}
+	return scanHeaders, nil
+}
+
+// scanSkipCont discards continuation lines that belong to a duplicate
+// mergetag / gpgsig / gpgsig-sha256 header that scanHeaders chose to drop.
+func scanSkipCont(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) > 0 && line[0] == ' ' {
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanSkipCont, nil
+	}
+	if len(line) > 0 {
+		s.pushBack(line, err)
+	}
+	return scanHeaders, nil
+}
+
+// scanExtraCont accumulates continuation lines for an unknown ExtraHeader
+// whose value spans multiple lines, then finalises the entry once the
+// continuation block ends.
+func scanExtraCont(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) > 0 && line[0] == ' ' {
+		s.extra.Value += string(line[1:])
+		if err == io.EOF {
+			s.finaliseExtra()
+			return nil, nil
+		}
+		return scanExtraCont, nil
+	}
+	s.finaliseExtra()
+	if len(line) > 0 {
+		s.pushBack(line, err)
+	}
+	return scanHeaders, nil
+}
+
+func (s *commitScanner) finaliseExtra() {
+	s.extra.Value = strings.TrimRight(s.extra.Value, "\n")
+	s.c.ExtraHeaders = append(s.c.ExtraHeaders, *s.extra)
+	s.extra = nil
+}
+
+// scanMessage drains the remaining bytes into the message buffer.
+func scanMessage(s *commitScanner) (commitState, error) {
+	for {
+		line, err := s.readLine()
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if len(line) > 0 {
+			s.msgbuf.Write(line)
+		}
+		if err == io.EOF {
+			return nil, nil
+		}
+	}
+}
+
+// isBlankLine reports whether line is the canonical header/body separator:
+// a single newline. Mirrors upstream's `*line == '\n'` test in
+// read_commit_extra_header_lines (commit.c:1502).
+func isBlankLine(line []byte) bool {
+	return len(line) == 1 && line[0] == '\n'
+}
+
+// splitHeader returns the header keyword (everything before the first space)
+// and the value (everything after, with the trailing newline stripped). If
+// the header has no value the returned data is nil.
+func splitHeader(line []byte) (string, []byte) {
+	trimmed := bytes.TrimRight(line, "\n")
+	key, value, ok := bytes.Cut(trimmed, []byte{' '})
+	if !ok {
+		return string(trimmed), nil
+	}
+	return string(key), value
+}

--- a/plumbing/object/commit_sha256_test.go
+++ b/plumbing/object/commit_sha256_test.go
@@ -1,0 +1,43 @@
+//go:build sha256
+// +build sha256
+
+package object
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func TestDecodeCommitSHA256ObjectIDs(t *testing.T) {
+	const (
+		treeID   = "151c11736080ee7fe882040a334ec2ae4a815deca7a3d63374500e107dbcda09"
+		parentID = "36561e87343747f0bc493eeeb04d910e5382c3419c42d412687e2aac5e4c40a1"
+		raw      = "tree " + treeID + "\n" +
+			"parent " + parentID + "\n" +
+			"author Foo <foo@example.local> 1427802494 +0200\n" +
+			"committer Foo <foo@example.local> 1427802494 +0200\n\n" +
+			"msg\n"
+	)
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.CommitObject)
+	if _, err := obj.Write([]byte(raw)); err != nil {
+		t.Fatal(err)
+	}
+
+	commit := &Commit{}
+	if err := commit.Decode(obj); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := commit.TreeHash.String(); got != treeID {
+		t.Fatalf("TreeHash = %q, want %q", got, treeID)
+	}
+	if len(commit.ParentHashes) != 1 {
+		t.Fatalf("ParentHashes length = %d, want 1", len(commit.ParentHashes))
+	}
+	if got := commit.ParentHashes[0].String(); got != parentID {
+		t.Fatalf("ParentHashes[0] = %q, want %q", got, parentID)
+	}
+}

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -42,6 +42,49 @@ func (s *SuiteCommit) TestDecodeNonCommit(c *C) {
 	c.Assert(err, Equals, ErrUnsupportedObject)
 }
 
+func (s *SuiteCommit) TestDecodeClearsExistingState(c *C) {
+	const raw = "tree eba74343e2f15d62adedfd8c883ee0262b5c8021\n\nfresh message\n"
+
+	staleSrc := &plumbing.MemoryObject{}
+	commit := &Commit{
+		Hash:         plumbing.NewHash("1111111111111111111111111111111111111111"),
+		Author:       Signature{Name: "Stale Author", Email: "author@example.local", When: time.Unix(1, 0).UTC()},
+		Committer:    Signature{Name: "Stale Committer", Email: "committer@example.local", When: time.Unix(2, 0).UTC()},
+		MergeTag:     "stale merge tag",
+		PGPSignature: "stale signature",
+		Message:      "stale message",
+		TreeHash:     plumbing.NewHash("2222222222222222222222222222222222222222"),
+		ParentHashes: []plumbing.Hash{
+			plumbing.NewHash("3333333333333333333333333333333333333333"),
+		},
+		Encoding: MessageEncoding("latin-1"),
+		ExtraHeaders: []ExtraHeader{
+			{Key: "x-stale", Value: "stale"},
+		},
+		s:   s.Storer,
+		src: staleSrc,
+	}
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.CommitObject)
+	_, err := obj.Write([]byte(raw))
+	c.Assert(err, IsNil)
+
+	c.Assert(commit.Decode(obj), IsNil)
+	c.Assert(commit.Hash, Equals, obj.Hash())
+	c.Assert(commit.Author, DeepEquals, Signature{})
+	c.Assert(commit.Committer, DeepEquals, Signature{})
+	c.Assert(commit.MergeTag, Equals, "")
+	c.Assert(commit.PGPSignature, Equals, "")
+	c.Assert(commit.Message, Equals, "fresh message\n")
+	c.Assert(commit.TreeHash.String(), Equals, "eba74343e2f15d62adedfd8c883ee0262b5c8021")
+	c.Assert(commit.ParentHashes, IsNil)
+	c.Assert(commit.Encoding, Equals, defaultUtf8CommitMessageEncoding)
+	c.Assert(commit.ExtraHeaders, IsNil)
+	c.Assert(commit.s, Equals, s.Storer)
+	c.Assert(commit.src, Equals, obj)
+}
+
 func (s *SuiteCommit) TestType(c *C) {
 	c.Assert(s.Commit.Type(), Equals, plumbing.CommitObject)
 }

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -488,6 +489,177 @@ func (s *SuiteCommit) TestPatchCancel(c *C) {
 	c.Assert(patch, IsNil)
 	c.Assert(err, ErrorMatches, "operation canceled")
 
+}
+
+func (s *SuiteCommit) TestDecodeRequiresTreeFirst(c *C) {
+	const (
+		validTree   = "eba74343e2f15d62adedfd8c883ee0262b5c8021"
+		validParent = "35e85108805c84807bc66a02d91535e1e24b38b9"
+		validIdent  = "Foo <foo@example.local> 1427802494 +0200"
+	)
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "missing tree",
+			raw:  "author " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "parent before tree",
+			raw:  "parent " + validParent + "\ntree " + validTree + "\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "extra header before tree",
+			raw:  "x-extra hi\ntree " + validTree + "\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "empty",
+			raw:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		c.Log(tc.name)
+		obj := &plumbing.MemoryObject{}
+		obj.SetType(plumbing.CommitObject)
+		_, err := obj.Write([]byte(tc.raw))
+		c.Assert(err, IsNil)
+
+		err = (&Commit{}).Decode(obj)
+		c.Assert(errors.Is(err, ErrMalformedCommit), Equals, true)
+	}
+}
+
+func (s *SuiteCommit) TestDecodeFirstOccurrenceWins(c *C) {
+	const (
+		treeA       = "eba74343e2f15d62adedfd8c883ee0262b5c8021"
+		treeB       = "0000000000000000000000000000000000000001"
+		parentA     = "35e85108805c84807bc66a02d91535e1e24b38b9"
+		parentB     = "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"
+		parentC     = "0000000000000000000000000000000000000002"
+		identA      = "Alice <alice@example.local> 1427802494 +0200"
+		identB      = "Bob <bob@example.local> 1427802495 +0200"
+		identAuthor = "Author Name <author@example.local> 1500000000 +0000"
+		identCommit = "Commit Name <commit@example.local> 1500000001 +0000"
+	)
+
+	cases := []struct {
+		name   string
+		raw    string
+		assert func(*Commit)
+	}{
+		{
+			name: "duplicate tree drops the second",
+			raw: "tree " + treeA + "\ntree " + treeB +
+				"\nauthor " + identAuthor + "\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.TreeHash.String(), Equals, treeA)
+			},
+		},
+		{
+			name: "duplicate author drops the second",
+			raw: "tree " + treeA + "\nauthor " + identA + "\nauthor " + identB +
+				"\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.Author.Name, Equals, "Alice")
+			},
+		},
+		{
+			name: "duplicate committer drops the second",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\ncommitter " + identA + "\ncommitter " + identB + "\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.Committer.Name, Equals, "Alice")
+			},
+		},
+		{
+			name: "parent after author is dropped",
+			raw: "tree " + treeA + "\nparent " + parentA +
+				"\nauthor " + identAuthor + "\nparent " + parentC +
+				"\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.ParentHashes, DeepEquals, []plumbing.Hash{plumbing.NewHash(parentA)})
+			},
+		},
+		{
+			name: "parent interleaved with extras is dropped",
+			raw: "tree " + treeA + "\nparent " + parentA + "\nparent " + parentB +
+				"\nx-other thing\nparent " + parentC +
+				"\nauthor " + identAuthor + "\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.ParentHashes, DeepEquals, []plumbing.Hash{
+					plumbing.NewHash(parentA),
+					plumbing.NewHash(parentB),
+				})
+			},
+		},
+		{
+			name: "missing committer is allowed (zero-valued)",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.Author.Name, Equals, "Author Name")
+				c.Assert(commit.Committer.Name, Equals, "")
+			},
+		},
+		{
+			name: "encoding between author and committer drops committer",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\nencoding latin-1\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.Author.Name, Equals, "Author Name")
+				c.Assert(commit.Encoding, Equals, MessageEncoding("latin-1"))
+				// committer was not at its canonical position
+				// (immediately after author) so it is dropped, matching
+				// upstream's parse_commit_date returning 0 and the
+				// subsequent standard_header_field filter.
+				c.Assert(commit.Committer.Name, Equals, "")
+			},
+		},
+		{
+			name: "author out of canonical position is dropped",
+			raw: "tree " + treeA + "\nencoding latin-1\nauthor " + identAuthor +
+				"\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.Encoding, Equals, MessageEncoding("latin-1"))
+				c.Assert(commit.Author.Name, Equals, "")
+				c.Assert(commit.Committer.Name, Equals, "")
+			},
+		},
+		{
+			name: "duplicate gpgsig drops the second and its continuations",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\ncommitter " + identCommit +
+				"\ngpgsig firstline\n morefirst\ngpgsig secondline\n moresecond\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.PGPSignature, Equals, "firstline\nmorefirst\n")
+			},
+		},
+		{
+			name: "gpgsig-sha256 headers are not exposed as extras",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\ncommitter " + identCommit +
+				"\ngpgsig-sha256 firstline\n morefirst\ngpgsig-sha256 secondline\n moresecond\n\nmsg\n",
+			assert: func(commit *Commit) {
+				c.Assert(commit.PGPSignature, Equals, "")
+				c.Assert(len(commit.ExtraHeaders), Equals, 0)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		c.Log(tc.name)
+		obj := &plumbing.MemoryObject{}
+		obj.SetType(plumbing.CommitObject)
+		_, err := obj.Write([]byte(tc.raw))
+		c.Assert(err, IsNil)
+
+		commit := &Commit{}
+		c.Assert(commit.Decode(obj), IsNil)
+		tc.assert(commit)
+	}
 }
 
 func (s *SuiteCommit) TestMalformedHeader(c *C) {

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -518,6 +518,30 @@ func (s *SuiteCommit) TestDecodeRequiresTreeFirst(c *C) {
 			name: "empty",
 			raw:  "",
 		},
+		{
+			name: "non-hex tree value",
+			raw:  "tree zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "tree value too short",
+			raw:  "tree abcd\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "tree value too long",
+			raw:  "tree " + validTree + "00\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "tree value missing",
+			raw:  "tree\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "non-hex parent value",
+			raw:  "tree " + validTree + "\nparent zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "parent value too short",
+			raw:  "tree " + validTree + "\nparent abcd\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
 	}
 
 	for _, tc := range cases {

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -277,6 +277,7 @@ change
 		err = newCommit.Decode(obj)
 		c.Assert(err, IsNil)
 		commit.Hash = obj.Hash()
+		commit.src = obj
 		c.Assert(newCommit, DeepEquals, commit)
 	}
 }
@@ -511,6 +512,7 @@ func (s *SuiteCommit) TestEncodeWithoutSignature(c *C) {
 	tests := []struct {
 		name      string
 		commitRaw string
+		mutate    func(*Commit)
 		expected  string
 	}{
 		{
@@ -616,6 +618,94 @@ initial commit
 Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
 `,
 		},
+		{
+			name: "non-canonical gpgsig-prefixed extra header is preserved",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig-key-id ABCDEF0123456789
+gpgsig -----BEGIN PGP SIGNATURE-----
+ sigline1
+ -----END PGP SIGNATURE-----
+
+initial commit
+`,
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig-key-id ABCDEF0123456789
+
+initial commit
+`,
+		},
+		{
+			name: "raw bytes preserved when only PGPSignature is mutated",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig -----BEGIN PGP SIGNATURE-----
+ sigline1
+ -----END PGP SIGNATURE-----
+gpgsig-sha256 -----BEGIN PGP SIGNATURE-----
+ sha256line1
+ -----END PGP SIGNATURE-----
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				c.PGPSignature = "different signature value"
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+
+initial commit
+`,
+		},
+		{
+			name: "timezone-only change triggers struct-encode",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig -----BEGIN PGP SIGNATURE-----
+ sigline1
+ -----END PGP SIGNATURE-----
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				tz := time.FixedZone("CEST", 2*60*60)
+				c.Author.When = c.Author.When.In(tz)
+				c.Committer.When = c.Committer.When.In(tz)
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 +0200
+committer John Doe <john.doe@example.com> 1755280730 +0200
+
+initial commit
+`,
+		},
+		{
+			name: "field mutation triggers struct-encode",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig -----BEGIN PGP SIGNATURE-----
+ sigline1
+ -----END PGP SIGNATURE-----
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				c.Message = "rewritten message\n"
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+
+rewritten message
+`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -627,6 +717,9 @@ Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
 
 		commit, err := DecodeCommit(s.Storer, obj)
 		c.Assert(err, IsNil)
+		if tc.mutate != nil {
+			tc.mutate(commit)
+		}
 
 		encoded := &plumbing.MemoryObject{}
 		err = commit.EncodeWithoutSignature(encoded)

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -706,6 +706,36 @@ committer John Doe <john.doe@example.com> 1755280730 -0700
 rewritten message
 `,
 		},
+		{
+			name: "standard-keyed ExtraHeaders are dropped on encode",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				c.Message = "rewritten message\n"
+				c.ExtraHeaders = []ExtraHeader{
+					{Key: "tree", Value: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},
+					{Key: "parent", Value: "feedfacefeedfacefeedfacefeedfacefeedface"},
+					{Key: "author", Value: "Fake <fake@example.com> 0 +0000"},
+					{Key: "committer", Value: "Fake <fake@example.com> 0 +0000"},
+					{Key: "encoding", Value: "fake-enc"},
+					{Key: "mergetag", Value: "fake mergetag"},
+					{Key: "gpgsig", Value: "fake-sig"},
+					{Key: "gpgsig-sha256", Value: "fake-sig-256"},
+					{Key: "x-real-extra", Value: "kept"},
+				}
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+x-real-extra kept
+
+rewritten message
+`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -629,12 +629,15 @@ func (s *SuiteCommit) TestDecodeFirstOccurrenceWins(c *C) {
 			},
 		},
 		{
-			name: "duplicate gpgsig drops the second and its continuations",
+			// Multiple gpgsig headers concatenate into a single
+			// signature buffer, mirroring upstream's
+			// parse_buffer_signed_by_header (commit.c:1186).
+			name: "multiple gpgsig headers concatenate",
 			raw: "tree " + treeA + "\nauthor " + identAuthor +
 				"\ncommitter " + identCommit +
 				"\ngpgsig firstline\n morefirst\ngpgsig secondline\n moresecond\n\nmsg\n",
 			assert: func(commit *Commit) {
-				c.Assert(commit.PGPSignature, Equals, "firstline\nmorefirst\n")
+				c.Assert(commit.PGPSignature, Equals, "firstline\nmorefirst\nsecondline\nmoresecond\n")
 			},
 		},
 		{

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -359,10 +359,6 @@ func (s *SuiteCommit) TestLongCommitMessageSerialization(c *C) {
 }
 
 func (s *SuiteCommit) TestPGPSignatureSerialization(c *C) {
-	encoded := &plumbing.MemoryObject{}
-	decoded := &Commit{}
-	commit := *s.Commit
-
 	pgpsignature := `-----BEGIN PGP SIGNATURE-----
 
 iQEcBAABAgAGBQJTZbQlAAoJEF0+sviABDDrZbQH/09PfE51KPVPlanr6q1v4/Ut
@@ -374,62 +370,40 @@ RUysgqjcpT8+iQM1PblGfHR4XAhuOqN5Fx06PSaFZhqvWFezJ28/CLyX5q+oIVk=
 =EFTF
 -----END PGP SIGNATURE-----
 `
-	commit.PGPSignature = pgpsignature
+	broken := beginpgp + "\nsome\ntrash\n" + endpgp + "text\n"
 
-	err := commit.Encode(encoded)
-	c.Assert(err, IsNil)
+	cases := []struct {
+		name         string
+		pgpSignature string
+		authorName   string
+	}{
+		{name: "pgp signature", pgpSignature: pgpsignature},
+		{name: "pgp signature with leading empty line", pgpSignature: "\n" + pgpsignature},
+		{name: "beginpgp marker in author name is not parsed as signature", authorName: beginpgp},
+		{name: "garbage between begin and end markers round-trips", pgpSignature: broken},
+	}
 
-	err = decoded.Decode(encoded)
-	c.Assert(err, IsNil)
-	c.Assert(decoded.PGPSignature, Equals, pgpsignature)
+	for _, tc := range cases {
+		c.Log(tc.name)
 
-	// signature with extra empty line, it caused "index out of range" when
-	// parsing it
+		commit := *s.Commit
+		commit.PGPSignature = tc.pgpSignature
+		if tc.authorName != "" {
+			commit.Author.Name = tc.authorName
+		}
 
-	pgpsignature2 := "\n" + pgpsignature
+		encoded := &plumbing.MemoryObject{}
+		decoded := &Commit{}
+		err := commit.Encode(encoded)
+		c.Assert(err, IsNil)
 
-	commit.PGPSignature = pgpsignature2
-	encoded = &plumbing.MemoryObject{}
-	decoded = &Commit{}
-
-	err = commit.Encode(encoded)
-	c.Assert(err, IsNil)
-
-	err = decoded.Decode(encoded)
-	c.Assert(err, IsNil)
-	c.Assert(decoded.PGPSignature, Equals, pgpsignature2)
-
-	// signature in author name
-
-	commit.PGPSignature = ""
-	commit.Author.Name = beginpgp
-	encoded = &plumbing.MemoryObject{}
-	decoded = &Commit{}
-
-	err = commit.Encode(encoded)
-	c.Assert(err, IsNil)
-
-	err = decoded.Decode(encoded)
-	c.Assert(err, IsNil)
-	c.Assert(decoded.PGPSignature, Equals, "")
-	c.Assert(decoded.Author.Name, Equals, beginpgp)
-
-	// broken signature
-
-	commit.PGPSignature = beginpgp + "\n" +
-		"some\n" +
-		"trash\n" +
-		endpgp +
-		"text\n"
-	encoded = &plumbing.MemoryObject{}
-	decoded = &Commit{}
-
-	err = commit.Encode(encoded)
-	c.Assert(err, IsNil)
-
-	err = decoded.Decode(encoded)
-	c.Assert(err, IsNil)
-	c.Assert(decoded.PGPSignature, Equals, commit.PGPSignature)
+		err = decoded.Decode(encoded)
+		c.Assert(err, IsNil)
+		c.Assert(decoded.PGPSignature, Equals, tc.pgpSignature)
+		if tc.authorName != "" {
+			c.Assert(decoded.Author.Name, Equals, tc.authorName)
+		}
+	}
 }
 
 func (s *SuiteCommit) TestStat(c *C) {
@@ -534,34 +508,37 @@ func (s *SuiteCommit) TestMalformedHeader(c *C) {
 }
 
 func (s *SuiteCommit) TestEncodeWithoutSignature(c *C) {
-	// Similar to TestString since no signature
-	encoded := &plumbing.MemoryObject{}
-	err := s.Commit.EncodeWithoutSignature(encoded)
-	c.Assert(err, IsNil)
-	er, err := encoded.Reader()
-	c.Assert(err, IsNil)
-	payload, err := io.ReadAll(er)
-	c.Assert(err, IsNil)
+	tests := []struct {
+		name      string
+		commitRaw string
+		expected  string
+	}{
+		{
+			name: "commit without signature",
+			commitRaw: `tree eba74343e2f15d62adedfd8c883ee0262b5c8021
+parent 35e85108805c84807bc66a02d91535e1e24b38b9
+parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69
+author Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200
+committer Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200
 
-	c.Assert(string(payload), Equals, ""+
-		"tree eba74343e2f15d62adedfd8c883ee0262b5c8021\n"+
-		"parent 35e85108805c84807bc66a02d91535e1e24b38b9\n"+
-		"parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69\n"+
-		"author Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200\n"+
-		"committer Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200\n"+
-		"\n"+
-		"Merge branch 'master' of github.com:tyba/git-fixture\n")
-}
+Merge branch 'master' of github.com:tyba/git-fixture
+`,
+			expected: `tree eba74343e2f15d62adedfd8c883ee0262b5c8021
+parent 35e85108805c84807bc66a02d91535e1e24b38b9
+parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69
+author Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200
+committer Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200
 
-func (s *SuiteCommit) TestEncodeWithoutSignatureJujutsu(c *C) {
-	object := &plumbing.MemoryObject{}
-	object.SetType(plumbing.CommitObject)
-	object.Write([]byte(`tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+Merge branch 'master' of github.com:tyba/git-fixture
+`,
+		},
+		{
+			name: "commit with change-id and gpgsig",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 author John Doe <john.doe@example.com> 1755280730 -0700
 committer John Doe <john.doe@example.com> 1755280730 -0700
 change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
 gpgsig -----BEGIN PGP SIGNATURE-----
- 
  iHUEABMIAB0WIQSZpnSpGKbQbDaLe5iiNQl48cTY5gUCaJ91XQAKCRCiNQl48cTY
  5vCYAP9Sf1yV9oUviRIxEA+4rsGIx0hI6kqFajJ/3TtBjyCTggD+PFnKOxdXeFL2
  GLwcCzFIsmQmkLxuLypsg+vueDSLpsM=
@@ -571,20 +548,8 @@ gpgsig -----BEGIN PGP SIGNATURE-----
 initial commit
 
 Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
-`))
-
-	commit, err := DecodeCommit(s.Storer, object)
-	c.Assert(err, IsNil)
-
-	// Similar to TestString since no signature
-	encoded := &plumbing.MemoryObject{}
-	err = commit.EncodeWithoutSignature(encoded)
-	er, err := encoded.Reader()
-	c.Assert(err, IsNil)
-	payload, err := io.ReadAll(er)
-	c.Assert(err, IsNil)
-
-	c.Assert(string(payload), Equals, `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+`,
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 author John Doe <john.doe@example.com> 1755280730 -0700
 committer John Doe <john.doe@example.com> 1755280730 -0700
 change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
@@ -592,7 +557,89 @@ change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
 initial commit
 
 Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
-`)
+`,
+		},
+		{
+			name: "gpgsig-sha256",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+gpgsig-sha256 -----BEGIN PGP SIGNATURE-----
+ iHUEABMIAB0WIQSZpnSpGKbQbDaLe5iiNQl48cTY5gUCaJ91XQAKCRCiNQl48cTY
+ 5vCYAP9Sf1yV9oUviRIxEA+4rsGIx0hI6kqFajJ/3TtBjyCTggD+PFnKOxdXeFL2
+ GLwcCzFIsmQmkLxuLypsg+vueDSLpsM=
+ =VucY
+ -----END PGP SIGNATURE-----
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`,
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`,
+		},
+		{
+			name: "gpgsig + gpgsig-sha256",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+gpgsig -----BEGIN PGP SIGNATURE-----
+ iHUEABMIAB0WIQSZpnSpGKbQbDaLe5iiNQl48cTY5gUCaJ91XQAKCRCiNQl48cTY
+ GLwcCzFIsmQmkLxuLypsg+vueDSLpsM=
+ =VucY
+ -----END PGP SIGNATURE-----
+gpgsig-sha256 -----BEGIN PGP SIGNATURE-----
+ iHUEABMIAB0WIQSZpnSpGKbQbDaLe5iiNQl48cTY5gUCaJ91XQAKCRCiNQl48cTY
+ =VucY
+ -----END PGP SIGNATURE-----
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`,
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		c.Log(tc.name)
+
+		obj := &plumbing.MemoryObject{}
+		obj.SetType(plumbing.CommitObject)
+		obj.Write([]byte(tc.commitRaw))
+
+		commit, err := DecodeCommit(s.Storer, obj)
+		c.Assert(err, IsNil)
+
+		encoded := &plumbing.MemoryObject{}
+		err = commit.EncodeWithoutSignature(encoded)
+		c.Assert(err, IsNil)
+
+		er, err := encoded.Reader()
+		c.Assert(err, IsNil)
+
+		payload, err := io.ReadAll(er)
+		c.Assert(err, IsNil)
+
+		c.Assert(string(payload), Equals, tc.expected)
+	}
 }
 
 func (s *SuiteCommit) TestEncodeExtraHeaders(c *C) {
@@ -618,20 +665,20 @@ initial commit
 	c.Assert(err, IsNil)
 
 	c.Assert(commit.ExtraHeaders, DeepEquals, []ExtraHeader{
-		ExtraHeader {
-			Key: "continuedheader",
+		ExtraHeader{
+			Key:   "continuedheader",
 			Value: "to be\ncontinued",
 		},
-		ExtraHeader {
-			Key: "continuedheader",
+		ExtraHeader{
+			Key:   "continuedheader",
 			Value: "to be\ncontinued\non\nmore than\na single line",
 		},
-		ExtraHeader {
-			Key: "simpleflag",
+		ExtraHeader{
+			Key:   "simpleflag",
 			Value: "",
 		},
-		ExtraHeader {
-			Key: "",
+		ExtraHeader{
+			Key:   "",
 			Value: "value no key",
 		},
 	})

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -87,11 +87,11 @@ func (s *ObjectsSuite) TestParseTree(c *C) {
 
 	c.Assert(tree.Entries, HasLen, 8)
 
-	tree.buildMap()
-	c.Assert(tree.m, HasLen, 8)
-	c.Assert(tree.m[".gitignore"].Name, Equals, ".gitignore")
-	c.Assert(tree.m[".gitignore"].Mode, Equals, filemode.Regular)
-	c.Assert(tree.m[".gitignore"].Hash.String(), Equals, "32858aad3c383ed1ff0a0f9bdf231d54a00c9e88")
+	entry, err := tree.entry(".gitignore")
+	c.Assert(err, IsNil)
+	c.Assert(entry.Name, Equals, ".gitignore")
+	c.Assert(entry.Mode, Equals, filemode.Regular)
+	c.Assert(entry.Hash.String(), Equals, "32858aad3c383ed1ff0a0f9bdf231d54a00c9e88")
 
 	count := 0
 	iter := tree.Files()

--- a/plumbing/object/signature.go
+++ b/plumbing/object/signature.go
@@ -1,6 +1,13 @@
 package object
 
-import "bytes"
+import (
+	"bytes"
+	"io"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/utils/ioutil"
+	"github.com/go-git/go-git/v5/utils/sync"
+)
 
 const (
 	signatureTypeUnknown signatureType = iota
@@ -99,4 +106,96 @@ func parseSignedBytes(b []byte) (int, signatureType) {
 		break
 	}
 	return match, t
+}
+
+// isSignatureHeader reports whether line is a canonical "gpgsig "/
+// "gpgsig-sha256 " header line. Other "gpgsig"-prefixed extra headers
+// are intentionally not matched.
+func isSignatureHeader(line []byte) bool {
+	return bytes.HasPrefix(line, []byte(headerpgp+" ")) ||
+		bytes.HasPrefix(line, []byte(headerpgp256+" "))
+}
+
+// stripObjectSignatures streams src into dst, producing the byte sequence
+// over which a PGP/GPG signature is computed:
+//
+//   - Canonical "gpgsig" and "gpgsig-sha256" headers (and their
+//     continuation lines) are dropped, mirroring upstream's
+//     remove_signature in commit.c.
+//   - For tag objects, the inline trailing PGP signature is additionally
+//     truncated, mirroring upstream's parse_signature in gpg-interface.c
+//     used by gpg_verify_tag.
+//
+// The returned object's type is set to objType. Used by both
+// Commit.EncodeWithoutSignature and Tag.EncodeWithoutSignature to
+// reproduce the exact bytes the signature was computed over.
+func stripObjectSignatures(dst, src plumbing.EncodedObject, objType plumbing.ObjectType) (err error) {
+	dst.SetType(objType)
+
+	r, err := src.Reader()
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(r, &err)
+
+	var input io.Reader = r
+	if objType == plumbing.TagObject {
+		raw, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		if sm, _ := parseSignedBytes(raw); sm >= 0 {
+			raw = raw[:sm]
+		}
+		input = bytes.NewReader(raw)
+	}
+
+	w, err := dst.Writer()
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(w, &err)
+
+	return stripHeaderSignatures(w, input)
+}
+
+// stripHeaderSignatures copies r to w, dropping canonical signature header
+// lines (gpgsig and gpgsig-sha256) and their continuation lines. Lines
+// past the blank line that closes the header block are copied verbatim.
+func stripHeaderSignatures(w io.Writer, r io.Reader) error {
+	br := sync.GetBufioReader(r)
+	defer sync.PutBufioReader(br)
+
+	var inBody, skipping bool
+	for {
+		line, rerr := br.ReadBytes('\n')
+		if rerr != nil && rerr != io.EOF {
+			return rerr
+		}
+
+		write := true
+		if !inBody {
+			switch {
+			case skipping && len(line) > 0 && line[0] == ' ':
+				write = false
+			case isSignatureHeader(line):
+				skipping = true
+				write = false
+			case len(line) == 1 && line[0] == '\n':
+				skipping = false
+				inBody = true
+			default:
+				skipping = false
+			}
+		}
+
+		if write && len(line) > 0 {
+			if _, werr := w.Write(line); werr != nil {
+				return werr
+			}
+		}
+		if rerr == io.EOF {
+			return nil
+		}
+	}
 }

--- a/plumbing/object/signature.go
+++ b/plumbing/object/signature.go
@@ -108,6 +108,27 @@ func parseSignedBytes(b []byte) (int, signatureType) {
 	return match, t
 }
 
+// countSignatureBlocks reports how many distinct armored signature blocks
+// start at a line boundary in b. Used by verification paths to reject
+// multi-signature payloads, matching upstream's check in gpg-interface.c
+// where parse_gpg_output bails out the first time it sees a second
+// exclusive status line (a second GOODSIG/BADSIG/etc.).
+func countSignatureBlocks(b []byte) int {
+	n, count := 0, 0
+	for n < len(b) {
+		i := b[n:]
+		if typeForSignature(i) != signatureTypeUnknown {
+			count++
+		}
+		if eol := bytes.IndexByte(i, '\n'); eol >= 0 {
+			n += eol + 1
+			continue
+		}
+		break
+	}
+	return count
+}
+
 // isSignatureHeader reports whether line is a canonical "gpgsig "/
 // "gpgsig-sha256 " header line. Other "gpgsig"-prefixed extra headers
 // are intentionally not matched.

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -83,12 +83,18 @@ func (t *Tag) Type() plumbing.ObjectType {
 	return plumbing.TagObject
 }
 
+func (t *Tag) reset() {
+	storer := t.s
+	*t = Tag{s: storer}
+}
+
 // Decode transforms a plumbing.EncodedObject into a Tag struct.
 func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	if o.Type() != plumbing.TagObject {
 		return ErrUnsupportedObject
 	}
 
+	t.reset()
 	t.Hash = o.Hash()
 	t.src = o
 
@@ -181,16 +187,26 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	defer ioutil.CheckClose(w, &err)
 
 	if _, err = fmt.Fprintf(w,
-		"object %s\ntype %s\ntag %s\ntagger ",
+		"object %s\ntype %s\ntag %s\n",
 		t.Target.String(), t.TargetType.Bytes(), t.Name); err != nil {
 		return err
 	}
 
-	if err = t.Tagger.Encode(w); err != nil {
-		return err
+	if !isZeroSignature(t.Tagger) {
+		if _, err = fmt.Fprint(w, "tagger "); err != nil {
+			return err
+		}
+
+		if err = t.Tagger.Encode(w); err != nil {
+			return err
+		}
+
+		if _, err = fmt.Fprint(w, "\n"); err != nil {
+			return err
+		}
 	}
 
-	if _, err = fmt.Fprint(w, "\n\n"); err != nil {
+	if _, err = fmt.Fprint(w, "\n"); err != nil {
 		return err
 	}
 
@@ -211,6 +227,10 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	}
 
 	return err
+}
+
+func isZeroSignature(s Signature) bool {
+	return s.Name == "" && s.Email == "" && s.When.IsZero()
 }
 
 // Commit returns the commit pointed to by the tag. If the tag points to a

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -1,9 +1,7 @@
 package object
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -98,60 +96,15 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
-	var skipPGPSig256 bool
-
-	for {
-		var line []byte
-		line, err = r.ReadBytes('\n')
-		if err != nil && err != io.EOF {
+	scanner := &tagScanner{r: r, t: t}
+	for state := scanTagObject; state != nil; {
+		state, err = state(scanner)
+		if err != nil {
 			return err
 		}
-
-		if skipPGPSig256 {
-			if len(line) > 0 && line[0] == ' ' {
-				if err == io.EOF {
-					return nil
-				}
-				continue
-			}
-			skipPGPSig256 = false
-		}
-
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			break // Start of message
-		}
-
-		split := bytes.SplitN(line, []byte{' '}, 2)
-		var value []byte
-		if len(split) == 2 {
-			value = split[1]
-		}
-		switch string(split[0]) {
-		case "object":
-			t.Target = plumbing.NewHash(string(value))
-		case "type":
-			t.TargetType, err = plumbing.ParseObjectType(string(value))
-			if err != nil {
-				return err
-			}
-		case "tag":
-			t.Name = string(value)
-		case "tagger":
-			t.Tagger.Decode(value)
-		case headerpgp256:
-			skipPGPSig256 = true
-		}
-
-		if err == io.EOF {
-			return nil
-		}
 	}
 
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
+	data := scanner.msgbuf.Bytes()
 	if sm, _ := parseSignedBytes(data); sm >= 0 {
 		t.PGPSignature = string(data[sm:])
 		data = data[:sm]

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -39,6 +39,9 @@ type Tag struct {
 	Target plumbing.Hash
 
 	s storer.EncodedObjectStorer
+	// src holds the encoded object this Tag was decoded from, used by
+	// EncodeWithoutSignature to recover the canonical signed bytes.
+	src plumbing.EncodedObject
 }
 
 // GetTag gets a tag from an object storer and decodes it.
@@ -84,6 +87,7 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	}
 
 	t.Hash = o.Hash()
+	t.src = o
 
 	reader, err := o.Reader()
 	if err != nil {
@@ -162,9 +166,52 @@ func (t *Tag) Encode(o plumbing.EncodedObject) error {
 	return t.encode(o, true)
 }
 
-// EncodeWithoutSignature export a Tag into a plumbing.EncodedObject without the signature (correspond to the payload of the PGP signature).
+// EncodeWithoutSignature exports a Tag into a plumbing.EncodedObject without
+// any signature data, producing the payload that PGP/GPG signatures are
+// computed over.
+//
+// Behaviour mirrors Commit.EncodeWithoutSignature:
+//
+//   - For Tags populated by Decode whose exported fields still match the
+//     source object, the payload is streamed from the raw source bytes with
+//     the inline trailing signature truncated and gpgsig/gpgsig-sha256
+//     headers (and their continuation lines) stripped verbatim. This
+//     preserves the exact bytes the signature was computed over, regardless
+//     of any normalization performed by Decode.
+//
+//   - For Tags constructed in memory, or for decoded Tags whose exported
+//     fields have been mutated, the payload is derived from the current
+//     struct fields. Mutation is detected by re-decoding the source object
+//     and comparing exported fields; if any differ, the in-memory
+//     representation prevails.
 func (t *Tag) EncodeWithoutSignature(o plumbing.EncodedObject) error {
+	if t.matchesSource() {
+		return stripObjectSignatures(o, t.src, plumbing.TagObject)
+	}
 	return t.encode(o, false)
+}
+
+// matchesSource reports whether t.src is set and re-decoding it produces a
+// Tag whose payload-affecting exported fields are identical to those of t.
+//
+// PGPSignature is intentionally excluded from the comparison: neither path
+// emits it as part of the verification payload, so mutating it must not
+// trigger a switch to struct-encode (which would change the byte layout the
+// caller is trying to verify against).
+func (t *Tag) matchesSource() bool {
+	if t.src == nil {
+		return false
+	}
+	fresh := &Tag{}
+	if err := fresh.Decode(t.src); err != nil {
+		return false
+	}
+	return t.Hash == fresh.Hash &&
+		t.Name == fresh.Name &&
+		signatureEqual(t.Tagger, fresh.Tagger) &&
+		t.Message == fresh.Message &&
+		t.TargetType == fresh.TargetType &&
+		t.Target == fresh.Target
 }
 
 func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,10 @@ import (
 	"github.com/go-git/go-git/v5/utils/ioutil"
 	"github.com/go-git/go-git/v5/utils/sync"
 )
+
+// ErrMalformedTag is returned when a tag object cannot be decoded because
+// its required headers (object, type, tag) are missing or out of order.
+var ErrMalformedTag = errors.New("malformed tag")
 
 // Tag represents an annotated tag object. It points to a single git object of
 // any type, but tags typically are applied to commit or blob objects. It

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -94,11 +94,23 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
+	var skipPGPSig256 bool
+
 	for {
 		var line []byte
 		line, err = r.ReadBytes('\n')
 		if err != nil && err != io.EOF {
 			return err
+		}
+
+		if skipPGPSig256 {
+			if len(line) > 0 && line[0] == ' ' {
+				if err == io.EOF {
+					return nil
+				}
+				continue
+			}
+			skipPGPSig256 = false
 		}
 
 		line = bytes.TrimSpace(line)
@@ -107,18 +119,24 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 		}
 
 		split := bytes.SplitN(line, []byte{' '}, 2)
+		var value []byte
+		if len(split) == 2 {
+			value = split[1]
+		}
 		switch string(split[0]) {
 		case "object":
-			t.Target = plumbing.NewHash(string(split[1]))
+			t.Target = plumbing.NewHash(string(value))
 		case "type":
-			t.TargetType, err = plumbing.ParseObjectType(string(split[1]))
+			t.TargetType, err = plumbing.ParseObjectType(string(value))
 			if err != nil {
 				return err
 			}
 		case "tag":
-			t.Name = string(split[1])
+			t.Name = string(value)
 		case "tagger":
-			t.Tagger.Decode(split[1])
+			t.Tagger.Decode(value)
+		case headerpgp256:
+			skipPGPSig256 = true
 		}
 
 		if err == io.EOF {
@@ -175,11 +193,12 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
-	// Note that this is highly sensitive to what it sent along in the message.
-	// Message *always* needs to end with a newline, or else the message and the
-	// signature will be concatenated into a corrupt object. Since this is a
-	// lower-level method, we assume you know what you are doing and have already
-	// done the needful on the message in the caller.
+	// Note that this is highly sensitive to what is sent along in the
+	// message. Message *always* needs to end with a newline, or else the
+	// message and the trailing signature will be concatenated into a
+	// corrupt object. Since this is a lower-level method, we assume you
+	// know what you are doing and have already done the needful on the
+	// message in the caller.
 	if includeSig {
 		if _, err = fmt.Fprint(w, t.PGPSignature); err != nil {
 			return err
@@ -256,7 +275,8 @@ func (t *Tag) String() string {
 }
 
 // Verify performs PGP verification of the tag with a provided armored
-// keyring and returns openpgp.Entity associated with verifying key on success.
+// keyring and returns openpgp.Entity associated with verifying key on
+// success.
 func (t *Tag) Verify(armoredKeyRing string) (*openpgp.Entity, error) {
 	keyRingReader := strings.NewReader(armoredKeyRing)
 	keyring, err := openpgp.ReadArmoredKeyRing(keyRingReader)

--- a/plumbing/object/tag_scanner.go
+++ b/plumbing/object/tag_scanner.go
@@ -1,0 +1,246 @@
+package object
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// tagScanner holds the working state of the tag decoder driven by the
+// stateFn loop in (*Tag).Decode. Each tagState reads one or more lines
+// from r, updates the in-progress *Tag and the scanner's bookkeeping,
+// and returns the state that should run next (or nil to stop).
+type tagScanner struct {
+	r      *bufio.Reader
+	t      *Tag
+	msgbuf bytes.Buffer
+
+	// pending holds a line that was read but the current state decided to
+	// hand back to the next state, paired with the io.EOF flag returned
+	// when the line was originally read.
+	pending    []byte
+	pendingErr error
+
+	// First-occurrence tracking: once the corresponding canonical
+	// header has been decoded at its expected position, subsequent
+	// occurrences (or out-of-position lines) are silently dropped,
+	// matching the strict layout enforced by upstream's
+	// parse_tag_buffer (tag.c:130).
+	//
+	// gpgsig-sha256 is recognized and skipped without exposing a new field
+	// in v5.
+	sawObject, sawType, sawName, sawTagger bool
+}
+
+// tagState is one step of the decoder state machine. Each function reads
+// the lines it needs, mutates *Tag via s.t, and returns the next state
+// to run (or nil to terminate the loop).
+type tagState func(*tagScanner) (tagState, error)
+
+// readLine returns the next line from the buffer, transparently
+// consuming any line that was previously pushed back by a state that
+// decided not to handle it.
+func (s *tagScanner) readLine() ([]byte, error) {
+	if s.pending != nil {
+		line, err := s.pending, s.pendingErr
+		s.pending, s.pendingErr = nil, nil
+		return line, err
+	}
+	return s.r.ReadBytes('\n')
+}
+
+// pushBack stashes an unconsumed line so the next state's readLine call
+// sees it. Only one line can be pushed back at a time.
+func (s *tagScanner) pushBack(line []byte, err error) {
+	s.pending = line
+	s.pendingErr = err
+}
+
+// scanTagObject expects the first non-empty header to be `object HASH`.
+// Anything else falls through to scanTagType so out-of-position canonical
+// fields are silently dropped (matching the existing decoder's
+// best-effort behaviour).
+func scanTagObject(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "object" {
+		s.t.Target = plumbing.NewHash(string(data))
+		s.sawObject = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagType, nil
+	}
+	s.pushBack(line, err)
+	return scanTagType, nil
+}
+
+// scanTagType accepts a `type` line at its canonical position
+// immediately after the object header. Any other header is pushed back
+// for scanTagName.
+func scanTagType(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "type" {
+		ot, perr := plumbing.ParseObjectType(string(data))
+		if perr != nil {
+			return nil, perr
+		}
+		s.t.TargetType = ot
+		s.sawType = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagName, nil
+	}
+	s.pushBack(line, err)
+	return scanTagName, nil
+}
+
+// scanTagName accepts a `tag` line at its canonical position. Any other
+// header is pushed back for scanTagTagger.
+func scanTagName(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "tag" {
+		s.t.Name = string(data)
+		s.sawName = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagTagger, nil
+	}
+	s.pushBack(line, err)
+	return scanTagTagger, nil
+}
+
+// scanTagTagger accepts a `tagger` line at its canonical position. Any
+// other header is pushed back for scanTagHeaders.
+func scanTagTagger(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "tagger" {
+		s.t.Tagger.Decode(data)
+		s.sawTagger = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagHeaders, nil
+	}
+	s.pushBack(line, err)
+	return scanTagHeaders, nil
+}
+
+// scanTagHeaders dispatches one header line. gpgsig-sha256 hands off to
+// scanTagSkipCont so the continuation block can be consumed; out-of-position
+// canonical fields and unknown headers are silently dropped.
+func scanTagHeaders(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, _ := splitHeader(line)
+	next := scanTagHeaders
+	switch key {
+	case "object", "type", "tag", "tagger":
+		// Out-of-canonical-position duplicates are dropped, mirroring the
+		// strict ordering of upstream's parse_tag_buffer.
+	case headerpgp256:
+		next = scanTagSkipCont
+	default:
+		// Unknown header: silently dropped (the Tag struct does not
+		// expose ExtraHeaders).
+	}
+
+	if err == io.EOF {
+		return nil, nil
+	}
+	return next, nil
+}
+
+// scanTagSkipCont discards continuation lines for a header scanTagHeaders chose
+// to drop. The first non-continuation line is pushed back so scanTagHeaders can
+// dispatch it.
+func scanTagSkipCont(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) > 0 && line[0] == ' ' {
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagSkipCont, nil
+	}
+	if len(line) > 0 {
+		s.pushBack(line, err)
+	}
+	return scanTagHeaders, nil
+}
+
+// scanTagMessage drains the remaining bytes into the message buffer.
+// (*Tag).Decode then runs parseSignedBytes over those bytes to peel off
+// the optional inline trailing PGP signature.
+func scanTagMessage(s *tagScanner) (tagState, error) {
+	for {
+		line, err := s.readLine()
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if len(line) > 0 {
+			s.msgbuf.Write(line)
+		}
+		if err == io.EOF {
+			return nil, nil
+		}
+	}
+}

--- a/plumbing/object/tag_scanner.go
+++ b/plumbing/object/tag_scanner.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -58,91 +59,81 @@ func (s *tagScanner) pushBack(line []byte, err error) {
 	s.pendingErr = err
 }
 
-// scanTagObject expects the first non-empty header to be `object HASH`.
-// Anything else falls through to scanTagType so out-of-position canonical
-// fields are silently dropped (matching the existing decoder's
-// best-effort behaviour).
+// scanTagObject requires the first line to be `object HASH`, mirroring
+// upstream's strict parse_tag_buffer (tag.c:151-156). Anything else
+// returns ErrMalformedTag.
 func scanTagObject(s *tagScanner) (tagState, error) {
 	line, err := s.readLine()
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	if len(line) == 0 {
-		return nil, nil
-	}
-	if isBlankLine(line) {
-		return scanTagMessage, nil
+	if len(line) == 0 || isBlankLine(line) {
+		return nil, fmt.Errorf("%w: missing object header", ErrMalformedTag)
 	}
 
 	key, data := splitHeader(line)
-	if key == "object" {
-		s.t.Target = plumbing.NewHash(string(data))
-		s.sawObject = true
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanTagType, nil
+	if key != "object" {
+		return nil, fmt.Errorf("%w: object header must be first", ErrMalformedTag)
 	}
-	s.pushBack(line, err)
+	h, herr := parseObjectIDHex(data, ErrMalformedTag, "object")
+	if herr != nil {
+		return nil, herr
+	}
+	s.t.Target = h
+	s.sawObject = true
+	if err == io.EOF {
+		return nil, nil
+	}
 	return scanTagType, nil
 }
 
-// scanTagType accepts a `type` line at its canonical position
-// immediately after the object header. Any other header is pushed back
-// for scanTagName.
+// scanTagType requires a `type` line immediately after the object header,
+// mirroring upstream's parse_tag_buffer (tag.c:158-166).
 func scanTagType(s *tagScanner) (tagState, error) {
 	line, err := s.readLine()
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	if len(line) == 0 {
-		return nil, nil
-	}
-	if isBlankLine(line) {
-		return scanTagMessage, nil
+	if len(line) == 0 || isBlankLine(line) {
+		return nil, fmt.Errorf("%w: missing type header", ErrMalformedTag)
 	}
 
 	key, data := splitHeader(line)
-	if key == "type" {
-		ot, perr := plumbing.ParseObjectType(string(data))
-		if perr != nil {
-			return nil, perr
-		}
-		s.t.TargetType = ot
-		s.sawType = true
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanTagName, nil
+	if key != "type" {
+		return nil, fmt.Errorf("%w: type header must follow object", ErrMalformedTag)
 	}
-	s.pushBack(line, err)
+	ot, perr := plumbing.ParseObjectType(string(data))
+	if perr != nil {
+		return nil, perr
+	}
+	s.t.TargetType = ot
+	s.sawType = true
+	if err == io.EOF {
+		return nil, nil
+	}
 	return scanTagName, nil
 }
 
-// scanTagName accepts a `tag` line at its canonical position. Any other
-// header is pushed back for scanTagTagger.
+// scanTagName requires a `tag` line immediately after the type header,
+// mirroring upstream's parse_tag_buffer (tag.c:186-194).
 func scanTagName(s *tagScanner) (tagState, error) {
 	line, err := s.readLine()
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	if len(line) == 0 {
-		return nil, nil
-	}
-	if isBlankLine(line) {
-		return scanTagMessage, nil
+	if len(line) == 0 || isBlankLine(line) {
+		return nil, fmt.Errorf("%w: missing tag header", ErrMalformedTag)
 	}
 
 	key, data := splitHeader(line)
-	if key == "tag" {
-		s.t.Name = string(data)
-		s.sawName = true
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanTagTagger, nil
+	if key != "tag" {
+		return nil, fmt.Errorf("%w: tag header must follow type", ErrMalformedTag)
 	}
-	s.pushBack(line, err)
+	s.t.Name = string(data)
+	s.sawName = true
+	if err == io.EOF {
+		return nil, nil
+	}
 	return scanTagTagger, nil
 }
 

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -308,10 +309,87 @@ func (s *TagSuite) TestTagDecodeSignatures(c *C) {
 	}
 }
 
+func (s *TagSuite) TestDecodeRequiresHeaders(c *C) {
+	const (
+		target = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
+		tagger = "Foo <foo@example.local> 1500000000 +0000"
+	)
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "empty",
+			raw:  "",
+		},
+		{
+			name: "missing object",
+			raw:  "type commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "object out of canonical position",
+			raw:  "type commit\nobject " + target + "\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "missing type",
+			raw:  "object " + target + "\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "missing tag",
+			raw:  "object " + target + "\ntype commit\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "duplicate object before type",
+			raw: "object " + target + "\nobject " + target +
+				"\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "duplicate type before tag",
+			raw: "object " + target + "\ntype commit\ntype blob" +
+				"\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "truncated after object header",
+			raw:  "object " + target + "\n",
+		},
+		{
+			name: "truncated after type header",
+			raw:  "object " + target + "\ntype commit\n",
+		},
+		{
+			name: "non-hex object value",
+			raw:  "object zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "object value too short",
+			raw:  "object abcd\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "object value too long",
+			raw:  "object " + target + "00\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "object value missing",
+			raw:  "object\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+	}
+
+	for _, tc := range cases {
+		c.Log(tc.name)
+		obj := &plumbing.MemoryObject{}
+		obj.SetType(plumbing.TagObject)
+		_, err := obj.Write([]byte(tc.raw))
+		c.Assert(err, IsNil)
+
+		err = (&Tag{}).Decode(obj)
+		c.Assert(errors.Is(err, ErrMalformedTag), Equals, true)
+	}
+}
+
 func (s *TagSuite) TestDecodeFirstOccurrenceWins(c *C) {
 	const (
 		targetA   = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
-		targetB   = "0000000000000000000000000000000000000001"
 		taggerA   = "Alice <alice@example.local> 1500000000 +0000"
 		taggerB   = "Bob <bob@example.local> 1500000001 +0000"
 		canonical = "object " + targetA +
@@ -323,22 +401,6 @@ func (s *TagSuite) TestDecodeFirstOccurrenceWins(c *C) {
 		raw    string
 		assert func(*Tag)
 	}{
-		{
-			name: "duplicate object drops the second",
-			raw: "object " + targetA + "\nobject " + targetB +
-				"\ntype commit\ntag v1\ntagger " + taggerA + "\n\nmsg\n",
-			assert: func(t *Tag) {
-				c.Assert(t.Target.String(), Equals, targetA)
-			},
-		},
-		{
-			name: "duplicate type drops the second",
-			raw: "object " + targetA + "\ntype commit\ntype blob" +
-				"\ntag v1\ntagger " + taggerA + "\n\nmsg\n",
-			assert: func(t *Tag) {
-				c.Assert(t.TargetType, Equals, plumbing.CommitObject)
-			},
-		},
 		{
 			name: "duplicate tag drops the second",
 			raw: "object " + targetA + "\ntype commit\ntag v1\ntag v1-override" +
@@ -353,26 +415,6 @@ func (s *TagSuite) TestDecodeFirstOccurrenceWins(c *C) {
 				"\ntagger " + taggerB + "\n\nmsg\n",
 			assert: func(t *Tag) {
 				c.Assert(t.Tagger.Name, Equals, "Alice")
-			},
-		},
-		{
-			name: "type at slot 1: type captured, misplaced object dropped",
-			raw: "type commit\nobject " + targetA + "\ntag v1\ntagger " + taggerA +
-				"\n\nmsg\n",
-			assert: func(t *Tag) {
-				c.Assert(t.TargetType, Equals, plumbing.CommitObject)
-				c.Assert(t.Target.IsZero(), Equals, true)
-				c.Assert(t.Name, Equals, "")
-				c.Assert(t.Tagger.Name, Equals, "")
-			},
-		},
-		{
-			name: "tagger at slot 4: tagger captured, misplaced tag dropped",
-			raw: "object " + targetA + "\ntype commit\ntagger " + taggerA +
-				"\ntag v1\n\nmsg\n",
-			assert: func(t *Tag) {
-				c.Assert(t.Tagger.Name, Equals, "Alice")
-				c.Assert(t.Name, Equals, "")
 			},
 		},
 		{
@@ -419,17 +461,6 @@ func (s *TagSuite) TestDecodeFirstOccurrenceWins(c *C) {
 				c.Assert(t.Tagger.Name, Equals, "Alice")
 				c.Assert(t.Message, Equals, "msg\n")
 				c.Assert(t.PGPSignature, Equals, "")
-			},
-		},
-		{
-			name: "truncated after object header",
-			raw:  "object " + targetA + "\n",
-			assert: func(t *Tag) {
-				c.Assert(t.Target.String(), Equals, targetA)
-				c.Assert(t.TargetType, Equals, plumbing.InvalidObject)
-				c.Assert(t.Name, Equals, "")
-				c.Assert(t.Tagger.Name, Equals, "")
-				c.Assert(t.Message, Equals, "")
 			},
 		},
 		{
@@ -848,32 +879,6 @@ tag message
 				t.PGPSignature = "different signature value"
 			},
 			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
-type commit
-tag v1
-tagger Test Tagger <tagger@example.local> 1700000000 +0000
-
-tag message
-`,
-		},
-		{
-			// Duplicates are preserved verbatim by the raw path: if
-			// the decoded struct still matches the source after
-			// re-decoding, the original bytes are streamed through
-			// (with only the canonical signature data stripped).
-			name: "duplicate-object preserved on raw path",
-			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
-object 4444444444444444444444444444444444444444
-type commit
-tag v1
-tagger Test Tagger <tagger@example.local> 1700000000 +0000
-
-tag message
------BEGIN PGP SIGNATURE-----
-inlineline1
------END PGP SIGNATURE-----
-`,
-			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
-object 4444444444444444444444444444444444444444
 type commit
 tag v1
 tagger Test Tagger <tagger@example.local> 1700000000 +0000

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -267,9 +267,208 @@ func (s *TagSuite) TestTagDecodeSignatures(c *C) {
 				c.Assert(t.PGPSignature, Equals, inline)
 			},
 		},
+		{
+			// parseSignedBytes returns the position of the LAST PGP
+			// block in the buffer, mirroring upstream's
+			// parse_signed_buffer (gpg-interface.c:702). Any earlier
+			// PGP-armored bytes embedded in the body stay part of the
+			// message; only the trailing block becomes t.PGPSignature.
+			name: "multiple inline PGP blocks: last is the signature",
+			raw: headers + "\nbody line 1\n" +
+				"-----BEGIN PGP SIGNATURE-----\nfakeline\n-----END PGP SIGNATURE-----\n" +
+				"body line 2\n" +
+				"-----BEGIN PGP SIGNATURE-----\nrealline\n-----END PGP SIGNATURE-----\n",
+			assert: func(t *Tag) {
+				c.Assert(
+					t.Message,
+					Equals,
+					"body line 1\n"+
+						"-----BEGIN PGP SIGNATURE-----\nfakeline\n-----END PGP SIGNATURE-----\n"+
+						"body line 2\n",
+				)
+				c.Assert(
+					t.PGPSignature,
+					Equals,
+					"-----BEGIN PGP SIGNATURE-----\nrealline\n-----END PGP SIGNATURE-----\n",
+				)
+			},
+		},
 	}
 
 	for _, tc := range tests {
+		c.Log(tc.name)
+		obj := &plumbing.MemoryObject{}
+		obj.SetType(plumbing.TagObject)
+		_, err := obj.Write([]byte(tc.raw))
+		c.Assert(err, IsNil)
+
+		tag := &Tag{}
+		c.Assert(tag.Decode(obj), IsNil)
+		tc.assert(tag)
+	}
+}
+
+func (s *TagSuite) TestDecodeFirstOccurrenceWins(c *C) {
+	const (
+		targetA   = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
+		targetB   = "0000000000000000000000000000000000000001"
+		taggerA   = "Alice <alice@example.local> 1500000000 +0000"
+		taggerB   = "Bob <bob@example.local> 1500000001 +0000"
+		canonical = "object " + targetA +
+			"\ntype commit\ntag v1\ntagger " + taggerA + "\n"
+	)
+
+	cases := []struct {
+		name   string
+		raw    string
+		assert func(*Tag)
+	}{
+		{
+			name: "duplicate object drops the second",
+			raw: "object " + targetA + "\nobject " + targetB +
+				"\ntype commit\ntag v1\ntagger " + taggerA + "\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Target.String(), Equals, targetA)
+			},
+		},
+		{
+			name: "duplicate type drops the second",
+			raw: "object " + targetA + "\ntype commit\ntype blob" +
+				"\ntag v1\ntagger " + taggerA + "\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.TargetType, Equals, plumbing.CommitObject)
+			},
+		},
+		{
+			name: "duplicate tag drops the second",
+			raw: "object " + targetA + "\ntype commit\ntag v1\ntag v1-override" +
+				"\ntagger " + taggerA + "\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Name, Equals, "v1")
+			},
+		},
+		{
+			name: "duplicate tagger drops the second",
+			raw: "object " + targetA + "\ntype commit\ntag v1\ntagger " + taggerA +
+				"\ntagger " + taggerB + "\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Tagger.Name, Equals, "Alice")
+			},
+		},
+		{
+			name: "type at slot 1: type captured, misplaced object dropped",
+			raw: "type commit\nobject " + targetA + "\ntag v1\ntagger " + taggerA +
+				"\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.TargetType, Equals, plumbing.CommitObject)
+				c.Assert(t.Target.IsZero(), Equals, true)
+				c.Assert(t.Name, Equals, "")
+				c.Assert(t.Tagger.Name, Equals, "")
+			},
+		},
+		{
+			name: "tagger at slot 4: tagger captured, misplaced tag dropped",
+			raw: "object " + targetA + "\ntype commit\ntagger " + taggerA +
+				"\ntag v1\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Tagger.Name, Equals, "Alice")
+				c.Assert(t.Name, Equals, "")
+			},
+		},
+		{
+			name: "missing tagger is allowed (zero-valued)",
+			raw:  "object " + targetA + "\ntype commit\ntag v1\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Name, Equals, "v1")
+				c.Assert(t.Tagger.Name, Equals, "")
+				c.Assert(t.Message, Equals, "msg\n")
+			},
+		},
+		{
+			name: "gpgsig-sha256 headers are skipped",
+			raw: canonical +
+				"gpgsig-sha256 firstline\n morefirst\n" +
+				"gpgsig-sha256 secondline\n moresecond\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.PGPSignature, Equals, "")
+				c.Assert(t.Message, Equals, "msg\n")
+			},
+		},
+		{
+			name: "single-line gpgsig-sha256 (no continuation)",
+			raw:  canonical + "gpgsig-sha256 short\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.PGPSignature, Equals, "")
+				c.Assert(t.Message, Equals, "msg\n")
+			},
+		},
+		{
+			name: "gpgsig-sha256 with empty value",
+			raw:  canonical + "gpgsig-sha256\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.PGPSignature, Equals, "")
+				c.Assert(t.Message, Equals, "msg\n")
+			},
+		},
+		{
+			name: "unknown extra header is dropped",
+			raw:  canonical + "x-some-extra value\n\nmsg\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Target.String(), Equals, targetA)
+				c.Assert(t.Name, Equals, "v1")
+				c.Assert(t.Tagger.Name, Equals, "Alice")
+				c.Assert(t.Message, Equals, "msg\n")
+				c.Assert(t.PGPSignature, Equals, "")
+			},
+		},
+		{
+			name: "truncated after object header",
+			raw:  "object " + targetA + "\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Target.String(), Equals, targetA)
+				c.Assert(t.TargetType, Equals, plumbing.InvalidObject)
+				c.Assert(t.Name, Equals, "")
+				c.Assert(t.Tagger.Name, Equals, "")
+				c.Assert(t.Message, Equals, "")
+			},
+		},
+		{
+			name: "EOF after tagger (no blank-line separator)",
+			raw:  "object " + targetA + "\ntype commit\ntag v1\ntagger " + taggerA + "\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Target.String(), Equals, targetA)
+				c.Assert(t.TargetType, Equals, plumbing.CommitObject)
+				c.Assert(t.Name, Equals, "v1")
+				c.Assert(t.Tagger.Name, Equals, "Alice")
+				c.Assert(t.Message, Equals, "")
+			},
+		},
+		{
+			name: "EOF on blank line (empty body)",
+			raw:  "object " + targetA + "\ntype commit\ntag v1\ntagger " + taggerA + "\n\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Name, Equals, "v1")
+				c.Assert(t.Message, Equals, "")
+			},
+		},
+		{
+			name: "message without trailing newline",
+			raw:  "object " + targetA + "\ntype commit\ntag v1\ntagger " + taggerA + "\n\npartial",
+			assert: func(t *Tag) {
+				c.Assert(t.Message, Equals, "partial")
+			},
+		},
+		{
+			name: "EOF mid-gpgsig-sha256 continuation",
+			raw:  canonical + "gpgsig-sha256 line1\n line2\n line3\n",
+			assert: func(t *Tag) {
+				c.Assert(t.PGPSignature, Equals, "")
+				c.Assert(t.Message, Equals, "")
+			},
+		},
+	}
+
+	for _, tc := range cases {
 		c.Log(tc.name)
 		obj := &plumbing.MemoryObject{}
 		obj.SetType(plumbing.TagObject)

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -212,6 +212,7 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent(c *C) {
 		err = newTag.Decode(obj)
 		c.Assert(err, IsNil)
 		tag.Hash = obj.Hash()
+		tag.src = obj
 		c.Assert(newTag, DeepEquals, tag)
 	}
 }
@@ -534,22 +535,226 @@ eQnkGpsz85DfEviLtk8cZjY/t6o8lPDLiwVjIzUBaA==
 }
 
 func (s *TagSuite) TestEncodeWithoutSignature(c *C) {
-	//Similar to TestString since no signature
-	encoded := &plumbing.MemoryObject{}
-	tag := s.tag(c, plumbing.NewHash("b742a2a9fa0afcfa9a6fad080980fbc26b007c69"))
-	err := tag.EncodeWithoutSignature(encoded)
-	c.Assert(err, IsNil)
-	er, err := encoded.Reader()
-	c.Assert(err, IsNil)
-	payload, err := io.ReadAll(er)
-	c.Assert(err, IsNil)
+	tests := []struct {
+		name     string
+		tagRaw   string
+		mutate   func(*Tag)
+		expected string
+	}{
+		{
+			name: "tag without signature",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
 
-	c.Assert(string(payload), Equals, ""+
-		"object f7b877701fbf855b44c0a9e86f3fdce2c298b07f\n"+
-		"type commit\n"+
-		"tag annotated-tag\n"+
-		"tagger Máximo Cuadros <mcuadros@gmail.com> 1474485215 +0200\n"+
-		"\n"+
-		"example annotated tag\n",
-	)
+plain tag message
+`,
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+plain tag message
+`,
+		},
+		{
+			name: "gpgsig-sha256 header",
+			tagRaw: "object 1eca38290a3131d0c90709496a9b2207a872631e\n" +
+				"type commit\n" +
+				"tag v1\n" +
+				"tagger Test Tagger <tagger@example.local> 1700000000 +0000\n" +
+				"gpgsig-sha256 -----BEGIN PGP SIGNATURE-----\n" +
+				" \n" +
+				" sha256line1\n" +
+				" sha256line2\n" +
+				" -----END PGP SIGNATURE-----\n" +
+				"\n" +
+				"tag message\n",
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			name: "inline trailing signature",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+-----BEGIN PGP SIGNATURE-----
+
+inlineline1
+inlineline2
+-----END PGP SIGNATURE-----
+`,
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			// Compat-mode primary SHA-1 layout: gpgsig-sha256 header
+			// (SHA-256 sig) plus inline trailing PGP block (SHA-1 sig).
+			// Both are stripped to produce the verification payload.
+			name: "gpgsig-sha256 + inline trailing",
+			tagRaw: "object 1eca38290a3131d0c90709496a9b2207a872631e\n" +
+				"type commit\n" +
+				"tag v1\n" +
+				"tagger Test Tagger <tagger@example.local> 1700000000 +0000\n" +
+				"gpgsig-sha256 -----BEGIN PGP SIGNATURE-----\n" +
+				" \n" +
+				" sha256line1\n" +
+				" -----END PGP SIGNATURE-----\n" +
+				"\n" +
+				"tag message\n" +
+				"-----BEGIN PGP SIGNATURE-----\n" +
+				"\n" +
+				"inlineline1\n" +
+				"-----END PGP SIGNATURE-----\n",
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			// Mutating only the inline signature must not trigger
+			// struct-encode: the raw bytes, with all signature data
+			// stripped, are still the canonical signed payload.
+			name: "raw bytes preserved when only inline signature is mutated",
+			tagRaw: "object 1eca38290a3131d0c90709496a9b2207a872631e\n" +
+				"type commit\n" +
+				"tag v1\n" +
+				"tagger Test Tagger <tagger@example.local> 1700000000 +0000\n" +
+				"gpgsig-sha256 -----BEGIN PGP SIGNATURE-----\n" +
+				" sha256line1\n" +
+				" -----END PGP SIGNATURE-----\n" +
+				"\n" +
+				"tag message\n" +
+				"-----BEGIN PGP SIGNATURE-----\n" +
+				"inlineline1\n" +
+				"-----END PGP SIGNATURE-----\n",
+			mutate: func(t *Tag) {
+				t.PGPSignature = "different signature value"
+			},
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			// Duplicates are preserved verbatim by the raw path: if
+			// the decoded struct still matches the source after
+			// re-decoding, the original bytes are streamed through
+			// (with only the canonical signature data stripped).
+			name: "duplicate-object preserved on raw path",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+object 4444444444444444444444444444444444444444
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+-----BEGIN PGP SIGNATURE-----
+inlineline1
+-----END PGP SIGNATURE-----
+`,
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+object 4444444444444444444444444444444444444444
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			name: "timezone-only change triggers struct-encode",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 -0700
+
+tag message
+-----BEGIN PGP SIGNATURE-----
+inlineline1
+-----END PGP SIGNATURE-----
+`,
+			mutate: func(t *Tag) {
+				tz := time.FixedZone("CEST", 2*60*60)
+				t.Tagger.When = t.Tagger.When.In(tz)
+			},
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0200
+
+tag message
+`,
+		},
+		{
+			name: "field mutation triggers struct-encode",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+-----BEGIN PGP SIGNATURE-----
+inlineline1
+-----END PGP SIGNATURE-----
+`,
+			mutate: func(t *Tag) {
+				t.Name = "v1-rewritten"
+			},
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1-rewritten
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		c.Log(tc.name)
+		obj := &plumbing.MemoryObject{}
+		obj.SetType(plumbing.TagObject)
+		_, err := obj.Write([]byte(tc.tagRaw))
+		c.Assert(err, IsNil)
+
+		tag := &Tag{}
+		c.Assert(tag.Decode(obj), IsNil)
+
+		if tc.mutate != nil {
+			tc.mutate(tag)
+		}
+
+		encoded := &plumbing.MemoryObject{}
+		err = tag.EncodeWithoutSignature(encoded)
+		c.Assert(err, IsNil)
+
+		er, err := encoded.Reader()
+		c.Assert(err, IsNil)
+
+		payload, err := io.ReadAll(er)
+		c.Assert(err, IsNil)
+
+		c.Assert(string(payload), Equals, tc.expected)
+	}
 }

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -218,6 +218,72 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent(c *C) {
 	}
 }
 
+func (s *TagSuite) TestTagEncodeOmitsZeroTagger(c *C) {
+	const raw = "object c029517f6300c2da0f4b651b8642506cd6aaf45e\n" +
+		"type commit\n" +
+		"tag v1\n" +
+		"\n" +
+		"msg\n"
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TagObject)
+	_, err := obj.Write([]byte(raw))
+	c.Assert(err, IsNil)
+
+	tag := &Tag{}
+	c.Assert(tag.Decode(obj), IsNil)
+	c.Assert(tag.Tagger, DeepEquals, Signature{})
+
+	encoded := &plumbing.MemoryObject{}
+	c.Assert(tag.Encode(encoded), IsNil)
+
+	r, err := encoded.Reader()
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	body, err := io.ReadAll(r)
+	c.Assert(err, IsNil)
+	c.Assert(string(body), Equals, raw)
+}
+
+func (s *TagSuite) TestTagDecodeClearsExistingState(c *C) {
+	const raw = "object c029517f6300c2da0f4b651b8642506cd6aaf45e\n" +
+		"type commit\n" +
+		"tag fresh\n" +
+		"\n" +
+		"fresh message\n"
+
+	store := memory.NewStorage()
+	staleSrc := &plumbing.MemoryObject{}
+	tag := &Tag{
+		Hash:         plumbing.NewHash("1111111111111111111111111111111111111111"),
+		Name:         "stale",
+		Tagger:       Signature{Name: "Stale", Email: "stale@example.local", When: time.Unix(1, 0).UTC()},
+		Message:      "stale message",
+		PGPSignature: "stale signature",
+		TargetType:   plumbing.BlobObject,
+		Target:       plumbing.NewHash("2222222222222222222222222222222222222222"),
+		s:            store,
+		src:          staleSrc,
+	}
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TagObject)
+	_, err := obj.Write([]byte(raw))
+	c.Assert(err, IsNil)
+
+	c.Assert(tag.Decode(obj), IsNil)
+	c.Assert(tag.Hash, Equals, obj.Hash())
+	c.Assert(tag.Name, Equals, "fresh")
+	c.Assert(tag.Tagger, DeepEquals, Signature{})
+	c.Assert(tag.Message, Equals, "fresh message\n")
+	c.Assert(tag.PGPSignature, Equals, "")
+	c.Assert(tag.TargetType, Equals, plumbing.CommitObject)
+	c.Assert(tag.Target.String(), Equals, "c029517f6300c2da0f4b651b8642506cd6aaf45e")
+	c.Assert(tag.s, Equals, store)
+	c.Assert(tag.src, Equals, obj)
+}
+
 func (s *TagSuite) TestTagDecodeSignatures(c *C) {
 	const (
 		target = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
@@ -557,6 +623,7 @@ func (s *TagSuite) TestStringNonCommit(c *C) {
 	tag := &Tag{
 		Target:     targetObj.Hash(),
 		Name:       "TAG TWO",
+		Tagger:     Signature{Name: "Test Tagger", Email: "tagger@example.local", When: time.Unix(0, 0).UTC()},
 		Message:    "tag two",
 		TargetType: plumbing.TagObject,
 	}
@@ -570,7 +637,7 @@ func (s *TagSuite) TestStringNonCommit(c *C) {
 
 	c.Assert(tag.String(), Equals,
 		"tag TAG TWO\n"+
-			"Tagger:  <>\n"+
+			"Tagger: Test Tagger <tagger@example.local>\n"+
 			"Date:   Thu Jan 01 00:00:00 1970 +0000\n"+
 			"\n"+
 			"tag two\n")

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -192,6 +192,17 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent(c *C) {
 			TargetType: plumbing.BlobObject,
 			Target:     plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
 		},
+		{
+			Name:       "signed",
+			Tagger:     Signature{Name: "Foo", Email: "foo@example.local", When: ts},
+			Message:    "Signed tag\n",
+			TargetType: plumbing.CommitObject,
+			Target:     plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45e"),
+			PGPSignature: "-----BEGIN PGP SIGNATURE-----\n" +
+				"\n" +
+				"inlineSig=\n" +
+				"-----END PGP SIGNATURE-----\n",
+		},
 	}
 	for _, tag := range tags {
 		obj := &plumbing.MemoryObject{}
@@ -202,6 +213,71 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent(c *C) {
 		c.Assert(err, IsNil)
 		tag.Hash = obj.Hash()
 		c.Assert(newTag, DeepEquals, tag)
+	}
+}
+
+func (s *TagSuite) TestTagDecodeSignatures(c *C) {
+	const (
+		target = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
+		tagger = "Foo <foo@example.local> 1500000000 +0000"
+		inline = "-----BEGIN PGP SIGNATURE-----\n\ninlineline1\ninlineline2\n-----END PGP SIGNATURE-----\n"
+	)
+	headers := "object " + target + "\ntype commit\ntag t\ntagger " + tagger + "\n"
+	sha256Block := "gpgsig-sha256 -----BEGIN PGP SIGNATURE-----\n" +
+		" \n" +
+		" sha256line1\n" +
+		" sha256line2\n" +
+		" -----END PGP SIGNATURE-----\n"
+
+	tests := []struct {
+		name   string
+		raw    string
+		assert func(*Tag)
+	}{
+		{
+			name: "no signature",
+			raw:  headers + "\nplain tag message\n",
+			assert: func(t *Tag) {
+				c.Assert(t.PGPSignature, Equals, "")
+				c.Assert(t.Message, Equals, "plain tag message\n")
+			},
+		},
+		{
+			name: "inline trailing PGP signature",
+			raw:  headers + "\nTag body\n" + inline,
+			assert: func(t *Tag) {
+				c.Assert(t.Message, Equals, "Tag body\n")
+				c.Assert(t.PGPSignature, Equals, inline)
+			},
+		},
+		{
+			name: "gpgsig-sha256 header only (synthetic, no inline trailer)",
+			raw:  headers + sha256Block + "\nTag body, header sig only\n",
+			assert: func(t *Tag) {
+				c.Assert(t.Message, Equals, "Tag body, header sig only\n")
+				c.Assert(t.PGPSignature, Equals, "")
+			},
+		},
+		{
+			name: "compat-mode, primary SHA-1 (gpgsig-sha256 header + inline trailer)",
+			raw:  headers + sha256Block + "\nDual-signed tag body\n" + inline,
+			assert: func(t *Tag) {
+				c.Assert(t.Message, Equals, "Dual-signed tag body\n")
+				c.Assert(t.PGPSignature, Equals, inline)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		c.Log(tc.name)
+		obj := &plumbing.MemoryObject{}
+		obj.SetType(plumbing.TagObject)
+		_, err := obj.Write([]byte(tc.raw))
+		c.Assert(err, IsNil)
+
+		tag := &Tag{}
+		c.Assert(tag.Decode(obj), IsNil)
+		tc.assert(tag)
 	}
 }
 

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -240,14 +240,19 @@ func (t *Tree) Type() plumbing.ObjectType {
 	return plumbing.TreeObject
 }
 
+func (t *Tree) reset() {
+	storer := t.s
+	*t = Tree{s: storer}
+}
+
 // Decode transform an plumbing.EncodedObject into a Tree struct
 func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	if o.Type() != plumbing.TreeObject {
 		return ErrUnsupportedObject
 	}
 
+	t.reset()
 	t.Hash = o.Hash()
-	t.Entries = nil
 	// assume tree is sorted as a valid tree should always be sorted.
 	t.entriesSorted = true
 	if o.Size() == 0 {

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -29,6 +29,7 @@ var (
 	ErrDirectoryNotFound = errors.New("directory not found")
 	ErrEntryNotFound     = errors.New("entry not found")
 	ErrEntriesNotSorted  = errors.New("entries in tree are not sorted")
+	ErrMalformedTree     = errors.New("malformed tree")
 )
 
 // Tree is basically like a directory - it references a bunch of other trees
@@ -37,9 +38,9 @@ type Tree struct {
 	Entries []TreeEntry
 	Hash    plumbing.Hash
 
-	s storer.EncodedObjectStorer
-	m map[string]*TreeEntry
-	t map[string]*Tree // tree path cache
+	s             storer.EncodedObjectStorer
+	t             map[string]*Tree // tree path cache
+	entriesSorted bool
 }
 
 // GetTree gets a tree from an object storer and decodes it.
@@ -182,16 +183,43 @@ func (t *Tree) dir(baseName string) (*Tree, error) {
 }
 
 func (t *Tree) entry(baseName string) (*TreeEntry, error) {
-	if t.m == nil {
-		t.buildMap()
-	}
-
-	entry, ok := t.m[baseName]
-	if !ok {
+	if t.entriesSorted {
+		if entry := t.searchEntry(baseName); entry != nil {
+			return entry, nil
+		}
 		return nil, ErrEntryNotFound
 	}
 
-	return entry, nil
+	pastName := baseName + "/"
+	for i := range t.Entries {
+		entry := &t.Entries[i]
+		if entry.Name == baseName {
+			return entry, nil
+		}
+		if treeEntrySortName(entry) > pastName {
+			break
+		}
+	}
+
+	return nil, ErrEntryNotFound
+}
+
+func (t *Tree) searchEntry(baseName string) *TreeEntry {
+	if i := t.searchEntryIndex(baseName); i < len(t.Entries) && t.Entries[i].Name == baseName {
+		return &t.Entries[i]
+	}
+
+	if i := t.searchEntryIndex(baseName + "/"); i < len(t.Entries) && t.Entries[i].Name == baseName {
+		return &t.Entries[i]
+	}
+
+	return nil
+}
+
+func (t *Tree) searchEntryIndex(name string) int {
+	return sort.Search(len(t.Entries), func(i int) bool {
+		return treeEntrySortName(&t.Entries[i]) >= name
+	})
 }
 
 // Files returns a FileIter allowing to iterate over the Tree
@@ -219,12 +247,12 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	}
 
 	t.Hash = o.Hash()
+	t.Entries = nil
+	// assume tree is sorted as a valid tree should always be sorted.
+	t.entriesSorted = true
 	if o.Size() == 0 {
 		return nil
 	}
-
-	t.Entries = nil
-	t.m = nil
 
 	reader, err := o.Reader()
 	if err != nil {
@@ -235,10 +263,14 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
+	var prevSortName string
 	for {
 		str, err := r.ReadString(' ')
 		if err != nil {
 			if err == io.EOF {
+				if len(str) != 0 {
+					return fmt.Errorf("%w: missing mode terminator", ErrMalformedTree)
+				}
 				break
 			}
 
@@ -248,25 +280,41 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 
 		mode, err := filemode.New(str)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w: malformed mode", ErrMalformedTree)
 		}
+		mode = canonicalTreeMode(mode)
 
 		name, err := r.ReadString(0)
-		if err != nil && err != io.EOF {
+		if err != nil {
+			if err == io.EOF {
+				return fmt.Errorf("%w: missing filename terminator", ErrMalformedTree)
+			}
 			return err
+		}
+		if len(name) == 1 {
+			return fmt.Errorf("%w: empty filename", ErrMalformedTree)
 		}
 
 		var hash plumbing.Hash
 		if _, err = io.ReadFull(r, hash[:]); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return fmt.Errorf("%w: truncated object id", ErrMalformedTree)
+			}
 			return err
 		}
 
 		baseName := name[:len(name)-1]
-		t.Entries = append(t.Entries, TreeEntry{
+		entry := TreeEntry{
 			Hash: hash,
 			Mode: mode,
 			Name: baseName,
-		})
+		}
+		sortName := treeEntrySortName(&entry)
+		if len(t.Entries) != 0 && prevSortName > sortName {
+			t.entriesSorted = false
+		}
+		prevSortName = sortName
+		t.Entries = append(t.Entries, entry)
 	}
 
 	return nil
@@ -279,19 +327,35 @@ func (s TreeEntrySorter) Len() int {
 }
 
 func (s TreeEntrySorter) Less(i, j int) bool {
-	name1 := s[i].Name
-	name2 := s[j].Name
-	if s[i].Mode == filemode.Dir {
-		name1 += "/"
-	}
-	if s[j].Mode == filemode.Dir {
-		name2 += "/"
-	}
-	return name1 < name2
+	return treeEntrySortName(&s[i]) < treeEntrySortName(&s[j])
 }
 
 func (s TreeEntrySorter) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
+}
+
+// Git compares tree entries as if directory names had a trailing slash.
+func treeEntrySortName(e *TreeEntry) string {
+	if e.Mode == filemode.Dir {
+		return e.Name + "/"
+	}
+	return e.Name
+}
+
+func canonicalTreeMode(mode filemode.FileMode) filemode.FileMode {
+	switch mode & 0o170000 {
+	case 0o040000:
+		return filemode.Dir
+	case 0o100000:
+		if mode&0o111 != 0 {
+			return filemode.Executable
+		}
+		return filemode.Regular
+	case 0o120000:
+		return filemode.Symlink
+	default:
+		return filemode.Submodule
+	}
 }
 
 // Encode transforms a Tree into a plumbing.EncodedObject.
@@ -327,13 +391,6 @@ func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	}
 
 	return err
-}
-
-func (t *Tree) buildMap() {
-	t.m = make(map[string]*TreeEntry)
-	for i := 0; i < len(t.Entries); i++ {
-		t.m[t.Entries[i].Name] = &t.Entries[i]
-	}
 }
 
 // Diff returns a list of changes between this tree and the provided one

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -8,6 +9,9 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
@@ -56,8 +60,8 @@ func (s *TreeSuite) TestType(c *C) {
 }
 
 func (s *TreeSuite) TestTree(c *C) {
-	expectedEntry, ok := s.Tree.m["vendor"]
-	c.Assert(ok, Equals, true)
+	expectedEntry, err := s.Tree.entry("vendor")
+	c.Assert(err, IsNil)
 	expected := expectedEntry.Hash
 
 	obtainedTree, err := s.Tree.Tree("vendor")
@@ -224,9 +228,9 @@ func (o *SortReadCloser) Read(p []byte) (int, error) {
 func (s *TreeSuite) TestTreeEntriesSorted(c *C) {
 	tree := &Tree{
 		Entries: []TreeEntry{
-			{"foo", filemode.Empty, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
-			{"bar", filemode.Empty, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
-			{"baz", filemode.Empty, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{"foo", filemode.Regular, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{"bar", filemode.Regular, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{"baz", filemode.Regular, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
 		},
 	}
 
@@ -249,9 +253,9 @@ func (s *TreeSuite) TestTreeDecodeEncodeIdempotent(c *C) {
 	trees := []*Tree{
 		{
 			Entries: []TreeEntry{
-				{"foo", filemode.Empty, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
-				{"bar", filemode.Empty, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
-				{"baz", filemode.Empty, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{"foo", filemode.Regular, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{"bar", filemode.Regular, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{"baz", filemode.Regular, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
 			},
 		},
 	}
@@ -264,7 +268,8 @@ func (s *TreeSuite) TestTreeDecodeEncodeIdempotent(c *C) {
 		err = newTree.Decode(obj)
 		c.Assert(err, IsNil)
 		tree.Hash = obj.Hash()
-		c.Assert(newTree, DeepEquals, tree)
+		c.Assert(newTree.Hash, Equals, tree.Hash)
+		c.Assert(newTree.Entries, DeepEquals, tree.Entries)
 	}
 }
 
@@ -1642,7 +1647,6 @@ func (s *TreeSuite) TestTreeDecodeReadBug(c *C) {
 		},
 		Hash: plumbing.Hash{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 		s:    (storer.EncodedObjectStorer)(nil),
-		m:    map[string]*TreeEntry(nil),
 	}
 
 	var obtained Tree
@@ -1665,4 +1669,307 @@ func FuzzDecode(f *testing.F) {
 		newTree := &Tree{}
 		newTree.Decode(obj)
 	})
+}
+
+type rawTreeEntry struct {
+	mode string
+	name string
+	hash []byte
+}
+
+func encodeRawTreeEntries(entries ...rawTreeEntry) []byte {
+	var buf bytes.Buffer
+	for _, e := range entries {
+		buf.WriteString(e.mode)
+		buf.WriteByte(' ')
+		buf.WriteString(e.name)
+		buf.WriteByte(0)
+		buf.Write(e.hash)
+	}
+	return buf.Bytes()
+}
+
+func decodeRawTree(t *testing.T, body []byte) (*Tree, error) {
+	t.Helper()
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	var tree Tree
+	err = tree.Decode(obj)
+	return &tree, err
+}
+
+func TestTreeDecodeRejectsMalformedEntries(t *testing.T) {
+	t.Parallel()
+
+	hash := bytes.Repeat([]byte{0xAA}, 20)
+
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "short object id",
+			body: append(append([]byte{}, []byte("100644 foo\x00")...), hash[:19]...),
+		},
+		{
+			name: "empty filename",
+			body: encodeRawTreeEntries(rawTreeEntry{"100644", "", hash}),
+		},
+		{
+			name: "missing filename terminator",
+			body: append(append([]byte{}, []byte("100644 foo")...), hash...),
+		},
+		{
+			name: "malformed mode",
+			body: encodeRawTreeEntries(rawTreeEntry{"10064x", "foo", hash}),
+		},
+		{
+			name: "trailing partial entry",
+			body: append(encodeRawTreeEntries(rawTreeEntry{"100644", "foo", hash}), []byte("100644 trailing")...),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree, err := decodeRawTree(t, tc.body)
+			require.ErrorIs(t, err, ErrMalformedTree)
+			assert.NotNil(t, tree)
+		})
+	}
+}
+
+func TestTreeDecodeCanonicalizesModes(t *testing.T) {
+	t.Parallel()
+
+	hash := bytes.Repeat([]byte{0xAA}, 20)
+	body := encodeRawTreeEntries(
+		rawTreeEntry{"100664", "regular", hash},
+		rawTreeEntry{"100111", "executable", hash},
+		rawTreeEntry{"120777", "symlink", hash},
+		rawTreeEntry{"040755", "directory", hash},
+		rawTreeEntry{"42", "submodule", hash},
+	)
+
+	tree, err := decodeRawTree(t, body)
+	require.NoError(t, err)
+	require.Len(t, tree.Entries, 5)
+	assert.Equal(t, filemode.Regular, tree.Entries[0].Mode)
+	assert.Equal(t, filemode.Executable, tree.Entries[1].Mode)
+	assert.Equal(t, filemode.Symlink, tree.Entries[2].Mode)
+	assert.Equal(t, filemode.Dir, tree.Entries[3].Mode)
+	assert.Equal(t, filemode.Submodule, tree.Entries[4].Mode)
+}
+
+func TestTreeDecodeEmptyClearsExistingEntries(t *testing.T) {
+	t.Parallel()
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+
+	tree := &Tree{
+		Entries: []TreeEntry{
+			{Name: "stale", Mode: filemode.Regular},
+		},
+	}
+
+	require.NoError(t, tree.Decode(obj))
+	assert.Empty(t, tree.Entries)
+}
+
+func TestTreeFindEntryDuplicates(t *testing.T) {
+	t.Parallel()
+
+	hashA := bytes.Repeat([]byte{0xAA}, 20)
+	hashB := bytes.Repeat([]byte{0xBB}, 20)
+	hashC := bytes.Repeat([]byte{0xCC}, 20)
+
+	cases := []struct {
+		name      string
+		body      []byte
+		lookup    string
+		wantHash  []byte
+		wantMode  filemode.FileMode
+		wantCount int
+	}{
+		{
+			name: "two regular files with same name",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"100644", "foo", hashA},
+				rawTreeEntry{"100644", "foo", hashB},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Regular,
+			wantCount: 2,
+		},
+		{
+			name: "triplicate regular file",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"100644", "foo", hashA},
+				rawTreeEntry{"100644", "foo", hashB},
+				rawTreeEntry{"100644", "foo", hashC},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Regular,
+			wantCount: 3,
+		},
+		{
+			name: "file shadows later directory of same name",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"100644", "foo", hashA},
+				rawTreeEntry{"40000", "foo", hashB},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Regular,
+			wantCount: 2,
+		},
+		{
+			name: "directory shadows later file of same name",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"40000", "foo", hashA},
+				rawTreeEntry{"100644", "foo", hashB},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Dir,
+			wantCount: 2,
+		},
+		{
+			name: "duplicate is not first entry",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"100644", "bar", hashC},
+				rawTreeEntry{"100644", "foo", hashA},
+				rawTreeEntry{"100644", "foo", hashB},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Regular,
+			wantCount: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.TreeObject)
+			w, err := obj.Writer()
+			require.NoError(t, err)
+			_, err = w.Write(tc.body)
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
+
+			var tree Tree
+			require.NoError(t, tree.Decode(obj))
+			require.Len(t, tree.Entries, tc.wantCount,
+				"all duplicate entries must be preserved in storage order")
+
+			got, err := tree.FindEntry(tc.lookup)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMode, got.Mode)
+			assert.Equal(t, 0, bytes.Compare(tc.wantHash, got.Hash[:]),
+				"FindEntry must return the first matching entry; got %s want %x",
+				got.Hash, tc.wantHash)
+		})
+	}
+}
+
+func TestTreeFindEntryStopsAtUnsortedEntryPastName(t *testing.T) {
+	t.Parallel()
+
+	hashA := bytes.Repeat([]byte{0xAA}, 20)
+	hashB := bytes.Repeat([]byte{0xBB}, 20)
+	body := encodeRawTreeEntries(
+		rawTreeEntry{"100644", "z", hashA},
+		rawTreeEntry{"100644", "foo", hashB},
+	)
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	var tree Tree
+	require.NoError(t, tree.Decode(obj))
+
+	got, err := tree.FindEntry("foo")
+	require.ErrorIs(t, err, ErrEntryNotFound)
+	assert.Nil(t, got)
+}
+
+func TestTreeFindEntryFindsDirectoryAfterLexicallyEarlierFile(t *testing.T) {
+	t.Parallel()
+
+	hashA := bytes.Repeat([]byte{0xAA}, 20)
+	hashB := bytes.Repeat([]byte{0xBB}, 20)
+	body := encodeRawTreeEntries(
+		rawTreeEntry{"100644", "foo.bar", hashA},
+		rawTreeEntry{"40000", "foo", hashB},
+	)
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	var tree Tree
+	require.NoError(t, tree.Decode(obj))
+
+	got, err := tree.FindEntry("foo")
+	require.NoError(t, err)
+	assert.Equal(t, filemode.Dir, got.Mode)
+	assert.Equal(t, 0, bytes.Compare(hashB, got.Hash[:]))
+}
+
+func TestTreeEncodePreservesDuplicateEntries(t *testing.T) {
+	t.Parallel()
+
+	hashABytes := bytes.Repeat([]byte{0xAA}, 20)
+	hashBBytes := bytes.Repeat([]byte{0xBB}, 20)
+	var hashA, hashB plumbing.Hash
+	copy(hashA[:], hashABytes)
+	copy(hashB[:], hashBBytes)
+
+	tree := &Tree{
+		Entries: []TreeEntry{
+			{Name: "foo", Mode: filemode.Regular, Hash: hashA},
+			{Name: "foo", Mode: filemode.Regular, Hash: hashB},
+		},
+	}
+
+	obj := &plumbing.MemoryObject{}
+	require.NoError(t, tree.Encode(obj))
+
+	r, err := obj.Reader()
+	require.NoError(t, err)
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	var want bytes.Buffer
+	want.WriteString("100644 foo")
+	want.WriteByte(0)
+	want.Write(hashABytes)
+	want.WriteString("100644 foo")
+	want.WriteByte(0)
+	want.Write(hashBBytes)
+	assert.Equal(t, want.Bytes(), got)
 }

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/go-git/go-git/v5/storage/memory"
 
 	. "gopkg.in/check.v1"
 )
@@ -1689,7 +1690,7 @@ func encodeRawTreeEntries(entries ...rawTreeEntry) []byte {
 	return buf.Bytes()
 }
 
-func decodeRawTree(t *testing.T, body []byte) (*Tree, error) {
+func newRawTreeObject(t *testing.T, body []byte) *plumbing.MemoryObject {
 	t.Helper()
 
 	obj := &plumbing.MemoryObject{}
@@ -1700,8 +1701,16 @@ func decodeRawTree(t *testing.T, body []byte) (*Tree, error) {
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
+	return obj
+}
+
+func decodeRawTree(t *testing.T, body []byte) (*Tree, error) {
+	t.Helper()
+
+	obj := newRawTreeObject(t, body)
+
 	var tree Tree
-	err = tree.Decode(obj)
+	err := tree.Decode(obj)
 	return &tree, err
 }
 
@@ -1783,6 +1792,82 @@ func TestTreeDecodeEmptyClearsExistingEntries(t *testing.T) {
 
 	require.NoError(t, tree.Decode(obj))
 	assert.Empty(t, tree.Entries)
+}
+
+func TestTreeDecodeClearsExistingState(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewStorage()
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+
+	tree := &Tree{
+		Hash: plumbing.NewHash("1111111111111111111111111111111111111111"),
+		Entries: []TreeEntry{
+			{Name: "stale", Mode: filemode.Regular},
+		},
+		s:             store,
+		t:             map[string]*Tree{"stale": &Tree{}},
+		entriesSorted: false,
+	}
+
+	require.NoError(t, tree.Decode(obj))
+	assert.Equal(t, obj.Hash(), tree.Hash)
+	assert.Empty(t, tree.Entries)
+	assert.Same(t, store, tree.s)
+	assert.Nil(t, tree.t)
+	assert.True(t, tree.entriesSorted)
+}
+
+func TestTreeDecodeClearsPathCache(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewStorage()
+	oldFileHash := bytes.Repeat([]byte{0xAA}, 20)
+	newFileHash := bytes.Repeat([]byte{0xBB}, 20)
+
+	oldSubtree := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"100644", "old", oldFileHash},
+	))
+	oldSubtreeHash, err := store.SetEncodedObject(oldSubtree)
+	require.NoError(t, err)
+
+	oldDir := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"40000", "sub", oldSubtreeHash[:]},
+	))
+	oldDirHash, err := store.SetEncodedObject(oldDir)
+	require.NoError(t, err)
+
+	oldRoot := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"40000", "dir", oldDirHash[:]},
+	))
+
+	newSubtree := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"100644", "new", newFileHash},
+	))
+	newSubtreeHash, err := store.SetEncodedObject(newSubtree)
+	require.NoError(t, err)
+
+	newDir := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"40000", "sub", newSubtreeHash[:]},
+	))
+	newDirHash, err := store.SetEncodedObject(newDir)
+	require.NoError(t, err)
+
+	newRoot := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"40000", "dir", newDirHash[:]},
+	))
+
+	tree := &Tree{s: store}
+	require.NoError(t, tree.Decode(oldRoot))
+	got, err := tree.FindEntry("dir/sub/old")
+	require.NoError(t, err)
+	assert.Equal(t, 0, bytes.Compare(oldFileHash, got.Hash[:]))
+
+	require.NoError(t, tree.Decode(newRoot))
+	got, err = tree.FindEntry("dir/sub/new")
+	require.NoError(t, err)
+	assert.Equal(t, 0, bytes.Compare(newFileHash, got.Hash[:]))
 }
 
 func TestTreeFindEntryDuplicates(t *testing.T) {

--- a/tests/objectverify/commit_test.go
+++ b/tests/objectverify/commit_test.go
@@ -4,6 +4,7 @@ package objectverify_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,6 +107,10 @@ func TestCommitVerifyAlignment(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			if tc.name == "double-signature" && os.Getenv("GIT_VERSION") == "v2.11.0" {
+				t.Skip("multi-signature rejection not yet established in Git 2.11.0")
+			}
 
 			repo := initRepo(t)
 			unsigned := tc.build()

--- a/tests/objectverify/commit_test.go
+++ b/tests/objectverify/commit_test.go
@@ -1,0 +1,185 @@
+//go:build linux
+
+package objectverify_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v5"
+)
+
+func TestCommitVerifyAlignment(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping commit verify")
+	}
+
+	if gpg == nil {
+		t.Error("gpg not available")
+		t.FailNow()
+	}
+
+	cases := []struct {
+		name string
+		// build returns the unsigned commit bytes that will be signed
+		// by gpg. The signature is injected as a single canonical
+		// "gpgsig" header in the standard location and the result is
+		// what both verifiers see, unless postSign rewrites it.
+		build func() []byte
+		// postSign optionally rewrites the signed object bytes (e.g.
+		// to inject a duplicated signature header). nil means use the
+		// standard injection path.
+		postSign func(signed []byte, sig string) []byte
+	}{
+		{
+			name: "valid",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				return assembleCommit(h, m)
+			},
+		},
+		{
+			name: "duplicate-tree",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				dup := append([]string{
+					h[0],
+					"tree 5555555555555555555555555555555555555555",
+				}, h[1:]...)
+				return assembleCommit(dup, m)
+			},
+		},
+		{
+			name: "duplicate-author",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				dup := []string{
+					h[0],
+					h[1],
+					h[2],
+					"author Override Author <override@example.local> 1700000001 +0000",
+					h[3],
+				}
+				return assembleCommit(dup, m)
+			},
+		},
+		{
+			name: "duplicate-committer",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				dup := []string{
+					h[0], h[1], h[2], h[3],
+					"committer Override Committer <override@example.local> 1700000001 +0000",
+				}
+				return assembleCommit(dup, m)
+			},
+		},
+		{
+			name: "misplaced-parent-after-committer",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				dup := []string{
+					h[0], h[1], h[2], h[3],
+					"parent 2222222222222222222222222222222222222222",
+				}
+				return assembleCommit(dup, m)
+			},
+		},
+		{
+			// Inject the same signature again as a second gpgsig
+			// header. Both occurrences sit before the blank line; both
+			// signers strip them when computing the payload.
+			name: "double-signature",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				return assembleCommit(h, m)
+			},
+			postSign: injectGpgSig,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := initRepo(t)
+			unsigned := tc.build()
+			sig := gpgSign(t, unsigned)
+			signed := injectGpgSig(unsigned, sig)
+			if tc.postSign != nil {
+				signed = tc.postSign(signed, sig)
+			}
+
+			hash := writeLooseObject(t, repo, "commit", signed)
+			gitErr := gitVerifyCommit(t, repo, hash)
+
+			r, err := git.PlainOpen(repo)
+			require.NoError(t, err)
+			commit, err := r.CommitObject(hash)
+			ggDecodeErr := err
+			var ggVerifyErr error
+			if ggDecodeErr == nil {
+				_, ggVerifyErr = commit.Verify(gpg.pubKey)
+			}
+
+			assertSameVerdict(t, "git verify-commit", gitErr, "go-git Verify",
+				combineErr(ggDecodeErr, ggVerifyErr))
+		})
+	}
+}
+
+// canonicalCommit returns the byte-exact unsigned commit body produced by
+// upstream `git commit-tree` for a single-parent commit. Used as the
+// baseline; individual scenarios mutate the header lines around it.
+func canonicalCommit() (headers []string, message string) {
+	return []string{
+			"tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+			"parent 1111111111111111111111111111111111111111",
+			"author Test Author <author@example.local> 1700000000 +0000",
+			"committer Test Committer <committer@example.local> 1700000000 +0000",
+		},
+		"signed commit message\n"
+}
+
+func assembleCommit(headers []string, message string) []byte {
+	var buf bytes.Buffer
+	for _, h := range headers {
+		buf.WriteString(h)
+		buf.WriteByte('\n')
+	}
+	buf.WriteByte('\n')
+	buf.WriteString(message)
+	return buf.Bytes()
+}
+
+// combineErr returns the first non-nil of decode, verify.
+// Decode failure is treated the same way as a verify failure.
+func combineErr(decode, verify error) error {
+	if decode != nil {
+		return decode
+	}
+	return verify
+}
+
+// assertSameVerdict fails the test unless both verifiers agree on
+// success-or-failure. It does not compare error messages, only verdicts.
+func assertSameVerdict(t *testing.T, leftLabel string, leftErr error, rightLabel string, rightErr error) {
+	t.Helper()
+	leftOK := leftErr == nil
+	rightOK := rightErr == nil
+	if leftOK == rightOK {
+		if !leftOK {
+			t.Logf("both verifiers rejected (expected for malformed input)\n  %s: %v\n  %s: %v",
+				leftLabel, leftErr, rightLabel, rightErr)
+		}
+		return
+	}
+	assert.Failf(t, "verifier verdicts diverge",
+		"%s succeeded=%v err=%v\n%s succeeded=%v err=%v",
+		leftLabel, leftOK, leftErr, rightLabel, rightOK, rightErr)
+}

--- a/tests/objectverify/main_test.go
+++ b/tests/objectverify/main_test.go
@@ -1,0 +1,369 @@
+//go:build linux
+
+package objectverify_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// gpgEnv is the isolated GnuPG home created once per package run. The key
+// is generated on demand at TestMain start and torn down at exit.
+type gpgEnv struct {
+	home   string
+	keyID  string
+	pubKey string
+}
+
+var gpg *gpgEnv
+
+func TestMain(m *testing.M) {
+	os.Exit(runMain(m))
+}
+
+// This test verifies that current ways of signing objects didn't change in
+// newer Git versions.
+func TestMatchTestBehaviourWithGit(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping injection oracle")
+	}
+	if gpg == nil {
+		t.Error("gpg not available")
+		t.FailNow()
+	}
+
+	repo := initRepo(t)
+	configureRepoSigning(t, repo, gpg.keyID)
+	treeHash := gitWriteEmptyTree(t, repo)
+
+	commitEnv := []string{
+		"GIT_AUTHOR_NAME=Author",
+		"GIT_AUTHOR_EMAIL=author@example.local",
+		"GIT_AUTHOR_DATE=1700000000 +0000",
+		"GIT_COMMITTER_NAME=Author",
+		"GIT_COMMITTER_EMAIL=author@example.local",
+		"GIT_COMMITTER_DATE=1700000000 +0000",
+	}
+
+	t.Run("commit", func(t *testing.T) {
+		t.Parallel()
+
+		commitHash := gitCommitTreeSigned(t, repo, treeHash, "msg\n", commitEnv)
+		gitRaw := readObjectBytes(t, repo, "commit", commitHash)
+
+		c := decodeCommit(t, gitRaw)
+		require.NotEmpty(t, c.PGPSignature, "git commit-tree -S did not emit a gpgsig header")
+		unsigned := encodeWithoutSignature(t, c)
+
+		oursRaw := injectGpgSig(unsigned, c.PGPSignature)
+
+		require.Equal(t, gitRaw, oursRaw,
+			"injectGpgSig output diverges from `git commit-tree -S`")
+	})
+
+	t.Run("tag", func(t *testing.T) {
+		t.Parallel()
+
+		commitHash := gitCommitTreeSigned(t, repo, treeHash, "msg for tag\n", commitEnv)
+		tagHash := gitTagSigned(t, repo, "v0", commitHash, "tag msg\n", commitEnv)
+		gitRaw := readObjectBytes(t, repo, "tag", tagHash)
+
+		tag := decodeTag(t, gitRaw)
+		require.NotEmpty(t, tag.PGPSignature, "git tag -s did not emit an inline signature")
+		unsigned := encodeTagWithoutSignature(t, tag)
+
+		oursRaw := append(append([]byte{}, unsigned...), []byte(tag.PGPSignature)...)
+
+		require.Equal(t, gitRaw, oursRaw,
+			"tag append output diverges from `git tag -s`")
+	})
+}
+
+func runMain(m *testing.M) int {
+	cleanup, ok := setupGPG()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if !ok {
+		// Tests will skip individually when gpg is nil.
+		return m.Run()
+	}
+	return m.Run()
+}
+
+func decodeCommit(t *testing.T, raw []byte) *object.Commit {
+	t.Helper()
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.CommitObject)
+	_, err := obj.Write(raw)
+	require.NoError(t, err)
+	c := &object.Commit{}
+	require.NoError(t, c.Decode(obj))
+	return c
+}
+
+func decodeTag(t *testing.T, raw []byte) *object.Tag {
+	t.Helper()
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TagObject)
+	_, err := obj.Write(raw)
+	require.NoError(t, err)
+	tag := &object.Tag{}
+	require.NoError(t, tag.Decode(obj))
+	return tag
+}
+
+func encodeWithoutSignature(t *testing.T, c *object.Commit) []byte {
+	t.Helper()
+	out := &plumbing.MemoryObject{}
+	require.NoError(t, c.EncodeWithoutSignature(out))
+	return readMemoryObject(t, out)
+}
+
+func encodeTagWithoutSignature(t *testing.T, tag *object.Tag) []byte {
+	t.Helper()
+	out := &plumbing.MemoryObject{}
+	require.NoError(t, tag.EncodeWithoutSignature(out))
+	return readMemoryObject(t, out)
+}
+
+func readMemoryObject(t *testing.T, o *plumbing.MemoryObject) []byte {
+	t.Helper()
+	r, err := o.Reader()
+	require.NoError(t, err)
+	b, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return b
+}
+
+func configureRepoSigning(t *testing.T, repo, keyID string) {
+	t.Helper()
+	// gpg.format is forced to openpgp because the host's global git
+	// config may set it to ssh, which would reinterpret user.signingkey
+	// as a path on disk.
+	for _, kv := range [][2]string{
+		{"user.signingkey", keyID},
+		{"user.email", "author@example.local"},
+		{"user.name", "Author"},
+		{"gpg.format", "openpgp"},
+		{"gpg.program", "gpg"},
+		{"commit.gpgsign", "false"},
+		{"tag.gpgsign", "false"},
+	} {
+		out, err := exec.Command("git", "-C", repo, "config", "--local", kv[0], kv[1]).CombinedOutput()
+		require.NoErrorf(t, err, "git config %s: %s", kv[0], out)
+	}
+}
+
+func gitWriteEmptyTree(t *testing.T, repo string) plumbing.Hash {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "write-tree")
+	out, err := cmd.Output()
+	require.NoError(t, err, "git write-tree")
+	return plumbing.NewHash(strings.TrimSpace(string(out)))
+}
+
+func gitCommitTreeSigned(t *testing.T, repo string, tree plumbing.Hash, msg string, envOverrides []string) plumbing.Hash {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "commit-tree", "-S", "-m", strings.TrimRight(msg, "\n"), tree.String())
+	cmd.Env = append(os.Environ(), envOverrides...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "git commit-tree -S: %s", stderr.String())
+	return plumbing.NewHash(strings.TrimSpace(string(out)))
+}
+
+func gitTagSigned(t *testing.T, repo, name string, target plumbing.Hash, msg string, envOverrides []string) plumbing.Hash {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "tag", "-s", "-m", strings.TrimRight(msg, "\n"), name, target.String())
+	cmd.Env = append(os.Environ(), envOverrides...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	require.NoErrorf(t, cmd.Run(), "git tag -s: %s", stderr.String())
+
+	rev, err := exec.Command("git", "-C", repo, "rev-parse", name).Output()
+	require.NoError(t, err)
+	return plumbing.NewHash(strings.TrimSpace(string(rev)))
+}
+
+func readObjectBytes(t *testing.T, repo, kind string, h plumbing.Hash) []byte {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repo, "cat-file", kind, h.String()).Output()
+	require.NoError(t, err, "git cat-file %s %s", kind, h.String())
+	return out
+}
+
+func setupGPG() (func(), bool) {
+	if _, err := exec.LookPath("gpg"); err != nil {
+		log.Printf("objectverify: skipping (gpg not in PATH): %v", err)
+		return nil, false
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		log.Printf("objectverify: skipping (git not in PATH): %v", err)
+		return nil, false
+	}
+
+	home, err := os.MkdirTemp("", "gpg-objectverify-*")
+	if err != nil {
+		log.Printf("objectverify: tempdir: %v", err)
+		return nil, false
+	}
+	if err := os.Chmod(home, 0o700); err != nil {
+		log.Printf("objectverify: chmod home: %v", err)
+		_ = os.RemoveAll(home)
+		return nil, false
+	}
+	if err := os.Setenv("GNUPGHOME", home); err != nil {
+		_ = os.RemoveAll(home)
+		return nil, false
+	}
+
+	cleanup := func() {
+		_ = exec.Command("gpgconf", "--kill", "all").Run()
+		_ = os.RemoveAll(home)
+		_ = os.Unsetenv("GNUPGHOME")
+	}
+
+	if err := generateGPGKey(); err != nil {
+		log.Printf("objectverify: generate key: %v", err)
+		return cleanup, false
+	}
+
+	keyID, err := readGPGKeyID()
+	if err != nil {
+		log.Printf("objectverify: read key id: %v", err)
+		return cleanup, false
+	}
+
+	pub, err := exportArmoredPublicKey(keyID)
+	if err != nil {
+		log.Printf("objectverify: export key: %v", err)
+		return cleanup, false
+	}
+
+	gpg = &gpgEnv{home: home, keyID: keyID, pubKey: pub}
+	return cleanup, true
+}
+
+func generateGPGKey() error {
+	cmd := exec.Command("gpg",
+		"--batch", "--pinentry-mode", "loopback", "--passphrase", "",
+		"--quick-generate-key",
+		"go-git verify <verify@go-git.test>",
+		"default", "default", "never")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gpg --quick-generate-key: %w: %s", err, out)
+	}
+	return nil
+}
+
+func readGPGKeyID() (string, error) {
+	out, err := exec.Command("gpg", "--list-secret-keys", "--with-colons").Output()
+	if err != nil {
+		return "", err
+	}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) > 9 && fields[0] == "fpr" {
+			return fields[9], nil
+		}
+	}
+	return "", errors.New("no fingerprint in gpg --list-secret-keys output")
+}
+
+func exportArmoredPublicKey(keyID string) (string, error) {
+	out, err := exec.Command("gpg", "--armor", "--export", keyID).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// gpgSign produces an ASCII-armored detached signature over payload using
+// the test key.
+func gpgSign(t *testing.T, payload []byte) string {
+	t.Helper()
+	cmd := exec.Command("gpg",
+		"--batch", "--pinentry-mode", "loopback", "--passphrase", "",
+		"--armor", "--detach-sign", "--local-user", gpg.keyID)
+	cmd.Stdin = bytes.NewReader(payload)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "gpg --detach-sign: %s", stderr.String())
+	return string(out)
+}
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	out, err := exec.Command("git", "-C", dir, "init", "--quiet").CombinedOutput()
+	require.NoErrorf(t, err, "git init: %s", out)
+	return dir
+}
+
+func writeLooseObject(t *testing.T, repo, objType string, content []byte) plumbing.Hash {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "hash-object", "-w", "--literally", "-t", objType, "--stdin")
+	cmd.Stdin = bytes.NewReader(content)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "git hash-object: %s", stderr.String())
+	return plumbing.NewHash(strings.TrimSpace(string(out)))
+}
+
+func gitVerifyCommit(t *testing.T, repo string, h plumbing.Hash) error {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "verify-commit", h.String())
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return nil
+}
+
+func gitVerifyTag(t *testing.T, repo string, h plumbing.Hash) error {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "verify-tag", h.String())
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return nil
+}
+
+func injectGpgSig(unsigned []byte, sig string) []byte {
+	sep := []byte("\n\n")
+	idx := bytes.Index(unsigned, sep)
+	if idx < 0 {
+		panic("injectGpgSig: no header/body separator")
+	}
+	sig = strings.TrimSuffix(sig, "\n")
+	indented := strings.ReplaceAll(sig, "\n", "\n ")
+	headerLine := "gpgsig " + indented + "\n"
+
+	var buf bytes.Buffer
+	buf.Write(unsigned[:idx+1]) // up to and including the \n that ends the last header
+	buf.WriteString(headerLine) // gpgsig + indented sig + closing \n
+	buf.Write(unsigned[idx+1:]) // empty-line \n + body
+	return buf.Bytes()
+}

--- a/tests/objectverify/tag_test.go
+++ b/tests/objectverify/tag_test.go
@@ -4,6 +4,7 @@ package objectverify_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -85,6 +86,10 @@ func TestTagVerifyAlignment(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			if tc.name == "double-signature" && os.Getenv("GIT_VERSION") == "v2.11.0" {
+				t.Skip("multi-signature rejection not yet established in Git 2.11.0")
+			}
 
 			repo := initRepo(t)
 			unsigned := tc.build()

--- a/tests/objectverify/tag_test.go
+++ b/tests/objectverify/tag_test.go
@@ -1,0 +1,137 @@
+//go:build linux
+
+package objectverify_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v5"
+)
+
+func TestTagVerifyAlignment(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping tag verify")
+	}
+
+	if gpg == nil {
+		t.Error("gpg not available")
+		t.FailNow()
+	}
+
+	cases := []struct {
+		name string
+		// build returns the unsigned tag bytes that will be signed by
+		// gpg. The signature is appended inline after the body, the
+		// canonical layout produced by `git tag -s`.
+		build func() []byte
+		// postSign optionally rewrites the signed object bytes (e.g.
+		// to append a second inline signature block).
+		postSign func(t *testing.T, signed []byte) []byte
+	}{
+		{
+			name: "valid",
+			build: func() []byte {
+				h, m := canonicalTag()
+				return assembleTag(h, m)
+			},
+		},
+		{
+			name: "duplicate-tag",
+			build: func() []byte {
+				h, m := canonicalTag()
+				dup := []string{
+					h[0], h[1], h[2],
+					"tag v1-override",
+					h[3],
+				}
+				return assembleTag(dup, m)
+			},
+		},
+		{
+			name: "duplicate-tagger",
+			build: func() []byte {
+				h, m := canonicalTag()
+				dup := []string{
+					h[0], h[1], h[2], h[3],
+					"tagger Override Tagger <override@example.local> 1700000001 +0000",
+				}
+				return assembleTag(dup, m)
+			},
+		},
+		{
+			name: "double-signature",
+			build: func() []byte {
+				h, m := canonicalTag()
+				return assembleTag(h, m)
+			},
+			postSign: func(t *testing.T, signed []byte) []byte {
+				// Append a second inline signature over the
+				// already-signed bytes. parse_signature in
+				// upstream and parseSignedBytes in go-git both
+				// pick the last PGP block, so the signed
+				// payload is the original tag plus the first
+				// signature.
+				sig2 := gpgSign(t, signed)
+				return append(append([]byte{}, signed...), []byte(sig2)...)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := initRepo(t)
+			unsigned := tc.build()
+			sig := gpgSign(t, unsigned)
+			signed := append(append([]byte{}, unsigned...), []byte(sig)...)
+			if tc.postSign != nil {
+				signed = tc.postSign(t, signed)
+			}
+
+			hash := writeLooseObject(t, repo, "tag", signed)
+			gitErr := gitVerifyTag(t, repo, hash)
+
+			r, err := git.PlainOpen(repo)
+			require.NoError(t, err)
+			tag, err := r.TagObject(hash)
+			ggDecodeErr := err
+			var ggVerifyErr error
+			if ggDecodeErr == nil {
+				_, ggVerifyErr = tag.Verify(gpg.pubKey)
+			}
+
+			assertSameVerdict(t, "git verify-tag", gitErr, "go-git Verify",
+				combineErr(ggDecodeErr, ggVerifyErr))
+		})
+	}
+}
+
+// canonicalTag returns the byte-exact unsigned annotated-tag body
+// produced by upstream `git tag -a` on a commit. Individual scenarios
+// mutate the header lines around it.
+func canonicalTag() (headers []string, message string) {
+	return []string{
+			"object 1eca38290a3131d0c90709496a9b2207a872631e",
+			"type commit",
+			"tag v1",
+			"tagger Test Tagger <tagger@example.local> 1700000000 +0000",
+		},
+		"signed annotated tag\n"
+}
+
+func assembleTag(headers []string, message string) []byte {
+	var buf bytes.Buffer
+	for _, h := range headers {
+		buf.WriteString(h)
+		buf.WriteByte('\n')
+	}
+	buf.WriteByte('\n')
+	buf.WriteString(message)
+	return buf.Bytes()
+}


### PR DESCRIPTION
- Ensures that unmodified `Commit` and `Tag` objects return their raw bytes (minus `gpgsign` and `gpgsign-sha256` headers).
- Aligns `Commit` and `Tag` interpretation with upstream: first instance of standard headers wins.
- Add conformance tests to ensure verification aligns with `git`. Note that duplicate signatures were valid back on `v2.11`, which is why that test is skipped during capability mode.
- Aligns `Tree` interpretation with upstream: first wins and unsorted tree is short-circuited.
