### PR TITLE
plumbing: objfile, Pass object format into Reader

### DIFF
--- a/plumbing/format/objfile/reader.go
+++ b/plumbing/format/objfile/reader.go
@@ -22,20 +22,25 @@ var (
 // Reader implements io.ReadCloser. Close should be called when finished with
 // the Reader. Close will not close the underlying io.Reader.
 type Reader struct {
-	multi  io.Reader
-	zlib   *sync.ZLibReader
-	hasher plumbing.Hasher
-	closed bool
+	multi        io.Reader
+	zlib         *sync.ZLibReader
+	hasher       plumbing.Hasher
+	objectFormat format.ObjectFormat
+	closed       bool
 }
 
-// NewReader returns a new Reader reading from r.
-func NewReader(r io.Reader) (*Reader, error) {
+// NewReader returns a new Reader reading from r and hashing objects with the
+// given object format.
+func NewReader(r io.Reader, objectFormat format.ObjectFormat) (*Reader, error) {
 	zlib, err := sync.GetZlibReader(r)
 	if err != nil {
 		return nil, packfile.ErrZLib.AddDetails("%s", err.Error())
 	}
 
-	return &Reader{zlib: zlib}, nil
+	return &Reader{
+		zlib:         zlib,
+		objectFormat: objectFormat,
+	}, nil
 }
 
 // Header reads the type and the size of object, and prepares the reader for read
@@ -88,7 +93,7 @@ func (r *Reader) readUntil(delim byte) ([]byte, error) {
 }
 
 func (r *Reader) prepareForRead(t plumbing.ObjectType, size int64) {
-	r.hasher = plumbing.NewHasher(format.SHA1, t, size)
+	r.hasher = plumbing.NewHasher(r.objectFormat, t, size)
 	r.multi = io.TeeReader(r.zlib, r.hasher)
 }
 

--- a/plumbing/format/objfile/reader_test.go
+++ b/plumbing/format/objfile/reader_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
 type SuiteReader struct {
@@ -23,18 +24,52 @@ func TestSuiteReader(t *testing.T) {
 }
 
 func (s *SuiteReader) TestReadObjfile() {
-	for k, fixture := range objfileFixtures {
-		com := fmt.Sprintf("test %d: ", k)
-		hash := plumbing.NewHash(fixture.hash)
-		content, _ := base64.StdEncoding.DecodeString(fixture.content)
-		data, _ := base64.StdEncoding.DecodeString(fixture.data)
+	tests := []struct {
+		name         string
+		objectFormat format.ObjectFormat
+	}{
+		{name: "sha1", objectFormat: format.SHA1},
+		{name: "sha256", objectFormat: format.SHA256},
+	}
 
-		testReader(s.T(), bytes.NewReader(data), hash, fixture.t, content, com)
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			for k, fixture := range objfileFixtures {
+				com := fmt.Sprintf("%s test %d: ", tt.name, k)
+				content, _ := base64.StdEncoding.DecodeString(fixture.content)
+				data, _ := base64.StdEncoding.DecodeString(fixture.data)
+				hash := readerFixtureHash(fixture, content, tt.objectFormat)
+
+				testReader(s.T(), bytes.NewReader(data), hash, fixture.t, content, tt.objectFormat, com)
+			}
+		})
 	}
 }
 
-func testReader(t *testing.T, source io.Reader, hash plumbing.Hash, o plumbing.ObjectType, content []byte, _ string) {
-	r, err := NewReader(source)
+func readerFixtureHash(
+	fixture objfileFixture,
+	content []byte,
+	objectFormat format.ObjectFormat,
+) plumbing.Hash {
+	if objectFormat == format.SHA1 {
+		return plumbing.NewHash(fixture.hash)
+	}
+
+	hasher := plumbing.NewHasher(objectFormat, fixture.t, int64(len(content)))
+	_, _ = hasher.Write(content)
+	return hasher.Sum()
+}
+
+func testReader(
+	t *testing.T,
+	source io.Reader,
+	hash plumbing.Hash,
+	o plumbing.ObjectType,
+	content []byte,
+	objectFormat format.ObjectFormat,
+	_ string,
+) {
+	r, err := NewReader(source, objectFormat)
 	assert.NoError(t, err)
 
 	typ, size, err := r.Header()
@@ -52,20 +87,20 @@ func testReader(t *testing.T, source io.Reader, hash plumbing.Hash, o plumbing.O
 
 func (s *SuiteReader) TestReadEmptyObjfile() {
 	source := bytes.NewReader([]byte{})
-	_, err := NewReader(source)
+	_, err := NewReader(source, format.SHA1)
 	s.NotNil(err)
 }
 
 func (s *SuiteReader) TestReadGarbage() {
 	source := bytes.NewReader([]byte("!@#$RO!@NROSADfinq@o#irn@oirfn"))
-	_, err := NewReader(source)
+	_, err := NewReader(source, format.SHA1)
 	s.NotNil(err)
 }
 
 func (s *SuiteReader) TestReadCorruptZLib() {
 	data, _ := base64.StdEncoding.DecodeString("eAFLysaalPUjBgAAAJsAHw")
 	source := bytes.NewReader(data)
-	r, err := NewReader(source)
+	r, err := NewReader(source, format.SHA1)
 	s.NoError(err)
 
 	_, _, err = r.Header()

--- a/plumbing/format/objfile/writer_test.go
+++ b/plumbing/format/objfile/writer_test.go
@@ -35,7 +35,7 @@ func (s *SuiteWriter) TestWriteObjfile() {
 		testWriter(s.T(), buffer, hash, fixture.t, content)
 
 		// Read the data back in from the buffer to be sure it matches
-		testReader(s.T(), buffer, hash, fixture.t, content, com)
+		testReader(s.T(), buffer, hash, fixture.t, content, format.SHA1, com)
 	}
 }
 
@@ -56,6 +56,7 @@ func testWriter(t *testing.T, dest io.Writer, hash plumbing.Hash, o plumbing.Obj
 
 func (s *SuiteWriter) TestWriteObjfileSHA256Hash() {
 	content := []byte("hello sha256\n")
+	hash := plumbing.NewHash("2928cdcdc8b78c930378ceba09ce9ca8b888fbfe1bffb2cceb42bdff9421cb52")
 	buf := bytes.NewBuffer(nil)
 	w := NewWriter(buf, format.SHA256)
 
@@ -66,11 +67,9 @@ func (s *SuiteWriter) TestWriteObjfileSHA256Hash() {
 	s.NoError(err)
 	s.Equal(int64(len(content)), written)
 
-	s.Equal(
-		"2928cdcdc8b78c930378ceba09ce9ca8b888fbfe1bffb2cceb42bdff9421cb52",
-		w.Hash().String(),
-	)
+	s.Equal(hash, w.Hash())
 	s.NoError(w.Close())
+	testReader(s.T(), bytes.NewReader(buf.Bytes()), hash, plumbing.BlobObject, content, format.SHA256, "")
 }
 
 func (s *SuiteWriter) TestWriteOverflow() {

--- a/plumbing/transport/http/dumb.go
+++ b/plumbing/transport/http/dumb.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-billy/v6"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/plumbing/format/objfile"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
@@ -258,7 +259,7 @@ func (r *fetchWalker) fetchObject(objHash plumbing.Hash, obj plumbing.EncodedObj
 		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
 	}
 
-	rd, err := objfile.NewReader(res.Body)
+	rd, err := objfile.NewReader(res.Body, objectFormatFromHash(objHash))
 	if err != nil {
 		return err
 	}
@@ -283,6 +284,13 @@ func (r *fetchWalker) fetchObject(objHash plumbing.Hash, obj plumbing.EncodedObj
 	}
 
 	return nil
+}
+
+func objectFormatFromHash(h plumbing.Hash) formatcfg.ObjectFormat {
+	if h.HexSize() == formatcfg.SHA256HexSize {
+		return formatcfg.SHA256
+	}
+	return formatcfg.SHA1
 }
 
 func (r *fetchWalker) fetch() error {

--- a/storage/filesystem/dotgit/reader.go
+++ b/storage/filesystem/dotgit/reader.go
@@ -35,7 +35,7 @@ func (e *EncodedObject) Reader() (io.ReadCloser, error) {
 
 		return nil, err
 	}
-	r, err := objfile.NewReader(f)
+	r, err := objfile.NewReader(f, e.dir.options.ObjectFormat)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -397,7 +397,7 @@ func (s *ObjectStorage) encodedObjectSizeFromUnpacked(h plumbing.Hash) (size int
 		return 0, err
 	}
 
-	r, err := objfile.NewReader(f)
+	r, err := objfile.NewReader(f, s.options.ObjectFormat)
 	if err != nil {
 		return 0, err
 	}
@@ -605,7 +605,7 @@ func (s *ObjectStorage) getFromUnpacked(h plumbing.Hash) (obj plumbing.EncodedOb
 		return cacheObj, nil
 	}
 
-	r, err := objfile.NewReader(f)
+	r, err := objfile.NewReader(f, s.options.ObjectFormat)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Thread the repository's object format through `objfile.NewReader` so `SHA-256` loose objects are hashed with `SHA-256` instead of being hard-coded to `SHA-1`. Update callers in dotgit, filesystem object storage, and the dumb HTTP transport, and extend reader/writer tests with `SHA-256` round-trip coverage.