### PR TITLE
Align object encoding with upstream

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check Package Prefix
         uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2.0.0
         with:
-          pattern: '^(\*|docs|rfcs|git|plumbing|utils|config|_examples|internal|storage|cli|build|backend|x): .+'
+          pattern: '^(\*|docs|rfcs|git|plumbing|utils|config|_examples|internal|storage|cli|build|backend|x|tests): .+'
           error: |
             Commit message(s) does not align with contribution acceptance criteria.
 

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -237,14 +237,22 @@ func (c *Commit) Type() plumbing.ObjectType {
 	return plumbing.CommitObject
 }
 
+func (c *Commit) reset() {
+	storer := c.s
+	*c = Commit{
+		Encoding: defaultUtf8CommitMessageEncoding,
+		s:        storer,
+	}
+}
+
 // Decode transforms a plumbing.EncodedObject into a Commit struct.
 func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	if o.Type() != plumbing.CommitObject {
 		return ErrUnsupportedObject
 	}
 
+	c.reset()
 	c.Hash = o.Hash()
-	c.Encoding = defaultUtf8CommitMessageEncoding
 	c.src = o
 
 	reader, err := o.Reader()

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -20,6 +20,7 @@ const (
 	beginpgp       string = "-----BEGIN PGP SIGNATURE-----"
 	endpgp         string = "-----END PGP SIGNATURE-----"
 	headerpgp      string = "gpgsig"
+	headerpgp256   string = "gpgsig-sha256"
 	headerencoding string = "encoding"
 
 	// https://github.com/git/git/blob/bcb6cae2966cc407ca1afc77413b3ef11103c175/Documentation/gitformat-signature.txt#L153
@@ -54,6 +55,10 @@ type Commit struct {
 	MergeTag string
 	// Signature is the cryptographic signature of the commit (e.g. SSH, X.509).
 	Signature string
+	// SignatureSHA256 is the SHA-256 cryptographic signature of the commit,
+	// stored under the "gpgsig-sha256" header. It may be present alongside
+	// Signature on commits produced in hash-algorithm compatibility mode.
+	SignatureSHA256 string
 	// Message is the commit message, contains arbitrary text.
 	Message string
 	// TreeHash is the hash of the root tree of the commit.
@@ -248,6 +253,7 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	var message bool
 	var mergetag bool
 	var pgpsig bool
+	var pgpsig256 bool
 	var msgbuf bytes.Buffer
 	var extraheader *ExtraHeader
 	for {
@@ -272,6 +278,15 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 				continue
 			}
 			pgpsig = false
+		}
+
+		if pgpsig256 {
+			if len(line) > 0 && line[0] == ' ' {
+				line = bytes.TrimLeft(line, " ")
+				c.SignatureSHA256 += string(line)
+				continue
+			}
+			pgpsig256 = false
 		}
 
 		if extraheader != nil {
@@ -316,6 +331,9 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 			case headerpgp:
 				c.Signature += string(data) + "\n"
 				pgpsig = true
+			case headerpgp256:
+				c.SignatureSHA256 += string(data) + "\n"
+				pgpsig256 = true
 			default:
 				h, maybecontinued := parseExtraHeader(originalLine)
 				if maybecontinued {
@@ -419,6 +437,18 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		// added after this section, as it will be added when the message is
 		// printed.
 		signature := strings.TrimSuffix(c.Signature, "\n")
+		lines := strings.Split(signature, "\n")
+		if _, err = fmt.Fprint(w, strings.Join(lines, "\n ")); err != nil {
+			return err
+		}
+	}
+
+	if c.SignatureSHA256 != "" && includeSig {
+		if _, err = fmt.Fprint(w, "\n"+headerpgp256+" "); err != nil {
+			return err
+		}
+
+		signature := strings.TrimSuffix(c.SignatureSHA256, "\n")
 		lines := strings.Split(signature, "\n")
 		if _, err = fmt.Fprint(w, strings.Join(lines, "\n ")); err != nil {
 			return err

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -42,6 +43,11 @@ type MessageEncoding string
 // in time, such as a timestamp, the author of the changes since the last
 // commit, a pointer to the previous commit(s), etc.
 // http://shafiulazam.com/gitbook/1_the_git_object_model.html
+//
+// When a Commit is populated by Decode it retains a reference to the source
+// plumbing.EncodedObject so that EncodeWithoutSignature can reproduce the
+// exact bytes the signature was computed over. Refer to EncodeWithoutSignature
+// for more information.
 type Commit struct {
 	// Hash of the commit object.
 	Hash plumbing.Hash
@@ -71,6 +77,9 @@ type Commit struct {
 	ExtraHeaders []ExtraHeader
 
 	s storer.EncodedObjectStorer
+	// src holds the encoded object this Commit was decoded from, used by
+	// EncodeWithoutSignature to recover the canonical signed bytes.
+	src plumbing.EncodedObject
 }
 
 // ExtraHeader holds any non-standard header
@@ -240,6 +249,7 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 
 	c.Hash = o.Hash()
 	c.Encoding = defaultUtf8CommitMessageEncoding
+	c.src = o
 
 	reader, err := o.Reader()
 	if err != nil {
@@ -359,9 +369,126 @@ func (c *Commit) Encode(o plumbing.EncodedObject) error {
 	return c.encode(o, true)
 }
 
-// EncodeWithoutSignature export a Commit into a plumbing.EncodedObject without the signature (correspond to the payload of the PGP signature).
+// EncodeWithoutSignature exports a Commit into a plumbing.EncodedObject
+// without any signature headers, producing the payload that PGP/GPG
+// signatures are computed over.
+//
+// Behaviour depends on how the Commit was created:
+//
+//   - For Commits populated by Decode whose exported fields still match the
+//     source object, the payload is streamed from the raw source bytes with
+//     gpgsig and gpgsig-sha256 headers (and their continuation lines)
+//     stripped verbatim. This preserves the exact bytes the signature was
+//     computed over, regardless of any normalization performed by Decode.
+//
+//   - For Commits constructed in memory, or for decoded Commits whose
+//     exported fields have been mutated, the payload is derived from the
+//     current struct fields. Mutation is detected by re-decoding the source
+//     object and comparing exported fields; if any differ, the in-memory
+//     representation prevails.
 func (c *Commit) EncodeWithoutSignature(o plumbing.EncodedObject) error {
+	if c.matchesSource() {
+		return stripSignaturesFromRaw(o, c.src)
+	}
 	return c.encode(o, false)
+}
+
+// matchesSource reports whether c.src is set and re-decoding it produces a
+// Commit whose payload-affecting exported fields are identical to those of
+// c. It is the auto-detection used by EncodeWithoutSignature to decide
+// between the raw bytes and the struct-encoded payload.
+//
+// Signature and SignatureSHA256 are intentionally excluded from the
+// comparison: neither path emits them, so mutating them must not trigger a
+// switch to struct-encode (which would change the byte layout the caller is
+// trying to verify against).
+func (c *Commit) matchesSource() bool {
+	if c.src == nil {
+		return false
+	}
+	fresh := &Commit{}
+	if err := fresh.Decode(c.src); err != nil {
+		return false
+	}
+	return c.Hash == fresh.Hash &&
+		signatureEqual(c.Author, fresh.Author) &&
+		signatureEqual(c.Committer, fresh.Committer) &&
+		c.MergeTag == fresh.MergeTag &&
+		c.Message == fresh.Message &&
+		c.TreeHash == fresh.TreeHash &&
+		c.Encoding == fresh.Encoding &&
+		slices.Equal(c.ParentHashes, fresh.ParentHashes) &&
+		slices.Equal(c.ExtraHeaders, fresh.ExtraHeaders)
+}
+
+func signatureEqual(a, b Signature) bool {
+	return a.Name == b.Name &&
+		a.Email == b.Email &&
+		a.When.Unix() == b.When.Unix() &&
+		a.When.Format("-0700") == b.When.Format("-0700")
+}
+
+// stripSignaturesFromRaw streams src into dst, dropping the canonical commit
+// signature headers ("gpgsig " and "gpgsig-sha256 ") together with their
+// continuation lines (those starting with a space). Everything past the
+// blank line that ends the header block is copied verbatim, as is any other
+// "gpgsig"-prefixed extra header (for example a user-defined "gpgsig-key-id")
+// that does not match one of the canonical signature headers.
+func stripSignaturesFromRaw(dst, src plumbing.EncodedObject) (err error) {
+	dst.SetType(plumbing.CommitObject)
+
+	r, err := src.Reader()
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(r, &err)
+
+	w, err := dst.Writer()
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(w, &err)
+
+	br := sync.GetBufioReader(r)
+	defer sync.PutBufioReader(br)
+
+	var inBody, skipping bool
+	for {
+		line, rerr := br.ReadBytes('\n')
+		if rerr != nil && rerr != io.EOF {
+			return rerr
+		}
+
+		write := true
+		if !inBody {
+			switch {
+			case skipping && len(line) > 0 && line[0] == ' ':
+				write = false
+			case isSignatureHeader(line):
+				skipping = true
+				write = false
+			case len(line) == 1 && line[0] == '\n':
+				skipping = false
+				inBody = true
+			default:
+				skipping = false
+			}
+		}
+
+		if write && len(line) > 0 {
+			if _, werr := w.Write(line); werr != nil {
+				return werr
+			}
+		}
+		if rerr == io.EOF {
+			return nil
+		}
+	}
+}
+
+func isSignatureHeader(line []byte) bool {
+	return bytes.HasPrefix(line, []byte(headerpgp+" ")) ||
+		bytes.HasPrefix(line, []byte(headerpgp256+" "))
 }
 
 func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -24,11 +24,6 @@ const (
 	headerpgp256   string = "gpgsig-sha256"
 	headerencoding string = "encoding"
 
-	// https://github.com/git/git/blob/bcb6cae2966cc407ca1afc77413b3ef11103c175/Documentation/gitformat-signature.txt#L153
-	// When a merge commit is created from a signed tag, the tag is embedded in
-	// the commit with the "mergetag" header.
-	headermergetag string = "mergetag"
-
 	defaultUtf8CommitMessageEncoding MessageEncoding = "UTF-8"
 )
 
@@ -56,9 +51,6 @@ type Commit struct {
 	// Committer is the one performing the commit, might be different from
 	// Author.
 	Committer Signature
-	// MergeTag is the embedded tag object when a merge commit is created by
-	// merging a signed tag.
-	MergeTag string
 	// Signature is the cryptographic signature of the commit (e.g. SSH, X.509).
 	Signature string
 	// SignatureSHA256 is the SHA-256 cryptographic signature of the commit,
@@ -328,7 +320,6 @@ func (c *Commit) matchesSource() bool {
 	return c.Hash == fresh.Hash &&
 		signatureEqual(c.Author, fresh.Author) &&
 		signatureEqual(c.Committer, fresh.Committer) &&
-		c.MergeTag == fresh.MergeTag &&
 		c.Message == fresh.Message &&
 		c.TreeHash == fresh.TreeHash &&
 		c.Encoding == fresh.Encoding &&
@@ -409,7 +400,7 @@ func isSignatureHeader(line []byte) bool {
 func isStandardHeader(key string) bool {
 	switch key {
 	case "tree", "parent", "author", "committer",
-		headerencoding, headermergetag, headerpgp, headerpgp256:
+		headerencoding, headerpgp, headerpgp256:
 		return true
 	}
 	return false
@@ -448,22 +439,6 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 
 	if err = c.Committer.Encode(w); err != nil {
 		return err
-	}
-
-	if c.MergeTag != "" {
-		if _, err = fmt.Fprint(w, "\n"+headermergetag+" "); err != nil {
-			return err
-		}
-
-		// Split tag information lines and re-write with a left padding and
-		// newline. Use join for this so it's clear that a newline should not be
-		// added after this section. The newline will be added either as part of
-		// the PGP signature or the commit message.
-		mergetag := strings.TrimSuffix(c.MergeTag, "\n")
-		lines := strings.Split(mergetag, "\n")
-		if _, err = fmt.Fprint(w, strings.Join(lines, "\n ")); err != nil {
-			return err
-		}
 	}
 
 	if string(c.Encoding) != "" && c.Encoding != defaultUtf8CommitMessageEncoding {

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"slices"
 	"strings"
 
@@ -295,7 +294,7 @@ func (c *Commit) Encode(o plumbing.EncodedObject) error {
 //     representation prevails.
 func (c *Commit) EncodeWithoutSignature(o plumbing.EncodedObject) error {
 	if c.matchesSource() {
-		return stripSignaturesFromRaw(o, c.src)
+		return stripObjectSignatures(o, c.src, plumbing.CommitObject)
 	}
 	return c.encode(o, false)
 }
@@ -332,69 +331,6 @@ func signatureEqual(a, b Signature) bool {
 		a.Email == b.Email &&
 		a.When.Unix() == b.When.Unix() &&
 		a.When.Format("-0700") == b.When.Format("-0700")
-}
-
-// stripSignaturesFromRaw streams src into dst, dropping the canonical commit
-// signature headers ("gpgsig " and "gpgsig-sha256 ") together with their
-// continuation lines (those starting with a space). Everything past the
-// blank line that ends the header block is copied verbatim, as is any other
-// "gpgsig"-prefixed extra header (for example a user-defined "gpgsig-key-id")
-// that does not match one of the canonical signature headers.
-func stripSignaturesFromRaw(dst, src plumbing.EncodedObject) (err error) {
-	dst.SetType(plumbing.CommitObject)
-
-	r, err := src.Reader()
-	if err != nil {
-		return err
-	}
-	defer ioutil.CheckClose(r, &err)
-
-	w, err := dst.Writer()
-	if err != nil {
-		return err
-	}
-	defer ioutil.CheckClose(w, &err)
-
-	br := sync.GetBufioReader(r)
-	defer sync.PutBufioReader(br)
-
-	var inBody, skipping bool
-	for {
-		line, rerr := br.ReadBytes('\n')
-		if rerr != nil && rerr != io.EOF {
-			return rerr
-		}
-
-		write := true
-		if !inBody {
-			switch {
-			case skipping && len(line) > 0 && line[0] == ' ':
-				write = false
-			case isSignatureHeader(line):
-				skipping = true
-				write = false
-			case len(line) == 1 && line[0] == '\n':
-				skipping = false
-				inBody = true
-			default:
-				skipping = false
-			}
-		}
-
-		if write && len(line) > 0 {
-			if _, werr := w.Write(line); werr != nil {
-				return werr
-			}
-		}
-		if rerr == io.EOF {
-			return nil
-		}
-	}
-}
-
-func isSignatureHeader(line []byte) bool {
-	return bytes.HasPrefix(line, []byte(headerpgp+" ")) ||
-		bytes.HasPrefix(line, []byte(headerpgp256+" "))
 }
 
 func isStandardHeader(key string) bool {

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -469,9 +469,21 @@ func (c *Commit) String() string {
 	)
 }
 
+// ErrMultipleSignatures is returned by Verify when the commit carries more
+// than one armored signature block. Mirrors upstream's parse_gpg_output
+// rejection of GOODSIG/BADSIG status lines after the first
+// (gpg-interface.c:257-269): multi-signature commits are intentionally
+// unsupported because their provenance cannot be reduced to a single
+// authoritative signer.
+var ErrMultipleSignatures = errors.New("commit has multiple signatures")
+
 // Verify performs PGP verification of the commit with a provided armored
 // keyring and returns openpgp.Entity associated with verifying key on success.
 func (c *Commit) Verify(armoredKeyRing string) (*openpgp.Entity, error) {
+	if countSignatureBlocks([]byte(c.Signature)) > 1 {
+		return nil, ErrMultipleSignatures
+	}
+
 	keyRingReader := strings.NewReader(armoredKeyRing)
 	keyring, err := openpgp.ReadArmoredKeyRing(keyRingReader)
 	if err != nil {

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -195,6 +195,11 @@ func (c *Commit) NumParents() int {
 // ErrParentNotFound is returned when the parent commit is not found.
 var ErrParentNotFound = errors.New("commit parent not found")
 
+// ErrMalformedCommit is returned when a commit object cannot be decoded
+// because its standard headers (tree, parent, author, committer) are missing,
+// duplicated, or out of order.
+var ErrMalformedCommit = errors.New("malformed commit")
+
 // Parent returns the ith parent of a commit.
 func (c *Commit) Parent(i int) (*Commit, error) {
 	if len(c.ParentHashes) == 0 || i > len(c.ParentHashes)-1 {
@@ -260,107 +265,17 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
-	var message bool
-	var mergetag bool
-	var pgpsig bool
-	var pgpsig256 bool
-	var msgbuf bytes.Buffer
-	var extraheader *ExtraHeader
-	for {
-		line, err := r.ReadBytes('\n')
-		if err != nil && err != io.EOF {
+	s := &commitScanner{r: r, c: c}
+	for state := scanTree; state != nil; {
+		state, err = state(s)
+		if err != nil {
 			return err
 		}
-
-		if mergetag {
-			if len(line) > 0 && line[0] == ' ' {
-				line = bytes.TrimLeft(line, " ")
-				c.MergeTag += string(line)
-				continue
-			}
-			mergetag = false
-		}
-
-		if pgpsig {
-			if len(line) > 0 && line[0] == ' ' {
-				line = bytes.TrimLeft(line, " ")
-				c.Signature += string(line)
-				continue
-			}
-			pgpsig = false
-		}
-
-		if pgpsig256 {
-			if len(line) > 0 && line[0] == ' ' {
-				line = bytes.TrimLeft(line, " ")
-				c.SignatureSHA256 += string(line)
-				continue
-			}
-			pgpsig256 = false
-		}
-
-		if extraheader != nil {
-			if len(line) > 0 && line[0] == ' ' {
-				extraheader.Value += string(line[1:])
-				continue
-			}
-			extraheader.Value = strings.TrimRight(extraheader.Value, "\n")
-			c.ExtraHeaders = append(c.ExtraHeaders, *extraheader)
-			extraheader = nil
-		}
-
-		if !message {
-			originalLine := line
-			line = bytes.TrimSpace(line)
-			if len(line) == 0 {
-				message = true
-				continue
-			}
-
-			split := bytes.SplitN(line, []byte{' '}, 2)
-
-			var data []byte
-			if len(split) == 2 {
-				data = split[1]
-			}
-
-			switch string(split[0]) {
-			case "tree":
-				c.TreeHash = plumbing.NewHash(string(data))
-			case "parent":
-				c.ParentHashes = append(c.ParentHashes, plumbing.NewHash(string(data)))
-			case "author":
-				c.Author.Decode(data)
-			case "committer":
-				c.Committer.Decode(data)
-			case headermergetag:
-				c.MergeTag += string(data) + "\n"
-				mergetag = true
-			case headerencoding:
-				c.Encoding = MessageEncoding(data)
-			case headerpgp:
-				c.Signature += string(data) + "\n"
-				pgpsig = true
-			case headerpgp256:
-				c.SignatureSHA256 += string(data) + "\n"
-				pgpsig256 = true
-			default:
-				h, maybecontinued := parseExtraHeader(originalLine)
-				if maybecontinued {
-					extraheader = &h
-				} else {
-					c.ExtraHeaders = append(c.ExtraHeaders, h)
-				}
-			}
-		} else {
-			msgbuf.Write(line)
-		}
-
-		if err == io.EOF {
-			break
-		}
 	}
-	c.Message = msgbuf.String()
+	if !s.sawTree {
+		return fmt.Errorf("%w: missing tree header", ErrMalformedCommit)
+	}
+	c.Message = s.msgbuf.String()
 	return nil
 }
 

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -491,6 +491,15 @@ func isSignatureHeader(line []byte) bool {
 		bytes.HasPrefix(line, []byte(headerpgp256+" "))
 }
 
+func isStandardHeader(key string) bool {
+	switch key {
+	case "tree", "parent", "author", "committer",
+		headerencoding, headermergetag, headerpgp, headerpgp256:
+		return true
+	}
+	return false
+}
+
 func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	o.SetType(plumbing.CommitObject)
 	w, err := o.Writer()
@@ -549,6 +558,9 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	}
 
 	for _, header := range c.ExtraHeaders {
+		if isStandardHeader(header.Key) {
+			continue
+		}
 		if _, err = fmt.Fprintf(w, "\n%s", header); err != nil {
 			return err
 		}

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -28,9 +28,13 @@ type commitScanner struct {
 	// First-occurrence tracking — once the corresponding field has been
 	// decoded, subsequent occurrences are silently dropped (matches
 	// upstream's find_commit_header / first-wins semantics).
+	//
+	// gpgsig/gpgsig-sha256 are NOT tracked here: upstream's
+	// parse_buffer_signed_by_header (commit.c:1186) accumulates every
+	// occurrence into one signature buffer, so we do the same on the
+	// scanner side to keep verification payloads byte-aligned.
 	sawTree, sawAuthor, sawCommitter bool
 	sawEncoding                      bool
-	sawPgp, sawPgp256                bool
 
 	// extra is the multi-line ExtraHeader currently being assembled.
 	extra *ExtraHeader
@@ -208,21 +212,11 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 			s.sawEncoding = true
 		}
 	case headerpgp:
-		if s.sawPgp {
-			next = scanSkipCont
-		} else {
-			s.c.Signature += string(data) + "\n"
-			s.sawPgp = true
-			next = scanPgpCont
-		}
+		s.c.Signature += string(data) + "\n"
+		next = scanPgpCont
 	case headerpgp256:
-		if s.sawPgp256 {
-			next = scanSkipCont
-		} else {
-			s.c.SignatureSHA256 += string(data) + "\n"
-			s.sawPgp256 = true
-			next = scanPgp256Cont
-		}
+		s.c.SignatureSHA256 += string(data) + "\n"
+		next = scanPgp256Cont
 	default:
 		h, multiline := parseExtraHeader(originalLine)
 		if multiline {
@@ -239,12 +233,14 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 	return next, nil
 }
 
-// scanPgpCont and scanPgp256Cont accumulate continuation lines for the
-// matching first-wins signature header. Continuations strip exactly one
-// leading space, mirroring upstream's `line + 1` (commit.c:1509). The first
-// non-continuation line is pushed back so scanHeaders can dispatch it.
-// Mergetag continuations go through scanExtraCont because mergetag is now
-// modelled as an entry in ExtraHeaders.
+// scanPgpCont and scanPgp256Cont accumulate continuation lines for a
+// signature header. Continuations strip exactly one leading space,
+// mirroring upstream's `line + 1` (commit.c:1509). The first
+// non-continuation line is pushed back so scanHeaders can dispatch it —
+// repeat occurrences of the same signature header land back here and
+// concatenate, matching upstream's parse_buffer_signed_by_header
+// (commit.c:1186). Mergetag continuations go through scanExtraCont
+// because mergetag is modelled as an entry in ExtraHeaders.
 func scanPgpCont(s *commitScanner) (commitState, error) {
 	return continuationCont(s, &s.c.Signature, scanPgpCont)
 }
@@ -264,25 +260,6 @@ func continuationCont(s *commitScanner, dst *string, self commitState) (commitSt
 			return nil, nil
 		}
 		return self, nil
-	}
-	if len(line) > 0 {
-		s.pushBack(line, err)
-	}
-	return scanHeaders, nil
-}
-
-// scanSkipCont discards continuation lines that belong to a duplicate
-// mergetag / gpgsig / gpgsig-sha256 header that scanHeaders chose to drop.
-func scanSkipCont(s *commitScanner) (commitState, error) {
-	line, err := s.readLine()
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-	if len(line) > 0 && line[0] == ' ' {
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanSkipCont, nil
 	}
 	if len(line) > 0 {
 		s.pushBack(line, err)

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -84,7 +84,11 @@ func scanTree(s *commitScanner) (commitState, error) {
 	if key != "tree" {
 		return nil, fmt.Errorf("%w: tree header must be first", ErrMalformedCommit)
 	}
-	s.c.TreeHash = plumbing.NewHash(string(data))
+	h, herr := parseObjectIDHex(data, ErrMalformedCommit, "tree")
+	if herr != nil {
+		return nil, herr
+	}
+	s.c.TreeHash = h
 	s.sawTree = true
 	if err == io.EOF {
 		return nil, nil
@@ -111,7 +115,11 @@ func scanParents(s *commitScanner) (commitState, error) {
 
 	key, data := splitHeader(line)
 	if key == "parent" {
-		s.c.ParentHashes = append(s.c.ParentHashes, plumbing.NewHash(string(data)))
+		h, herr := parseObjectIDHex(data, ErrMalformedCommit, "parent")
+		if herr != nil {
+			return nil, herr
+		}
+		s.c.ParentHashes = append(s.c.ParentHashes, h)
 		if err == io.EOF {
 			return nil, nil
 		}
@@ -329,4 +337,15 @@ func splitHeader(line []byte) (string, []byte) {
 		return string(trimmed), nil
 	}
 	return string(key), value
+}
+
+func parseObjectIDHex(data []byte, malformedErr error, header string) (plumbing.Hash, error) {
+	if len(data) != 40 && len(data) != 64 {
+		return plumbing.ZeroHash, fmt.Errorf("%w: bad %s hash", malformedErr, header)
+	}
+	h, ok := plumbing.FromHex(string(data))
+	if !ok {
+		return plumbing.ZeroHash, fmt.Errorf("%w: bad %s hash", malformedErr, header)
+	}
+	return h, nil
 }

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -1,0 +1,365 @@
+package object
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// commitScanner holds the working state of the commit decoder driven by the
+// stateFn loop in (*Commit).Decode. Each commitState reads one or more lines
+// from r, updates the in-progress *Commit and the scanner's bookkeeping, and
+// returns the state that should run next (or nil to stop).
+type commitScanner struct {
+	r      *bufio.Reader
+	c      *Commit
+	msgbuf bytes.Buffer
+
+	// pending holds a line that was read but the current state decided to
+	// hand back to the next state, paired with the io.EOF flag that was
+	// returned when the line was originally read.
+	pending    []byte
+	pendingErr error
+
+	// First-occurrence tracking — once the corresponding field has been
+	// decoded, subsequent occurrences are silently dropped (matches
+	// upstream's find_commit_header / first-wins semantics).
+	sawTree, sawAuthor, sawCommitter bool
+	sawEncoding, sawMergetag         bool
+	sawPgp, sawPgp256                bool
+
+	// extra is the multi-line ExtraHeader currently being assembled.
+	extra *ExtraHeader
+}
+
+// commitState is one step of the decoder state machine. Each function reads
+// the lines it needs, mutates *Commit via s.c, and returns the next state to
+// run (or nil to terminate the loop).
+type commitState func(*commitScanner) (commitState, error)
+
+// readLine returns the next line from the buffer, transparently consuming any
+// line that was previously pushed back by a state that decided not to handle
+// it.
+func (s *commitScanner) readLine() ([]byte, error) {
+	if s.pending != nil {
+		line, err := s.pending, s.pendingErr
+		s.pending, s.pendingErr = nil, nil
+		return line, err
+	}
+	line, err := s.r.ReadBytes('\n')
+	if err != nil && err != io.EOF {
+		return line, err
+	}
+	return line, err
+}
+
+// pushBack stashes an unconsumed line so the next state's readLine call sees
+// it. Only one line can be pushed back at a time.
+func (s *commitScanner) pushBack(line []byte, err error) {
+	s.pending = line
+	s.pendingErr = err
+}
+
+// scanTree expects the first non-empty header to be `tree HASH`. Anything
+// else (or an empty buffer) is rejected with ErrMalformedCommit, matching
+// upstream's `bogus commit object` check.
+func scanTree(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 || isBlankLine(line) {
+		return nil, fmt.Errorf("%w: missing tree header", ErrMalformedCommit)
+	}
+
+	key, data := splitHeader(line)
+	if key != "tree" {
+		return nil, fmt.Errorf("%w: tree header must be first", ErrMalformedCommit)
+	}
+	s.c.TreeHash = plumbing.NewHash(string(data))
+	s.sawTree = true
+	if err == io.EOF {
+		return nil, nil
+	}
+	return scanParents, nil
+}
+
+// scanParents consumes contiguous `parent HASH` lines. The first non-parent
+// line ends the parent block and is handed off to scanAuthor; any later
+// `parent` line is silently dropped (matches upstream's parse_commit_buffer
+// exiting its parent loop at the first non-parent line and
+// read_commit_extra_header_lines filtering `parent` out of extras).
+func scanParents(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "parent" {
+		s.c.ParentHashes = append(s.c.ParentHashes, plumbing.NewHash(string(data)))
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanParents, nil
+	}
+	s.pushBack(line, err)
+	return scanAuthor, nil
+}
+
+// scanAuthor accepts an `author` line at its canonical position immediately
+// after the parent block. Any other header here is pushed back for
+// scanCommitter; an out-of-place author is therefore silently dropped.
+// Mirrors upstream's parse_commit_date func.
+func scanAuthor(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "author" {
+		s.c.Author.Decode(data)
+		s.sawAuthor = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanCommitter, nil
+	}
+	s.pushBack(line, err)
+	return scanCommitter, nil
+}
+
+// scanCommitter accepts a `committer` line at its canonical position
+// immediately after the author. Any other header is pushed back for
+// scanHeaders. Same upstream rationale as scanAuthor.
+func scanCommitter(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "committer" {
+		s.c.Committer.Decode(data)
+		s.sawCommitter = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanHeaders, nil
+	}
+	s.pushBack(line, err)
+	return scanHeaders, nil
+}
+
+// scanHeaders dispatches one header line. Continuation-bearing headers
+// (mergetag, gpgsig, gpgsig-sha256, and unknown extras whose value is
+// continued on subsequent lines) hand off to a dedicated continuation state
+// that handles the `<space>...` lines and then returns here.
+func scanHeaders(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanMessage, nil
+	}
+
+	originalLine := line
+	key, data := splitHeader(line)
+
+	var next commitState = scanHeaders
+	switch key {
+	case "tree", "parent", "author", "committer":
+		// Anything reaching scanHeaders with one of these keys is out of
+		// canonical position — duplicate tree, parent past the contiguous
+		// block, or author/committer not at their expected slot. Drop them
+		// the same way upstream's standard_header_field filter excludes
+		// them from the extras list (read_commit_extra_header_lines,
+		// commit.c:1520-1522).
+	case headerencoding:
+		if !s.sawEncoding {
+			s.c.Encoding = MessageEncoding(data)
+			s.sawEncoding = true
+		}
+	case headermergetag:
+		if s.sawMergetag {
+			next = scanSkipCont
+		} else {
+			s.c.MergeTag += string(data) + "\n"
+			s.sawMergetag = true
+			next = scanMergetagCont
+		}
+	case headerpgp:
+		if s.sawPgp {
+			next = scanSkipCont
+		} else {
+			s.c.Signature += string(data) + "\n"
+			s.sawPgp = true
+			next = scanPgpCont
+		}
+	case headerpgp256:
+		if s.sawPgp256 {
+			next = scanSkipCont
+		} else {
+			s.c.SignatureSHA256 += string(data) + "\n"
+			s.sawPgp256 = true
+			next = scanPgp256Cont
+		}
+	default:
+		h, multiline := parseExtraHeader(originalLine)
+		if multiline {
+			s.extra = &h
+			next = scanExtraCont
+		} else {
+			s.c.ExtraHeaders = append(s.c.ExtraHeaders, h)
+		}
+	}
+
+	if err == io.EOF {
+		return nil, nil
+	}
+	return next, nil
+}
+
+// scanMergetagCont, scanPgpCont, scanPgp256Cont accumulate continuation
+// lines for the matching first-wins header. Continuations strip exactly one
+// leading space, mirroring upstream's `line + 1` (commit.c:1509). The first
+// non-continuation line is pushed back so scanHeaders can dispatch it.
+func scanMergetagCont(s *commitScanner) (commitState, error) {
+	return continuationCont(s, &s.c.MergeTag, scanMergetagCont)
+}
+
+func scanPgpCont(s *commitScanner) (commitState, error) {
+	return continuationCont(s, &s.c.Signature, scanPgpCont)
+}
+
+func scanPgp256Cont(s *commitScanner) (commitState, error) {
+	return continuationCont(s, &s.c.SignatureSHA256, scanPgp256Cont)
+}
+
+func continuationCont(s *commitScanner, dst *string, self commitState) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) > 0 && line[0] == ' ' {
+		*dst += string(line[1:])
+		if err == io.EOF {
+			return nil, nil
+		}
+		return self, nil
+	}
+	if len(line) > 0 {
+		s.pushBack(line, err)
+	}
+	return scanHeaders, nil
+}
+
+// scanSkipCont discards continuation lines that belong to a duplicate
+// mergetag / gpgsig / gpgsig-sha256 header that scanHeaders chose to drop.
+func scanSkipCont(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) > 0 && line[0] == ' ' {
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanSkipCont, nil
+	}
+	if len(line) > 0 {
+		s.pushBack(line, err)
+	}
+	return scanHeaders, nil
+}
+
+// scanExtraCont accumulates continuation lines for an unknown ExtraHeader
+// whose value spans multiple lines, then finalises the entry once the
+// continuation block ends.
+func scanExtraCont(s *commitScanner) (commitState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) > 0 && line[0] == ' ' {
+		s.extra.Value += string(line[1:])
+		if err == io.EOF {
+			s.finaliseExtra()
+			return nil, nil
+		}
+		return scanExtraCont, nil
+	}
+	s.finaliseExtra()
+	if len(line) > 0 {
+		s.pushBack(line, err)
+	}
+	return scanHeaders, nil
+}
+
+func (s *commitScanner) finaliseExtra() {
+	s.extra.Value = strings.TrimRight(s.extra.Value, "\n")
+	s.c.ExtraHeaders = append(s.c.ExtraHeaders, *s.extra)
+	s.extra = nil
+}
+
+// scanMessage drains the remaining bytes into the message buffer.
+func scanMessage(s *commitScanner) (commitState, error) {
+	for {
+		line, err := s.readLine()
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if len(line) > 0 {
+			s.msgbuf.Write(line)
+		}
+		if err == io.EOF {
+			return nil, nil
+		}
+	}
+}
+
+// isBlankLine reports whether line is the canonical header/body separator —
+// a single newline. Mirrors upstream's `*line == '\n'` test in
+// read_commit_extra_header_lines (commit.c:1502).
+func isBlankLine(line []byte) bool {
+	return len(line) == 1 && line[0] == '\n'
+}
+
+// splitHeader returns the header keyword (everything before the first space)
+// and the value (everything after, with the trailing newline stripped). If
+// the header has no value the returned data is nil.
+func splitHeader(line []byte) (string, []byte) {
+	trimmed := bytes.TrimRight(line, "\n")
+	key, value, ok := bytes.Cut(trimmed, []byte{' '})
+	if !ok {
+		return string(trimmed), nil
+	}
+	return string(key), value
+}

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -29,7 +29,7 @@ type commitScanner struct {
 	// decoded, subsequent occurrences are silently dropped (matches
 	// upstream's find_commit_header / first-wins semantics).
 	sawTree, sawAuthor, sawCommitter bool
-	sawEncoding, sawMergetag         bool
+	sawEncoding                      bool
 	sawPgp, sawPgp256                bool
 
 	// extra is the multi-line ExtraHeader currently being assembled.
@@ -207,14 +207,6 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 			s.c.Encoding = MessageEncoding(data)
 			s.sawEncoding = true
 		}
-	case headermergetag:
-		if s.sawMergetag {
-			next = scanSkipCont
-		} else {
-			s.c.MergeTag += string(data) + "\n"
-			s.sawMergetag = true
-			next = scanMergetagCont
-		}
 	case headerpgp:
 		if s.sawPgp {
 			next = scanSkipCont
@@ -247,14 +239,12 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 	return next, nil
 }
 
-// scanMergetagCont, scanPgpCont, scanPgp256Cont accumulate continuation
-// lines for the matching first-wins header. Continuations strip exactly one
+// scanPgpCont and scanPgp256Cont accumulate continuation lines for the
+// matching first-wins signature header. Continuations strip exactly one
 // leading space, mirroring upstream's `line + 1` (commit.c:1509). The first
 // non-continuation line is pushed back so scanHeaders can dispatch it.
-func scanMergetagCont(s *commitScanner) (commitState, error) {
-	return continuationCont(s, &s.c.MergeTag, scanMergetagCont)
-}
-
+// Mergetag continuations go through scanExtraCont because mergetag is now
+// modelled as an entry in ExtraHeaders.
 func scanPgpCont(s *commitScanner) (commitState, error) {
 	return continuationCont(s, &s.c.Signature, scanPgpCont)
 }

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -687,21 +687,24 @@ func (s *SuiteCommit) TestDecodeFirstOccurrenceWins() {
 			},
 		},
 		{
-			name: "duplicate gpgsig drops the second and its continuations",
+			// Multiple gpgsig headers concatenate into a single
+			// signature buffer, mirroring upstream's
+			// parse_buffer_signed_by_header (commit.c:1186).
+			name: "multiple gpgsig headers concatenate",
 			raw: "tree " + treeA + "\nauthor " + identAuthor +
 				"\ncommitter " + identCommit +
 				"\ngpgsig firstline\n morefirst\ngpgsig secondline\n moresecond\n\nmsg\n",
 			assert: func(c *Commit) {
-				s.Equal("firstline\nmorefirst\n", c.Signature)
+				s.Equal("firstline\nmorefirst\nsecondline\nmoresecond\n", c.Signature)
 			},
 		},
 		{
-			name: "duplicate gpgsig-sha256 drops the second and its continuations",
+			name: "multiple gpgsig-sha256 headers concatenate",
 			raw: "tree " + treeA + "\nauthor " + identAuthor +
 				"\ncommitter " + identCommit +
 				"\ngpgsig-sha256 firstline\n morefirst\ngpgsig-sha256 secondline\n moresecond\n\nmsg\n",
 			assert: func(c *Commit) {
-				s.Equal("firstline\nmorefirst\n", c.SignatureSHA256)
+				s.Equal("firstline\nmorefirst\nsecondline\nmoresecond\n", c.SignatureSHA256)
 			},
 		},
 		{

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -46,6 +46,49 @@ func (s *SuiteCommit) TestDecodeNonCommit() {
 	s.ErrorIs(err, ErrUnsupportedObject)
 }
 
+func (s *SuiteCommit) TestDecodeClearsExistingState() {
+	const raw = "tree eba74343e2f15d62adedfd8c883ee0262b5c8021\n\nfresh message\n"
+
+	staleSrc := &plumbing.MemoryObject{}
+	commit := &Commit{
+		Hash:            plumbing.NewHash("1111111111111111111111111111111111111111"),
+		Author:          Signature{Name: "Stale Author", Email: "author@example.local", When: time.Unix(1, 0).UTC()},
+		Committer:       Signature{Name: "Stale Committer", Email: "committer@example.local", When: time.Unix(2, 0).UTC()},
+		Signature:       "stale signature",
+		SignatureSHA256: "stale sha256 signature",
+		Message:         "stale message",
+		TreeHash:        plumbing.NewHash("2222222222222222222222222222222222222222"),
+		ParentHashes: []plumbing.Hash{
+			plumbing.NewHash("3333333333333333333333333333333333333333"),
+		},
+		Encoding: MessageEncoding("latin-1"),
+		ExtraHeaders: []ExtraHeader{
+			{Key: "x-stale", Value: "stale"},
+		},
+		s:   s.Storer,
+		src: staleSrc,
+	}
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.CommitObject)
+	_, err := obj.Write([]byte(raw))
+	s.NoError(err)
+
+	s.NoError(commit.Decode(obj))
+	s.Equal(obj.Hash(), commit.Hash)
+	s.Equal(Signature{}, commit.Author)
+	s.Equal(Signature{}, commit.Committer)
+	s.Equal("", commit.Signature)
+	s.Equal("", commit.SignatureSHA256)
+	s.Equal("fresh message\n", commit.Message)
+	s.Equal("eba74343e2f15d62adedfd8c883ee0262b5c8021", commit.TreeHash.String())
+	s.Nil(commit.ParentHashes)
+	s.Equal(defaultUtf8CommitMessageEncoding, commit.Encoding)
+	s.Nil(commit.ExtraHeaders)
+	s.Equal(s.Storer, commit.s)
+	s.Equal(obj, commit.src)
+}
+
 func (s *SuiteCommit) TestType() {
 	s.Equal(plumbing.CommitObject, s.Commit.Type())
 }

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -287,6 +287,7 @@ change
 		err = newCommit.Decode(obj)
 		s.NoError(err)
 		commit.Hash = obj.Hash()
+		commit.src = obj
 		s.Equal(commit, newCommit)
 	}
 }
@@ -565,6 +566,7 @@ func (s *SuiteCommit) TestEncodeWithoutSignature() {
 	tests := []struct {
 		name      string
 		commitRaw string
+		mutate    func(*Commit)
 		expected  string
 	}{
 		{
@@ -674,6 +676,95 @@ initial commit
 Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
 `,
 		},
+		{
+			name: "non-canonical gpgsig-prefixed extra header is preserved",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig-key-id ABCDEF0123456789
+gpgsig -----BEGIN PGP SIGNATURE-----
+ sigline1
+ -----END PGP SIGNATURE-----
+
+initial commit
+`,
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig-key-id ABCDEF0123456789
+
+initial commit
+`,
+		},
+		{
+			name: "raw bytes preserved when only Signature is mutated",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig -----BEGIN PGP SIGNATURE-----
+ sigline1
+ -----END PGP SIGNATURE-----
+gpgsig-sha256 -----BEGIN PGP SIGNATURE-----
+ sha256line1
+ -----END PGP SIGNATURE-----
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				c.Signature = "different signature value"
+				c.SignatureSHA256 = "different sha256 sig"
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+
+initial commit
+`,
+		},
+		{
+			name: "timezone-only change triggers struct-encode",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig -----BEGIN PGP SIGNATURE-----
+ sigline1
+ -----END PGP SIGNATURE-----
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				tz := time.FixedZone("CEST", 2*60*60)
+				c.Author.When = c.Author.When.In(tz)
+				c.Committer.When = c.Committer.When.In(tz)
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 +0200
+committer John Doe <john.doe@example.com> 1755280730 +0200
+
+initial commit
+`,
+		},
+		{
+			name: "field mutation triggers struct-encode",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+gpgsig -----BEGIN PGP SIGNATURE-----
+ sigline1
+ -----END PGP SIGNATURE-----
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				c.Message = "rewritten message\n"
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+
+rewritten message
+`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -684,6 +775,10 @@ Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
 
 			commit, err := DecodeCommit(s.Storer, obj)
 			s.Require().NoError(err)
+
+			if tc.mutate != nil {
+				tc.mutate(commit)
+			}
 
 			encoded := &plumbing.MemoryObject{}
 			err = commit.EncodeWithoutSignature(encoded)

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -765,6 +765,36 @@ committer John Doe <john.doe@example.com> 1755280730 -0700
 rewritten message
 `,
 		},
+		{
+			name: "standard-keyed ExtraHeaders are dropped on encode",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				c.Message = "rewritten message\n"
+				c.ExtraHeaders = []ExtraHeader{
+					{Key: "tree", Value: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},
+					{Key: "parent", Value: "feedfacefeedfacefeedfacefeedfacefeedface"},
+					{Key: "author", Value: "Fake <fake@example.com> 0 +0000"},
+					{Key: "committer", Value: "Fake <fake@example.com> 0 +0000"},
+					{Key: "encoding", Value: "fake-enc"},
+					{Key: "mergetag", Value: "fake mergetag"},
+					{Key: "gpgsig", Value: "fake-sig"},
+					{Key: "gpgsig-sha256", Value: "fake-sig-256"},
+					{Key: "x-real-extra", Value: "kept"},
+				}
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+x-real-extra kept
+
+rewritten message
+`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -262,7 +262,9 @@ change
 				plumbing.NewHash("f000000000000000000000000000000000000002"),
 				plumbing.NewHash("f000000000000000000000000000000000000003"),
 			},
-			MergeTag: tag,
+			ExtraHeaders: []ExtraHeader{
+				{Key: "mergetag", Value: strings.TrimRight(tag, "\n")},
+			},
 			Encoding: defaultUtf8CommitMessageEncoding,
 		},
 		{
@@ -274,7 +276,9 @@ change
 				plumbing.NewHash("f000000000000000000000000000000000000002"),
 				plumbing.NewHash("f000000000000000000000000000000000000003"),
 			},
-			MergeTag:  tag,
+			ExtraHeaders: []ExtraHeader{
+				{Key: "mergetag", Value: strings.TrimRight(tag, "\n")},
+			},
 			Signature: pgpsignature,
 			Encoding:  defaultUtf8CommitMessageEncoding,
 		},
@@ -700,6 +704,22 @@ func (s *SuiteCommit) TestDecodeFirstOccurrenceWins() {
 				s.Equal("firstline\nmorefirst\n", c.SignatureSHA256)
 			},
 		},
+		{
+			// Octopus signed merge: every mergetag header survives as
+			// its own ExtraHeader entry. mergetag is just an extra in
+			// upstream's data model — there is no dedicated field.
+			name: "multiple mergetag headers each become an ExtraHeader",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\ncommitter " + identCommit +
+				"\nmergetag tag-one\n line1\n line2\n" +
+				"mergetag tag-two\n only-line\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal([]ExtraHeader{
+					{Key: "mergetag", Value: "tag-one\nline1\nline2"},
+					{Key: "mergetag", Value: "tag-two\nonly-line"},
+				}, c.ExtraHeaders)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -938,6 +958,10 @@ rewritten message
 `,
 		},
 		{
+			// mergetag is intentionally preserved here: in upstream Git
+			// it is just another extra header (not in
+			// standard_header_field), so go-git keeps any "mergetag"
+			// entry in ExtraHeaders rather than filtering it out.
 			name: "standard-keyed ExtraHeaders are dropped on encode",
 			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 author John Doe <john.doe@example.com> 1755280730 -0700
@@ -962,6 +986,7 @@ initial commit
 			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 author John Doe <john.doe@example.com> 1755280730 -0700
 committer John Doe <john.doe@example.com> 1755280730 -0700
+mergetag fake mergetag
 x-real-extra kept
 
 rewritten message

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -373,11 +373,7 @@ func (s *SuiteCommit) TestLongCommitMessageSerialization() {
 }
 
 func (s *SuiteCommit) TestPGPSignatureSerialization() {
-	encoded := &plumbing.MemoryObject{}
-	decoded := &Commit{}
-	commit := *s.Commit
-
-	pgpsignature := `-----BEGIN PGP SIGNATURE-----
+	pgpsig1 := `-----BEGIN PGP SIGNATURE-----
 
 iQEcBAABAgAGBQJTZbQlAAoJEF0+sviABDDrZbQH/09PfE51KPVPlanr6q1v4/Ut
 LQxfojUWiLQdg2ESJItkcuweYg+kc3HCyFejeDIBw9dpXt00rY26p05qrpnG+85b
@@ -388,62 +384,81 @@ RUysgqjcpT8+iQM1PblGfHR4XAhuOqN5Fx06PSaFZhqvWFezJ28/CLyX5q+oIVk=
 =EFTF
 -----END PGP SIGNATURE-----
 `
-	commit.Signature = pgpsignature
+	pgpsig256 := `-----BEGIN PGP SIGNATURE-----
 
-	err := commit.Encode(encoded)
-	s.NoError(err)
+iHUEABYKAB0WIQTMqU0ycQ3f6g3PMoWMmmmF4LuV8QUCYGebVwAKCRCMmmmF4LuV
+8VtyAP9LbuXAhtK6FQqOjKybBwlV70rLcXVP24ubDuz88VVwSgD+LuObsasWq6/U
+TssDKHUR2taa53bQYjkZQBpvvwOrLgc=
+=YQUf
+-----END PGP SIGNATURE-----
+`
+	broken := beginpgp + "\nsome\ntrash\n" + endpgp + "text\n"
 
-	err = decoded.Decode(encoded)
-	s.NoError(err)
-	s.Equal(pgpsignature, decoded.Signature)
+	cases := []struct {
+		name       string
+		sig        string
+		sig256     string
+		authorName string
+	}{
+		{name: "sha1 only", sig: pgpsig1},
+		{name: "sha256 only", sig256: pgpsig256},
+		{name: "sha1 and sha256", sig: pgpsig1, sig256: pgpsig256},
+		// Regression: a leading empty line previously caused "index out of
+		// range" when parsing the signature.
+		{name: "sha1 with leading empty line", sig: "\n" + pgpsig1},
+		{name: "sha256 with leading empty line", sig256: "\n" + pgpsig256},
+		{name: "beginpgp marker in author name is not parsed as signature", authorName: beginpgp},
+		{name: "garbage between begin and end markers round-trips", sig: broken},
+	}
 
-	// signature with extra empty line, it caused "index out of range" when
-	// parsing it
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			commit := *s.Commit
+			commit.Signature = tc.sig
+			commit.SignatureSHA256 = tc.sig256
+			if tc.authorName != "" {
+				commit.Author.Name = tc.authorName
+			}
 
-	pgpsignature2 := "\n" + pgpsignature
+			encoded := &plumbing.MemoryObject{}
+			s.NoError(commit.Encode(encoded))
 
-	commit.Signature = pgpsignature2
-	encoded = &plumbing.MemoryObject{}
-	decoded = &Commit{}
+			payload := readAll(s.T(), encoded)
+			if tc.sig != "" {
+				s.Contains(payload, "\n"+headerpgp+" ")
+			}
+			if tc.sig256 != "" {
+				s.Contains(payload, "\n"+headerpgp256+" ")
+			}
 
-	err = commit.Encode(encoded)
-	s.NoError(err)
+			decoded := &Commit{}
+			s.NoError(decoded.Decode(encoded))
+			s.Equal(tc.sig, decoded.Signature)
+			s.Equal(tc.sig256, decoded.SignatureSHA256)
+			if tc.authorName != "" {
+				s.Equal(tc.authorName, decoded.Author.Name)
+			}
 
-	err = decoded.Decode(encoded)
-	s.NoError(err)
-	s.Equal(pgpsignature2, decoded.Signature)
+			if tc.sig != "" || tc.sig256 != "" {
+				stripped := &plumbing.MemoryObject{}
+				s.NoError(commit.EncodeWithoutSignature(stripped))
+				s.NotContains(readAll(s.T(), stripped), "gpgsig")
+			}
+		})
+	}
+}
 
-	// signature in author name
-
-	commit.Signature = ""
-	commit.Author.Name = beginpgp
-	encoded = &plumbing.MemoryObject{}
-	decoded = &Commit{}
-
-	err = commit.Encode(encoded)
-	s.NoError(err)
-
-	err = decoded.Decode(encoded)
-	s.NoError(err)
-	s.Equal("", decoded.Signature)
-	s.Equal(beginpgp, decoded.Author.Name)
-
-	// broken signature
-
-	commit.Signature = beginpgp + "\n" +
-		"some\n" +
-		"trash\n" +
-		endpgp +
-		"text\n"
-	encoded = &plumbing.MemoryObject{}
-	decoded = &Commit{}
-
-	err = commit.Encode(encoded)
-	s.NoError(err)
-
-	err = decoded.Decode(encoded)
-	s.NoError(err)
-	s.Equal(commit.Signature, decoded.Signature)
+func readAll(t *testing.T, o *plumbing.MemoryObject) string {
+	t.Helper()
+	r, err := o.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }
 
 func (s *SuiteCommit) TestStat() {
@@ -547,30 +562,33 @@ func (s *SuiteCommit) TestMalformedHeader() {
 }
 
 func (s *SuiteCommit) TestEncodeWithoutSignature() {
-	// Similar to TestString since no signature
-	encoded := &plumbing.MemoryObject{}
-	err := s.Commit.EncodeWithoutSignature(encoded)
-	s.NoError(err)
-	er, err := encoded.Reader()
-	s.NoError(err)
-	payload, err := io.ReadAll(er)
-	s.NoError(err)
+	tests := []struct {
+		name      string
+		commitRaw string
+		expected  string
+	}{
+		{
+			name: "commit without signature",
+			commitRaw: `tree eba74343e2f15d62adedfd8c883ee0262b5c8021
+parent 35e85108805c84807bc66a02d91535e1e24b38b9
+parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69
+author Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200
+committer Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200
 
-	s.Equal(""+
-		"tree eba74343e2f15d62adedfd8c883ee0262b5c8021\n"+
-		"parent 35e85108805c84807bc66a02d91535e1e24b38b9\n"+
-		"parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69\n"+
-		"author Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200\n"+
-		"committer Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200\n"+
-		"\n"+
-		"Merge branch 'master' of github.com:tyba/git-fixture\n",
-		string(payload))
-}
+Merge branch 'master' of github.com:tyba/git-fixture
+`,
+			expected: `tree eba74343e2f15d62adedfd8c883ee0262b5c8021
+parent 35e85108805c84807bc66a02d91535e1e24b38b9
+parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69
+author Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200
+committer Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200
 
-func (s *SuiteCommit) TestEncodeWithoutSignatureJujutsu() {
-	object := &plumbing.MemoryObject{}
-	object.SetType(plumbing.CommitObject)
-	object.Write([]byte(`tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+Merge branch 'master' of github.com:tyba/git-fixture
+`,
+		},
+		{
+			name: "commit with change-id and gpgsig",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 author John Doe <john.doe@example.com> 1755280730 -0700
 committer John Doe <john.doe@example.com> 1755280730 -0700
 change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
@@ -585,21 +603,8 @@ gpgsig -----BEGIN PGP SIGNATURE-----
 initial commit
 
 Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
-`))
-
-	commit, err := DecodeCommit(s.Storer, object)
-	s.NoError(err)
-
-	// Similar to TestString since no signature
-	encoded := &plumbing.MemoryObject{}
-	err = commit.EncodeWithoutSignature(encoded)
-	s.NoError(err)
-	er, err := encoded.Reader()
-	s.NoError(err)
-	payload, err := io.ReadAll(er)
-	s.NoError(err)
-
-	s.Equal(`tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+`,
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 author John Doe <john.doe@example.com> 1755280730 -0700
 committer John Doe <john.doe@example.com> 1755280730 -0700
 change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
@@ -607,7 +612,92 @@ change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
 initial commit
 
 Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
-`, string(payload))
+`,
+		},
+		{
+			name: "gpgsig-sha256",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+gpgsig-sha256 -----BEGIN PGP SIGNATURE-----
+ 
+ iHUEABMIAB0WIQSZpnSpGKbQbDaLe5iiNQl48cTY5gUCaJ91XQAKCRCiNQl48cTY
+ 5vCYAP9Sf1yV9oUviRIxEA+4rsGIx0hI6kqFajJ/3TtBjyCTggD+PFnKOxdXeFL2
+ GLwcCzFIsmQmkLxuLypsg+vueDSLpsM=
+ =VucY
+ -----END PGP SIGNATURE-----
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`,
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`,
+		},
+		{
+			name: "gpgsig + gpgsig-sha256",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+gpgsig -----BEGIN PGP SIGNATURE-----
+ 
+ iHUEABMIAB0WIQSZpnSpGKbQbDaLe5iiNQl48cTY5gUCaJ91XQAKCRCiNQl48cTY
+ GLwcCzFIsmQmkLxuLypsg+vueDSLpsM=
+ =VucY
+ -----END PGP SIGNATURE-----
+gpgsig-sha256 -----BEGIN PGP SIGNATURE-----
+ 
+ iHUEABMIAB0WIQSZpnSpGKbQbDaLe5iiNQl48cTY5gUCaJ91XQAKCRCiNQl48cTY
+ =VucY
+ -----END PGP SIGNATURE-----
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`,
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+change-id wxmuynokkzxmuwxwvnnpnptoyuypknwv
+
+initial commit
+
+Change-Id: I6a6a696432d51cbff02d53234ccaca6b151afc34
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.CommitObject)
+			obj.Write([]byte(tc.commitRaw))
+
+			commit, err := DecodeCommit(s.Storer, obj)
+			s.Require().NoError(err)
+
+			encoded := &plumbing.MemoryObject{}
+			err = commit.EncodeWithoutSignature(encoded)
+			s.NoError(err)
+
+			er, err := encoded.Reader()
+			s.NoError(err)
+
+			payload, err := io.ReadAll(er)
+			s.NoError(err)
+
+			s.Equal(tc.expected, string(payload))
+		})
+	}
 }
 
 func (s *SuiteCommit) TestEncodeExtraHeaders() {

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -544,6 +544,178 @@ func (s *SuiteCommit) TestPatchCancel() {
 	s.ErrorContains(err, "operation canceled")
 }
 
+func (s *SuiteCommit) TestDecodeRequiresTreeFirst() {
+	const (
+		validTree   = "eba74343e2f15d62adedfd8c883ee0262b5c8021"
+		validParent = "35e85108805c84807bc66a02d91535e1e24b38b9"
+		validIdent  = "Foo <foo@example.local> 1427802494 +0200"
+	)
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "missing tree",
+			raw:  "author " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "parent before tree",
+			raw:  "parent " + validParent + "\ntree " + validTree + "\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "extra header before tree",
+			raw:  "x-extra hi\ntree " + validTree + "\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "empty",
+			raw:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.CommitObject)
+			_, err := obj.Write([]byte(tc.raw))
+			s.NoError(err)
+
+			err = (&Commit{}).Decode(obj)
+			s.ErrorIs(err, ErrMalformedCommit)
+		})
+	}
+}
+
+func (s *SuiteCommit) TestDecodeFirstOccurrenceWins() {
+	const (
+		treeA       = "eba74343e2f15d62adedfd8c883ee0262b5c8021"
+		treeB       = "0000000000000000000000000000000000000001"
+		parentA     = "35e85108805c84807bc66a02d91535e1e24b38b9"
+		parentB     = "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"
+		parentC     = "0000000000000000000000000000000000000002"
+		identA      = "Alice <alice@example.local> 1427802494 +0200"
+		identB      = "Bob <bob@example.local> 1427802495 +0200"
+		identAuthor = "Author Name <author@example.local> 1500000000 +0000"
+		identCommit = "Commit Name <commit@example.local> 1500000001 +0000"
+	)
+
+	cases := []struct {
+		name   string
+		raw    string
+		assert func(*Commit)
+	}{
+		{
+			name: "duplicate tree drops the second",
+			raw: "tree " + treeA + "\ntree " + treeB +
+				"\nauthor " + identAuthor + "\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal(treeA, c.TreeHash.String())
+			},
+		},
+		{
+			name: "duplicate author drops the second",
+			raw: "tree " + treeA + "\nauthor " + identA + "\nauthor " + identB +
+				"\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal("Alice", c.Author.Name)
+			},
+		},
+		{
+			name: "duplicate committer drops the second",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\ncommitter " + identA + "\ncommitter " + identB + "\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal("Alice", c.Committer.Name)
+			},
+		},
+		{
+			name: "parent after author is dropped",
+			raw: "tree " + treeA + "\nparent " + parentA +
+				"\nauthor " + identAuthor + "\nparent " + parentC +
+				"\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal([]plumbing.Hash{plumbing.NewHash(parentA)}, c.ParentHashes)
+			},
+		},
+		{
+			name: "parent interleaved with extras is dropped",
+			raw: "tree " + treeA + "\nparent " + parentA + "\nparent " + parentB +
+				"\nx-other thing\nparent " + parentC +
+				"\nauthor " + identAuthor + "\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal([]plumbing.Hash{
+					plumbing.NewHash(parentA),
+					plumbing.NewHash(parentB),
+				}, c.ParentHashes)
+			},
+		},
+		{
+			name: "missing committer is allowed (zero-valued)",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal("Author Name", c.Author.Name)
+				s.Empty(c.Committer.Name)
+			},
+		},
+		{
+			name: "encoding between author and committer drops committer",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\nencoding latin-1\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal("Author Name", c.Author.Name)
+				s.Equal(MessageEncoding("latin-1"), c.Encoding)
+				// committer was not at its canonical position
+				// (immediately after author) so it is dropped, matching
+				// upstream's parse_commit_date returning 0 and the
+				// subsequent standard_header_field filter.
+				s.Empty(c.Committer.Name)
+			},
+		},
+		{
+			name: "author out of canonical position is dropped",
+			raw: "tree " + treeA + "\nencoding latin-1\nauthor " + identAuthor +
+				"\ncommitter " + identCommit + "\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal(MessageEncoding("latin-1"), c.Encoding)
+				s.Empty(c.Author.Name)
+				s.Empty(c.Committer.Name)
+			},
+		},
+		{
+			name: "duplicate gpgsig drops the second and its continuations",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\ncommitter " + identCommit +
+				"\ngpgsig firstline\n morefirst\ngpgsig secondline\n moresecond\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal("firstline\nmorefirst\n", c.Signature)
+			},
+		},
+		{
+			name: "duplicate gpgsig-sha256 drops the second and its continuations",
+			raw: "tree " + treeA + "\nauthor " + identAuthor +
+				"\ncommitter " + identCommit +
+				"\ngpgsig-sha256 firstline\n morefirst\ngpgsig-sha256 secondline\n moresecond\n\nmsg\n",
+			assert: func(c *Commit) {
+				s.Equal("firstline\nmorefirst\n", c.SignatureSHA256)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.CommitObject)
+			_, err := obj.Write([]byte(tc.raw))
+			s.NoError(err)
+
+			c := &Commit{}
+			s.Require().NoError(c.Decode(obj))
+			tc.assert(c)
+		})
+	}
+}
+
 func (s *SuiteCommit) TestMalformedHeader() {
 	encoded := &plumbing.MemoryObject{}
 	decoded := &Commit{}

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -575,6 +575,30 @@ func (s *SuiteCommit) TestDecodeRequiresTreeFirst() {
 			name: "empty",
 			raw:  "",
 		},
+		{
+			name: "non-hex tree value",
+			raw:  "tree zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "tree value too short",
+			raw:  "tree abcd\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "tree value too long",
+			raw:  "tree " + validTree + "00\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "tree value missing",
+			raw:  "tree\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "non-hex parent value",
+			raw:  "tree " + validTree + "\nparent zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
+		{
+			name: "parent value too short",
+			raw:  "tree " + validTree + "\nparent abcd\nauthor " + validIdent + "\ncommitter " + validIdent + "\n\nmsg\n",
+		},
 	}
 
 	for _, tc := range cases {

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -100,11 +100,11 @@ func (s *ObjectsSuite) TestParseTree() {
 
 	s.Len(tree.Entries, 8)
 
-	tree.buildMap()
-	s.Len(tree.m, 8)
-	s.Equal(".gitignore", tree.m[".gitignore"].Name)
-	s.Equal(filemode.Regular, tree.m[".gitignore"].Mode)
-	s.Equal("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88", tree.m[".gitignore"].Hash.String())
+	entry, err := tree.entry(".gitignore")
+	s.NoError(err)
+	s.Equal(".gitignore", entry.Name)
+	s.Equal(filemode.Regular, entry.Mode)
+	s.Equal("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88", entry.Hash.String())
 
 	count := 0
 	iter := tree.Files()

--- a/plumbing/object/signature.go
+++ b/plumbing/object/signature.go
@@ -1,6 +1,13 @@
 package object
 
-import "bytes"
+import (
+	"bytes"
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+	"github.com/go-git/go-git/v6/utils/sync"
+)
 
 const (
 	signatureTypeUnknown signatureType = iota
@@ -96,4 +103,96 @@ func parseSignedBytes(b []byte) (int, signatureType) {
 		break
 	}
 	return match, t
+}
+
+// isSignatureHeader reports whether line is a canonical "gpgsig "/
+// "gpgsig-sha256 " header line. Other "gpgsig"-prefixed extra headers
+// are intentionally not matched.
+func isSignatureHeader(line []byte) bool {
+	return bytes.HasPrefix(line, []byte(headerpgp+" ")) ||
+		bytes.HasPrefix(line, []byte(headerpgp256+" "))
+}
+
+// stripObjectSignatures streams src into dst, producing the byte sequence
+// over which a PGP/GPG signature is computed:
+//
+//   - Canonical "gpgsig" and "gpgsig-sha256" headers (and their
+//     continuation lines) are dropped, mirroring upstream's
+//     remove_signature in commit.c.
+//   - For tag objects, the inline trailing PGP signature is additionally
+//     truncated, mirroring upstream's parse_signature in gpg-interface.c
+//     used by gpg_verify_tag.
+//
+// The returned object's type is set to objType. Used by both
+// Commit.EncodeWithoutSignature and Tag.EncodeWithoutSignature to
+// reproduce the exact bytes the signature was computed over.
+func stripObjectSignatures(dst, src plumbing.EncodedObject, objType plumbing.ObjectType) (err error) {
+	dst.SetType(objType)
+
+	r, err := src.Reader()
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(r, &err)
+
+	var input io.Reader = r
+	if objType == plumbing.TagObject {
+		raw, err := io.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		if sm, _ := parseSignedBytes(raw); sm >= 0 {
+			raw = raw[:sm]
+		}
+		input = bytes.NewReader(raw)
+	}
+
+	w, err := dst.Writer()
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(w, &err)
+
+	return stripHeaderSignatures(w, input)
+}
+
+// stripHeaderSignatures copies r to w, dropping canonical signature header
+// lines (gpgsig and gpgsig-sha256) and their continuation lines. Lines
+// past the blank line that closes the header block are copied verbatim.
+func stripHeaderSignatures(w io.Writer, r io.Reader) error {
+	br := sync.GetBufioReader(r)
+	defer sync.PutBufioReader(br)
+
+	var inBody, skipping bool
+	for {
+		line, rerr := br.ReadBytes('\n')
+		if rerr != nil && rerr != io.EOF {
+			return rerr
+		}
+
+		write := true
+		if !inBody {
+			switch {
+			case skipping && len(line) > 0 && line[0] == ' ':
+				write = false
+			case isSignatureHeader(line):
+				skipping = true
+				write = false
+			case len(line) == 1 && line[0] == '\n':
+				skipping = false
+				inBody = true
+			default:
+				skipping = false
+			}
+		}
+
+		if write && len(line) > 0 {
+			if _, werr := w.Write(line); werr != nil {
+				return werr
+			}
+		}
+		if rerr == io.EOF {
+			return nil
+		}
+	}
 }

--- a/plumbing/object/signature.go
+++ b/plumbing/object/signature.go
@@ -105,6 +105,27 @@ func parseSignedBytes(b []byte) (int, signatureType) {
 	return match, t
 }
 
+// countSignatureBlocks reports how many distinct armored signature blocks
+// start at a line boundary in b. Used by verification paths to reject
+// multi-signature payloads, matching upstream's check in gpg-interface.c
+// where parse_gpg_output bails out the first time it sees a second
+// exclusive status line (a second GOODSIG/BADSIG/etc.).
+func countSignatureBlocks(b []byte) int {
+	n, count := 0, 0
+	for n < len(b) {
+		i := b[n:]
+		if typeForSignature(i) != signatureTypeUnknown {
+			count++
+		}
+		if eol := bytes.IndexByte(i, '\n'); eol >= 0 {
+			n += eol + 1
+			continue
+		}
+		break
+	}
+	return count
+}
+
 // isSignatureHeader reports whether line is a canonical "gpgsig "/
 // "gpgsig-sha256 " header line. Other "gpgsig"-prefixed extra headers
 // are intentionally not matched.

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -88,12 +88,18 @@ func (t *Tag) Type() plumbing.ObjectType {
 	return plumbing.TagObject
 }
 
+func (t *Tag) reset() {
+	storer := t.s
+	*t = Tag{s: storer}
+}
+
 // Decode transforms a plumbing.EncodedObject into a Tag struct.
 func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	if o.Type() != plumbing.TagObject {
 		return ErrUnsupportedObject
 	}
 
+	t.reset()
 	t.Hash = o.Hash()
 	t.src = o
 
@@ -186,13 +192,23 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	defer ioutil.CheckClose(w, &err)
 
 	if _, err = fmt.Fprintf(w,
-		"object %s\ntype %s\ntag %s\ntagger ",
+		"object %s\ntype %s\ntag %s\n",
 		t.Target.String(), t.TargetType.Bytes(), t.Name); err != nil {
 		return err
 	}
 
-	if err = t.Tagger.Encode(w); err != nil {
-		return err
+	if !isZeroSignature(t.Tagger) {
+		if _, err = fmt.Fprint(w, "tagger "); err != nil {
+			return err
+		}
+
+		if err = t.Tagger.Encode(w); err != nil {
+			return err
+		}
+
+		if _, err = fmt.Fprint(w, "\n"); err != nil {
+			return err
+		}
 	}
 
 	// gpgsig-sha256 is emitted between the tagger line and the blank line
@@ -200,7 +216,7 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	// add_header_signature insertion point (commit.c:1142-1171), which
 	// builtin/tag.c:do_sign reuses when signing tags in compat mode.
 	if t.SignatureSHA256 != "" && includeSig {
-		if _, err = fmt.Fprint(w, "\n"+headerpgp256+" "); err != nil {
+		if _, err = fmt.Fprint(w, headerpgp256+" "); err != nil {
 			return err
 		}
 		sig := strings.TrimSuffix(t.SignatureSHA256, "\n")
@@ -208,9 +224,12 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		if _, err = fmt.Fprint(w, strings.Join(lines, "\n ")); err != nil {
 			return err
 		}
+		if _, err = fmt.Fprint(w, "\n"); err != nil {
+			return err
+		}
 	}
 
-	if _, err = fmt.Fprint(w, "\n\n"); err != nil {
+	if _, err = fmt.Fprint(w, "\n"); err != nil {
 		return err
 	}
 
@@ -231,6 +250,10 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	}
 
 	return err
+}
+
+func isZeroSignature(s Signature) bool {
+	return s.Name == "" && s.Email == "" && s.When.IsZero()
 }
 
 // Commit returns the commit pointed to by the tag. If the tag points to a

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,6 +12,10 @@ import (
 	"github.com/go-git/go-git/v6/utils/ioutil"
 	"github.com/go-git/go-git/v6/utils/sync"
 )
+
+// ErrMalformedTag is returned when a tag object cannot be decoded because
+// its required headers (object, type, tag) are missing or out of order.
+var ErrMalformedTag = errors.New("malformed tag")
 
 // Tag represents an annotated tag object. It points to a single git object of
 // any type, but tags typically are applied to commit or blob objects. It

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -1,9 +1,7 @@
 package object
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -103,66 +101,15 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
-	// pgpsig256 is true while we're inside a multi-line "gpgsig-sha256"
-	// header, so continuation lines (those starting with a space) get
-	// appended to SignatureSHA256 instead of being parsed as separate
-	// headers.
-	var pgpsig256 bool
-
-	for {
-		var line []byte
-		line, err = r.ReadBytes('\n')
-		if err != nil && err != io.EOF {
+	s := &tagScanner{r: r, t: t}
+	for state := scanTagObject; state != nil; {
+		state, err = state(s)
+		if err != nil {
 			return err
 		}
-
-		if pgpsig256 {
-			if len(line) > 0 && line[0] == ' ' {
-				t.SignatureSHA256 += string(line[1:])
-				if err == io.EOF {
-					return nil
-				}
-				continue
-			}
-			pgpsig256 = false
-		}
-
-		line = bytes.TrimSpace(line)
-		if len(line) == 0 {
-			break // Start of message
-		}
-
-		split := bytes.SplitN(line, []byte{' '}, 2)
-		var value []byte
-		if len(split) == 2 {
-			value = split[1]
-		}
-		switch string(split[0]) {
-		case "object":
-			t.Target = plumbing.NewHash(string(value))
-		case "type":
-			t.TargetType, err = plumbing.ParseObjectType(string(value))
-			if err != nil {
-				return err
-			}
-		case "tag":
-			t.Name = string(value)
-		case "tagger":
-			t.Tagger.Decode(value)
-		case headerpgp256:
-			t.SignatureSHA256 += string(value) + "\n"
-			pgpsig256 = true
-		}
-
-		if err == io.EOF {
-			return nil
-		}
 	}
 
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
+	data := s.msgbuf.Bytes()
 	if sm, _ := parseSignedBytes(data); sm >= 0 {
 		t.Signature = string(data[sm:])
 		data = data[:sm]

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -44,6 +44,9 @@ type Tag struct {
 	Target plumbing.Hash
 
 	s storer.EncodedObjectStorer
+	// src holds the encoded object this Tag was decoded from, used by
+	// EncodeWithoutSignature to recover the canonical signed bytes.
+	src plumbing.EncodedObject
 }
 
 // GetTag gets a tag from an object storer and decodes it.
@@ -89,6 +92,7 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	}
 
 	t.Hash = o.Hash()
+	t.src = o
 
 	reader, err := o.Reader()
 	if err != nil {
@@ -173,9 +177,52 @@ func (t *Tag) Encode(o plumbing.EncodedObject) error {
 	return t.encode(o, true)
 }
 
-// EncodeWithoutSignature export a Tag into a plumbing.EncodedObject without the signature (correspond to the payload of the PGP signature).
+// EncodeWithoutSignature exports a Tag into a plumbing.EncodedObject without
+// any signature data, producing the payload that PGP/GPG signatures are
+// computed over.
+//
+// Behaviour mirrors Commit.EncodeWithoutSignature:
+//
+//   - For Tags populated by Decode whose exported fields still match the
+//     source object, the payload is streamed from the raw source bytes with
+//     the inline trailing signature truncated and gpgsig/gpgsig-sha256
+//     headers (and their continuation lines) stripped verbatim. This
+//     preserves the exact bytes the signature was computed over, regardless
+//     of any normalization performed by Decode.
+//
+//   - For Tags constructed in memory, or for decoded Tags whose exported
+//     fields have been mutated, the payload is derived from the current
+//     struct fields. Mutation is detected by re-decoding the source object
+//     and comparing exported fields; if any differ, the in-memory
+//     representation prevails.
 func (t *Tag) EncodeWithoutSignature(o plumbing.EncodedObject) error {
+	if t.matchesSource() {
+		return stripObjectSignatures(o, t.src, plumbing.TagObject)
+	}
 	return t.encode(o, false)
+}
+
+// matchesSource reports whether t.src is set and re-decoding it produces a
+// Tag whose payload-affecting exported fields are identical to those of t.
+//
+// Signature and SignatureSHA256 are intentionally excluded from the
+// comparison: neither path emits them as part of the verification payload,
+// so mutating them must not trigger a switch to struct-encode (which would
+// change the byte layout the caller is trying to verify against).
+func (t *Tag) matchesSource() bool {
+	if t.src == nil {
+		return false
+	}
+	fresh := &Tag{}
+	if err := fresh.Decode(t.src); err != nil {
+		return false
+	}
+	return t.Hash == fresh.Hash &&
+		t.Name == fresh.Name &&
+		signatureEqual(t.Tagger, fresh.Tagger) &&
+		t.Message == fresh.Message &&
+		t.TargetType == fresh.TargetType &&
+		t.Target == fresh.Target
 }
 
 func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -32,8 +32,12 @@ type Tag struct {
 	Tagger Signature
 	// Message is an arbitrary text message.
 	Message string
-	// Signature is the cryptographic signature of the tag (e.g. SSH, X.509).
+	// Signature is the cryptographic signature appended after the message
+	// body. This is the canonical tag signature in upstream Git.
 	Signature string
+	// SignatureSHA256 is the cryptographic signature stored under the
+	// "gpgsig-sha256" header.
+	SignatureSHA256 string
 	// TargetType is the object type of the target.
 	TargetType plumbing.ObjectType
 	// Target is the hash of the target object.
@@ -95,11 +99,28 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
+	// pgpsig256 is true while we're inside a multi-line "gpgsig-sha256"
+	// header, so continuation lines (those starting with a space) get
+	// appended to SignatureSHA256 instead of being parsed as separate
+	// headers.
+	var pgpsig256 bool
+
 	for {
 		var line []byte
 		line, err = r.ReadBytes('\n')
 		if err != nil && err != io.EOF {
 			return err
+		}
+
+		if pgpsig256 {
+			if len(line) > 0 && line[0] == ' ' {
+				t.SignatureSHA256 += string(line[1:])
+				if err == io.EOF {
+					return nil
+				}
+				continue
+			}
+			pgpsig256 = false
 		}
 
 		line = bytes.TrimSpace(line)
@@ -108,18 +129,25 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 		}
 
 		split := bytes.SplitN(line, []byte{' '}, 2)
+		var value []byte
+		if len(split) == 2 {
+			value = split[1]
+		}
 		switch string(split[0]) {
 		case "object":
-			t.Target = plumbing.NewHash(string(split[1]))
+			t.Target = plumbing.NewHash(string(value))
 		case "type":
-			t.TargetType, err = plumbing.ParseObjectType(string(split[1]))
+			t.TargetType, err = plumbing.ParseObjectType(string(value))
 			if err != nil {
 				return err
 			}
 		case "tag":
-			t.Name = string(split[1])
+			t.Name = string(value)
 		case "tagger":
-			t.Tagger.Decode(split[1])
+			t.Tagger.Decode(value)
+		case headerpgp256:
+			t.SignatureSHA256 += string(value) + "\n"
+			pgpsig256 = true
 		}
 
 		if err == io.EOF {
@@ -168,6 +196,21 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
+	// gpgsig-sha256 is emitted between the tagger line and the blank line
+	// that separates headers from the body, matching upstream's
+	// add_header_signature insertion point (commit.c:1142-1171), which
+	// builtin/tag.c:do_sign reuses when signing tags in compat mode.
+	if t.SignatureSHA256 != "" && includeSig {
+		if _, err = fmt.Fprint(w, "\n"+headerpgp256+" "); err != nil {
+			return err
+		}
+		sig := strings.TrimSuffix(t.SignatureSHA256, "\n")
+		lines := strings.Split(sig, "\n")
+		if _, err = fmt.Fprint(w, strings.Join(lines, "\n ")); err != nil {
+			return err
+		}
+	}
+
 	if _, err = fmt.Fprint(w, "\n\n"); err != nil {
 		return err
 	}
@@ -176,11 +219,12 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
-	// Note that this is highly sensitive to what it sent along in the message.
-	// Message *always* needs to end with a newline, or else the message and the
-	// signature will be concatenated into a corrupt object. Since this is a
-	// lower-level method, we assume you know what you are doing and have already
-	// done the needful on the message in the caller.
+	// Note that this is highly sensitive to what is sent along in the
+	// message. Message *always* needs to end with a newline, or else the
+	// message and the trailing signature will be concatenated into a
+	// corrupt object. Since this is a lower-level method, we assume you
+	// know what you are doing and have already done the needful on the
+	// message in the caller.
 	if includeSig {
 		if _, err = fmt.Fprint(w, t.Signature); err != nil {
 			return err
@@ -257,7 +301,8 @@ func (t *Tag) String() string {
 }
 
 // Verify performs PGP verification of the tag with a provided armored
-// keyring and returns openpgp.Entity associated with verifying key on success.
+// keyring and returns openpgp.Entity associated with verifying key on
+// success.
 func (t *Tag) Verify(armoredKeyRing string) (*openpgp.Entity, error) {
 	keyRingReader := strings.NewReader(armoredKeyRing)
 	keyring, err := openpgp.ReadArmoredKeyRing(keyRingReader)

--- a/plumbing/object/tag_scanner.go
+++ b/plumbing/object/tag_scanner.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -59,91 +60,81 @@ func (s *tagScanner) pushBack(line []byte, err error) {
 	s.pendingErr = err
 }
 
-// scanTagObject expects the first non-empty header to be `object HASH`.
-// Anything else falls through to scanTagType so out-of-position canonical
-// fields are silently dropped (matching the existing decoder's
-// best-effort behaviour).
+// scanTagObject requires the first line to be `object HASH`, mirroring
+// upstream's strict parse_tag_buffer (tag.c:151-156). Anything else
+// returns ErrMalformedTag.
 func scanTagObject(s *tagScanner) (tagState, error) {
 	line, err := s.readLine()
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	if len(line) == 0 {
-		return nil, nil
-	}
-	if isBlankLine(line) {
-		return scanTagMessage, nil
+	if len(line) == 0 || isBlankLine(line) {
+		return nil, fmt.Errorf("%w: missing object header", ErrMalformedTag)
 	}
 
 	key, data := splitHeader(line)
-	if key == "object" {
-		s.t.Target = plumbing.NewHash(string(data))
-		s.sawObject = true
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanTagType, nil
+	if key != "object" {
+		return nil, fmt.Errorf("%w: object header must be first", ErrMalformedTag)
 	}
-	s.pushBack(line, err)
+	h, herr := parseObjectIDHex(data, ErrMalformedTag, "object")
+	if herr != nil {
+		return nil, herr
+	}
+	s.t.Target = h
+	s.sawObject = true
+	if err == io.EOF {
+		return nil, nil
+	}
 	return scanTagType, nil
 }
 
-// scanTagType accepts a `type` line at its canonical position
-// immediately after the object header. Any other header is pushed back
-// for scanTagName.
+// scanTagType requires a `type` line immediately after the object header,
+// mirroring upstream's parse_tag_buffer (tag.c:158-166).
 func scanTagType(s *tagScanner) (tagState, error) {
 	line, err := s.readLine()
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	if len(line) == 0 {
-		return nil, nil
-	}
-	if isBlankLine(line) {
-		return scanTagMessage, nil
+	if len(line) == 0 || isBlankLine(line) {
+		return nil, fmt.Errorf("%w: missing type header", ErrMalformedTag)
 	}
 
 	key, data := splitHeader(line)
-	if key == "type" {
-		ot, perr := plumbing.ParseObjectType(string(data))
-		if perr != nil {
-			return nil, perr
-		}
-		s.t.TargetType = ot
-		s.sawType = true
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanTagName, nil
+	if key != "type" {
+		return nil, fmt.Errorf("%w: type header must follow object", ErrMalformedTag)
 	}
-	s.pushBack(line, err)
+	ot, perr := plumbing.ParseObjectType(string(data))
+	if perr != nil {
+		return nil, perr
+	}
+	s.t.TargetType = ot
+	s.sawType = true
+	if err == io.EOF {
+		return nil, nil
+	}
 	return scanTagName, nil
 }
 
-// scanTagName accepts a `tag` line at its canonical position. Any other
-// header is pushed back for scanTagTagger.
+// scanTagName requires a `tag` line immediately after the type header,
+// mirroring upstream's parse_tag_buffer (tag.c:186-194).
 func scanTagName(s *tagScanner) (tagState, error) {
 	line, err := s.readLine()
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	if len(line) == 0 {
-		return nil, nil
-	}
-	if isBlankLine(line) {
-		return scanTagMessage, nil
+	if len(line) == 0 || isBlankLine(line) {
+		return nil, fmt.Errorf("%w: missing tag header", ErrMalformedTag)
 	}
 
 	key, data := splitHeader(line)
-	if key == "tag" {
-		s.t.Name = string(data)
-		s.sawName = true
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanTagTagger, nil
+	if key != "tag" {
+		return nil, fmt.Errorf("%w: tag header must follow type", ErrMalformedTag)
 	}
-	s.pushBack(line, err)
+	s.t.Name = string(data)
+	s.sawName = true
+	if err == io.EOF {
+		return nil, nil
+	}
 	return scanTagTagger, nil
 }
 

--- a/plumbing/object/tag_scanner.go
+++ b/plumbing/object/tag_scanner.go
@@ -1,0 +1,252 @@
+package object
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// tagScanner holds the working state of the tag decoder driven by the
+// stateFn loop in (*Tag).Decode. Each tagState reads one or more lines
+// from r, updates the in-progress *Tag and the scanner's bookkeeping,
+// and returns the state that should run next (or nil to stop).
+type tagScanner struct {
+	r      *bufio.Reader
+	t      *Tag
+	msgbuf bytes.Buffer
+
+	// pending holds a line that was read but the current state decided to
+	// hand back to the next state, paired with the io.EOF flag returned
+	// when the line was originally read.
+	pending    []byte
+	pendingErr error
+
+	// First-occurrence tracking — once the corresponding canonical
+	// header has been decoded at its expected position, subsequent
+	// occurrences (or out-of-position lines) are silently dropped,
+	// matching the strict layout enforced by upstream's
+	// parse_tag_buffer (tag.c:130).
+	//
+	// gpgsig-sha256 is NOT tracked here: upstream's
+	// parse_buffer_signed_by_header (commit.c:1186) accumulates every
+	// occurrence into one signature buffer, so we do the same.
+	sawObject, sawType, sawName, sawTagger bool
+}
+
+// tagState is one step of the decoder state machine. Each function reads
+// the lines it needs, mutates *Tag via s.t, and returns the next state
+// to run (or nil to terminate the loop).
+type tagState func(*tagScanner) (tagState, error)
+
+// readLine returns the next line from the buffer, transparently
+// consuming any line that was previously pushed back by a state that
+// decided not to handle it.
+func (s *tagScanner) readLine() ([]byte, error) {
+	if s.pending != nil {
+		line, err := s.pending, s.pendingErr
+		s.pending, s.pendingErr = nil, nil
+		return line, err
+	}
+	return s.r.ReadBytes('\n')
+}
+
+// pushBack stashes an unconsumed line so the next state's readLine call
+// sees it. Only one line can be pushed back at a time.
+func (s *tagScanner) pushBack(line []byte, err error) {
+	s.pending = line
+	s.pendingErr = err
+}
+
+// scanTagObject expects the first non-empty header to be `object HASH`.
+// Anything else falls through to scanTagType so out-of-position canonical
+// fields are silently dropped (matching the existing decoder's
+// best-effort behaviour).
+func scanTagObject(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "object" {
+		s.t.Target = plumbing.NewHash(string(data))
+		s.sawObject = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagType, nil
+	}
+	s.pushBack(line, err)
+	return scanTagType, nil
+}
+
+// scanTagType accepts a `type` line at its canonical position
+// immediately after the object header. Any other header is pushed back
+// for scanTagName.
+func scanTagType(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "type" {
+		ot, perr := plumbing.ParseObjectType(string(data))
+		if perr != nil {
+			return nil, perr
+		}
+		s.t.TargetType = ot
+		s.sawType = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagName, nil
+	}
+	s.pushBack(line, err)
+	return scanTagName, nil
+}
+
+// scanTagName accepts a `tag` line at its canonical position. Any other
+// header is pushed back for scanTagTagger.
+func scanTagName(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "tag" {
+		s.t.Name = string(data)
+		s.sawName = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagTagger, nil
+	}
+	s.pushBack(line, err)
+	return scanTagTagger, nil
+}
+
+// scanTagTagger accepts a `tagger` line at its canonical position. Any
+// other header is pushed back for scanTagHeaders.
+func scanTagTagger(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	if key == "tagger" {
+		s.t.Tagger.Decode(data)
+		s.sawTagger = true
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagHeaders, nil
+	}
+	s.pushBack(line, err)
+	return scanTagHeaders, nil
+}
+
+// scanTagHeaders dispatches one header line. gpgsig-sha256 hands off to
+// scanTagPgp256Cont so the continuation block can be consumed; out-of-
+// canonical-position fields and unknown headers are silently dropped.
+func scanTagHeaders(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) == 0 {
+		return nil, nil
+	}
+	if isBlankLine(line) {
+		return scanTagMessage, nil
+	}
+
+	key, data := splitHeader(line)
+	next := scanTagHeaders
+	switch key {
+	case "object", "type", "tag", "tagger":
+		// Out-of-canonical-position duplicates are dropped, mirroring the
+		// strict ordering of upstream's parse_tag_buffer.
+	case headerpgp256:
+		s.t.SignatureSHA256 += string(data) + "\n"
+		next = scanTagPgp256Cont
+	default:
+		// Unknown header — silently dropped (the Tag struct does not
+		// expose ExtraHeaders).
+	}
+
+	if err == io.EOF {
+		return nil, nil
+	}
+	return next, nil
+}
+
+// scanTagPgp256Cont accumulates continuation lines for the gpgsig-sha256
+// header. Continuations strip exactly one leading space, mirroring
+// upstream's `line + 1` (commit.c:1509). The first non-continuation line
+// is pushed back so scanTagHeaders can dispatch it — repeat occurrences
+// of the same header land back here and concatenate, matching upstream's
+// parse_buffer_signed_by_header (commit.c:1186).
+func scanTagPgp256Cont(s *tagScanner) (tagState, error) {
+	line, err := s.readLine()
+	if err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(line) > 0 && line[0] == ' ' {
+		s.t.SignatureSHA256 += string(line[1:])
+		if err == io.EOF {
+			return nil, nil
+		}
+		return scanTagPgp256Cont, nil
+	}
+	if len(line) > 0 {
+		s.pushBack(line, err)
+	}
+	return scanTagHeaders, nil
+}
+
+// scanTagMessage drains the remaining bytes into the message buffer.
+// (*Tag).Decode then runs parseSignedBytes over those bytes to peel off
+// the optional inline trailing PGP signature.
+func scanTagMessage(s *tagScanner) (tagState, error) {
+	for {
+		line, err := s.readLine()
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+		if len(line) > 0 {
+			s.msgbuf.Write(line)
+		}
+		if err == io.EOF {
+			return nil, nil
+		}
+	}
+}

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -199,6 +199,37 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent() {
 			TargetType: plumbing.BlobObject,
 			Target:     plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
 		},
+		{
+			Name:       "signed",
+			Tagger:     Signature{Name: "Foo", Email: "foo@example.local", When: ts},
+			Message:    "Signed tag\n",
+			TargetType: plumbing.CommitObject,
+			Target:     plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45e"),
+			Signature: "-----BEGIN PGP SIGNATURE-----\n" +
+				"\n" +
+				"inlineSig=\n" +
+				"-----END PGP SIGNATURE-----\n",
+		},
+		{
+			// Compat mode in a SHA-1 primary repo: the SHA-256 sig is
+			// embedded as a "gpgsig-sha256" header, and the SHA-1 sig
+			// is appended inline. Mirrors the primary buffer produced
+			// by builtin/tag.c:do_sign.
+			Name:       "compat-primary-sha1",
+			Tagger:     Signature{Name: "Foo", Email: "foo@example.local", When: ts},
+			Message:    "Compat-mode tag, primary SHA-1\n",
+			TargetType: plumbing.CommitObject,
+			Target:     plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45e"),
+			SignatureSHA256: "-----BEGIN PGP SIGNATURE-----\n" +
+				"\n" +
+				"sha256line1\n" +
+				"sha256line2\n" +
+				"-----END PGP SIGNATURE-----\n",
+			Signature: "-----BEGIN PGP SIGNATURE-----\n" +
+				"\n" +
+				"inlineSHA1=\n" +
+				"-----END PGP SIGNATURE-----\n",
+		},
 	}
 	for _, tag := range tags {
 		obj := &plumbing.MemoryObject{}
@@ -209,6 +240,92 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent() {
 		s.NoError(err)
 		tag.Hash = obj.Hash()
 		s.Equal(tag, newTag)
+	}
+}
+
+func (s *TagSuite) TestTagDecodeRoundTrip() {
+	const (
+		target  = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
+		tagger  = "Foo <foo@example.local> 1500000000 +0000"
+		sha256B = "-----BEGIN PGP SIGNATURE-----\n\nsha256line1\nsha256line2\n-----END PGP SIGNATURE-----\n"
+		inlineB = "-----BEGIN PGP SIGNATURE-----\n\ninlineline1\ninlineline2\n-----END PGP SIGNATURE-----\n"
+	)
+	headers := "object " + target + "\ntype commit\ntag t\ntagger " + tagger + "\n"
+	sha256Block := "gpgsig-sha256 -----BEGIN PGP SIGNATURE-----\n" +
+		" \n" +
+		" sha256line1\n" +
+		" sha256line2\n" +
+		" -----END PGP SIGNATURE-----\n"
+
+	tests := []struct {
+		name   string
+		raw    string
+		assert func(*Tag)
+	}{
+		{
+			name: "no signature",
+			raw:  headers + "\nplain tag message\n",
+			assert: func(t *Tag) {
+				s.Empty(t.Signature)
+				s.Empty(t.SignatureSHA256)
+				s.Equal("plain tag message\n", t.Message)
+			},
+		},
+		{
+			name: "inline trailing PGP signature",
+			raw:  headers + "\nTag body\n" + inlineB,
+			assert: func(t *Tag) {
+				s.Equal("Tag body\n", t.Message)
+				s.Equal(inlineB, t.Signature)
+				s.Empty(t.SignatureSHA256)
+			},
+		},
+		{
+			// Synthetic: upstream's do_sign always pairs the
+			// gpgsig-sha256 header with an inline trailing
+			// signature. Kept here to confirm the decoder/encoder
+			// don't depend on the trailer being present.
+			name: "gpgsig-sha256 header only (synthetic, no inline trailer)",
+			raw:  headers + sha256Block + "\nTag body, header sig only\n",
+			assert: func(t *Tag) {
+				s.Equal("Tag body, header sig only\n", t.Message)
+				s.Equal(sha256B, t.SignatureSHA256)
+				s.Empty(t.Signature)
+			},
+		},
+		{
+			// Real compat-mode layout for a SHA-1 primary repo: the
+			// SHA-256 sig is embedded as a "gpgsig-sha256" header,
+			// and the SHA-1 sig is appended inline.
+			name: "compat-mode, primary SHA-1 (gpgsig-sha256 header + inline trailer)",
+			raw:  headers + sha256Block + "\nDual-signed tag body\n" + inlineB,
+			assert: func(t *Tag) {
+				s.Equal("Dual-signed tag body\n", t.Message)
+				s.Equal(sha256B, t.SignatureSHA256)
+				s.Equal(inlineB, t.Signature)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.TagObject)
+			_, err := obj.Write([]byte(tc.raw))
+			s.NoError(err)
+
+			tag := &Tag{}
+			s.Require().NoError(tag.Decode(obj))
+			tc.assert(tag)
+
+			encoded := &plumbing.MemoryObject{}
+			s.NoError(tag.Encode(encoded))
+			er, err := encoded.Reader()
+			s.NoError(err)
+			roundTripped, err := io.ReadAll(er)
+			s.NoError(err)
+			s.Equal(tc.raw, string(roundTripped))
+		})
 	}
 }
 

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -244,6 +244,74 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent() {
 	}
 }
 
+func (s *TagSuite) TestTagEncodeOmitsZeroTagger() {
+	const raw = "object c029517f6300c2da0f4b651b8642506cd6aaf45e\n" +
+		"type commit\n" +
+		"tag v1\n" +
+		"\n" +
+		"msg\n"
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TagObject)
+	_, err := obj.Write([]byte(raw))
+	s.NoError(err)
+
+	tag := &Tag{}
+	s.NoError(tag.Decode(obj))
+	s.Equal(Signature{}, tag.Tagger)
+
+	encoded := &plumbing.MemoryObject{}
+	s.NoError(tag.Encode(encoded))
+
+	r, err := encoded.Reader()
+	s.NoError(err)
+	defer r.Close()
+
+	body, err := io.ReadAll(r)
+	s.NoError(err)
+	s.Equal(raw, string(body))
+}
+
+func (s *TagSuite) TestTagDecodeClearsExistingState() {
+	const raw = "object c029517f6300c2da0f4b651b8642506cd6aaf45e\n" +
+		"type commit\n" +
+		"tag fresh\n" +
+		"\n" +
+		"fresh message\n"
+
+	store := memory.NewStorage()
+	staleSrc := &plumbing.MemoryObject{}
+	tag := &Tag{
+		Hash:            plumbing.NewHash("1111111111111111111111111111111111111111"),
+		Name:            "stale",
+		Tagger:          Signature{Name: "Stale", Email: "stale@example.local", When: time.Unix(1, 0).UTC()},
+		Message:         "stale message",
+		Signature:       "stale signature",
+		SignatureSHA256: "stale sha256 signature",
+		TargetType:      plumbing.BlobObject,
+		Target:          plumbing.NewHash("2222222222222222222222222222222222222222"),
+		s:               store,
+		src:             staleSrc,
+	}
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TagObject)
+	_, err := obj.Write([]byte(raw))
+	s.NoError(err)
+
+	s.NoError(tag.Decode(obj))
+	s.Equal(obj.Hash(), tag.Hash)
+	s.Equal("fresh", tag.Name)
+	s.Equal(Signature{}, tag.Tagger)
+	s.Equal("fresh message\n", tag.Message)
+	s.Equal("", tag.Signature)
+	s.Equal("", tag.SignatureSHA256)
+	s.Equal(plumbing.CommitObject, tag.TargetType)
+	s.Equal("c029517f6300c2da0f4b651b8642506cd6aaf45e", tag.Target.String())
+	s.Equal(store, tag.s)
+	s.Equal(obj, tag.src)
+}
+
 func (s *TagSuite) TestTagDecodeRoundTrip() {
 	const (
 		target  = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
@@ -608,6 +676,7 @@ func (s *TagSuite) TestStringNonCommit() {
 	tag := &Tag{
 		Target:     targetObj.Hash(),
 		Name:       "TAG TWO",
+		Tagger:     Signature{Name: "Test Tagger", Email: "tagger@example.local", When: time.Unix(0, 0).UTC()},
 		Message:    "tag two",
 		TargetType: plumbing.TagObject,
 	}
@@ -621,7 +690,7 @@ func (s *TagSuite) TestStringNonCommit() {
 
 	s.Equal(
 		"tag TAG TWO\n"+
-			"Tagger:  <>\n"+
+			"Tagger: Test Tagger <tagger@example.local>\n"+
 			"Date:   Thu Jan 01 00:00:00 1970 +0000\n"+
 			"\n"+
 			"tag two\n",

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -355,10 +355,88 @@ func (s *TagSuite) TestTagDecodeRoundTrip() {
 	}
 }
 
+func (s *TagSuite) TestDecodeRequiresHeaders() {
+	const (
+		target = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
+		tagger = "Foo <foo@example.local> 1500000000 +0000"
+	)
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "empty",
+			raw:  "",
+		},
+		{
+			name: "missing object",
+			raw:  "type commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "object out of canonical position",
+			raw:  "type commit\nobject " + target + "\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "missing type",
+			raw:  "object " + target + "\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "missing tag",
+			raw:  "object " + target + "\ntype commit\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "duplicate object before type",
+			raw: "object " + target + "\nobject " + target +
+				"\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "duplicate type before tag",
+			raw: "object " + target + "\ntype commit\ntype blob" +
+				"\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "truncated after object header",
+			raw:  "object " + target + "\n",
+		},
+		{
+			name: "truncated after type header",
+			raw:  "object " + target + "\ntype commit\n",
+		},
+		{
+			name: "non-hex object value",
+			raw:  "object zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "object value too short",
+			raw:  "object abcd\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "object value too long",
+			raw:  "object " + target + "00\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+		{
+			name: "object value missing",
+			raw:  "object\ntype commit\ntag v1\ntagger " + tagger + "\n\nmsg\n",
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.TagObject)
+			_, err := obj.Write([]byte(tc.raw))
+			s.NoError(err)
+
+			err = (&Tag{}).Decode(obj)
+			s.ErrorIs(err, ErrMalformedTag)
+		})
+	}
+}
+
 func (s *TagSuite) TestDecodeFirstOccurrenceWins() {
 	const (
 		targetA   = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
-		targetB   = "0000000000000000000000000000000000000001"
 		taggerA   = "Alice <alice@example.local> 1500000000 +0000"
 		taggerB   = "Bob <bob@example.local> 1500000001 +0000"
 		canonical = "object " + targetA +
@@ -370,22 +448,6 @@ func (s *TagSuite) TestDecodeFirstOccurrenceWins() {
 		raw    string
 		assert func(*Tag)
 	}{
-		{
-			name: "duplicate object drops the second",
-			raw: "object " + targetA + "\nobject " + targetB +
-				"\ntype commit\ntag v1\ntagger " + taggerA + "\n\nmsg\n",
-			assert: func(t *Tag) {
-				s.Equal(targetA, t.Target.String())
-			},
-		},
-		{
-			name: "duplicate type drops the second",
-			raw: "object " + targetA + "\ntype commit\ntype blob" +
-				"\ntag v1\ntagger " + taggerA + "\n\nmsg\n",
-			assert: func(t *Tag) {
-				s.Equal(plumbing.CommitObject, t.TargetType)
-			},
-		},
 		{
 			name: "duplicate tag drops the second",
 			raw: "object " + targetA + "\ntype commit\ntag v1\ntag v1-override" +
@@ -400,26 +462,6 @@ func (s *TagSuite) TestDecodeFirstOccurrenceWins() {
 				"\ntagger " + taggerB + "\n\nmsg\n",
 			assert: func(t *Tag) {
 				s.Equal("Alice", t.Tagger.Name)
-			},
-		},
-		{
-			name: "type at slot 1: type captured, misplaced object dropped",
-			raw: "type commit\nobject " + targetA + "\ntag v1\ntagger " + taggerA +
-				"\n\nmsg\n",
-			assert: func(t *Tag) {
-				s.Equal(plumbing.CommitObject, t.TargetType)
-				s.True(t.Target.IsZero())
-				s.Empty(t.Name)
-				s.Empty(t.Tagger.Name)
-			},
-		},
-		{
-			name: "tagger at slot 4: tagger captured, misplaced tag dropped",
-			raw: "object " + targetA + "\ntype commit\ntagger " + taggerA +
-				"\ntag v1\n\nmsg\n",
-			assert: func(t *Tag) {
-				s.Equal("Alice", t.Tagger.Name)
-				s.Empty(t.Name)
 			},
 		},
 		{
@@ -467,17 +509,6 @@ func (s *TagSuite) TestDecodeFirstOccurrenceWins() {
 				s.Equal("msg\n", t.Message)
 				s.Empty(t.Signature)
 				s.Empty(t.SignatureSHA256)
-			},
-		},
-		{
-			name: "truncated after object header",
-			raw:  "object " + targetA + "\n",
-			assert: func(t *Tag) {
-				s.Equal(targetA, t.Target.String())
-				s.Equal(plumbing.InvalidObject, t.TargetType)
-				s.Empty(t.Name)
-				s.Empty(t.Tagger.Name)
-				s.Empty(t.Message)
 			},
 		},
 		{
@@ -902,32 +933,6 @@ tag message
 				t.SignatureSHA256 = "different sha256 sig"
 			},
 			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
-type commit
-tag v1
-tagger Test Tagger <tagger@example.local> 1700000000 +0000
-
-tag message
-`,
-		},
-		{
-			// Duplicates are preserved verbatim by the raw path: if
-			// the decoded struct still matches the source after
-			// re-decoding, the original bytes are streamed through
-			// (with only the canonical signature data stripped).
-			name: "duplicate-object preserved on raw path",
-			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
-object 4444444444444444444444444444444444444444
-type commit
-tag v1
-tagger Test Tagger <tagger@example.local> 1700000000 +0000
-
-tag message
------BEGIN PGP SIGNATURE-----
-inlineline1
------END PGP SIGNATURE-----
-`,
-			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
-object 4444444444444444444444444444444444444444
 type commit
 tag v1
 tagger Test Tagger <tagger@example.local> 1700000000 +0000

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -239,6 +239,7 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent() {
 		err = newTag.Decode(obj)
 		s.NoError(err)
 		tag.Hash = obj.Hash()
+		tag.src = obj
 		s.Equal(tag, newTag)
 	}
 }
@@ -586,23 +587,228 @@ eQnkGpsz85DfEviLtk8cZjY/t6o8lPDLiwVjIzUBaA==
 }
 
 func (s *TagSuite) TestEncodeWithoutSignature() {
-	// Similar to TestString since no signature
-	encoded := &plumbing.MemoryObject{}
-	tag := s.tag(plumbing.NewHash("b742a2a9fa0afcfa9a6fad080980fbc26b007c69"))
-	err := tag.EncodeWithoutSignature(encoded)
-	s.NoError(err)
-	er, err := encoded.Reader()
-	s.NoError(err)
-	payload, err := io.ReadAll(er)
-	s.NoError(err)
+	tests := []struct {
+		name     string
+		tagRaw   string
+		mutate   func(*Tag)
+		expected string
+	}{
+		{
+			name: "tag without signature",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
 
-	s.Equal(""+
-		"object f7b877701fbf855b44c0a9e86f3fdce2c298b07f\n"+
-		"type commit\n"+
-		"tag annotated-tag\n"+
-		"tagger Máximo Cuadros <mcuadros@gmail.com> 1474485215 +0200\n"+
-		"\n"+
-		"example annotated tag\n",
-		string(payload),
-	)
+plain tag message
+`,
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+plain tag message
+`,
+		},
+		{
+			name: "gpgsig-sha256 header",
+			tagRaw: "object 1eca38290a3131d0c90709496a9b2207a872631e\n" +
+				"type commit\n" +
+				"tag v1\n" +
+				"tagger Test Tagger <tagger@example.local> 1700000000 +0000\n" +
+				"gpgsig-sha256 -----BEGIN PGP SIGNATURE-----\n" +
+				" \n" +
+				" sha256line1\n" +
+				" sha256line2\n" +
+				" -----END PGP SIGNATURE-----\n" +
+				"\n" +
+				"tag message\n",
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			name: "inline trailing signature",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+-----BEGIN PGP SIGNATURE-----
+
+inlineline1
+inlineline2
+-----END PGP SIGNATURE-----
+`,
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			// Compat-mode primary SHA-1 layout: gpgsig-sha256 header
+			// (SHA-256 sig) plus inline trailing PGP block (SHA-1 sig).
+			// Both are stripped to produce the verification payload.
+			name: "gpgsig-sha256 + inline trailing",
+			tagRaw: "object 1eca38290a3131d0c90709496a9b2207a872631e\n" +
+				"type commit\n" +
+				"tag v1\n" +
+				"tagger Test Tagger <tagger@example.local> 1700000000 +0000\n" +
+				"gpgsig-sha256 -----BEGIN PGP SIGNATURE-----\n" +
+				" \n" +
+				" sha256line1\n" +
+				" -----END PGP SIGNATURE-----\n" +
+				"\n" +
+				"tag message\n" +
+				"-----BEGIN PGP SIGNATURE-----\n" +
+				"\n" +
+				"inlineline1\n" +
+				"-----END PGP SIGNATURE-----\n",
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			// Mutating only the signature fields must not trigger
+			// struct-encode: the raw bytes (with both signatures
+			// stripped) are still the canonical signed payload.
+			name: "raw bytes preserved when only signatures are mutated",
+			tagRaw: "object 1eca38290a3131d0c90709496a9b2207a872631e\n" +
+				"type commit\n" +
+				"tag v1\n" +
+				"tagger Test Tagger <tagger@example.local> 1700000000 +0000\n" +
+				"gpgsig-sha256 -----BEGIN PGP SIGNATURE-----\n" +
+				" sha256line1\n" +
+				" -----END PGP SIGNATURE-----\n" +
+				"\n" +
+				"tag message\n" +
+				"-----BEGIN PGP SIGNATURE-----\n" +
+				"inlineline1\n" +
+				"-----END PGP SIGNATURE-----\n",
+			mutate: func(t *Tag) {
+				t.Signature = "different signature value"
+				t.SignatureSHA256 = "different sha256 sig"
+			},
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			// Duplicates are preserved verbatim by the raw path: if
+			// the decoded struct still matches the source after
+			// re-decoding, the original bytes are streamed through
+			// (with only the canonical signature data stripped).
+			name: "duplicate-object preserved on raw path",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+object 4444444444444444444444444444444444444444
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+-----BEGIN PGP SIGNATURE-----
+inlineline1
+-----END PGP SIGNATURE-----
+`,
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+object 4444444444444444444444444444444444444444
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+		{
+			name: "timezone-only change triggers struct-encode",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 -0700
+
+tag message
+-----BEGIN PGP SIGNATURE-----
+inlineline1
+-----END PGP SIGNATURE-----
+`,
+			mutate: func(t *Tag) {
+				tz := time.FixedZone("CEST", 2*60*60)
+				t.Tagger.When = t.Tagger.When.In(tz)
+			},
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0200
+
+tag message
+`,
+		},
+		{
+			name: "field mutation triggers struct-encode",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+-----BEGIN PGP SIGNATURE-----
+inlineline1
+-----END PGP SIGNATURE-----
+`,
+			mutate: func(t *Tag) {
+				t.Name = "v1-rewritten"
+			},
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1-rewritten
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.TagObject)
+			_, err := obj.Write([]byte(tc.tagRaw))
+			s.Require().NoError(err)
+
+			tag := &Tag{}
+			s.Require().NoError(tag.Decode(obj))
+
+			if tc.mutate != nil {
+				tc.mutate(tag)
+			}
+
+			encoded := &plumbing.MemoryObject{}
+			err = tag.EncodeWithoutSignature(encoded)
+			s.NoError(err)
+
+			er, err := encoded.Reader()
+			s.NoError(err)
+
+			payload, err := io.ReadAll(er)
+			s.NoError(err)
+
+			s.Equal(tc.expected, string(payload))
+		})
+	}
 }

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -306,6 +306,31 @@ func (s *TagSuite) TestTagDecodeRoundTrip() {
 				s.Equal(inlineB, t.Signature)
 			},
 		},
+		{
+			// parseSignedBytes returns the position of the LAST PGP
+			// block in the buffer, mirroring upstream's
+			// parse_signed_buffer (gpg-interface.c:702). Any earlier
+			// PGP-armored bytes embedded in the body stay part of the
+			// message; only the trailing block becomes t.Signature.
+			name: "multiple inline PGP blocks: last is the signature",
+			raw: headers + "\nbody line 1\n" +
+				"-----BEGIN PGP SIGNATURE-----\nfakeline\n-----END PGP SIGNATURE-----\n" +
+				"body line 2\n" +
+				"-----BEGIN PGP SIGNATURE-----\nrealline\n-----END PGP SIGNATURE-----\n",
+			assert: func(t *Tag) {
+				s.Equal(
+					"body line 1\n"+
+						"-----BEGIN PGP SIGNATURE-----\nfakeline\n-----END PGP SIGNATURE-----\n"+
+						"body line 2\n",
+					t.Message,
+				)
+				s.Equal(
+					"-----BEGIN PGP SIGNATURE-----\nrealline\n-----END PGP SIGNATURE-----\n",
+					t.Signature,
+				)
+				s.Empty(t.SignatureSHA256)
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -326,6 +351,181 @@ func (s *TagSuite) TestTagDecodeRoundTrip() {
 			roundTripped, err := io.ReadAll(er)
 			s.NoError(err)
 			s.Equal(tc.raw, string(roundTripped))
+		})
+	}
+}
+
+func (s *TagSuite) TestDecodeFirstOccurrenceWins() {
+	const (
+		targetA   = "c029517f6300c2da0f4b651b8642506cd6aaf45e"
+		targetB   = "0000000000000000000000000000000000000001"
+		taggerA   = "Alice <alice@example.local> 1500000000 +0000"
+		taggerB   = "Bob <bob@example.local> 1500000001 +0000"
+		canonical = "object " + targetA +
+			"\ntype commit\ntag v1\ntagger " + taggerA + "\n"
+	)
+
+	cases := []struct {
+		name   string
+		raw    string
+		assert func(*Tag)
+	}{
+		{
+			name: "duplicate object drops the second",
+			raw: "object " + targetA + "\nobject " + targetB +
+				"\ntype commit\ntag v1\ntagger " + taggerA + "\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal(targetA, t.Target.String())
+			},
+		},
+		{
+			name: "duplicate type drops the second",
+			raw: "object " + targetA + "\ntype commit\ntype blob" +
+				"\ntag v1\ntagger " + taggerA + "\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal(plumbing.CommitObject, t.TargetType)
+			},
+		},
+		{
+			name: "duplicate tag drops the second",
+			raw: "object " + targetA + "\ntype commit\ntag v1\ntag v1-override" +
+				"\ntagger " + taggerA + "\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal("v1", t.Name)
+			},
+		},
+		{
+			name: "duplicate tagger drops the second",
+			raw: "object " + targetA + "\ntype commit\ntag v1\ntagger " + taggerA +
+				"\ntagger " + taggerB + "\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal("Alice", t.Tagger.Name)
+			},
+		},
+		{
+			name: "type at slot 1: type captured, misplaced object dropped",
+			raw: "type commit\nobject " + targetA + "\ntag v1\ntagger " + taggerA +
+				"\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal(plumbing.CommitObject, t.TargetType)
+				s.True(t.Target.IsZero())
+				s.Empty(t.Name)
+				s.Empty(t.Tagger.Name)
+			},
+		},
+		{
+			name: "tagger at slot 4: tagger captured, misplaced tag dropped",
+			raw: "object " + targetA + "\ntype commit\ntagger " + taggerA +
+				"\ntag v1\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal("Alice", t.Tagger.Name)
+				s.Empty(t.Name)
+			},
+		},
+		{
+			name: "missing tagger is allowed (zero-valued)",
+			raw:  "object " + targetA + "\ntype commit\ntag v1\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal("v1", t.Name)
+				s.Empty(t.Tagger.Name)
+				s.Equal("msg\n", t.Message)
+			},
+		},
+		{
+			// gpgsig-sha256 headers concatenate, mirroring upstream's
+			// parse_buffer_signed_by_header (commit.c:1186) — same
+			// behaviour the commit scanner has for gpgsig.
+			name: "multiple gpgsig-sha256 headers concatenate",
+			raw: canonical +
+				"gpgsig-sha256 firstline\n morefirst\n" +
+				"gpgsig-sha256 secondline\n moresecond\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal("firstline\nmorefirst\nsecondline\nmoresecond\n", t.SignatureSHA256)
+			},
+		},
+		{
+			name: "single-line gpgsig-sha256 (no continuation)",
+			raw:  canonical + "gpgsig-sha256 short\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal("short\n", t.SignatureSHA256)
+			},
+		},
+		{
+			name: "gpgsig-sha256 with empty value",
+			raw:  canonical + "gpgsig-sha256\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal("\n", t.SignatureSHA256)
+			},
+		},
+		{
+			name: "unknown extra header is dropped",
+			raw:  canonical + "x-some-extra value\n\nmsg\n",
+			assert: func(t *Tag) {
+				s.Equal(targetA, t.Target.String())
+				s.Equal("v1", t.Name)
+				s.Equal("Alice", t.Tagger.Name)
+				s.Equal("msg\n", t.Message)
+				s.Empty(t.Signature)
+				s.Empty(t.SignatureSHA256)
+			},
+		},
+		{
+			name: "truncated after object header",
+			raw:  "object " + targetA + "\n",
+			assert: func(t *Tag) {
+				s.Equal(targetA, t.Target.String())
+				s.Equal(plumbing.InvalidObject, t.TargetType)
+				s.Empty(t.Name)
+				s.Empty(t.Tagger.Name)
+				s.Empty(t.Message)
+			},
+		},
+		{
+			name: "EOF after tagger (no blank-line separator)",
+			raw:  "object " + targetA + "\ntype commit\ntag v1\ntagger " + taggerA + "\n",
+			assert: func(t *Tag) {
+				s.Equal(targetA, t.Target.String())
+				s.Equal(plumbing.CommitObject, t.TargetType)
+				s.Equal("v1", t.Name)
+				s.Equal("Alice", t.Tagger.Name)
+				s.Empty(t.Message)
+			},
+		},
+		{
+			name: "EOF on blank line (empty body)",
+			raw:  "object " + targetA + "\ntype commit\ntag v1\ntagger " + taggerA + "\n\n",
+			assert: func(t *Tag) {
+				s.Equal("v1", t.Name)
+				s.Empty(t.Message)
+			},
+		},
+		{
+			name: "message without trailing newline",
+			raw:  "object " + targetA + "\ntype commit\ntag v1\ntagger " + taggerA + "\n\npartial",
+			assert: func(t *Tag) {
+				s.Equal("partial", t.Message)
+			},
+		},
+		{
+			name: "EOF mid-gpgsig-sha256 continuation",
+			raw:  canonical + "gpgsig-sha256 line1\n line2\n line3\n",
+			assert: func(t *Tag) {
+				s.Equal("line1\nline2\nline3\n", t.SignatureSHA256)
+				s.Empty(t.Message)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.TagObject)
+			_, err := obj.Write([]byte(tc.raw))
+			s.NoError(err)
+
+			tag := &Tag{}
+			s.Require().NoError(tag.Decode(obj))
+			tc.assert(tag)
 		})
 	}
 }

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -29,6 +29,7 @@ var (
 	ErrDirectoryNotFound = errors.New("directory not found")
 	ErrEntryNotFound     = errors.New("entry not found")
 	ErrEntriesNotSorted  = errors.New("entries in tree are not sorted")
+	ErrMalformedTree     = errors.New("malformed tree")
 )
 
 // Tree is basically like a directory - it references a bunch of other trees
