### PR TITLE
v5: config: validate submodule names

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -399,7 +399,8 @@ func unmarshalSubmodules(fc *format.Config, submodules map[string]*Submodule) {
 		m := &Submodule{}
 		m.unmarshal(sub)
 
-		if m.Validate() == ErrModuleBadPath {
+		if err := m.Validate(); errors.Is(err, ErrModuleBadPath) ||
+			errors.Is(err, ErrModuleBadName) {
 			continue
 		}
 

--- a/config/modules.go
+++ b/config/modules.go
@@ -3,8 +3,11 @@ package config
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"regexp"
+	"strings"
 
+	"github.com/go-git/go-git/v5/internal/pathutil"
 	format "github.com/go-git/go-git/v5/plumbing/format/config"
 )
 
@@ -12,6 +15,7 @@ var (
 	ErrModuleEmptyURL  = errors.New("module config: empty URL")
 	ErrModuleEmptyPath = errors.New("module config: empty path")
 	ErrModuleBadPath   = errors.New("submodule has an invalid path")
+	ErrModuleBadName   = errors.New("ignoring suspicious submodule name")
 )
 
 var (
@@ -94,6 +98,10 @@ type Submodule struct {
 
 // Validate validates the fields and sets the default values.
 func (m *Submodule) Validate() error {
+	if err := validSubmoduleName(m.Name); err != nil {
+		return fmt.Errorf("%w: %q", ErrModuleBadName, m.Name)
+	}
+
 	if m.Path == "" {
 		return ErrModuleEmptyPath
 	}
@@ -108,6 +116,50 @@ func (m *Submodule) Validate() error {
 
 	return nil
 }
+
+// validSubmoduleName mirrors canonical Git's check_submodule_name in
+// submodule-config.c [1]: reject empty names and any name with a ".."
+// path component, using both '/' and '\\' as separators so the rule
+// is consistent across platforms. The component check is delegated to
+// `pathutil.IsHFSDot` and `pathutil.IsNTFSDot` with `.` as the needle,
+// which both cover the bare ".." case and reject components that
+// resolve to ".." after HFS+ Unicode normalisation (ignored code
+// points, e.g. `.<U+200C>.`) or NTFS trailing-space/dot/ADS
+// canonicalisation (e.g. `.. `, `..::$INDEX_ALLOCATION`).
+// `.gitmodules` is attacker-controlled by definition, so both checks
+// run unconditionally regardless of host OS.
+//
+// The additional checks (bare ".", NUL byte, leading or trailing
+// separator, drive-letter prefix) close go-git-specific edge cases
+// the canonical loop does not exercise: canonical Git treats names
+// as opaque C strings, while Go strings carry NULs through and the
+// billy filesystem layer is path-aware in ways Git's working storage
+// is not.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/submodule-config.c#L214-L237
+func validSubmoduleName(name string) error {
+	if name == "" || name == "." {
+		return ErrModuleBadName
+	}
+	for _, seg := range strings.FieldsFunc(name, isPathSep) {
+		if pathutil.IsHFSDot(seg, ".") || pathutil.IsNTFSDot(seg, ".", "") {
+			return ErrModuleBadName
+		}
+	}
+	// go-git-specific defensive checks beyond canonical Git.
+	if strings.ContainsRune(name, 0) {
+		return ErrModuleBadName
+	}
+	if isPathSep(rune(name[0])) || isPathSep(rune(name[len(name)-1])) {
+		return ErrModuleBadName
+	}
+	if len(name) >= 2 && name[1] == ':' {
+		return ErrModuleBadName
+	}
+	return nil
+}
+
+func isPathSep(r rune) bool { return r == '/' || r == '\\' }
 
 func (m *Submodule) unmarshal(s *format.Subsection) {
 	m.raw = s

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -1,13 +1,17 @@
 package config
 
-import . "gopkg.in/check.v1"
+import (
+	"errors"
+
+	. "gopkg.in/check.v1"
+)
 
 type ModulesSuite struct{}
 
 var _ = Suite(&ModulesSuite{})
 
 func (s *ModulesSuite) TestValidateMissingURL(c *C) {
-	m := &Submodule{Path: "foo"}
+	m := &Submodule{Name: "foo", Path: "foo"}
 	c.Assert(m.Validate(), Equals, ErrModuleEmptyURL)
 }
 
@@ -27,6 +31,7 @@ func (s *ModulesSuite) TestValidateBadPath(c *C) {
 
 	for _, p := range input {
 		m := &Submodule{
+			Name: "ok",
 			Path: p,
 			URL:  "https://example.com/",
 		}
@@ -35,8 +40,68 @@ func (s *ModulesSuite) TestValidateBadPath(c *C) {
 }
 
 func (s *ModulesSuite) TestValidateMissingName(c *C) {
-	m := &Submodule{URL: "bar"}
+	m := &Submodule{Name: "ok", URL: "bar"}
 	c.Assert(m.Validate(), Equals, ErrModuleEmptyPath)
+}
+
+func (s *ModulesSuite) TestValidateBadName(c *C) {
+	input := []string{
+		// Plain shapes the parser must reject regardless of OS.
+		"",
+		".",
+		"..",
+		"../x",
+		"a/../../b",
+		"/abs",
+		`C:\win`,
+		"x\x00y",
+		"x/",
+		"/x",
+		`.\..\foo`,
+		"modules/../escape",
+
+		// HFS+ ignores certain Unicode code points during path
+		// normalisation, so these all resolve to ".." on macOS.
+		".\u200c.",             // ZWNJ between dots
+		"\u200c..",             // leading ZWNJ
+		"..\u200c",             // trailing ZWNJ
+		"\u200c.\u200d.\u200e", // ZWNJ + ZWJ + LRM
+		"a/.\u200c./b",         // hidden ".." mid-path
+
+		// NTFS strips trailing spaces, dots, and an alternate-data
+		// -stream suffix during canonicalisation, so these all
+		// resolve to ".." on Windows.
+		".. ",
+		"..  ",
+		"....",
+		".. .",
+		"..::$INDEX_ALLOCATION",
+		"..:foo",
+		"a/.. /b",
+	}
+	for _, n := range input {
+		m := &Submodule{
+			Name: n,
+			Path: "ok",
+			URL:  "https://example.com/",
+		}
+		// Validate wraps the sentinel with the offending name
+		// (canonical-Git wording: "ignoring suspicious submodule
+		// name: <name>"), so use errors.Is.
+		c.Assert(errors.Is(m.Validate(), ErrModuleBadName), Equals, true,
+			Commentf("name %q", n))
+	}
+}
+
+func (s *ModulesSuite) TestValidateGoodName(c *C) {
+	for _, n := range []string{"foo", "lib-foo", "deps/x", "x.y"} {
+		m := &Submodule{
+			Name: n,
+			Path: "ok",
+			URL:  "https://example.com/",
+		}
+		c.Assert(m.Validate(), IsNil, Commentf("name %q", n))
+	}
 }
 
 func (s *ModulesSuite) TestMarshal(c *C) {

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -130,18 +130,26 @@ func (s *ModulesSuite) TestUnmarshal(c *C) {
 [submodule "suspicious"]
         path = ../../foo/bar
         url = https://github.com/foo/bar.git
+[submodule ".."]
+        path = deps/x
+        url = https://github.com/foo/bar.git
 `)
 
 	cfg := NewModules()
 	err := cfg.Unmarshal(input)
 	c.Assert(err, IsNil)
 
+	// The "suspicious" entry is dropped because of its `..` path,
+	// and the `..` entry is dropped because of its suspicious name
+	// (canonical Git's "ignoring suspicious submodule name" rule).
 	c.Assert(cfg.Submodules, HasLen, 2)
 	c.Assert(cfg.Submodules["qux"].Name, Equals, "qux")
 	c.Assert(cfg.Submodules["qux"].URL, Equals, "https://github.com/foo/qux.git")
 	c.Assert(cfg.Submodules["foo/bar"].Name, Equals, "foo/bar")
 	c.Assert(cfg.Submodules["foo/bar"].URL, Equals, "https://github.com/foo/bar.git")
 	c.Assert(cfg.Submodules["foo/bar"].Branch, Equals, "dev")
+	_, hasDotDot := cfg.Submodules[".."]
+	c.Assert(hasDotDot, Equals, false)
 }
 
 func (s *ModulesSuite) TestUnmarshalMarshal(c *C) {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -75,6 +75,10 @@ var (
 	// ErrEmptyRefFile is returned when a reference file is attempted to be read,
 	// but the file is empty
 	ErrEmptyRefFile = errors.New("ref file is empty")
+	// ErrModuleNameEscape is returned when a submodule name would
+	// resolve outside the modules/ subtree, mirroring canonical Git's
+	// "ignoring suspicious submodule name" defence.
+	ErrModuleNameEscape = errors.New("submodule name escapes modules/ directory")
 )
 
 // Options holds configuration for the storage.
@@ -1127,9 +1131,20 @@ func (d *DotGit) PackRefs() (err error) {
 	return nil
 }
 
-// Module return a billy.Filesystem pointing to the module folder
+// Module returns a billy.Filesystem pointing to the module folder.
+//
+// As a defence in depth against submodule name path traversal,
+// refuse names whose joined path leaves the modules/ subtree once
+// cleaned. The config-layer parser also validates submodule names,
+// but Module may be reached from any caller that constructs a
+// Submodule struct programmatically and so bypasses the parser.
 func (d *DotGit) Module(name string) (billy.Filesystem, error) {
-	return d.fs.Chroot(d.fs.Join(modulePath, name))
+	p := d.fs.Join(modulePath, name)
+	cleaned := path.Clean(filepath.ToSlash(p))
+	if cleaned != modulePath && !strings.HasPrefix(cleaned, modulePath+"/") {
+		return nil, ErrModuleNameEscape
+	}
+	return d.fs.Chroot(p)
 }
 
 func (d *DotGit) AddAlternate(remote string) error {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -3,6 +3,7 @@ package dotgit
 import (
 	"bufio"
 	"encoding/hex"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-billy/v5/util"
 	fixtures "github.com/go-git/go-git-fixtures/v4"
@@ -43,6 +45,32 @@ func (s *SuiteDotGit) TemporalFilesystem(c *C) (fs billy.Filesystem) {
 	}
 
 	return fs
+}
+
+func (s *SuiteDotGit) TestModuleRejectsEscapingNames(c *C) {
+	d := New(memfs.New())
+	// Only true path-traversal cases — names like "/etc" or
+	// "modules/../escape" land inside modules/ once Join cleans
+	// them, so the containment check correctly accepts those.
+	bad := []string{
+		"..",
+		"../x",
+		"foo/../..",
+		"a/b/c/../../../..",
+	}
+	for _, n := range bad {
+		_, err := d.Module(n)
+		c.Assert(errors.Is(err, ErrModuleNameEscape), Equals, true,
+			Commentf("name %q", n))
+	}
+}
+
+func (s *SuiteDotGit) TestModuleAcceptsBenignNames(c *C) {
+	d := New(memfs.New())
+	for _, n := range []string{"foo", "lib/foo", "x.y"} {
+		_, err := d.Module(n)
+		c.Assert(err, IsNil, Commentf("name %q", n))
+	}
 }
 
 func (s *SuiteDotGit) TestInitialize(c *C) {

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -2,12 +2,16 @@ package git
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
 	"github.com/go-git/go-git/v5/storage/memory"
 
 	fixtures "github.com/go-git/go-git-fixtures/v4"
@@ -573,4 +577,48 @@ func (s *SubmoduleSuite) TestSubmoduleRelativeURLRemoteWithoutURLs(c *C) {
 	c.Assert(subRepo, IsNil)
 	c.Assert(err, ErrorMatches,
 		`resolving relative submodule URL: remote "origin" has no configured URL`)
+}
+
+// TestSubmoduleRepositoryRejectsEscapingName covers the storage-layer
+// defence against submodule name path traversal. Constructing a
+// Submodule with `Name = ".."` programmatically (bypassing the
+// .gitmodules parser) must not result in `Repository()` opening a
+// storer rooted in the parent's `.git/` directory, and must leave the
+// parent's HEAD reference untouched.
+func (s *SubmoduleSuite) TestSubmoduleRepositoryRejectsEscapingName(c *C) {
+	dotfs := memfs.New()
+	wtfs := memfs.New()
+	// Use filesystem.NewStorage rather than memory.NewStorage for the
+	// parent because only the filesystem-backed ModuleStorer exercises
+	// the dotgit defence; the in-memory implementation maps names to
+	// storage units directly without traversing a path.
+	storer := filesystem.NewStorage(dotfs, cache.NewObjectLRUDefault())
+	r, err := Init(storer, wtfs)
+	c.Assert(err, IsNil)
+
+	wt, err := r.Worktree()
+	c.Assert(err, IsNil)
+
+	headBefore, err := storer.Reference(plumbing.HEAD)
+	c.Assert(err, IsNil)
+
+	sm := &Submodule{
+		initialized: true,
+		c: &config.Submodule{
+			Name: "..",
+			Path: "deps/x",
+			URL:  "https://example.com/",
+		},
+		w: wt,
+	}
+
+	repo, err := sm.Repository()
+	c.Assert(err, NotNil)
+	c.Assert(errors.Is(err, dotgit.ErrModuleNameEscape), Equals, true)
+	c.Assert(repo, IsNil)
+
+	headAfter, err := storer.Reference(plumbing.HEAD)
+	c.Assert(err, IsNil)
+	c.Assert(headBefore.Target(), Equals, headAfter.Target(),
+		Commentf("parent HEAD must not be overwritten"))
 }


### PR DESCRIPTION
`Submodule.Validate()` validated `Path` against `dotdotPath` but left `Name` unchecked, so submodule names with unusual shapes (empty, bare `.`/`..`, names containing `..` components, NUL bytes, or leading or trailing separators) were accepted at parse time and propagated to `DotGit.Module(name)`, which joined them into the on-disk modules path without verifying the result stayed under `modules/`.

The parser now mirrors canonical Git's `check_submodule_name` from `submodule-config.c` [1], extended with a few defensive checks for go-git-specific edge cases. The storage layer adds an independent path-containment check in `DotGit.Module(name)`, so any caller that constructs a `Submodule` programmatically — including the transactional storage wrapper — is also protected, and a regression test exercises the storage-layer defence end-to-end. Nested but contained names like `lib/foo` continue to work; only path-traversal shapes are refused.

[1]: https://github.com/git/git/blob/v2.54.0/submodule-config.c#L214-L237

Backport of #2079.