### PR TITLE
v5: plumbing: format decoder input bounds and contracts

### DIFF
--- a/plumbing/format/idxfile/decoder.go
+++ b/plumbing/format/idxfile/decoder.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 
 	"github.com/go-git/go-git/v5/plumbing/hash"
 	"github.com/go-git/go-git/v5/utils/binary"
@@ -25,35 +26,88 @@ const (
 	objectIDLength = hash.Size
 )
 
+// Byte sizes of the idx v2 layout elements, used by the size formula
+// in [validateIdxV2Size]. See [gitformat-pack] for the canonical
+// layout.
+//
+// [gitformat-pack]: https://git-scm.com/docs/gitformat-pack
+const (
+	headerLen     = 8          // magic + version
+	fanoutLen     = fanout * 4 // uint32 per bucket
+	crc32Len      = 4          // CRC32 per object
+	offset32Len   = 4          // 32-bit offset per object
+	offset64Len   = 8          // 64-bit overflow offset
+	trailerHashes = 2          // pack checksum + idx checksum, each hashsz
+)
+
+// statInput is the optional shape the [Decoder] probes for at the
+// start of [Decoder.Decode] to learn the on-disk length of the idx
+// blob, which it uses to validate the canonical-Git size formula
+// before any allocations driven by the fanout table. Callers that
+// pass an [*os.File] or a `billy.File` backed by an `*os.File`
+// (the production call sites in `storage/filesystem`) satisfy it
+// directly; arbitrary [io.Reader]s do not, and decode for them
+// retains the pre-existing behaviour of erroring out at the
+// truncated-payload boundary instead.
+//
+// The interface is intentionally unexported so the public
+// [NewDecoder] signature stays compatible with v5.
+type statInput interface {
+	Stat() (fs.FileInfo, error)
+}
+
 // Decoder reads and decodes idx files from an input stream.
 type Decoder struct {
 	io.Reader
-	h hash.Hash
+	src io.Reader
+	h   hash.Hash
 }
 
 // NewDecoder builds a new idx stream decoder, that reads from r.
 func NewDecoder(r io.Reader) *Decoder {
 	h := hash.New(crypto.SHA1)
 	tr := io.TeeReader(r, h)
-	return &Decoder{tr, h}
+	return &Decoder{tr, r, h}
 }
 
 // Decode reads from the stream and decode the content into the MemoryIndex struct.
 func (d *Decoder) Decode(idx *MemoryIndex) error {
+	idxSize := int64(-1)
+	if in, ok := d.src.(statInput); ok {
+		fi, err := in.Stat()
+		if err != nil {
+			return fmt.Errorf("%w: stat input: %w", ErrMalformedIdxFile, err)
+		}
+		idxSize = fi.Size()
+	}
+
 	if err := validateHeader(d); err != nil {
 		return err
 	}
 
-	flow := []func(*MemoryIndex, io.Reader) error{
+	headerFlow := []func(*MemoryIndex, io.Reader) error{
 		readVersion,
 		readFanout,
+	}
+	for _, f := range headerFlow {
+		if err := f(idx, d); err != nil {
+			return err
+		}
+	}
+
+	if idxSize >= 0 {
+		if err := validateIdxV2Size(idx, idxSize); err != nil {
+			return err
+		}
+	}
+
+	bodyFlow := []func(*MemoryIndex, io.Reader) error{
 		readObjectNames,
 		readCRC32,
 		readOffsets,
 		readPackChecksum,
 	}
-
-	for _, f := range flow {
+	for _, f := range bodyFlow {
 		if err := f(idx, d); err != nil {
 			return err
 		}
@@ -198,4 +252,104 @@ func readIdxChecksum(idx *MemoryIndex, r io.Reader) error {
 	}
 
 	return nil
+}
+
+// validateIdxV2Size enforces the size formula used by canonical Git
+// load_idx for idx v2 files: the on-disk length must lie within
+// [minSize, maxSize] where
+//
+//	perObject = hashsz + crc32Len + offset32Len
+//	minSize   = headerLen + fanoutLen + trailerHashes*hashsz + nr*perObject
+//	maxSize   = minSize + (nr-1)*offset64Len     when nr > 0
+//
+// with nr taken from the last fanout entry and hashsz fixed at
+// [objectIDLength] (SHA-1 in v5). Multiplications use a self-checking
+// overflow guard so inputs whose claimed object count overflows the
+// formula are rejected rather than wrapping into a smaller value.
+func validateIdxV2Size(idx *MemoryIndex, idxSize int64) error {
+	nr := int64(idx.Fanout[fanout-1])
+	hashsz := int64(objectIDLength)
+
+	minSize := minIdxV2Size(nr, hashsz)
+	maxSize := maxIdxV2Size(nr, hashsz)
+	if minSize < 0 || maxSize < 0 {
+		return fmt.Errorf("%w: object count %d is inconsistent with file size", ErrMalformedIdxFile, nr)
+	}
+
+	if idxSize < minSize || idxSize > maxSize {
+		return fmt.Errorf("%w: file size %d is inconsistent with object count %d", ErrMalformedIdxFile, idxSize, nr)
+	}
+	return nil
+}
+
+// minIdxV2Size returns the minimum on-disk size of an idx v2 file
+// holding nr objects with the given hash size, mirroring the
+// computation in canonical Git load_idx. Returns -1 when any
+// intermediate multiplication or addition would overflow int64.
+func minIdxV2Size(nr, hashsz int64) int64 {
+	perObject := hashsz + crc32Len + offset32Len
+	fixed := int64(headerLen+fanoutLen) + trailerHashes*hashsz
+
+	objects, ok := mulInt64(nr, perObject)
+	if !ok {
+		return -1
+	}
+	sum, ok := addInt64(fixed, objects)
+	if !ok {
+		return -1
+	}
+	return sum
+}
+
+// maxIdxV2Size returns the maximum on-disk size of an idx v2 file
+// holding nr objects with the given hash size, mirroring the
+// computation in canonical Git load_idx. Returns -1 on overflow.
+func maxIdxV2Size(nr, hashsz int64) int64 {
+	minSize := minIdxV2Size(nr, hashsz)
+	if minSize < 0 {
+		return -1
+	}
+	if nr == 0 {
+		return minSize
+	}
+	overflow, ok := mulInt64(nr-1, offset64Len)
+	if !ok {
+		return -1
+	}
+	sum, ok := addInt64(minSize, overflow)
+	if !ok {
+		return -1
+	}
+	return sum
+}
+
+// mulInt64 returns a*b and whether the result fits in an int64 without
+// overflow. Negative operands or overflow yield ok=false. The overflow
+// check uses the standard self-inverse identity: a*b/b == a only when
+// the multiplication did not wrap.
+func mulInt64(a, b int64) (int64, bool) {
+	if a < 0 || b < 0 {
+		return 0, false
+	}
+	if a == 0 || b == 0 {
+		return 0, true
+	}
+	c := a * b
+	if c/b != a {
+		return 0, false
+	}
+	return c, true
+}
+
+// addInt64 returns a+b and whether the result fits in an int64 without
+// overflow. Negative operands or overflow yield ok=false.
+func addInt64(a, b int64) (int64, bool) {
+	if a < 0 || b < 0 {
+		return 0, false
+	}
+	c := a + b
+	if c < a {
+		return 0, false
+	}
+	return c, true
 }

--- a/plumbing/format/idxfile/decoder_test.go
+++ b/plumbing/format/idxfile/decoder_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
@@ -288,4 +289,111 @@ func idxV2Header() []byte {
 	buf.Write([]byte{255, 't', 'O', 'c'})
 	binary.Write(&buf, binary.BigEndian, uint32(2))
 	return buf.Bytes()
+}
+
+// TestDecoderSizeFormulaBoundary exercises the [minSize, maxSize] range
+// enforced by the size formula when the input exposes Stat. The
+// boundary is asymmetric for nr > 1: each extra 8-byte offset64 slot
+// extends maxSize by 8. Inputs at the edge of the legal range must
+// pass the size check (failing later with the trailing checksum
+// mismatch, since the payload is zero-filled); inputs one byte
+// outside must be rejected with a size-related error.
+func TestDecoderSizeFormulaBoundary(t *testing.T) {
+	t.Parallel()
+
+	const hashsz = 20 // SHA-1
+	const headerLen = 8 + 4*256
+	minSize := func(nr int64) int64 {
+		return headerLen + nr*(hashsz+8) + 2*hashsz
+	}
+	maxSize := func(nr int64) int64 {
+		m := minSize(nr)
+		if nr > 0 {
+			m += (nr - 1) * 8
+		}
+		return m
+	}
+	build := func(nr uint32, total int64) []byte {
+		buf := append(idxV2Header(), writeFanout(nr, nil)...)
+		if int64(len(buf)) > total {
+			t.Fatalf("header+fanout exceeds requested total: %d > %d", len(buf), total)
+		}
+		return append(buf, make([]byte, total-int64(len(buf)))...)
+	}
+
+	tests := []struct {
+		name      string
+		nr        uint32
+		size      int64
+		passesLen bool // true: size check passes (later parsing may fail)
+	}{
+		{"nr=1, at minSize", 1, minSize(1), true},
+		{"nr=1, one byte below minSize", 1, minSize(1) - 1, false},
+		{"nr=1, one byte above maxSize", 1, maxSize(1) + 1, false},
+		{"nr=2, at minSize", 2, minSize(2), true},
+		{"nr=2, at maxSize", 2, maxSize(2), true},
+		{"nr=2, one byte below minSize", 2, minSize(2) - 1, false},
+		{"nr=2, one byte above maxSize", 2, maxSize(2) + 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			idx := new(MemoryIndex)
+			d := NewDecoder(fromBytes(build(tt.nr, tt.size)))
+			err := d.Decode(idx)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrMalformedIdxFile)
+			if tt.passesLen {
+				// Payload is zero-filled, so we reach the trailing
+				// checksum comparison and fail there. The size check
+				// itself must not fire.
+				require.ErrorContains(t, err, "checksum mismatch")
+			} else {
+				require.ErrorContains(t, err, "inconsistent with object count")
+			}
+		})
+	}
+}
+
+// TestDecoderRejectsInconsistentObjectCount asserts that a fanout
+// table whose object count would overflow the size formula is
+// rejected when the input exposes Stat.
+func TestDecoderRejectsInconsistentObjectCount(t *testing.T) {
+	t.Parallel()
+
+	// Header (\xff t O c) + version 2 + fanout where fanout[0..255] all
+	// claim 0x4C4C4C4C objects. The byte count cannot possibly accommodate
+	// that many object names.
+	var buf bytes.Buffer
+	buf.Write([]byte{0xff, 't', 'O', 'c', 0, 0, 0, 2})
+	for range 256 {
+		_ = binary.Write(&buf, binary.BigEndian, uint32(0x4C4C4C4C))
+	}
+
+	idx := new(MemoryIndex)
+	d := NewDecoder(fromBytes(buf.Bytes()))
+	err := d.Decode(idx)
+	if !errors.Is(err, ErrMalformedIdxFile) {
+		t.Fatalf("expected ErrMalformedIdxFile, got %v", err)
+	}
+}
+
+// TestDecoderSizeCheckSkippedForBareReader documents the
+// backward-compat path: when the input does not expose Stat (here a
+// raw [bytes.Reader]), the size formula is not applied, and a
+// truncated payload surfaces as the underlying read error. The
+// production call sites in `storage/filesystem` always pass a
+// `billy.File` whose concrete type has Stat, so the formula does run
+// there.
+func TestDecoderSizeCheckSkippedForBareReader(t *testing.T) {
+	t.Parallel()
+
+	buf := append(idxV2Header(), writeFanout(1, nil)...)
+
+	idx := new(MemoryIndex)
+	d := NewDecoder(bytes.NewReader(buf))
+	err := d.Decode(idx)
+	require.ErrorIs(t, err, io.EOF)
 }

--- a/plumbing/format/idxfile/helpers_test.go
+++ b/plumbing/format/idxfile/helpers_test.go
@@ -1,0 +1,34 @@
+package idxfile_test
+
+import (
+	"bytes"
+	"io/fs"
+	"time"
+)
+
+// bytesInput wraps an in-memory idx blob with a Stat method so that
+// the [Decoder] can probe its on-disk length and apply the size
+// formula. The interface is unexported in [Decoder]; the type
+// assertion succeeds on any value that exposes both
+// [io.Reader] and `Stat() (fs.FileInfo, error)`.
+type bytesInput struct {
+	*bytes.Reader
+	size int64
+}
+
+func fromBytes(b []byte) *bytesInput {
+	return &bytesInput{Reader: bytes.NewReader(b), size: int64(len(b))}
+}
+
+func (b *bytesInput) Stat() (fs.FileInfo, error) {
+	return bytesInputInfo(b.size), nil
+}
+
+type bytesInputInfo int64
+
+func (i bytesInputInfo) Name() string       { return "" }
+func (i bytesInputInfo) Size() int64        { return int64(i) }
+func (i bytesInputInfo) Mode() fs.FileMode  { return 0 }
+func (i bytesInputInfo) ModTime() time.Time { return time.Time{} }
+func (i bytesInputInfo) IsDir() bool        { return false }
+func (i bytesInputInfo) Sys() any           { return nil }

--- a/plumbing/format/objfile/reader.go
+++ b/plumbing/format/objfile/reader.go
@@ -11,9 +11,10 @@ import (
 )
 
 var (
-	ErrClosed       = errors.New("objfile: already closed")
-	ErrHeader       = errors.New("objfile: invalid header")
-	ErrNegativeSize = errors.New("objfile: negative object size")
+	ErrClosed        = errors.New("objfile: already closed")
+	ErrHeader        = errors.New("objfile: invalid header")
+	ErrHeaderNotRead = errors.New("objfile: Header must be called before Read")
+	ErrNegativeSize  = errors.New("objfile: negative object size")
 )
 
 // Reader reads and decodes compressed objfile data from a provided io.Reader.
@@ -100,12 +101,23 @@ func (r *Reader) prepareForRead(t plumbing.ObjectType, size int64) {
 //
 // If Read encounters the end of the data stream it will return err == io.EOF,
 // either in the current call if n > 0 or in a subsequent call.
+//
+// Read returns ErrHeaderNotRead if Header has not been called successfully.
 func (r *Reader) Read(p []byte) (n int, err error) {
+	if r.multi == nil {
+		return 0, ErrHeaderNotRead
+	}
 	return r.multi.Read(p)
 }
 
 // Hash returns the hash of the object data stream that has been read so far.
+// It returns the zero plumbing.Hash if Header has not been called
+// successfully — guarding against the nil hasher that prepareForRead has
+// not yet allocated.
 func (r *Reader) Hash() plumbing.Hash {
+	if r.multi == nil {
+		return plumbing.ZeroHash
+	}
 	return r.hasher.Sum()
 }
 

--- a/plumbing/format/objfile/reader_test.go
+++ b/plumbing/format/objfile/reader_test.go
@@ -65,3 +65,39 @@ func (s *SuiteReader) TestReadCorruptZLib(c *C) {
 	_, _, err = r.Header()
 	c.Assert(err, NotNil)
 }
+
+func (s *SuiteReader) TestReaderReadBeforeHeader(c *C) {
+	data, _ := base64.StdEncoding.DecodeString(objfileFixtures[0].data)
+	source := bytes.NewReader(data)
+
+	r, err := NewReader(source)
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	var buf [16]byte
+	n, err := r.Read(buf[:])
+	c.Assert(err, Equals, ErrHeaderNotRead)
+	c.Assert(n, Equals, 0)
+
+	c.Assert(r.Hash(), Equals, plumbing.ZeroHash)
+}
+
+func (s *SuiteReader) TestReaderReadAfterHeaderError(c *C) {
+	// This zlib stream decompresses to bytes that do not form a valid
+	// loose-object header, so Header() returns an error.
+	data, _ := base64.StdEncoding.DecodeString("eAFLysaalPUjBgAAAJsAHw")
+	source := bytes.NewReader(data)
+
+	r, err := NewReader(source)
+	c.Assert(err, IsNil)
+	defer r.Close()
+
+	_, _, err = r.Header()
+	c.Assert(err, NotNil)
+
+	// Read must return an error rather than accessing uninitialised state.
+	var buf [16]byte
+	n, readErr := r.Read(buf[:])
+	c.Assert(readErr, NotNil)
+	c.Assert(n, Equals, 0)
+}

--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -78,7 +78,13 @@ func (o *FSObject) Reader() (io.ReadCloser, error) {
 			_ = f.Close()
 			return nil, err
 		}
-		return ioutil.NewReadCloserWithCloser(r, f.Close), nil
+		// Cap the lazy stream at the resolved object size: well-formed
+		// content reaches EOF inside the bound, an inflated stream that
+		// runs past surfaces ErrInflatedSizeMismatch on the byte just
+		// past the limit. For delta-resolved objects o.size is the
+		// expanded size, which is what the caller is reading here.
+		bounded := newBoundedReadCloser(r, o.size)
+		return ioutil.NewReadCloserWithCloser(bounded, f.Close), nil
 	}
 	r, err := p.getObjectContent(o.offset)
 	if err != nil {

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -33,7 +33,95 @@ var (
 	// fit into its accumulator because the input declares more continuation
 	// bytes than the type can hold.
 	ErrLengthOverflow = errors.New("variable-length integer overflow")
+	// ErrInflatedSizeMismatch is returned when a packfile object inflates to
+	// more bytes than the size declared in its object header. A well-formed
+	// packfile never produces more data than the declared size; exceeding it
+	// indicates a structurally invalid entry.
+	ErrInflatedSizeMismatch = errors.New("packfile: inflated object exceeds declared size")
 )
+
+// boundedWriter passes writes through to w up to limit bytes total, then
+// returns ErrInflatedSizeMismatch. It is used to enforce that a packfile
+// object's inflated length does not exceed the size declared in its header.
+type boundedWriter struct {
+	w     io.Writer
+	limit int64
+	n     int64
+}
+
+// Write forwards p to the underlying writer while keeping the running total
+// at or below limit. On overrun it forwards the legal prefix and reports
+// the number of bytes actually consumed alongside ErrInflatedSizeMismatch,
+// matching the contract in io.Writer. A write error from the underlying
+// writer during overrun-handling is joined with ErrInflatedSizeMismatch so
+// it is not silently dropped.
+func (b *boundedWriter) Write(p []byte) (int, error) {
+	if b.n+int64(len(p)) > b.limit {
+		remain := int(b.limit - b.n)
+		err := error(ErrInflatedSizeMismatch)
+		if remain > 0 {
+			n, werr := b.w.Write(p[:remain])
+			b.n += int64(n)
+			if werr != nil {
+				err = errors.Join(ErrInflatedSizeMismatch, werr)
+			}
+			return n, err
+		}
+		return 0, err
+	}
+	n, err := b.w.Write(p)
+	b.n += int64(n)
+	return n, err
+}
+
+// boundedReadCloser wraps a ReadCloser and reports ErrInflatedSizeMismatch
+// once more than limit bytes have been read. It is used by the on-demand
+// object reader returned from FSObject.Reader so that a lazy Read of a
+// packfile object cannot stream past its declared inflated size.
+//
+// The implementation builds on io.LimitedReader with the standard
+// overrun-detection trick: request limit+1 bytes from the underlying so
+// that the moment the sentinel byte materializes (LimitedReader.N drops
+// to zero) we know the source produced more than limit bytes.
+type boundedReadCloser struct {
+	lr      io.LimitedReader
+	closer  io.Closer
+	overrun bool
+}
+
+// newBoundedReadCloser wraps rc so that the cumulative bytes returned from
+// Read never exceed limit. The first call that would have returned a byte
+// past limit instead returns ErrInflatedSizeMismatch; subsequent calls
+// keep returning the same error. A negative limit is treated as zero, so
+// the first byte produced by rc surfaces ErrInflatedSizeMismatch.
+func newBoundedReadCloser(rc io.ReadCloser, limit int64) *boundedReadCloser {
+	if limit < 0 {
+		limit = 0
+	}
+	return &boundedReadCloser{
+		lr:     io.LimitedReader{R: rc, N: limit + 1},
+		closer: rc,
+	}
+}
+
+// Read forwards Read up to the configured byte limit. When the underlying
+// stream produces the limit+1 sentinel byte, the legal prefix is returned
+// alongside ErrInflatedSizeMismatch; on subsequent calls only the error
+// is returned.
+func (b *boundedReadCloser) Read(p []byte) (int, error) {
+	if b.overrun {
+		return 0, ErrInflatedSizeMismatch
+	}
+	n, err := b.lr.Read(p)
+	if b.lr.N == 0 {
+		b.overrun = true
+		return n - 1, ErrInflatedSizeMismatch
+	}
+	return n, err
+}
+
+// Close closes the underlying ReadCloser.
+func (b *boundedReadCloser) Close() error { return b.closer.Close() }
 
 // ObjectHeader contains the information related to the object, this information
 // is collected from the previous bytes to the content of the object.
@@ -333,10 +421,18 @@ func (s *Scanner) readLength(first byte) (int64, error) {
 }
 
 // NextObject writes the content of the next object into the reader, returns
-// the number of bytes written, the CRC32 of the content and an error, if any
+// the number of bytes written, the CRC32 of the content and an error, if any.
+//
+// When a prior NextObjectHeader has stashed the object header in
+// pendingObject, the inflated stream is bounded by the header's declared
+// length and surfaces ErrInflatedSizeMismatch on overrun.
 func (s *Scanner) NextObject(w io.Writer) (written int64, crc32 uint32, err error) {
+	declaredSize := int64(-1)
+	if s.pendingObject != nil {
+		declaredSize = s.pendingObject.Length
+	}
 	s.pendingObject = nil
-	written, err = s.copyObject(w)
+	written, err = s.copyObject(w, declaredSize)
 
 	s.r.Flush()
 	crc32 = s.crc.Sum32()
@@ -345,23 +441,39 @@ func (s *Scanner) NextObject(w io.Writer) (written int64, crc32 uint32, err erro
 	return
 }
 
-// ReadObject returns a reader for the object content and an error
+// ReadObject returns a reader for the object content and an error.
+//
+// When a prior NextObjectHeader has stashed the object header in
+// pendingObject, the returned reader is bounded by the header's declared
+// length so callers cannot stream past the declared inflated size; an
+// overrun surfaces ErrInflatedSizeMismatch on the byte just past the
+// limit.
 func (s *Scanner) ReadObject() (io.ReadCloser, error) {
+	declaredSize := int64(-1)
+	if s.pendingObject != nil {
+		declaredSize = s.pendingObject.Length
+	}
 	s.pendingObject = nil
 	zr, err := sync.GetZlibReader(s.r)
 	if err != nil {
 		return nil, fmt.Errorf("zlib reset error: %s", err)
 	}
 
-	return ioutil.NewReadCloserWithCloser(zr.Reader, func() error {
+	rc := ioutil.NewReadCloserWithCloser(zr.Reader, func() error {
 		sync.PutZlibReader(zr)
 		return nil
-	}), nil
+	})
+	if declaredSize >= 0 {
+		return newBoundedReadCloser(rc, declaredSize), nil
+	}
+	return rc, nil
 }
 
-// ReadRegularObject reads and write a non-deltified object
-// from it zlib stream in an object entry in the packfile.
-func (s *Scanner) copyObject(w io.Writer) (n int64, err error) {
+// copyObject inflates a non-deltified object's zlib stream into w. When
+// declaredSize is non-negative, the write sink is wrapped in a
+// boundedWriter so an overrun surfaces ErrInflatedSizeMismatch instead
+// of being silently appended.
+func (s *Scanner) copyObject(w io.Writer, declaredSize int64) (n int64, err error) {
 	zr, err := sync.GetZlibReader(s.r)
 	defer sync.PutZlibReader(zr)
 
@@ -370,8 +482,14 @@ func (s *Scanner) copyObject(w io.Writer) (n int64, err error) {
 	}
 
 	defer ioutil.CheckClose(zr.Reader, &err)
+
+	sink := w
+	if declaredSize >= 0 {
+		sink = &boundedWriter{w: w, limit: declaredSize}
+	}
+
 	buf := sync.GetByteSlice()
-	n, err = io.CopyBuffer(w, zr.Reader, *buf)
+	n, err = io.CopyBuffer(sink, zr.Reader, *buf)
 	sync.PutByteSlice(buf)
 	return
 }

--- a/plumbing/format/packfile/scanner_bounded_test.go
+++ b/plumbing/format/packfile/scanner_bounded_test.go
@@ -1,0 +1,231 @@
+package packfile
+
+import (
+	"bytes"
+	"compress/zlib"
+	"crypto/sha1"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMinimalPack writes a single-object packfile to a buffer. The
+// object header advertises declaredSize as the uncompressed length, but
+// the zlib payload supplied by compressedBody may inflate to more. The
+// SHA-1 footer is computed over all preceding bytes.
+func buildMinimalPack(tb testing.TB, typ plumbing.ObjectType, declaredSize int64, compressedBody []byte) []byte {
+	tb.Helper()
+
+	var buf bytes.Buffer
+	h := sha1.New()
+	w := io.MultiWriter(&buf, h)
+
+	// Pack header: magic, version=2, count=1.
+	_, _ = w.Write([]byte{'P', 'A', 'C', 'K'})
+	_ = binary.Write(w, binary.BigEndian, uint32(2))
+	_ = binary.Write(w, binary.BigEndian, uint32(1))
+
+	// Object header: variable-length encoding of (type, declaredSize).
+	// First byte: high nibble = type, low nibble = size[3:0]; MSB set
+	// if more size bytes follow. Subsequent bytes carry 7 bits each.
+	t := int64(typ)
+	first := byte((t << firstLengthBits) | (declaredSize & int64(maskFirstLength)))
+	sz := declaredSize >> firstLengthBits
+	var hdrBytes []byte
+	for sz != 0 {
+		hdrBytes = append(hdrBytes, first|byte(maskContinue))
+		first = byte(sz & int64(maskLength))
+		sz >>= lengthBits
+	}
+	hdrBytes = append(hdrBytes, first)
+	_, _ = w.Write(hdrBytes)
+
+	// Compressed payload.
+	_, _ = w.Write(compressedBody)
+
+	// SHA-1 trailer (20 bytes).
+	_, _ = buf.Write(h.Sum(nil))
+
+	return buf.Bytes()
+}
+
+// TestNextObjectRejectsOversizedInflate verifies that NextObject stops
+// accepting bytes and returns ErrInflatedSizeMismatch when the inflated
+// stream produces more data than the object header's declared size.
+func TestNextObjectRejectsOversizedInflate(t *testing.T) {
+	t.Parallel()
+
+	const realSize = 1 << 20  // 1 MiB actual content
+	const declaredSize = 4096 // 4 KiB declared in header — deliberately a lie
+
+	var rawBuf bytes.Buffer
+	zw := zlib.NewWriter(&rawBuf)
+	_, err := zw.Write(make([]byte, realSize))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	pack := buildMinimalPack(t, plumbing.BlobObject, declaredSize, rawBuf.Bytes())
+
+	s := NewScanner(bytes.NewReader(pack))
+	_, _, err = s.Header()
+	require.NoError(t, err)
+
+	oh, err := s.NextObjectHeader()
+	require.NoError(t, err)
+	require.Equal(t, plumbing.BlobObject, oh.Type)
+	require.Equal(t, int64(declaredSize), oh.Length)
+
+	var sink bytes.Buffer
+	_, _, err = s.NextObject(&sink)
+	require.ErrorIs(t, err, ErrInflatedSizeMismatch)
+	require.LessOrEqual(t, int64(sink.Len()), int64(declaredSize),
+		"wrote %d bytes but declared bound was %d", sink.Len(), declaredSize)
+}
+
+// TestReadObjectRejectsOversizedInflate verifies that the lazy reader
+// returned from ReadObject surfaces ErrInflatedSizeMismatch on the byte
+// just past the declared inflated size.
+func TestReadObjectRejectsOversizedInflate(t *testing.T) {
+	t.Parallel()
+
+	const realSize = 1 << 16  // 64 KiB actual content
+	const declaredSize = 4096 // 4 KiB declared in header
+
+	var rawBuf bytes.Buffer
+	zw := zlib.NewWriter(&rawBuf)
+	_, err := zw.Write(make([]byte, realSize))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	pack := buildMinimalPack(t, plumbing.BlobObject, declaredSize, rawBuf.Bytes())
+
+	s := NewScanner(bytes.NewReader(pack))
+	_, _, err = s.Header()
+	require.NoError(t, err)
+
+	_, err = s.NextObjectHeader()
+	require.NoError(t, err)
+
+	rc, err := s.ReadObject()
+	require.NoError(t, err)
+	defer rc.Close()
+
+	got, err := io.ReadAll(rc)
+	require.ErrorIs(t, err, ErrInflatedSizeMismatch)
+	require.LessOrEqual(t, len(got), declaredSize)
+}
+
+// TestBoundedReadCloser exercises the contract used by FSObject.Reader:
+// reads up to limit pass through, the byte just past the limit surfaces
+// ErrInflatedSizeMismatch, and exact-fit streams cleanly reach io.EOF.
+func TestBoundedReadCloser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("exact fit reads to EOF", func(t *testing.T) {
+		t.Parallel()
+
+		rc := io.NopCloser(bytes.NewReader([]byte("hello")))
+		b := newBoundedReadCloser(rc, 5)
+		got, err := io.ReadAll(b)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(got))
+	})
+
+	t.Run("overrun surfaces ErrInflatedSizeMismatch", func(t *testing.T) {
+		t.Parallel()
+
+		rc := io.NopCloser(bytes.NewReader([]byte("hello world")))
+		b := newBoundedReadCloser(rc, 5)
+		got, err := io.ReadAll(b)
+		assert.ErrorIs(t, err, ErrInflatedSizeMismatch)
+		assert.Equal(t, "hello", string(got))
+	})
+
+	t.Run("subsequent Reads after overrun keep returning the error", func(t *testing.T) {
+		t.Parallel()
+
+		rc := io.NopCloser(bytes.NewReader([]byte("hello world")))
+		b := newBoundedReadCloser(rc, 5)
+		buf := make([]byte, 16)
+		_, err := b.Read(buf)
+		require.ErrorIs(t, err, ErrInflatedSizeMismatch)
+		_, err = b.Read(buf)
+		require.ErrorIs(t, err, ErrInflatedSizeMismatch)
+	})
+
+	t.Run("Close forwards to underlying", func(t *testing.T) {
+		t.Parallel()
+
+		var closed bool
+		rc := readCloserFn{
+			Reader:  bytes.NewReader(nil),
+			closeFn: func() error { closed = true; return nil },
+		}
+		b := newBoundedReadCloser(rc, 0)
+		require.NoError(t, b.Close())
+		assert.True(t, closed)
+	})
+}
+
+// TestBoundedWriter exercises the boundedWriter sink: writes up to
+// limit pass through, an oversized write returns the legal prefix
+// alongside ErrInflatedSizeMismatch, and writes after the limit return
+// only the error.
+func TestBoundedWriter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("writes within limit pass through", func(t *testing.T) {
+		t.Parallel()
+
+		var sink bytes.Buffer
+		bw := &boundedWriter{w: &sink, limit: 10}
+		n, err := bw.Write([]byte("hello"))
+		require.NoError(t, err)
+		assert.Equal(t, 5, n)
+		assert.Equal(t, "hello", sink.String())
+	})
+
+	t.Run("oversized write returns prefix and error", func(t *testing.T) {
+		t.Parallel()
+
+		var sink bytes.Buffer
+		bw := &boundedWriter{w: &sink, limit: 5}
+		n, err := bw.Write([]byte("hello world"))
+		require.ErrorIs(t, err, ErrInflatedSizeMismatch)
+		assert.Equal(t, 5, n)
+		assert.Equal(t, "hello", sink.String())
+	})
+
+	t.Run("write past limit returns error only", func(t *testing.T) {
+		t.Parallel()
+
+		var sink bytes.Buffer
+		bw := &boundedWriter{w: &sink, limit: 3}
+		_, err := bw.Write([]byte("abc"))
+		require.NoError(t, err)
+		n, err := bw.Write([]byte("d"))
+		require.ErrorIs(t, err, ErrInflatedSizeMismatch)
+		assert.Equal(t, 0, n)
+	})
+
+	t.Run("error sentinel is ErrInflatedSizeMismatch", func(t *testing.T) {
+		t.Parallel()
+
+		var sink bytes.Buffer
+		bw := &boundedWriter{w: &sink, limit: 0}
+		_, err := bw.Write([]byte("x"))
+		assert.True(t, errors.Is(err, ErrInflatedSizeMismatch))
+	})
+}
+
+type readCloserFn struct {
+	io.Reader
+	closeFn func() error
+}
+
+func (r readCloserFn) Close() error { return r.closeFn() }


### PR DESCRIPTION
Backport of #2119 