### PR TITLE
git: worktree, fix successive branch checkouts from same commit. Fixes #2124

### DIFF
--- a/options.go
+++ b/options.go
@@ -460,6 +460,12 @@ type ResetOptions struct {
 
 	// SkipSparseDirValidation will skip the validation for SparseDirs.
 	SkipSparseDirValidation bool
+
+	// fromTree is used internally by Checkout to pass the tree that the
+	// worktree is currently at, before HEAD is updated. This ensures that
+	// HardReset and KeepReset properly diff from the actual previous state
+	// rather than the new HEAD.
+	fromTree *object.Tree
 }
 
 // Validate validates the fields and sets the default values.

--- a/worktree.go
+++ b/worktree.go
@@ -215,6 +215,16 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 		ro.Mode = SoftReset
 	}
 
+	// For HardReset and KeepReset, capture the current tree BEFORE updating
+	// HEAD. This ensures resetWorktreeToTree correctly diffs from where we
+	// actually are, not from where HEAD will point after the update.
+	if ro.Mode == HardReset || ro.Mode == KeepReset {
+		ro.fromTree, err = w.headTree()
+		if err != nil {
+			return err
+		}
+	}
+
 	if !opts.Hash.IsZero() && !opts.Create {
 		err = w.setHEADToCommit(opts.Hash)
 	} else {
@@ -350,11 +360,20 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	// resetting HEAD. resetWorktreeToTree will diff prevTree→t and apply only
 	// those changes to the worktree. Since the diff is tree-to-tree, untracked
 	// files are invisible and are never deleted — matching real git reset --hard.
+	//
+	// If opts.fromTree is set (by Checkout), use that instead of calling
+	// headTree(). This handles the case where HEAD was already updated before
+	// Reset was called (e.g., in Checkout), ensuring we diff from the actual
+	// previous state rather than the new HEAD.
 	var prevTree *object.Tree
 	if opts.Mode == HardReset || opts.Mode == KeepReset {
-		prevTree, err = w.headTree()
-		if err != nil {
-			return err
+		if opts.fromTree != nil {
+			prevTree = opts.fromTree
+		} else {
+			prevTree, err = w.headTree()
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1043,6 +1043,101 @@ func (s *WorktreeSuite) TestCheckoutForceSparseUntrackedPreserved() {
 	s.NotEmpty(phpFiles, "expected php/ files after sparse checkout switch")
 }
 
+// TestCheckoutSuccessiveBranchesFromSameCommit verifies that when creating
+// and checking out multiple branches from the same base commit, each branch
+// gets a clean worktree without files from previous iterations.
+// This is a regression test for issue #2124.
+func (s *WorktreeSuite) TestCheckoutSuccessiveBranchesFromSameCommit() {
+	fs := memfs.New()
+	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
+		URL: s.GetBasicLocalRepositoryURL(),
+	})
+	s.Require().NoError(err)
+	defer func() { _ = r.Close() }()
+
+	w, err := r.Worktree()
+	s.Require().NoError(err)
+
+	// Record the initial HEAD hash
+	head, err := r.Head()
+	s.Require().NoError(err)
+	baseHash := head.Hash()
+
+	// Helper to create a branch, checkout, add a file, and commit
+	createBranchWithFile := func(branchName, fileName string) {
+		// Create and set the branch reference to the base hash
+		branchRef := plumbing.NewBranchReferenceName(branchName)
+		ref := plumbing.NewHashReference(branchRef, baseHash)
+		err := r.Storer.SetReference(ref)
+		s.Require().NoError(err)
+
+		// Force checkout the branch
+		err = w.Checkout(&CheckoutOptions{
+			Branch: branchRef,
+			Force:  true,
+		})
+		s.Require().NoError(err)
+
+		// Verify HEAD points to the branch
+		head, err := r.Head()
+		s.Require().NoError(err)
+		s.Equal(branchRef.String(), head.Name().String())
+		s.Equal(baseHash, head.Hash())
+
+		// Create and add a file
+		f, err := w.Filesystem().Create(fileName)
+		s.Require().NoError(err)
+		_, err = f.Write([]byte("content of " + fileName))
+		s.Require().NoError(err)
+		s.Require().NoError(f.Close())
+
+		_, err = w.Add(fileName)
+		s.Require().NoError(err)
+
+		_, err = w.Commit("Add "+fileName, &CommitOptions{
+			Author: &object.Signature{
+				Name:  "Test",
+				Email: "test@example.com",
+				When:  time.Now(),
+			},
+		})
+		s.Require().NoError(err)
+	}
+
+	// Iteration 1: Create branch1 with test1.txt
+	createBranchWithFile("branch1", "test1.txt")
+
+	// Verify test1.txt exists
+	_, err = w.Filesystem().Stat("test1.txt")
+	s.Require().NoError(err, "test1.txt should exist after committing to branch1")
+
+	// Iteration 2: Create branch2 with test2.txt
+	// This should start from the base commit, NOT from branch1's commit
+	createBranchWithFile("branch2", "test2.txt")
+
+	// Critical assertion: test1.txt should NOT exist in branch2's worktree
+	// because branch2 was created from baseHash which doesn't have test1.txt
+	_, err = w.Filesystem().Stat("test1.txt")
+	s.Require().Error(err, "test1.txt should NOT exist after checking out branch2 (issue #2124)")
+
+	// Verify only test2.txt exists
+	_, err = w.Filesystem().Stat("test2.txt")
+	s.Require().NoError(err, "test2.txt should exist after committing to branch2")
+
+	// Iteration 3: Create branch3 with test3.txt
+	createBranchWithFile("branch3", "test3.txt")
+
+	// Neither test1.txt nor test2.txt should exist
+	_, err = w.Filesystem().Stat("test1.txt")
+	s.Require().Error(err, "test1.txt should NOT exist in branch3")
+	_, err = w.Filesystem().Stat("test2.txt")
+	s.Require().Error(err, "test2.txt should NOT exist in branch3")
+
+	// Only test3.txt should exist
+	_, err = w.Filesystem().Stat("test3.txt")
+	s.Require().NoError(err, "test3.txt should exist after committing to branch3")
+}
+
 func (s *WorktreeSuite) TestCheckoutCreateWithHash() {
 	w := &Worktree{
 		r:          s.Repository,


### PR DESCRIPTION
## Summary

Fixes #2124 - When checking out multiple branches from the same base commit with `Force:true`, files from previous iterations were incorrectly preserved in the worktree.

## Root Cause

`Checkout()` updated HEAD before calling `Reset()`, so when `Reset()` captured the "previous" tree via `headTree()`, it got the tree from the NEW commit (just set by Checkout) rather than the OLD commit (where the worktree actually was). This caused `resetWorktreeToTree` to diff the same tree against itself, resulting in no changes.

## Solution

Capture the current tree BEFORE updating HEAD in `Checkout()`, and pass it to `Reset()` via a new internal field in `ResetOptions`. This ensures `HardReset` and `KeepReset` properly diff from the actual previous state.

## Changes

- Added internal `fromTree` field to `ResetOptions`
- Modified `Checkout()` to capture tree before updating HEAD
- Modified `Reset()` to use provided `fromTree` when available
- Added comprehensive regression test `TestCheckoutSuccessiveBranchesFromSameCommit`

## Testing

- ✅ All existing tests pass (100+ worktree and reset tests)
- ✅ New regression test reproduces and validates the fix for issue #2124
- ✅ Verified behavior matches git's handling of successive branch checkouts

## AI Disclosure

This contribution was assisted by Claude Sonnet 4.5 as documented in the `Assisted-by:` commit trailer, in accordance with the [AI Contribution Policy](https://github.com/go-git/go-git/blob/main/AI_POLICY.md).