### PR TITLE
storage: filesystem, Use repository object format for writing loose objects

### DIFF
--- a/plumbing/format/objfile/writer.go
+++ b/plumbing/format/objfile/writer.go
@@ -17,10 +17,11 @@ var ErrOverflow = errors.New("objfile: declared data length exceeded (overflow)"
 // io.Writer. Close should be called when finished with the Writer. Close will
 // not close the underlying io.Writer.
 type Writer struct {
-	raw    io.Writer
-	hasher plumbing.Hasher
-	multi  io.Writer
-	zlib   sync.ZlibWriter
+	raw          io.Writer
+	hasher       plumbing.Hasher
+	multi        io.Writer
+	zlib         sync.ZlibWriter
+	objectFormat format.ObjectFormat
 
 	closed  bool
 	pending int64 // number of unwritten bytes
@@ -28,15 +29,17 @@ type Writer struct {
 	closeErr error
 }
 
-// NewWriter returns a new Writer writing to w.
+// NewWriter returns a new Writer writing to w and hashing objects with the
+// given object format.
 //
 // The returned Writer implements io.WriteCloser. Close should be called when
 // finished with the Writer. Close will not close the underlying io.Writer.
-func NewWriter(w io.Writer) *Writer {
+func NewWriter(w io.Writer, objectFormat format.ObjectFormat) *Writer {
 	zlib := sync.GetZlibWriter(w)
 	return &Writer{
-		raw:  w,
-		zlib: zlib,
+		raw:          w,
+		zlib:         zlib,
+		objectFormat: objectFormat,
 	}
 }
 
@@ -65,7 +68,7 @@ func (w *Writer) WriteHeader(t plumbing.ObjectType, size int64) error {
 func (w *Writer) prepareForWrite(t plumbing.ObjectType, size int64) {
 	w.pending = size
 
-	w.hasher = plumbing.NewHasher(format.SHA1, t, size)
+	w.hasher = plumbing.NewHasher(w.objectFormat, t, size)
 	w.multi = io.MultiWriter(w.zlib, w.hasher)
 }
 

--- a/plumbing/format/objfile/writer_test.go
+++ b/plumbing/format/objfile/writer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
 type SuiteWriter struct {
@@ -40,7 +41,7 @@ func (s *SuiteWriter) TestWriteObjfile() {
 
 func testWriter(t *testing.T, dest io.Writer, hash plumbing.Hash, o plumbing.ObjectType, content []byte) {
 	size := int64(len(content))
-	w := NewWriter(dest)
+	w := NewWriter(dest, format.SHA1)
 
 	err := w.WriteHeader(o, size)
 	assert.NoError(t, err)
@@ -53,9 +54,28 @@ func testWriter(t *testing.T, dest io.Writer, hash plumbing.Hash, o plumbing.Obj
 	assert.NoError(t, w.Close())
 }
 
+func (s *SuiteWriter) TestWriteObjfileSHA256Hash() {
+	content := []byte("hello sha256\n")
+	buf := bytes.NewBuffer(nil)
+	w := NewWriter(buf, format.SHA256)
+
+	err := w.WriteHeader(plumbing.BlobObject, int64(len(content)))
+	s.NoError(err)
+
+	written, err := io.Copy(w, bytes.NewReader(content))
+	s.NoError(err)
+	s.Equal(int64(len(content)), written)
+
+	s.Equal(
+		"2928cdcdc8b78c930378ceba09ce9ca8b888fbfe1bffb2cceb42bdff9421cb52",
+		w.Hash().String(),
+	)
+	s.NoError(w.Close())
+}
+
 func (s *SuiteWriter) TestWriteOverflow() {
 	buf := bytes.NewBuffer(nil)
-	w := NewWriter(buf)
+	w := NewWriter(buf, format.SHA1)
 
 	err := w.WriteHeader(plumbing.BlobObject, 8)
 	s.NoError(err)
@@ -71,7 +91,7 @@ func (s *SuiteWriter) TestWriteOverflow() {
 
 func (s *SuiteWriter) TestNewWriterInvalidType() {
 	buf := bytes.NewBuffer(nil)
-	w := NewWriter(buf)
+	w := NewWriter(buf, format.SHA1)
 
 	err := w.WriteHeader(plumbing.InvalidObject, 8)
 	s.ErrorIs(err, plumbing.ErrInvalidType)
@@ -79,7 +99,7 @@ func (s *SuiteWriter) TestNewWriterInvalidType() {
 
 func (s *SuiteWriter) TestNewWriterInvalidSize() {
 	buf := bytes.NewBuffer(nil)
-	w := NewWriter(buf)
+	w := NewWriter(buf, format.SHA1)
 
 	err := w.WriteHeader(plumbing.BlobObject, -1)
 	s.ErrorIs(err, ErrNegativeSize)

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -481,7 +481,7 @@ func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) er
 func (d *DotGit) NewObject() (*ObjectWriter, error) {
 	d.cleanObjectList()
 
-	return newObjectWriter(d.fs)
+	return newObjectWriter(d.fs, d.options.ObjectFormat)
 }
 
 // ObjectsWithPrefix returns the hashes of objects that have the given prefix.

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -338,14 +338,14 @@ type ObjectWriter struct {
 	f  billy.File
 }
 
-func newObjectWriter(fs billy.Filesystem) (*ObjectWriter, error) {
+func newObjectWriter(fs billy.Filesystem, objectFormat formatcfg.ObjectFormat) (*ObjectWriter, error) {
 	f, err := fs.TempFile(fs.Join(objectsPath, packPath), "tmp_obj_")
 	if err != nil {
 		return nil, err
 	}
 
 	return &ObjectWriter{
-		Writer: (*objfile.NewWriter(f)),
+		Writer: (*objfile.NewWriter(f, objectFormat)),
 		fs:     fs,
 		f:      f,
 	}, nil

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
 )
 
@@ -76,6 +77,41 @@ func (s *FsSuite) TestIterEncodedObjectsSHA256HashesRoundTrip() {
 		return nil
 	})
 	s.Require().NoError(err)
+}
+
+func (s *FsSuite) TestSetEncodedObjectSHA256LooseObjectRoundTrip() {
+	fs := osfs.New(s.T().TempDir())
+	o := NewStorageWithOptions(
+		fs,
+		cache.NewObjectLRUDefault(),
+		Options{ObjectFormat: formatcfg.SHA256},
+	)
+	s.Require().NoError(o.Init())
+
+	obj := o.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+
+	content := []byte("hello sha256\n")
+	writer, err := obj.Writer()
+	s.Require().NoError(err)
+	_, err = writer.Write(content)
+	s.Require().NoError(err)
+	s.Require().NoError(writer.Close())
+
+	hash, err := o.SetEncodedObject(obj)
+	s.Require().NoError(err)
+	s.Equal("2928cdcdc8b78c930378ceba09ce9ca8b888fbfe1bffb2cceb42bdff9421cb52", hash.String())
+	s.Require().NoError(o.HasEncodedObject(hash))
+	s.Require().FileExists(filepath.Join(fs.Root(), "objects", hash.String()[:2], hash.String()[2:]))
+
+	roundTrip, err := o.EncodedObject(plumbing.BlobObject, hash)
+	s.Require().NoError(err)
+	reader, err := roundTrip.Reader()
+	s.Require().NoError(err)
+	defer reader.Close()
+	roundTripContent, err := io.ReadAll(reader)
+	s.Require().NoError(err)
+	s.Equal(content, roundTripContent)
 }
 
 func firstNonMatching(packfileHash string) *fixtures.Fixture {

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -176,6 +176,8 @@ func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
 
 		s.ConfigStorage.objectFormat = of
 		s.ModuleStorage.objectFormat = of
+		s.options.ObjectFormat = of
+		s.oh = plumbing.FromObjectFormat(of)
 		s.hasher = plumbing.NewHasher(of, plumbing.AnyObject, 0)
 		s.h = s.hasher.Hash
 	}

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -107,6 +108,113 @@ func (s *WorktreeSuite) TestCommitInitial() {
 	s.Require().NoError(err)
 
 	assertStorageStatus(s, r, 1, 1, 1, expected)
+}
+
+func (s *WorktreeSuite) TestCommitInitialObjectFormats() {
+	tests := []struct {
+		name         string
+		objectFormat formatcfg.ObjectFormat
+		expectedHash string
+	}{
+		{
+			name:         "sha1",
+			objectFormat: formatcfg.SHA1,
+			expectedHash: "98c4ac7c29c913f7461eae06e024dc18e80d23a4",
+		},
+		{
+			name:         "sha256",
+			objectFormat: formatcfg.SHA256,
+			expectedHash: "9b86829db2f5159fe91032056e9aa60fc400c233bb2fc91ed7e966b996b2cd30",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			expected := plumbing.NewHash(tt.expectedHash)
+			fs := memfs.New()
+			storage := memory.NewStorage(memory.WithObjectFormat(tt.objectFormat))
+
+			r, err := Init(storage, WithWorkTree(fs), WithObjectFormat(tt.objectFormat))
+			s.Require().NoError(err)
+
+			w, err := r.Worktree()
+			s.Require().NoError(err)
+
+			err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
+			s.Require().NoError(err)
+
+			_, err = w.Add("foo")
+			s.Require().NoError(err)
+
+			hash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+			s.Require().NoError(err)
+			s.Equal(expected, hash)
+			s.Len(hash.String(), tt.objectFormat.HexSize())
+			s.Require().NoError(storage.HasEncodedObject(hash))
+
+			commit, err := r.CommitObject(hash)
+			s.Require().NoError(err)
+			s.Equal(hash, commit.Hash)
+			s.Equal("foo\n", commit.Message)
+			s.Len(commit.TreeHash.String(), tt.objectFormat.HexSize())
+			s.Require().NoError(storage.HasEncodedObject(commit.TreeHash))
+
+			tree, err := commit.Tree()
+			s.Require().NoError(err)
+			file, err := tree.File("foo")
+			s.Require().NoError(err)
+			s.Len(file.Hash.String(), tt.objectFormat.HexSize())
+			s.Require().NoError(storage.HasEncodedObject(file.Hash))
+			content, err := file.Contents()
+			s.Require().NoError(err)
+			s.Equal("foo", content)
+
+			assertStorageStatus(s, r, 1, 1, 1, hash)
+		})
+	}
+}
+
+func (s *WorktreeSuite) TestSetReferencesInSHA256Repository() {
+	fs := memfs.New()
+	storage := memory.NewStorage(memory.WithObjectFormat(formatcfg.SHA256))
+
+	r, err := Init(storage, WithWorkTree(fs), WithObjectFormat(formatcfg.SHA256))
+	s.Require().NoError(err)
+
+	w, err := r.Worktree()
+	s.Require().NoError(err)
+
+	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
+	s.Require().NoError(err)
+
+	_, err = w.Add("foo")
+	s.Require().NoError(err)
+
+	hash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+	s.Require().NoError(err)
+	s.Len(hash.String(), formatcfg.SHA256.HexSize())
+
+	tests := []struct {
+		name string
+		ref  plumbing.ReferenceName
+	}{
+		{name: "branch", ref: plumbing.ReferenceName("refs/heads/feature")},
+		{name: "tag", ref: plumbing.ReferenceName("refs/tags/v1.0.0")},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			ref := plumbing.NewHashReference(tt.ref, hash)
+			err := r.Storer.SetReference(ref)
+			s.Require().NoError(err)
+
+			got, err := r.Reference(tt.ref, false)
+			s.Require().NoError(err)
+			s.Equal(ref.Name(), got.Name())
+			s.Equal(hash, got.Hash())
+			s.Len(got.Hash().String(), formatcfg.SHA256.HexSize())
+		})
+	}
 }
 
 func (s *WorktreeSuite) TestNothingToCommit() {


### PR DESCRIPTION
Pass the configured object format into the `objfile` writer so `SHA-256` repositories create loose objects at their `SHA-256` object IDs instead of writing `SHA-1`-addressed files. Add `SHA-256` writer and filesystem round-trip coverage.

Expand tests at repository level for creation of commits and refs for `SHA-256`.

Relates to https://github.com/entireio/cli/issues/1133.