### PR TITLE
plumbing: object, Isolate tests from host git config.

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -14,15 +14,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/go-git/go-git/v6/config"
+	testconfig "github.com/go-git/go-git/v6/internal/test/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
-	"github.com/go-git/go-git/v6/x/plugin"
-	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
 )
 
 type BaseSuite struct {
@@ -56,21 +54,7 @@ func (s *BaseSuite) SetupSuite() {
 // default test user data. Tests that need specific config values should
 // register their own ConfigSource.
 func registerTestConfigLoader() {
-	resetPluginEntry("config-loader")
-
-	err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
-		return xconfig.NewStatic(defaultTestConfig(), defaultTestConfig())
-	})
-	if err != nil {
-		panic(fmt.Errorf("failed to register config storers: %v", err))
-	}
-}
-
-func defaultTestConfig() config.Config {
-	cfg := config.NewConfig()
-	cfg.User.Name = "Test User"
-	cfg.User.Email = "test@example.com"
-	return *cfg
+	testconfig.RegisterDefault()
 }
 
 func (s *BaseSuite) buildBasicRepository() {

--- a/internal/test/config/config.go
+++ b/internal/test/config/config.go
@@ -1,0 +1,48 @@
+// Package config provides test helpers that isolate test suites from the
+// host's global git configuration. It replaces the NewAuto() ConfigLoader
+// plugin (registered by x/plugin/plugin_config.go init()) with a static
+// config so tests are not affected by developer-specific settings such as
+// commit.gpgSign.
+package config
+
+import (
+	"fmt"
+
+	_ "unsafe" // for go:linkname
+
+	gitconfig "github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/x/plugin"
+	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
+)
+
+//go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
+func resetPluginEntry(name plugin.Name)
+
+// DefaultConfig returns a minimal git config suitable for tests.
+func DefaultConfig() gitconfig.Config {
+	cfg := gitconfig.NewConfig()
+	cfg.User.Name = "Test User"
+	cfg.User.Email = "test@example.com"
+	return *cfg
+}
+
+// RegisterDefault replaces the auto-detected ConfigLoader plugin with a
+// static config containing only user.name and user.email. Call this from
+// TestMain before m.Run().
+func RegisterDefault() {
+	cfg := DefaultConfig()
+	Register(cfg, cfg)
+}
+
+// Register replaces the auto-detected ConfigLoader plugin with a static
+// config using the provided global and system configs.
+func Register(global, system gitconfig.Config) {
+	resetPluginEntry("config-loader")
+
+	err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
+		return xconfig.NewStatic(global, system)
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to register test config loader: %v", err))
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -7,10 +7,9 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/config"
+	testconfig "github.com/go-git/go-git/v6/internal/test/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
-	"github.com/go-git/go-git/v6/x/plugin"
-	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
 )
 
 type OptionsSuite struct {
@@ -121,11 +120,7 @@ func (s *OptionsSuite) TestCloneOptionsValidate_RelativeDotDot() {
 // given config as the global config. It returns a cleanup function that
 // restores the default test ConfigSource.
 func (s *OptionsSuite) registerGlobalConfig(cfg *config.Config) func() {
-	resetPluginEntry("config-loader")
-	err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
-		return xconfig.NewStatic(*cfg, *config.NewConfig())
-	})
-	s.NoError(err)
+	testconfig.Register(*cfg, *config.NewConfig())
 
 	return func() {
 		registerTestConfigLoader()

--- a/plumbing/object/main_test.go
+++ b/plumbing/object/main_test.go
@@ -1,33 +1,13 @@
 package object_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
-	_ "unsafe"
-
-	"github.com/go-git/go-git/v6/config"
-	"github.com/go-git/go-git/v6/x/plugin"
-	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
+	testconfig "github.com/go-git/go-git/v6/internal/test/config"
 )
 
-//go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
-func resetPluginEntry(name plugin.Name)
-
 func TestMain(m *testing.M) {
-	resetPluginEntry("config-loader")
-
-	cfg := config.NewConfig()
-	cfg.User.Name = "Test User"
-	cfg.User.Email = "test@example.com"
-
-	err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
-		return xconfig.NewStatic(*cfg, *cfg)
-	})
-	if err != nil {
-		panic(fmt.Errorf("failed to register test config loader: %v", err))
-	}
-
+	testconfig.RegisterDefault()
 	os.Exit(m.Run())
 }

--- a/plumbing/object/main_test.go
+++ b/plumbing/object/main_test.go
@@ -1,0 +1,33 @@
+package object_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	_ "unsafe"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/x/plugin"
+	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
+)
+
+//go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
+func resetPluginEntry(name plugin.Name)
+
+func TestMain(m *testing.M) {
+	resetPluginEntry("config-loader")
+
+	cfg := config.NewConfig()
+	cfg.User.Name = "Test User"
+	cfg.User.Email = "test@example.com"
+
+	err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
+		return xconfig.NewStatic(*cfg, *cfg)
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to register test config loader: %v", err))
+	}
+
+	os.Exit(m.Run())
+}

--- a/x/plumbing/worktree/main_test.go
+++ b/x/plumbing/worktree/main_test.go
@@ -1,33 +1,13 @@
 package worktree
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
-	_ "unsafe"
-
-	"github.com/go-git/go-git/v6/config"
-	"github.com/go-git/go-git/v6/x/plugin"
-	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
+	testconfig "github.com/go-git/go-git/v6/internal/test/config"
 )
 
-//go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
-func resetPluginEntry(name plugin.Name)
-
 func TestMain(m *testing.M) {
-	resetPluginEntry("config-loader")
-
-	cfg := config.NewConfig()
-	cfg.User.Name = "Test User"
-	cfg.User.Email = "test@example.com"
-
-	err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
-		return xconfig.NewStatic(*cfg, *cfg)
-	})
-	if err != nil {
-		panic(fmt.Errorf("failed to register test config loader: %v", err))
-	}
-
+	testconfig.RegisterDefault()
 	os.Exit(m.Run())
 }

--- a/x/plumbing/worktree/main_test.go
+++ b/x/plumbing/worktree/main_test.go
@@ -1,0 +1,33 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	_ "unsafe"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/x/plugin"
+	xconfig "github.com/go-git/go-git/v6/x/plugin/config"
+)
+
+//go:linkname resetPluginEntry github.com/go-git/go-git/v6/x/plugin.resetEntry
+func resetPluginEntry(name plugin.Name)
+
+func TestMain(m *testing.M) {
+	resetPluginEntry("config-loader")
+
+	cfg := config.NewConfig()
+	cfg.User.Name = "Test User"
+	cfg.User.Email = "test@example.com"
+
+	err := plugin.Register(plugin.ConfigLoader(), func() plugin.ConfigSource {
+		return xconfig.NewStatic(*cfg, *cfg)
+	})
+	if err != nil {
+		panic(fmt.Errorf("failed to register test config loader: %v", err))
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Tests that create in-memory repositories and commit via the top-level git.Init/Worktree.Commit API inherit the host global git config through the NewAuto() ConfigLoader plugin. When a developer has commit.gpgSign=true, these tests fail because no ObjectSigner plugin is registered.

Add TestMain to plumbing/object and x/plumbing/worktree that replaces NewAuto() with a static config, mirroring the existing pattern in the root git package.

Assisted-by:i Cursor with Claude Opus 4.6 <noreply@anthropic.com>