### PR TITLE
storage: filesystem, Enable low-memory mode during packfile indexing.

### DIFF
--- a/clone_bench_test.go
+++ b/clone_bench_test.go
@@ -1,0 +1,53 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+)
+
+// BenchmarkWritePackfile benchmarks the client-side pack reception path:
+// raw packfile bytes are written through PackfileWriter into filesystem
+// storage, which concurrently builds the pack index. This isolates the
+// memory-intensive buildIndex phase from transport and server overhead.
+func BenchmarkWritePackfile(b *testing.B) {
+	f := fixtures.ByURL("https://github.com/src-d/go-git.git").One()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		fs := osfs.New(b.TempDir())
+		storage := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{})
+
+		pf, err := f.Packfile()
+		require.NoError(b, err)
+
+		err = packfile.WritePackfileToObjectStorage(storage, pf)
+		require.NoError(b, err)
+	}
+}
+
+// BenchmarkWritePackfileHighMemory benchmarks the same path with
+// HighMemoryMode enabled to provide a baseline comparison.
+func BenchmarkWritePackfileHighMemory(b *testing.B) {
+	f := fixtures.ByURL("https://github.com/src-d/go-git.git").One()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		fs := osfs.New(b.TempDir())
+		storage := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{
+			HighMemoryMode: true,
+		})
+
+		pf, err := f.Packfile()
+		require.NoError(b, err)
+
+		err = packfile.WritePackfileToObjectStorage(storage, pf)
+		require.NoError(b, err)
+	}
+}

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -30,9 +30,18 @@ var (
 // Parser decodes a packfile and calls any observer associated to it. Is used
 // to generate indexes.
 type Parser struct {
-	storage       storer.EncodedObjectStorer
-	cache         *parserCache
-	lowMemoryMode bool
+	storage           storer.EncodedObjectStorer
+	lowMemoryProvider LowMemoryCapable
+	cache             *parserCache
+	lowMemoryMode     bool
+
+	// parentRefCount tracks how many pending OFS-delta objects reference
+	// each parent offset, and parentHashCount tracks how many pending
+	// REF-delta objects reference each parent hash. In low-memory mode,
+	// object content is only freed from cache once both counts reach zero.
+	// Nil when not in low-memory mode.
+	parentRefCount  map[int64]int
+	parentHashCount map[plumbing.Hash]int
 
 	scanner   *Scanner
 	observers []Observer
@@ -80,6 +89,10 @@ func NewParser(data io.Reader, opts ...ParserOption) *Parser {
 		p.lowMemoryMode = ok && lm.LowMemoryMode()
 	}
 
+	if p.lowMemoryProvider != nil {
+		p.lowMemoryMode = p.lowMemoryProvider.LowMemoryMode()
+	}
+
 	if p.scanner.seeker == nil {
 		p.lowMemoryMode = false
 	}
@@ -107,15 +120,16 @@ func (p *Parser) storeOrCache(oh *ObjectHeader) error {
 	}
 
 	if p.cache != nil {
-		o := oh
-		for p.lowMemoryMode && o.content != nil {
-			sync.PutBytesBuffer(o.content)
-			o.content = nil
-
-			if o.parent == nil || o.parent.content == nil {
-				break
+		if p.lowMemoryMode && p.parentRefCount != nil {
+			// Free content for objects that have no remaining children
+			// needing their content. Walk up the parent chain.
+			for o := oh; o != nil && o.content != nil; o = o.parent {
+				if p.parentRefCount[o.Offset] > 0 || p.parentHashCount[o.Hash] > 0 {
+					break
+				}
+				sync.PutBytesBuffer(o.content)
+				o.content = nil
 			}
-			o = o.parent
 		}
 		p.cache.Add(oh)
 	}
@@ -183,10 +197,24 @@ func (p *Parser) Parse() (plumbing.Hash, error) {
 		return plumbing.ZeroHash, err
 	}
 
+	if p.lowMemoryMode {
+		p.parentRefCount = make(map[int64]int, len(pendingDeltas))
+		for _, oh := range pendingDeltas {
+			p.parentRefCount[oh.OffsetReference]++
+		}
+		p.parentHashCount = make(map[plumbing.Hash]int, len(pendingDeltaREFs))
+		for _, oh := range pendingDeltaREFs {
+			p.parentHashCount[oh.Reference]++
+		}
+	}
+
 	for _, oh := range pendingDeltaREFs {
 		err := p.processDelta(oh)
 		if err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("processing ref-delta at offset %v: %w", oh.Offset, err)
+		}
+		if p.parentHashCount != nil {
+			p.parentHashCount[oh.Reference]--
 		}
 	}
 
@@ -194,6 +222,9 @@ func (p *Parser) Parse() (plumbing.Hash, error) {
 		err := p.processDelta(oh)
 		if err != nil {
 			return plumbing.ZeroHash, fmt.Errorf("processing ofs-delta at offset %v: %w", oh.Offset, err)
+		}
+		if p.parentRefCount != nil {
+			p.parentRefCount[oh.OffsetReference]--
 		}
 	}
 
@@ -292,7 +323,7 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 		return bytes.NewReader(parent.content.Bytes()), nil
 	}
 
-	// If parent is a Delta object, the inflated object must come
+	// If parent is a delta object, the inflated object must come
 	// from either cache or storage, else we would need to inflate
 	// it to then inflate the current object, which could go on
 	// indefinitely.

--- a/plumbing/format/packfile/parser_options.go
+++ b/plumbing/format/packfile/parser_options.go
@@ -57,3 +57,20 @@ func WithHighMemoryMode() ParserOption {
 		p.lowMemoryMode = false
 	}
 }
+
+// WithLowMemoryCapable sets the provider used to determine whether the parser
+// should operate in low-memory mode. This primarily affects the scanner, which
+// skips buffering raw delta content in memory when low-memory mode is active.
+// Additionally, when a storage is also set, decoded object content is released
+// from memory immediately after writing to storage, trading CPU (seeks) for
+// lower peak heap.
+//
+// Has no effect if the reader does not implement io.Seeker.
+//
+// Precedence: this option overrides both the storage's own LowMemoryCapable
+// advertisement and the WithHighMemoryMode option.
+func WithLowMemoryCapable(lmc LowMemoryCapable) ParserOption {
+	return func(p *Parser) {
+		p.lowMemoryProvider = lmc
+	}
+}

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -430,3 +430,71 @@ func TestMalformedPack(t *testing.T) {
 	_, err = parser.Parse()
 	require.ErrorContains(t, err, "malformed pack")
 }
+
+type stubLowMemoryCapable struct{ lowMemory bool }
+
+func (s *stubLowMemoryCapable) LowMemoryMode() bool { return s.lowMemory }
+
+func TestWithLowMemoryCapable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		provider          packfile.LowMemoryCapable
+		seekable          bool
+		wantLowMemoryMode bool
+	}{
+		{
+			name:              "nil provider",
+			provider:          nil,
+			seekable:          true,
+			wantLowMemoryMode: false,
+		},
+		{
+			name:              "provider returns true, seekable reader",
+			provider:          &stubLowMemoryCapable{true},
+			seekable:          true,
+			wantLowMemoryMode: true,
+		},
+		{
+			name:              "provider returns true, non-seekable reader",
+			provider:          &stubLowMemoryCapable{true},
+			seekable:          false,
+			wantLowMemoryMode: false,
+		},
+		{
+			name:              "provider returns false",
+			provider:          &stubLowMemoryCapable{false},
+			seekable:          true,
+			wantLowMemoryMode: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pf, pfErr := fixtures.Basic().One().Packfile()
+			require.NoError(t, pfErr)
+
+			var reader io.Reader
+			if tc.seekable {
+				f, err := os.CreateTemp(t.TempDir(), "pack")
+				require.NoError(t, err)
+				defer f.Close()
+				_, err = io.Copy(f, pf)
+				require.NoError(t, err)
+				_, err = f.Seek(0, io.SeekStart)
+				require.NoError(t, err)
+				reader = f
+			} else {
+				// Wrap in a struct to strip io.Seeker.
+				reader = struct{ io.Reader }{pf}
+			}
+
+			parser := packfile.NewParser(reader, packfile.WithLowMemoryCapable(tc.provider))
+			field := reflect.ValueOf(parser).Elem().FieldByName("lowMemoryMode")
+			assert.Equal(t, tc.wantLowMemoryMode, field.Bool())
+		})
+	}
+}

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/format/revfile"
 	plumbhash "github.com/go-git/go-git/v6/plumbing/hash"
 	"github.com/go-git/go-git/v6/storage"