@@ -37,9 +38,9 @@ type Tree struct {
 	Entries []TreeEntry
 	Hash    plumbing.Hash
 
-	s storer.EncodedObjectStorer
-	m map[string]*TreeEntry
-	t map[string]*Tree // tree path cache
+	s             storer.EncodedObjectStorer
+	t             map[string]*Tree // tree path cache
+	entriesSorted bool
 }
 
 // GetTree gets a tree from an object storer and decodes it.
@@ -182,16 +183,43 @@ func (t *Tree) dir(baseName string) (*Tree, error) {
 }
 
 func (t *Tree) entry(baseName string) (*TreeEntry, error) {
-	if t.m == nil {
-		t.buildMap()
-	}
-
-	entry, ok := t.m[baseName]
-	if !ok {
+	if t.entriesSorted {
+		if entry := t.searchEntry(baseName); entry != nil {
+			return entry, nil
+		}
 		return nil, ErrEntryNotFound
 	}
 
-	return entry, nil
+	pastName := baseName + "/"
+	for i := range t.Entries {
+		entry := &t.Entries[i]
+		if entry.Name == baseName {
+			return entry, nil
+		}
+		if treeEntrySortName(entry) > pastName {
+			break
+		}
+	}
+
+	return nil, ErrEntryNotFound
+}
+
+func (t *Tree) searchEntry(baseName string) *TreeEntry {
+	if i := t.searchEntryIndex(baseName); i < len(t.Entries) && t.Entries[i].Name == baseName {
+		return &t.Entries[i]
+	}
+
+	if i := t.searchEntryIndex(baseName + "/"); i < len(t.Entries) && t.Entries[i].Name == baseName {
+		return &t.Entries[i]
+	}
+
+	return nil
+}
+
+func (t *Tree) searchEntryIndex(name string) int {
+	return sort.Search(len(t.Entries), func(i int) bool {
+		return treeEntrySortName(&t.Entries[i]) >= name
+	})
 }
 
 // Files returns a FileIter allowing to iterate over the Tree
@@ -219,12 +247,12 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	}
 
 	t.Hash = o.Hash()
