### PR TITLE
git: Expose AlternatesFS on PlainOpenOptions

### DIFF
--- a/options.go
+++ b/options.go
@@ -813,6 +813,10 @@ type PlainOpenOptions struct {
 	// DetectDotGit defines whether parent directories should be
 	// walked until a .git directory or file is found.
 	DetectDotGit bool
+	// AlternatesFS provides the billy filesystem to be used for Git Alternates.
+	// If none is provided, it falls back to using the underlying instance used for
+	// DotGit.
+	AlternatesFS billy.Filesystem
 }
 
 // Validate validates the fields and sets the default values.

--- a/options.go
+++ b/options.go
@@ -814,8 +814,8 @@ type PlainOpenOptions struct {
 	// walked until a .git directory or file is found.
 	DetectDotGit bool
 	// AlternatesFS provides the billy filesystem to be used for Git Alternates.
-	// If none is provided, it falls back to using the underlying instance used for
-	// DotGit.
+	// If none is provided, it falls back to the repository's .git directory
+	// filesystem.
 	AlternatesFS billy.Filesystem
 }
 

--- a/repository.go
+++ b/repository.go
@@ -439,7 +439,9 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 	}
 	repositoryFs = dotgit.NewRepositoryFilesystem(dot, dotGitCommon)
 
-	s := filesystem.NewStorage(repositoryFs, cache.NewObjectLRUDefault())
+	s := filesystem.NewStorageWithOptions(repositoryFs, cache.NewObjectLRUDefault(), filesystem.Options{
+		AlternatesFS: o.AlternatesFS,
+	})
 
 	return Open(s, wt)
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -1399,6 +1399,42 @@ func (s *RepositorySuite) TestPlainOpenNotExistsDetectDotGit() {
 	s.Nil(r)
 }
 
+func (s *RepositorySuite) TestPlainOpenAlternatesFS() {
+	root := s.T().TempDir()
+	src := filepath.Join(root, "src")
+	shared := filepath.Join(root, "shared")
+
+	srcRepo, err := PlainClone(src, &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	s.Require().NoError(err)
+
+	head, err := srcRepo.Head()
+	s.Require().NoError(err)
+
+	_, err = PlainInit(shared, false)
+	s.Require().NoError(err)
+
+	infoDir := filepath.Join(shared, GitDirName, "objects", "info")
+	s.Require().NoError(os.MkdirAll(infoDir, 0o755))
+	altLine := filepath.Join(src, GitDirName, "objects") + "\n"
+	s.Require().NoError(os.WriteFile(filepath.Join(infoDir, "alternates"), []byte(altLine), 0o644))
+
+	// Without AlternatesFS the absolute alternate path cannot be resolved
+	// from within the .git filesystem.
+	r, err := PlainOpen(shared)
+	s.Require().NoError(err)
+	_, err = r.CommitObject(head.Hash())
+	s.Error(err)
+
+	r, err = PlainOpenWithOptions(shared, &PlainOpenOptions{
+		AlternatesFS: osfs.New(root),
+	})
+	s.Require().NoError(err)
+
+	commit, err := r.CommitObject(head.Hash())
+	s.NoError(err)
+	s.NotNil(commit)
+}
+
 func (s *RepositorySuite) TestPlainClone() {
 	dir := "rel-dir"
 	err := os.Mkdir(dir, 0o755)


### PR DESCRIPTION
`filesystem.Options.AlternatesFS` lets go-git resolve `objects/info/alternates` paths that point outside the `.git` filesystem, but `PlainOpenWithOptions` had no way to pass it through. Callers currently have to open the repo, type-assert the storer, rebuild storage with `NewStorageWithOptions`, and reopen.

Add `AlternatesFS` to `PlainOpenOptions` and thread it through to `NewStorageWithOptions`. A nil value keeps current behavior so the #953 hardening is unchanged unless the caller opts in.

Fixes #2085