### PR TITLE
git: submodule, canonical remote for relative URLs

### DIFF
--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -13,7 +13,7 @@ import (
 var (
 	isSchemeRegExp = regexp.MustCompile(`^[^:]+://`)
 
-	// Ref: https://github.com/git/git/blob/master/Documentation/urls.txt#L37
+	// Ref: https://github.com/git/git/blob/v2.54.0/Documentation/urls.adoc#L41-L48
 	scpLikeURLRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5}):)?(?P<path>[^\\].*)$`)
 
 	fileIssueWindows = regexp.MustCompile(`^/[A-Za-z]:(/|\\)`)
@@ -28,7 +28,38 @@ func MatchesScheme(url string) bool {
 // MatchesScpLike returns true if the given string matches an SCP-like
 // format scheme.
 func MatchesScpLike(url string) bool {
-	return scpLikeURLRegExp.MatchString(url)
+	if !scpLikeURLRegExp.MatchString(url) {
+		return false
+	}
+	// Mirror canonical Git's url_is_local_not_ssh in connect.c[1] for
+	// the cases the regex above cannot disambiguate by itself: a URL
+	// is treated as a local path (not SCP-style SSH) when a `/`
+	// precedes the first `:` (e.g. `./relative:path`,
+	// `/abs/with:colon/file`), or — on Windows only — when it has a
+	// DOS drive prefix like `C:foo` where the host is a single
+	// ASCII letter.
+	//
+	// [1]: https://github.com/git/git/blob/v2.54.0/connect.c#L710-L716
+	if before, _, _ := strings.Cut(url, ":"); strings.Contains(before, "/") {
+		return false
+	}
+	if runtime.GOOS == "windows" && hasDosDrivePrefix(url) {
+		return false
+	}
+	return true
+}
+
+// hasDosDrivePrefix reports whether s begins with `<letter>:` (a
+// Windows drive prefix such as `C:` or `c:`). Mirrors canonical Git's
+// win32_has_dos_drive_prefix[1].
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/compat/win32/path-utils.c#L20-L29
+func hasDosDrivePrefix(s string) bool {
+	if len(s) < 2 || s[1] != ':' {
+		return false
+	}
+	c := s[0]
+	return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
 }
 
 // FindScpLikeComponents returns the user, host, port and path of the

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -1,6 +1,7 @@
 package url
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -101,5 +102,49 @@ func (s *URLSuite) TestFindScpLikeComponents() {
 		s.Equal(tc.host, host, tc.url)
 		s.Equal(tc.port, port, tc.url)
 		s.Equal(tc.path, path, tc.url)
+	}
+}
+
+func (s *URLSuite) TestMatchesScpLikeRejectsLocalPaths() {
+	// Cases that look superficially SCP-like but are actually local
+	// paths per canonical Git's url_is_local_not_ssh — a `/` before
+	// the first `:` means a local path. See
+	// https://github.com/git/git/blob/v2.54.0/connect.c#L710-L716.
+	for _, url := range []string{
+		"/abs/path/with:colon/file",
+		"./relative:path",
+		"./relative/with:colon",
+		"sub/dir:foo",
+	} {
+		s.False(MatchesScpLike(url), url)
+	}
+}
+
+func (s *URLSuite) TestMatchesScpLikeWindowsDrivePrefix() {
+	// On Windows, drive-letter paths (`C:foo`, `C:/foo`, `C:\foo`)
+	// match the SCP regex's host=`C` pattern but are local. Canonical
+	// Git rejects them via has_dos_drive_prefix; we mirror that.
+	if runtime.GOOS != "windows" {
+		s.T().Skip("Windows-only: drive-prefix disambiguation is platform-specific")
+	}
+	for _, url := range []string{
+		"C:foo",
+		"C:/path/to/repo",
+		`C:\path\to\repo`,
+		"d:relative",
+	} {
+		s.False(MatchesScpLike(url), url)
+	}
+}
+
+func (s *URLSuite) TestMatchesScpLikeStillAcceptsRealSCP() {
+	// Regression-guard: the new disambiguation logic must not reject
+	// canonical SCP forms.
+	for _, url := range []string{
+		"git@github.com:james/bond",
+		"user@host.example.com:path/to/repo.git",
+		"host:path",
+	} {
+		s.True(MatchesScpLike(url), url)
 	}
 }

--- a/submodule.go
+++ b/submodule.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 
 	"github.com/go-git/go-billy/v6"
 
@@ -140,7 +141,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 		return nil, err
 	}
 
-	if !path.IsAbs(moduleEndpoint.Path) && moduleEndpoint.Scheme == "file" {
+	if !path.IsAbs(moduleEndpoint.Path) && !filepath.IsAbs(moduleEndpoint.Path) && moduleEndpoint.Scheme == "file" {
 		base, err := defaultRemote(s.w.r)
 		if err != nil {
 			return nil, fmt.Errorf("resolving relative submodule URL: %w", err)

--- a/submodule.go
+++ b/submodule.go
@@ -141,12 +141,12 @@ func (s *Submodule) Repository() (*Repository, error) {
 	}
 
 	if !path.IsAbs(moduleEndpoint.Path) && moduleEndpoint.Scheme == "file" {
-		remotes, err := s.w.r.Remotes()
+		base, err := defaultRemote(s.w.r)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("resolving relative submodule URL: %w", err)
 		}
 
-		rootEndpoint, err := transport.ParseURL(remotes[0].c.URLs[0])
+		rootEndpoint, err := transport.ParseURL(base.URLs[0])
 		if err != nil {
 			return nil, err
 		}
@@ -161,6 +161,49 @@ func (s *Submodule) Repository() (*Repository, error) {
 	})
 
 	return r, err
+}
+
+// defaultRemote returns the remote that relative submodule URLs are
+// resolved against, mirroring canonical Git's repo_default_remote
+// (remote.c) and resolve_relative_url (builtin/submodule--helper.c):
+//
+//  1. if HEAD is on a branch with branch.<name>.remote configured,
+//     use that remote;
+//  2. else if exactly one remote is configured, use it;
+//  3. otherwise fall back to DefaultRemoteName ("origin").
+//
+// Each rule falls through unconditionally: a branch lookup that
+// finds the branch but with an empty Remote does not short-circuit
+// rule (2). Returns an error when the chosen remote is not configured.
+func defaultRemote(r *Repository) (*config.RemoteConfig, error) {
+	cfg, err := r.Config()
+	if err != nil {
+		return nil, err
+	}
+
+	if ref, err := r.Reference(plumbing.HEAD, false); err == nil &&
+		ref.Type() == plumbing.SymbolicReference &&
+		ref.Target().IsBranch() {
+		if b, ok := cfg.Branches[ref.Target().Short()]; ok && b.Remote != "" {
+			return lookupRemote(cfg, b.Remote)
+		}
+	}
+
+	if len(cfg.Remotes) == 1 {
+		for _, rc := range cfg.Remotes {
+			return rc, nil
+		}
+	}
+
+	return lookupRemote(cfg, DefaultRemoteName)
+}
+
+func lookupRemote(cfg *config.Config, name string) (*config.RemoteConfig, error) {
+	rc, ok := cfg.Remotes[name]
+	if !ok {
+		return nil, fmt.Errorf("remote %q not found", name)
+	}
+	return rc, nil
 }
 
 // Update the registered submodule to match what the superproject expects, the

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -342,6 +342,164 @@ func TestSubmoduleParseScp(t *testing.T) {
 	})
 }
 
+func TestDefaultRemote(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name      string
+		remotes   map[string]string // remote name → URL
+		branches  map[string]string // branch name → branch.<name>.remote value
+		head      *plumbing.Reference
+		want      string // expected remote name
+		wantErrIn string // substring required in error message; "" means no error
+	}
+
+	hashRef := plumbing.NewHashReference(plumbing.HEAD, plumbing.NewHash("0000000000000000000000000000000000000001"))
+	mainSym := plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main"))
+	tagSym := plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.ReferenceName("refs/tags/v1"))
+
+	cases := []testCase{
+		{
+			name:     "branch-override-wins",
+			remotes:  map[string]string{"origin": "file:///o", "upstream": "file:///u"},
+			branches: map[string]string{"main": "upstream"},
+			head:     mainSym,
+			want:     "upstream",
+		},
+		{
+			name:      "branch-override-with-bogus-remote",
+			remotes:   map[string]string{"origin": "file:///o", "upstream": "file:///u"},
+			branches:  map[string]string{"main": "bogus"},
+			head:      mainSym,
+			wantErrIn: `remote "bogus" not found`,
+		},
+		{
+			name:    "single-remote-wins-over-origin-fallback",
+			remotes: map[string]string{"upstream": "file:///u"},
+			head:    hashRef,
+			want:    "upstream",
+		},
+		{
+			name:     "single-remote-with-empty-branch-remote",
+			remotes:  map[string]string{"upstream": "file:///u"},
+			branches: map[string]string{"main": ""},
+			head:     mainSym,
+			want:     "upstream",
+		},
+		{
+			name:    "origin-fallback-among-multiple",
+			remotes: map[string]string{"origin": "file:///o", "upstream": "file:///u"},
+			head:    hashRef,
+			want:    "origin",
+		},
+		{
+			name:      "origin-fallback-not-present",
+			remotes:   map[string]string{"upstream": "file:///u", "fork": "file:///f"},
+			head:      hashRef,
+			wantErrIn: `remote "origin" not found`,
+		},
+		{
+			name:      "no-remotes",
+			wantErrIn: `remote "origin" not found`,
+		},
+		{
+			name:     "unborn-branch",
+			remotes:  map[string]string{"origin": "file:///o", "upstream": "file:///u"},
+			branches: map[string]string{"main": "upstream"},
+			head:     mainSym,
+			want:     "upstream",
+		},
+		{
+			name:    "head-on-tag-falls-through",
+			remotes: map[string]string{"origin": "file:///o", "upstream": "file:///u"},
+			head:    tagSym,
+			want:    "origin",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &Repository{Storer: memory.NewStorage()}
+			cfg, err := r.Config()
+			require.NoError(t, err)
+			for name, url := range tc.remotes {
+				cfg.Remotes[name] = &config.RemoteConfig{
+					Name: name,
+					URLs: []string{url},
+				}
+			}
+			for name, remote := range tc.branches {
+				cfg.Branches[name] = &config.Branch{Name: name, Remote: remote}
+			}
+			require.NoError(t, r.Storer.SetConfig(cfg))
+
+			if tc.head != nil {
+				require.NoError(t, r.Storer.SetReference(tc.head))
+			}
+
+			got, err := defaultRemote(r)
+			if tc.wantErrIn != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrIn)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got.Name)
+		})
+	}
+}
+
+func TestSubmoduleRelativeURLPicksOrigin(t *testing.T) {
+	t.Parallel()
+
+	// Two remotes plus a relative submodule URL. With the prior code,
+	// remotes[0] from map iteration could be either origin or upstream;
+	// the resolved submodule URL therefore differed across runs. Loop
+	// 20× to exercise different map orderings within a single test run
+	// — every iteration must resolve against origin.
+	for i := range 20 {
+		parent := &Repository{
+			Storer: memory.NewStorage(),
+			wt:     memfs.New(),
+		}
+		cfg, err := parent.Config()
+		require.NoError(t, err)
+		cfg.Remotes["origin"] = &config.RemoteConfig{
+			Name: "origin",
+			URLs: []string{"file:///parent/origin"},
+		}
+		cfg.Remotes["upstream"] = &config.RemoteConfig{
+			Name: "upstream",
+			URLs: []string{"file:///parent/upstream"},
+		}
+		require.NoError(t, parent.Storer.SetConfig(cfg))
+
+		sub := &Submodule{
+			initialized: true,
+			w:           &Worktree{Filesystem: memfs.New(), r: parent},
+			c: &config.Submodule{
+				Name: "child",
+				Path: "child",
+				URL:  "../child",
+			},
+		}
+
+		subRepo, err := sub.Repository()
+		require.NoError(t, err, "iteration %d", i)
+
+		remotes, err := subRepo.Remotes()
+		require.NoError(t, err)
+		require.Len(t, remotes, 1, "iteration %d", i)
+		require.Equal(t,
+			"file:///parent/child",
+			remotes[0].Config().URLs[0],
+			"iteration %d: expected URL resolved against origin", i,
+		)
+	}
+}
+
 func submoduleHashFromIndex(t *testing.T, r *Repository, name string) plumbing.Hash {
 	t.Helper()
 

--- a/submodule_windows_test.go
+++ b/submodule_windows_test.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package git
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// TestSubmoduleWindowsAbsoluteURLNotJoined verifies that absolute
+// Windows paths in a submodule URL are recognised as absolute and
+// therefore skip the relative-URL resolution branch. `path.IsAbs`
+// alone returns false for `C:\…` and `\\server\share\…`; the
+// production code pairs it with `filepath.IsAbs` so those cases
+// don't get wrongly joined onto the superproject's remote URL.
+func TestSubmoduleWindowsAbsoluteURLNotJoined(t *testing.T) {
+	t.Parallel()
+
+	for _, url := range []string{
+		`C:\path\to\submodule`,
+		`\\server\share\submodule`,
+	} {
+		t.Run(url, func(t *testing.T) {
+			t.Parallel()
+
+			parent := &Repository{
+				Storer: memory.NewStorage(),
+				wt:     memfs.New(),
+			}
+			cfg, err := parent.Config()
+			require.NoError(t, err)
+			cfg.Remotes["origin"] = &config.RemoteConfig{
+				Name: "origin",
+				URLs: []string{"file:///parent/origin"},
+			}
+			require.NoError(t, parent.Storer.SetConfig(cfg))
+
+			sub := &Submodule{
+				initialized: true,
+				w:           &Worktree{Filesystem: memfs.New(), r: parent},
+				c: &config.Submodule{
+					Name: "child",
+					Path: "child",
+					URL:  url,
+				},
+			}
+
+			subRepo, err := sub.Repository()
+			require.NoError(t, err)
+
+			remotes, err := subRepo.Remotes()
+			require.NoError(t, err)
+			require.Len(t, remotes, 1)
+
+			got := remotes[0].Config().URLs[0]
+			require.NotContains(t, got, "/parent/origin",
+				"absolute Windows submodule URL was wrongly joined onto the parent's remote: %q", got)
+		})
+	}
+}


### PR DESCRIPTION
A relative submodule URL like `../sibling` has to be joined onto a base URL — the superproject's remote — to produce the actual URL to clone. Submodule.Repository() picked `Repository.Remotes()[0]` as the base. That slice is built by iterating a Go map, so its order is randomized: in any superproject with more than one remote (the common `origin` + `upstream` fork setup), the chosenbase flipped between runs and the same `git submodule update` could clone the sibling from either namespace.

Canonical Git is deterministic[1] [2]: it uses `branch.<HEAD>.remote` if configured, the sole remote when there is exactly one, otherwise the literal `"origin"`. The submodule helper[3] then joins the relative URL onto that remote's URL.

Mirror that rule in an unexported `defaultRemote` and call it from the relative-URL branch. Tests cover the rule directly and the end-to-end submodule flow; the integration test loops to catch any future regression that re-introduces map-order dependence.

[1]: https://github.com/git/git/blob/v2.54.0/remote.c#L1801-L1809
[2]: https://github.com/git/git/blob/v2.54.0/remote.c#L655-L669
[3]: https://github.com/git/git/blob/v2.54.0/builtin/submodule--helper.c#L53-L75