### PR TITLE
git: Stop validating symlink target paths

### DIFF
--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -107,7 +107,7 @@ func (sfs *worktreeFilesystem) Lstat(filename string) (os.FileInfo, error) {
 }
 
 func (sfs *worktreeFilesystem) Symlink(target, link string) error {
-	if err := sfs.validPath(target, link); err != nil {
+	if err := sfs.validPath(link); err != nil {
 		return fmt.Errorf("symlink: %w", err)
 	}
 	if err := sfs.validSymlinkName(link); err != nil {

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -197,7 +197,7 @@ func assertOpsRejected(t *testing.T, fs *worktreeFilesystem, p string) {
 	assert.ErrorContains(t, err, "readlink:", "Readlink should reject %q", p)
 }
 
-func TestWorktreeFilesystemSymlinkRejectsDangerousPaths(t *testing.T) {
+func TestWorktreeFilesystemSymlinkRejectsDangerousLinkNames(t *testing.T) {
 	t.Parallel()
 
 	badPaths := []string{
@@ -218,9 +218,6 @@ func TestWorktreeFilesystemSymlinkRejectsDangerousPaths(t *testing.T) {
 			err := fs.Symlink("safe-target.txt", p)
 			assert.ErrorContains(t, err, "symlink:", "Symlink should reject link name %q", p)
 
-			err = fs.Symlink(p, "safe-link")
-			assert.ErrorContains(t, err, "symlink:", "Symlink should reject target %q", p)
-
 			assertOpsRejected(t, fs, p)
 		})
 	}
@@ -238,6 +235,34 @@ func TestWorktreeFilesystemSymlinkAllowsValidLink(t *testing.T) {
 	assert.Equal(t, "target.txt", got)
 
 	assertOpsRejected(t, fs, ".git/config")
+}
+
+func TestWorktreeFilesystemSymlinkAllowsArbitraryTargets(t *testing.T) {
+	t.Parallel()
+
+	targets := []string{
+		"/etc/passwd",
+		"/absolute/path/to/file",
+		"../sibling",
+		"../../elsewhere",
+		"a/../b",
+		".git/config",
+	}
+
+	for _, target := range targets {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+
+			fs := newWorktreeFilesystem(memfs.New(), false, false)
+
+			link := "link"
+			require.NoError(t, fs.Symlink(target, link))
+
+			got, err := fs.Readlink(link)
+			require.NoError(t, err)
+			assert.Equal(t, filepath.FromSlash(target), got)
+		})
+	}
 }
 
 func TestWorktreeFilesystemReadlinkValidatesPath(t *testing.T) {
@@ -357,9 +382,6 @@ func TestWorktreeFilesystemAbsolutePaths(t *testing.T) {
 
 				err := fs.Symlink("safe-target.txt", tc.path)
 				assert.ErrorContains(t, err, "symlink:", "Symlink should reject link %q", tc.path)
-
-				err = fs.Symlink(tc.path, "safe-link")
-				assert.ErrorContains(t, err, "symlink:", "Symlink should reject target %q", tc.path)
 				return
 			}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -527,6 +527,56 @@ func (s *WorktreeSuite) TestCheckoutSymlink() {
 	s.NoError(err)
 }
 
+func TestCheckoutSymlinkArbitraryTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("git doesn't support symlinks by default in windows")
+	}
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{name: "rel", target: "target"},
+		{name: "absolute", target: "/etc/passwd"},
+		{name: "dot-dot relative", target: "../../outside"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			r, err := PlainInit(dir, false)
+			require.NoError(t, err)
+
+			w, err := r.Worktree()
+			require.NoError(t, err)
+
+			require.NoError(t, w.filesystem.Symlink(tc.target, "link"))
+			_, err = w.Add("link")
+			require.NoError(t, err)
+			_, err = w.Commit("add symlink", &CommitOptions{Author: defaultSignature()})
+			require.NoError(t, err)
+
+			require.NoError(t, r.Storer.SetIndex(&index.Index{Version: 2}))
+			w.filesystem = newWorktreeFilesystem(
+				osfs.New(filepath.Join(dir, "worktree-empty")), true, true)
+
+			require.NoError(t, w.Checkout(&CheckoutOptions{}))
+
+			status, err := w.Status()
+			require.NoError(t, err)
+			assert.True(t, status.IsClean())
+
+			got, err := w.filesystem.Readlink("link")
+			require.NoError(t, err)
+			assert.Equal(t, tc.target, got)
+		})
+	}
+}
+
 func (s *WorktreeSuite) TestCheckoutSparse() {
 	fs := memfs.New()
 	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{


### PR DESCRIPTION
The Symlink wrapper was running validPath on both the target and the link. Targets are an opaque string the kernel resolves at use time, so legitimate worktrees commonly contain symlinks pointing to absolute paths or escaping via "..". Validating them as worktree paths rejected those checkouts. Containment is enforced on the link name, which is where the wrapper actually controls placement.

Reverts https://github.com/go-git/go-git/commit/0ae66bd80af9a8710f19579cb99242cfa6248447, which added validation on symlink target which does not align with upstream.

Relates to #2107.