### PR TITLE
plumbing: format decoder input bounds and contracts

### DIFF
--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -87,251 +87,326 @@ func (p *pattern) Match(path []string, isDir bool) MatchResult {
 	return Exclude
 }
 
-// wildmatch implements gitignore-compatible pattern matching with support for
-// POSIX character classes and proper bracket expression handling
+// The wildmatch implementation below ports the matcher from canonical Git's
+// wildmatch.c at tag v2.54.0[1]. The algorithm is preserved exactly; the Go
+// shape trades C idioms (raw pointers, NUL-terminated strings, goto-based
+// control flow) for string slicing, explicit bounds checks, and a regular
+// switch. Returned codes match upstream so callers can prune recursion the
+// same way.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/wildmatch.c
+
+// wildmatch return codes mirror the WM_* constants from upstream wildmatch.h.
+// wmAbortToStarStar lets a recursive call signal to its caller that it hit a
+// '/' boundary while expanding a non-'**' star, so the outer '*' can prune
+// further alternatives instead of re-trying them.
+const (
+	wmMatch           = 0
+	wmNoMatch         = 1
+	wmAbortAll        = -1
+	wmAbortToStarStar = -2
+)
+
+// wildmatch flags mirror the WM_* flag bits in upstream wildmatch.h. The
+// current go-git API does not expose case-insensitive matching, and the
+// matcher splits paths on '/' before dispatching here, so wmCasefold and
+// wmPathname code paths are kept for upstream parity but never exercised by
+// the public Match.
+const (
+	wmCasefold = 1
+	wmPathname = 2
+)
+
+// wildmatch reports whether text matches the wildcard pattern. It is a thin
+// wrapper over dowild; the gitignore matcher splits paths on '/' before
+// dispatching, so dowild always operates on a single pattern/text segment
+// with flags=0.
 func wildmatch(pattern, text string) bool {
+	return dowild(pattern, text, 0) == wmMatch
+}
+
+// dowild walks pattern and text in lock-step, recursing at each '*' to try
+// every text suffix and propagating wmMatch, wmNoMatch, wmAbortAll, or
+// wmAbortToStarStar back up so callers can prune work the same way the
+// upstream C implementation does (wildmatch.c#L59-L283).
+func dowild(p, text string, flags int) int {
 	pi, ti := 0, 0
-	plen, tlen := len(pattern), len(text)
+	for pi < len(p) {
+		pCh := p[pi]
+		var tCh byte
+		atEndOfText := ti >= len(text)
+		if !atEndOfText {
+			tCh = text[ti]
+		}
+		if atEndOfText && pCh != '*' {
+			return wmAbortAll
+		}
+		if flags&wmCasefold != 0 && isASCIIUpper(tCh) {
+			tCh += 'a' - 'A'
+		}
+		if flags&wmCasefold != 0 && isASCIIUpper(pCh) {
+			pCh += 'a' - 'A'
+		}
 
-	// Track star positions for backtracking
-	starIdx, matchIdx := -1, -1
-
-	for ti < tlen {
-		if pi < plen {
-			pc := pattern[pi]
-
-			switch pc {
-			case '\\':
-				// Trailing '\' with nothing to escape: Git's wildmatch advances
-				// past it into NUL and the literal comparison fails, so we fall
-				// through to backtracking (or NOMATCH if no '*' to retry).
-				if pi+1 >= plen {
-					break
-				}
-				pi++
-				if pattern[pi] == text[ti] {
+		switch pCh {
+		case '\\':
+			// Literal match with the following character. A trailing '\'
+			// has no character to escape; canonical Git reads NUL (the C
+			// string terminator) into p_ch and the default-case compare
+			// fails because t_ch can never be NUL (the surrounding check
+			// returned wmAbortAll when text was exhausted). We mirror that
+			// by returning wmNoMatch directly.
+			if pi+1 >= len(p) {
+				return wmNoMatch
+			}
+			pi++
+			pCh = p[pi]
+			if tCh != pCh {
+				return wmNoMatch
+			}
+			pi++
+			ti++
+		case '?':
+			// Match any character except '/'.
+			if flags&wmPathname != 0 && tCh == '/' {
+				return wmNoMatch
+			}
+			pi++
+			ti++
+		case '*':
+			pi++
+			var matchSlash bool
+			if pi < len(p) && p[pi] == '*' {
+				prevPi := pi
+				for pi < len(p) && p[pi] == '*' {
 					pi++
-					ti++
-					continue
 				}
+				switch {
+				case flags&wmPathname == 0:
+					// Without WM_PATHNAME, '*' == '**'.
+					matchSlash = true
+				case (prevPi < 2 || p[prevPi-2] == '/') &&
+					(pi >= len(p) || p[pi] == '/' ||
+						(pi+1 < len(p) && p[pi] == '\\' && p[pi+1] == '/')):
+					// At a '/<**>/' boundary: optionally match the slash as
+					// nothing, recursing past it so that foo/<*><*>/bar
+					// matches both foo/bar and foo/a/bar.
+					if pi < len(p) && p[pi] == '/' &&
+						dowild(p[pi+1:], text[ti:], flags) == wmMatch {
+						return wmMatch
+					}
+					matchSlash = true
+				}
+			} else {
+				// Single '*': without WM_PATHNAME crosses '/'; with it,
+				// does not.
+				matchSlash = flags&wmPathname == 0
+			}
 
-			case '?':
-				// Question mark matches any single character
+			if pi >= len(p) {
+				// Trailing "**" matches everything; trailing "*" matches only
+				// when no '/' remains in text.
+				if !matchSlash && strings.IndexByte(text[ti:], '/') >= 0 {
+					return wmAbortToStarStar
+				}
+				return wmMatch
+			} else if !matchSlash && p[pi] == '/' {
+				// One '*' followed by '/' with WM_PATHNAME: advance text to
+				// the next '/' so the outer loop consumes it.
+				slash := strings.IndexByte(text[ti:], '/')
+				if slash < 0 {
+					return wmAbortAll
+				}
+				ti += slash
+				// Fall through to the outer-loop advance.
 				pi++
 				ti++
 				continue
+			}
 
-			case '*':
-				// Star matches zero or more characters
-				starIdx = pi
-				matchIdx = ti
+			for {
+				if ti >= len(text) {
+					return wmAbortAll
+				}
+				tCh = text[ti]
+				// Try to advance faster when '*' is followed by a literal.
+				// Everything before the next occurrence of that literal
+				// must belong to '*'. With matchSlash=false, stop at the
+				// first '/'.
+				if !isGlobSpecial(p[pi]) {
+					pCh = p[pi]
+					if flags&wmCasefold != 0 && isASCIIUpper(pCh) {
+						pCh += 'a' - 'A'
+					}
+					for ti < len(text) {
+						tCh = text[ti]
+						if !matchSlash && tCh == '/' {
+							break
+						}
+						if flags&wmCasefold != 0 && isASCIIUpper(tCh) {
+							tCh += 'a' - 'A'
+						}
+						if tCh == pCh {
+							break
+						}
+						ti++
+					}
+					if ti >= len(text) || tCh != pCh {
+						if matchSlash {
+							return wmAbortAll
+						}
+						return wmAbortToStarStar
+					}
+				}
+				matched := dowild(p[pi:], text[ti:], flags)
+				if matched != wmNoMatch {
+					if !matchSlash || matched != wmAbortToStarStar {
+						return matched
+					}
+				} else if !matchSlash && tCh == '/' {
+					return wmAbortToStarStar
+				}
+				ti++
+			}
+		case '[':
+			pi++
+			if pi >= len(p) {
+				return wmAbortAll
+			}
+			pCh = p[pi]
+			if pCh == '^' {
+				pCh = '!'
+			}
+			negated := pCh == '!'
+			if negated {
 				pi++
-				continue
-
-			case '[':
-				// Bracket expression
-				bracketEnd := findBracketEnd(pattern, pi)
-				if bracketEnd > pi && matchBracket(pattern[pi:bracketEnd+1], text[ti]) {
-					pi = bracketEnd + 1
-					ti++
-					continue
+				if pi >= len(p) {
+					return wmAbortAll
 				}
-				// If bracket match failed and we have a star, backtrack
-				if starIdx >= 0 {
-					pi = starIdx + 1
-					matchIdx++
-					ti = matchIdx
-					continue
-				}
-				return false
-
-			default:
-				if pc == text[ti] {
+				pCh = p[pi]
+			}
+			var prevCh byte
+			matched := false
+			// The C source uses a do/while loop terminating when p_ch == ']';
+			// each iteration ends with prev_ch = p_ch and p_ch = *++p. NUL
+			// from the C string is detected here with explicit pi bounds
+			// checks before every read.
+			for {
+				switch {
+				case pCh == '\\':
 					pi++
-					ti++
-					continue
+					if pi >= len(p) {
+						return wmAbortAll
+					}
+					pCh = p[pi]
+					if tCh == pCh {
+						matched = true
+					}
+				case pCh == '-' && prevCh != 0 &&
+					pi+1 < len(p) && p[pi+1] != ']':
+					pi++
+					pCh = p[pi]
+					if pCh == '\\' {
+						pi++
+						if pi >= len(p) {
+							return wmAbortAll
+						}
+						pCh = p[pi]
+					}
+					if tCh <= pCh && tCh >= prevCh {
+						matched = true
+					} else if flags&wmCasefold != 0 && isASCIILower(tCh) {
+						tUpper := tCh - ('a' - 'A')
+						if tUpper <= pCh && tUpper >= prevCh {
+							matched = true
+						}
+					}
+					pCh = 0 // resets prev_ch for next iteration
+				case pCh == '[' && pi+1 < len(p) && p[pi+1] == ':':
+					// POSIX class [:name:]. Walk forward to the next ']';
+					// if it isn't preceded by ':' the construct is not a
+					// class, so rewind and treat the '[' as a literal.
+					s := pi + 2
+					pi = s
+					for pi < len(p) && p[pi] != ']' {
+						pi++
+					}
+					if pi >= len(p) {
+						return wmAbortAll
+					}
+					nameLen := pi - s - 1
+					if nameLen < 0 || p[pi-1] != ':' {
+						pi = s - 2
+						pCh = '['
+						if tCh == pCh {
+							matched = true
+						}
+						// Fall through to the loop tail with pCh='[' so the
+						// post-step records it as prev_ch.
+						break
+					}
+					classMatched, valid := matchPOSIXClass(p[s:pi-1], tCh, flags)
+					if !valid {
+						return wmAbortAll
+					}
+					if classMatched {
+						matched = true
+					}
+					pCh = 0 // resets prev_ch
+				default:
+					if tCh == pCh {
+						matched = true
+					}
 				}
+				prevCh = pCh
+				pi++
+				if pi >= len(p) {
+					return wmAbortAll
+				}
+				if p[pi] == ']' {
+					break
+				}
+				pCh = p[pi]
 			}
-		}
-
-		// No match, try backtracking to last star
-		if starIdx >= 0 {
-			pi = starIdx + 1
-			matchIdx++
-			ti = matchIdx
-			continue
-		}
-
-		return false
-	}
-
-	// Skip trailing stars in pattern
-	for pi < plen && pattern[pi] == '*' {
-		pi++
-	}
-
-	return pi == plen
-}
-
-// findBracketEnd finds the closing ] of a bracket expression starting at position start
-func findBracketEnd(pattern string, start int) int {
-	if start >= len(pattern) || pattern[start] != '[' {
-		return -1
-	}
-
-	i := start + 1
-	// Handle negation
-	if i < len(pattern) && (pattern[i] == '!' || pattern[i] == '^') {
-		i++
-	}
-	// Handle ] at start
-	if i < len(pattern) && pattern[i] == ']' {
-		i++
-	}
-
-	for i < len(pattern) {
-		if pattern[i] == ']' {
-			return i
-		}
-		switch {
-		case pattern[i] == '\\' && i+1 < len(pattern):
-			i += 2
-		case pattern[i] == '[' && i+1 < len(pattern) && pattern[i+1] == ':':
-			if _, end, ok := parsePosixClass(pattern, i); ok {
-				i = end
-			} else {
-				// Not a valid character class, treat [ as literal and continue
-				i++
+			if matched == negated ||
+				(flags&wmPathname != 0 && tCh == '/') {
+				return wmNoMatch
 			}
+			pi++
+			ti++
 		default:
-			i++
+			if tCh != pCh {
+				return wmNoMatch
+			}
+			pi++
+			ti++
 		}
 	}
-	return -1
+
+	if ti < len(text) {
+		return wmNoMatch
+	}
+	return wmMatch
 }
 
-// matchBracket matches a single character against a bracket expression
-// The pattern should be the complete bracket expression including [ and ]
-// Based on Git's wildmatch.c implementation
-func matchBracket(bracketExpr string, ch byte) bool {
-	if len(bracketExpr) < 2 || bracketExpr[0] != '[' {
-		return false
+// isGlobSpecial mirrors is_glob_special() from upstream ctype.c. Bytes that
+// can start or modify a wildmatch sub-pattern are "special"; everything else
+// is literal text and may be fast-skipped in the '*' loop.
+func isGlobSpecial(c byte) bool {
+	switch c {
+	case '*', '?', '[', '\\':
+		return true
 	}
-
-	i := 1
-	var prevCh byte
-	var pCh byte
-	negate := false
-	matched := false
-
-	// Check for negation
-	if i >= len(bracketExpr) {
-		return false
-	}
-	pCh = bracketExpr[i]
-	if pCh == '^' {
-		pCh = '!'
-	}
-	if pCh == '!' {
-		negate = true
-		i++
-	}
-
-	prevCh = 0
-
-	// Loop through bracket expression until we find the closing ]
-	for {
-		if i >= len(bracketExpr) {
-			return false
-		}
-		pCh = bracketExpr[i]
-
-		switch {
-		case pCh == '\\':
-			// Escaped character
-			i++
-			if i >= len(bracketExpr) {
-				return false
-			}
-			pCh = bracketExpr[i]
-			if ch == pCh {
-				matched = true
-			}
-		case pCh == '-' && prevCh != 0 && i+1 < len(bracketExpr) && bracketExpr[i+1] != ']':
-			// Range: prev_ch through next character
-			i++
-			pCh = bracketExpr[i]
-			if pCh == '\\' {
-				i++
-				if i >= len(bracketExpr) {
-					return false
-				}
-				pCh = bracketExpr[i]
-			}
-			// Check if ch is in range [prevCh, pCh]
-			if ch <= pCh && ch >= prevCh {
-				matched = true
-			}
-			pCh = 0 // Reset prev_ch
-		case pCh == '[' && i+1 < len(bracketExpr) && bracketExpr[i+1] == ':':
-			if className, end, ok := parsePosixClass(bracketExpr, i); ok {
-				classMatch, valid := matchCharClass(className, ch)
-				if !valid {
-					// Malformed [:class:] string - entire pattern fails
-					return false
-				}
-				if classMatch {
-					matched = true
-				}
-				i = end - 1 // loop's i++ advances past ']'
-				pCh = 0     // Reset prev_ch after character class
-			} else if ch == '[' {
-				// Didn't find ":]", so treat [ as a literal character in the set
-				matched = true
-				// pCh stays as '[', will be set to prev_ch at bottom of loop
-			}
-		case ch == pCh:
-			// Literal character match
-			matched = true
-		}
-
-		prevCh = pCh
-		i++
-		// Check for the closing bracket
-		if i < len(bracketExpr) && bracketExpr[i] == ']' {
-			break
-		}
-	}
-
-	if negate {
-		return !matched
-	}
-	return matched
+	return false
 }
 
-// parsePosixClass parses a POSIX character class header of the form [:name:]
-// starting at s[start], where s[start] is '[' and s[start+1] is ':'. On
-// success it returns the class name (between [: and :]) and the index just
-// past the closing ']'. ok is false when the form is malformed: no closing
-// ']', empty name, or missing trailing ':'.
-func parsePosixClass(s string, start int) (name string, end int, ok bool) {
-	classStart := start + 2
-	j := classStart
-	for j < len(s) && s[j] != ']' {
-		j++
-	}
-	if j >= len(s) || j == classStart || s[j-1] != ':' {
-		return "", 0, false
-	}
-	return s[classStart : j-1], j + 1, true
-}
-
-// matchCharClass checks if a character matches a POSIX character class.
-// Classification is ASCII-only to match Git's wildmatch (sane-ctype.h):
-// high-bit bytes never satisfy any class.
-// Returns (matched, valid) where valid indicates if the class name was recognized.
-func matchCharClass(class string, ch byte) (bool, bool) {
-	switch class {
+// matchPOSIXClass evaluates a [:name:] character-class entry within a bracket
+// expression. Classification is ASCII-only to mirror sane-ctype.h: bytes
+// with the high bit set never satisfy any class. valid is false when the
+// class name is unrecognized — wildmatch.c propagates that as wmAbortAll
+// ("malformed [:class:] string").
+func matchPOSIXClass(name string, ch byte, flags int) (matched, valid bool) {
+	switch name {
 	case "alnum":
 		return isASCIIAlpha(ch) || isASCIIDigit(ch), true
 	case "alpha":
@@ -354,11 +429,16 @@ func matchCharClass(class string, ch byte) (bool, bool) {
 		return ch == ' ' || ch == '\t' || ch == '\n' ||
 			ch == '\v' || ch == '\f' || ch == '\r', true
 	case "upper":
-		return ch >= 'A' && ch <= 'Z', true
+		if ch >= 'A' && ch <= 'Z' {
+			return true, true
+		}
+		if flags&wmCasefold != 0 && isASCIILower(ch) {
+			return true, true
+		}
+		return false, true
 	case "xdigit":
 		return isASCIIDigit(ch) || (ch >= 'a' && ch <= 'f') || (ch >= 'A' && ch <= 'F'), true
 	default:
-		// Malformed/unknown character class
 		return false, false
 	}
 }
@@ -369,6 +449,14 @@ func isASCIIAlpha(ch byte) bool {
 
 func isASCIIDigit(ch byte) bool {
 	return ch >= '0' && ch <= '9'
+}
+
+func isASCIIUpper(ch byte) bool {
+	return ch >= 'A' && ch <= 'Z'
+}
+
+func isASCIILower(ch byte) bool {
+	return ch >= 'a' && ch <= 'z'
 }
 
 func isASCIIPunct(ch byte) bool {

--- a/plumbing/format/idxfile/decoder.go
+++ b/plumbing/format/idxfile/decoder.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 
 	"github.com/go-git/go-git/v6/plumbing/hash"
 	"github.com/go-git/go-git/v6/utils/binary"
@@ -23,42 +24,87 @@ const (
 	fanout = 256
 )
 
-// Decoder reads and decodes idx files from an input stream.
-type Decoder struct {
+// Byte sizes of the idx v2 layout elements, used by the size formula
+// in [validateIdxV2Size]. See [gitformat-pack] for the canonical
+// layout.
+//
+// [gitformat-pack]: https://git-scm.com/docs/gitformat-pack
+const (
+	headerLen     = 8          // magic + version
+	fanoutLen     = fanout * 4 // uint32 per bucket
+	crc32Len      = 4          // CRC32 per object
+	offset32Len   = 4          // 32-bit offset per object
+	offset64Len   = 8          // 64-bit overflow offset
+	trailerHashes = 2          // pack checksum + idx checksum, each hashsz
+)
+
+// Input is the input to a [Decoder]. The decoder reads loose-object
+// bytes from it and calls Stat to learn the on-disk length, which it
+// uses to validate the canonical-Git size formula before any
+// allocations driven by the fanout table.
+//
+// [os.File] and the go-billy [File] type satisfy Input directly.
+//
+// [File]: https://pkg.go.dev/github.com/go-git/go-billy/v6#File
+type Input interface {
 	io.Reader
-	h hash.Hash
+	Stat() (fs.FileInfo, error)
 }
 
-// NewDecoder builds a new idx stream decoder, that reads from r.
-func NewDecoder(r io.Reader, h hash.Hash) *Decoder {
-	tr := io.TeeReader(r, h)
-	return &Decoder{tr, h}
+// Decoder reads and decodes idx files from an [Input].
+type Decoder struct {
+	in Input
+	h  hash.Hash
 }
 
-// Decode reads from the stream and decode the content into the MemoryIndex struct.
+// NewDecoder builds a new idx decoder that reads from in.
+func NewDecoder(in Input, h hash.Hash) *Decoder {
+	return &Decoder{in, h}
+}
+
+// Decode reads from the input and decodes the content into idx.
 func (d *Decoder) Decode(idx *MemoryIndex) error {
+	fi, err := d.in.Stat()
+	if err != nil {
+		return fmt.Errorf("%w: stat input: %w", ErrMalformedIdxFile, err)
+	}
+	idxSize := fi.Size()
+
 	d.h.Reset()
-	if err := validateHeader(d); err != nil {
+	r := io.TeeReader(d.in, d.h)
+
+	if err := validateHeader(r); err != nil {
 		return err
 	}
 
-	flow := []func(*MemoryIndex, io.Reader) error{
+	headerFlow := []func(*MemoryIndex, io.Reader) error{
 		readVersion,
 		readFanout,
+	}
+	for _, f := range headerFlow {
+		if err := f(idx, r); err != nil {
+			return err
+		}
+	}
+
+	if err := validateIdxV2Size(idx, idxSize); err != nil {
+		return err
+	}
+
+	bodyFlow := []func(*MemoryIndex, io.Reader) error{
 		readObjectNames,
 		readCRC32,
 		readOffsets,
 		readPackChecksum,
 	}
-
-	for _, f := range flow {
-		if err := f(idx, d); err != nil {
+	for _, f := range bodyFlow {
+		if err := f(idx, r); err != nil {
 			return err
 		}
 	}
 
 	actual := d.h.Sum(nil)
-	if err := readIdxChecksum(idx, d); err != nil {
+	if err := readIdxChecksum(idx, r); err != nil {
 		return err
 	}
 
@@ -199,4 +245,104 @@ func readIdxChecksum(idx *MemoryIndex, r io.Reader) error {
 	}
 
 	return nil
+}
+
+// validateIdxV2Size enforces the size formula used by canonical Git
+// load_idx for idx v2 files: the on-disk length must lie within
+// [minSize, maxSize] where
+//
+//	perObject = hashsz + crc32Len + offset32Len
+//	minSize   = headerLen + fanoutLen + trailerHashes*hashsz + nr*perObject
+//	maxSize   = minSize + (nr-1)*offset64Len     when nr > 0
+//
+// with nr taken from the last fanout entry and hashsz from the
+// configured object ID size. Multiplications use a self-checking
+// overflow guard so inputs whose claimed object count overflows the
+// formula are rejected rather than wrapping into a smaller value.
+func validateIdxV2Size(idx *MemoryIndex, idxSize int64) error {
+	nr := int64(idx.Fanout[fanout-1])
+	hashsz := int64(idx.idSize())
+
+	minSize := minIdxV2Size(nr, hashsz)
+	maxSize := maxIdxV2Size(nr, hashsz)
+	if minSize < 0 || maxSize < 0 {
+		return fmt.Errorf("%w: object count %d is inconsistent with file size", ErrMalformedIdxFile, nr)
+	}
+
+	if idxSize < minSize || idxSize > maxSize {
+		return fmt.Errorf("%w: file size %d is inconsistent with object count %d", ErrMalformedIdxFile, idxSize, nr)
+	}
+	return nil
+}
+
+// minIdxV2Size returns the minimum on-disk size of an idx v2 file
+// holding nr objects with the given hash size, mirroring the
+// computation in canonical Git load_idx. Returns -1 when any
+// intermediate multiplication or addition would overflow int64.
+func minIdxV2Size(nr, hashsz int64) int64 {
+	perObject := hashsz + crc32Len + offset32Len
+	fixed := int64(headerLen+fanoutLen) + trailerHashes*hashsz
+
+	objects, ok := mulInt64(nr, perObject)
+	if !ok {
+		return -1
+	}
+	sum, ok := addInt64(fixed, objects)
+	if !ok {
+		return -1
+	}
+	return sum
+}
+
+// maxIdxV2Size returns the maximum on-disk size of an idx v2 file
+// holding nr objects with the given hash size, mirroring the
+// computation in canonical Git load_idx. Returns -1 on overflow.
+func maxIdxV2Size(nr, hashsz int64) int64 {
+	minSize := minIdxV2Size(nr, hashsz)
+	if minSize < 0 {
+		return -1
+	}
+	if nr == 0 {
+		return minSize
+	}
+	overflow, ok := mulInt64(nr-1, offset64Len)
+	if !ok {
+		return -1
+	}
+	sum, ok := addInt64(minSize, overflow)
+	if !ok {
+		return -1
+	}
+	return sum
+}
+
+// mulInt64 returns a*b and whether the result fits in an int64 without
+// overflow. Negative operands or overflow yield ok=false. The overflow
+// check uses the standard self-inverse identity: a*b/b == a only when
+// the multiplication did not wrap.
+func mulInt64(a, b int64) (int64, bool) {
+	if a < 0 || b < 0 {
+		return 0, false
+	}
+	if a == 0 || b == 0 {
+		return 0, true
+	}
+	c := a * b
+	if c/b != a {
+		return 0, false
+	}
+	return c, true
+}
+
+// addInt64 returns a+b and whether the result fits in an int64 without
+// overflow. Negative operands or overflow yield ok=false.
+func addInt64(a, b int64) (int64, bool) {
+	if a < 0 || b < 0 {
+		return 0, false
+	}
+	c := a + b
+	if c < a {
+		return 0, false
+	}
+	return c, true
 }

--- a/plumbing/format/idxfile/decoder_test.go
+++ b/plumbing/format/idxfile/decoder_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"io"
 	"testing"
 
@@ -57,12 +58,13 @@ func (s *IdxfileSuite) TestDecode() {
 }
 
 func (s *IdxfileSuite) TestDecode64bitsOffsets() {
-	f := bytes.NewBufferString(fixtureLarge4GB)
+	raw, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewBufferString(fixtureLarge4GB)))
+	s.Require().NoError(err)
 
 	idx := new(MemoryIndex)
 
-	d := NewDecoder(base64.NewDecoder(base64.StdEncoding, f), hash.New(crypto.SHA1))
-	err := d.Decode(idx)
+	d := NewDecoder(FromBytes(raw), hash.New(crypto.SHA1))
+	err = d.Decode(idx)
 	s.NoError(err)
 
 	expected := map[string]uint64{
@@ -135,9 +137,8 @@ func BenchmarkDecode(b *testing.B) {
 
 	hasher := hash.New(crypto.SHA1)
 	for b.Loop() {
-		f := bytes.NewBuffer(fixture)
 		idx := new(MemoryIndex)
-		d := NewDecoder(f, hasher)
+		d := NewDecoder(FromBytes(fixture), hasher)
 		if err := d.Decode(idx); err != nil {
 			b.Errorf("unexpected error decoding: %s", err)
 		}
@@ -238,7 +239,12 @@ func TestDecodeErrors(t *testing.T) {
 				buf = append(buf, writeFanout(1, nil)...)
 				return buf
 			},
-			wantErr: io.EOF,
+			// The size formula now rejects the input before the
+			// reader gets a chance to report EOF: a single-object
+			// idx v2 needs at least 1100 bytes for SHA-1, and the
+			// header+fanout alone is only 1032.
+			wantErr:         ErrMalformedIdxFile,
+			wantErrContains: "inconsistent with object count",
 		},
 		{
 			name: "checksum mismatch",
@@ -259,7 +265,7 @@ func TestDecodeErrors(t *testing.T) {
 			t.Parallel()
 
 			idx := new(MemoryIndex)
-			d := NewDecoder(bytes.NewReader(tt.input()), hash.New(crypto.SHA1))
+			d := NewDecoder(FromBytes(tt.input()), hash.New(crypto.SHA1))
 
 			err := d.Decode(idx)
 			require.Error(t, err)
@@ -296,4 +302,89 @@ func idxV2Header() []byte {
 	buf.Write([]byte{255, 't', 'O', 'c'})
 	binary.Write(&buf, binary.BigEndian, uint32(2))
 	return buf.Bytes()
+}
+
+// TestDecoderSizeFormulaBoundary exercises the [minSize, maxSize] range
+// enforced by validateIdxV2Size. The boundary is asymmetric for nr > 1:
+// each extra 8-byte offset64 slot extends maxSize by 8. Inputs at the
+// edge of the legal range must pass the size check (failing later with
+// the trailing checksum mismatch, since the payload is zero-filled);
+// inputs one byte outside must be rejected with a size-related error.
+func TestDecoderSizeFormulaBoundary(t *testing.T) {
+	t.Parallel()
+
+	const hashsz = 20 // SHA-1
+	const headerLen = 8 + 4*256
+	minSize := func(nr int64) int64 {
+		return headerLen + nr*(hashsz+8) + 2*hashsz
+	}
+	maxSize := func(nr int64) int64 {
+		m := minSize(nr)
+		if nr > 0 {
+			m += (nr - 1) * 8
+		}
+		return m
+	}
+	build := func(nr uint32, total int64) []byte {
+		buf := append(idxV2Header(), writeFanout(nr, nil)...)
+		if int64(len(buf)) > total {
+			t.Fatalf("header+fanout exceeds requested total: %d > %d", len(buf), total)
+		}
+		return append(buf, make([]byte, total-int64(len(buf)))...)
+	}
+
+	tests := []struct {
+		name      string
+		nr        uint32
+		size      int64
+		passesLen bool // true: size check passes (later parsing may fail)
+	}{
+		{"nr=1, at minSize", 1, minSize(1), true},
+		{"nr=1, one byte below minSize", 1, minSize(1) - 1, false},
+		{"nr=1, one byte above maxSize", 1, maxSize(1) + 1, false},
+		{"nr=2, at minSize", 2, minSize(2), true},
+		{"nr=2, at maxSize", 2, maxSize(2), true},
+		{"nr=2, one byte below minSize", 2, minSize(2) - 1, false},
+		{"nr=2, one byte above maxSize", 2, maxSize(2) + 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			idx := new(MemoryIndex)
+			d := NewDecoder(FromBytes(build(tt.nr, tt.size)), hash.New(crypto.SHA1))
+			err := d.Decode(idx)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrMalformedIdxFile)
+			if tt.passesLen {
+				// Payload is zero-filled, so we reach the trailing
+				// checksum comparison and fail there. The size check
+				// itself must not fire.
+				require.ErrorContains(t, err, "checksum mismatch")
+			} else {
+				require.ErrorContains(t, err, "inconsistent with object count")
+			}
+		})
+	}
+}
+
+func TestDecoderRejectsInconsistentObjectCount(t *testing.T) {
+	t.Parallel()
+
+	// Header (\xff t O c) + version 2 + fanout where fanout[0..255] all
+	// claim 0x4C4C4C4C objects. The byte count cannot possibly accommodate
+	// that many object names.
+	var buf bytes.Buffer
+	buf.Write([]byte{0xff, 't', 'O', 'c', 0, 0, 0, 2})
+	for range 256 {
+		_ = binary.Write(&buf, binary.BigEndian, uint32(0x4C4C4C4C))
+	}
+
+	idx := new(MemoryIndex)
+	d := NewDecoder(FromBytes(buf.Bytes()), hash.New(crypto.SHA1))
+	err := d.Decode(idx)
+	if !errors.Is(err, ErrMalformedIdxFile) {
+		t.Fatalf("expected ErrMalformedIdxFile, got %v", err)
+	}
 }

--- a/plumbing/format/idxfile/encoder_test.go
+++ b/plumbing/format/idxfile/encoder_test.go
@@ -27,7 +27,7 @@ func TestEncode(t *testing.T) {
 
 	validIdxFn := func() *MemoryIndex {
 		idx := NewMemoryIndex(crypto.SHA1.Size())
-		d := NewDecoder(bytes.NewBuffer(expected), hash.New(crypto.SHA1))
+		d := NewDecoder(FromBytes(expected), hash.New(crypto.SHA1))
 		err := d.Decode(idx)
 		require.NoError(t, err)
 		return idx
@@ -152,7 +152,7 @@ func TestEncodeDecodeRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			idx := NewMemoryIndex(tc.hasher.Size())
-			d := NewDecoder(bytes.NewBuffer(expected), hash.New(tc.hasher))
+			d := NewDecoder(FromBytes(expected), hash.New(tc.hasher))
 			err = d.Decode(idx)
 			require.NoError(t, err)
 
@@ -181,7 +181,7 @@ func TestDecodeEncode(t *testing.T) {
 		}
 
 		idx := NewMemoryIndex(h.Size())
-		d := NewDecoder(bytes.NewBuffer(expected), hash.New(h))
+		d := NewDecoder(FromBytes(expected), hash.New(h))
 		err = d.Decode(idx)
 		require.NoError(t, err)
 

--- a/plumbing/format/idxfile/fuzz_helpers.go
+++ b/plumbing/format/idxfile/fuzz_helpers.go
@@ -67,13 +67,18 @@ func buildMinimalRev(count, hashSize int) []byte {
 }
 
 // buildOOBOffset64Idx constructs a structurally valid v2 idx file
-// whose single 32-bit offset entry is marked as a 64-bit overflow
-// (MSB set) but whose lower 31 bits point past the only allocated
-// 64-bit offset slot. The idx decodes successfully; using it must
-// fail with [ErrMalformedIdxFile] rather than crash.
+// whose 32-bit offset entry for the first object is marked as a
+// 64-bit overflow (MSB set) but whose lower 31 bits point past the
+// only allocated 64-bit offset slot. The idx decodes successfully;
+// using it must fail with [ErrMalformedIdxFile] rather than reach
+// the post-decode lookups in an inconsistent state.
 //
-// The returned hash is the name of the single object — pass it to
+// The returned hash is the name of the first object — pass it to
 // FindOffset to exercise the malformed-input path.
+//
+// The fixture has two objects so the on-disk length satisfies the
+// idx v2 size formula applied during Decode; only with `nr > 1`
+// does the formula permit any 8-byte offset64 slots.
 //
 // Lives outside `_test.go` so the OSS-Fuzz harness, which does not
 // see other test files when extracting fuzz targets, can reach it
@@ -85,22 +90,30 @@ func buildOOBOffset64Idx() ([]byte, plumbing.Hash) {
 	buf.Write(idxHeader)
 	_ = binary.Write(&buf, binary.BigEndian, uint32(2))
 
-	// Fanout: one object whose first byte is 0x00, so all 256 entries
-	// hold the cumulative count 1.
+	// Fanout: two objects whose first bytes are 0x00, so all 256
+	// entries hold the cumulative count 2.
 	for range 256 {
-		_ = binary.Write(&buf, binary.BigEndian, uint32(1))
+		_ = binary.Write(&buf, binary.BigEndian, uint32(2))
 	}
 
-	// One name (any valid 20-byte hash with first byte 0x00).
-	name := make([]byte, hashSize)
-	name[hashSize-1] = 0x01
-	buf.Write(name)
+	// Two names (both valid 20-byte hashes with first byte 0x00,
+	// in ascending order so the table remains well-formed).
+	name1 := make([]byte, hashSize)
+	name1[hashSize-1] = 0x01
+	name2 := make([]byte, hashSize)
+	name2[hashSize-1] = 0x02
+	buf.Write(name1)
+	buf.Write(name2)
 
-	// CRC32 (one entry, value irrelevant).
-	buf.Write(make([]byte, 4))
+	// CRC32 (two entries, values irrelevant).
+	buf.Write(make([]byte, 8))
 
-	// Offset32: MSB set, lower 31 bits = 5 → references Offset64[40:48].
+	// Offset32 for object 1: MSB set, lower 31 bits = 5 → references
+	// Offset64[40:48]; only one 8-byte slot exists, so this is out
+	// of range.
 	_ = binary.Write(&buf, binary.BigEndian, uint32(0x80000005))
+	// Offset32 for object 2: a small in-range value.
+	_ = binary.Write(&buf, binary.BigEndian, uint32(0))
 
 	// Offset64: a single 8-byte slot — the lookup above is out of range.
 	_ = binary.Write(&buf, binary.BigEndian, uint64(0x12345678))
@@ -115,7 +128,7 @@ func buildOOBOffset64Idx() ([]byte, plumbing.Hash) {
 
 	var h plumbing.Hash
 	h.ResetBySize(hashSize)
-	_, _ = h.Write(name)
+	_, _ = h.Write(name1)
 	return buf.Bytes(), h
 }
 

--- a/plumbing/format/idxfile/fuzz_test.go
+++ b/plumbing/format/idxfile/fuzz_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto"
 	"testing"
+	"testing/fstest"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/hash"
@@ -96,8 +97,15 @@ func FuzzMemoryIndex(f *testing.F) {
 	f.Add([]byte{})
 
 	f.Fuzz(func(_ *testing.T, idxData []byte) {
+		// fstest.MapFS instead of the FromBytes helper so this file
+		// compiles under OSS-Fuzz, which rewrites fuzz_test.go to a
+		// non-test name and cannot see test-only helpers.
+		in, err := fstest.MapFS{"idx": {Data: idxData}}.Open("idx")
+		if err != nil {
+			return
+		}
 		idx := new(MemoryIndex)
-		d := NewDecoder(bytes.NewReader(idxData), hash.New(crypto.SHA1))
+		d := NewDecoder(in, hash.New(crypto.SHA1))
 		if err := d.Decode(idx); err != nil {
 			// Expected for most fuzz inputs.
 			return

--- a/plumbing/format/idxfile/helpers_test.go
+++ b/plumbing/format/idxfile/helpers_test.go
@@ -1,0 +1,32 @@
+package idxfile
+
+import (
+	"bytes"
+	"io/fs"
+	"time"
+)
+
+// FromBytes wraps an in-memory idx blob as an [Input]. It is only
+// available in tests so production code is steered toward passing
+// the underlying file directly.
+func FromBytes(b []byte) Input {
+	return bytesInput{Reader: bytes.NewReader(b), size: int64(len(b))}
+}
+
+type bytesInput struct {
+	*bytes.Reader
+	size int64
+}
+
+func (b bytesInput) Stat() (fs.FileInfo, error) {
+	return bytesInputInfo(b.size), nil
+}
+
+type bytesInputInfo int64
+
+func (i bytesInputInfo) Name() string       { return "" }
+func (i bytesInputInfo) Size() int64        { return int64(i) }
+func (i bytesInputInfo) Mode() fs.FileMode  { return 0 }
+func (i bytesInputInfo) ModTime() time.Time { return time.Time{} }
+func (i bytesInputInfo) IsDir() bool        { return false }
+func (i bytesInputInfo) Sys() any           { return nil }

--- a/plumbing/format/idxfile/idxfile_test.go
+++ b/plumbing/format/idxfile/idxfile_test.go
@@ -161,13 +161,15 @@ var fixtureOffsets = []int64{
 }
 
 func fixtureIndex() (*idxfile.MemoryIndex, error) {
-	f := bytes.NewBufferString(fixtureLarge4GB)
+	raw, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewBufferString(fixtureLarge4GB)))
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error decoding fixture: %s", err)
+	}
 
 	idx := new(idxfile.MemoryIndex)
 
-	d := idxfile.NewDecoder(base64.NewDecoder(base64.StdEncoding, f), hash.New(crypto.SHA1))
-	err := d.Decode(idx)
-	if err != nil {
+	d := idxfile.NewDecoder(idxfile.FromBytes(raw), hash.New(crypto.SHA1))
+	if err := d.Decode(idx); err != nil {
 		return nil, fmt.Errorf("unexpected error decoding index: %s", err)
 	}
 

--- a/plumbing/format/idxfile/lazy_index_test.go
+++ b/plumbing/format/idxfile/lazy_index_test.go
@@ -345,7 +345,7 @@ func TestMemoryIndexOffset64OutOfRange(t *testing.T) {
 	idxBytes, h := buildOOBOffset64Idx()
 
 	idx := new(MemoryIndex)
-	d := NewDecoder(bytes.NewReader(idxBytes), hash.New(crypto.SHA1))
+	d := NewDecoder(FromBytes(idxBytes), hash.New(crypto.SHA1))
 	require.NoError(t, d.Decode(idx))
 
 	_, err := idx.FindOffset(h)
@@ -437,17 +437,14 @@ func BenchmarkScannerFindOffset(b *testing.B) {
 }
 
 func fixtureLazyIndex(withRev bool) (*LazyIndex, error) {
-	f := bytes.NewBufferString(fixtureLarge4GB)
-	memIdx := new(MemoryIndex)
-	d := NewDecoder(base64.NewDecoder(base64.StdEncoding, f), hash.New(crypto.SHA1))
-	if err := d.Decode(memIdx); err != nil {
+	idxBytes, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewBufferString(fixtureLarge4GB)))
+	if err != nil {
 		return nil, err
 	}
 
-	// Re-decode the raw idx bytes for ReadAt.
-	raw := bytes.NewBufferString(fixtureLarge4GB)
-	idxBytes, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, raw))
-	if err != nil {
+	memIdx := new(MemoryIndex)
+	d := NewDecoder(FromBytes(idxBytes), hash.New(crypto.SHA1))
+	if err := d.Decode(memIdx); err != nil {
 		return nil, err
 	}
 

--- a/plumbing/format/objfile/reader.go
+++ b/plumbing/format/objfile/reader.go
@@ -13,9 +13,10 @@ import (
 
 // Errors returned by the objfile package.
 var (
-	ErrClosed       = errors.New("objfile: already closed")
-	ErrHeader       = errors.New("objfile: invalid header")
-	ErrNegativeSize = errors.New("objfile: negative object size")
+	ErrClosed        = errors.New("objfile: already closed")
+	ErrHeader        = errors.New("objfile: invalid header")
+	ErrHeaderNotRead = errors.New("objfile: Header must be called before Read")
+	ErrNegativeSize  = errors.New("objfile: negative object size")
 )
 
 // Reader reads and decodes compressed objfile data from a provided io.Reader.
@@ -104,12 +105,26 @@ func (r *Reader) prepareForRead(t plumbing.ObjectType, size int64) {
 //
 // If Read encounters the end of the data stream it will return err == io.EOF,
 // either in the current call if n > 0 or in a subsequent call.
+//
+// Read returns ErrHeaderNotRead if Header has not been called successfully.
 func (r *Reader) Read(p []byte) (n int, err error) {
+	if r.multi == nil {
+		return 0, ErrHeaderNotRead
+	}
 	return r.multi.Read(p)
 }
 
 // Hash returns the hash of the object data stream that has been read so far.
+// It returns a zero plumbing.Hash carrying the Reader's configured object
+// format if Header has not been called successfully — the format matters
+// because [plumbing.Hash] encodes it internally and the result feeds
+// serialisers that emit a format-sized byte slice.
 func (r *Reader) Hash() plumbing.Hash {
+	if r.multi == nil {
+		var h plumbing.Hash
+		h.ResetBySize(r.objectFormat.Size())
+		return h
+	}
 	return r.hasher.Sum()
 }
 

--- a/plumbing/format/objfile/reader_test.go
+++ b/plumbing/format/objfile/reader_test.go
@@ -106,3 +106,57 @@ func (s *SuiteReader) TestReadCorruptZLib() {
 	_, _, err = r.Header()
 	s.NotNil(err)
 }
+
+func (s *SuiteReader) TestReaderReadBeforeHeader() {
+	tests := []struct {
+		name         string
+		objectFormat format.ObjectFormat
+		wantSize     int
+	}{
+		{name: "sha1", objectFormat: format.SHA1, wantSize: format.SHA1Size},
+		{name: "sha256", objectFormat: format.SHA256, wantSize: format.SHA256Size},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			data, _ := base64.StdEncoding.DecodeString(objfileFixtures[0].data)
+			source := bytes.NewReader(data)
+
+			r, err := NewReader(source, tt.objectFormat)
+			s.NoError(err)
+			defer r.Close()
+
+			var buf [16]byte
+			n, err := r.Read(buf[:])
+			s.ErrorIs(err, ErrHeaderNotRead)
+			s.Equal(0, n)
+
+			// The zero hash must carry the Reader's configured object
+			// format so callers that serialise it emit the right number
+			// of bytes.
+			h := r.Hash()
+			s.True(h.IsZero())
+			s.Equal(tt.wantSize, h.Size())
+		})
+	}
+}
+
+func (s *SuiteReader) TestReaderReadAfterHeaderError() {
+	// This zlib stream decompresses to bytes that do not form a valid
+	// loose-object header, so Header() returns an error.
+	data, _ := base64.StdEncoding.DecodeString("eAFLysaalPUjBgAAAJsAHw")
+	source := bytes.NewReader(data)
+
+	r, err := NewReader(source, format.SHA1)
+	s.NoError(err)
+	defer r.Close()
+
+	_, _, err = r.Header()
+	s.Error(err)
+
+	// Read must return an error rather than accessing uninitialised state.
+	var buf [16]byte
+	n, readErr := r.Read(buf[:])
+	s.Error(readErr)
+	s.Equal(0, n)
+}

--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -95,7 +95,7 @@ func (o *FSObject) Reader() (io.ReadCloser, error) {
 		}
 		return nil, err
 	}
-	return &zlibReadCloser{r: zr, f: file, rbuf: br}, nil
+	return NewBoundedReadCloser(&zlibReadCloser{r: zr, f: file, rbuf: br}, o.size), nil
 }
 
 type zlibReadCloser struct {

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -318,7 +318,7 @@ func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, er
 
 	switch oh.Type {
 	case plumbing.CommitObject, plumbing.TreeObject, plumbing.BlobObject, plumbing.TagObject:
-		err = p.scanner.inflateContent(oh.ContentOffset, w)
+		err = p.scanner.inflateContent(oh.ContentOffset, w, oh.Size)
 
 	case plumbing.REFDeltaObject, plumbing.OFSDeltaObject:
 		var parent plumbing.EncodedObject
@@ -344,7 +344,7 @@ func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, er
 		// duplicate copy of the delta payload.
 		if oh.content == nil {
 			oh.content = gogitsync.GetBytesBuffer()
-			err = p.scanner.inflateContent(oh.ContentOffset, oh.content)
+			err = p.scanner.inflateContent(oh.ContentOffset, oh.content, oh.Size)
 			if err != nil {
 				return nil, fmt.Errorf("cannot inflate content: %w", err)
 			}

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -252,7 +252,7 @@ func (p *Parser) ensureContent(oh *ObjectHeader) error {
 		deltaData := sync.GetBytesBuffer()
 		defer sync.PutBytesBuffer(deltaData)
 
-		err = p.scanner.inflateContent(oh.ContentOffset, deltaData)
+		err = p.scanner.inflateContent(oh.ContentOffset, deltaData, oh.Size)
 		if err != nil {
 			return fmt.Errorf("inflating content at offset %v: %w", oh.ContentOffset, err)
 		}
@@ -355,7 +355,7 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 	}
 	parent.content.Grow(growHint(parent.Size))
 
-	err := p.scanner.inflateContent(parent.ContentOffset, parent.content)
+	err := p.scanner.inflateContent(parent.ContentOffset, parent.content, parent.Size)
 	if err != nil {
 		return nil, ErrReferenceDeltaNotFound
 	}

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -34,7 +34,96 @@ var (
 	ErrUnsupportedVersion = NewError("unsupported packfile version")
 	// ErrSeekNotSupported returned if seek is not support.
 	ErrSeekNotSupported = NewError("not seek support")
+	// ErrInflatedSizeMismatch is returned when a packfile object inflates to
+	// more bytes than the size declared in its object header. A well-formed
+	// packfile never produces more data than the declared size; exceeding it
+	// indicates a structurally invalid entry.
+	ErrInflatedSizeMismatch = errors.New("packfile: inflated object exceeds declared size")
 )
+
+// boundedWriter passes writes through to w up to limit bytes total, then
+// returns ErrInflatedSizeMismatch. It is used to enforce that a packfile
+// object's inflated length does not exceed the size declared in its header.
+type boundedWriter struct {
+	w     io.Writer
+	limit int64
+	n     int64
+}
+
+// Write forwards p to the underlying writer while keeping the running total
+// at or below limit. On overrun it forwards the legal prefix and reports
+// the number of bytes actually consumed alongside ErrInflatedSizeMismatch,
+// matching the contract in io.Writer. A write error from the underlying
+// writer during overrun-handling is joined with ErrInflatedSizeMismatch so
+// it is not silently dropped.
+func (b *boundedWriter) Write(p []byte) (int, error) {
+	if b.n+int64(len(p)) > b.limit {
+		remain := int(b.limit - b.n)
+		err := error(ErrInflatedSizeMismatch)
+		if remain > 0 {
+			n, werr := b.w.Write(p[:remain])
+			b.n += int64(n)
+			if werr != nil {
+				err = errors.Join(ErrInflatedSizeMismatch, werr)
+			}
+			return n, err
+		}
+		return 0, err
+	}
+	n, err := b.w.Write(p)
+	b.n += int64(n)
+	return n, err
+}
+
+// BoundedReadCloser wraps a ReadCloser and reports ErrInflatedSizeMismatch
+// once more than limit bytes have been read. It is used by the on-demand
+// object readers to enforce the same bound that the scanner applies during
+// a forward scan, so a lazy Read of a packfile object cannot stream past
+// its declared inflated size.
+//
+// The implementation builds on io.LimitedReader with the standard
+// overrun-detection trick: request limit+1 bytes from the underlying so
+// that the moment the sentinel byte materializes (LimitedReader.N drops
+// to zero) we know the source produced more than limit bytes.
+type BoundedReadCloser struct {
+	lr      io.LimitedReader
+	closer  io.Closer
+	overrun bool
+}
+
+// NewBoundedReadCloser wraps rc so that the cumulative bytes returned from
+// Read never exceed limit. The first call that would have returned a byte
+// past limit instead returns ErrInflatedSizeMismatch; subsequent calls
+// keep returning the same error. A negative limit is treated as zero, so
+// the first byte produced by rc surfaces ErrInflatedSizeMismatch.
+func NewBoundedReadCloser(rc io.ReadCloser, limit int64) *BoundedReadCloser {
+	if limit < 0 {
+		limit = 0
+	}
+	return &BoundedReadCloser{
+		lr:     io.LimitedReader{R: rc, N: limit + 1},
+		closer: rc,
+	}
+}
+
+// Read forwards Read up to the configured byte limit. When the underlying
+// stream produces the limit+1 sentinel byte, the legal prefix is returned
+// alongside ErrInflatedSizeMismatch; on subsequent calls only the error
+// is returned.
+func (b *BoundedReadCloser) Read(p []byte) (int, error) {
+	if b.overrun {
+		return 0, ErrInflatedSizeMismatch
+	}
+	n, err := b.lr.Read(p)
+	if b.lr.N == 0 {
+		b.overrun = true
+		return n - 1, ErrInflatedSizeMismatch
+	}
+	return n, err
+}
+
+// Close closes the underlying ReadCloser.
+func (b *BoundedReadCloser) Close() error { return b.closer.Close() }
 
 // Scanner provides sequential access to the data stored in a Git packfile.
 //
@@ -228,7 +317,7 @@ func (r *Scanner) WriteObject(oh *ObjectHeader, writer io.Writer) error {
 		return plumbing.ErrObjectNotFound
 	}
 
-	err := r.inflateContent(oh.ContentOffset, writer)
+	err := r.inflateContent(oh.ContentOffset, writer, oh.Size)
 	if err != nil {
 		return ErrReferenceDeltaNotFound
 	}
@@ -236,7 +325,8 @@ func (r *Scanner) WriteObject(oh *ObjectHeader, writer io.Writer) error {
 	return nil
 }
 
-func (r *Scanner) inflateContent(contentOffset int64, writer io.Writer) error {
+func (r *Scanner) inflateContent(contentOffset int64, writer io.Writer, declaredSize int64) error {
+	bounded := &boundedWriter{w: writer, limit: declaredSize}
 	_, err := r.Seek(contentOffset, io.SeekStart)
 	if err != nil {
 		return err
@@ -244,11 +334,11 @@ func (r *Scanner) inflateContent(contentOffset int64, writer io.Writer) error {
 
 	zr, err := gogitsync.GetZlibReader(r.scannerReader)
 	if err != nil {
-		return fmt.Errorf("zlib reset error: %s", err)
+		return fmt.Errorf("zlib reset error: %w", err)
 	}
 	defer gogitsync.PutZlibReader(zr)
 
-	_, err = ioutil.CopyBufferPool(writer, zr)
+	_, err = ioutil.CopyBufferPool(bounded, zr)
 	return err
 }
 
@@ -412,7 +502,7 @@ func objectEntry(r *Scanner) (stateFn, error) {
 
 	zr, err := gogitsync.GetZlibReader(r.scannerReader)
 	if err != nil {
-		return nil, fmt.Errorf("zlib reset error: %s", err)
+		return nil, fmt.Errorf("zlib reset error: %w", err)
 	}
 	defer gogitsync.PutZlibReader(zr)
 
@@ -438,6 +528,13 @@ func objectEntry(r *Scanner) (stateFn, error) {
 		oh.content = gogitsync.GetBytesBuffer()
 		mw = io.MultiWriter(mw, oh.content)
 	}
+
+	// Bind the inflated stream by the size declared in the object header.
+	// A well-formed packfile never produces more inflated bytes than that
+	// value, so any overrun signals a malformed entry. For delta entries
+	// the declared size is the size of the delta instruction stream, not
+	// the resolved object.
+	mw = &boundedWriter{w: mw, limit: oh.Size}
 
 	_, err = ioutil.CopyBufferPool(mw, zr)
 	if err != nil {

--- a/plumbing/format/packfile/scanner_test.go
+++ b/plumbing/format/packfile/scanner_test.go
@@ -2,7 +2,10 @@ package packfile
 
 import (
 	"bytes"
+	"compress/zlib"
+	"crypto/sha1"
 	"encoding/binary"
+	"errors"
 	"io"
 	"reflect"
 	"runtime"
@@ -299,3 +302,188 @@ func mustPackfile(tb testing.TB, f *fixtures.Fixture) billy.File {
 	}
 	return pf
 }
+
+// buildMinimalPack writes a single-object packfile to a buffer.
+// The object header advertises declaredSize as the uncompressed length,
+// but the zlib payload supplied by compressedBody may inflate to more.
+// The SHA-1 footer is computed over all preceding bytes.
+func buildMinimalPack(tb testing.TB, typ plumbing.ObjectType, declaredSize int64, compressedBody []byte) []byte {
+	tb.Helper()
+
+	var buf bytes.Buffer
+	h := sha1.New()
+	w := io.MultiWriter(&buf, h)
+
+	// Pack header: magic, version=2, count=1.
+	_, _ = w.Write([]byte{'P', 'A', 'C', 'K'})
+	_ = binary.Write(w, binary.BigEndian, uint32(2))
+	_ = binary.Write(w, binary.BigEndian, uint32(1))
+
+	// Object header: variable-length encoding of (type, declaredSize).
+	// First byte: high nibble = type, low nibble = size[3:0]; MSB set
+	// if more size bytes follow. Subsequent bytes carry 7 bits each.
+	t := int64(typ)
+	first := byte((t << firstLengthBits) | (declaredSize & int64(maskFirstLength)))
+	sz := declaredSize >> firstLengthBits
+	var hdrBytes []byte
+	for sz != 0 {
+		hdrBytes = append(hdrBytes, first|maskContinue)
+		first = byte(sz & int64(maskLength))
+		sz >>= lengthBits
+	}
+	hdrBytes = append(hdrBytes, first)
+	_, _ = w.Write(hdrBytes)
+
+	// Compressed payload.
+	_, _ = w.Write(compressedBody)
+
+	// SHA-1 trailer (20 bytes).
+	_, _ = buf.Write(h.Sum(nil))
+
+	return buf.Bytes()
+}
+
+// TestInflateContentRejectsOversizedInflate verifies that inflateContent
+// stops reading and returns ErrInflatedSizeMismatch when an inflate exceeds
+// the bound passed in by the caller. The packfile is well-formed (declared
+// size matches the inflated payload) so the forward scan succeeds; the
+// rejection is forced by passing a smaller bound to inflateContent.
+func TestInflateContentRejectsOversizedInflate(t *testing.T) {
+	t.Parallel()
+
+	const size = 1 << 20 // 1 MiB
+
+	var rawBuf bytes.Buffer
+	zw := zlib.NewWriter(&rawBuf)
+	_, err := zw.Write(make([]byte, size))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	pack := buildMinimalPack(t, plumbing.BlobObject, size, rawBuf.Bytes())
+
+	s := NewScanner(bytes.NewReader(pack))
+
+	require.True(t, s.Scan(), "expected header section")
+	require.True(t, s.Scan(), "expected object section")
+	require.NoError(t, s.Error())
+
+	oh := s.Data().Value().(ObjectHeader)
+	require.Equal(t, plumbing.BlobObject, oh.Type)
+
+	var sink bytes.Buffer
+	// Force the bound to fire by declaring a much smaller cap to
+	// inflateContent than the actual inflated payload size.
+	inflateErr := s.inflateContent(oh.ContentOffset, &sink, 4096)
+
+	assert.ErrorIs(t, inflateErr, ErrInflatedSizeMismatch,
+		"expected ErrInflatedSizeMismatch from oversized inflate")
+	assert.LessOrEqual(t, int64(sink.Len()), int64(4096),
+		"inflated %d bytes but declared bound was %d", sink.Len(), 4096)
+}
+
+// TestObjectEntryRejectsOversizedInflate verifies that the forward-scan
+// path (objectEntry) refuses to stream more inflated bytes into the hasher
+// and storer than the object header's declared size, by failing Scan with
+// ErrInflatedSizeMismatch.
+func TestObjectEntryRejectsOversizedInflate(t *testing.T) {
+	t.Parallel()
+
+	const realSize = 1 << 20  // 1 MiB actual content
+	const declaredSize = 4096 // 4 KiB declared in header — deliberately a lie
+
+	var rawBuf bytes.Buffer
+	zw := zlib.NewWriter(&rawBuf)
+	_, err := zw.Write(make([]byte, realSize))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	pack := buildMinimalPack(t, plumbing.BlobObject, declaredSize, rawBuf.Bytes())
+
+	s := NewScanner(bytes.NewReader(pack))
+
+	require.True(t, s.Scan(), "expected header section")
+	assert.False(t, s.Scan(), "expected object section to fail")
+	assert.ErrorIs(t, s.Error(), ErrInflatedSizeMismatch,
+		"expected ErrInflatedSizeMismatch from oversized inflate during scan")
+}
+
+// TestBoundedReadCloser exercises the contract used by FSObject.Reader and
+// ondemandObject.Reader: reads up to limit pass through, the byte just past
+// the limit surfaces ErrInflatedSizeMismatch, and exact-fit streams cleanly
+// reach io.EOF.
+func TestBoundedReadCloser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact fit reads to EOF", func(t *testing.T) {
+		t.Parallel()
+
+		rc := io.NopCloser(bytes.NewReader([]byte("hello")))
+		b := NewBoundedReadCloser(rc, 5)
+		got, err := io.ReadAll(b)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(got))
+	})
+
+	t.Run("overrun surfaces ErrInflatedSizeMismatch", func(t *testing.T) {
+		t.Parallel()
+
+		rc := io.NopCloser(bytes.NewReader([]byte("hello world")))
+		b := NewBoundedReadCloser(rc, 5)
+		got, err := io.ReadAll(b)
+		assert.ErrorIs(t, err, ErrInflatedSizeMismatch)
+		assert.Equal(t, "hello", string(got))
+	})
+
+	t.Run("Close forwards to underlying", func(t *testing.T) {
+		t.Parallel()
+
+		var closed bool
+		rc := readCloserFn{
+			Reader: bytes.NewReader(nil),
+			closeFn: func() error {
+				closed = true
+				return nil
+			},
+		}
+		b := NewBoundedReadCloser(rc, 0)
+		require.NoError(t, b.Close())
+		assert.True(t, closed)
+	})
+
+	t.Run("negative limit is treated as zero", func(t *testing.T) {
+		t.Parallel()
+
+		rc := io.NopCloser(bytes.NewReader([]byte("hello")))
+		b := NewBoundedReadCloser(rc, -1)
+		got, err := io.ReadAll(b)
+		assert.ErrorIs(t, err, ErrInflatedSizeMismatch)
+		assert.Empty(t, got)
+	})
+}
+
+// TestBoundedWriterOverrunJoinsWriteError pins the contract that a write
+// error from the underlying writer surfaced while writing the legal prefix
+// on overrun is joined with ErrInflatedSizeMismatch rather than silently
+// dropped.
+func TestBoundedWriterOverrunJoinsWriteError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("downstream write failure")
+	bw := &boundedWriter{w: errWriter{err: wantErr}, limit: 4}
+
+	n, err := bw.Write([]byte("hello"))
+	assert.Equal(t, 0, n)
+	assert.ErrorIs(t, err, ErrInflatedSizeMismatch)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+type errWriter struct{ err error }
+
+func (e errWriter) Write(_ []byte) (int, error) { return 0, e.err }
+
+type readCloserFn struct {
+	io.Reader
+	closeFn func() error
+}
+
+func (r readCloserFn) Close() error { return r.closeFn() }

--- a/storage/filesystem/mmap/fsobject.go
+++ b/storage/filesystem/mmap/fsobject.go
@@ -109,7 +109,7 @@ func (o *ondemandObject) Reader() (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &zlibReadCloser{r: zr, rbuf: br}, nil
+	return packfile.NewBoundedReadCloser(&zlibReadCloser{r: zr, rbuf: br}, o.size), nil
 }
 
 // Hash holds the object's ID.


### PR DESCRIPTION
Four changes align `plumbing/format/*` decoder behavior with canonical Git invariants and clarify two internal API contracts.

`idxfile.Decoder.Decode` ports the size-consistency formula from `packfile.c:load_idx`[1]: an idx v2 file with `nr` objects (the last fanout entry) and hash size `hashsz` must have an on-disk length in `[minSize, maxSize]` derived from `nr` via overflow-checked multiplication. The decoder now buffers the input at the top of `Decode` and rejects inputs whose declared object count is inconsistent with the file size. All current callers in `storage/filesystem` and the HTTP dumb transport pass file-backed readers (the dumb transport opens the .idx after it has been downloaded to local storage), so the buffer cost is at most one allocation the size of the .idx file; in practice that is bounded by the size of the underlying pack file.

`packfile.Scanner` enforces the structural invariant that a packfile object's inflated length does not exceed the size declared in its header, at every site that consumes the inflated stream. The streaming `inflateContent` and forward-scan `objectEntry` paths wrap their write sinks in `boundedWriter`, which returns `ErrInflatedSizeMismatch` on overrun. The lazy `FSObject.Reader` and mmap `ondemandObject.Reader` wrap their returned `zlibReadCloser` in `BoundedReadCloser`, so an `io.ReadAll` on an opened object cannot stream past the declared size either. The call sites in `parser.go` and `packfile.go` thread the declared size through, including the delta paths where the size refers to the delta instruction stream rather than the resolved result.

`gitignore.wildmatch` is replaced with a port of the recursive `dowild` function in canonical Git's `wildmatch.c`[2] at tag v2.54.0. The previous Go implementation was an iterative backtracker; the port preserves the upstream algorithm exactly — including the `WM_ABORT_TO_STARSTAR` and `WM_ABORT_ALL` shortcuts, the bracket-expression state machine, and POSIX character-class evaluation — while taking an idiomatic Go shape: string slicing in place of `[]byte` conversions, `strings.IndexByte` instead of a hand-rolled helper, and a regular switch in place of the C `goto`-via-bool pattern. The `t3070-wildmatch.sh`-anchored conformance suite passes unchanged.

`objfile.Reader.Read` and `Reader.Hash` now require a successful `Header` call before they will return data, returning the new `ErrHeaderNotRead` sentinel (and a zero `plumbing.Hash{}` respectively) otherwise. The two-phase contract — `Header`, then `Read` — is unchanged; this commit makes it explicit at the API surface.

[1]: https://github.com/git/git/blob/v2.54.0/packfile.c#L232-L258
[2]: https://github.com/git/git/blob/v2.54.0/wildmatch.c#L59-L283