### PR TITLE
storage: filesystem, Make ObjectStorage a pointer field

### DIFF
--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -22,7 +22,7 @@ type Storage struct {
 	dir    *dotgit.DotGit
 	hasher plumbing.Hasher
 
-	ObjectStorage
+	*ObjectStorage
 	ReferenceStorage
 	IndexStorage
 	ShallowStorage
@@ -123,7 +123,7 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 		dir:    dir,
 		hasher: hasher,
 
-		ObjectStorage:    *NewObjectStorageWithOptions(dir, c, ops),
+		ObjectStorage:    NewObjectStorageWithOptions(dir, c, ops),
 		ReferenceStorage: ReferenceStorage{dir: dir},
 		IndexStorage:     IndexStorage{dir: dir, h: hasher.Hash, cache: ops.IndexCache, skipHash: skipHash},
 		ShallowStorage:   ShallowStorage{dir: dir},


### PR DESCRIPTION
## Summary

Change ObjectStorage from an embedded value to a pointer field in the Storage struct. ObjectStorage contains mutexes (muI and muP) which should not be copied. Embedding by value causes the mutex to be copied when Storage is copied, which violates Go's concurrency safety rules.

## Changes

- Change `ObjectStorage` to `*ObjectStorage` in Storage struct
- Update initialization to use pointer instead of dereferencing

## Why

- ObjectStorage contains `sync.RWMutex` fields (muI and muP) which should not be copied per Go's concurrency rules
- Using a pointer ensures the mutex is never copied and the same ObjectStorage instance is shared across all copies of Storage

## Test plan

- [ ] Existing tests pass
- [ ] Verify no mutex copy warnings with `go vet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)