+	t.Entries = nil
+	// assume tree is sorted as a valid tree should always be sorted.
+	t.entriesSorted = true
 	if o.Size() == 0 {
 		return nil
 	}
-
-	t.Entries = nil
-	t.m = nil
 
 	reader, err := o.Reader()
 	if err != nil {
@@ -235,10 +263,14 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
+	var prevSortName string
 	for {
 		str, err := r.ReadString(' ')
 		if err != nil {
 			if err == io.EOF {
+				if len(str) != 0 {
+					return fmt.Errorf("%w: missing mode terminator", ErrMalformedTree)
+				}
 				break
 			}
 
@@ -248,26 +280,42 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 
 		mode, err := filemode.New(str)
 		if err != nil {
-			return err
+			return fmt.Errorf("%w: malformed mode", ErrMalformedTree)
 		}
+		mode = canonicalTreeMode(mode)
 
 		name, err := r.ReadString(0)
-		if err != nil && err != io.EOF {
+		if err != nil {
+			if err == io.EOF {
+				return fmt.Errorf("%w: missing filename terminator", ErrMalformedTree)
+			}
 			return err
+		}
+		if len(name) == 1 {
+			return fmt.Errorf("%w: empty filename", ErrMalformedTree)
 		}
 
 		var hash plumbing.Hash
 		hash.ResetBySize(t.Hash.Size())
 		if _, err = hash.ReadFrom(r); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return fmt.Errorf("%w: truncated object id", ErrMalformedTree)
+			}
 			return err
 		}
 
 		baseName := name[:len(name)-1]
-		t.Entries = append(t.Entries, TreeEntry{
+		entry := TreeEntry{
 			Hash: hash,
 			Mode: mode,
 			Name: baseName,
-		})
+		}
+		sortName := treeEntrySortName(&entry)
+		if len(t.Entries) != 0 && prevSortName > sortName {
+			t.entriesSorted = false
+		}
+		prevSortName = sortName
+		t.Entries = append(t.Entries, entry)
 	}
 
 	return nil
@@ -281,19 +329,35 @@ func (s TreeEntrySorter) Len() int {
 }
 
 func (s TreeEntrySorter) Less(i, j int) bool {
-	name1 := s[i].Name
-	name2 := s[j].Name
-	if s[i].Mode == filemode.Dir {
-		name1 += "/"
-	}
-	if s[j].Mode == filemode.Dir {
-		name2 += "/"
-	}
-	return name1 < name2
+	return treeEntrySortName(&s[i]) < treeEntrySortName(&s[j])
 }
 
 func (s TreeEntrySorter) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
+}
+
+// Git compares tree entries as if directory names had a trailing slash.
+func treeEntrySortName(e *TreeEntry) string {
+	if e.Mode == filemode.Dir {
+		return e.Name + "/"
+	}
+	return e.Name
+}
+
+func canonicalTreeMode(mode filemode.FileMode) filemode.FileMode {
+	switch mode & 0o170000 {
+	case 0o040000:
+		return filemode.Dir
+	case 0o100000:
+		if mode&0o111 != 0 {
+			return filemode.Executable
+		}
+		return filemode.Regular
+	case 0o120000:
+		return filemode.Symlink
+	default:
+		return filemode.Submodule
+	}
 }
 
 // Encode transforms a Tree into a plumbing.EncodedObject.
