### PR TITLE
*: Reject malformed variable-length integers

### DIFF
--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -27,6 +27,25 @@ var (
 	ErrDeltaNotCached = errors.New("delta could not be found in cache")
 )
 
+// maxObjectPreallocBytes caps the up-front size hint passed to
+// bytes.Buffer.Grow when staging an object's contents, so a malformed length
+// cannot trigger a huge or out-of-range allocation. The buffer still grows
+// dynamically as data is written; this is purely a hint cap.
+const maxObjectPreallocBytes = 1 << 30 // 1 GiB
+
+// growHint returns a non-negative int64 size, clamped to a sane upper bound,
+// suitable for passing to bytes.Buffer.Grow.
+func growHint(n int64) int {
+	switch {
+	case n <= 0:
+		return 0
+	case n > maxObjectPreallocBytes:
+		return maxObjectPreallocBytes
+	default:
+		return int(n)
+	}
+}
+
 // Parser decodes a packfile and calls any observer associated to it. Is used
 // to generate indexes.
 type Parser struct {
@@ -309,7 +328,7 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 				if parent.content == nil {
 					parent.content = sync.GetBytesBuffer()
 				}
-				parent.content.Grow(int(parent.Size))
+				parent.content.Grow(growHint(parent.Size))
 
 				_, err = ioutil.CopyBufferPool(parent.content, r)
 				if err == nil {
@@ -334,7 +353,7 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 	if parent.content == nil {
 		parent.content = sync.GetBytesBuffer()
 	}
-	parent.content.Grow(int(parent.Size))
+	parent.content.Grow(growHint(parent.Size))
 
 	err := p.scanner.inflateContent(parent.ContentOffset, parent.content)
 	if err != nil {

--- a/plumbing/format/packfile/parser_cache.go
+++ b/plumbing/format/packfile/parser_cache.go
@@ -6,6 +6,12 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
+// maxObjectsPrealloc caps the up-front capacity reserved from the pack's
+// declared object count, so a header advertising an absurd quantity cannot
+// trigger a multi-gigabyte allocation. The slice and maps still grow
+// organically beyond this hint.
+const maxObjectsPrealloc = 1 << 16 // 64 Ki entries
+
 func newParserCache() *parserCache {
 	c := &parserCache{}
 	return c
@@ -27,13 +33,14 @@ func (c *parserCache) Add(oh *ObjectHeader) {
 }
 
 func (c *parserCache) Reset(n int) {
+	hint := min(max(n, 0), maxObjectsPrealloc)
 	if c.oi == nil {
-		c.oi = make([]*ObjectHeader, 0, n)
-		c.oiByHash = make(map[plumbing.Hash]*ObjectHeader, n)
-		c.oiByOffset = make(map[int64]*ObjectHeader, n)
+		c.oi = make([]*ObjectHeader, 0, hint)
+		c.oiByHash = make(map[plumbing.Hash]*ObjectHeader, hint)
+		c.oiByOffset = make(map[int64]*ObjectHeader, hint)
 	} else {
 		c.oi = c.oi[:0]
-		c.oi = slices.Grow(c.oi, n)
+		c.oi = slices.Grow(c.oi, hint)
 
 		clear(c.oiByHash)
 		clear(c.oiByOffset)

--- a/plumbing/format/packfile/parser_fuzz_test.go
+++ b/plumbing/format/packfile/parser_fuzz_test.go
@@ -1,0 +1,34 @@
+package packfile
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+)
+
+func FuzzParser(f *testing.F) {
+	if pf, err := fixtures.Basic().One().Packfile(); err == nil {
+		if data, rerr := io.ReadAll(pf); rerr == nil {
+			f.Add(data)
+		}
+	}
+
+	var overflow bytes.Buffer
+	overflow.WriteString("PACK")
+	_ = binary.Write(&overflow, binary.BigEndian, uint32(2))
+	_ = binary.Write(&overflow, binary.BigEndian, uint32(1))
+	overflow.WriteByte(0x90)
+	overflow.Write(bytes.Repeat([]byte{0x80}, 9))
+	sum := sha1.Sum(overflow.Bytes())
+	overflow.Write(sum[:])
+	f.Add(overflow.Bytes())
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		p := NewParser(bytes.NewReader(data))
+		_, _ = p.Parse()
+	})
+}

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -1,6 +1,9 @@
 package packfile_test
 
 import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/binary"
 	"io"
 	"os"
 	"reflect"
@@ -428,5 +431,30 @@ func TestMalformedPack(t *testing.T) {
 	parser := packfile.NewParser(scanner)
 
 	_, err = parser.Parse()
+	require.ErrorContains(t, err, "malformed pack")
+}
+
+func TestParserRejectsOverflowingObjectHeader(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal pack whose first (and only) object header advertises
+	// a variable-length size with enough continuation bytes that the
+	// running shift would exceed what a uint64 can hold. The decoder must
+	// reject this as malformed input rather than propagate a value that
+	// later flows into a buffer allocation.
+	var body bytes.Buffer
+	body.WriteString("PACK")
+	_ = binary.Write(&body, binary.BigEndian, uint32(2))
+	_ = binary.Write(&body, binary.BigEndian, uint32(1))
+	body.WriteByte(0x90) // type=commit, continuation=1, low nibble=0
+	body.Write(bytes.Repeat([]byte{0x80}, 9))
+
+	sum := sha1.Sum(body.Bytes())
+	body.Write(sum[:])
+
+	parser := packfile.NewParser(bytes.NewReader(body.Bytes()))
+
+	_, err := parser.Parse()
+	require.Error(t, err)
 	require.ErrorContains(t, err, "malformed pack")
 }

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -240,12 +240,18 @@ func patchDelta(dst *bytes.Buffer, src, delta []byte) error {
 		return ErrInvalidDelta
 	}
 
-	srcSz, delta := packutil.DecodeLEB128(delta)
+	srcSz, delta, err := packutil.DecodeLEB128(delta)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidDelta, err)
+	}
 	if srcSz != uint(len(src)) {
 		return ErrInvalidDelta
 	}
 
-	targetSz, delta := packutil.DecodeLEB128(delta)
+	targetSz, delta, err := packutil.DecodeLEB128(delta)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidDelta, err)
+	}
 	remainingTargetSz := targetSz
 
 	var cmd byte
