### PR TITLE
v5: plumbing: transport/ssh, Shell-quote path

### DIFF
--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -252,7 +252,39 @@ func (c *command) setAuthFromEndpoint() error {
 }
 
 func endpointToCommand(cmd string, ep *transport.Endpoint) string {
-	return fmt.Sprintf("%s '%s'", cmd, ep.Path)
+	var b strings.Builder
+	b.WriteString(cmd)
+	b.WriteByte(' ')
+	writeShellQuote(&b, ep.Path)
+	return b.String()
+}
+
+// writeShellQuote writes s to b, wrapped in single quotes with
+// embedded single quotes and exclamation marks escaped using the
+// POSIX close-escape-reopen idiom:
+//
+//	' becomes '\''
+//	! becomes '\!'
+//
+// It is a direct port of canonical Git's sq_quote_buf (quote.c).
+// The bang escape keeps the result safe when re-evaluated under
+// csh-derived shells that perform history expansion. The output is
+// safe to pass as a single argument through any POSIX shell and
+// round-trips through git-shell's sq_dequote_to_argv.
+func writeShellQuote(b *strings.Builder, s string) {
+	b.Grow(len(s) + 2)
+	b.WriteByte('\'')
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\'' || c == '!' {
+			b.WriteString(`'\`)
+			b.WriteByte(c)
+			b.WriteByte('\'')
+			continue
+		}
+		b.WriteByte(c)
+	}
+	b.WriteByte('\'')
 }
 
 func overrideConfig(overrides *ssh.ClientConfig, c *ssh.ClientConfig) {

--- a/plumbing/transport/ssh/common_test.go
+++ b/plumbing/transport/ssh/common_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gliderlabs/ssh"
 	"github.com/kevinburke/ssh_config"
+	"github.com/stretchr/testify/assert"
 	stdssh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/testdata"
 	. "gopkg.in/check.v1"
@@ -251,4 +252,52 @@ func (s *SuiteCommon) TestCommandWithInvalidAuthMethod(c *C) {
 
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, "invalid auth method")
+}
+
+func TestEndpointToCommand(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		cmd  string
+		path string
+		want string
+	}{
+		{
+			name: "plain path",
+			cmd:  "git-upload-pack",
+			path: "/repo.git",
+			want: "git-upload-pack '/repo.git'",
+		},
+		{
+			name: "path with single-quote injection payload",
+			cmd:  "git-upload-pack",
+			path: "/repo.git'; touch /tmp/x ; #",
+			want: `git-upload-pack '/repo.git'\''; touch /tmp/x ; #'`,
+		},
+		{
+			name: "bang is escaped for csh history expansion",
+			cmd:  "git-upload-pack",
+			path: "/repo!.git",
+			want: `git-upload-pack '/repo'\!'.git'`,
+		},
+		{
+			name: "mixed quote and bang",
+			cmd:  "git-upload-pack",
+			path: "/a'b!c",
+			want: `git-upload-pack '/a'\''b'\!'c'`,
+		},
+		{
+			name: "inert shell metacharacters pass through",
+			cmd:  "git-upload-pack",
+			path: "/a\\b\"c$d`e",
+			want: "git-upload-pack '/a\\b\"c$d`e'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ep := &transport.Endpoint{Path: tc.path}
+			assert.Equal(t, tc.want, endpointToCommand(tc.cmd, ep))
+		})
+	}
 }


### PR DESCRIPTION
The SSH transport interpolates `ep.Path` into the remote-exec command line via `endpointToCommand`. The previous formatter wrapped the value in literal single quotes via `'%s'`, which diverges from canonical Git's wire format for any path containing characters the shell treats specially.

Port `sq_quote_buf`[1] from canonical Git into a `writeShellQuote` helper and route the path through it. The helper escapes the same character set that upstream Git escapes (`'` and `!`), so the bytes go-git puts on the wire match what `git` itself would send for the same input. Benign paths are byte-identical to the previous output; paths containing `'` or `!` now round-trip correctly through any POSIX shell and through `git-shell`'s `sq_dequote_to_argv`.

Add a table-driven `TestEndpointToCommand` covering the plain case, both characters that `sq_quote_buf` escapes, mixed inputs, and inert metacharacters that pass through unchanged.

Back-port from #2067.

[1]: https://github.com/git/git/blob/v2.54.0/quote.c#L28