### PR TITLE
plumbing: object, tree entry validation

### DIFF
--- a/internal/pathutil/hfs.go
+++ b/internal/pathutil/hfs.go
@@ -97,3 +97,15 @@ func IsHFSDotGit(part string) bool { return IsHFSDot(part, "git") }
 // ".gitmodules", catching attempts to plant the file via Unicode
 // code points that HFS+ would strip during normalisation.
 func IsHFSDotGitmodules(part string) bool { return IsHFSDot(part, "gitmodules") }
+
+// IsHFSDotGitattributes reports whether part is an HFS+ equivalent of
+// ".gitattributes".
+func IsHFSDotGitattributes(part string) bool { return IsHFSDot(part, "gitattributes") }
+
+// IsHFSDotGitignore reports whether part is an HFS+ equivalent of
+// ".gitignore".
+func IsHFSDotGitignore(part string) bool { return IsHFSDot(part, "gitignore") }
+
+// IsHFSDotMailmap reports whether part is an HFS+ equivalent of
+// ".mailmap".
+func IsHFSDotMailmap(part string) bool { return IsHFSDot(part, "mailmap") }

--- a/internal/pathutil/hfs_test.go
+++ b/internal/pathutil/hfs_test.go
@@ -107,3 +107,30 @@ func TestIsHFSDotGitmodules(t *testing.T) {
 		})
 	}
 }
+
+func TestIsHFSDotMetadataFamily(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		fn   func(string) bool
+		hit  string
+	}{
+		{"IsHFSDotGitattributes", IsHFSDotGitattributes, ".gitattributes"},
+		{"IsHFSDotGitignore", IsHFSDotGitignore, ".gitignore"},
+		{"IsHFSDotMailmap", IsHFSDotMailmap, ".mailmap"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Canonical name and one zero-width variant hit.
+			assert.True(t, tc.fn(tc.hit), "expected %s(%q) to be true", tc.name, tc.hit)
+			disguised := tc.hit[:2] + "\u200c" + tc.hit[2:]
+			assert.True(t, tc.fn(disguised), "expected %s(%q) to be true", tc.name, disguised)
+			// Unrelated names miss.
+			assert.False(t, tc.fn(".gitmodules"), "expected %s(%q) to be false", tc.name, ".gitmodules")
+			assert.False(t, tc.fn(""), "expected %s(empty) to be false", tc.name)
+		})
+	}
+}

--- a/internal/pathutil/ntfs.go
+++ b/internal/pathutil/ntfs.go
@@ -170,13 +170,33 @@ func IsNTFSDot(name, dotgit, shortnamePrefix string) bool {
 	return onlySpacesAndPeriods(8)
 }
 
-// IsNTFSDotGitmodules reports whether part is an NTFS-equivalent of
-// ".gitmodules" — the file name (or any of its variants that NTFS
-// would resolve to it) that attackers can use to plant submodule
-// configuration disguised as a symlink. The 6-character canonical
-// short-name prefix "gi7eba" mirrors upstream Git's is_ntfs_dotgitmodules.
+// IsNTFSDotGitmodules reports whether part is an NTFS equivalent of
+// ".gitmodules" — the file name or any variant that NTFS would
+// resolve to it. The 6-character canonical short-name prefix "gi7eba"
+// mirrors upstream Git's is_ntfs_dotgitmodules.
 func IsNTFSDotGitmodules(part string) bool {
 	return IsNTFSDot(part, "gitmodules", "gi7eba")
+}
+
+// IsNTFSDotGitattributes reports whether part is an NTFS equivalent
+// of ".gitattributes". The short-name prefix "gi7d29" mirrors upstream
+// Git's is_ntfs_dotgitattributes.
+func IsNTFSDotGitattributes(part string) bool {
+	return IsNTFSDot(part, "gitattributes", "gi7d29")
+}
+
+// IsNTFSDotGitignore reports whether part is an NTFS equivalent of
+// ".gitignore". The short-name prefix "gi250a" mirrors upstream Git's
+// is_ntfs_dotgitignore.
+func IsNTFSDotGitignore(part string) bool {
+	return IsNTFSDot(part, "gitignore", "gi250a")
+}
+
+// IsNTFSDotMailmap reports whether part is an NTFS equivalent of
+// ".mailmap". The short-name prefix "maba30" mirrors upstream Git's
+// is_ntfs_dotmailmap.
+func IsNTFSDotMailmap(part string) bool {
+	return IsNTFSDot(part, "mailmap", "maba30")
 }
 
 func asciiToLower(c byte) byte {

--- a/internal/pathutil/ntfs_test.go
+++ b/internal/pathutil/ntfs_test.go
@@ -185,3 +185,30 @@ func TestIsNTFSDotGitmodules(t *testing.T) {
 		})
 	}
 }
