### PR TITLE
plumbing: format/idxfile, Validate offset64 indices

### DIFF
--- a/plumbing/format/idxfile/fuzz_helpers.go
+++ b/plumbing/format/idxfile/fuzz_helpers.go
@@ -2,7 +2,10 @@ package idxfile
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/binary"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 // buildMinimalIdx constructs a minimal valid idx v2 file with the given
@@ -61,6 +64,59 @@ func buildMinimalRev(count, hashSize int) []byte {
 
 	buf.Write(make([]byte, hashSize*2))
 	return buf.Bytes()
+}
+
+// buildOOBOffset64Idx constructs a structurally valid v2 idx file
+// whose single 32-bit offset entry is marked as a 64-bit overflow
+// (MSB set) but whose lower 31 bits point past the only allocated
+// 64-bit offset slot. The idx decodes successfully; using it must
+// fail with [ErrMalformedIdxFile] rather than crash.
+//
+// The returned hash is the name of the single object — pass it to
+// FindOffset to exercise the malformed-input path.
+//
+// Lives outside `_test.go` so the OSS-Fuzz harness, which does not
+// see other test files when extracting fuzz targets, can reach it
+// from FuzzMemoryIndex's seed corpus.
+func buildOOBOffset64Idx() ([]byte, plumbing.Hash) {
+	const hashSize = 20
+
+	var buf bytes.Buffer
+	buf.Write(idxHeader)
+	_ = binary.Write(&buf, binary.BigEndian, uint32(2))
+
+	// Fanout: one object whose first byte is 0x00, so all 256 entries
+	// hold the cumulative count 1.
+	for range 256 {
+		_ = binary.Write(&buf, binary.BigEndian, uint32(1))
+	}
+
+	// One name (any valid 20-byte hash with first byte 0x00).
+	name := make([]byte, hashSize)
+	name[hashSize-1] = 0x01
+	buf.Write(name)
+
+	// CRC32 (one entry, value irrelevant).
+	buf.Write(make([]byte, 4))
+
+	// Offset32: MSB set, lower 31 bits = 5 → references Offset64[40:48].
+	_ = binary.Write(&buf, binary.BigEndian, uint32(0x80000005))
+
+	// Offset64: a single 8-byte slot — the lookup above is out of range.
+	_ = binary.Write(&buf, binary.BigEndian, uint64(0x12345678))
+
+	// Pack checksum (zeros — the LazyIndex test passes the same value
+	// in as the expected pack hash so it matches).
+	buf.Write(make([]byte, hashSize))
+
+	// Idx checksum: SHA1 of everything written so far.
+	sum := sha1.Sum(buf.Bytes())
+	buf.Write(sum[:])
+
+	var h plumbing.Hash
+	h.ResetBySize(hashSize)
+	_, _ = h.Write(name)
+	return buf.Bytes(), h
 }
 
 // nopCloserReaderAt wraps a bytes.Reader to satisfy ReadAtCloser.

