### PR TITLE
worktree: allow symlink targets containing ".."

### DIFF
--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -107,7 +107,15 @@ func (sfs *worktreeFilesystem) Lstat(filename string) (os.FileInfo, error) {
 }
 
 func (sfs *worktreeFilesystem) Symlink(target, link string) error {
-	if err := sfs.validPath(target, link); err != nil {
+	// Only validate the symlink name (link), not the target.
+	// Git does not validate symlink targets - they are just strings
+	// stored in blobs. Upstream git reads the blob content and calls
+	// symlink(2) directly without validation (entry.c write_entry at
+	// v2.54.0[1]). Targets can legitimately contain ".." or other
+	// path components that would be dangerous for worktree operations.
+	//
+	// [1]: https://github.com/git/git/blob/v2.54.0/entry.c#L388
+	if err := sfs.validPath(link); err != nil {
 		return fmt.Errorf("symlink: %w", err)
 	}
 	if err := sfs.validSymlinkName(link); err != nil {

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -199,7 +199,7 @@ func assertOpsRejected(t *testing.T, fs *worktreeFilesystem, p string) {
 func TestWorktreeFilesystemSymlinkRejectsDangerousPaths(t *testing.T) {
 	t.Parallel()
 
-	badPaths := []string{
+	badLinkNames := []string{
 		".git",
 		".git/config",
 		".git/hooks/pre-commit",
@@ -208,17 +208,19 @@ func TestWorktreeFilesystemSymlinkRejectsDangerousPaths(t *testing.T) {
 		"a/../../etc/passwd",
 	}
 
-	for _, p := range badPaths {
+	for _, p := range badLinkNames {
 		t.Run(p, func(t *testing.T) {
 			t.Parallel()
 
 			fs := newWorktreeFilesystem(memfs.New(), false, false)
 
+			// Symlink NAME (link) must be validated and rejected
 			err := fs.Symlink("safe-target.txt", p)
 			assert.ErrorContains(t, err, "symlink:", "Symlink should reject link name %q", p)
 
-			err = fs.Symlink(p, "safe-link")
-			assert.ErrorContains(t, err, "symlink:", "Symlink should reject target %q", p)
+			// Symlink TARGET is NOT validated by git - any target is allowed
+			// This matches git's behavior where targets can be dangerous paths.
+			// The OS filesystem provides the security boundary.
 
 			assertOpsRejected(t, fs, p)
 		})
@@ -237,6 +239,42 @@ func TestWorktreeFilesystemSymlinkAllowsValidLink(t *testing.T) {
 	assert.Equal(t, "target.txt", got)
 
 	assertOpsRejected(t, fs, ".git/config")
+}
+
+func TestWorktreeFilesystemSymlinkAllowsDangerousTargets(t *testing.T) {
+	t.Parallel()
+
+	// Git allows symlink targets to contain dangerous paths like "..",
+	// ".git", or paths that escape the worktree. The symlink target is
+	// just a string stored in the blob - git doesn't validate it.
+	// This matches upstream git behavior (verified with git v2.54.0).
+	dangerousTargets := []string{
+		"../escape",
+		"../../escape",
+		"a/../../etc/passwd",
+		".git/config",
+		".git/hooks/pre-commit",
+		"git~1/HEAD",
+		"../sibling",
+	}
+
+	for _, target := range dangerousTargets {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+
+			fs := newWorktreeFilesystem(memfs.New(), false, false)
+
+			// Symlink targets are NOT validated - matches git behavior
+			err := fs.Symlink(target, "link")
+			require.NoError(t, err, "Symlink should allow target %q", target)
+
+			got, err := fs.Readlink("link")
+			require.NoError(t, err)
+			// Normalize path separators for cross-platform comparison
+			// (Windows converts forward slashes to backslashes in symlink targets)
+			assert.Equal(t, filepath.ToSlash(target), filepath.ToSlash(got))
+		})
+	}
 }
 
 func TestWorktreeFilesystemReadlinkValidatesPath(t *testing.T) {
@@ -357,8 +395,8 @@ func TestWorktreeFilesystemAbsolutePaths(t *testing.T) {
 				err := fs.Symlink("safe-target.txt", tc.path)
 				assert.ErrorContains(t, err, "symlink:", "Symlink should reject link %q", tc.path)
 
-				err = fs.Symlink(tc.path, "safe-link")
-				assert.ErrorContains(t, err, "symlink:", "Symlink should reject target %q", tc.path)
+				// Symlink targets are NOT validated - matches git behavior
+				// Any target path is allowed
 				return
 			}
 


### PR DESCRIPTION
## Summary

Fix symlink creation to match git's behavior by only validating the symlink name (where it's created), not the target (what it points to).

## Details

Git does not validate symlink targets - they are strings stored in blobs that can legitimately contain `..` or other path components. Upstream git reads the blob content and calls `symlink(2)` directly without validation ([entry.c write_entry at v2.54.0](https://github.com/git/git/blob/v2.54.0/entry.c#L388)).

This fixes cloning repositories with symlinks like `tests/foo -> ../bar` which previously failed with `invalid path: cannot use ".."`.

## Changes

- Modified `worktreeFilesystem.Symlink()` to only validate the symlink name (link), not the target
- Added comment with reference to upstream git source
- Updated tests to reflect correct behavior:
  - Removed assertions expecting symlink targets to be rejected
  - Added `TestWorktreeFilesystemSymlinkAllowsDangerousTargets()` to verify dangerous targets are allowed

## Test plan

- All existing tests pass
- Verified with the failing repository: `go run ./_examples/clone/main.go https://github.com/lorin/openstack-ansible-modules.git ~/working/temp` now succeeds

Fixes #2107

🤖 Generated with [Claude Code](https://claude.com/claude-code)