### PR TITLE
plumbing: format/packfile, Test patchDeltaWriter cap

### DIFF
--- a/plumbing/format/packfile/delta_test.go
+++ b/plumbing/format/packfile/delta_test.go
@@ -3,12 +3,14 @@ package packfile
 import (
 	"bytes"
 	"io"
+	"math"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
 type DeltaSuite struct {
@@ -192,6 +194,31 @@ func (s *DeltaSuite) TestMaxCopySizeDeltaReader() {
 	err = resultRC.Close()
 	s.NoError(err)
 	s.Equal(targetBuf, result)
+}
+
+func (s *DeltaSuite) TestPatchDeltaWriterOversizedTargetHeader() {
+	// patchDeltaWriter must bound the preemptive Buffer.Grow at
+	// maxPatchPreemptionSize regardless of the targetSz advertised in
+	// the delta header, matching the behaviour of patchDelta. The
+	// header here encodes targetSz = math.MaxInt64; with the cap in
+	// place the function reaches the command loop, runs out of input,
+	// and returns an error.
+	var hdr bytes.Buffer
+	hdr.WriteByte(0x00) // srcSz = 0
+
+	n := uint64(math.MaxInt64)
+	for n >= 0x80 {
+		hdr.WriteByte(byte(n) | 0x80)
+		n >>= 7
+	}
+	hdr.WriteByte(byte(n))
+
+	var dst bytes.Buffer
+	_, _, err := patchDeltaWriter(
+		&dst, bytes.NewReader(nil), &hdr,
+		plumbing.BlobObject, nil, format.SHA1,
+	)
+	s.Error(err)
 }
 
 func FuzzPatchDelta(f *testing.F) {

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -338,10 +338,14 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 	}
 
 	// Avoid several interactions expanding the buffer, which can be quite
-	// inefficient on large deltas. The hint is clamped because targetSz
-	// is decoded from untrusted input and Grow takes a non-negative int.
+	// inefficient on large deltas. The preemptive growth is capped at
+	// maxPatchPreemptionSize so that the header-derived targetSz cannot
+	// drive a large allocation; this mirrors patchDelta.
 	if b, ok := dst.(*bytes.Buffer); ok {
-		b.Grow(int(min(targetSz, maxPatchPreemptionSize)))
+		// The hint is clamped because targetSz is decoded from untrusted
+		// input and Grow takes a non-negative int.
+		growSz := min(targetSz, maxPatchPreemptionSize)
+		b.Grow(int(growSz))
 	}
 
 	// If header still needs to be written, caller will provide


### PR DESCRIPTION
`patchDeltaWriter`'s preemptive `Buffer.Grow` is already clamped at `maxPatchPreemptionSize` since 5b89cb5a, but no test covered that path end-to-end. Add a regression test that constructs a delta whose header advertises a `math.MaxInt64` `targetSz` and asserts the call returns an error rather than driving the allocation.

Also restate the rationale for the clamp in the comment, naming both the input-validation goal and the symmetry with `patchDelta`.