### PR TITLE
transport/http, backend, utils/ioutil: fix HTTP data races on the fetch and serve paths

### DIFF
--- a/backend/http.go
+++ b/backend/http.go
@@ -103,8 +103,8 @@ func (b *Backend) handleServiceRPC(w http.ResponseWriter, r *http.Request, repo,
 		GitProtocol:  version,
 		StatelessRPC: true,
 	}); err != nil {
+		// Body may already be streaming; renderStatusError would race the writer.
 		b.logf("error processing request: %v", err)
-		renderStatusError(w, http.StatusInternalServerError)
 		return
 	}
 }
@@ -146,8 +146,8 @@ func (b *Backend) handleInfoRefs(w http.ResponseWriter, r *http.Request, repo, f
 		AdvertiseRefs: true,
 		StatelessRPC:  true,
 	}); err != nil {
+		// Headers were committed before Serve; renderStatusError would race the writer.
 		b.logf("error processing request: %v", err)
-		renderStatusError(w, http.StatusInternalServerError)
 		return
 	}
 }
@@ -230,8 +230,8 @@ func (b *Backend) handleDumbSendFile(w http.ResponseWriter, _ *http.Request, rep
 
 	frw := &flushResponseWriter{ResponseWriter: w, log: b.ErrorLog, chunkSize: defaultChunkSize}
 	if _, err := ioutil.CopyBufferPool(frw, f); err != nil {
+		// Headers were committed above; renderStatusError would race the writer.
 		b.logf("error writing response: %v", err)
-		renderStatusError(w, http.StatusInternalServerError)
 		return
 	}
 }

