### PR TITLE
git: Revert "git: Expand worktreeFilesystem validation"

### DIFF
--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -107,7 +107,7 @@ func (sfs *worktreeFilesystem) Lstat(filename string) (os.FileInfo, error) {
 }
 
 func (sfs *worktreeFilesystem) Symlink(target, link string) error {
-	if err := sfs.validPath(target, link); err != nil {
+	if err := sfs.validPath(link); err != nil {
 		return fmt.Errorf("symlink: %w", err)
 	}
 	if err := sfs.validSymlinkName(link); err != nil {

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -217,9 +217,6 @@ func TestWorktreeFilesystemSymlinkRejectsDangerousPaths(t *testing.T) {
 			err := fs.Symlink("safe-target.txt", p)
 			assert.ErrorContains(t, err, "symlink:", "Symlink should reject link name %q", p)
 
-			err = fs.Symlink(p, "safe-link")
-			assert.ErrorContains(t, err, "symlink:", "Symlink should reject target %q", p)
-
 			assertOpsRejected(t, fs, p)
 		})
 	}


### PR DESCRIPTION
This reverts commit 0ae66bd80af9a8710f19579cb99242cfa6248447.

Fixes: Issue #2107
Signed-off-by: Nicolas Simonds <github@submedia.net>