### PR TITLE
v5: plumbing: format/idxfile, Validate offset64 indices

### DIFF
--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -2,6 +2,7 @@ package idxfile
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sort"
 	"sync"
@@ -126,7 +127,10 @@ func (idx *MemoryIndex) FindOffset(h plumbing.Hash) (int64, error) {
 		return 0, plumbing.ErrObjectNotFound
 	}
 
-	offset := idx.getOffset(k, i)
+	offset, err := idx.getOffset(k, i)
+	if err != nil {
+		return 0, err
+	}
 
 	// Save the offset for reverse lookup
 	idx.mu.Lock()
@@ -141,17 +145,19 @@ func (idx *MemoryIndex) FindOffset(h plumbing.Hash) (int64, error) {
 
 const isO64Mask = uint64(1) << 31
 
-func (idx *MemoryIndex) getOffset(firstLevel, secondLevel int) uint64 {
+func (idx *MemoryIndex) getOffset(firstLevel, secondLevel int) (uint64, error) {
 	offset := secondLevel << 2
 	ofs := encbin.BigEndian.Uint32(idx.Offset32[firstLevel][offset : offset+4])
 
 	if (uint64(ofs) & isO64Mask) != 0 {
 		offset := 8 * (uint64(ofs) & ^isO64Mask)
-		n := encbin.BigEndian.Uint64(idx.Offset64[offset : offset+8])
-		return n
+		if offset+8 > uint64(len(idx.Offset64)) {
+			return 0, fmt.Errorf("%w: offset64 index out of range", ErrMalformedIdxFile)
+		}
+		return encbin.BigEndian.Uint64(idx.Offset64[offset : offset+8]), nil
 	}
 
-	return uint64(ofs)
+	return uint64(ofs), nil
 }
 
 // FindCRC32 implements the Index interface.
@@ -209,8 +215,11 @@ func (idx *MemoryIndex) genOffsetHash() error {
 		mappedFirstLevel := idx.FanoutMapping[firstLevel]
 		for secondLevel := uint32(0); i < fanoutValue; i++ {
 			copy(hash[:], idx.Names[mappedFirstLevel][secondLevel*objectIDLength:])
-			offset := int64(idx.getOffset(mappedFirstLevel, int(secondLevel)))
-			offsetHash[offset] = hash
+			off, err := idx.getOffset(mappedFirstLevel, int(secondLevel))
+			if err != nil {
+				return err
+			}
+			offsetHash[int64(off)] = hash
 			secondLevel++
 		}
 	}
@@ -291,7 +300,11 @@ func (i *idxfileEntryIter) Next() (*Entry, error) {
 		mappedFirstLevel := i.idx.FanoutMapping[i.firstLevel]
 		entry := new(Entry)
 		copy(entry.Hash[:], i.idx.Names[mappedFirstLevel][i.secondLevel*objectIDLength:])
-		entry.Offset = i.idx.getOffset(mappedFirstLevel, i.secondLevel)
+		var err error
+		entry.Offset, err = i.idx.getOffset(mappedFirstLevel, i.secondLevel)
+		if err != nil {
+			return nil, err
+		}
 		entry.CRC32 = i.idx.getCRC32(mappedFirstLevel, i.secondLevel)
 
 		i.secondLevel++

--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -151,7 +151,7 @@ func (idx *MemoryIndex) getOffset(firstLevel, secondLevel int) (uint64, error) {
 
 	if (uint64(ofs) & isO64Mask) != 0 {
 		offset := 8 * (uint64(ofs) & ^isO64Mask)
-		if offset+8 > uint64(len(idx.Offset64)) {
+		if l := uint64(len(idx.Offset64)); l < 8 || offset > l-8 {
 			return 0, fmt.Errorf("%w: offset64 index out of range", ErrMalformedIdxFile)
 		}
 		return encbin.BigEndian.Uint64(idx.Offset64[offset : offset+8]), nil

--- a/plumbing/format/idxfile/idxfile_test.go
+++ b/plumbing/format/idxfile/idxfile_test.go
@@ -2,7 +2,9 @@ package idxfile_test
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"sync"
@@ -12,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/idxfile"
 
 	fixtures "github.com/go-git/go-git-fixtures/v4"
+	"github.com/stretchr/testify/require"
 	. "gopkg.in/check.v1"
 )
 
@@ -198,4 +201,55 @@ func TestOffsetHashConcurrentPopulation(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestMemoryIndexOffset64OutOfRange(t *testing.T) {
+	t.Parallel()
+
+	const hashSize = 20
+
+	var buf bytes.Buffer
+	buf.Write([]byte{255, 't', 'O', 'c'})
+	binary.Write(&buf, binary.BigEndian, uint32(2))
+
+	// Fanout: one object whose first byte is 0x00, so all 256 entries
+	// hold the cumulative count 1.
+	for range 256 {
+		binary.Write(&buf, binary.BigEndian, uint32(1))
+	}
+
+	// One name (any valid 20-byte hash with first byte 0x00).
+	name := make([]byte, hashSize)
+	name[hashSize-1] = 0x01
+	buf.Write(name)
+	buf.Write(make([]byte, 4)) // CRC32
+
+	// Offset32: MSB set, lower 31 bits = 5 → references Offset64[40:48].
+	binary.Write(&buf, binary.BigEndian, uint32(0x80000005))
+
+	// Offset64: a single 8-byte slot — the lookup above is out of range.
+	binary.Write(&buf, binary.BigEndian, uint64(0x12345678))
+
+	buf.Write(make([]byte, hashSize)) // pack checksum
+
+	sum := sha1.Sum(buf.Bytes())
+	buf.Write(sum[:])
+
+	idx := new(idxfile.MemoryIndex)
+	require.NoError(t, idxfile.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(idx))
+
+	var h plumbing.Hash
+	copy(h[:], name)
+
+	_, err := idx.FindOffset(h)
+	require.ErrorIs(t, err, idxfile.ErrMalformedIdxFile)
+
+	_, err = idx.FindHash(0)
+	require.ErrorIs(t, err, idxfile.ErrMalformedIdxFile)
+
+	iter, err := idx.Entries()
+	require.NoError(t, err)
+	_, err = iter.Next()
+	require.ErrorIs(t, err, idxfile.ErrMalformedIdxFile)
+	iter.Close()
 }


### PR DESCRIPTION
When a 32-bit offset entry has its MSB set, the lower 31 bits index into the `Offset64` table. `MemoryIndex.getOffset` did not validate that the resulting position fell inside the decoded table; an idx with an MSB-set entry whose lower bits exceed the number of decoded 64-bit entries would index past the end of the table.

Bounds-check the lookup against the decoded table size and return `ErrMalformedIdxFile` when the index is out of range. The unexported `getOffset` now returns `(uint64, error)`; the change propagates through `FindOffset`, `genOffsetHash`, and the `Entries` iterator.

Backport of #2083.