### PR TITLE
plumbing: format/packfile, Tighten delta validation

### DIFF
--- a/plumbing/format/packfile/delta_test.go
+++ b/plumbing/format/packfile/delta_test.go
@@ -226,6 +226,12 @@ func FuzzPatchDelta(f *testing.F) {
 	f.Add([]byte("some value"), []byte("\n\x0e\x0evalue"))
 	f.Add([]byte("some value"), []byte("\n\x0e\x0eva"))
 	f.Add([]byte("some value"), []byte("\n\x80\x80\x80\x80\x80\x802\x7fvalue"))
+	// Two copy-from-delta ops whose declared sizes each fit within
+	// targetSz but whose sum exceeds it. Header: srcSz=10, targetSz=10.
+	f.Add([]byte("AAAAAAAAAA"), []byte("\n\n\aBBBBBBB\aCCCCCCC"))
+	// Two copy-from-src ops with the same shape: cmd=0x90 takes one
+	// size byte and reads from offset 0 of src.
+	f.Add([]byte("AAAAAAAAAA"), []byte("\n\n\x90\a\x90\a"))
 
 	f.Fuzz(func(_ *testing.T, input1, input2 []byte) {
 		PatchDelta(input1, input2)

--- a/plumbing/format/packfile/diff_delta.go
+++ b/plumbing/format/packfile/diff_delta.go
@@ -19,9 +19,6 @@ const (
 	// https://github.com/git/git/blob/f7466e94375b3be27f229c78873f0acf8301c0a5/diff-delta.c#L428
 	// Max size of a copy operation (64KB).
 	maxCopySize = 64 * 1024
-
-	// Min size of a copy operation.
-	minCopySize = 4
 )
 
 // GetDelta returns an EncodedObject of type OFSDeltaObject. Base and Target object,

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -338,13 +338,16 @@ func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, er
 			return nil, fmt.Errorf("cannot find base object: %w", err)
 		}
 
+		// The scanner pre-populates oh.content for delta objects when
+		// running outside low-memory mode; only inflate when we don't
+		// already hold the bytes, otherwise this would append a
+		// duplicate copy of the delta payload.
 		if oh.content == nil {
 			oh.content = gogitsync.GetBytesBuffer()
-		}
-
-		err = p.scanner.inflateContent(oh.ContentOffset, oh.content)
-		if err != nil {
-			return nil, fmt.Errorf("cannot inflate content: %w", err)
+			err = p.scanner.inflateContent(oh.ContentOffset, oh.content)
+			if err != nil {
+				return nil, fmt.Errorf("cannot inflate content: %w", err)
+			}
 		}
 
 		obj.SetType(parent.Type())

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -31,8 +31,10 @@ const (
 	// preemptively made available for a patch operation.
 	maxPatchPreemptionSize uint = 65536
 
-	// minDeltaSize defines the smallest size for a delta.
-	minDeltaSize = 4
+	// minDeltaSize is the smallest valid delta: a 1-byte srcSz LEB128
+	// header followed by a 1-byte targetSz LEB128 header (the
+	// shortest case being targetSz=0 with no operations).
+	minDeltaSize = 2
 )
 
 type offset struct {
@@ -141,7 +143,7 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 		baseBuf := bufio.NewReader(baseRd)
 		basePos := uint(0)
 
-		for {
+		for remainingTargetSz > 0 {
 			cmd, err := deltaBuf.ReadByte()
 			if err == io.EOF {
 				_ = dstWr.CloseWithError(ErrInvalidDelta)
@@ -165,9 +167,9 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 					return
 				}
 
-				if invalidSize(sz, targetSz) ||
+				if invalidSize(sz, remainingTargetSz) ||
 					invalidOffsetSize(offset, sz, srcSz) {
-					_ = dstWr.Close()
+					_ = dstWr.CloseWithError(ErrInvalidDelta)
 					return
 				}
 
@@ -209,7 +211,7 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 
 			case isCopyFromDelta(cmd):
 				sz := uint(cmd) // cmd is the size itself
-				if invalidSize(sz, targetSz) {
+				if invalidSize(sz, remainingTargetSz) {
 					_ = dstWr.CloseWithError(ErrInvalidDelta)
 					return
 				}
@@ -224,22 +226,25 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 				_ = dstWr.CloseWithError(ErrDeltaCmd)
 				return
 			}
-
-			if remainingTargetSz <= 0 {
-				_ = dstWr.Close()
-				return
-			}
 		}
+
+		// Mirror upstream's `data != top` post-loop check: every byte
+		// of the delta payload must be consumed.
+		if _, err := deltaBuf.ReadByte(); err == nil {
+			_ = dstWr.CloseWithError(ErrInvalidDelta)
+			return
+		} else if err != io.EOF {
+			_ = dstWr.CloseWithError(err)
+			return
+		}
+
+		_ = dstWr.Close()
 	}()
 
 	return dstRd, nil
 }
 
 func patchDelta(dst *bytes.Buffer, src, delta []byte) error {
-	if len(delta) < minCopySize {
-		return ErrInvalidDelta
-	}
-
 	srcSz, delta, err := packutil.DecodeLEB128(delta)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrInvalidDelta, err)
@@ -254,16 +259,15 @@ func patchDelta(dst *bytes.Buffer, src, delta []byte) error {
 	}
 	remainingTargetSz := targetSz
 
-	var cmd byte
-
 	growSz := min(targetSz, maxPatchPreemptionSize)
 	dst.Grow(int(growSz))
-	for {
+
+	for remainingTargetSz > 0 {
 		if len(delta) == 0 {
 			return ErrInvalidDelta
 		}
 
-		cmd = delta[0]
+		cmd := delta[0]
 		delta = delta[1:]
 
 		switch {
@@ -280,16 +284,16 @@ func patchDelta(dst *bytes.Buffer, src, delta []byte) error {
 				return err
 			}
 
-			if invalidSize(sz, targetSz) ||
+			if invalidSize(sz, remainingTargetSz) ||
 				invalidOffsetSize(offset, sz, srcSz) {
-				break
+				return ErrInvalidDelta
 			}
 			dst.Write(src[offset : offset+sz])
 			remainingTargetSz -= sz
 
 		case isCopyFromDelta(cmd):
 			sz := uint(cmd) // cmd is the size itself
-			if invalidSize(sz, targetSz) {
+			if invalidSize(sz, remainingTargetSz) {
 				return ErrInvalidDelta
 			}
 
@@ -304,10 +308,12 @@ func patchDelta(dst *bytes.Buffer, src, delta []byte) error {
 		default:
 			return ErrDeltaCmd
 		}
+	}
 
-		if remainingTargetSz <= 0 {
-			break
-		}
+	// Mirror upstream's `data != top` post-loop check: every byte of
+	// the delta payload must be consumed.
+	if len(delta) != 0 {
+		return ErrInvalidDelta
 	}
 
 	return nil
@@ -371,7 +377,7 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 	baselr := io.LimitReader(sr, 0).(*io.LimitedReader)
 	deltalr := io.LimitReader(deltaBuf, 0).(*io.LimitedReader)
 
-	for {
+	for remainingTargetSz > 0 {
 		buf := *bufp
 		cmd, err := deltaBuf.ReadByte()
 		if err == io.EOF {
@@ -392,9 +398,9 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 				return 0, plumbing.ZeroHash, err
 			}
 
-			if invalidSize(sz, targetSz) ||
+			if invalidSize(sz, remainingTargetSz) ||
 				invalidOffsetSize(offset, sz, srcSz) {
-				return 0, plumbing.ZeroHash, err
+				return 0, plumbing.ZeroHash, ErrInvalidDelta
 			}
 
 			if _, err := sr.Seek(int64(offset), io.SeekStart); err != nil {
@@ -407,7 +413,7 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 			remainingTargetSz -= sz
 		case isCopyFromDelta(cmd):
 			sz := uint(cmd) // cmd is the size itself
-			if invalidSize(sz, targetSz) {
+			if invalidSize(sz, remainingTargetSz) {
 				return 0, plumbing.ZeroHash, ErrInvalidDelta
 			}
 			deltalr.N = int64(sz)
@@ -417,11 +423,16 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 
 			remainingTargetSz -= sz
 		default:
-			return 0, plumbing.ZeroHash, err
+			return 0, plumbing.ZeroHash, ErrDeltaCmd
 		}
-		if remainingTargetSz <= 0 {
-			break
-		}
+	}
+
+	// Mirror upstream's `data != top` post-loop check: every byte of
+	// the delta payload must be consumed.
+	if _, err := deltaBuf.ReadByte(); err == nil {
+		return 0, plumbing.ZeroHash, ErrInvalidDelta
+	} else if err != io.EOF {
+		return 0, plumbing.ZeroHash, err
 	}
 
 	return targetSz, hasher.Sum(), nil
@@ -502,8 +513,9 @@ func decodeSize(cmd byte, delta []byte) (uint, []byte, error) {
 	return sz, delta, nil
 }
 
-func invalidSize(sz, targetSz uint) bool {
-	return sz > targetSz
+// invalidSize reports whether sz exceeds the remaining target size.
+func invalidSize(sz, remaining uint) bool {
+	return sz > remaining
 }
 
 func invalidOffsetSize(offset, sz, srcSz uint) bool {

--- a/plumbing/format/packfile/patch_delta_test.go
+++ b/plumbing/format/packfile/patch_delta_test.go
@@ -2,11 +2,13 @@ package packfile
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/plumbing"
 	packutil "github.com/go-git/go-git/v6/plumbing/format/packfile/util"
 )
 
@@ -82,4 +84,130 @@ func TestDecodeLEB128(t *testing.T) {
 			assert.Equal(t, tc.wantRest, gotRest, "remaining bytes mismatch")
 		})
 	}
+}
+
+// buildDelta assembles a delta byte stream from a (srcSz, targetSz)
+// header and a sequence of pre-encoded operations.
+func buildDelta(srcSz, targetSz int, ops ...[]byte) []byte {
+	var b bytes.Buffer
+	b.Write(deltaEncodeSize(srcSz))
+	b.Write(deltaEncodeSize(targetSz))
+	for _, op := range ops {
+		b.Write(op)
+	}
+	return b.Bytes()
+}
+
+// insertOp encodes a copy-from-delta op of the given payload.
+func insertOp(data []byte) []byte {
+	return append([]byte{byte(len(data))}, data...)
+}
+
+// TestPatchDeltaRejectsOversizedCopies asserts that a delta whose
+// individual copy operations each fit within the declared target size,
+// but whose cumulative output would exceed it, is rejected before any
+// write past the declared target size happens.
+func TestPatchDeltaRejectsOversizedCopies(t *testing.T) {
+	t.Parallel()
+
+	src := bytes.Repeat([]byte("A"), 64)
+
+	cases := []struct {
+		name     string
+		targetSz uint
+		delta    []byte
+	}{
+		{
+			// Two copy-from-src ops, each individually fits but
+			// their sum (126) exceeds targetSz (64).
+			name:     "copy-from-src cumulative overflow",
+			targetSz: 64,
+			delta: buildDelta(64, 64,
+				encodeCopyOperation(0, 63),
+				encodeCopyOperation(0, 63),
+			),
+		},
+		{
+			// Two copy-from-delta ops, each fits but their sum (14)
+			// exceeds targetSz (10).
+			name:     "copy-from-delta cumulative overflow",
+			targetSz: 10,
+			delta: buildDelta(64, 10,
+				insertOp(bytes.Repeat([]byte{'x'}, 7)),
+				insertOp(bytes.Repeat([]byte{'x'}, 7)),
+			),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := PatchDelta(src, tc.delta)
+			assert.ErrorIs(t, err, ErrInvalidDelta)
+
+			// The buffer fed to patchDelta must never be written past
+			// targetSz: that is the property the validation protects.
+			b := &bytes.Buffer{}
+			_ = patchDelta(b, src, tc.delta)
+			assert.LessOrEqual(t, uint(b.Len()), tc.targetSz,
+				"patchDelta wrote past the declared target size")
+		})
+	}
+}
+
+// TestReaderFromDeltaRejectsOversizedCopies covers the streaming
+// counterpart and asserts that the reader surfaces ErrInvalidDelta to
+// the consumer rather than silently truncating the stream when a
+// crafted delta would write past the declared target size.
+func TestReaderFromDeltaRejectsOversizedCopies(t *testing.T) {
+	t.Parallel()
+
+	src := bytes.Repeat([]byte("A"), 64)
+	base := &plumbing.MemoryObject{}
+	_, _ = base.Write(src)
+
+	delta := buildDelta(64, 64,
+		encodeCopyOperation(0, 63),
+		encodeCopyOperation(0, 63),
+	)
+
+	rc, err := ReaderFromDelta(base, io.NopCloser(bytes.NewReader(delta)))
+	assert.NoError(t, err)
+	out, err := io.ReadAll(rc)
+	assert.ErrorIs(t, err, ErrInvalidDelta)
+	assert.LessOrEqual(t, len(out), 64,
+		"ReaderFromDelta yielded more bytes than the declared target size")
+}
+
+// TestPatchDeltaRejectsTrailingBytes asserts that a delta whose
+// operations exactly fill the declared target size but is followed by
+// extra bytes is rejected, matching upstream's `data != top` post-loop
+// sanity check.
+func TestPatchDeltaRejectsTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	src := bytes.Repeat([]byte("A"), 64)
+	delta := buildDelta(64, 64,
+		encodeCopyOperation(0, 64),
+		[]byte{0x00, 0x01, 0x02}, // unused trailing bytes
+	)
+
+	_, err := PatchDelta(src, delta)
+	assert.ErrorIs(t, err, ErrInvalidDelta)
+}
+
+// TestPatchDeltaAcceptsEmptyTarget asserts that a delta whose declared
+// target size is zero and which carries no operations succeeds and
+// produces an empty result, matching upstream's behaviour of treating
+// `data == top && size == 0` as success.
+func TestPatchDeltaAcceptsEmptyTarget(t *testing.T) {
+	t.Parallel()
+
+	src := []byte("hello")
+	delta := buildDelta(len(src), 0)
+
+	out, err := PatchDelta(src, delta)
+	assert.NoError(t, err)
+	assert.Empty(t, out)
 }


### PR DESCRIPTION
Each delta operation's declared size is validated against the size still remaining in the target buffer, not the total target size. The previous check against the total accepted a sequence of operations whose cumulative output would exceed the declared target, leaving the unsigned remaining counter unable to reach zero and the loop free to keep writing past the declared target until the delta payload was consumed.

Three sibling code paths shared the flaw and are updated together: `patchDelta` (used by `PatchDelta` and `ApplyDelta`), `ReaderFromDelta`, and `patchDeltaWriter` (used by the packfile parser).

The loop structure is rewritten as `for remainingTargetSz > 0` so the invariant is explicit, and a post-loop check rejects deltas that leave bytes unconsumed -- matching the `data != top` sanity check in `patch-delta.c`[1]. Empty-target deltas (header-only, no operations) are now accepted, also matching upstream.

Several incidental defects on the same call paths are fixed: `patchDelta`'s copy-from-src failure used `break`, which only exited the switch and let the loop keep consuming delta bytes; `patchDeltaWriter` returned `(0, ZeroHash, nil)` on invalid input, silently reporting success; and `ReaderFromDelta`'s copy-from-src failure closed the writer without an error, silently truncating the consumer stream. Each now propagates `ErrInvalidDelta` (or `ErrDeltaCmd`) consistently.

`packfile.getMemoryObject` was re-inflating delta payloads into the buffer the scanner had already populated, appending a duplicate copy that previously went unnoticed because the loop silently ignored anything past the target. The fix matches the cached-content pattern already used in `Scanner.WriteObject`.

[1]: https://github.com/git/git/blob/c2c5f6b1e479f2c38e0e01345350620944e3527f/patch-delta.c