### PR TITLE
v5: git: submodule, error on remote without URLs

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -197,8 +197,8 @@ func defaultRemote(r *Repository) (*config.RemoteConfig, error) {
 	}
 
 	if len(cfg.Remotes) == 1 {
-		for _, rc := range cfg.Remotes {
-			return rc, nil
+		for name := range cfg.Remotes {
+			return lookupRemote(cfg, name)
 		}
 	}
 
@@ -209,6 +209,9 @@ func lookupRemote(cfg *config.Config, name string) (*config.RemoteConfig, error)
 	rc, ok := cfg.Remotes[name]
 	if !ok {
 		return nil, fmt.Errorf("remote %q not found", name)
+	}
+	if len(rc.URLs) == 0 {
+		return nil, fmt.Errorf("remote %q has no configured URL", name)
 	}
 	return rc, nil
 }

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -530,3 +530,35 @@ func (s *SubmoduleSuite) TestSubmoduleRelativeURLPicksOrigin(c *C) {
 			Commentf("iteration %d: expected URL resolved against origin", i))
 	}
 }
+
+func (s *SubmoduleSuite) TestSubmoduleRelativeURLRemoteWithoutURLs(c *C) {
+	// Defense in depth: a relative submodule URL must be joined onto
+	// the chosen parent remote. If that remote has no configured URL,
+	// earlier code panicked on `base.URLs[0]`. Mutating the in-memory
+	// config directly bypasses SetConfig's validation, mirroring the
+	// on-disk case where a `[remote "origin"]` section with no
+	// `url =` entry could be loaded.
+	parent := &Repository{
+		Storer: memory.NewStorage(),
+		wt:     memfs.New(),
+	}
+	cfg, err := parent.Config()
+	c.Assert(err, IsNil)
+	cfg.Remotes["origin"] = &config.RemoteConfig{Name: "origin", URLs: nil}
+
+	sub := &Submodule{
+		initialized: true,
+		w:           &Worktree{Filesystem: memfs.New(), r: parent},
+		c: &config.Submodule{
+			Name: "child",
+			Path: "child",
+			URL:  "../child",
+		},
+	}
+
+	subRepo, err := sub.Repository()
+	c.Assert(err, NotNil)
+	c.Assert(subRepo, IsNil)
+	c.Assert(err, ErrorMatches,
+		`resolving relative submodule URL: remote "origin" has no configured URL`)
+}


### PR DESCRIPTION
`defaultRemote`, introduced on this branch in a675ed42, returns a `*RemoteConfig` that `submodule.Repository()` then dereferences as `base.URLs[0]` to join a relative submodule URL. `RemoteConfig.Validate()` rejects an empty `URLs` slice on `SetConfig`, but a config that bypasses validation — for example a hand-edited `[remote "origin"]` section with no `url =` entry loaded from disk — could still produce a remote with no URLs and panic the caller with `index out of range [0] with length 0`.

Promote the invariant into `lookupRemote` and route the single-remote branch through it as well, so any code path that asks `defaultRemote` for the resolution base gets a usable remote or a clear `remote %q has no configured URL` error.

Backport of #2076.