@@ -329,13 +393,6 @@ func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	}
 
 	return err
-}
-
-func (t *Tree) buildMap() {
-	t.m = make(map[string]*TreeEntry)
-	for i := 0; i < len(t.Entries); i++ {
-		t.m[t.Entries[i].Name] = &t.Entries[i]
-	}
 }
 
 // Diff returns a list of changes between this tree and the provided one

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -240,14 +240,19 @@ func (t *Tree) Type() plumbing.ObjectType {
 	return plumbing.TreeObject
 }
 
+func (t *Tree) reset() {
+	storer := t.s
+	*t = Tree{s: storer}
+}
+
 // Decode transform an plumbing.EncodedObject into a Tree struct
 func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	if o.Type() != plumbing.TreeObject {
 		return ErrUnsupportedObject
 	}
 
+	t.reset()
 	t.Hash = o.Hash()
-	t.Entries = nil
 	// assume tree is sorted as a valid tree should always be sorted.
 	t.entriesSorted = true
 	if o.Size() == 0 {

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/memory"
 )
 
 type TreeSuite struct {
@@ -1746,7 +1747,7 @@ func encodeRawTreeEntries(entries ...rawTreeEntry) []byte {
 	return buf.Bytes()
 }
 
-func decodeRawTree(t *testing.T, body []byte) (*Tree, error) {
+func newRawTreeObject(t *testing.T, body []byte) *plumbing.MemoryObject {
 	t.Helper()
 
 	obj := &plumbing.MemoryObject{}
@@ -1757,8 +1758,16 @@ func decodeRawTree(t *testing.T, body []byte) (*Tree, error) {
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
+	return obj
+}
+
+func decodeRawTree(t *testing.T, body []byte) (*Tree, error) {
+	t.Helper()
+
+	obj := newRawTreeObject(t, body)
+
 	var tree Tree
-	err = tree.Decode(obj)
+	err := tree.Decode(obj)
 	return &tree, err
 }
 
@@ -1840,6 +1849,82 @@ func TestTreeDecodeEmptyClearsExistingEntries(t *testing.T) {
 
 	require.NoError(t, tree.Decode(obj))
 	assert.Empty(t, tree.Entries)
+}
+
+func TestTreeDecodeClearsExistingState(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewStorage()
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+
+	tree := &Tree{
+		Hash: plumbing.NewHash("1111111111111111111111111111111111111111"),
+		Entries: []TreeEntry{
+			{Name: "stale", Mode: filemode.Regular},
+		},
+		s:             store,
+		t:             map[string]*Tree{"stale": {}},
+		entriesSorted: false,
+	}
+
+	require.NoError(t, tree.Decode(obj))
+	assert.Equal(t, obj.Hash(), tree.Hash)
+	assert.Empty(t, tree.Entries)
+	assert.Same(t, store, tree.s)
+	assert.Nil(t, tree.t)
+	assert.True(t, tree.entriesSorted)
+}
+
+func TestTreeDecodeClearsPathCache(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewStorage()
+	oldFileHash := bytes.Repeat([]byte{0xAA}, 20)
+	newFileHash := bytes.Repeat([]byte{0xBB}, 20)
+
+	oldSubtree := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"100644", "old", oldFileHash},
+	))
+	oldSubtreeHash, err := store.SetEncodedObject(oldSubtree)
+	require.NoError(t, err)
+
+	oldDir := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"40000", "sub", oldSubtreeHash.Bytes()},
+	))
+	oldDirHash, err := store.SetEncodedObject(oldDir)
+	require.NoError(t, err)
+
+	oldRoot := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"40000", "dir", oldDirHash.Bytes()},
+	))
+
+	newSubtree := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"100644", "new", newFileHash},
+	))
+	newSubtreeHash, err := store.SetEncodedObject(newSubtree)
+	require.NoError(t, err)
+
+	newDir := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"40000", "sub", newSubtreeHash.Bytes()},
+	))
+	newDirHash, err := store.SetEncodedObject(newDir)
+	require.NoError(t, err)
+
+	newRoot := newRawTreeObject(t, encodeRawTreeEntries(
+		rawTreeEntry{"40000", "dir", newDirHash.Bytes()},
+	))
+
+	tree := &Tree{s: store}
+	require.NoError(t, tree.Decode(oldRoot))
+	got, err := tree.FindEntry("dir/sub/old")
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.Hash.Compare(oldFileHash))
+
+	require.NoError(t, tree.Decode(newRoot))
+	got, err = tree.FindEntry("dir/sub/new")
+	require.NoError(t, err)
+	assert.Equal(t, 0, got.Hash.Compare(newFileHash))
 }
 
 func TestTreeFindEntryDuplicates(t *testing.T) {

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -8,6 +9,8 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -60,8 +63,8 @@ func (s *TreeSuite) TestType() {
 }
 
 func (s *TreeSuite) TestTree() {
-	expectedEntry, ok := s.Tree.m["vendor"]
-	s.True(ok)
+	expectedEntry, err := s.Tree.entry("vendor")
+	s.NoError(err)
 	expected := expectedEntry.Hash
 
 	obtainedTree, err := s.Tree.Tree("vendor")
@@ -308,9 +311,9 @@ func (o *SortReadCloser) Read(p []byte) (int, error) {
 func (s *TreeSuite) TestTreeEntriesSorted() {
 	tree := &Tree{
 		Entries: []TreeEntry{
-			{"foo", filemode.Empty, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
-			{"bar", filemode.Empty, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
-			{"baz", filemode.Empty, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{"foo", filemode.Regular, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{"bar", filemode.Regular, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{"baz", filemode.Regular, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
 		},
 	}
 
@@ -333,9 +336,9 @@ func (s *TreeSuite) TestTreeDecodeEncodeIdempotent() {
 	trees := []*Tree{
 		{
 			Entries: []TreeEntry{
-				{"foo", filemode.Empty, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
-				{"bar", filemode.Empty, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
-				{"baz", filemode.Empty, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{"foo", filemode.Regular, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{"bar", filemode.Regular, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{"baz", filemode.Regular, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
 			},
 		},
 	}
@@ -348,7 +351,7 @@ func (s *TreeSuite) TestTreeDecodeEncodeIdempotent() {
 		err = newTree.Decode(obj)
 		s.NoError(err)
 		tree.Hash = obj.Hash()
-		s.Equal(tree, newTree)
+		s.EqualExportedValues(tree, newTree)
 	}
 }
 
@@ -1723,4 +1726,308 @@ func (s *TreeSuite) TestTreeDecodeReadBug() {
 			s.Equal(expected.Entries[i], obtained.Entries[i])
 		}
 	}
+}
+
+type rawTreeEntry struct {
+	mode string
+	name string
+	hash []byte
+}
+
+func encodeRawTreeEntries(entries ...rawTreeEntry) []byte {
+	var buf bytes.Buffer
+	for _, e := range entries {
+		buf.WriteString(e.mode)
+		buf.WriteByte(' ')
+		buf.WriteString(e.name)
+		buf.WriteByte(0)
+		buf.Write(e.hash)
+	}
+	return buf.Bytes()
+}
+
+func decodeRawTree(t *testing.T, body []byte) (*Tree, error) {
+	t.Helper()
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	var tree Tree
+	err = tree.Decode(obj)
+	return &tree, err
+}
+
+func TestTreeDecodeRejectsMalformedEntries(t *testing.T) {
+	t.Parallel()
+
+	hash := bytes.Repeat([]byte{0xAA}, 20)
+
+	cases := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "short object id",
+			body: append(append([]byte{}, []byte("100644 foo\x00")...), hash[:19]...),
+		},
+		{
+			name: "empty filename",
+			body: encodeRawTreeEntries(rawTreeEntry{"100644", "", hash}),
+		},
+		{
+			name: "missing filename terminator",
+			body: append(append([]byte{}, []byte("100644 foo")...), hash...),
+		},
+		{
+			name: "malformed mode",
+			body: encodeRawTreeEntries(rawTreeEntry{"10064x", "foo", hash}),
+		},
+		{
+			name: "trailing partial entry",
+			body: append(encodeRawTreeEntries(rawTreeEntry{"100644", "foo", hash}), []byte("100644 trailing")...),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree, err := decodeRawTree(t, tc.body)
+			require.ErrorIs(t, err, ErrMalformedTree)
+			assert.NotNil(t, tree)
+		})
+	}
+}
+
+func TestTreeDecodeCanonicalizesModes(t *testing.T) {
+	t.Parallel()
+
+	hash := bytes.Repeat([]byte{0xAA}, 20)
+	body := encodeRawTreeEntries(
+		rawTreeEntry{"100664", "regular", hash},
+		rawTreeEntry{"100111", "executable", hash},
+		rawTreeEntry{"120777", "symlink", hash},
+		rawTreeEntry{"040755", "directory", hash},
+		rawTreeEntry{"42", "submodule", hash},
+	)
+
+	tree, err := decodeRawTree(t, body)
+	require.NoError(t, err)
+	require.Len(t, tree.Entries, 5)
+	assert.Equal(t, filemode.Regular, tree.Entries[0].Mode)
+	assert.Equal(t, filemode.Executable, tree.Entries[1].Mode)
+	assert.Equal(t, filemode.Symlink, tree.Entries[2].Mode)
+	assert.Equal(t, filemode.Dir, tree.Entries[3].Mode)
+	assert.Equal(t, filemode.Submodule, tree.Entries[4].Mode)
+}
+
+func TestTreeDecodeEmptyClearsExistingEntries(t *testing.T) {
+	t.Parallel()
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+
+	tree := &Tree{
+		Entries: []TreeEntry{
+			{Name: "stale", Mode: filemode.Regular},
+		},
+	}
+
+	require.NoError(t, tree.Decode(obj))
+	assert.Empty(t, tree.Entries)
+}
+
+func TestTreeFindEntryDuplicates(t *testing.T) {
+	t.Parallel()
+
+	hashA := bytes.Repeat([]byte{0xAA}, 20)
+	hashB := bytes.Repeat([]byte{0xBB}, 20)
+	hashC := bytes.Repeat([]byte{0xCC}, 20)
+
+	cases := []struct {
+		name      string
+		body      []byte
+		lookup    string
+		wantHash  []byte
+		wantMode  filemode.FileMode
+		wantCount int
+	}{
+		{
+			name: "two regular files with same name",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"100644", "foo", hashA},
+				rawTreeEntry{"100644", "foo", hashB},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Regular,
+			wantCount: 2,
+		},
+		{
+			name: "triplicate regular file",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"100644", "foo", hashA},
+				rawTreeEntry{"100644", "foo", hashB},
+				rawTreeEntry{"100644", "foo", hashC},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Regular,
+			wantCount: 3,
+		},
+		{
+			name: "file shadows later directory of same name",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"100644", "foo", hashA},
+				rawTreeEntry{"40000", "foo", hashB},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Regular,
+			wantCount: 2,
+		},
+		{
+			name: "directory shadows later file of same name",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"40000", "foo", hashA},
+				rawTreeEntry{"100644", "foo", hashB},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Dir,
+			wantCount: 2,
+		},
+		{
+			name: "duplicate is not first entry",
+			body: encodeRawTreeEntries(
+				rawTreeEntry{"100644", "bar", hashC},
+				rawTreeEntry{"100644", "foo", hashA},
+				rawTreeEntry{"100644", "foo", hashB},
+			),
+			lookup:    "foo",
+			wantHash:  hashA,
+			wantMode:  filemode.Regular,
+			wantCount: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.TreeObject)
+			w, err := obj.Writer()
+			require.NoError(t, err)
+			_, err = w.Write(tc.body)
+			require.NoError(t, err)
+			require.NoError(t, w.Close())
+
+			var tree Tree
+			require.NoError(t, tree.Decode(obj))
+			require.Len(t, tree.Entries, tc.wantCount,
+				"all duplicate entries must be preserved in storage order")
+
+			got, err := tree.FindEntry(tc.lookup)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantMode, got.Mode)
+			assert.Equal(t, 0, bytes.Compare(tc.wantHash, got.Hash.Bytes()),
+				"FindEntry must return the first matching entry; got %s want %x",
+				got.Hash, tc.wantHash)
+		})
+	}
+}
+
+func TestTreeFindEntryStopsAtUnsortedEntryPastName(t *testing.T) {
+	t.Parallel()
+
+	hashA := bytes.Repeat([]byte{0xAA}, 20)
+	hashB := bytes.Repeat([]byte{0xBB}, 20)
+	body := encodeRawTreeEntries(
+		rawTreeEntry{"100644", "z", hashA},
+		rawTreeEntry{"100644", "foo", hashB},
+	)
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	var tree Tree
+	require.NoError(t, tree.Decode(obj))
+
+	got, err := tree.FindEntry("foo")
+	require.ErrorIs(t, err, ErrEntryNotFound)
+	assert.Nil(t, got)
+}
+
+func TestTreeFindEntryFindsDirectoryAfterLexicallyEarlierFile(t *testing.T) {
+	t.Parallel()
+
+	hashA := bytes.Repeat([]byte{0xAA}, 20)
+	hashB := bytes.Repeat([]byte{0xBB}, 20)
+	body := encodeRawTreeEntries(
+		rawTreeEntry{"100644", "foo.bar", hashA},
+		rawTreeEntry{"40000", "foo", hashB},
+	)
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TreeObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	var tree Tree
+	require.NoError(t, tree.Decode(obj))
+
+	got, err := tree.FindEntry("foo")
+	require.NoError(t, err)
+	assert.Equal(t, filemode.Dir, got.Mode)
+	assert.Equal(t, 0, bytes.Compare(hashB, got.Hash.Bytes()))
+}
+
+func TestTreeEncodePreservesDuplicateEntries(t *testing.T) {
+	t.Parallel()
+
+	hashABytes := bytes.Repeat([]byte{0xAA}, 20)
+	hashBBytes := bytes.Repeat([]byte{0xBB}, 20)
+	hashA, ok := plumbing.FromBytes(hashABytes)
+	require.True(t, ok)
+	hashB, ok := plumbing.FromBytes(hashBBytes)
+	require.True(t, ok)
+
+	tree := &Tree{
+		Entries: []TreeEntry{
+			{Name: "foo", Mode: filemode.Regular, Hash: hashA},
+			{Name: "foo", Mode: filemode.Regular, Hash: hashB},
+		},
+	}
+
+	obj := &plumbing.MemoryObject{}
+	require.NoError(t, tree.Encode(obj))
+
+	r, err := obj.Reader()
+	require.NoError(t, err)
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	var want bytes.Buffer
+	want.WriteString("100644 foo")
+	want.WriteByte(0)
+	want.Write(hashABytes)
+	want.WriteString("100644 foo")
+	want.WriteByte(0)
+	want.Write(hashBBytes)
+	assert.Equal(t, want.Bytes(), got)
 }

--- a/tests/objectverify/commit_test.go
+++ b/tests/objectverify/commit_test.go
@@ -4,6 +4,7 @@ package objectverify_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,6 +107,10 @@ func TestCommitVerifyAlignment(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			if tc.name == "double-signature" && os.Getenv("GIT_VERSION") == "v2.11.0" {
+				t.Skip("multi-signature rejection not yet established in Git 2.11.0")
+			}
 
 			repo := initRepo(t)
 			unsigned := tc.build()

--- a/tests/objectverify/commit_test.go
+++ b/tests/objectverify/commit_test.go
@@ -1,0 +1,185 @@
+//go:build linux
+
+package objectverify_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6"
+)
+
+func TestCommitVerifyAlignment(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping commit verify")
+	}
+
+	if gpg == nil {
+		t.Error("gpg not available")
+		t.FailNow()
+	}
+
+	cases := []struct {
+		name string
+		// build returns the unsigned commit bytes that will be signed
+		// by gpg. The signature is injected as a single canonical
+		// "gpgsig" header in the standard location and the result is
+		// what both verifiers see, unless postSign rewrites it.
+		build func() []byte
+		// postSign optionally rewrites the signed object bytes (e.g.
+		// to inject a duplicated signature header). nil means use the
+		// standard injection path.
+		postSign func(signed []byte, sig string) []byte
+	}{
+		{
+			name: "valid",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				return assembleCommit(h, m)
+			},
+		},
+		{
+			name: "duplicate-tree",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				dup := append([]string{
+					h[0],
+					"tree 5555555555555555555555555555555555555555",
+				}, h[1:]...)
+				return assembleCommit(dup, m)
+			},
+		},
+		{
+			name: "duplicate-author",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				dup := []string{
+					h[0],
+					h[1],
+					h[2],
+					"author Override Author <override@example.local> 1700000001 +0000",
+					h[3],
+				}
+				return assembleCommit(dup, m)
+			},
+		},
+		{
+			name: "duplicate-committer",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				dup := []string{
+					h[0], h[1], h[2], h[3],
+					"committer Override Committer <override@example.local> 1700000001 +0000",
+				}
+				return assembleCommit(dup, m)
+			},
+		},
+		{
+			name: "misplaced-parent-after-committer",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				dup := []string{
+					h[0], h[1], h[2], h[3],
+					"parent 2222222222222222222222222222222222222222",
+				}
+				return assembleCommit(dup, m)
+			},
+		},
+		{
+			// Inject the same signature again as a second gpgsig
+			// header. Both occurrences sit before the blank line; both
+			// signers strip them when computing the payload.
+			name: "double-signature",
+			build: func() []byte {
+				h, m := canonicalCommit()
+				return assembleCommit(h, m)
+			},
+			postSign: injectGpgSig,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := initRepo(t)
+			unsigned := tc.build()
+			sig := gpgSign(t, unsigned)
+			signed := injectGpgSig(unsigned, sig)
+			if tc.postSign != nil {
+				signed = tc.postSign(signed, sig)
+			}
+
+			hash := writeLooseObject(t, repo, "commit", signed)
+			gitErr := gitVerifyCommit(t, repo, hash)
+
+			r, err := git.PlainOpen(repo)
+			require.NoError(t, err)
+			commit, err := r.CommitObject(hash)
+			ggDecodeErr := err
+			var ggVerifyErr error
+			if ggDecodeErr == nil {
+				_, ggVerifyErr = commit.Verify(gpg.pubKey)
+			}
+
+			assertSameVerdict(t, "git verify-commit", gitErr, "go-git Verify",
+				combineErr(ggDecodeErr, ggVerifyErr))
+		})
+	}
+}
+
+// canonicalCommit returns the byte-exact unsigned commit body produced by
+// upstream `git commit-tree` for a single-parent commit. Used as the
+// baseline; individual scenarios mutate the header lines around it.
+func canonicalCommit() (headers []string, message string) {
+	return []string{
+			"tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904",
+			"parent 1111111111111111111111111111111111111111",
+			"author Test Author <author@example.local> 1700000000 +0000",
+			"committer Test Committer <committer@example.local> 1700000000 +0000",
+		},
+		"signed commit message\n"
+}
+
+func assembleCommit(headers []string, message string) []byte {
+	var buf bytes.Buffer
+	for _, h := range headers {
+		buf.WriteString(h)
+		buf.WriteByte('\n')
+	}
+	buf.WriteByte('\n')
+	buf.WriteString(message)
+	return buf.Bytes()
+}
+
+// combineErr returns the first non-nil of decode, verify.
+// Decode failure is treated the same way as a verify failure.
+func combineErr(decode, verify error) error {
+	if decode != nil {
+		return decode
+	}
+	return verify
+}
+
+// assertSameVerdict fails the test unless both verifiers agree on
+// success-or-failure. It does not compare error messages, only verdicts.
+func assertSameVerdict(t *testing.T, leftLabel string, leftErr error, rightLabel string, rightErr error) {
+	t.Helper()
+	leftOK := leftErr == nil
+	rightOK := rightErr == nil
+	if leftOK == rightOK {
+		if !leftOK {
+			t.Logf("both verifiers rejected (expected for malformed input)\n  %s: %v\n  %s: %v",
+				leftLabel, leftErr, rightLabel, rightErr)
+		}
+		return
+	}
+	assert.Failf(t, "verifier verdicts diverge",
+		"%s succeeded=%v err=%v\n%s succeeded=%v err=%v",
+		leftLabel, leftOK, leftErr, rightLabel, rightOK, rightErr)
+}