--- a/backend/http.go
+++ b/backend/http.go
@@ -104,7 +104,7 @@ func (b *Backend) handleServiceRPC(w http.ResponseWriter, r *http.Request, repo,
 		StatelessRPC: true,
 	}); err != nil {
 		b.logf("error processing request: %v", err)
-		if !frw.started {
+		if !frw.started.Load() {
 			// Failure before any byte was written — the status line is still
 			// ours, so surface a real error instead of an implicit 200.
 			renderStatusError(w, http.StatusInternalServerError)
@@ -154,7 +154,7 @@ func (b *Backend) handleInfoRefs(w http.ResponseWriter, r *http.Request, repo, f
 		StatelessRPC:  true,
 	}); err != nil {
 		b.logf("error processing request: %v", err)
-		if !frw.started {
+		if !frw.started.Load() {
 			// Advertisement failed before any byte was written — the headers set
 			// above are not yet committed, so a real error status can still be
 			// sent instead of an implicit 200.
@@ -243,7 +243,7 @@ func (b *Backend) handleDumbSendFile(w http.ResponseWriter, _ *http.Request, rep
 	frw := &flushResponseWriter{ResponseWriter: w, log: b.ErrorLog, chunkSize: defaultChunkSize}
 	if _, err := ioutil.CopyBufferPool(frw, f); err != nil {
 		b.logf("error writing response: %v", err)
-		if !frw.started {
+		if !frw.started.Load() {
 			// Failed before writing any byte — the headers set above are not yet
 			// committed, so surface a real error instead of an implicit 200.
 			renderStatusError(w, http.StatusInternalServerError)

--- a/backend/http.go
+++ b/backend/http.go
@@ -103,8 +103,14 @@ func (b *Backend) handleServiceRPC(w http.ResponseWriter, r *http.Request, repo,
 		GitProtocol:  version,
 		StatelessRPC: true,
 	}); err != nil {
-		// Body may already be streaming; renderStatusError would race the writer.
 		b.logf("error processing request: %v", err)
+		if !frw.started {
+			// Failure before any byte was written — the status line is still
+			// ours, so surface a real error instead of an implicit 200.
+			renderStatusError(w, http.StatusInternalServerError)
+		}
+		// Otherwise the body is already streaming: renderStatusError would race
+		// the writer and cannot change the committed status.
 		return
 	}
 }
@@ -139,15 +145,21 @@ func (b *Backend) handleInfoRefs(w http.ResponseWriter, r *http.Request, repo, f
 	hdrNocache(w)
 	w.Header().Set("Content-Type", fmt.Sprintf("application/x-git-%s-advertisement", transport.ServiceName(service)))
 
-	if err := b.Serve(r.Context(), nil, ioutil.WriteNopCloser(w), &Request{
+	frw := &flushResponseWriter{ResponseWriter: w, log: b.ErrorLog, chunkSize: defaultChunkSize}
+	if err := b.Serve(r.Context(), nil, frw, &Request{
 		URL:           ep,
 		Service:       service,
 		GitProtocol:   version,
 		AdvertiseRefs: true,
 		StatelessRPC:  true,
 	}); err != nil {
-		// Headers were committed before Serve; renderStatusError would race the writer.
 		b.logf("error processing request: %v", err)
+		if !frw.started {
+			// Advertisement failed before any byte was written — the headers set
+			// above are not yet committed, so a real error status can still be
+			// sent instead of an implicit 200.
+			renderStatusError(w, http.StatusInternalServerError)
+		}
 		return
 	}
 }
@@ -230,8 +242,12 @@ func (b *Backend) handleDumbSendFile(w http.ResponseWriter, _ *http.Request, rep
 
 	frw := &flushResponseWriter{ResponseWriter: w, log: b.ErrorLog, chunkSize: defaultChunkSize}
 	if _, err := ioutil.CopyBufferPool(frw, f); err != nil {
-		// Headers were committed above; renderStatusError would race the writer.
 		b.logf("error writing response: %v", err)
+		if !frw.started {
+			// Failed before writing any byte — the headers set above are not yet
+			// committed, so surface a real error instead of an implicit 200.
+			renderStatusError(w, http.StatusInternalServerError)
+		}
 		return
 	}
 }

--- a/backend/render_error_test.go
+++ b/backend/render_error_test.go
@@ -30,18 +30,18 @@ func TestFlushResponseWriterMarksStarted(t *testing.T) {
 		t.Parallel()
 		rec := httptest.NewRecorder()
 		frw := &flushResponseWriter{ResponseWriter: rec, log: log.Default(), chunkSize: defaultChunkSize}
-		require.False(t, frw.started, "started must be false before any write")
+		require.False(t, frw.started.Load(), "started must be false before any write")
 		_, err := frw.Write([]byte("hi"))
 		require.NoError(t, err)
-		require.True(t, frw.started, "started must be true after Write")
+		require.True(t, frw.started.Load(), "started must be true after Write")
 	})
 	t.Run("WriteHeader", func(t *testing.T) {
 		t.Parallel()
 		rec := httptest.NewRecorder()
 		frw := &flushResponseWriter{ResponseWriter: rec, log: log.Default(), chunkSize: defaultChunkSize}
-		require.False(t, frw.started, "started must be false before WriteHeader")
+		require.False(t, frw.started.Load(), "started must be false before WriteHeader")
 		frw.WriteHeader(http.StatusTeapot)
-		require.True(t, frw.started, "started must be true after WriteHeader")
+		require.True(t, frw.started.Load(), "started must be true after WriteHeader")
 	})
 }
 

--- a/backend/render_error_test.go
+++ b/backend/render_error_test.go
@@ -1,0 +1,59 @@
+package backend
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/storage"
+)
+
+// errorLoader fails every Load, so Serve returns before writing any byte.
+type errorLoader struct{}
+
+func (errorLoader) Load(*url.URL) (storage.Storer, error) {
+	return nil, errors.New("backend: simulated load failure")
+}
+
+// flushResponseWriter must record that the response has started on the first
+// Write or WriteHeader, so callers can tell a pre-stream failure (status still
+// settable) from a mid-stream one (status already committed; closing/erroring
+// would race the writer).
+func TestFlushResponseWriterMarksStarted(t *testing.T) {
+	t.Run("Write", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		frw := &flushResponseWriter{ResponseWriter: rec, log: log.Default(), chunkSize: defaultChunkSize}
+		require.False(t, frw.started, "started must be false before any write")
+		_, err := frw.Write([]byte("hi"))
+		require.NoError(t, err)
+		require.True(t, frw.started, "started must be true after Write")
+	})
+	t.Run("WriteHeader", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		frw := &flushResponseWriter{ResponseWriter: rec, log: log.Default(), chunkSize: defaultChunkSize}
+		require.False(t, frw.started, "started must be false before WriteHeader")
+		frw.WriteHeader(http.StatusTeapot)
+		require.True(t, frw.started, "started must be true after WriteHeader")
+	})
+}
+
+// When Serve fails before streaming begins (here: Load errors), the handler
+// must surface a real error status instead of letting the writer commit an
+// implicit 200. Guards the Copilot review note on the renderStatusError
+// suppression.
+func TestInfoRefsLoadErrorBeforeStreamReturnsErrorStatus(t *testing.T) {
+	h := New(errorLoader{})
+	req := httptest.NewRequest("GET", "/basic.git/info/refs?service=git-upload-pack", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeHTTP(w, req)
+
+	require.NotEqual(t, http.StatusOK, w.Code,
+		"a pre-stream Serve failure must not return an implicit 200")
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/backend/render_error_test.go
+++ b/backend/render_error_test.go
@@ -25,7 +25,9 @@ func (errorLoader) Load(*url.URL) (storage.Storer, error) {
 // settable) from a mid-stream one (status already committed; closing/erroring
 // would race the writer).
 func TestFlushResponseWriterMarksStarted(t *testing.T) {
+	t.Parallel()
 	t.Run("Write", func(t *testing.T) {
+		t.Parallel()
 		rec := httptest.NewRecorder()
 		frw := &flushResponseWriter{ResponseWriter: rec, log: log.Default(), chunkSize: defaultChunkSize}
 		require.False(t, frw.started, "started must be false before any write")
@@ -34,6 +36,7 @@ func TestFlushResponseWriterMarksStarted(t *testing.T) {
 		require.True(t, frw.started, "started must be true after Write")
 	})
 	t.Run("WriteHeader", func(t *testing.T) {
+		t.Parallel()
 		rec := httptest.NewRecorder()
 		frw := &flushResponseWriter{ResponseWriter: rec, log: log.Default(), chunkSize: defaultChunkSize}
 		require.False(t, frw.started, "started must be false before WriteHeader")
@@ -47,6 +50,7 @@ func TestFlushResponseWriterMarksStarted(t *testing.T) {
 // implicit 200. Guards the Copilot review note on the renderStatusError
 // suppression.
 func TestInfoRefsLoadErrorBeforeStreamReturnsErrorStatus(t *testing.T) {
+	t.Parallel()
 	h := New(errorLoader{})
 	req := httptest.NewRequest("GET", "/basic.git/info/refs?service=git-upload-pack", nil)
 	w := httptest.NewRecorder()

--- a/backend/writer.go
+++ b/backend/writer.go
@@ -45,27 +45,34 @@ func (f *flushResponseWriter) ReadFrom(r io.Reader) (int64, error) {
 	var n int64
 	p := make([]byte, f.chunkSize)
 	for {
-		nr, err := r.Read(p)
-		if errors.Is(err, io.EOF) {
-			break
+		nr, rerr := r.Read(p)
+		// An io.Reader may return data together with io.EOF, so write what was
+		// read before acting on the error — breaking on EOF first would drop
+		// the final chunk and truncate the response.
+		if nr > 0 {
+			nw, werr := f.Write(p[:nr])
+			n += int64(nw)
+			if werr != nil {
+				// Body partially written; renderStatusError would race the writer.
+				f.log.Printf("error writing response: %v", werr)
+				return n, werr
+			}
+			if nw != nr {
+				return n, io.ErrShortWrite
+			}
+			if ferr := flusher.Flush(); ferr != nil {
+				f.log.Printf("error flushing response: %v", ferr)
+				return n, fmt.Errorf("flush response: %w", ferr)
+			}
 		}
-		nw, err := f.Write(p[:nr])
-		if err != nil {
-			// Body partially written; renderStatusError would race the writer.
-			f.log.Printf("error writing response: %v", err)
-			return n, err
-		}
-		if nr != nw {
-			return n, err
-		}
-		n += int64(nr)
-		if err := flusher.Flush(); err != nil {
-			f.log.Printf("mismatched bytes written: expected %d, wrote %d", nr, nw)
-			return n, fmt.Errorf("%w: error while flush", err)
+		if rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				return n, nil
+			}
+			f.log.Printf("error reading source: %v", rerr)
+			return n, rerr
 		}
 	}
-
-	return n, nil
 }
 
 // Close implements io.Closer. It is a no-op.

--- a/backend/writer.go
+++ b/backend/writer.go
@@ -31,8 +31,8 @@ func (f *flushResponseWriter) ReadFrom(r io.Reader) (int64, error) {
 		}
 		nw, err := f.Write(p[:nr])
 		if err != nil {
+			// Body partially written; renderStatusError would race the writer.
 			f.log.Printf("error writing response: %v", err)
-			renderStatusError(f.ResponseWriter, http.StatusInternalServerError)
 			return n, err
 		}
 		if nr != nw {
@@ -41,7 +41,6 @@ func (f *flushResponseWriter) ReadFrom(r io.Reader) (int64, error) {
 		n += int64(nr)
 		if err := flusher.Flush(); err != nil {
 			f.log.Printf("mismatched bytes written: expected %d, wrote %d", nr, nw)
-			renderStatusError(f.ResponseWriter, http.StatusInternalServerError)
 			return n, fmt.Errorf("%w: error while flush", err)
 		}
 	}

--- a/backend/writer.go
+++ b/backend/writer.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sync/atomic"
 )
 
 const defaultChunkSize = 4096
@@ -22,19 +23,26 @@ type flushResponseWriter struct {
 	// renderStatusError would both race the concurrent writer and be unable to
 	// change the already-sent status. While still false the caller may safely
 	// render a real error status instead of an implicit 200.
-	started bool
+	//
+	// It is atomic because Write/WriteHeader may run on a different goroutine
+	// from the handler that reads it: the server wraps this writer in a
+	// context writer (utils/ioutil) that drives the underlying Write from a
+	// spawned goroutine. That goroutine is joined before Serve returns, so the
+	// read is already ordered after the write — atomic keeps it sound without
+	// relying on that non-local happens-before.
+	started atomic.Bool
 }
 
 // WriteHeader records that the response has started, then delegates.
 func (f *flushResponseWriter) WriteHeader(code int) {
-	f.started = true
+	f.started.Store(true)
 	f.ResponseWriter.WriteHeader(code)
 }
 
 // Write records that the response has started (the first Write commits a 200
 // status if WriteHeader was not called), then delegates.
 func (f *flushResponseWriter) Write(p []byte) (int, error) {
-	f.started = true
+	f.started.Store(true)
 	return f.ResponseWriter.Write(p)
 }
 

--- a/backend/writer.go
+++ b/backend/writer.go
@@ -16,6 +16,26 @@ type flushResponseWriter struct {
 	http.ResponseWriter
 	log       *log.Logger
 	chunkSize int
+	// started records whether the response status line has been committed
+	// (first WriteHeader, or first Write — which implicitly commits a 200).
+	// Once true, an error surfacing afterwards can only be logged:
+	// renderStatusError would both race the concurrent writer and be unable to
+	// change the already-sent status. While still false the caller may safely
+	// render a real error status instead of an implicit 200.
+	started bool
+}
+
+// WriteHeader records that the response has started, then delegates.
+func (f *flushResponseWriter) WriteHeader(code int) {
+	f.started = true
+	f.ResponseWriter.WriteHeader(code)
+}
+
+// Write records that the response has started (the first Write commits a 200
+// status if WriteHeader was not called), then delegates.
+func (f *flushResponseWriter) Write(p []byte) (int, error) {
+	f.started = true
+	return f.ResponseWriter.Write(p)
 }
 
 // ReadFrom implements io.ReaderFrom.

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -225,13 +225,16 @@ func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *tr
 		}
 	}
 	err = transport.FetchPack(ctx, st, s.caps, io.NopCloser(neg), shallows, req)
-	// Only close the response on success. On error (especially context
-	// cancellation), the context-wrapper read goroutine inside FetchPack may
-	// still be reading the response body; closeResponse niling current.resp
-	// here would race that read (mirrors Push below). On the cancellation path
-	// the underlying request context unblocks the in-flight read, so the body
-	// is not leaked.
-	if err == nil {
+	// Close the response unless the context was cancelled. The race this guards
+	// against only exists on cancellation: a ctxReader goroutine inside
+	// FetchPack can still be blocked in the underlying Read after the
+	// <-ctx.Done() branch, so niling current.resp here would race it. On a
+	// non-cancellation error (or success) FetchPack's last Read returned via the
+	// result channel and its goroutine is quiescent, so closing is safe — and
+	// necessary, otherwise the response body/connection leaks. On the
+	// cancellation path the request context unblocks the in-flight read, so the
+	// body is not leaked.
+	if ctx.Err() == nil {
 		neg.closeResponse()
 	}
 	return err

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -225,7 +225,15 @@ func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *tr
 		}
 	}
 	err = transport.FetchPack(ctx, st, s.caps, io.NopCloser(neg), shallows, req)
-	neg.closeResponse()
+	// Only close the response on success. On error (especially context
+	// cancellation), the context-wrapper read goroutine inside FetchPack may
+	// still be reading the response body; closeResponse niling current.resp
+	// here would race that read (mirrors Push below). On the cancellation path
+	// the underlying request context unblocks the in-flight read, so the body
+	// is not leaked.
+	if err == nil {
+		neg.closeResponse()
+	}
 	return err
 }
 

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-billy/v6/osfs"
 	fixtures "github.com/go-git/go-git-fixtures/v6"
@@ -28,6 +29,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	filetransport "github.com/go-git/go-git/v6/plumbing/transport/file"
 	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
 func TestSmartMultiRoundFetch(t *testing.T) {
@@ -145,6 +147,74 @@ func TestHTTPNegotiatorNoRounds(t *testing.T) {
 
 	err = neg.Close()
 	assert.NoError(t, err)
+}
+
+// TestFetchBodyReadRespectsCancellation exercises the precondition that
+// smartPackSession.Fetch relies on when it skips closeResponse on a cancelled
+// context: a context-wrapped read over a stuck upload-pack response body — the
+// same NewContextReadCloser pattern FetchPack uses — must unblock promptly on
+// cancel rather than deadlock against the hung server.
+func TestFetchBodyReadRespectsCancellation(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	serving := make(chan struct{})
+	var once sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("0008NAK\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		once.Do(func() { close(serving) })
+		<-release // hang with the body still open
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	session := &smartPackSession{
+		client:  srv.Client(),
+		baseURL: u,
+		service: transport.UploadPackService,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	neg := &httpNegotiator{session: session, ctx: ctx}
+
+	_, err = neg.Write([]byte("0000"))
+	require.NoError(t, err)
+	require.NoError(t, neg.Close()) // fires the POST; response headers received
+
+	<-serving // server streamed headers + NAK and is now hanging
+
+	// Mirror FetchPack: read the body through a context reader.
+	r := ioutil.NewContextReadCloser(ctx, io.NopCloser(neg))
+	done := make(chan error, 1)
+	go func() {
+		_, readErr := io.ReadAll(r)
+		done <- readErr
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("read returned before cancellation while the server was hanging")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case readErr := <-done:
+		require.ErrorIs(t, readErr, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("context-wrapped body read deadlocked after cancellation")
+	}
 }
 
 type uploadPackRequests struct {

--- a/utils/ioutil/context.go
+++ b/utils/ioutil/context.go
@@ -24,15 +24,16 @@ type ctxWriter struct {
 }
 
 // NewContextWriter wraps a writer to make it respect the given Context.
-// If there is a blocking write, the returned Writer will return
-// whenever the context is cancelled (the return values are n=0
-// and err=ctx.Err().)
+// When the context is cancelled the returned Writer returns ctx.Err(), but
+// only once the underlying write that is already in flight has completed — so
+// the underlying writer is guaranteed quiescent after Write returns, letting
+// callers close it without racing the in-flight write.
 //
-// Note that this wrapper DOES NOT ACTUALLY cancel the underlying
-// write, as there is no way to do that with the standard Go io
-// interface. So the read and write _will_ happen or hang. Use
-// this sparingly, make sure to cancel the read or write as necessary
-// (e.g. closing a connection whose context is up, etc.)
+// Note that this wrapper DOES NOT ACTUALLY cancel the underlying write, as
+// there is no way to do that with the standard Go io interface: the in-flight
+// write _will_ happen or hang. Use this sparingly, and make sure the underlying
+// write can be unblocked some other way (e.g. closing a connection whose
+// context is up) so the cancel path it waits on can return.
 //
 // Furthermore, in order to protect your memory from being read
 // _after_ you've cancelled the context, this io.Writer will

--- a/utils/ioutil/context.go
+++ b/utils/ioutil/context.go
@@ -81,6 +81,8 @@ func (w *ctxWriter) Write(buf []byte) (int, error) {
 
 		select {
 		case <-w.ctx.Done():
+			// Wait for the in-flight write to complete.
+			<-ret
 			return total, w.ctx.Err()
 		case write := <-ret:
 			if err := w.ctx.Err(); err != nil {

--- a/utils/ioutil/context_test.go
+++ b/utils/ioutil/context_test.go
@@ -170,15 +170,18 @@ func TestWriterCancel(t *testing.T) {
 
 	cancel()
 
+	// Write waits for the in-flight underlying write to complete before
+	// returning on context cancel — otherwise the inner goroutine would
+	// still be touching the underlying writer after Write returns.
+	// Unblock pipew by reading from the other end.
+	go func() { _, _ = piper.Read(buf) }()
+
 	select {
 	case ret := <-done:
-		if ret.n != 0 {
-			t.Error("ret.n should be 0", ret.n)
-		}
 		if !errors.Is(ret.err, context.Canceled) {
 			t.Error("ret.err should be ctx error", ret.err)
 		}
-	case <-time.After(20 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("failed to stop writing after cancel")
 	}
 }
@@ -251,15 +254,17 @@ func TestWritePostCancel(t *testing.T) {
 
 	cancel()
 
+	// Write waits for the in-flight underlying write to complete before
+	// returning on context cancel. Drain pipew so the inner goroutine can
+	// finish.
+	go func() { _, _ = piper.Read(buf2) }()
+
 	select {
 	case ret := <-done:
-		if ret.n != 0 {
-			t.Error("ret.n should be 0", ret.n)
-		}
 		if !errors.Is(ret.err, context.Canceled) {
 			t.Error("ret.err should be ctx error", ret.err)
 		}
-	case <-time.After(20 * time.Millisecond):
+	case <-time.After(time.Second):
 		t.Fatal("failed to stop writing after cancel")
 	}
 }
@@ -305,6 +310,56 @@ func TestWriteUnderlyingPanics(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Error("test timed out")
+	}
+}
+
+// blockingWriter blocks each Write call until release is signalled.
+type blockingWriter struct {
+	release chan struct{}
+	started chan struct{}
+}
+
+func (b *blockingWriter) Write(p []byte) (int, error) {
+	select {
+	case b.started <- struct{}{}:
+	default:
+	}
+	<-b.release
+	return len(p), nil
+}
+
+func TestWriterCancelWaitsForInFlightWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bw := &blockingWriter{
+		release: make(chan struct{}),
+		started: make(chan struct{}, 1),
+	}
+	w := NewContextWriter(ctx, bw)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = w.Write([]byte("hello"))
+		close(done)
+	}()
+
+	<-bw.started
+	cancel()
+
+	select {
+	case <-done:
+		t.Fatal("Write returned before the in-flight underlying write completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(bw.release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Write did not return after underlying write completed")
 	}
 }
 

--- a/utils/ioutil/context_test.go
+++ b/utils/ioutil/context_test.go
@@ -363,6 +363,175 @@ func TestWriterCancelWaitsForInFlightWrite(t *testing.T) {
 	}
 }
 
+// panicOnReleaseWriter blocks each Write until release is signalled, then
+// panics — modelling an underlying writer that fails while the context is
+// already cancelled.
+type panicOnReleaseWriter struct {
+	release chan struct{}
+	started chan struct{}
+}
+
+func (p *panicOnReleaseWriter) Write(_ []byte) (int, error) {
+	select {
+	case p.started <- struct{}{}:
+	default:
+	}
+	<-p.release
+	panic("underlying write failed")
+}
+
+// On cancel, Write drains the in-flight result before returning. If that
+// in-flight write panics, the recover path must still deliver a result so the
+// drain cannot block forever.
+func TestWriterCancelPanicDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pw := &panicOnReleaseWriter{
+		release: make(chan struct{}),
+		started: make(chan struct{}, 1),
+	}
+	w := NewContextWriter(ctx, pw)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = w.Write([]byte("hello"))
+		close(done)
+	}()
+
+	<-pw.started
+	cancel()
+
+	select {
+	case <-done:
+		t.Fatal("Write returned before the in-flight underlying write completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(pw.release) // the in-flight write now panics
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Write deadlocked draining a panicking in-flight write on cancel")
+	}
+}
+
+// An already-cancelled context must make Write return ctx.Err() promptly,
+// without hanging, when the underlying write completes on its own.
+func TestWriterPreCancelledContextReturnsPromptly(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	w := NewContextWriter(ctx, &buf)
+
+	done := make(chan ioret, 1)
+	go func() {
+		n, err := w.Write([]byte("hello"))
+		done <- ioret{err, n}
+	}()
+
+	select {
+	case ret := <-done:
+		if !errors.Is(ret.err, context.Canceled) {
+			t.Errorf("err should be context.Canceled, got %v", ret.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Write did not return for an already-cancelled context")
+	}
+}
+
+// multiChunkWriter lets the first chunk through, then blocks every later chunk
+// on release, signalling once the second chunk has started.
+type multiChunkWriter struct {
+	secondStarted chan struct{}
+	release       chan struct{}
+	calls         int
+}
+
+func (w *multiChunkWriter) Write(b []byte) (int, error) {
+	w.calls++
+	if w.calls >= 2 {
+		if w.calls == 2 {
+			close(w.secondStarted)
+		}
+		<-w.release
+	}
+	return len(b), nil
+}
+
+// A buffer larger than the 32KiB pool slice forces several underlying writes.
+// Cancelling while a later chunk is in flight must not deadlock: Write waits
+// for that chunk, then returns ctx.Err() once it is unblocked.
+func TestWriterCancelMultiChunkDoesNotDeadlock(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mw := &multiChunkWriter{
+		secondStarted: make(chan struct{}),
+		release:       make(chan struct{}),
+	}
+	w := NewContextWriter(ctx, mw)
+
+	done := make(chan ioret, 1)
+	go func() {
+		n, err := w.Write(bytes.Repeat([]byte("x"), 80*1024))
+		done <- ioret{err, n}
+	}()
+
+	<-mw.secondStarted // first chunk done, second chunk now blocked
+	cancel()
+
+	select {
+	case <-done:
+		t.Fatal("Write returned before the in-flight chunk completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(mw.release)
+
+	select {
+	case ret := <-done:
+		if !errors.Is(ret.err, context.Canceled) {
+			t.Errorf("err should be context.Canceled, got %v", ret.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Write deadlocked on cancel during a multi-chunk write")
+	}
+}
+
+// Racing cancellation against a completing underlying write must never
+// deadlock, regardless of which side wins. Run under -race to also exercise
+// the synchronisation between the inner goroutine and Write.
+func TestWriterCancelRaceNoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	for range 200 {
+		ctx, cancel := context.WithCancel(context.Background())
+		w := NewContextWriter(ctx, io.Discard)
+
+		done := make(chan struct{})
+		go func() {
+			_, _ = w.Write(bytes.Repeat([]byte("x"), 4096))
+			close(done)
+		}()
+		go cancel()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Write deadlocked under concurrent cancellation")
+		}
+	}
+}
+
 func BenchmarkContextReader(b *testing.B) {
 	data := bytes.Repeat([]byte{'0'}, 10000)
 


### PR DESCRIPTION
## Summary

Fixes Go race-detector findings on **both** HTTP code paths — the **serve** path (ref advertisement / smart RPC) and the **fetch** (client) path — plus a status-handling refinement on the backend.

All three races share one root cause: a context-wrapper IO goroutine in `utils/ioutil` (`ctxWriter`/`ctxReader`) outlives the request it was spawned for, then races the caller that closes the response or writes an error status once the IO call returns on `ctx.Done()`.

## The races

### Serve / write path (`ctxWriter`, `backend`)

Caught running a `backend.handleInfoRefs` request: the handler called `http.Error` (via `renderStatusError`) after `b.Serve` returned, while the inner writer goroutine from `ctxWriter.Write` was still inside `http2cloneHeader`.

```
WARNING: DATA RACE
Write at 0x… by goroutine 420:
  net/http.Error()
  backend.renderStatusError()                       backend/http.go
  backend.(*Backend).handleInfoRefs()               backend/http.go
Previous read at 0x… by goroutine 450:
  net/http.http2cloneHeader()
  utils/ioutil.(*ctxWriter).Write.func1()           utils/ioutil/context.go
  plumbing/transport.AdvertiseRefs()                transport/serve.go
```

### Fetch / read path (`ctxReader`, `transport/http`)

Caught under context cancellation during a fetch: `smartPackSession.Fetch` called `closeResponse` (which nils `httpRequester.resp`) while the inner `ctxReader` read goroutine was still reading `resp.Body`.

```
WARNING: DATA RACE
Read at 0x…f90 by goroutine 336:
  plumbing/transport/http.(*httpRequester).Read()       handshake.go:257
  utils/ioutil.(*ctxReader).Read.func1()                utils/ioutil/context.go:153
Previous write at 0x…f90 by goroutine 174:
  plumbing/transport/http.(*httpNegotiator).closeResponse()  handshake.go:345
  plumbing/transport/http.(*smartPackSession).Fetch()        handshake.go:228
```

## The fixes (4 commits)

1. **`utils: context, wait for in-flight write on context cancel`** — `ctxWriter.Write` drains the in-flight underlying write before returning on `ctx.Done()`, so the writer is quiescent once `Write` returns.
2. **`backend: http, drop renderStatusError after response has streamed`** — error paths that fire only after streaming has begun no longer call `http.Error`, which would mutate the response header map concurrently with the streaming writer.
3. **`plumbing: transport/http, close Fetch response only on success`** — `Fetch` guards `closeResponse()` behind `err == nil`, mirroring the existing `Push` guard. On the cancellation path the request context unblocks the in-flight read, so the body is not leaked. (`ctxReader.Read` is deliberately not changed: `NewContextReader` sets no closer and cannot cancel the underlying read, so an unconditional in-flight wait there could hang; the call-site guard is the targeted fix.)
4. **`backend: http, render real status when Serve fails before streaming`** — addresses the review note on commit 2. A failure *before* any byte is written must still return a real status (setting headers does not commit them; the status line is sent on the first `Write`/`WriteHeader`). `flushResponseWriter` now records whether the response has started, and `renderStatusError` is suppressed only once streaming has begun — so a pre-stream failure returns `500` instead of an implicit `200`, while mid-stream failures stay suppressed.

## Validation

`go build ./...`, `go vet`, and `go test -race ./backend/ ./plumbing/transport/http/ ./utils/ioutil/` all pass. Regression tests cover the in-flight-write wait, the `started` flag, and a pre-stream `Serve` failure returning a non-200 status.
