### PR TITLE
plumbing: transport/ssh, Shell-quote path and args

### DIFF
--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"strconv"
@@ -278,9 +277,40 @@ func (c *sshConn) Stderr() io.Reader {
 
 func buildCommand(req *transport.Request) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s '%s'", req.Command, req.URL.Path)
+	b.WriteString(req.Command)
+	b.WriteByte(' ')
+	writeShellQuote(&b, req.URL.Path)
 	for _, arg := range req.Args {
-		fmt.Fprintf(&b, " '%s'", arg)
+		b.WriteByte(' ')
+		writeShellQuote(&b, arg)
 	}
 	return b.String()
+}
+
+// writeShellQuote writes s to b, wrapped in single quotes with
+// embedded single quotes and exclamation marks escaped using the
+// POSIX close-escape-reopen idiom:
+//
+//	' becomes '\''
+//	! becomes '\!'
+//
+// It is a direct port of canonical Git's sq_quote_buf (quote.c).
+// The bang escape keeps the result safe when re-evaluated under
+// csh-derived shells that perform history expansion. The output is
+// safe to pass as a single argument through any POSIX shell and
+// round-trips through git-shell's sq_dequote_to_argv.
+func writeShellQuote(b *strings.Builder, s string) {
+	b.Grow(len(s) + 2)
+	b.WriteByte('\'')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\'' || c == '!' {
+			b.WriteString(`'\`)
+			b.WriteByte(c)
+			b.WriteByte('\'')
+			continue
+		}
+		b.WriteByte(c)
+	}
+	b.WriteByte('\'')
 }

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -93,6 +93,73 @@ func sshClientOptions() Options {
 	}
 }
 
+func TestBuildCommand(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		command string
+		path    string
+		args    []string
+		want    string
+	}{
+		{
+			name:    "plain path",
+			command: "git-upload-pack",
+			path:    "/repo.git",
+			want:    "git-upload-pack '/repo.git'",
+		},
+		{
+			name:    "path with single-quote injection payload",
+			command: "git-upload-pack",
+			path:    "/repo.git'; touch /tmp/x ; #",
+			want:    `git-upload-pack '/repo.git'\''; touch /tmp/x ; #'`,
+		},
+		{
+			name:    "arg with single-quote injection payload",
+			command: "git-lfs-authenticate",
+			path:    "/repo.git",
+			args:    []string{`download'; rm -rf / ; #`},
+			want:    `git-lfs-authenticate '/repo.git' 'download'\''; rm -rf / ; #'`,
+		},
+		{
+			name:    "empty args has no trailing space",
+			command: "git-upload-pack",
+			path:    "/repo.git",
+			args:    []string{},
+			want:    "git-upload-pack '/repo.git'",
+		},
+		{
+			name:    "bang is escaped for csh history expansion",
+			command: "git-upload-pack",
+			path:    "/repo!.git",
+			want:    `git-upload-pack '/repo'\!'.git'`,
+		},
+		{
+			name:    "mixed quote and bang",
+			command: "git-upload-pack",
+			path:    "/a'b!c",
+			want:    `git-upload-pack '/a'\''b'\!'c'`,
+		},
+		{
+			name:    "inert shell metacharacters pass through",
+			command: "git-upload-pack",
+			path:    "/a\\b\"c$d`e",
+			want:    "git-upload-pack '/a\\b\"c$d`e'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := &transport.Request{
+				Command: tc.command,
+				URL:     &url.URL{Path: tc.path},
+				Args:    tc.args,
+			}
+			assert.Equal(t, tc.want, buildCommand(req))
+		})
+	}
+}
+
 func TestSSHTransport_Connect(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The SSH transport interpolates `req.URL.Path` and each entry of `req.Args` into the remote-exec command line. The previous formatter wrapped each value in literal single quotes via `'%s'`, which diverges from canonical Git's wire format for any value containing characters that the shell treats specially.

Port `sq_quote_buf`[1] from canonical Git into a `shellQuote` helper and route both the path and each `req.Args` entry through it. The helper escapes the same character set that upstream Git escapes (`'` and `!`), so the bytes go-git puts on the wire match what `git` itself would send for the same input. Benign inputs are byte-identical to the previous output; values containing `'` or `!` now round-trip correctly through any POSIX shell and through `git-shell`'s `sq_dequote_to_argv`.

Add a table-driven `TestBuildCommand` covering the plain case, both characters that `sq_quote_buf` escapes, mixed inputs, and inert metacharacters that pass through unchanged.

[1]: https://github.com/git/git/blob/v2.54.0/quote.c#L28