### PR TITLE
internal: server/git, Fix TestGitServer_Timeout flakiness on Windows CI

### DIFF
--- a/internal/server/git/git_test.go
+++ b/internal/server/git/git_test.go
@@ -176,20 +176,24 @@ func TestGitServer_Timeout(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 
-	// Stay idle past the configured Timeout; the server must close
-	// the connection, surfacing as a Read error.
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
 	buf := make([]byte, 1)
+
+	// Send a single byte to anchor the server's idle clock close to
+	// the client's start of measurement. The pkt-line decoder needs
+	// 4 bytes for the length header, so the server consumes this byte
+	// and then re-enters Read for the next byte, arming a fresh idle
+	// deadline at approximately wall-clock parity with the client.
+	// Recording start before the write means elapsed includes the
+	// brief Write/scheduling latency, so the lower-bound assertion is
+	// robust against goroutine scheduling skew on shared CI runners.
 	start := time.Now()
+	_, err = conn.Write([]byte{'0'})
+	require.NoError(t, err)
+
 	_, err = conn.Read(buf)
 	elapsed := time.Since(start)
 	assert.Error(t, err, "server should close idle connection past Timeout")
-	// Allow a generous tolerance for timer/scheduling jitter on shared
-	// CI runners. We measure elapsed from the client's perspective but
-	// the server arms its deadline a few ms earlier (during accept and
-	// the first Read), so client-measured elapsed underestimates the
-	// real server timeout. A 30ms tolerance still catches a server that
-	// closes substantially earlier than configured.
 	assert.GreaterOrEqual(t, elapsed, srv.Timeout-30*time.Millisecond, "server should not close before Timeout elapses")
 }
 


### PR DESCRIPTION
Fixes a flaky `TestGitServer_Timeout` reported by @AriehSchneier in #2053.

The test compares an elapsed duration measured on the client goroutine against the server's idle timeout, but the server arms its deadline on a separate goroutine. On loaded Windows runners the server can arm the deadline before the client captures `start := time.Now()`, causing elapsed to fall short.

This change anchors the two clocks by sending a 1-byte probe before timing: pkt-line decoding needs 4 bytes for the length header, so the server consumes the byte and re-enters `Read`, arming a fresh idle deadline at approximately the same wall-clock moment as the client's `start`. Recording `start` before the `Write` keeps any scheduling latency on the elapsed side, making the lower-bound assertion robust.

Note: the server-side proposal in #2053 (deferring the initial `updateDeadline()` to first `Read`) does not eliminate the race because `serverConn.Read` already calls `updateDeadline()` at the start of every read.

cc @AriehSchneier