--- a/plumbing/format/idxfile/fuzz_test.go
+++ b/plumbing/format/idxfile/fuzz_test.go
@@ -2,9 +2,11 @@ package idxfile
 
 import (
 	"bytes"
+	"crypto"
 	"testing"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/hash"
 )
 
 func FuzzLazyIndex(f *testing.F) {
@@ -49,6 +51,57 @@ func FuzzLazyIndex(f *testing.F) {
 			return
 		}
 		defer idx.Close()
+
+		// Exercise all Index methods — none should panic.
+		testHash := plumbing.NewHash("abcdef1234567890abcdef1234567890abcdef12")
+		_, _ = idx.Contains(testHash)
+		_, _ = idx.FindOffset(testHash)
+		_, _ = idx.FindCRC32(testHash)
+		_, _ = idx.FindHash(42)
+		_, _ = idx.Count()
+
+		if iter, err := idx.Entries(); err == nil {
+			for range 100 {
+				if _, err := iter.Next(); err != nil {
+					break
+				}
+			}
+			_ = iter.Close()
+		}
+
+		if iter, err := idx.EntriesByOffset(); err == nil {
+			for range 100 {
+				if _, err := iter.Next(); err != nil {
+					break
+				}
+			}
+			_ = iter.Close()
+		}
+	})
+}
+
+func FuzzMemoryIndex(f *testing.F) {
+	// One seed that decodes successfully but exercises the post-decode
+	// methods on a malformed offset64 index — anchors the regression
+	// fixed by validating offset64 indices in getOffset.
+	oob, _ := buildOOBOffset64Idx()
+	f.Add(oob)
+
+	// Structurally valid prefixes; most will fail decode (e.g. the
+	// SHA1 trailer is zeros in buildMinimalIdx) but exercise the
+	// reader paths.
+	f.Add(buildMinimalIdx(3, 20))
+	f.Add(buildMinimalIdx(0, 20))
+	f.Add([]byte{0xff, 't', 'O', 'c', 0, 0, 0, 2})
+	f.Add([]byte{})
+
+	f.Fuzz(func(_ *testing.T, idxData []byte) {
+		idx := new(MemoryIndex)
+		d := NewDecoder(bytes.NewReader(idxData), hash.New(crypto.SHA1))
+		if err := d.Decode(idx); err != nil {
+			// Expected for most fuzz inputs.
+			return
+		}
 
 		// Exercise all Index methods — none should panic.
 		testHash := plumbing.NewHash("abcdef1234567890abcdef1234567890abcdef12")

--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -141,7 +141,10 @@ func (idx *MemoryIndex) FindOffset(h plumbing.Hash) (int64, error) {
 		return 0, plumbing.ErrObjectNotFound
 	}
 
-	offset := idx.getOffset(k, i)
+	offset, err := idx.getOffset(k, i)
+	if err != nil {
+		return 0, err
+	}
 
 	// Save the offset for reverse lookup
 	idx.mu.Lock()
@@ -156,17 +159,19 @@ func (idx *MemoryIndex) FindOffset(h plumbing.Hash) (int64, error) {
 
 const isO64Mask = uint64(1) << 31
 
-func (idx *MemoryIndex) getOffset(firstLevel, secondLevel int) uint64 {
+func (idx *MemoryIndex) getOffset(firstLevel, secondLevel int) (uint64, error) {
 	offset := secondLevel << 2
 	ofs := encbin.BigEndian.Uint32(idx.Offset32[firstLevel][offset : offset+4])
 
 	if (uint64(ofs) & isO64Mask) != 0 {
 		offset := 8 * (uint64(ofs) & ^isO64Mask)
-		n := encbin.BigEndian.Uint64(idx.Offset64[offset : offset+8])
-		return n
+		if offset+8 > uint64(len(idx.Offset64)) {
+			return 0, fmt.Errorf("%w: offset64 index out of range", ErrMalformedIdxFile)
+		}
+		return encbin.BigEndian.Uint64(idx.Offset64[offset : offset+8]), nil
 	}
 
-	return uint64(ofs)
+	return uint64(ofs), nil
 }
 
 // FindCRC32 implements the Index interface.
@@ -239,8 +244,11 @@ func (idx *MemoryIndex) genOffsetHash() error {
 				return fmt.Errorf("cannot write name to hash: %w", err)
 			}
 
-			offset := int64(idx.getOffset(mappedFirstLevel, int(secondLevel)))
-			offsetHash[offset] = hash
+			off, err := idx.getOffset(mappedFirstLevel, int(secondLevel))
+			if err != nil {
+				return err
+			}
+			offsetHash[int64(off)] = hash
 			secondLevel++
 		}
 	}
@@ -333,7 +341,10 @@ func (i *idxfileEntryIter) Next() (*Entry, error) {
 			return nil, fmt.Errorf("cannot write entry hash: %w", err)
 		}
 
-		entry.Offset = i.idx.getOffset(mappedFirstLevel, i.secondLevel)
+		entry.Offset, err = i.idx.getOffset(mappedFirstLevel, i.secondLevel)
+		if err != nil {
+			return nil, err
+		}
 		entry.CRC32 = i.idx.getCRC32(mappedFirstLevel, i.secondLevel)
 
 		i.secondLevel++

--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -165,7 +165,7 @@ func (idx *MemoryIndex) getOffset(firstLevel, secondLevel int) (uint64, error) {
 
 	if (uint64(ofs) & isO64Mask) != 0 {
 		offset := 8 * (uint64(ofs) & ^isO64Mask)
-		if offset+8 > uint64(len(idx.Offset64)) {
+		if l := uint64(len(idx.Offset64)); l < 8 || offset > l-8 {
 			return 0, fmt.Errorf("%w: offset64 index out of range", ErrMalformedIdxFile)
 		}
 		return encbin.BigEndian.Uint64(idx.Offset64[offset : offset+8]), nil

--- a/plumbing/format/idxfile/lazy_index.go
+++ b/plumbing/format/idxfile/lazy_index.go
@@ -45,6 +45,7 @@ type openFileFunc func() (ReadAtCloser, error)
 type LazyIndex struct {
 	hashSize int
 	count    int
+	count64  int
 
 	// Section byte offsets within the idx file.
 	fanoutStart int
@@ -157,6 +158,7 @@ func (s *LazyIndex) init(packHash plumbing.Hash) error {
 	if err != nil {
 		return err
 	}
+	s.count64 = n64
 
 	// The pack checksum sits right after the 64-bit offset table.
 	packBuf := make([]byte, s.hashSize)
@@ -349,6 +351,10 @@ func (s *LazyIndex) offset(idx io.ReaderAt, pos int) (uint64, error) {
 	off32 := binary.BigEndian.Uint32(buf[:])
 	if uint64(off32)&is64bitsMask != 0 {
 		loIndex := int(uint64(off32) & ^is64bitsMask)
+		if loIndex >= s.count64 {
+			return 0, fmt.Errorf("%w: offset64 index %d out of range (have %d entries)",
+				ErrMalformedIdxFile, loIndex, s.count64)
+		}
 		var buf64 [off64Size]byte
 		off64Pos := int64(s.off64Start + loIndex*off64Size)
 		if _, err := idx.ReadAt(buf64[:], off64Pos); err != nil {

--- a/plumbing/format/idxfile/lazy_index_test.go
+++ b/plumbing/format/idxfile/lazy_index_test.go
@@ -3,7 +3,6 @@ package idxfile
 import (
 	"bytes"
 	"crypto"
-	"crypto/sha1"
 	"encoding/base64"
 	"encoding/binary"
 	"io"
@@ -340,61 +339,10 @@ func TestLazyIndexInitErrors(t *testing.T) {
 	}
 }
 
-// buildOOBOffset64Idx constructs a structurally valid v2 idx file
-// whose single 32-bit offset entry is marked as a 64-bit overflow
-// (MSB set) but whose lower 31 bits point past the only allocated
-// 64-bit offset slot. The idx decodes successfully; using it must
-// fail with [ErrMalformedIdxFile] rather than panic.
-//
-// The returned hash is the name of the single object — pass it to
-// FindOffset to exercise the bug.
-func buildOOBOffset64Idx(t testing.TB) ([]byte, plumbing.Hash) {
-	t.Helper()
-
-	const hashSize = 20
-
-	var buf bytes.Buffer
-	buf.Write(idxHeader)
-	_ = binary.Write(&buf, binary.BigEndian, uint32(2))
-
-	// Fanout: one object whose first byte is 0x00, so all 256 entries
-	// hold the cumulative count 1.
-	for range 256 {
-		_ = binary.Write(&buf, binary.BigEndian, uint32(1))
-	}
-
-	// One name (any valid 20-byte hash with first byte 0x00).
-	name := make([]byte, hashSize)
-	name[hashSize-1] = 0x01
-	buf.Write(name)
-
-	// CRC32 (one entry, value irrelevant).
-	buf.Write(make([]byte, 4))
-
-	// Offset32: MSB set, lower 31 bits = 5 → references Offset64[40:48].
-	_ = binary.Write(&buf, binary.BigEndian, uint32(0x80000005))
-
-	// Offset64: a single 8-byte slot — the lookup above is out of range.
-	_ = binary.Write(&buf, binary.BigEndian, uint64(0x12345678))
-
-	// Pack checksum (zeros — the LazyIndex test passes the same value
-	// in as the expected pack hash so it matches).
-	buf.Write(make([]byte, hashSize))
-
-	// Idx checksum: SHA1 of everything written so far.
-	sum := sha1.Sum(buf.Bytes())
-	buf.Write(sum[:])
-
-	var h plumbing.Hash
-	h.ResetBySize(hashSize)
-	_, _ = h.Write(name)
-	return buf.Bytes(), h
-}
-
 func TestMemoryIndexOffset64OutOfRange(t *testing.T) {
 	t.Parallel()
 
-	idxBytes, h := buildOOBOffset64Idx(t)
+	idxBytes, h := buildOOBOffset64Idx()
 
 	idx := new(MemoryIndex)
 	d := NewDecoder(bytes.NewReader(idxBytes), hash.New(crypto.SHA1))
@@ -416,7 +364,7 @@ func TestMemoryIndexOffset64OutOfRange(t *testing.T) {
 func TestLazyIndexOffset64OutOfRange(t *testing.T) {
 	t.Parallel()
 
-	idxBytes, h := buildOOBOffset64Idx(t)
+	idxBytes, h := buildOOBOffset64Idx()
 
 	const hashSize = 20
 

--- a/plumbing/format/idxfile/lazy_index_test.go
+++ b/plumbing/format/idxfile/lazy_index_test.go
@@ -3,6 +3,7 @@ package idxfile
 import (
 	"bytes"
 	"crypto"
+	"crypto/sha1"
 	"encoding/base64"
 	"encoding/binary"
 	"io"
@@ -337,6 +338,105 @@ func TestLazyIndexInitErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// buildOOBOffset64Idx constructs a structurally valid v2 idx file
+// whose single 32-bit offset entry is marked as a 64-bit overflow
+// (MSB set) but whose lower 31 bits point past the only allocated
+// 64-bit offset slot. The idx decodes successfully; using it must
+// fail with [ErrMalformedIdxFile] rather than panic.
+//
+// The returned hash is the name of the single object — pass it to
+// FindOffset to exercise the bug.
+func buildOOBOffset64Idx(t testing.TB) ([]byte, plumbing.Hash) {
+	t.Helper()
+
+	const hashSize = 20
+
+	var buf bytes.Buffer
+	buf.Write(idxHeader)
+	_ = binary.Write(&buf, binary.BigEndian, uint32(2))
+
+	// Fanout: one object whose first byte is 0x00, so all 256 entries
+	// hold the cumulative count 1.
+	for range 256 {
+		_ = binary.Write(&buf, binary.BigEndian, uint32(1))
+	}
+
+	// One name (any valid 20-byte hash with first byte 0x00).
+	name := make([]byte, hashSize)
+	name[hashSize-1] = 0x01
+	buf.Write(name)
+
+	// CRC32 (one entry, value irrelevant).
+	buf.Write(make([]byte, 4))
+
+	// Offset32: MSB set, lower 31 bits = 5 → references Offset64[40:48].
+	_ = binary.Write(&buf, binary.BigEndian, uint32(0x80000005))
+
+	// Offset64: a single 8-byte slot — the lookup above is out of range.
+	_ = binary.Write(&buf, binary.BigEndian, uint64(0x12345678))
+
+	// Pack checksum (zeros — the LazyIndex test passes the same value
+	// in as the expected pack hash so it matches).
+	buf.Write(make([]byte, hashSize))
+
+	// Idx checksum: SHA1 of everything written so far.
+	sum := sha1.Sum(buf.Bytes())
+	buf.Write(sum[:])
+
+	var h plumbing.Hash
+	h.ResetBySize(hashSize)
+	_, _ = h.Write(name)
+	return buf.Bytes(), h
+}
+
+func TestMemoryIndexOffset64OutOfRange(t *testing.T) {
+	t.Parallel()
+
+	idxBytes, h := buildOOBOffset64Idx(t)
+
+	idx := new(MemoryIndex)
+	d := NewDecoder(bytes.NewReader(idxBytes), hash.New(crypto.SHA1))
+	require.NoError(t, d.Decode(idx))
+
+	_, err := idx.FindOffset(h)
+	require.ErrorIs(t, err, ErrMalformedIdxFile)
+
+	_, err = idx.FindHash(0)
+	require.ErrorIs(t, err, ErrMalformedIdxFile)
+
+	iter, err := idx.Entries()
+	require.NoError(t, err)
+	_, err = iter.Next()
+	require.ErrorIs(t, err, ErrMalformedIdxFile)
+	_ = iter.Close()
+}
+
+func TestLazyIndexOffset64OutOfRange(t *testing.T) {
+	t.Parallel()
+
+	idxBytes, h := buildOOBOffset64Idx(t)
+
+	const hashSize = 20
+
+	var revBuf bytes.Buffer
+	revBuf.Write([]byte{'R', 'I', 'D', 'X'})
+	_ = binary.Write(&revBuf, binary.BigEndian, uint32(1))
+	_ = binary.Write(&revBuf, binary.BigEndian, uint32(1)) // sha1 hash function id
+	_ = binary.Write(&revBuf, binary.BigEndian, uint32(0)) // single rev entry
+	revBuf.Write(make([]byte, hashSize*2))
+
+	packHash := extractPackHash(idxBytes, hashSize)
+	openIdx := readerAtOpener(idxBytes)
+	openRev := readerAtOpener(revBuf.Bytes())
+
+	idx, err := NewLazyIndex(openIdx, openRev, packHash)
+	require.NoError(t, err)
+	defer idx.Close()
+
+	_, err = idx.FindOffset(h)
+	require.ErrorIs(t, err, ErrMalformedIdxFile)
 }
 
 func extractPackHash(idx []byte, hashSize int) plumbing.Hash {


### PR DESCRIPTION
When a 32-bit offset entry has its MSB set, the lower 31 bits index into the `Offset64` table. Neither `MemoryIndex.getOffset` nor `LazyIndex.offset` validated that the resulting position fell inside the decoded table; an idx with an MSB-set entry whose lower bits exceed the number of decoded 64-bit entries would index past the end of the table.

Bounds-check both lookups against the decoded table size and return `ErrMalformedIdxFile` when the index is out of range. `MemoryIndex`'s unexported `getOffset` now returns `(uint64, error)`; the change propagates through `FindOffset`, `genOffsetHash`, and the `Entries` iterator. `LazyIndex` caches the 64-bit-entry count discovered during init and uses it for the same check before issuing the `ReadAt`.