+
+func TestIsNTFSDotMetadataFamily(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		fn        func(string) bool
+		canonical string
+		short     string
+	}{
+		{"IsNTFSDotGitattributes", IsNTFSDotGitattributes, ".gitattributes", "gi7d29~1"},
+		{"IsNTFSDotGitignore", IsNTFSDotGitignore, ".gitignore", "gi250a~1"},
+		{"IsNTFSDotMailmap", IsNTFSDotMailmap, ".mailmap", "maba30~1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, tc.fn(tc.canonical), "%s(%q)", tc.name, tc.canonical)
+			assert.True(t, tc.fn(tc.canonical+" "), "%s(%q)", tc.name, tc.canonical+" ")
+			assert.True(t, tc.fn(tc.canonical+":foo"), "%s(%q)", tc.name, tc.canonical+":foo")
+			assert.True(t, tc.fn(tc.short), "%s(%q)", tc.name, tc.short)
+			assert.False(t, tc.fn(".gitmodules"), "%s(%q)", tc.name, ".gitmodules")
+			assert.False(t, tc.fn(""), "%s(empty)", tc.name)
+		})
+	}
+}

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -31,6 +31,7 @@ var (
 	ErrEntryNotFound     = errors.New("entry not found")
 	ErrEntriesNotSorted  = errors.New("entries in tree are not sorted")
 	ErrMalformedTree     = errors.New("malformed tree")
+	ErrDuplicateEntry    = errors.New("duplicate entry in tree")
 )
 
 // Tree is basically like a directory - it references a bunch of other trees
@@ -386,6 +387,15 @@ func canonicalTreeMode(mode filemode.FileMode) filemode.FileMode {
 
 // Encode transforms a Tree into a plumbing.EncodedObject.
 // The tree entries must be sorted by name.
+//
+// Each entry name is validated against pathutil.ValidTreePath so that
+// the encoder cannot produce a tree object containing components such
+// as ".git", "..", control characters, or HFS+/NTFS variants of ".git".
+// Encode also rejects duplicate names — including the file/dir
+// collision `foo` and `foo/` — so the output is well-formed regardless
+// of how the in-memory Tree was assembled. Callers that need to emit
+// such bytes for testing or recovery should write them directly via
+// plumbing.EncodedObject rather than through this method.
 func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	o.SetType(plumbing.TreeObject)
 	w, err := o.Writer()
@@ -399,10 +409,16 @@ func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 		return ErrEntriesNotSorted
 	}
 
