### PR TITLE
v5: git: Stop validating symlink target paths

### DIFF
--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -106,7 +106,7 @@ func (sfs *worktreeFilesystem) Lstat(filename string) (os.FileInfo, error) {
 }
 
 func (sfs *worktreeFilesystem) Symlink(target, link string) error {
-	if err := sfs.validPath(target, link); err != nil {
+	if err := sfs.validPath(link); err != nil {
 		return fmt.Errorf("symlink: %w", err)
 	}
 	if err := sfs.validSymlinkName(link); err != nil {

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
@@ -473,6 +474,60 @@ func (s *WorktreeSuite) TestCheckoutSymlink(c *C) {
 	target, err := w.Filesystem.Readlink("bar")
 	c.Assert(target, Equals, "not-exists")
 	c.Assert(err, IsNil)
+}
+
+func TestCheckoutSymlinkArbitraryTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("git doesn't support symlinks by default in windows")
+	}
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{name: "rel", target: "target"},
+		{name: "absolute", target: "/etc/passwd"},
+		{name: "dot-dot relative", target: "../../outside"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			wtFS := osfs.New(dir, osfs.WithBoundOS())
+
+			dotFS, err := wtFS.Chroot(".git")
+			require.NoError(t, err)
+			storage := filesystem.NewStorage(dotFS, cache.NewObjectLRUDefault())
+
+			r, err := Init(storage, wtFS)
+			require.NoError(t, err)
+
+			w, err := r.Worktree()
+			require.NoError(t, err)
+
+			require.NoError(t, w.Filesystem.Symlink(tc.target, "link"))
+			_, err = w.Add("link")
+			require.NoError(t, err)
+			_, err = w.Commit("add symlink", &CommitOptions{Author: defaultSignature()})
+			require.NoError(t, err)
+
+			require.NoError(t, r.Storer.SetIndex(&index.Index{Version: 2}))
+			w.Filesystem = newWorktreeFilesystem(
+				osfs.New(filepath.Join(dir, "worktree-empty")), true, true)
+
+			require.NoError(t, w.Checkout(&CheckoutOptions{}))
+
+			_, err = w.Status()
+			require.NoError(t, err)
+
+			got, err := w.Filesystem.Readlink("link")
+			require.NoError(t, err)
+			assert.Equal(t, tc.target, got)
+		})
+	}
 }
 
 func (s *WorktreeSuite) TestCheckoutSparse(c *C) {
@@ -2123,7 +2178,6 @@ func (s *WorktreeSuite) TestAddFilenameStartingWithDot(c *C) {
 	file = status.File("foo/bar/baz")
 	c.Assert(file.Staging, Equals, Added)
 	c.Assert(file.Worktree, Equals, Unmodified)
-
 }
 
 func (s *WorktreeSuite) TestAddGlobErrorNoMatches(c *C) {
@@ -2491,7 +2545,6 @@ func (s *WorktreeSuite) TestMove(c *C) {
 	c.Assert(status, HasLen, 2)
 	c.Assert(status.File("LICENSE").Staging, Equals, Deleted)
 	c.Assert(status.File("foo").Staging, Equals, Added)
-
 }
 
 func (s *WorktreeSuite) TestMoveNotExistentEntry(c *C) {
@@ -3364,7 +3417,6 @@ func (s *WorktreeSuite) TestRestoreBoth(c *C) {
 }
 
 func TestFilePermissions(t *testing.T) {
-
 	// Initialize an in memory repository
 	remoteUrl := t.TempDir()
 
@@ -3421,5 +3473,4 @@ func TestFilePermissions(t *testing.T) {
 		assert.Equal(t, expectedEntry.Name, idx.Entries[i].Name)
 		assert.Equal(t, expectedEntry.Mode, idx.Entries[i].Mode)
 	}
-
 }


### PR DESCRIPTION
The Symlink wrapper was running validPath on both the target and the link. Targets are an opaque string the kernel resolves at use time, so legitimate worktrees commonly contain symlinks pointing to absolute paths or escaping via "..". Validating them as worktree paths rejected those checkouts. Containment is enforced on the link name, which is where the wrapper actually controls placement.

Reverts https://github.com/go-git/go-git/commit/0ae66bd80af9a8710f19579cb99242cfa6248447, which added validation on symlink target which does not align with upstream.

Backport of: https://github.com/go-git/go-git/pull/2114.
Fixes: https://github.com/go-git/go-git/issues/2107.