@@ -281,9 +282,11 @@ func (d *DotGit) DeleteReflog(name plumbing.ReferenceName) error {
 
 // NewObjectPack return a writer for a new packfile, it saves the packfile to
 // disk and also generates and save the index for the given packfile.
-func (d *DotGit) NewObjectPack() (*PackWriter, error) {
+// lmc optionally controls whether the parser operates in low-memory mode;
+// pass nil to use the default (high-memory) behaviour.
+func (d *DotGit) NewObjectPack(lmc packfile.LowMemoryCapable) (*PackWriter, error) {
 	d.cleanPackList()
-	return newPackWrite(d.fs, d.options.ObjectFormat, d.options.WriteReverseIndex)
+	return newPackWrite(d.fs, d.options.ObjectFormat, d.options.WriteReverseIndex, lmc)
 }
 
 // ObjectPacks returns the list of availables packfiles

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -734,7 +734,7 @@ func createPackWithRev(t *testing.T, opts Options) (*DotGit, plumbing.Hash, bill
 	dot := NewWithOptions(fs, opts)
 	require.NoError(t, dot.Initialize())
 
-	w, err := dot.NewObjectPack()
+	w, err := dot.NewObjectPack(nil)
 	require.NoError(t, err)
 
 	pf, pfErr := f.Packfile()

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -27,18 +27,19 @@ import (
 type PackWriter struct {
 	Notify func(plumbing.Hash, *idxfile.Writer)
 
-	fs       billy.Filesystem
-	fr, fw   billy.File
-	synced   *syncedReader
-	checksum plumbing.Hash
-	parser   *packfile.Parser
-	writer   *idxfile.Writer
-	result   chan error
-	format   formatcfg.ObjectFormat
-	writeRev bool
+	fs               billy.Filesystem
+	fr, fw           billy.File
+	synced           *syncedReader
+	checksum         plumbing.Hash
+	parser           *packfile.Parser
+	writer           *idxfile.Writer
+	result           chan error
+	format           formatcfg.ObjectFormat
+	writeRev         bool
+	lowMemoryCapable packfile.LowMemoryCapable
 }
 
-func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev bool) (*PackWriter, error) {
+func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev bool, lmc packfile.LowMemoryCapable) (*PackWriter, error) {
 	fw, err := fs.TempFile(fs.Join(objectsPath, packPath), "tmp_pack_")
 	if err != nil {
 		return nil, err
@@ -50,13 +51,14 @@ func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev b
 	}
 
 	writer := &PackWriter{
-		fs:       fs,
-		fw:       fw,
-		fr:       fr,
-		synced:   newSyncedReader(fw, fr),
-		result:   make(chan error),
-		format:   format,
-		writeRev: writeRev,
+		fs:               fs,
+		fw:               fw,
+		fr:               fr,
+		synced:           newSyncedReader(fw, fr),
+		result:           make(chan error),
+		format:           format,
+		writeRev:         writeRev,
+		lowMemoryCapable: lmc,
 	}
 
 	writer.checksum.ResetBySize(format.Size())
@@ -71,7 +73,8 @@ func (w *PackWriter) buildIndex() {
 
 	w.parser = packfile.NewParser(w.synced,
 		packfile.WithScannerObservers(w.writer),
-		packfile.WithObjectFormat(w.format))
+		packfile.WithObjectFormat(w.format),
+		packfile.WithLowMemoryCapable(w.lowMemoryCapable))
 
 	h, err := w.parser.Parse()
 	if err != nil {

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -26,7 +26,7 @@ func BenchmarkNewObjectPack(b *testing.B) {
 	fs := osfs.New(b.TempDir())
 
 	for b.Loop() {
-		w, err := newPackWrite(fs, config.SHA1, false)
+		w, err := newPackWrite(fs, config.SHA1, false, nil)
 
 		require.NoError(b, err)
 		pf, pfErr := f.Packfile()
@@ -46,7 +46,7 @@ func TestNewObjectPack(t *testing.T) {
 	fs := osfs.New(t.TempDir())
 	dot := New(fs)
 
-	w, err := dot.NewObjectPack()
+	w, err := dot.NewObjectPack(nil)
 	require.NoError(t, err)
 
 	pf, pfErr := f.Packfile()
@@ -92,7 +92,7 @@ func TestNewObjectPackUnused(t *testing.T) {
 	fs := osfs.New(t.TempDir())
 	dot := New(fs)
 
-	w, err := dot.NewObjectPack()
+	w, err := dot.NewObjectPack(nil)
 	require.NoError(t, err)
 
 	assert.NoError(t, w.Close())
@@ -159,7 +159,7 @@ func TestPackWriterUnusedNotify(t *testing.T) {
 	t.Parallel()
 	fs := osfs.New(t.TempDir())
 
-	w, err := newPackWrite(fs, config.SHA1, false)
+	w, err := newPackWrite(fs, config.SHA1, false, nil)
 	require.NoError(t, err)
 
 	w.Notify = func(_ plumbing.Hash, _ *idxfile.Writer) {
@@ -186,7 +186,7 @@ func TestPackWriterPermissions(t *testing.T) {
 			dot := New(tc.fs)
 			require.NoError(t, dot.Initialize())
 
-			w, err := dot.NewObjectPack()
+			w, err := dot.NewObjectPack(nil)
 			require.NoError(t, err)
 
 			pf, pfErr := f.Packfile()
@@ -236,7 +236,7 @@ func TestPackWriterExistingReadOnly(t *testing.T) {
 
 			writePack := func() {
 				t.Helper()
-				w, err := dot.NewObjectPack()
+				w, err := dot.NewObjectPack(nil)
 				require.NoError(t, err)
 
 				pf, pfErr := f.Packfile()
@@ -312,7 +312,7 @@ func TestPackWriterRejectsNonRegularFile(t *testing.T) {
 				fmt.Sprintf("pack-%s%s", f.PackfileHash, ext))
 			require.NoError(t, fs.MkdirAll(path, 0o755))
 
-			w, err := dot.NewObjectPack()
+			w, err := dot.NewObjectPack(nil)
 			require.NoError(t, err)
 
 			pf, pfErr := f.Packfile()
@@ -323,6 +323,97 @@ func TestPackWriterRejectsNonRegularFile(t *testing.T) {
 			err = w.Close()
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "unexpected file type")
+		})
+	}
+}
+
+type lowMemStub struct{ lowMemory bool }
+
+func (s *lowMemStub) LowMemoryMode() bool { return s.lowMemory }
+
+func TestNewObjectPackLowMemory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic pack without deltas", func(t *testing.T) {
+		t.Parallel()
+
+		f := fixtures.Basic().One()
+
+		fs := osfs.New(t.TempDir())
+		dot := New(fs)
+
+		w, err := dot.NewObjectPack(&lowMemStub{true})
+		require.NoError(t, err)
+
+		pf, pfErr := f.Packfile()
+		require.NoError(t, pfErr)
+		_, err = io.Copy(w, pf)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		pfPath := fmt.Sprintf("objects/pack/pack-%s.pack", f.PackfileHash)
+		idxPath := fmt.Sprintf("objects/pack/pack-%s.idx", f.PackfileHash)
+
+		stat, err := fs.Stat(pfPath)
+		require.NoError(t, err)
+		assert.Equal(t, int64(84794), stat.Size())
+
+		stat, err = fs.Stat(idxPath)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1940), stat.Size())
+	})
+
+	t.Run("pack with OFS-delta objects", func(t *testing.T) {
+		t.Parallel()
+
+		f := fixtures.ByURL("https://github.com/src-d/go-git.git").One()
+
+		fs := osfs.New(t.TempDir())
+		dot := New(fs)
+
+		w, err := dot.NewObjectPack(&lowMemStub{true})
+		require.NoError(t, err)
+
+		pf, pfErr := f.Packfile()
+		require.NoError(t, pfErr)
+		_, err = io.Copy(w, pf)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		pfPath := fmt.Sprintf("objects/pack/pack-%s.pack", f.PackfileHash)
+		idxPath := fmt.Sprintf("objects/pack/pack-%s.idx", f.PackfileHash)
+
+		_, err = fs.Stat(pfPath)
+		require.NoError(t, err)
+
+		_, err = fs.Stat(idxPath)
+		require.NoError(t, err)
+	})
+}
+
+func BenchmarkNewObjectPackMemory(b *testing.B) {
+	f := fixtures.ByURL("https://github.com/src-d/go-git.git").One()
+
+	for _, tc := range []struct {
+		name string
+		lmc  packfile.LowMemoryCapable
+	}{
+		{"high_memory", nil},
+		{"low_memory", &lowMemStub{true}},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				fs := osfs.New(b.TempDir())
+				w, err := newPackWrite(fs, config.SHA1, false, tc.lmc)
+				require.NoError(b, err)
+
+				pf, pfErr := f.Packfile()
+				require.NoError(b, pfErr)
+				_, err = io.Copy(w, pf)
+				require.NoError(b, err)
+				require.NoError(b, w.Close())
+			}
 		})
 	}
 }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -292,13 +292,18 @@ func (s *ObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 	return plumbing.NewMemoryObject(s.oh)
 }
 
+// LowMemoryMode returns true if low memory mode is enabled for this storage.
+func (s *ObjectStorage) LowMemoryMode() bool {
+	return !s.options.HighMemoryMode
+}
+
 // PackfileWriter returns a writer for creating a new packfile.
 func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
 
-	w, err := s.dir.NewObjectPack()
+	w, err := s.dir.NewObjectPack(s)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The buildIndex() path in PackWriter created the packfile parser without
any LowMemoryCapable provider, so low-memory mode was never activated
during pack reception. This caused PlainClone to keep all decoded delta
content in heap for the duration of pack parsing.

Add a WithLowMemoryCapable parser option and wire it from ObjectStorage
through NewObjectPack into buildIndex(). In low-memory mode the parser
now tracks a per-offset reference count of pending delta children;
storeOrCache only releases decoded content once no more deltas reference
that parent. This avoids the CPU cost of recursive re-resolution while
still freeing memory for objects that are no longer needed.

Potential fixes for #1673 . Benchmark doesn't show much result as Golang
memory benchmark track total allocation, not peak usage.

BenchmarkWritePackfile (src-d/go-git fixture, Apple M4 Pro):

  name                        B/op       allocs/op
  WritePackfile (before)      35,019,392  71,914
  WritePackfile (after)       35,494,608  74,846
  WritePackfileHighMemory     34,461,986  71,904

Assisted-by: OpenCode with Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Cedric BAIL <cedric.bail@appdirect.com>