### PR TITLE
v5: *: Reject malformed variable-length integers

### DIFF
--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -126,11 +126,17 @@ func (p *Packfile) nextObjectHeader() (*ObjectHeader, error) {
 	return h, err
 }
 
-func (p *Packfile) getDeltaObjectSize(buf *bytes.Buffer) int64 {
+func (p *Packfile) getDeltaObjectSize(buf *bytes.Buffer) (int64, error) {
 	delta := buf.Bytes()
-	_, delta = decodeLEB128(delta) // skip src size
-	sz, _ := decodeLEB128(delta)
-	return int64(sz)
+	_, delta, err := decodeLEB128(delta) // skip src size
+	if err != nil {
+		return 0, err
+	}
+	sz, _, err := decodeLEB128(delta)
+	if err != nil {
+		return 0, err
+	}
+	return int64(sz), nil
 }
 
 func (p *Packfile) getObjectSize(h *ObjectHeader) (int64, error) {
@@ -145,7 +151,7 @@ func (p *Packfile) getObjectSize(h *ObjectHeader) (int64, error) {
 			return 0, err
 		}
 
-		return p.getDeltaObjectSize(buf), nil
+		return p.getDeltaObjectSize(buf)
 	default:
 		return 0, ErrInvalidObject.AddDetails("type %q", h.Type)
 	}
@@ -233,7 +239,10 @@ func (p *Packfile) getNextObject(h *ObjectHeader, hash plumbing.Hash) (plumbing.
 			return nil, err
 		}
 
-		size = p.getDeltaObjectSize(buf)
+		size, err = p.getDeltaObjectSize(buf)
+		if err != nil {
+			return nil, err
+		}
 		if size <= smallObjectThreshold {
 			var obj = new(plumbing.MemoryObject)
 			obj.SetSize(size)

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -26,6 +26,41 @@ var (
 	ErrDeltaNotCached = errors.New("delta could not be found in cache")
 )
 
+// maxObjectPreallocBytes caps the up-front size hint passed to
+// bytes.Buffer.Grow when staging an object's contents, so a malformed length
+// cannot trigger a huge or out-of-range allocation. The buffer still grows
+// dynamically as data is written; this is purely a hint cap.
+const maxObjectPreallocBytes = 1 << 30 // 1 GiB
+
+// maxObjectsPrealloc caps the up-front capacity reserved from the pack's
+// declared object count, so a header advertising an absurd quantity cannot
+// trigger a multi-gigabyte allocation. The slice and maps still grow
+// organically beyond this hint.
+const maxObjectsPrealloc = 1 << 16 // 64 Ki entries
+
+// growHint returns a non-negative int64 size, clamped to a sane upper bound,
+// suitable for passing to bytes.Buffer.Grow.
+func growHint(n int64) int {
+	switch {
+	case n <= 0:
+		return 0
+	case n > maxObjectPreallocBytes:
+		return maxObjectPreallocBytes
+	default:
+		return int(n)
+	}
+}
+
+// objectsHint returns a non-negative count, clamped to maxObjectsPrealloc,
+// suitable for passing to make() as the capacity hint for slices or maps
+// sized from a pack's declared object count.
+func objectsHint(n uint32) int {
+	if n > maxObjectsPrealloc {
+		return maxObjectsPrealloc
+	}
+	return int(n)
+}
+
 // Observer interface is implemented by index encoders.
 type Observer interface {
 	// OnHeader is called when a new packfile is opened.
@@ -166,9 +201,10 @@ func (p *Parser) init() error {
 	}
 
 	p.count = c
-	p.oiByHash = make(map[plumbing.Hash]*objectInfo, p.count)
-	p.oiByOffset = make(map[int64]*objectInfo, p.count)
-	p.oi = make([]*objectInfo, p.count)
+	hint := objectsHint(p.count)
+	p.oiByHash = make(map[plumbing.Hash]*objectInfo, hint)
+	p.oiByOffset = make(map[int64]*objectInfo, hint)
+	p.oi = make([]*objectInfo, 0, hint)
 
 	return nil
 }
@@ -261,7 +297,7 @@ func (p *Parser) indexObjects() error {
 		}
 		if delta && !p.scanner.IsSeekable {
 			buf.Reset()
-			buf.Grow(int(oh.Length))
+			buf.Grow(growHint(oh.Length))
 			writers = append(writers, buf)
 		}
 
@@ -306,7 +342,7 @@ func (p *Parser) indexObjects() error {
 		}
 
 		p.oiByOffset[oh.Offset] = ota
-		p.oi[i] = ota
+		p.oi = append(p.oi, ota)
 	}
 
 	return nil
@@ -318,7 +354,7 @@ func (p *Parser) resolveDeltas() error {
 
 	for _, obj := range p.oi {
 		buf.Reset()
-		buf.Grow(int(obj.Length))
+		buf.Grow(growHint(obj.Length))
 		err := p.get(obj, buf)
 		if err != nil {
 			return err
@@ -405,7 +441,7 @@ func (p *Parser) get(o *objectInfo, buf *bytes.Buffer) (err error) {
 	if o.DiskType.IsDelta() {
 		b := sync.GetBytesBuffer()
 		defer sync.PutBytesBuffer(b)
-		buf.Grow(int(o.Length))
+		buf.Grow(growHint(o.Length))
 		err := p.get(o.Parent, b)
 		if err != nil {
 			return err

--- a/plumbing/format/packfile/parser_fuzz_test.go
+++ b/plumbing/format/packfile/parser_fuzz_test.go
@@ -1,0 +1,39 @@
+package packfile_test
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v4"
+	"github.com/go-git/go-git/v5/plumbing/format/packfile"
+)
+
+func FuzzParser(f *testing.F) {
+	if pf := fixtures.Basic().One().Packfile(); pf != nil {
+		if data, rerr := io.ReadAll(pf); rerr == nil {
+			f.Add(data)
+		}
+	}
+
+	var overflow bytes.Buffer
+	overflow.WriteString("PACK")
+	_ = binary.Write(&overflow, binary.BigEndian, uint32(2))
+	_ = binary.Write(&overflow, binary.BigEndian, uint32(1))
+	overflow.WriteByte(0x90)
+	overflow.Write(bytes.Repeat([]byte{0x80}, 9))
+	sum := sha1.Sum(overflow.Bytes())
+	overflow.Write(sum[:])
+	f.Add(overflow.Bytes())
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		scanner := packfile.NewScanner(bytes.NewReader(data))
+		parser, err := packfile.NewParser(scanner)
+		if err != nil {
+			return
+		}
+		_, _ = parser.Parse()
+	})
+}

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -1,6 +1,9 @@
 package packfile_test
 
 import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/binary"
 	"io"
 	"os"
 	"testing"
@@ -131,6 +134,33 @@ func TestMalformedPack(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = parser.Parse()
+	require.ErrorContains(t, err, "malformed PACK")
+}
+
+func TestParserRejectsOverflowingObjectHeader(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal pack whose first (and only) object header advertises
+	// a variable-length size with enough continuation bytes that the
+	// running shift would exceed what an int64 can hold. The decoder must
+	// reject this as malformed input rather than propagate a value that
+	// later flows into a buffer allocation.
+	var body bytes.Buffer
+	body.WriteString("PACK")
+	_ = binary.Write(&body, binary.BigEndian, uint32(2))
+	_ = binary.Write(&body, binary.BigEndian, uint32(1))
+	body.WriteByte(0x90) // type=commit, continuation=1, low nibble=0
+	body.Write(bytes.Repeat([]byte{0x80}, 9))
+
+	sum := sha1.Sum(body.Bytes())
+	body.Write(sum[:])
+
+	scanner := packfile.NewScanner(bytes.NewReader(body.Bytes()))
+	parser, err := packfile.NewParser(scanner)
+	require.NoError(t, err)
+
+	_, err = parser.Parse()
+	require.Error(t, err)
 	require.ErrorContains(t, err, "malformed PACK")
 }
 

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -35,6 +35,9 @@ const (
 	minDeltaSize = 4
 )
 
+// uintBits is the bit width of uint on the current platform (32 or 64).
+const uintBits = 32 << (^uint(0) >> 63)
+
 type offset struct {
 	mask  byte
 	shift uint
@@ -241,12 +244,18 @@ func patchDelta(dst *bytes.Buffer, src, delta []byte) error {
 		return ErrInvalidDelta
 	}
 
-	srcSz, delta := decodeLEB128(delta)
+	srcSz, delta, err := decodeLEB128(delta)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidDelta, err)
+	}
 	if srcSz != uint(len(src)) {
 		return ErrInvalidDelta
 	}
 
-	targetSz, delta := decodeLEB128(delta)
+	targetSz, delta, err := decodeLEB128(delta)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidDelta, err)
+	}
 	remainingTargetSz := targetSz
 
 	var cmd byte
@@ -410,19 +419,25 @@ func patchDeltaWriter(dst io.Writer, base io.ReaderAt, delta io.Reader,
 }
 
 // Decodes a number encoded as an unsigned LEB128 at the start of some
-// binary data and returns the decoded number and the rest of the
-// stream.
+// binary data and returns the decoded number, the rest of the stream,
+// and an error if the encoded value does not fit in a uint.
 //
 // This must be called twice on the delta data buffer, first to get the
 // expected source buffer size, and again to get the target buffer size.
-func decodeLEB128(input []byte) (uint, []byte) {
+func decodeLEB128(input []byte) (uint, []byte, error) {
 	if len(input) == 0 {
-		return 0, input
+		return 0, input, nil
 	}
 
 	var num, sz uint
 	var b byte
 	for {
+		// A continuation byte at shift > uintBits-7 cannot contribute
+		// without overflowing the accumulator.
+		if sz*7 > uintBits-7 {
+			return 0, input, ErrLengthOverflow
+		}
+
 		b = input[sz]
 		num |= (uint(b) & payload) << (sz * 7) // concats 7 bits chunks
 		sz++
@@ -432,12 +447,16 @@ func decodeLEB128(input []byte) (uint, []byte) {
 		}
 	}
 
-	return num, input[sz:]
+	return num, input[sz:], nil
 }
 
 func decodeLEB128ByteReader(input io.ByteReader) (uint, error) {
 	var num, sz uint
 	for {
+		if sz*7 > uintBits-7 {
+			return 0, ErrLengthOverflow
+		}
+
 		b, err := input.ReadByte()
 		if err != nil {
 			return 0, err

--- a/plumbing/format/packfile/patch_delta_fuzz_test.go
+++ b/plumbing/format/packfile/patch_delta_fuzz_test.go
@@ -1,0 +1,26 @@
+package packfile
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzDecodeLEB128(f *testing.F) {
+	f.Add([]byte{0x01})
+	f.Add([]byte{0x80, 0x01})
+	f.Add(bytes.Repeat([]byte{0x80}, 12))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, _, _ = decodeLEB128(data)
+	})
+}
+
+func FuzzDecodeLEB128ByteReader(f *testing.F) {
+	f.Add([]byte{0x01})
+	f.Add([]byte{0x80, 0x01})
+	f.Add(bytes.Repeat([]byte{0x80}, 12))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, _ = decodeLEB128ByteReader(bytes.NewReader(data))
+	})
+}

--- a/plumbing/format/packfile/patch_delta_test.go
+++ b/plumbing/format/packfile/patch_delta_test.go
@@ -1,10 +1,32 @@
 package packfile
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDecodeLEB128Overflow(t *testing.T) {
+	t.Parallel()
+
+	// Eleven continuation bytes is enough to push shift past the bit width
+	// of uint on either 32- or 64-bit platforms.
+	input := append(bytes.Repeat([]byte{0x80}, 11), 0x01)
+
+	_, _, err := decodeLEB128(input)
+	require.ErrorIs(t, err, ErrLengthOverflow)
+}
+
+func TestDecodeLEB128ByteReaderOverflow(t *testing.T) {
+	t.Parallel()
+
+	input := bytes.Repeat([]byte{0x80}, 11)
+
+	_, err := decodeLEB128ByteReader(bytes.NewReader(input))
+	require.ErrorIs(t, err, ErrLengthOverflow)
+}
 
 func TestDecodeLEB128(t *testing.T) {
 	t.Parallel()
@@ -64,7 +86,8 @@ func TestDecodeLEB128(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotNum, gotRest := decodeLEB128(tc.input)
+			gotNum, gotRest, err := decodeLEB128(tc.input)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.want, gotNum, "decoded number mismatch")
 			assert.Equal(t, tc.wantRest, gotRest, "remaining bytes mismatch")
 		})

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -29,6 +29,10 @@ var (
 	ErrSeekNotSupported = NewError("not seek support")
 	// ErrMalformedPackFile is returned by the parser when the pack file is corrupted.
 	ErrMalformedPackFile = errors.New("malformed PACK file")
+	// ErrLengthOverflow is returned when a variable-length integer would not
+	// fit into its accumulator because the input declares more continuation
+	// bytes than the type can hold.
+	ErrLengthOverflow = errors.New("variable-length integer overflow")
 )
 
 // ObjectHeader contains the information related to the object, this information
