### PR TITLE
v5: git: submodule, Fix relative URL resolution

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-git/v5/config"
+	giturl "github.com/go-git/go-git/v5/internal/url"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/format/index"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -138,10 +140,23 @@ func (s *Submodule) Repository() (*Repository, error) {
 		return nil, err
 	}
 
-	if !path.IsAbs(moduleEndpoint.Path) && moduleEndpoint.Protocol == "file" {
+	// A relative submodule URL such as "../X.git" must resolve against
+	// the parent repository's remote URL, not against the process CWD.
+	// Detect relativity from the raw configured URL because
+	// transport.NewEndpoint normalizes local paths to absolute form via
+	// filepath.Abs, which would otherwise mask the relative form here.
+	if giturl.IsLocalEndpoint(s.c.URL) &&
+		!path.IsAbs(s.c.URL) && !filepath.IsAbs(s.c.URL) {
+
 		remotes, err := s.w.r.Remotes()
 		if err != nil {
 			return nil, err
+		}
+		if len(remotes) == 0 {
+			return nil, fmt.Errorf(
+				"submodule %q has relative URL %q but parent has no remote configured",
+				s.c.Name, s.c.URL,
+			)
 		}
 
 		rootEndpoint, err := transport.NewEndpoint(remotes[0].c.URLs[0])
@@ -149,7 +164,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 			return nil, err
 		}
 
-		rootEndpoint.Path = path.Join(rootEndpoint.Path, moduleEndpoint.Path)
+		rootEndpoint.Path = path.Join(rootEndpoint.Path, s.c.URL)
 		*moduleEndpoint = *rootEndpoint
 	}
 

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -278,3 +278,105 @@ func (s *SubmoduleSuite) TestSubmoduleParseScp(c *C) {
 	_, err := submodule.Repository()
 	c.Assert(err, IsNil)
 }
+
+// newSubmoduleForRelativeURL constructs an in-memory Repository with
+// the given parent remote URL configured as origin, plus a Submodule
+// whose configured URL is the given submoduleURL. Returns the
+// submodule for direct Repository() invocation. Pass parentRemoteURL
+// = "" to omit the origin remote entirely.
+func newSubmoduleForRelativeURL(c *C, parentRemoteURL, submoduleName, submoduleURL string) *Submodule {
+	repo := &Repository{
+		Storer: memory.NewStorage(),
+		wt:     memfs.New(),
+	}
+	if parentRemoteURL != "" {
+		_, err := repo.CreateRemote(&config.RemoteConfig{
+			Name: DefaultRemoteName,
+			URLs: []string{parentRemoteURL},
+		})
+		c.Assert(err, IsNil)
+	}
+	worktree := &Worktree{
+		Filesystem: memfs.New(),
+		r:          repo,
+	}
+	return &Submodule{
+		initialized: true,
+		c: &config.Submodule{
+			Name: submoduleName,
+			URL:  submoduleURL,
+		},
+		w: worktree,
+	}
+}
+
+func (s *SubmoduleSuite) TestRepositoryRelativeURLHTTPSParent(c *C) {
+	sm := newSubmoduleForRelativeURL(c,
+		"https://example.invalid/group/proj.git", "basic", "../X.git")
+
+	r, err := sm.Repository()
+	c.Assert(err, IsNil)
+
+	remotes, err := r.Remotes()
+	c.Assert(err, IsNil)
+	c.Assert(remotes, HasLen, 1)
+	c.Assert(remotes[0].Config().URLs[0], Equals,
+		"https://example.invalid/group/X.git")
+}
+
+func (s *SubmoduleSuite) TestRepositoryRelativeURLSSHParent(c *C) {
+	sm := newSubmoduleForRelativeURL(c,
+		"ssh://git@example.invalid/group/proj.git", "basic", "../X.git")
+
+	r, err := sm.Repository()
+	c.Assert(err, IsNil)
+
+	remotes, err := r.Remotes()
+	c.Assert(err, IsNil)
+	c.Assert(remotes, HasLen, 1)
+	c.Assert(remotes[0].Config().URLs[0], Equals,
+		"ssh://git@example.invalid/group/X.git")
+}
+
+func (s *SubmoduleSuite) TestRepositoryRelativeURLDeepTraversal(c *C) {
+	sm := newSubmoduleForRelativeURL(c,
+		"https://example.invalid/group/proj.git", "basic", "../../org/X.git")
+
+	r, err := sm.Repository()
+	c.Assert(err, IsNil)
+
+	remotes, err := r.Remotes()
+	c.Assert(err, IsNil)
+	c.Assert(remotes, HasLen, 1)
+	c.Assert(remotes[0].Config().URLs[0], Equals,
+		"https://example.invalid/org/X.git")
+}
+
+func (s *SubmoduleSuite) TestRepositoryAbsoluteLocalURLPreserved(c *C) {
+	raw := "/abs/path/X.git"
+	sm := newSubmoduleForRelativeURL(c, "", "basic", raw)
+
+	r, err := sm.Repository()
+	c.Assert(err, IsNil)
+
+	remotes, err := r.Remotes()
+	c.Assert(err, IsNil)
+	c.Assert(remotes, HasLen, 1)
+
+	// transport.NewEndpoint -> parseFile normalizes via filepath.Abs;
+	// on Windows this prepends a drive letter. Mirror that here so the
+	// assertion is portable. The point of this test is that the
+	// relative-resolution branch is skipped for absolute inputs, not
+	// the exact form parseFile produces.
+	expected, err := filepath.Abs(raw)
+	c.Assert(err, IsNil)
+	c.Assert(remotes[0].Config().URLs[0], Equals, "file://"+expected)
+}
+
+func (s *SubmoduleSuite) TestRepositoryRelativeURLNoParentRemote(c *C) {
+	sm := newSubmoduleForRelativeURL(c, "", "basic", "../X.git")
+
+	_, err := sm.Repository()
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, `submodule "basic" has relative URL "\.\./X\.git" but parent has no remote configured`)
+}


### PR DESCRIPTION
Reported by @N0zoM1z0, thank you! 🙇 

---

A relative submodule URL such as `url = ../X.git` in `.gitmodules` should be resolved against the parent repository's remote URL, per git-submodule(1)[1] and canonical Git. Currently it is resolved against the process's current working directory and persisted as a `file://` remote: an incorrect, working-directory-dependent target.

The cause is in `Submodule.Repository()`. The configured URL is fed through `transport.NewEndpoint`, which hands scheme-less paths to `parseFile`, which calls `filepath.Abs` unconditionally. The follow-up gate `!path.IsAbs(moduleEndpoint.Path)` is therefore always false for any input that wasn't already absolute, and the relative-URL branch never fires. The eager absolutization was introduced when the relative-URL handling was rewritten to use `transport.NewEndpoint` in 9706315a; the original `net/url.Parse` form added in 81d429bc did not exhibit the issue.

Detect the relative form from the raw `s.c.URL` string before `transport.NewEndpoint` normalizes it, using `IsLocalEndpoint` plus both `path.IsAbs` and `filepath.IsAbs` to handle POSIX and Windows absolute paths. When the form is relative, look up the parent's remote and join the raw URL against `rootEndpoint.Path` with `path.Join`. While here, replace the implicit panic on `remotes[0]` with an explicit error when the parent has no remote configured.

Add unit tests covering relative URLs against HTTPS and SSH parents, deep traversal (`../../`), absolute local URLs (whose behaviour is preserved), and the no-parent-remote error.

[1]: https://git-scm.com/docs/git-submodule