### PR TITLE
config: validate submodule names

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -684,7 +684,8 @@ func unmarshalSubmodules(fc *format.Config, submodules map[string]*Submodule) {
 		m := &Submodule{}
 		m.unmarshal(sub)
 
-		if errors.Is(m.Validate(), ErrModuleBadPath) {
+		if err := m.Validate(); errors.Is(err, ErrModuleBadPath) ||
+			errors.Is(err, ErrModuleBadName) {
 			continue
 		}
 

--- a/config/modules.go
+++ b/config/modules.go
@@ -3,8 +3,11 @@ package config
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"regexp"
+	"strings"
 
+	"github.com/go-git/go-git/v6/internal/pathutil"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
@@ -15,6 +18,9 @@ var (
 	ErrModuleEmptyPath = errors.New("module config: empty path")
 	// ErrModuleBadPath is returned when a submodule has an invalid path.
 	ErrModuleBadPath = errors.New("submodule has an invalid path")
+	// ErrModuleBadName is returned when a submodule's name is not safe
+	// for use as a path component.
+	ErrModuleBadName = errors.New("ignoring suspicious submodule name")
 )
 
 // Matches module paths with dotdot ".." components.
@@ -95,6 +101,10 @@ type Submodule struct {
 
 // Validate validates the fields and sets the default values.
 func (m *Submodule) Validate() error {
+	if err := validSubmoduleName(m.Name); err != nil {
+		return fmt.Errorf("%w: %q", ErrModuleBadName, m.Name)
+	}
+
 	if m.Path == "" {
 		return ErrModuleEmptyPath
 	}
@@ -109,6 +119,50 @@ func (m *Submodule) Validate() error {
 
 	return nil
 }
+
+// validSubmoduleName mirrors canonical Git's check_submodule_name in
+// submodule-config.c [1]: reject empty names and any name with a ".."
+// path component, using both '/' and '\\' as separators so the rule
+// is consistent across platforms. The component check is delegated to
+// `pathutil.IsHFSDot` and `pathutil.IsNTFSDot` with `.` as the needle,
+// which both cover the bare ".." case and reject components that
+// resolve to ".." after HFS+ Unicode normalisation (ignored code
+// points, e.g. `.<U+200C>.`) or NTFS trailing-space/dot/ADS
+// canonicalisation (e.g. `.. `, `..::$INDEX_ALLOCATION`).
+// `.gitmodules` is attacker-controlled by definition, so both checks
+// run unconditionally regardless of host OS.
+//
+// The additional checks (bare ".", NUL byte, leading or trailing
+// separator, drive-letter prefix) close go-git-specific edge cases
+// the canonical loop does not exercise: canonical Git treats names
+// as opaque C strings, while Go strings carry NULs through and the
+// billy filesystem layer is path-aware in ways Git's working storage
+// is not.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/submodule-config.c#L214-L237
+func validSubmoduleName(name string) error {
+	if name == "" || name == "." {
+		return ErrModuleBadName
+	}
+	for _, seg := range strings.FieldsFunc(name, isPathSep) {
+		if pathutil.IsHFSDot(seg, ".") || pathutil.IsNTFSDot(seg, ".", "") {
+			return ErrModuleBadName
+		}
+	}
+	// go-git-specific defensive checks beyond canonical Git.
+	if strings.ContainsRune(name, 0) {
+		return ErrModuleBadName
+	}
+	if isPathSep(rune(name[0])) || isPathSep(rune(name[len(name)-1])) {
+		return ErrModuleBadName
+	}
+	if len(name) >= 2 && name[1] == ':' {
+		return ErrModuleBadName
+	}
+	return nil
+}
+
+func isPathSep(r rune) bool { return r == '/' || r == '\\' }
 
 func (m *Submodule) unmarshal(s *format.Subsection) {
 	m.raw = s

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -16,7 +16,7 @@ func TestModulesSuite(t *testing.T) {
 }
 
 func (s *ModulesSuite) TestValidateMissingURL() {
-	m := &Submodule{Path: "foo"}
+	m := &Submodule{Name: "foo", Path: "foo"}
 	s.Equal(ErrModuleEmptyURL, m.Validate())
 }
 
@@ -36,6 +36,7 @@ func (s *ModulesSuite) TestValidateBadPath() {
 
 	for _, p := range input {
 		m := &Submodule{
+			Name: "ok",
 			Path: p,
 			URL:  "https://example.com/",
 		}
@@ -44,8 +45,67 @@ func (s *ModulesSuite) TestValidateBadPath() {
 }
 
 func (s *ModulesSuite) TestValidateMissingName() {
-	m := &Submodule{URL: "bar"}
+	m := &Submodule{Name: "ok", URL: "bar"}
 	s.Equal(ErrModuleEmptyPath, m.Validate())
+}
+
+func (s *ModulesSuite) TestValidateBadName() {
+	input := []string{
+		// Plain shapes the parser must reject regardless of OS.
+		"",
+		".",
+		"..",
+		"../x",
+		"a/../../b",
+		"/abs",
+		`C:\win`,
+		"x\x00y",
+		"x/",
+		"/x",
+		`.\..\foo`,
+		"modules/../escape",
+
+		// HFS+ ignores certain Unicode code points during path
+		// normalisation, so these all resolve to ".." on macOS.
+		".\u200c.",             // ZWNJ between dots
+		"\u200c..",             // leading ZWNJ
+		"..\u200c",             // trailing ZWNJ
+		"\u200c.\u200d.\u200e", // ZWNJ + ZWJ + LRM
+		"a/.\u200c./b",         // hidden ".." mid-path
+
+		// NTFS strips trailing spaces, dots, and an alternate-data
+		// -stream suffix during canonicalisation, so these all
+		// resolve to ".." on Windows.
+		".. ",
+		"..  ",
+		"....",
+		".. .",
+		"..::$INDEX_ALLOCATION",
+		"..:foo",
+		"a/.. /b",
+	}
+	for _, n := range input {
+		m := &Submodule{
+			Name: n,
+			Path: "ok",
+			URL:  "https://example.com/",
+		}
+		// Validate wraps the sentinel with the offending name
+		// (canonical-Git wording: "ignoring suspicious submodule
+		// name: <name>"), so use ErrorIs.
+		s.ErrorIs(m.Validate(), ErrModuleBadName, "name %q", n)
+	}
+}
+
+func (s *ModulesSuite) TestValidateGoodName() {
+	for _, n := range []string{"foo", "lib-foo", "deps/x", "x.y"} {
+		m := &Submodule{
+			Name: n,
+			Path: "ok",
+			URL:  "https://example.com/",
+		}
+		s.NoError(m.Validate(), "name %q", n)
+	}
 }
 
 func (s *ModulesSuite) TestMarshal() {
@@ -74,18 +134,25 @@ func (s *ModulesSuite) TestUnmarshal() {
 [submodule "suspicious"]
         path = ../../foo/bar
         url = https://github.com/foo/bar.git
+[submodule ".."]
+        path = deps/x
+        url = https://github.com/foo/bar.git
 `)
 
 	cfg := NewModules()
 	err := cfg.Unmarshal(input)
 	s.NoError(err)
 
+	// The "suspicious" entry is dropped because of its `..` path,
+	// and the `..` entry is dropped because of its suspicious name
+	// (canonical Git's "ignoring suspicious submodule name" rule).
 	s.Len(cfg.Submodules, 2)
 	s.Equal("qux", cfg.Submodules["qux"].Name)
 	s.Equal("https://github.com/foo/qux.git", cfg.Submodules["qux"].URL)
 	s.Equal("foo/bar", cfg.Submodules["foo/bar"].Name)
 	s.Equal("https://github.com/foo/bar.git", cfg.Submodules["foo/bar"].URL)
 	s.Equal("dev", cfg.Submodules["foo/bar"].Branch)
+	s.NotContains(cfg.Submodules, "..")
 }
 
 func (s *ModulesSuite) TestUnmarshalMarshal() {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -78,6 +78,10 @@ var (
 	// ErrEmptyRefFile is returned when a reference file is attempted to be read,
 	// but the file is empty
 	ErrEmptyRefFile = errors.New("ref file is empty")
+	// ErrModuleNameEscape is returned when a submodule name would
+	// resolve outside the modules/ subtree, mirroring canonical Git's
+	// "ignoring suspicious submodule name" defence.
+	ErrModuleNameEscape = errors.New("submodule name escapes modules/ directory")
 )
 
 // Options holds configuration for the storage.
@@ -1273,8 +1277,19 @@ func (d *DotGit) PackRefs() (err error) {
 }
 
 // Module return a billy.Filesystem pointing to the module folder
+//
+// As a defence in depth against submodule name path traversal,
+// refuse names whose joined path leaves the modules/ subtree once
+// cleaned. The config-layer parser also validates submodule names,
+// but Module may be reached from any caller that constructs a
+// Submodule struct programmatically and so bypasses the parser.
 func (d *DotGit) Module(name string) (billy.Filesystem, error) {
-	return d.fs.Chroot(d.fs.Join(modulePath, name))
+	p := d.fs.Join(modulePath, name)
+	cleaned := path.Clean(filepath.ToSlash(p))
+	if cleaned != modulePath && !strings.HasPrefix(cleaned, modulePath+"/") {
+		return nil, ErrModuleNameEscape
+	}
+	return d.fs.Chroot(p)
 }
 
 // AddAlternate appends an alternate object directory path to the alternates file.

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -39,6 +39,31 @@ func TestSuiteDotGit(t *testing.T) {
 
 func (s *SuiteDotGit) EmptyFS() (fs billy.Filesystem) { return memfs.New() }
 
+func (s *SuiteDotGit) TestModuleRejectsEscapingNames() {
+	d := New(s.EmptyFS())
+	// Only true path-traversal cases — names like "/etc" or
+	// "modules/../escape" land inside modules/ once Join cleans
+	// them, so the containment check correctly accepts those.
+	bad := []string{
+		"..",
+		"../x",
+		"foo/../..",
+		"a/b/c/../../../..",
+	}
+	for _, n := range bad {
+		_, err := d.Module(n)
+		s.ErrorIs(err, ErrModuleNameEscape, "name %q", n)
+	}
+}
+
+func (s *SuiteDotGit) TestModuleAcceptsBenignNames() {
+	d := New(s.EmptyFS())
+	for _, n := range []string{"foo", "lib/foo", "x.y"} {
+		_, err := d.Module(n)
+		s.Require().NoError(err, "name %q", n)
+	}
+}
+
 func (s *SuiteDotGit) TestInitialize() {
 	fs := s.EmptyFS()
 

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
 
@@ -655,4 +658,46 @@ func TestSubmoduleRepositoryURLResolution(t *testing.T) {
 			require.Equal(t, tc.wantRemote, remotes[0].Config().URLs[0])
 		})
 	}
+}
+
+// TestSubmoduleRepositoryRejectsEscapingName covers the storage-layer
+// defence against submodule name path traversal. Constructing a
+// Submodule with `Name = ".."` programmatically (bypassing the
+// .gitmodules parser) must not result in `Repository()` opening a
+// storer rooted in the parent's `.git/` directory, and must leave the
+// parent's HEAD reference untouched.
+func TestSubmoduleRepositoryRejectsEscapingName(t *testing.T) {
+	t.Parallel()
+
+	dotfs := memfs.New()
+	wtfs := memfs.New()
+	storer := filesystem.NewStorage(dotfs, cache.NewObjectLRUDefault())
+	r, err := Init(storer, WithWorkTree(wtfs))
+	require.NoError(t, err)
+
+	wt, err := r.Worktree()
+	require.NoError(t, err)
+
+	headBefore, err := storer.Reference(plumbing.HEAD)
+	require.NoError(t, err)
+
+	sm := &Submodule{
+		initialized: true,
+		c: &config.Submodule{
+			Name: "..",
+			Path: "deps/x",
+			URL:  "https://example.com/",
+		},
+		w: wt,
+	}
+
+	repo, err := sm.Repository()
+	require.Error(t, err)
+	require.ErrorIs(t, err, dotgit.ErrModuleNameEscape)
+	require.Nil(t, repo)
+
+	headAfter, err := storer.Reference(plumbing.HEAD)
+	require.NoError(t, err)
+	require.Equal(t, headBefore.Target(), headAfter.Target(),
+		"parent HEAD must not be overwritten")
 }


### PR DESCRIPTION
`Submodule.Validate()` validated `Path` against `dotdotPath` but left `Name` unchecked, so submodule names with unusual shapes (empty, bare `.`/`..`, names containing `..` components, NUL bytes, or leading or trailing separators) were accepted at parse time and propagated to `DotGit.Module(name)`, which joined them into the on-disk modules path without verifying the result stayed under `modules/`.

The parser now mirrors canonical Git's `check_submodule_name` from `submodule-config.c` [1], extended with a few defensive checks for go-git-specific edge cases. The storage layer adds an independent path-containment check in `DotGit.Module(name)`, so any caller that constructs a `Submodule` programmatically — including the transactional storage wrapper — is also protected, and a regression test exercises the storage-layer defence end-to-end. Nested but contained names like `lib/foo` continue to work; only path-traversal shapes are refused.

[1]: https://github.com/git/git/blob/v2.54.0/submodule-config.c#L214-L237