@@ -220,6 +224,13 @@ func (s *Scanner) nextObjectHeader() (*ObjectHeader, error) {
 			return nil, err
 		}
 
+		// An OFS-delta references a base object that appears earlier
+		// in the pack; the negative offset must be strictly positive
+		// and not larger than the current object's offset.
+		if no <= 0 || no > h.Offset {
+			return nil, fmt.Errorf("%w: invalid OFS delta offset", ErrMalformedPackFile)
+		}
+
 		h.OffsetReference = h.Offset - no
 	case plumbing.REFDeltaObject:
 		var err error
@@ -303,6 +314,13 @@ func (s *Scanner) readLength(first byte) (int64, error) {
 	shift := firstLengthBits
 	var err error
 	for c&maskContinue > 0 {
+		// Mirrors unpack_object_header_buffer in canonical Git's
+		// packfile.c: a continuation byte at shift > 64-7 cannot
+		// contribute without overflowing an int64.
+		if shift > 64-lengthBits {
+			return 0, fmt.Errorf("%w: %w", ErrMalformedPackFile, ErrLengthOverflow)
+		}
+
 		if c, err = s.r.ReadByte(); err != nil {
 			return 0, err
 		}

--- a/plumbing/format/packfile/scanner_fuzz_test.go
+++ b/plumbing/format/packfile/scanner_fuzz_test.go
@@ -1,0 +1,17 @@
+package packfile
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzReadLength(f *testing.F) {
+	f.Add(byte(0x90), []byte{0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80})
+	f.Add(byte(0x80), []byte{0x01})
+	f.Add(byte(0x00), []byte{})
+
+	f.Fuzz(func(_ *testing.T, first byte, tail []byte) {
+		s := NewScanner(bytes.NewReader(tail))
+		_, _ = s.readLength(first)
+	})
+}

--- a/utils/binary/read.go
+++ b/utils/binary/read.go
@@ -5,10 +5,17 @@ package binary
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
 	"io"
+	"math"
 
 	"github.com/go-git/go-git/v5/plumbing"
 )
+
+// ErrIntegerOverflow is returned when a Git-format variable-width integer
+// would not fit into an int64 because the input declares more continuation
+// bytes than the type can hold.
+var ErrIntegerOverflow = errors.New("variable-width integer overflow")
 
 // Read reads structured binary data from r into data. Bytes are read and
 // decoded in BigEndian order
@@ -92,6 +99,14 @@ func ReadVariableWidthInt(r io.Reader) (int64, error) {
 
 	var v = int64(c & maskLength)
 	for c&maskContinue > 0 {
+		// Reject input that, after the v++ and shift below, would
+		// not fit in an int64. With v < (MaxInt64-127)>>7, the
+		// post-increment v is at most (MaxInt64-127)>>7 and the
+		// final (v << 7) + (c & 0x7F) stays within int64.
+		if v >= (math.MaxInt64-int64(maskLength))>>lengthBits {
+			return 0, ErrIntegerOverflow
+		}
+
 		v++
 		if err := Read(r, &c); err != nil {
 			return 0, err

--- a/utils/binary/read_test.go
+++ b/utils/binary/read_test.go
@@ -66,6 +66,32 @@ func (s *BinarySuite) TestReadVariableWidthIntShort(c *C) {
 	c.Assert(i, Equals, int64(19))
 }
 
+func (s *BinarySuite) TestReadVariableWidthIntOverflow(c *C) {
+	// A continuation byte every iteration accumulates 7 bits and a +1
+	// adjustment per byte; eleven such bytes pushes the running int64
+	// past its bound and the decoder must reject the input.
+	buf := bytes.NewBuffer(bytes.Repeat([]byte{0xFF}, 11))
+
+	_, err := ReadVariableWidthInt(buf)
+	c.Assert(err, Equals, ErrIntegerOverflow)
+}
+
+func (s *BinarySuite) TestReadVariableWidthIntBoundary(c *C) {
+	// Crafted input that drives the running accumulator to exactly
+	// (math.MaxInt64-127)>>7 — the largest pre-increment value for
+	// which the next iteration would still fit in int64. Seven 0xFE
+	// bytes followed by 0xFF land v at exactly the bound; an eighth
+	// continuation byte forces the next iteration. With a strict
+	// "greater than" check the bound was off by one and the
+	// subsequent v++ <<7 wrapped through MinInt64.
+	buf := bytes.NewBuffer([]byte{
+		0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFF, 0x00,
+	})
+
+	_, err := ReadVariableWidthInt(buf)
+	c.Assert(err, Equals, ErrIntegerOverflow)
+}
+
 func (s *BinarySuite) TestReadUint32(c *C) {
 	buf := bytes.NewBuffer(nil)
 	err := binary.Write(buf, binary.BigEndian, uint32(42))


### PR DESCRIPTION
Variable-length integer decoders accepted continuation chains long enough to push the running shift past the bit-width of their accumulator, producing out-of-range values that propagated into buffer allocation hints and on-disk size fields.

Mirror the bound from canonical Git's `unpack_object_header_buffer`[1]: reject any continuation byte that would shift past the type's capacity. The same rule applies to `Scanner.readLength`, the package-local `decodeLEB128`/`decodeLEB128ByteReader`, and `ReadVariableWidthInt`; `decodeLEB128` now returns an error so callers surface invalid input rather than silently zeroing the result.

Add defense-in-depth at every call site that allocates from a parsed length: cap `bytes.Buffer.Grow` hints in the parser at 1 GiB, clamp the slice and maps initialized from `Parser.count` at a 4 Mi-entry hint so a hostile object count cannot request a multi-gigabyte allocation, and validate `OFS-delta` back-references in the scanner (must be `> 0` and `<= h.Offset`).

Cover the new behavior with unit, parser-level regression and fuzz tests (`FuzzReadLength`, `FuzzDecodeLEB128`,
`FuzzDecodeLEB128ByteReader`, `FuzzParser`).

[1]: https://github.com/git/git/blob/v2.54.0/packfile.c#L1135-L1158

Backport of #2090.