+	seen := make(map[string]struct{}, len(t.Entries))
 	for _, entry := range t.Entries {
-		if strings.IndexByte(entry.Name, 0) != -1 {
-			return fmt.Errorf("malformed filename %q", entry.Name)
+		if err := pathutil.ValidTreePath(entry.Name); err != nil {
+			return err
 		}
+		if _, dup := seen[entry.Name]; dup {
+			return fmt.Errorf("%w: %q", ErrDuplicateEntry, entry.Name)
+		}
+		seen[entry.Name] = struct{}{}
+
 		if _, err = fmt.Fprintf(w, "%o %s", entry.Mode, entry.Name); err != nil {
 			return err
 		}

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -396,17 +396,20 @@ func canonicalTreeMode(mode filemode.FileMode) filemode.FileMode {
 }
 
 // Encode transforms a Tree into a plumbing.EncodedObject.
-// The tree entries must be sorted by name.
 //
-// Each entry name is validated against pathutil.ValidTreePath so that
-// the encoder cannot produce a tree object containing components such
-// as ".git", "..", control characters, or HFS+/NTFS variants of ".git".
-// Encode also rejects duplicate names — including the file/dir
-// collision `foo` and `foo/` — so the output is well-formed regardless
-// of how the in-memory Tree was assembled. Callers that need to emit
-// such bytes for testing or recovery should write them directly via
+// The tree is run through Tree.Validate before any bytes are written,
+// so the encoder cannot produce a tree object containing components
+// such as ".git", "..", control characters, HFS+/NTFS variants of
+// ".git", null entry hashes, oversize names, mis-sorted or duplicate
+// entries, or symlinks disguised as ".gitmodules"/".gitattributes"/
+// ".gitignore"/".mailmap". Callers that need to emit such bytes for
+// testing or recovery should write them directly via
 // plumbing.EncodedObject rather than through this method.
 func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
+	if err := t.Validate(); err != nil {
+		return err
+	}
+
 	o.SetType(plumbing.TreeObject)
 	w, err := o.Writer()
 	if err != nil {
@@ -415,20 +418,7 @@ func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 
 	defer ioutil.CheckClose(w, &err)
 
-	if !sort.IsSorted(TreeEntrySorter(t.Entries)) {
-		return ErrEntriesNotSorted
-	}
-
-	seen := make(map[string]struct{}, len(t.Entries))
 	for _, entry := range t.Entries {
-		if err := pathutil.ValidTreePath(entry.Name); err != nil {
-			return err
-		}
-		if _, dup := seen[entry.Name]; dup {
-			return fmt.Errorf("%w: %q", ErrDuplicateEntry, entry.Name)
-		}
-		seen[entry.Name] = struct{}{}
-
 		if _, err = fmt.Fprintf(w, "%o %s", entry.Mode, entry.Name); err != nil {
 			return err
 		}

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -32,7 +32,17 @@ var (
 	ErrEntriesNotSorted  = errors.New("entries in tree are not sorted")
 	ErrMalformedTree     = errors.New("malformed tree")
 	ErrDuplicateEntry    = errors.New("duplicate entry in tree")
+	ErrInvalidTree       = errors.New("invalid tree")
 )
+
+// maxTreeEntryNameLen mirrors the default of upstream Git's
+// `fsck.treeEntryLargeName.maxTreeEntryLen` configuration (fsck.c
+// in v2.54.0[1]). 4096 bytes is well above any realistic tree-entry
+// name; entries longer than this almost always indicate a malformed
+// or hand-crafted tree object.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/fsck.c#L26
+const maxTreeEntryNameLen = 4096
 
 // Tree is basically like a directory - it references a bunch of other trees
 // and/or blobs (i.e. files and sub-directories)
@@ -433,6 +443,112 @@ func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	}
 
 	return err
+}
+
+// Validate reports whether the tree object obeys the same structural
+// rules upstream Git's fsck_tree[1] enforces. It is the read-side
+// counterpart to Tree.Encode's producer-side gate: Decode is permissive
+// so that inspection and recovery tools can read trees with unusual
+// entries, and callers that want fsck-shaped reporting call Validate.
+//
+// The returned error wraps ErrInvalidTree (and, where applicable,
+// ErrEntriesNotSorted, ErrDuplicateEntry, or pathutil.ErrInvalidPath)
+// so callers can match either the umbrella or specific rule with
+// errors.Is. When multiple rules are violated they are reported
+// together via errors.Join.
+//
+// Two fsck_tree warnings — zero-padded modes and the non-canonical
+// 0100664 bits — are not surfaced here. Both rely on inspecting the
+// original octal string from the wire, which canonicalTreeMode
+// discards during Decode. Detecting them would require a parallel
+// raw-mode field on TreeEntry; the structural rules below are the
+// load-bearing ones for refusing malformed trees.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/fsck.c#L616-L800
+func (t *Tree) Validate() error {
+	var errs []error
+	add := func(err error) {
+		errs = append(errs, fmt.Errorf("%w: %w", ErrInvalidTree, err))
+	}
+
+	seen := make(map[string]struct{}, len(t.Entries))
+	var prevSortName string
+
+	for i := range t.Entries {
+		e := &t.Entries[i]
+
+		if e.Hash.IsZero() {
+			add(fmt.Errorf("entry %q points to null hash", e.Name))
+		}
+
+		switch {
+		case e.Name == "":
+			add(errors.New("contains empty entry name"))
+		case strings.ContainsRune(e.Name, '/'):
+			add(fmt.Errorf("entry name %q contains a slash", e.Name))
+		default:
+			if err := pathutil.ValidTreePath(e.Name); err != nil {
+				add(err)
+			}
+			if _, dup := seen[e.Name]; dup {
+				add(fmt.Errorf("%w: %q", ErrDuplicateEntry, e.Name))
+			}
+			seen[e.Name] = struct{}{}
+
+			if len(e.Name) > maxTreeEntryNameLen {
+				add(fmt.Errorf("entry name length %d exceeds %d", len(e.Name), maxTreeEntryNameLen))
+			}
+		}
+
+		// Mode validation against the canonical set. Decode normalises
+		// the wire bytes via canonicalTreeMode, so this rule mainly
+		// catches programmatically-built trees with garbage modes;
+		// the zero-padded-mode and non-canonical-bit checks fsck_tree
+		// runs against the raw wire form are out of reach without
+		// retaining the original octal string.
+		if !isValidTreeMode(e.Mode) {
+			add(fmt.Errorf("entry %q has bad mode %o", e.Name, e.Mode))
+		}
+
+		// Symlink-disguised metadata files. Mirrors the four FSCK_MSG_*
+		// _SYMLINK reports in fsck_tree.
+		if e.Mode == filemode.Symlink {
+			switch {
+			case pathutil.IsHFSDotGitmodules(e.Name) || pathutil.IsNTFSDotGitmodules(e.Name):
+				add(errors.New(".gitmodules is a symlink"))
+			case pathutil.IsHFSDotGitattributes(e.Name) || pathutil.IsNTFSDotGitattributes(e.Name):
+				add(errors.New(".gitattributes is a symlink"))
+			case pathutil.IsHFSDotGitignore(e.Name) || pathutil.IsNTFSDotGitignore(e.Name):
+				add(errors.New(".gitignore is a symlink"))
+			case pathutil.IsHFSDotMailmap(e.Name) || pathutil.IsNTFSDotMailmap(e.Name):
+				add(errors.New(".mailmap is a symlink"))
+			}
+		}
+
+		sortName := treeEntrySortName(e)
+		if i > 0 && prevSortName > sortName {
+			add(ErrEntriesNotSorted)
+		}
+		prevSortName = sortName
+	}
+
+	return errors.Join(errs...)
+}
+
+// isValidTreeMode reports whether mode is one of the canonical tree
+// modes upstream Git accepts in fsck_tree, including the non-canonical
+// 0100664 that upstream tolerates outside --strict mode.
+func isValidTreeMode(mode filemode.FileMode) bool {
+	switch mode {
+	case filemode.Regular,
+		filemode.Executable,
+		filemode.Symlink,
+		filemode.Dir,
+		filemode.Submodule,
+		filemode.Deprecated:
+		return true
+	}
+	return false
 }
 
 // Diff returns a list of changes between this tree and the provided one

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -2082,40 +2082,88 @@ func TestTreeFindEntryFindsDirectoryAfterLexicallyEarlierFile(t *testing.T) {
 	assert.Equal(t, 0, bytes.Compare(hashB, got.Hash.Bytes()))
 }
 
-func TestTreeEncodePreservesDuplicateEntries(t *testing.T) {
+// TestTreeEncodeRejectsDuplicateEntries pins the duplicate-name check
+// in Tree.Encode. Two entries sharing a name — whether two files, two
+// directories, or a file/dir collision where the dir's sort name `foo/`
+// puts it elsewhere in the sorted order — must be rejected with
+// ErrDuplicateEntry rather than written to the object.
+func TestTreeEncodeRejectsDuplicateEntries(t *testing.T) {
 	t.Parallel()
 
-	hashABytes := bytes.Repeat([]byte{0xAA}, 20)
-	hashBBytes := bytes.Repeat([]byte{0xBB}, 20)
-	hashA, ok := plumbing.FromBytes(hashABytes)
+	hashA, ok := plumbing.FromBytes(bytes.Repeat([]byte{0xAA}, 20))
 	require.True(t, ok)
-	hashB, ok := plumbing.FromBytes(hashBBytes)
+	hashB, ok := plumbing.FromBytes(bytes.Repeat([]byte{0xBB}, 20))
 	require.True(t, ok)
 
-	tree := &Tree{
-		Entries: []TreeEntry{
-			{Name: "foo", Mode: filemode.Regular, Hash: hashA},
-			{Name: "foo", Mode: filemode.Regular, Hash: hashB},
+	cases := []struct {
+		name    string
+		entries []TreeEntry
+	}{
+		{
+			name: "two files with the same name",
+			entries: []TreeEntry{
+				{Name: "foo", Mode: filemode.Regular, Hash: hashA},
+				{Name: "foo", Mode: filemode.Regular, Hash: hashB},
+			},
+		},
+		{
+			name: "file and directory with the same name",
+			entries: []TreeEntry{
+				{Name: "foo", Mode: filemode.Regular, Hash: hashA},
+				{Name: "foo", Mode: filemode.Dir, Hash: hashB},
+			},
 		},
 	}
 
-	obj := &plumbing.MemoryObject{}
-	require.NoError(t, tree.Encode(obj))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	r, err := obj.Reader()
-	require.NoError(t, err)
-	got, err := io.ReadAll(r)
-	require.NoError(t, err)
-	require.NoError(t, r.Close())
+			tree := &Tree{Entries: tc.entries}
+			sort.Sort(TreeEntrySorter(tree.Entries))
+			obj := &plumbing.MemoryObject{}
+			err := tree.Encode(obj)
+			require.ErrorIs(t, err, ErrDuplicateEntry)
+		})
+	}
+}
 
-	var want bytes.Buffer
-	want.WriteString("100644 foo")
-	want.WriteByte(0)
-	want.Write(hashABytes)
-	want.WriteString("100644 foo")
-	want.WriteByte(0)
-	want.Write(hashBBytes)
-	assert.Equal(t, want.Bytes(), got)
+// TestTreeEncodeRejectsDangerousNames pins the entry-name validation in
+// Tree.Encode: a tree assembled in memory with components that
+// pathutil.ValidTreePath refuses must fail at the encoder boundary so
+// the library cannot produce such tree objects through its API.
+func TestTreeEncodeRejectsDangerousNames(t *testing.T) {
+	t.Parallel()
+
+	hash, ok := plumbing.FromBytes(bytes.Repeat([]byte{0xAA}, 20))
+	require.True(t, ok)
+
+	cases := []struct {
+		name  string
+		entry string
+	}{
+		{"final-component .git", ".git"},
+		{"parent traversal", ".."},
+		{"current directory", "."},
+		{"NTFS trailing space on .git", ".git "},
+		{"NTFS short-name alias git~1", "git~1"},
+		{"HFS+ zero-width character in .git", ".g\u200cit"},
+		{"embedded NUL in name", "foo\x00bar"},
+		{"control character", "foo\x01bar"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree := &Tree{
+				Entries: []TreeEntry{{Name: tc.entry, Mode: filemode.Regular, Hash: hash}},
+			}
+			obj := &plumbing.MemoryObject{}
+			err := tree.Encode(obj)
+			require.ErrorIs(t, err, pathutil.ErrInvalidPath)
+		})
+	}
 }
 
 // TestTreeEntryFileRejectsDangerousNames pins the validation gate added

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"sort"
+	"strings"
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
@@ -313,9 +314,9 @@ func (o *SortReadCloser) Read(p []byte) (int, error) {
 func (s *TreeSuite) TestTreeEntriesSorted() {
 	tree := &Tree{
 		Entries: []TreeEntry{
-			{"foo", filemode.Regular, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
-			{"bar", filemode.Regular, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
-			{"baz", filemode.Regular, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{Name: "foo", Mode: filemode.Regular, Hash: plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{Name: "bar", Mode: filemode.Regular, Hash: plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			{Name: "baz", Mode: filemode.Regular, Hash: plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
 		},
 	}
 
@@ -338,9 +339,9 @@ func (s *TreeSuite) TestTreeDecodeEncodeIdempotent() {
 	trees := []*Tree{
 		{
 			Entries: []TreeEntry{
-				{"foo", filemode.Regular, plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
-				{"bar", filemode.Regular, plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
-				{"baz", filemode.Regular, plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{Name: "foo", Mode: filemode.Regular, Hash: plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{Name: "bar", Mode: filemode.Regular, Hash: plumbing.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				{Name: "baz", Mode: filemode.Regular, Hash: plumbing.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
 			},
 		},
 	}
@@ -2262,4 +2263,203 @@ func TestTreeWalkerNextRejectsDangerousNames(t *testing.T) {
 			assert.ErrorIs(t, err, pathutil.ErrInvalidPath)
 		})
 	}
+}
+
+// TestTreeValidateAcceptsWellFormed pins the negative case: a tree
+// with canonical modes, sorted unique entries, and ordinary names
+// passes Validate cleanly. Anchors the rest of the rule-by-rule
+// coverage as deviations from this baseline.
+func TestTreeValidateAcceptsWellFormed(t *testing.T) {
+	t.Parallel()
+
+	hash := bytes.Repeat([]byte{0xAA}, 20)
+	body := encodeRawTreeEntries(
+		rawTreeEntry{"100644", "alpha", hash},
+		rawTreeEntry{"100755", "beta", hash},
+		rawTreeEntry{"120000", "gamma", hash},
+		rawTreeEntry{"40000", "subdir", hash},
+		rawTreeEntry{"160000", "submod", hash},
+	)
+	tree, err := decodeRawTree(t, body)
+	require.NoError(t, err)
+	assert.NoError(t, tree.Validate())
+}
+
+// TestTreeValidateRejectsFsckRules exercises each rule fsck_tree
+// enforces. Each case constructs a raw tree object that decodes
+// cleanly (Decode is intentionally permissive) and then asserts
+// Validate flags the corresponding rule. Sentinels are checked via
+// errors.Is where the rule has one; otherwise the error message is
+// matched.
+func TestTreeValidateRejectsFsckRules(t *testing.T) {
+	t.Parallel()
+
+	hash := bytes.Repeat([]byte{0xAA}, 20)
+	zero := make([]byte, 20)
+
+	cases := []struct {
+		name       string
+		entries    []rawTreeEntry
+		wantIs     error
+		wantString string
+	}{
+		{
+			name:       "null hash",
+			entries:    []rawTreeEntry{{"100644", "file", zero}},
+			wantString: "points to null hash",
+		},
+		{
+			name:       "slash in name",
+			entries:    []rawTreeEntry{{"100644", "dir/file", hash}},
+			wantString: "contains a slash",
+		},
+		{
+			name:    "dot component",
+			entries: []rawTreeEntry{{"100644", ".", hash}},
+			wantIs:  pathutil.ErrInvalidPath,
+		},
+		{
+			name:    "dotdot component",
+			entries: []rawTreeEntry{{"100644", "..", hash}},
+			wantIs:  pathutil.ErrInvalidPath,
+		},
+		{
+			name:    "dotgit component",
+			entries: []rawTreeEntry{{"100644", ".git", hash}},
+			wantIs:  pathutil.ErrInvalidPath,
+		},
+		{
+			name: "duplicate entries",
+			entries: []rawTreeEntry{
+				{"100644", "foo", hash},
+				{"100644", "foo", hash},
+			},
+			wantIs: ErrDuplicateEntry,
+		},
+		{
+			// canonicalTreeMode maps the non-canonical 0100664 down
+			// to the canonical Regular mode at Decode, so Validate
+			// sees a well-formed entry and accepts it. The rule is
+			// kept in the table to document that the canonicalising
+			// step swallows it.
+			name:       "0100664 normalises to Regular and validates",
+			entries:    []rawTreeEntry{{"100664", "file", hash}},
+			wantString: "",
+		},
+		{
+			name:       "symlinked .gitmodules",
+			entries:    []rawTreeEntry{{"120000", ".gitmodules", hash}},
+			wantString: ".gitmodules is a symlink",
+		},
+		{
+			name:       "symlinked .gitattributes",
+			entries:    []rawTreeEntry{{"120000", ".gitattributes", hash}},
+			wantString: ".gitattributes is a symlink",
+		},
+		{
+			name:       "symlinked .gitignore",
+			entries:    []rawTreeEntry{{"120000", ".gitignore", hash}},
+			wantString: ".gitignore is a symlink",
+		},
+		{
+			name:       "symlinked .mailmap",
+			entries:    []rawTreeEntry{{"120000", ".mailmap", hash}},
+			wantString: ".mailmap is a symlink",
+		},
+		{
+			name: "mis-sorted entries",
+			entries: []rawTreeEntry{
+				{"100644", "zeta", hash},
+				{"100644", "alpha", hash},
+			},
+			wantIs: ErrEntriesNotSorted,
+		},
+		{
+			name:       "name too long",
+			entries:    []rawTreeEntry{{"100644", strings.Repeat("a", maxTreeEntryNameLen+1), hash}},
+			wantString: "exceeds 4096",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree, err := decodeRawTree(t, encodeRawTreeEntries(tc.entries...))
+			require.NoError(t, err, "Decode should be permissive")
+
+			err = tree.Validate()
+			if tc.wantIs == nil && tc.wantString == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrInvalidTree)
+			if tc.wantIs != nil {
+				assert.ErrorIs(t, err, tc.wantIs)
+			}
+			if tc.wantString != "" {
+				assert.Contains(t, err.Error(), tc.wantString)
+			}
+		})
+	}
+}
+
+// TestTreeValidateEmptyName covers the case fsck_tree calls
+// has_empty_name. Tree.Decode rejects an empty entry name at parse,
+// so the test constructs the in-memory tree directly to reach the
+// Validate rule.
+func TestTreeValidateEmptyName(t *testing.T) {
+	t.Parallel()
+
+	tree := &Tree{
+		Entries: []TreeEntry{{
+			Name: "",
+			Mode: filemode.Regular,
+			Hash: plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		}},
+	}
+	err := tree.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidTree)
+	assert.Contains(t, err.Error(), "empty entry name")
+}
+
+// TestTreeValidateBadInMemoryMode pins the bad-mode rule against
+// programmatically-constructed entries. Wire-decoded modes go through
+// canonicalTreeMode and always land on a valid value, so this rule is
+// only reachable when a caller sets a non-canonical Mode by hand.
+func TestTreeValidateBadInMemoryMode(t *testing.T) {
+	t.Parallel()
+
+	tree := &Tree{
+		Entries: []TreeEntry{{
+			Name: "file",
+			Mode: filemode.FileMode(0o12345),
+			Hash: plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		}},
+	}
+	err := tree.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidTree)
+	assert.Contains(t, err.Error(), "bad mode")
+}
+
+// TestTreeValidateReportsAllRules confirms that Validate accumulates
+// multiple rule violations into a single joined error rather than
+// returning on the first failure.
+func TestTreeValidateReportsAllRules(t *testing.T) {
+	t.Parallel()
+
+	zero := make([]byte, 20)
+	tree, err := decodeRawTree(t, encodeRawTreeEntries(
+		rawTreeEntry{"100644", "..", zero}, // dotdot + null hash
+	))
+	require.NoError(t, err)
+
+	verr := tree.Validate()
+	require.Error(t, verr)
+	assert.ErrorIs(t, verr, ErrInvalidTree)
+	assert.ErrorIs(t, verr, pathutil.ErrInvalidPath)
+	assert.Contains(t, verr.Error(), "null hash")
 }

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -312,6 +312,14 @@ func (h *buildTreeHelper) BuildTree(idx *index.Index, _ *CommitOptions) (plumbin
 }
 
 func (h *buildTreeHelper) commitIndexEntry(e *index.Entry) error {
+	// Index entries with a zero hash point at no object — Tree.Encode
+	// (through Tree.Validate) refuses to write them, and the pre-fsck
+	// behavior of #1773 was to accept the entry but never reach a
+	// healthy tree. Skip them here so the resulting tree is well-formed.
+	if e.Hash.IsZero() {
+		return nil
+	}
+
 	parts := strings.Split(e.Name, "/")
 
 	var fullpath string

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -854,11 +854,25 @@ func (s *WorktreeSuite) buildChildCommit(storage *memory.Storage, parent *object
 		Mode: filemode.Regular,
 		Hash: blobHash,
 	})
-	tree := &object.Tree{Entries: entries}
-	sort.Sort(object.TreeEntrySorter(tree.Entries))
+	sort.Sort(object.TreeEntrySorter(entries))
+
+	// Tree.Encode validates entry names through pathutil.ValidTreePath
+	// and would refuse a path component like ".git/config" — the precise
+	// shape this test needs to plant. Assemble the tree object bytes
+	// directly so the malicious tree reaches the cherry-pick boundary.
+	var buf bytes.Buffer
+	for _, e := range entries {
+		fmt.Fprintf(&buf, "%o %s", e.Mode, e.Name)
+		buf.WriteByte(0)
+		buf.Write(e.Hash.Bytes())
+	}
 	treeObj := storage.NewEncodedObject()
-	err = tree.Encode(treeObj)
+	treeObj.SetType(plumbing.TreeObject)
+	tw, err := treeObj.Writer()
 	s.Require().NoError(err)
+	_, err = tw.Write(buf.Bytes())
+	s.Require().NoError(err)
+	s.Require().NoError(tw.Close())
 	treeHash, err := storage.SetEncodedObject(treeObj)
 	s.Require().NoError(err)
 

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -531,15 +532,8 @@ func buildCommitWithEntry(t *testing.T, s storer.Storer, parent *object.Commit, 
 	leafHash := blobHash
 
 	for i := len(parts) - 1; i >= 1; i-- {
-		tree := &object.Tree{
-			Entries: []object.TreeEntry{
-				{Name: parts[i], Mode: leafMode, Hash: leafHash},
-			},
-		}
-		treeObj := s.NewEncodedObject()
-		require.NoError(t, tree.Encode(treeObj))
-		leafHash, err = s.SetEncodedObject(treeObj)
-		require.NoError(t, err)
+		entry := object.TreeEntry{Name: parts[i], Mode: leafMode, Hash: leafHash}
+		leafHash = storeRawTree(t, s, []object.TreeEntry{entry})
 		leafMode = filemode.Dir
 	}
 
@@ -553,12 +547,8 @@ func buildCommitWithEntry(t *testing.T, s storer.Storer, parent *object.Commit, 
 		Mode: leafMode,
 		Hash: leafHash,
 	})
-	rootTree := &object.Tree{Entries: entries}
-	sort.Sort(object.TreeEntrySorter(rootTree.Entries))
-	rootObj := s.NewEncodedObject()
-	require.NoError(t, rootTree.Encode(rootObj))
-	rootHash, err := s.SetEncodedObject(rootObj)
-	require.NoError(t, err)
+	sort.Sort(object.TreeEntrySorter(entries))
+	rootHash := storeRawTree(t, s, entries)
 
 	commit := &object.Commit{
 		Author:       *defaultSignature(),
@@ -575,6 +565,34 @@ func buildCommitWithEntry(t *testing.T, s storer.Storer, parent *object.Commit, 
 	result, err := object.GetCommit(s, commitHash)
 	require.NoError(t, err)
 	return result
+}
+
+// storeRawTree writes a tree object to s by assembling the raw
+// `<mode> SP <name> NUL <hash>` bytes for each entry. Tests that plant
+// trees containing components like ".git", "..", or HFS+/NTFS variants
+// use this helper because Tree.Encode runs Tree.Validate and refuses
+// those names — the escape hatch documented on Tree.Encode's godoc.
+func storeRawTree(t *testing.T, s storer.Storer, entries []object.TreeEntry) plumbing.Hash {
+	t.Helper()
+
+	var buf bytes.Buffer
+	for _, e := range entries {
+		fmt.Fprintf(&buf, "%o %s", e.Mode, e.Name)
+		buf.WriteByte(0)
+		buf.Write(e.Hash.Bytes())
+	}
+
+	obj := s.NewEncodedObject()
+	obj.SetType(plumbing.TreeObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write(buf.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	hash, err := s.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
 }
 
 func gitConfig(t *testing.T, dir, key, value string) {


### PR DESCRIPTION
Closes the encode/decode boundary that #2081 and #2097 left tolerant. `Tree.Encode` previously accepted entry names like `.git`, `..`, control characters, or HFS+/NTFS `.git` disguises, and never checked for duplicates; `Tree.Decode` did not validate names at all.

`Tree.Encode` now runs each name through `pathutil.ValidTreePath` and rejects duplicate names — including the file/dir collision where `foo` and `foo/` share a bare name. Callers that need to emit non-conformant bytes write them via `plumbing.EncodedObject` directly.

`Tree.Decode` stays permissive — upstream Git makes the same split between `parse_tree_buffer` and `fsck_tree`[1], and the permissive parse keeps inspection and recovery use cases working. The new `Tree.Validate` is the opt-in read-side counterpart, mirroring `fsck_tree`'s structural rules: null hashes, slashes, empty/`.`/`..`/`.git` names, bad file modes, duplicates, mis-sort, oversized names, and the four `*_SYMLINK` rules for `.gitmodules`/`.gitattributes`/`.gitignore`/`.mailmap`. Violations come back as `errors.Join` of rule errors wrapping `ErrInvalidTree`.

Two `fsck_tree` warnings need the raw octal mode string — zero-padded and non-canonical `0100664` modes — which `canonicalTreeMode` drops at parse. Those are wire-only and best handled by a future buffer-level validator.

[1]: https://github.com/git/git/blob/v2.54.0/fsck.c#L616-L800