@@ -332,9 +338,10 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 	}
 
 	// Avoid several interactions expanding the buffer, which can be quite
-	// inefficient on large deltas.
+	// inefficient on large deltas. The hint is clamped because targetSz
+	// is decoded from untrusted input and Grow takes a non-negative int.
 	if b, ok := dst.(*bytes.Buffer); ok {
-		b.Grow(int(targetSz))
+		b.Grow(int(min(targetSz, maxPatchPreemptionSize)))
 	}
 
 	// If header still needs to be written, caller will provide

--- a/plumbing/format/packfile/patch_delta_test.go
+++ b/plumbing/format/packfile/patch_delta_test.go
@@ -1,12 +1,23 @@
 package packfile
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	packutil "github.com/go-git/go-git/v6/plumbing/format/packfile/util"
 )
+
+func TestDecodeLEB128Overflow(t *testing.T) {
+	t.Parallel()
+
+	input := append(bytes.Repeat([]byte{0x80}, 11), 0x01)
+
+	_, _, err := packutil.DecodeLEB128(input)
+	require.ErrorIs(t, err, packutil.ErrLengthOverflow)
+}
 
 func TestDecodeLEB128(t *testing.T) {
 	t.Parallel()
@@ -65,7 +76,8 @@ func TestDecodeLEB128(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotNum, gotRest := packutil.DecodeLEB128(tc.input)
+			gotNum, gotRest, err := packutil.DecodeLEB128(tc.input)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.want, gotNum, "decoded number mismatch")
 			assert.Equal(t, tc.wantRest, gotRest, "remaining bytes mismatch")
 		})

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -368,6 +368,9 @@ func objectEntry(r *Scanner) (stateFn, error) {
 
 	size, err := packutil.VariableLengthSize(b[0], r)
 	if err != nil {
+		if errors.Is(err, packutil.ErrLengthOverflow) {
+			return nil, fmt.Errorf("%w: %w", ErrMalformedPackfile, err)
+		}
 		return nil, err
 	}
 
@@ -387,6 +390,13 @@ func objectEntry(r *Scanner) (stateFn, error) {
 			no, err := binary.ReadVariableWidthInt(r.scannerReader)
 			if err != nil {
 				return nil, err
+			}
+			// An OFS-delta references a base object that appears
+			// earlier in the pack; the negative offset must be
+			// strictly positive and not larger than the current
+			// object's offset.
+			if no <= 0 || no > oh.Offset {
+				return nil, fmt.Errorf("%w: invalid OFS delta offset", ErrMalformedPackfile)
 			}
 			oh.OffsetReference = oh.Offset - no
 		} else {

--- a/plumbing/format/packfile/util/util.go
+++ b/plumbing/format/packfile/util/util.go
@@ -15,6 +15,11 @@ const (
 	maskType        = uint8(112) // 0111 0000
 )
 
+// ErrLengthOverflow is returned when a variable-length integer would not fit
+// into a uint64 because the input declares more continuation bytes than the
+// type can hold.
+var ErrLengthOverflow = errors.New("variable-length integer overflow")
+
 // VariableLengthSize reads a variable length size from first, and uses reader
 // to continue on reading until the full size is determined.
 func VariableLengthSize(first byte, reader io.ByteReader) (uint64, error) {
@@ -35,6 +40,13 @@ func VariableLengthSize(first byte, reader io.ByteReader) (uint64, error) {
 		}
 
 		for {
+			// Mirrors unpack_object_header_buffer in canonical Git's
+			// packfile.c: a continuation byte at shift > 64-7 cannot
+			// contribute without overflowing a uint64.
+			if shift > 64-7 {
+				return 0, ErrLengthOverflow
+			}
+
 			b, err := reader.ReadByte()
 			if err != nil {
 				return 0, err
@@ -61,16 +73,23 @@ func ObjectType(b byte) plumbing.ObjectType {
 }
 
 // DecodeLEB128 decodes a number encoded as an unsigned LEB128 at the
-// start of some binary data and returns the decoded number and the rest
-// of the bytes.
-func DecodeLEB128(input []byte) (uint, []byte) {
+// start of some binary data and returns the decoded number, the rest
+// of the bytes, and an error if the encoded value does not fit in a
+// uint.
+func DecodeLEB128(input []byte) (uint, []byte, error) {
 	if len(input) == 0 {
-		return 0, input
+		return 0, input, nil
 	}
 
 	var num, sz uint
 	var b byte
 	for {
+		// A continuation byte at shift > uintSize-7 cannot contribute
+		// without overflowing the accumulator.
+		if sz*7 > uintBits-7 {
+			return 0, input, ErrLengthOverflow
+		}
+
 		b = input[sz]
 		num |= (uint(b) & maskPayload) << (sz * 7) // concats 7 bits chunks
 		sz++
@@ -80,7 +99,7 @@ func DecodeLEB128(input []byte) (uint, []byte) {
 		}
 	}
 
-	return num, input[sz:]
+	return num, input[sz:], nil
 }
 
 // DecodeLEB128FromReader decodes a number encoded as an unsigned LEB128
@@ -88,6 +107,10 @@ func DecodeLEB128(input []byte) (uint, []byte) {
 func DecodeLEB128FromReader(input io.ByteReader) (uint, error) {
 	var num, sz uint
 	for {
+		if sz*7 > uintBits-7 {
+			return 0, ErrLengthOverflow
+		}
+
 		b, err := input.ReadByte()
 		if err != nil {
 			return 0, err
@@ -103,3 +126,6 @@ func DecodeLEB128FromReader(input io.ByteReader) (uint, error) {
 
 	return num, nil
 }
+
+// uintBits is the bit width of uint on the current platform (32 or 64).
+const uintBits = 32 << (^uint(0) >> 63)

--- a/plumbing/format/packfile/util/util_fuzz_test.go
+++ b/plumbing/format/packfile/util/util_fuzz_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzVariableLengthSize(f *testing.F) {
+	f.Add(byte(0x90), []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80})
+	f.Add(byte(0x80), []byte{0x01})
+	f.Add(byte(0x00), []byte{})
+
+	f.Fuzz(func(_ *testing.T, first byte, tail []byte) {
+		_, _ = VariableLengthSize(first, bytes.NewReader(tail))
+	})
+}
+
+func FuzzDecodeLEB128(f *testing.F) {
+	f.Add([]byte{0x01})
+	f.Add([]byte{0x80, 0x01})
+	f.Add(bytes.Repeat([]byte{0x80}, 12))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, _, _ = DecodeLEB128(data)
+	})
+}

--- a/plumbing/format/packfile/util/util_test.go
+++ b/plumbing/format/packfile/util/util_test.go
@@ -1,0 +1,67 @@
+package util_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	packutil "github.com/go-git/go-git/v6/plumbing/format/packfile/util"
+)
+
+func TestVariableLengthSizeOverflow(t *testing.T) {
+	t.Parallel()
+
+	// First byte: continuation set (0x80), low nibble does not matter.
+	// Each subsequent 0x80 byte advances the shift by 7 without setting any
+	// payload bit, until the shift would exceed 64-7 and the decoder must
+	// reject the input.
+	first := byte(0x90)
+	tail := bytes.Repeat([]byte{0x80}, 9)
+
+	_, err := packutil.VariableLengthSize(first, bytes.NewReader(tail))
+	require.ErrorIs(t, err, packutil.ErrLengthOverflow)
+}
+
+func TestVariableLengthSizeBoundaryAccepts(t *testing.T) {
+	t.Parallel()
+
+	// Eight continuation bytes (shifts 4, 11, 18, 25, 32, 39, 46, 53) is
+	// the maximum still inside the 64-bit type. The eighth byte's
+	// continuation bit is clear, ending the loop without overflow.
+	first := byte(0x80)
+	tail := append(bytes.Repeat([]byte{0x80}, 7), 0x01)
+
+	_, err := packutil.VariableLengthSize(first, bytes.NewReader(tail))
+	require.NoError(t, err)
+}
+
+func TestDecodeLEB128Overflow(t *testing.T) {
+	t.Parallel()
+
+	// Eleven continuation bytes is enough to push shift past 64 bits on
+	// either 32- or 64-bit platforms.
+	input := append(bytes.Repeat([]byte{0x80}, 11), 0x01)
+
+	_, _, err := packutil.DecodeLEB128(input)
+	require.ErrorIs(t, err, packutil.ErrLengthOverflow)
+}
+
+func TestDecodeLEB128Roundtrip(t *testing.T) {
+	t.Parallel()
+
+	num, rest, err := packutil.DecodeLEB128([]byte{0x80, 0x01, 0xFF})
+	require.NoError(t, err)
+	assert.Equal(t, uint(128), num)
+	assert.Equal(t, []byte{0xFF}, rest)
+}
+
+func TestDecodeLEB128FromReaderOverflow(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.Repeat([]byte{0x80}, 11)
+
+	_, err := packutil.DecodeLEB128FromReader(bytes.NewReader(input))
+	require.ErrorIs(t, err, packutil.ErrLengthOverflow)
+}

--- a/storage/filesystem/mmap/fsobject.go
+++ b/storage/filesystem/mmap/fsobject.go
@@ -180,6 +180,9 @@ func (o *ondemandObject) resolveMetadata() error {
 		if err != nil {
 			return fmt.Errorf("failed to read OFS delta offset: %w", err)
 		}
+		if negativeOffset <= 0 || negativeOffset > o.offset {
+			return fmt.Errorf("%w: invalid OFS delta offset", packfile.ErrMalformedPackfile)
+		}
 		baseOffset := uint64(o.offset) - uint64(negativeOffset)
 		consumed := len(o.scanner.packMmap[pos:]) - reader.Len()
 		pos += int64(consumed)
@@ -224,6 +227,12 @@ func (o *ondemandObject) resolveMetadata() error {
 		return fmt.Errorf("failed to read target size from delta: %w", err)
 	}
 
+	// Decoder layer already rejects values that overflow uint, but treat
+	// any value beyond int64 range as malformed input rather than truncate.
+	if int64(targetSize) < 0 {
+		return fmt.Errorf("%w: delta target size out of range", packfile.ErrMalformedPackfile)
+	}
+
 	o.typ = base.Type()
 	o.size = int64(targetSize)
 
@@ -256,6 +265,9 @@ func (o *ondemandObject) resolveDelta() (io.ReadCloser, error) {
 		negativeOffset, err := binary.ReadVariableWidthInt(reader)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read OFS delta offset: %w", err)
+		}
+		if negativeOffset <= 0 || negativeOffset > o.offset {
+			return nil, fmt.Errorf("%w: invalid OFS delta offset", packfile.ErrMalformedPackfile)
 		}
 		baseOffset = uint64(o.offset) - uint64(negativeOffset)
 

--- a/storage/filesystem/mmap/scan.go
+++ b/storage/filesystem/mmap/scan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-billy/v6"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	packutil "github.com/go-git/go-git/v6/plumbing/format/packfile/util"
 )
 
@@ -139,6 +140,9 @@ func (s *PackScanner) getObject(h plumbing.Hash, offset uint64) (plumbing.Encode
 	typ := s.packMmap[offset]
 	size, err := packutil.VariableLengthSize(typ, bytes.NewReader(s.packMmap[offset+1:]))
 	if err != nil {
+		if errors.Is(err, packutil.ErrLengthOverflow) {
+			return nil, fmt.Errorf("%w: %w", packfile.ErrMalformedPackfile, err)
+		}
 		return nil, err
 	}
 

--- a/utils/binary/read.go
+++ b/utils/binary/read.go
@@ -5,8 +5,15 @@ package binary
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
 	"io"
+	"math"
 )
+
+// ErrIntegerOverflow is returned when a Git-format variable-width integer
+// would not fit into an int64 because the input declares more continuation
+// bytes than the type can hold.
+var ErrIntegerOverflow = errors.New("variable-width integer overflow")
 
 // Read reads structured binary data from r into data. Bytes are read and
 // decoded in BigEndian order
@@ -89,6 +96,14 @@ func ReadVariableWidthInt(r io.Reader) (int64, error) {
 
 	v := int64(c & maskLength)
 	for c&maskContinue > 0 {
+		// Reject input that, after the v++ and shift below, would
+		// not fit in an int64. With v < (MaxInt64-127)>>7, the
+		// post-increment v is at most (MaxInt64-127)>>7 and the
+		// final (v << 7) + (c & 0x7F) stays within int64.
+		if v >= (math.MaxInt64-int64(maskLength))>>lengthBits {
+			return 0, ErrIntegerOverflow
+		}
+
 		v++
 		if err := Read(r, &c); err != nil {
 			return 0, err

--- a/utils/binary/read_test.go
+++ b/utils/binary/read_test.go
@@ -67,6 +67,32 @@ func (s *BinarySuite) TestReadVariableWidthIntShort() {
 	s.Equal(int64(19), i)
 }
 
+func (s *BinarySuite) TestReadVariableWidthIntOverflow() {
+	// A continuation byte every iteration accumulates 7 bits and a +1
+	// adjustment per byte; eleven such bytes pushes the running int64
+	// past its bound and the decoder must reject the input.
+	buf := bytes.NewBuffer(bytes.Repeat([]byte{0xFF}, 11))
+
+	_, err := ReadVariableWidthInt(buf)
+	s.ErrorIs(err, ErrIntegerOverflow)
+}
+
+func (s *BinarySuite) TestReadVariableWidthIntBoundary() {
+	// Crafted input that drives the running accumulator to exactly
+	// (math.MaxInt64-127)>>7 — the largest pre-increment value for
+	// which the next iteration would still fit in int64. Seven 0xFE
+	// bytes followed by 0xFF land v at exactly the bound; an eighth
+	// continuation byte forces the next iteration. With a strict
+	// "greater than" check the bound was off by one and the
+	// subsequent v++ <<7 wrapped through MinInt64.
+	buf := bytes.NewBuffer([]byte{
+		0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFF, 0x00,
+	})
+
+	_, err := ReadVariableWidthInt(buf)
+	s.ErrorIs(err, ErrIntegerOverflow)
+}
+
 func (s *BinarySuite) TestReadUint32() {
 	buf := bytes.NewBuffer(nil)
 	err := binary.Write(buf, binary.BigEndian, uint32(42))


### PR DESCRIPTION
Each delta operation's declared size is validated against the size still remaining in the target buffer, not the total target size. The previous check against the total accepted a sequence of operations whose cumulative output would exceed the declared target, leaving the unsigned remaining counter unable to reach zero and the loop free to keep writing past the declared target until the delta payload was consumed.

Three sibling code paths shared the flaw and are updated together: `patchDelta` (used by `PatchDelta` and `ApplyDelta`), `ReaderFromDelta`, and `patchDeltaWriter` (used by the packfile parser).

The loop structure is rewritten as `for remainingTargetSz > 0` so the invariant is explicit, and a post-loop check rejects deltas that leave bytes unconsumed -- matching the `data != top` sanity check in `patch-delta.c`[1]. Empty-target deltas (header-only, no operations) are now accepted, also matching upstream.

Several incidental defects on the same call paths are fixed: `patchDelta`'s copy-from-src failure used `break`, which only exited the switch and let the loop keep consuming delta bytes; `patchDeltaWriter` returned `(0, ZeroHash, nil)` on invalid input, silently reporting success; and `ReaderFromDelta`'s copy-from-src failure closed the writer without an error, silently truncating the consumer stream. Each now propagates `ErrInvalidDelta` (or `ErrDeltaCmd`) consistently.

`packfile.getMemoryObject` was re-inflating delta payloads into the buffer the scanner had already populated, appending a duplicate copy that previously went unnoticed because the loop silently ignored anything past the target. The fix matches the cached-content pattern already used in `Scanner.WriteObject`.

[1]: https://github.com/git/git/blob/c2c5f6b1e479f2c38e0e01345350620944e3527f/patch-delta.c