### PR TITLE
plumbing: format/packfile, Pool bufio.Reader in patchDeltaWriter

### DIFF
--- a/plumbing/format/packfile/delta_test.go
+++ b/plumbing/format/packfile/delta_test.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"math"
@@ -215,7 +216,7 @@ func (s *DeltaSuite) TestPatchDeltaWriterOversizedTargetHeader() {
 
 	var dst bytes.Buffer
 	_, _, err := patchDeltaWriter(
-		&dst, bytes.NewReader(nil), &hdr,
+		&dst, bytes.NewReader(nil), bufio.NewReader(&hdr),
 		plumbing.BlobObject, nil, format.SHA1,
 	)
 	s.Error(err)

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -532,7 +532,10 @@ func (p *Parser) applyPatchBaseHeader(ota *ObjectHeader, delta io.Reader, target
 		typ = ota.parent.Type
 	}
 
-	sz, h, err := patchDeltaWriter(target, parentContents, delta, typ, wh, p.objectFormat)
+	deltaBuf := sync.GetBufioReader(delta)
+	defer sync.PutBufioReader(deltaBuf)
+
+	sz, h, err := patchDeltaWriter(target, parentContents, deltaBuf, typ, wh, p.objectFormat)
 	if err != nil {
 		return err
 	}

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -319,10 +319,9 @@ func patchDelta(dst *bytes.Buffer, src, delta []byte) error {
 	return nil
 }
 
-func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
+func patchDeltaWriter(dst io.Writer, base io.ReaderAt, deltaBuf *bufio.Reader,
 	typ plumbing.ObjectType, writeHeader objectHeaderWriter, of format.ObjectFormat,
 ) (uint, plumbing.Hash, error) {
-	deltaBuf := bufio.NewReader(delta)
 	srcSz, err := packutil.DecodeLEB128FromReader(deltaBuf)
 	if err != nil {
 		if err == io.EOF {


### PR DESCRIPTION
## Summary

`patchDeltaWriter` allocated a new `bufio.Reader` for every delta object processed during pack
parsing. On a clone of `go-git/go-git` (26K objects) this produced **73 MB** of buffer allocations
(23% of total). This change uses the existing `sync.GetBufioReader`/`PutBufioReader` pool in
`applyPatchBaseHeader` so that `bufio.Reader` instances are reused across delta resolution calls.

## Motivation

Profiling `PlainClone` of `go-git/go-git.git` showed `bufio.NewReaderSize` inside
`patchDeltaWriter` → `buildIndex` as the second largest allocator (73 MB cumulative, 23%
of total). Every delta object created a 4 KB `bufio.Reader` that was immediately discarded
after use. The `utils/sync` package already provides a `bufio.Reader` pool (`GetBufioReader`/
`PutBufioReader`) that was not being used in this path.

## Benchmark

Cloning `go-git/go-git.git` (26,119 objects) on Apple M4 Pro:

```
              TotalAlloc   Sys      Time
v5:           178 MB       121 MB   11.6s
v6 (before):  280 MB       181 MB    8.3s
v6 (after):   222 MB       184 MB    7.9s
```

The change reduces `TotalAlloc` by **58 MB (21%)**, closing the gap with v5 from +57% to +25%.

`ReaderFromDelta` (line 110) intentionally keeps its own `bufio.NewReaderSize(deltaRC, 1024)`
because it runs inside a goroutine with a different ownership model.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>