### PR TITLE
git: Allow MkdirAll on worktree-root paths

### DIFF
--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -124,6 +124,14 @@ func (sfs *worktreeFilesystem) Readlink(link string) (string, error) {
 }
 
 func (sfs *worktreeFilesystem) MkdirAll(path string, perm fs.FileMode) error {
+	// MkdirAll on the worktree root is a no-op: the root always exists,
+	// so there is nothing to materialise. Mirroring the tolerance that
+	// validReadPath gives to read-side operations avoids breaking callers
+	// that walk a directory tree and pass the relative-to-root prefix
+	// ("") through to the worktree FS.
+	if path == "" || path == "." || path == "/" {
+		return nil
+	}
 	if err := sfs.validPath(path); err != nil {
 		return fmt.Errorf("mkdirall: %w", err)
 	}

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -139,6 +139,31 @@ func TestWorktreeFilesystemAllowsValidPaths(t *testing.T) {
 	}
 }
 
+// TestWorktreeFilesystemMkdirAllRootIsNoop locks in the contract that
+// MkdirAll on a root-equivalent path is a silent no-op against the
+// wrapper. validPath itself still rejects "", ".", and "/" (see
+// TestValidPath), but MkdirAll specifically tolerates them because
+// "ensure the root exists" is always trivially satisfied.
+func TestWorktreeFilesystemMkdirAllRootIsNoop(t *testing.T) {
+	t.Parallel()
+
+	rootPaths := []string{"", ".", "/"}
+	for _, p := range rootPaths {
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+
+			mfs := memfs.New()
+			fs := newWorktreeFilesystem(mfs, true, true)
+
+			require.NoError(t, fs.MkdirAll(p, 0o755))
+
+			entries, err := mfs.ReadDir("/")
+			require.NoError(t, err)
+			assert.Empty(t, entries, "MkdirAll(%q) must not materialise a directory entry", p)
+		})
+	}
+}
+
 func TestWorktreeFilesystemReturnsWorktreeFilesystem(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The worktree filesystem wrapper rejects `""`, `"."`, and `"/"` in `MkdirAll` via `validPath`, even though `validReadPath` was already relaxed to treat those paths as legitimate references to the worktree root. The asymmetry was deliberate for genuine mutations — mutating the root itself is not a sensible operation for `Create` or `Remove` — but `MkdirAll` on an existing directory is not a mutation: it asks the filesystem to ensure a directory exists, against one that always does.

Short-circuit `MkdirAll` to a no-op for root-equivalents before `validPath` runs. `validPath` itself stays strict, so the other mutating operations continue to reject the root and the existing `TestValidPath` table is untouched. A new `TestWorktreeFilesystemMkdirAllRootIsNoop` locks in the no-op contract against the wrapper.