--- a/tests/objectverify/main_test.go
+++ b/tests/objectverify/main_test.go
@@ -1,0 +1,369 @@
+//go:build linux
+
+package objectverify_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+// gpgEnv is the isolated GnuPG home created once per package run. The key
+// is generated on demand at TestMain start and torn down at exit.
+type gpgEnv struct {
+	home   string
+	keyID  string
+	pubKey string
+}
+
+var gpg *gpgEnv
+
+func TestMain(m *testing.M) {
+	os.Exit(runMain(m))
+}
+
+// This test verifies that current ways of signing objects didn't change in
+// newer Git versions.
+func TestMatchTestBehaviourWithGit(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping injection oracle")
+	}
+	if gpg == nil {
+		t.Error("gpg not available")
+		t.FailNow()
+	}
+
+	repo := initRepo(t)
+	configureRepoSigning(t, repo, gpg.keyID)
+	treeHash := gitWriteEmptyTree(t, repo)
+
+	commitEnv := []string{
+		"GIT_AUTHOR_NAME=Author",
+		"GIT_AUTHOR_EMAIL=author@example.local",
+		"GIT_AUTHOR_DATE=1700000000 +0000",
+		"GIT_COMMITTER_NAME=Author",
+		"GIT_COMMITTER_EMAIL=author@example.local",
+		"GIT_COMMITTER_DATE=1700000000 +0000",
+	}
+
+	t.Run("commit", func(t *testing.T) {
+		t.Parallel()
+
+		commitHash := gitCommitTreeSigned(t, repo, treeHash, "msg\n", commitEnv)
+		gitRaw := readObjectBytes(t, repo, "commit", commitHash)
+
+		c := decodeCommit(t, gitRaw)
+		require.NotEmpty(t, c.Signature, "git commit-tree -S did not emit a gpgsig header")
+		unsigned := encodeWithoutSignature(t, c)
+
+		oursRaw := injectGpgSig(unsigned, c.Signature)
+
+		require.Equal(t, gitRaw, oursRaw,
+			"injectGpgSig output diverges from `git commit-tree -S`")
+	})
+
+	t.Run("tag", func(t *testing.T) {
+		t.Parallel()
+
+		commitHash := gitCommitTreeSigned(t, repo, treeHash, "msg for tag\n", commitEnv)
+		tagHash := gitTagSigned(t, repo, "v0", commitHash, "tag msg\n", commitEnv)
+		gitRaw := readObjectBytes(t, repo, "tag", tagHash)
+
+		tag := decodeTag(t, gitRaw)
+		require.NotEmpty(t, tag.Signature, "git tag -s did not emit an inline signature")
+		unsigned := encodeTagWithoutSignature(t, tag)
+
+		oursRaw := append(append([]byte{}, unsigned...), []byte(tag.Signature)...)
+
+		require.Equal(t, gitRaw, oursRaw,
+			"tag append output diverges from `git tag -s`")
+	})
+}
+
+func runMain(m *testing.M) int {
+	cleanup, ok := setupGPG()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if !ok {
+		// Tests will skip individually when gpg is nil.
+		return m.Run()
+	}
+	return m.Run()
+}
+
+func decodeCommit(t *testing.T, raw []byte) *object.Commit {
+	t.Helper()
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.CommitObject)
+	_, err := obj.Write(raw)
+	require.NoError(t, err)
+	c := &object.Commit{}
+	require.NoError(t, c.Decode(obj))
+	return c
+}
+
+func decodeTag(t *testing.T, raw []byte) *object.Tag {
+	t.Helper()
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TagObject)
+	_, err := obj.Write(raw)
+	require.NoError(t, err)
+	tag := &object.Tag{}
+	require.NoError(t, tag.Decode(obj))
+	return tag
+}
+
+func encodeWithoutSignature(t *testing.T, c *object.Commit) []byte {
+	t.Helper()
+	out := &plumbing.MemoryObject{}
+	require.NoError(t, c.EncodeWithoutSignature(out))
+	return readMemoryObject(t, out)
+}
+
+func encodeTagWithoutSignature(t *testing.T, tag *object.Tag) []byte {
+	t.Helper()
+	out := &plumbing.MemoryObject{}
+	require.NoError(t, tag.EncodeWithoutSignature(out))
+	return readMemoryObject(t, out)
+}
+
+func readMemoryObject(t *testing.T, o *plumbing.MemoryObject) []byte {
+	t.Helper()
+	r, err := o.Reader()
+	require.NoError(t, err)
+	b, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return b
+}
+
+func configureRepoSigning(t *testing.T, repo, keyID string) {
+	t.Helper()
+	// gpg.format is forced to openpgp because the host's global git
+	// config may set it to ssh, which would reinterpret user.signingkey
+	// as a path on disk.
+	for _, kv := range [][2]string{
+		{"user.signingkey", keyID},
+		{"user.email", "author@example.local"},
+		{"user.name", "Author"},
+		{"gpg.format", "openpgp"},
+		{"gpg.program", "gpg"},
+		{"commit.gpgsign", "false"},
+		{"tag.gpgsign", "false"},
+	} {
+		out, err := exec.Command("git", "-C", repo, "config", "--local", kv[0], kv[1]).CombinedOutput()
+		require.NoErrorf(t, err, "git config %s: %s", kv[0], out)
+	}
+}
+
+func gitWriteEmptyTree(t *testing.T, repo string) plumbing.Hash {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "write-tree")
+	out, err := cmd.Output()
+	require.NoError(t, err, "git write-tree")
+	return plumbing.NewHash(strings.TrimSpace(string(out)))
+}
+
+func gitCommitTreeSigned(t *testing.T, repo string, tree plumbing.Hash, msg string, envOverrides []string) plumbing.Hash {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "commit-tree", "-S", "-m", strings.TrimRight(msg, "\n"), tree.String())
+	cmd.Env = append(os.Environ(), envOverrides...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "git commit-tree -S: %s", stderr.String())
+	return plumbing.NewHash(strings.TrimSpace(string(out)))
+}
+
+func gitTagSigned(t *testing.T, repo, name string, target plumbing.Hash, msg string, envOverrides []string) plumbing.Hash {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "tag", "-s", "-m", strings.TrimRight(msg, "\n"), name, target.String())
+	cmd.Env = append(os.Environ(), envOverrides...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	require.NoErrorf(t, cmd.Run(), "git tag -s: %s", stderr.String())
+
+	rev, err := exec.Command("git", "-C", repo, "rev-parse", name).Output()
+	require.NoError(t, err)
+	return plumbing.NewHash(strings.TrimSpace(string(rev)))
+}
+
+func readObjectBytes(t *testing.T, repo, kind string, h plumbing.Hash) []byte {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repo, "cat-file", kind, h.String()).Output()
+	require.NoError(t, err, "git cat-file %s %s", kind, h.String())
+	return out
+}
+
+func setupGPG() (func(), bool) {
+	if _, err := exec.LookPath("gpg"); err != nil {
+		log.Printf("objectverify: skipping (gpg not in PATH): %v", err)
+		return nil, false
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		log.Printf("objectverify: skipping (git not in PATH): %v", err)
+		return nil, false
+	}
+
+	home, err := os.MkdirTemp("", "gpg-objectverify-*")
+	if err != nil {
+		log.Printf("objectverify: tempdir: %v", err)
+		return nil, false
+	}
+	if err := os.Chmod(home, 0o700); err != nil {
+		log.Printf("objectverify: chmod home: %v", err)
+		_ = os.RemoveAll(home)
+		return nil, false
+	}
+	if err := os.Setenv("GNUPGHOME", home); err != nil {
+		_ = os.RemoveAll(home)
+		return nil, false
+	}
+
+	cleanup := func() {
+		_ = exec.Command("gpgconf", "--kill", "all").Run()
+		_ = os.RemoveAll(home)
+		_ = os.Unsetenv("GNUPGHOME")
+	}
+
+	if err := generateGPGKey(); err != nil {
+		log.Printf("objectverify: generate key: %v", err)
+		return cleanup, false
+	}
+
+	keyID, err := readGPGKeyID()
+	if err != nil {
+		log.Printf("objectverify: read key id: %v", err)
+		return cleanup, false
+	}
+
+	pub, err := exportArmoredPublicKey(keyID)
+	if err != nil {
+		log.Printf("objectverify: export key: %v", err)
+		return cleanup, false
+	}
+
+	gpg = &gpgEnv{home: home, keyID: keyID, pubKey: pub}
+	return cleanup, true
+}
+
+func generateGPGKey() error {
+	cmd := exec.Command("gpg",
+		"--batch", "--pinentry-mode", "loopback", "--passphrase", "",
+		"--quick-generate-key",
+		"go-git verify <verify@go-git.test>",
+		"default", "default", "never")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gpg --quick-generate-key: %w: %s", err, out)
+	}
+	return nil
+}
+
+func readGPGKeyID() (string, error) {
+	out, err := exec.Command("gpg", "--list-secret-keys", "--with-colons").Output()
+	if err != nil {
+		return "", err
+	}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		fields := strings.Split(line, ":")
+		if len(fields) > 9 && fields[0] == "fpr" {
+			return fields[9], nil
+		}
+	}
+	return "", errors.New("no fingerprint in gpg --list-secret-keys output")
+}
+
+func exportArmoredPublicKey(keyID string) (string, error) {
+	out, err := exec.Command("gpg", "--armor", "--export", keyID).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// gpgSign produces an ASCII-armored detached signature over payload using
+// the test key.
+func gpgSign(t *testing.T, payload []byte) string {
+	t.Helper()
+	cmd := exec.Command("gpg",
+		"--batch", "--pinentry-mode", "loopback", "--passphrase", "",
+		"--armor", "--detach-sign", "--local-user", gpg.keyID)
+	cmd.Stdin = bytes.NewReader(payload)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "gpg --detach-sign: %s", stderr.String())
+	return string(out)
+}
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	out, err := exec.Command("git", "-C", dir, "init", "--quiet").CombinedOutput()
+	require.NoErrorf(t, err, "git init: %s", out)
+	return dir
+}
+
+func writeLooseObject(t *testing.T, repo, objType string, content []byte) plumbing.Hash {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "hash-object", "-w", "--literally", "-t", objType, "--stdin")
+	cmd.Stdin = bytes.NewReader(content)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "git hash-object: %s", stderr.String())
+	return plumbing.NewHash(strings.TrimSpace(string(out)))
+}
+
+func gitVerifyCommit(t *testing.T, repo string, h plumbing.Hash) error {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "verify-commit", h.String())
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return nil
+}
+
+func gitVerifyTag(t *testing.T, repo string, h plumbing.Hash) error {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repo, "verify-tag", h.String())
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return nil
+}
+
+func injectGpgSig(unsigned []byte, sig string) []byte {
+	sep := []byte("\n\n")
+	idx := bytes.Index(unsigned, sep)
+	if idx < 0 {
+		panic("injectGpgSig: no header/body separator")
+	}
+	sig = strings.TrimSuffix(sig, "\n")
+	indented := strings.ReplaceAll(sig, "\n", "\n ")
+	headerLine := "gpgsig " + indented + "\n"
+
+	var buf bytes.Buffer
+	buf.Write(unsigned[:idx+1]) // up to and including the \n that ends the last header
+	buf.WriteString(headerLine) // gpgsig + indented sig + closing \n
+	buf.Write(unsigned[idx+1:]) // empty-line \n + body
+	return buf.Bytes()
+}

