### PR TITLE
plumbing: format/pktline, validate reader/writer inputs

### DIFF
--- a/plumbing/format/pktline/error.go
+++ b/plumbing/format/pktline/error.go
@@ -10,8 +10,14 @@ var (
 	// error line.
 	ErrInvalidErrorLine = errors.New("expected an error-line")
 
-	// ErrNilWriter is returned when a nil writer is passed to WritePacket.
+	// ErrNilWriter is returned when a nil writer is passed to a write function.
 	ErrNilWriter = errors.New("nil writer")
+
+	// ErrNilReader is returned when a nil reader is passed to a read function.
+	ErrNilReader = errors.New("nil reader")
+
+	// ErrNilError is returned when a nil error is passed to WriteError.
+	ErrNilError = errors.New("nil error")
 
 	errPrefix = []byte("ERR ")
 )

--- a/plumbing/format/pktline/pktline.go
+++ b/plumbing/format/pktline/pktline.go
@@ -61,12 +61,23 @@ func WriteString(w io.Writer, s string) (n int, err error) {
 
 // WriteError writes an error packet.
 func WriteError(w io.Writer, e error) (n int, err error) {
+	if w == nil {
+		return 0, ErrNilWriter
+	}
+	if e == nil {
+		return 0, ErrNilError
+	}
+
 	return Writef(w, "%s%s\n", errPrefix, e.Error())
 }
 
 // WriteFlush writes a flush packet.
 // This always writes 4 bytes.
 func WriteFlush(w io.Writer) (err error) {
+	if w == nil {
+		return ErrNilWriter
+	}
+
 	defer func() {
 		if err == nil {
 			trace.Packet.Printf("packet: > 0000")
@@ -80,6 +91,10 @@ func WriteFlush(w io.Writer) (err error) {
 // WriteDelim writes a delimiter packet.
 // This always writes 4 bytes.
 func WriteDelim(w io.Writer) (err error) {
+	if w == nil {
+		return ErrNilWriter
+	}
+
 	defer func() {
 		if err == nil {
 			trace.Packet.Printf("packet: > 0001")
@@ -93,6 +108,10 @@ func WriteDelim(w io.Writer) (err error) {
 // WriteResponseEnd writes a response-end packet.
 // This always writes 4 bytes.
 func WriteResponseEnd(w io.Writer) (err error) {
+	if w == nil {
+		return ErrNilWriter
+	}
+
 	defer func() {
 		if err == nil {
 			trace.Packet.Printf("packet: > 0002")
@@ -114,10 +133,17 @@ func WriteResponseEnd(w io.Writer) (err error) {
 // 1 is a delim packet, 2 is a response-end packet, and a length greater or
 // equal to 4 is a data packet.
 func Read(r io.Reader, p []byte) (l int, err error) {
+	if r == nil {
+		return Err, ErrNilReader
+	}
+	if len(p) < LenSize {
+		return Err, fmt.Errorf("%w: small pkt-line buffer", ErrInvalidPktLen)
+	}
+
 	_, err = io.ReadFull(r, p[:LenSize])
 	if err != nil {
 		if errors.Is(err, io.ErrUnexpectedEOF) {
-			return Err, fmt.Errorf("%w: short pkt-line %d", ErrInvalidPktLen, len(p[:LenSize]))
+			return Err, fmt.Errorf("%w: short pkt-line %d", ErrInvalidPktLen, LenSize)
 		}
 		return Err, err
 	}
@@ -135,13 +161,16 @@ func Read(r io.Reader, p []byte) (l int, err error) {
 		trace.Packet.Printf("packet: < %04x", length)
 		return length, nil
 	}
+	if length > len(p) {
+		return Err, io.ErrUnexpectedEOF
+	}
 
 	_, err = io.ReadFull(r, p[LenSize:length])
 	if err != nil {
 		return Err, err
 	}
 
-	if bytes.HasPrefix(p[LenSize:], errPrefix) {
+	if bytes.HasPrefix(p[LenSize:length], errPrefix) {
 		err = &ErrorLine{
 			Text: string(bytes.TrimSpace(p[LenSize+errPrefixSize : length])),
 		}
@@ -182,6 +211,10 @@ func ReadLine(r io.Reader) (l int, p []byte, err error) {
 //
 // The error can be of type *ErrorLine if the packet is an error packet.
 func PeekLine(r ioutil.ReadPeeker) (l int, p []byte, err error) {
+	if r == nil {
+		return Err, nil, ErrNilReader
+	}
+
 	n, err := r.Peek(LenSize)
 	if err != nil {
 		return Err, nil, err

--- a/plumbing/format/pktline/pktline.go
+++ b/plumbing/format/pktline/pktline.go
@@ -126,7 +126,9 @@ func WriteResponseEnd(w io.Writer) (err error) {
 // length.
 //
 // If p is less than 4 bytes, Read returns ErrInvalidPktLen. If p cannot hold
-// the entire packet, Read returns io.ErrUnexpectedEOF.
+// the entire packet, Read discards the packet and returns io.ErrUnexpectedEOF;
+// the stream is left positioned after the packet so subsequent pkt-line reads
+// stay in sync.
 // The error can be of type *ErrorLine if the packet is an error packet.
 //
 // Use packet length to determine the type of packet i.e. 0 is a flush packet,
@@ -162,6 +164,8 @@ func Read(r io.Reader, p []byte) (l int, err error) {
 		return length, nil
 	}
 	if length > len(p) {
+		// Drain the payload so subsequent pkt-line reads stay in sync.
+		_, _ = io.CopyN(io.Discard, r, int64(length-LenSize))
 		return Err, io.ErrUnexpectedEOF
 	}
 

--- a/plumbing/format/pktline/pktline_fuzz_test.go
+++ b/plumbing/format/pktline/pktline_fuzz_test.go
@@ -1,0 +1,99 @@
+package pktline
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func FuzzRead(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("0000"))
+	f.Add([]byte("0001"))
+	f.Add([]byte("0002"))
+	f.Add([]byte("0003"))
+	f.Add([]byte("0004"))
+	f.Add([]byte("0005a"))
+	f.Add([]byte("0008ERR "))
+	f.Add([]byte("000cERR EOF\n"))
+	f.Add([]byte("fff1"))
+	f.Add([]byte("0008XRR 0005E"))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		for _, size := range []int{0, 1, LenSize - 1, LenSize, MaxSize} {
+			buf := make([]byte, size)
+			if len(buf) >= LenSize+1+len("RR ") {
+				copy(buf[LenSize+1:], "RR ")
+			}
+			_, _ = Read(bytes.NewReader(data), buf)
+		}
+	})
+}
+
+func FuzzPeekLine(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("0000"))
+	f.Add([]byte("0001"))
+	f.Add([]byte("0002"))
+	f.Add([]byte("0003"))
+	f.Add([]byte("0004"))
+	f.Add([]byte("0005a"))
+	f.Add([]byte("0008ERR "))
+	f.Add([]byte("000cERR EOF\n"))
+	f.Add([]byte("fff1"))
+	f.Add([]byte("0008XRR 0005E"))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		_, _, _ = PeekLine(bufio.NewReader(bytes.NewReader(data)))
+	})
+}
+
+func FuzzReadLine(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("0000"))
+	f.Add([]byte("0001"))
+	f.Add([]byte("0002"))
+	f.Add([]byte("0003"))
+	f.Add([]byte("0004"))
+	f.Add([]byte("0005a"))
+	f.Add([]byte("0008ERR "))
+	f.Add([]byte("000cERR EOF\n"))
+	f.Add([]byte("fff1"))
+	f.Add([]byte("0008XRR 0005E"))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		r := bytes.NewReader(data)
+		for {
+			before := r.Len()
+			_, _, err := ReadLine(r)
+			if err != nil || r.Len() == 0 || r.Len() == before {
+				break
+			}
+		}
+	})
+}
+
+func FuzzScanner(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte("0000"))
+	f.Add([]byte("0001"))
+	f.Add([]byte("0002"))
+	f.Add([]byte("0003"))
+	f.Add([]byte("0004"))
+	f.Add([]byte("0005a"))
+	f.Add([]byte("0008ERR "))
+	f.Add([]byte("000cERR EOF\n"))
+	f.Add([]byte("fff1"))
+	f.Add([]byte("0008XRR 0005E"))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		sc := NewScanner(bytes.NewReader(data))
+		for range 100 {
+			if !sc.Scan() {
+				break
+			}
+			_, _, _ = sc.Len(), sc.Bytes(), sc.Text()
+		}
+		_ = sc.Err()
+	})
+}

--- a/plumbing/format/pktline/pktline_read_test.go
+++ b/plumbing/format/pktline/pktline_read_test.go
@@ -340,6 +340,144 @@ func (s *SuiteReader) TestReadPacketError() {
 	s.Equal("ERR EOF\n", string(p))
 }
 
+func (s *SuiteReader) TestReadInvalidBuffer() {
+	for _, test := range []struct {
+		name     string
+		input    string
+		buf      []byte
+		expected error
+	}{
+		{
+			name:     "short length buffer",
+			input:    "0005E",
+			buf:      make([]byte, pktline.LenSize-1),
+			expected: pktline.ErrInvalidPktLen,
+		},
+		{
+			name:     "short payload buffer",
+			input:    "0005E",
+			buf:      make([]byte, pktline.LenSize),
+			expected: io.ErrUnexpectedEOF,
+		},
+	} {
+		test := test
+		s.Run(test.name, func() {
+			var (
+				length int
+				err    error
+			)
+			if s.NotPanics(func() {
+				length, err = pktline.Read(strings.NewReader(test.input), test.buf)
+			}) {
+				s.Equal(pktline.Err, length)
+				s.ErrorIs(err, test.expected)
+			}
+		})
+	}
+}
+
+func (s *SuiteReader) TestNilReaders() {
+	for _, test := range []struct {
+		name string
+		read func() (int, []byte, error)
+	}{
+		{
+			name: "read",
+			read: func() (int, []byte, error) {
+				length, err := pktline.Read(nil, make([]byte, pktline.LenSize))
+				return length, nil, err
+			},
+		},
+		{
+			name: "read line",
+			read: func() (int, []byte, error) {
+				return pktline.ReadLine(nil)
+			},
+		},
+		{
+			name: "peek line",
+			read: func() (int, []byte, error) {
+				return pktline.PeekLine(nil)
+			},
+		},
+	} {
+		test := test
+		s.Run(test.name, func() {
+			var (
+				length  int
+				payload []byte
+				err     error
+			)
+			if s.NotPanics(func() {
+				length, payload, err = test.read()
+			}) {
+				s.Equal(pktline.Err, length)
+				s.Nil(payload)
+				s.ErrorIs(err, pktline.ErrNilReader)
+			}
+		})
+	}
+}
+
+func (s *SuiteReader) TestReadShortPacketStaleBuffer() {
+	for _, test := range []struct {
+		name   string
+		input  string
+		length int
+	}{
+		{name: "one byte payload", input: "0005E", length: 5},
+		{name: "two byte payload", input: "0006ER", length: 6},
+		{name: "three byte payload", input: "0007ERR", length: 7},
+	} {
+		test := test
+		s.Run(test.name, func() {
+			p := make([]byte, pktline.MaxSize)
+			p[5], p[6], p[7] = 'R', 'R', ' '
+
+			var (
+				length int
+				err    error
+			)
+			if s.NotPanics(func() {
+				length, err = pktline.Read(strings.NewReader(test.input), p)
+			}) {
+				s.Equal(test.length, length)
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *SuiteReader) TestScanShortPacketAfterStalePrefix() {
+	for _, test := range []struct {
+		name        string
+		shortPacket string
+		payload     string
+	}{
+		{name: "one byte payload", shortPacket: "0005E", payload: "E"},
+		{name: "two byte payload", shortPacket: "0006ER", payload: "ER"},
+		{name: "three byte payload", shortPacket: "0007ERR", payload: "ERR"},
+	} {
+		test := test
+		s.Run(test.name, func() {
+			var buf bytes.Buffer
+			buf.WriteString("0008XRR ")
+			buf.WriteString(test.shortPacket)
+
+			sc := pktline.NewScanner(&buf)
+			var payloads []string
+			if s.NotPanics(func() {
+				for sc.Scan() {
+					payloads = append(payloads, sc.Text())
+				}
+			}) {
+				s.NoError(sc.Err())
+				s.Equal([]string{"XRR ", test.payload}, payloads)
+			}
+		})
+	}
+}
+
 // returns nSection sections, each of them with nLines pkt-lines (not
 // counting the flush-pkt:
 //

--- a/plumbing/format/pktline/pktline_read_test.go
+++ b/plumbing/format/pktline/pktline_read_test.go
@@ -360,7 +360,6 @@ func (s *SuiteReader) TestReadInvalidBuffer() {
 			expected: io.ErrUnexpectedEOF,
 		},
 	} {
-		test := test
 		s.Run(test.name, func() {
 			var (
 				length int
@@ -401,7 +400,6 @@ func (s *SuiteReader) TestNilReaders() {
 			},
 		},
 	} {
-		test := test
 		s.Run(test.name, func() {
 			var (
 				length  int
@@ -429,7 +427,6 @@ func (s *SuiteReader) TestReadShortPacketStaleBuffer() {
 		{name: "two byte payload", input: "0006ER", length: 6},
 		{name: "three byte payload", input: "0007ERR", length: 7},
 	} {
-		test := test
 		s.Run(test.name, func() {
 			p := make([]byte, pktline.MaxSize)
 			p[5], p[6], p[7] = 'R', 'R', ' '
@@ -458,7 +455,6 @@ func (s *SuiteReader) TestScanShortPacketAfterStalePrefix() {
 		{name: "two byte payload", shortPacket: "0006ER", payload: "ER"},
 		{name: "three byte payload", shortPacket: "0007ERR", payload: "ERR"},
 	} {
-		test := test
 		s.Run(test.name, func() {
 			var buf bytes.Buffer
 			buf.WriteString("0008XRR ")

--- a/plumbing/format/pktline/pktline_read_test.go
+++ b/plumbing/format/pktline/pktline_read_test.go
@@ -375,6 +375,25 @@ func (s *SuiteReader) TestReadInvalidBuffer() {
 	}
 }
 
+func (s *SuiteReader) TestReadShortBufferKeepsStreamInSync() {
+	var buf bytes.Buffer
+	_, err := pktline.WriteString(&buf, "hello world")
+	s.NoError(err)
+	_, err = pktline.WriteString(&buf, "next")
+	s.NoError(err)
+
+	small := make([]byte, pktline.LenSize+2)
+	length, err := pktline.Read(&buf, small)
+	s.Equal(pktline.Err, length)
+	s.ErrorIs(err, io.ErrUnexpectedEOF)
+
+	full := make([]byte, pktline.MaxSize)
+	length, err = pktline.Read(&buf, full)
+	s.NoError(err)
+	s.Equal(pktline.LenSize+len("next"), length)
+	s.Equal("next", string(full[pktline.LenSize:length]))
+}
+
 func (s *SuiteReader) TestNilReaders() {
 	for _, test := range []struct {
 		name string

--- a/plumbing/format/pktline/pktline_write_test.go
+++ b/plumbing/format/pktline/pktline_write_test.go
@@ -89,7 +89,6 @@ func (s *SuiteWriter) TestNilWriter() {
 			},
 		},
 	} {
-		test := test
 		s.Run(test.name, func() {
 			var err error
 			if s.NotPanics(func() {
@@ -111,7 +110,6 @@ func (s *SuiteWriter) TestWriteErrorInvalidInput() {
 		{name: "nil writer", writer: nil, err: nil, expected: pktline.ErrNilWriter},
 		{name: "nil error", writer: io.Discard, err: nil, expected: pktline.ErrNilError},
 	} {
-		test := test
 		s.Run(test.name, func() {
 			var (
 				n   int

--- a/plumbing/format/pktline/pktline_write_test.go
+++ b/plumbing/format/pktline/pktline_write_test.go
@@ -3,6 +3,7 @@ package pktline_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -27,6 +28,103 @@ func (s *SuiteWriter) TestFlush() {
 
 	obtained := buf.Bytes()
 	s.Equal([]byte("0000"), obtained)
+}
+
+func (s *SuiteWriter) TestNilWriter() {
+	for _, test := range []struct {
+		name  string
+		write func() error
+	}{
+		{
+			name: "write",
+			write: func() error {
+				_, err := pktline.Write(nil, []byte("payload"))
+				return err
+			},
+		},
+		{
+			name: "write string",
+			write: func() error {
+				_, err := pktline.WriteString(nil, "payload")
+				return err
+			},
+		},
+		{
+			name: "write line",
+			write: func() error {
+				_, err := pktline.Writeln(nil, "payload")
+				return err
+			},
+		},
+		{
+			name: "write format",
+			write: func() error {
+				_, err := pktline.Writef(nil, "%s", "payload")
+				return err
+			},
+		},
+		{
+			name: "write error",
+			write: func() error {
+				_, err := pktline.WriteError(nil, io.EOF)
+				return err
+			},
+		},
+		{
+			name: "write flush",
+			write: func() error {
+				return pktline.WriteFlush(nil)
+			},
+		},
+		{
+			name: "write delim",
+			write: func() error {
+				return pktline.WriteDelim(nil)
+			},
+		},
+		{
+			name: "write response end",
+			write: func() error {
+				return pktline.WriteResponseEnd(nil)
+			},
+		},
+	} {
+		test := test
+		s.Run(test.name, func() {
+			var err error
+			if s.NotPanics(func() {
+				err = test.write()
+			}) {
+				s.ErrorIs(err, pktline.ErrNilWriter)
+			}
+		})
+	}
+}
+
+func (s *SuiteWriter) TestWriteErrorInvalidInput() {
+	for _, test := range []struct {
+		name     string
+		writer   io.Writer
+		err      error
+		expected error
+	}{
+		{name: "nil writer", writer: nil, err: nil, expected: pktline.ErrNilWriter},
+		{name: "nil error", writer: io.Discard, err: nil, expected: pktline.ErrNilError},
+	} {
+		test := test
+		s.Run(test.name, func() {
+			var (
+				n   int
+				err error
+			)
+			if s.NotPanics(func() {
+				n, err = pktline.WriteError(test.writer, test.err)
+			}) {
+				s.Zero(n)
+				s.ErrorIs(err, test.expected)
+			}
+		})
+	}
 }
 
 func (s *SuiteWriter) TestEncode() {


### PR DESCRIPTION
Guard the read and write entry points against `nil` `io.Reader`/`io.Writer` and undersized buffers so callers receive a typed error instead of a panic. Tighten Read so a stale prefix in a recycled buffer cannot be misread as an error-line, and refuse payloads larger than the caller's buffer.