### PR TITLE
storage: filesystem, Search alternates in HashesWithPrefix

### DIFF
--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -763,6 +763,7 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 			if err == io.EOF {
 				break
 			} else if err != nil {
+				_ = ei.Close()
 				return nil, err
 			}
 			if e.Hash.HasPrefix(prefix) {

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -769,10 +769,30 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 				if _, ok := seen[e.Hash]; ok {
 					continue
 				}
+				seen[e.Hash] = struct{}{}
 				hashes = append(hashes, e.Hash)
 			}
 		}
 		_ = ei.Close()
+	}
+
+	if err := s.initAlternates(); err != nil {
+		return nil, err
+	}
+	s.muA.RLock()
+	defer s.muA.RUnlock()
+	for _, alt := range s.alternates {
+		altHashes, err := alt.HashesWithPrefix(prefix)
+		if err != nil {
+			return nil, err
+		}
+		for _, h := range altHashes {
+			if _, ok := seen[h]; ok {
+				continue
+			}
+			seen[h] = struct{}{}
+			hashes = append(hashes, h)
+		}
 	}
 
 	return hashes, nil

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -815,6 +815,37 @@ func (s *FsSuite) TestObjectStorageAlternatesHasEncodedObject() {
 	s.Require().NoError(err)
 }
 
+// TestObjectStorageAlternatesHashesWithPrefix verifies HashesWithPrefix
+// finds objects stored in alternates.
+func (s *FsSuite) TestObjectStorageAlternatesHashesWithPrefix() {
+	baseDir := s.T().TempDir()
+	templateFs, err := fixtures.Basic().ByTag(".git").One().DotGit(fixtures.WithTargetDir(func() string { return baseDir }))
+	s.Require().NoError(err)
+	commitHash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+
+	workDotGit := filepath.Join(baseDir, "work", ".git")
+	alternatesDir := filepath.Join(workDotGit, "objects", "info")
+	err = os.MkdirAll(alternatesDir, 0o755)
+	s.Require().NoError(err)
+	alternatesFile := filepath.Join(alternatesDir, "alternates")
+	err = os.WriteFile(alternatesFile, []byte(templateFs.Root()+"/objects\n"), 0o644)
+	s.Require().NoError(err)
+
+	rootFs := osfs.New(baseDir)
+	workFs, err := rootFs.Chroot(filepath.Join("work", ".git"))
+	s.Require().NoError(err)
+	dg := dotgit.NewWithOptions(workFs, dotgit.Options{AlternatesFS: rootFs})
+	storage := NewObjectStorage(dg, cache.NewObjectLRUDefault())
+
+	hashes, err := storage.HashesWithPrefix(commitHash.Bytes()[:4])
+	s.Require().NoError(err)
+	s.Len(hashes, 1)
+	s.Equal(commitHash, hashes[0])
+
+	err = storage.Close()
+	s.Require().NoError(err)
+}
+
 // TestObjectStorageAlternatesEncodedObjectSize verifies EncodedObjectSize
 // correctly checks alternates.
 func (s *FsSuite) TestObjectStorageAlternatesEncodedObjectSize() {


### PR DESCRIPTION
`EncodedObject`, `HasEncodedObject` and `EncodedObjectSize` all fall back to alternate object stores, but `HashesWithPrefix` only consults local loose objects and packs. With alternates configured, `ResolveRevision` on an abbreviated hash that lives in the alternate returns `ErrReferenceNotFound` even though the full hash resolves.

This iterates alternates after local lookup, deduplicating against results already collected. It also marks pack hits as seen so a hash present in multiple packs or in both a pack and an alternate is returned once.