--- a/tests/objectverify/tag_test.go
+++ b/tests/objectverify/tag_test.go
@@ -4,6 +4,7 @@ package objectverify_test
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -85,6 +86,10 @@ func TestTagVerifyAlignment(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
+			if tc.name == "double-signature" && os.Getenv("GIT_VERSION") == "v2.11.0" {
+				t.Skip("multi-signature rejection not yet established in Git 2.11.0")
+			}
 
 			repo := initRepo(t)
 			unsigned := tc.build()

--- a/tests/objectverify/tag_test.go
+++ b/tests/objectverify/tag_test.go
@@ -1,0 +1,137 @@
+//go:build linux
+
+package objectverify_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6"
+)
+
+func TestTagVerifyAlignment(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping tag verify")
+	}
+
+	if gpg == nil {
+		t.Error("gpg not available")
+		t.FailNow()
+	}
+
+	cases := []struct {
+		name string
+		// build returns the unsigned tag bytes that will be signed by
+		// gpg. The signature is appended inline after the body, the
+		// canonical layout produced by `git tag -s`.
+		build func() []byte
+		// postSign optionally rewrites the signed object bytes (e.g.
+		// to append a second inline signature block).
+		postSign func(t *testing.T, signed []byte) []byte
+	}{
+		{
+			name: "valid",
+			build: func() []byte {
+				h, m := canonicalTag()
+				return assembleTag(h, m)
+			},
+		},
+		{
+			name: "duplicate-tag",
+			build: func() []byte {
+				h, m := canonicalTag()
+				dup := []string{
+					h[0], h[1], h[2],
+					"tag v1-override",
+					h[3],
+				}
+				return assembleTag(dup, m)
+			},
+		},
+		{
+			name: "duplicate-tagger",
+			build: func() []byte {
+				h, m := canonicalTag()
+				dup := []string{
+					h[0], h[1], h[2], h[3],
+					"tagger Override Tagger <override@example.local> 1700000001 +0000",
+				}
+				return assembleTag(dup, m)
+			},
+		},
+		{
+			name: "double-signature",
+			build: func() []byte {
+				h, m := canonicalTag()
+				return assembleTag(h, m)
+			},
+			postSign: func(t *testing.T, signed []byte) []byte {
+				// Append a second inline signature over the
+				// already-signed bytes. parse_signature in
+				// upstream and parseSignedBytes in go-git both
+				// pick the last PGP block, so the signed
+				// payload is the original tag plus the first
+				// signature.
+				sig2 := gpgSign(t, signed)
+				return append(append([]byte{}, signed...), []byte(sig2)...)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := initRepo(t)
+			unsigned := tc.build()
+			sig := gpgSign(t, unsigned)
+			signed := append(append([]byte{}, unsigned...), []byte(sig)...)
+			if tc.postSign != nil {
+				signed = tc.postSign(t, signed)
+			}
+
+			hash := writeLooseObject(t, repo, "tag", signed)
+			gitErr := gitVerifyTag(t, repo, hash)
+
+			r, err := git.PlainOpen(repo)
+			require.NoError(t, err)
+			tag, err := r.TagObject(hash)
+			ggDecodeErr := err
+			var ggVerifyErr error
+			if ggDecodeErr == nil {
+				_, ggVerifyErr = tag.Verify(gpg.pubKey)
+			}
+
+			assertSameVerdict(t, "git verify-tag", gitErr, "go-git Verify",
+				combineErr(ggDecodeErr, ggVerifyErr))
+		})
+	}
+}
+
+// canonicalTag returns the byte-exact unsigned annotated-tag body
+// produced by upstream `git tag -a` on a commit. Individual scenarios
+// mutate the header lines around it.
+func canonicalTag() (headers []string, message string) {
+	return []string{
+			"object 1eca38290a3131d0c90709496a9b2207a872631e",
+			"type commit",
+			"tag v1",
+			"tagger Test Tagger <tagger@example.local> 1700000000 +0000",
+		},
+		"signed annotated tag\n"
+}
+
+func assembleTag(headers []string, message string) []byte {
+	var buf bytes.Buffer
+	for _, h := range headers {
+		buf.WriteString(h)
+		buf.WriteByte('\n')
+	}
+	buf.WriteByte('\n')
+	buf.WriteString(message)
+	return buf.Bytes()
+}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -3761,7 +3762,7 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 func TestTreeContainsDirs(t *testing.T) {
 	t.Parallel()
 	buildTree := func() *object.Tree {
-		return &object.Tree{
+		tree := &object.Tree{
 			Entries: []object.TreeEntry{
 				{Name: "foo", Mode: filemode.Dir},
 				{Name: "bar", Mode: filemode.Dir},
@@ -3769,6 +3770,9 @@ func TestTreeContainsDirs(t *testing.T) {
 				{Name: "this-is-regular", Mode: filemode.Regular},
 			},
 		}
+
+		sort.Sort(object.TreeEntrySorter(tree.Entries))
+		return tree
 	}
 
 	tests := []struct {


### PR DESCRIPTION
- Ensures that unmodified `Commit` and `Tag` objects return their raw bytes (minus `gpgsign` and `gpgsign-sha256` headers).
- Aligns `Commit` and `Tag` interpretation with upstream: first instance of standard headers wins.
- Drop `MergeTag` in favour of `ExtraHeaders`.
- Add conformance tests to ensure verification aligns with `git`. Note that duplicate signatures were valid back on `v2.11`, which is why that test is skipped during capability mode.
- Aligns `Tree` interpretation with upstream: first wins and unsorted tree is short-circuited.
