### PR TITLE
plumbing, storage: add CloseIdleDescriptors soft-close primitive

### DIFF
--- a/internal/packhandle/cursor_reader.go
+++ b/internal/packhandle/cursor_reader.go
@@ -9,6 +9,15 @@ import (
 	"github.com/go-git/go-git/v6/internal/sharedfile"
 )
 
+// ErrInvalidSeekWhence is returned by [cursorReader.Seek] when
+// whence is not one of [io.SeekStart], [io.SeekCurrent], or
+// [io.SeekEnd].
+var ErrInvalidSeekWhence = errors.New("packhandle: invalid whence")
+
+// ErrNegativeSeekPosition is returned by [cursorReader.Seek]
+// when the resolved absolute offset would be negative.
+var ErrNegativeSeekPosition = errors.New("packhandle: negative seek position")
+
 // cursorReader is the concrete reader returned by both
 // [PackHandle.OpenPackReader] and [PackHandle.OpenRandomReader].
 // Each cursor holds its own offset and one [sharedfile.SharedFile]
@@ -68,10 +77,10 @@ func (c *cursorReader) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekEnd:
 		abs = c.size + offset
 	default:
-		return 0, errors.New("packhandle: invalid whence")
+		return 0, ErrInvalidSeekWhence
 	}
 	if abs < 0 {
-		return 0, errors.New("packhandle: negative seek position")
+		return 0, ErrNegativeSeekPosition
 	}
 	c.offset = abs
 	return abs, nil

--- a/internal/packhandle/packhandle.go
+++ b/internal/packhandle/packhandle.go
@@ -115,6 +115,13 @@ func (h *PackHandle) OpenRandomReader() (RandomReader, error) {
 // immutable post-creation and its on-disk identity is pinned via
 // packHash, so the size is invariant for the lifetime of this
 // handle. Failures are not cached; the next call retries.
+//
+// The cache uses an [atomic.Int64] with zero as the unset
+// sentinel. Pack sizes are never zero — every valid pack carries
+// at least a 12-byte header and a footer hash — so a zero load
+// unambiguously means "not yet cached." If that invariant ever
+// changes, this loop will re-Size on every call and the cache
+// becomes dead code.
 func (h *PackHandle) packSize() (int64, error) {
 	if v := h.sizeVal.Load(); v != 0 {
 		return v, nil

--- a/internal/packhandle/packhandle.go
+++ b/internal/packhandle/packhandle.go
@@ -26,6 +26,20 @@ const defaultGracePeriod = 1 * time.Second
 // idle grace period. .idx and .rev descriptors are owned by the
 // returned [idxfile.Index].
 //
+// Lifecycle contract:
+//
+//   - Each cursor returned by [PackHandle.OpenPackReader] or
+//     [PackHandle.OpenRandomReader] acquires one reference on the
+//     underlying [sharedfile.SharedFile]; cursor.Close releases
+//     it. While at least one cursor is live the .pack FD cannot
+//     be torn down by the grace timer.
+//   - [PackHandle.Close] is synchronous: the .pack FD and any
+//     cached [idxfile.LazyIndex] FDs are closed before the call
+//     returns. Cursors opened before Close keep working until
+//     their own Close releases the last reference; calls on a
+//     cursor whose underlying FD has been closed see
+//     [fs.ErrClosed].
+//
 // All methods are safe for concurrent use.
 type PackHandle struct {
 	sources  Sources

--- a/internal/packhandle/packhandle.go
+++ b/internal/packhandle/packhandle.go
@@ -174,3 +174,39 @@ func (h *PackHandle) Meta() (PackMeta, error) {
 	h.metaVal = &meta
 	return meta, nil
 }
+
+// CloseIdleDescriptors releases the .pack file descriptor and
+// the idx/rev descriptors of any cached [idxfile.LazyIndex]
+// without marking the [PackHandle] closed. Active acquired
+// readers continue to work; FDs held by in-flight readers close
+// the instant the last refcount drops to zero. Subsequent
+// [PackHandle.OpenPackReader] and [PackHandle.Index] operations
+// reopen FDs on demand and resume normal grace-timer behaviour.
+//
+// Idempotent and safe to call concurrently with the open paths
+// and itself. A no-op after [PackHandle.Close]; the closed flag
+// short-circuits before touching either [sharedfile.SharedFile].
+//
+// PackHandle-level caches survive: the cached [PackMeta] and
+// the cached [idxfile.LazyIndex] pointer are not reset. A
+// caller that wants to discard the PackHandle entirely uses
+// Close; a subsequent Close after CloseIdleDescriptors still
+// flips each underlying [sharedfile.SharedFile]'s closed flag
+// exactly once via its idempotent Close.
+func (h *PackHandle) CloseIdleDescriptors() error {
+	if h.closed.Load() {
+		return nil
+	}
+
+	packErr := h.pack.ReleaseNow()
+
+	h.indexMu.Lock()
+	idx := h.indexVal
+	h.indexMu.Unlock()
+
+	var idxErr error
+	if idx != nil {
+		idxErr = idx.CloseIdleDescriptors()
+	}
+	return errors.Join(packErr, idxErr)
+}

--- a/internal/packhandle/packhandle_bench_test.go
+++ b/internal/packhandle/packhandle_bench_test.go
@@ -130,6 +130,52 @@ func BenchmarkPackHandleAcquireGrace(b *testing.B) {
 	}
 }
 
+// BenchmarkPackHandleCloseIdleReopen measures one full
+// soft-close + reopen cycle: `OpenPackReader → ReadAt → Close →
+// CloseIdleDescriptors → repeat`. Compared against the warm
+// `BenchmarkPackHandleAcquireGrace` baseline, the per-iteration
+// delta is the cost of one pack-`SharedFile` reopen. Load-bearing
+// for callers deciding how often to invoke the soft-close
+// between read bursts.
+func BenchmarkPackHandleCloseIdleReopen(b *testing.B) {
+	ph := newEmbedFixturePackHandle(b)
+	b.Cleanup(func() { _ = ph.Close() })
+
+	packSize := packSizeFromFixture(b)
+	validRange := packSize - 64
+	if validRange <= 0 {
+		b.Fatalf("pack too small: %d bytes", packSize)
+	}
+
+	// Warm-up so the first iteration is not biased by initial
+	// mmap setup.
+	warm, err := ph.OpenPackReader()
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = warm.Close()
+
+	buf := make([]byte, 64)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := ph.OpenPackReader()
+		if err != nil {
+			b.Fatal(err)
+		}
+		off := int64(i) % validRange
+		if _, err := r.(io.ReaderAt).ReadAt(buf, off); err != nil && err != io.EOF {
+			b.Fatal(err)
+		}
+		_ = r.Close()
+
+		if err := ph.CloseIdleDescriptors(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // BenchmarkPackHandleParallelReadAt measures concurrent ReadAt against one
 // PackHandle (sibling cursorReaders, one per goroutine) versus a direct
 // (*os.File).ReadAt ceiling on the same underlying file. The baseline shows

--- a/internal/packhandle/packhandle_test.go
+++ b/internal/packhandle/packhandle_test.go
@@ -355,3 +355,125 @@ func TestPackSize_FailureNotCached(t *testing.T) {
 		t.Fatalf("Pack.Size called %d times; want 2 (first fails, second succeeds and caches; third hits cache)", got)
 	}
 }
+
+// countingOpen wraps a Source.Open with an open-counter so tests
+// can assert reopen behaviour after CloseIdleDescriptors.
+func countingOpen(src packhandle.Source, ctr *atomic.Int64) packhandle.Source {
+	return packhandle.Source{
+		Open: func() (packhandle.ReadAtCloser, error) {
+			ctr.Add(1)
+			return src.Open()
+		},
+		Size: src.Size,
+	}
+}
+
+// TestCloseIdleDescriptors_ReleasesAndAllowsReuse drives the
+// soft-close end to end: it acquires the .pack (via a cursor)
+// and the LazyIndex (via Index()), invokes
+// CloseIdleDescriptors, and verifies that subsequent operations
+// re-open every FD without erroring. The check rests on
+// Source.Open counters — bytes-Reader fixtures otherwise don't
+// observe Close.
+func TestCloseIdleDescriptors_ReleasesAndAllowsReuse(t *testing.T) {
+	t.Parallel()
+	srcs, hash := validSourcesFromFixture(t)
+
+	var packOpens, idxOpens, revOpens atomic.Int64
+	srcs.Pack = countingOpen(srcs.Pack, &packOpens)
+	srcs.Idx = countingOpen(srcs.Idx, &idxOpens)
+	srcs.Rev = countingOpen(srcs.Rev, &revOpens)
+
+	h, err := packhandle.New(srcs, hash)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer h.Close()
+
+	// Force a .pack open + an Index() materialisation (which
+	// opens idx and rev via LazyIndex.init).
+	r, err := h.OpenRandomReader()
+	if err != nil {
+		t.Fatalf("OpenRandomReader: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatalf("close cursor: %v", err)
+	}
+	if _, err := h.Index(); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+
+	packBefore := packOpens.Load()
+	idxBefore := idxOpens.Load()
+	revBefore := revOpens.Load()
+	if packBefore == 0 || idxBefore == 0 || revBefore == 0 {
+		t.Fatalf("setup: open counters pack=%d idx=%d rev=%d, want all >0",
+			packBefore, idxBefore, revBefore)
+	}
+
+	if err := h.CloseIdleDescriptors(); err != nil {
+		t.Fatalf("CloseIdleDescriptors: %v", err)
+	}
+
+	// Subsequent .pack read reopens the .pack FD.
+	r2, err := h.OpenRandomReader()
+	if err != nil {
+		t.Fatalf("OpenRandomReader after CloseIdleDescriptors: %v", err)
+	}
+	var buf [4]byte
+	if _, err := r2.ReadAt(buf[:], 0); err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("ReadAt after CloseIdleDescriptors: %v", err)
+	}
+	_ = r2.Close()
+
+	// Subsequent LazyIndex query reopens idx and rev via
+	// EntriesByOffset, which acquires both shared files.
+	idx, err := h.Index()
+	if err != nil {
+		t.Fatalf("Index after CloseIdleDescriptors: %v", err)
+	}
+	iter, err := idx.EntriesByOffset()
+	if err != nil {
+		t.Fatalf("Index.EntriesByOffset: %v", err)
+	}
+	if _, err := iter.Next(); err != nil {
+		t.Fatalf("iter.Next: %v", err)
+	}
+	if err := iter.Close(); err != nil {
+		t.Fatalf("iter.Close: %v", err)
+	}
+
+	if packOpens.Load() <= packBefore {
+		t.Fatalf(".pack open counter did not advance: before=%d after=%d",
+			packBefore, packOpens.Load())
+	}
+	if idxOpens.Load() <= idxBefore {
+		t.Fatalf(".idx open counter did not advance: before=%d after=%d",
+			idxBefore, idxOpens.Load())
+	}
+	if revOpens.Load() <= revBefore {
+		t.Fatalf(".rev open counter did not advance: before=%d after=%d",
+			revBefore, revOpens.Load())
+	}
+}
+
+// TestCloseIdleDescriptors_AfterCloseIsNoop verifies the no-op
+// fast path on closed PackHandles: the closed flag
+// short-circuits before touching either SharedFile.
+func TestCloseIdleDescriptors_AfterCloseIsNoop(t *testing.T) {
+	t.Parallel()
+	srcs, hash := validSourcesFromFixture(t)
+	h, err := packhandle.New(srcs, hash)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := h.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := h.CloseIdleDescriptors(); err != nil {
+		t.Fatalf("CloseIdleDescriptors after Close: %v", err)
+	}
+	if err := h.CloseIdleDescriptors(); err != nil {
+		t.Fatalf("CloseIdleDescriptors repeat after Close: %v", err)
+	}
+}

--- a/internal/sharedfile/sharedfile.go
+++ b/internal/sharedfile/sharedfile.go
@@ -25,6 +25,18 @@ var ErrClosed = fs.ErrClosed
 // shared across concurrent acquirers, and closed after a grace
 // period once the refcount drops to zero.
 //
+// Lifecycle contract:
+//
+//   - [SharedFile.Acquire] pins the underlying file descriptor
+//     until the matching [SharedFile.Release]. While at least one
+//     reference is held the FD cannot be torn down by the grace
+//     timer or [SharedFile.ReleaseNow].
+//   - [SharedFile.Close] is synchronous: it returns only after
+//     the underlying FD has been closed. Acquires that race a
+//     Close return [ErrClosed]; ReadAt calls on a descriptor
+//     handed out before Close see [fs.ErrClosed] on the next
+//     read, since the OS-level FD has been released.
+//
 // All methods are safe for concurrent use.
 type SharedFile struct {
 	mu          sync.Mutex

--- a/internal/sharedfile/sharedfile.go
+++ b/internal/sharedfile/sharedfile.go
@@ -31,12 +31,13 @@ type SharedFile struct {
 	open        func() (ReadAtCloser, error)
 	gracePeriod time.Duration
 
-	file     ReadAtCloser
-	refs     int
-	gen      uint64
-	timer    *time.Timer
-	closed   bool
-	isClosed atomic.Bool
+	file           ReadAtCloser
+	refs           int
+	gen            uint64
+	timer          *time.Timer
+	closed         bool
+	isClosed       atomic.Bool
+	immediateClose bool // set by ReleaseNow when refs>0; consumed by Release
 }
 
 // New returns a new SharedFile that opens files via open and
@@ -90,6 +91,17 @@ func (s *SharedFile) Release() {
 		return
 	}
 
+	// Soft-close via ReleaseNow latches immediateClose; fire that
+	// inline now instead of scheduling the grace timer. The flag
+	// clears on the close transition, restoring normal grace-timer
+	// behaviour for future Releases.
+	if s.immediateClose {
+		s.immediateClose = false
+		_ = s.file.Close()
+		s.file = nil
+		return
+	}
+
 	gen := s.gen
 	s.timer = time.AfterFunc(s.gracePeriod, func() {
 		s.mu.Lock()
@@ -135,4 +147,55 @@ func (s *SharedFile) Close() error {
 		s.file = nil
 	}
 	return err
+}
+
+// ReleaseNow closes the underlying file without marking the
+// [SharedFile] permanently closed. The next [SharedFile.Acquire]
+// reopens via the constructor's open function.
+//
+// The FD closes inline when refs==0, bypassing the grace timer.
+// When refs>0 the SharedFile latches an immediate-close flag:
+// in-flight readers complete normally, the FD closes the instant
+// the last [SharedFile.Release] drops refs to zero, and
+// subsequent Acquires reopen and resume normal grace-timer
+// behaviour.
+//
+// Idempotent and safe to call concurrently. A no-op on a
+// SharedFile already permanently closed (returns nil); the
+// terminal [SharedFile.Close] path has already disposed the FD.
+// ReleaseNow never sets s.closed.
+//
+// The returned error covers only the inline-close case (refs==0).
+// When the latch fires via a subsequent Release, any error from
+// the deferred Close is discarded — Release has no return value
+// and the original ReleaseNow caller is no longer on the stack.
+func (s *SharedFile) ReleaseNow() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return nil
+	}
+
+	// Cancel any pending grace-period close and invalidate any
+	// already-queued timer callback via the gen bump.
+	if s.timer != nil {
+		s.timer.Stop()
+		s.timer = nil
+	}
+	s.gen++
+
+	if s.refs == 0 {
+		if s.file == nil {
+			return nil
+		}
+		err := s.file.Close()
+		s.file = nil
+		return err
+	}
+
+	// refs > 0: latch immediate close for the next refs == 0
+	// transition. In-flight readers complete normally.
+	s.immediateClose = true
+	return nil
 }

--- a/internal/sharedfile/sharedfile_bench_test.go
+++ b/internal/sharedfile/sharedfile_bench_test.go
@@ -1,0 +1,60 @@
+package sharedfile
+
+import (
+	"bytes"
+	"testing"
+)
+
+// BenchmarkSharedFileAcquireRelease measures the cost of one
+// Acquire+Release round-trip on a warm [SharedFile]; refs never
+// drops below 1 between iterations, so the FD stays open and
+// the modified refs==0 branch is not hit every loop.
+//
+// Purpose: catch regressions in the hot path introduced by the
+// `if s.immediateClose` arm in Release. That arm lives in the
+// refs==0 path and fires only on the last refcount drop, so this
+// benchmark measures the more common refs>0 fast path.
+func BenchmarkSharedFileAcquireRelease(b *testing.B) {
+	opener := func() (ReadAtCloser, error) {
+		return &memCloser{Reader: bytes.NewReader([]byte("hello"))}, nil
+	}
+	sf := New(opener, 0)
+	b.Cleanup(func() { _ = sf.Close() })
+
+	// Hold one reference for the whole benchmark so every
+	// Acquire+Release pair lands on the refs>0 fast path.
+	if _, err := sf.Acquire(); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { sf.Release() })
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := sf.Acquire(); err != nil {
+			b.Fatal(err)
+		}
+		sf.Release()
+	}
+}
+
+// BenchmarkSharedFileAcquireReleaseLastDrop measures the cost
+// of the modified refs==0 arm in Release — the path that now
+// checks the immediateClose latch. With gracePeriod==0 and no
+// latch set the cost should be effectively identical to the
+// pre-change baseline. Use benchstat against a recording on
+// main to verify no regression.
+func BenchmarkSharedFileAcquireReleaseLastDrop(b *testing.B) {
+	opener := func() (ReadAtCloser, error) {
+		return &memCloser{Reader: bytes.NewReader([]byte("hello"))}, nil
+	}
+	sf := New(opener, 0)
+	b.Cleanup(func() { _ = sf.Close() })
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := sf.Acquire(); err != nil {
+			b.Fatal(err)
+		}
+		sf.Release() // refs drops to 0 every iteration
+	}
+}

--- a/internal/sharedfile/sharedfile_test.go
+++ b/internal/sharedfile/sharedfile_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -330,4 +331,205 @@ func TestSharedFile_GracePeriodCancelledByClose(t *testing.T) {
 	// Close cancels the grace timer and closes immediately.
 	require.NoError(t, sf.Close())
 	assert.True(t, tf.closed.Load())
+}
+
+// TestSharedFile_ReleaseNow groups the cases for the soft-close
+// primitive that closes the FD now and (when refs>0) latches the
+// next refs==0 transition to close immediately.
+func TestSharedFile_ReleaseNow(t *testing.T) {
+	t.Parallel()
+
+	newReleaseNowOpener := func() (opener func() (ReadAtCloser, error), opens *atomic.Int32, tf *memCloser) {
+		var counter atomic.Int32
+		file := &memCloser{Reader: bytes.NewReader([]byte("data"))}
+		return func() (ReadAtCloser, error) {
+			counter.Add(1)
+			file.closed.Store(false)
+			return file, nil
+		}, &counter, file
+	}
+
+	t.Run("NoRefs_FileNil_IsNoop", func(t *testing.T) {
+		t.Parallel()
+		opener, opens, tf := newReleaseNowOpener()
+		sf := New(opener, 0) // gracePeriod = 0
+		defer sf.Close()
+
+		_, err := sf.Acquire()
+		require.NoError(t, err)
+		sf.Release()
+		// With zero grace period, Release scheduled an
+		// AfterFunc(0); poll for the async close so the next
+		// ReleaseNow observes refs==0 && file==nil.
+		assert.Eventually(t, tf.closed.Load, time.Second, 10*time.Millisecond,
+			"file should close after grace period")
+
+		// Strict no-op: no opener invocation, no error, no panic.
+		require.NoError(t, sf.ReleaseNow())
+		assert.Equal(t, int32(1), opens.Load())
+	})
+
+	t.Run("NoRefs_ClosesInline_GracePending", func(t *testing.T) {
+		t.Parallel()
+		opener, opens, tf := newReleaseNowOpener()
+		sf := New(opener, time.Minute) // long, so the timer won't fire
+		defer sf.Close()
+
+		_, err := sf.Acquire()
+		require.NoError(t, err)
+		sf.Release()
+		// Grace timer pending; FD still open.
+		assert.False(t, tf.closed.Load())
+
+		// ReleaseNow cancels the timer and closes the FD inline.
+		require.NoError(t, sf.ReleaseNow())
+		assert.True(t, tf.closed.Load())
+		assert.Equal(t, int32(1), opens.Load())
+
+		// SharedFile is reusable.
+		_, err = sf.Acquire()
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), opens.Load())
+		sf.Release()
+	})
+
+	t.Run("WithRefs_LatchesCloseOnZero", func(t *testing.T) {
+		t.Parallel()
+		opener, opens, tf := newReleaseNowOpener()
+		sf := New(opener, time.Minute)
+		defer sf.Close()
+
+		_, err := sf.Acquire()
+		require.NoError(t, err)
+		// refs=1; FD open.
+
+		require.NoError(t, sf.ReleaseNow())
+		// Refs still 1, so FD stays open.
+		assert.False(t, tf.closed.Load())
+
+		sf.Release()
+		// Refs reached 0; latch fired; FD closed immediately (no
+		// grace period observed).
+		assert.True(t, tf.closed.Load())
+		assert.Equal(t, int32(1), opens.Load())
+
+		// Subsequent Acquire reopens.
+		_, err = sf.Acquire()
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), opens.Load())
+		sf.Release()
+	})
+
+	t.Run("LatchSurvivesReacquire", func(t *testing.T) {
+		t.Parallel()
+		opener, opens, tf := newReleaseNowOpener()
+		sf := New(opener, time.Minute)
+		defer sf.Close()
+
+		_, err := sf.Acquire()
+		require.NoError(t, err)
+		// refs=1.
+
+		require.NoError(t, sf.ReleaseNow())
+		// Latch set; refs=1.
+
+		_, err = sf.Acquire()
+		require.NoError(t, err)
+		// refs=2. Acquire does not clear the latch.
+		assert.Equal(t, int32(1), opens.Load(), "should reuse existing FD")
+		assert.False(t, tf.closed.Load())
+
+		sf.Release()
+		// refs=1; not yet zero.
+		assert.False(t, tf.closed.Load())
+
+		sf.Release()
+		// refs=0; latch fires; FD closes.
+		assert.True(t, tf.closed.Load())
+
+		// Next Acquire reopens (latch cleared on close).
+		_, err = sf.Acquire()
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), opens.Load())
+		sf.Release()
+	})
+
+	t.Run("PreservesGraceBehaviourAfterLatchedClose", func(t *testing.T) {
+		t.Parallel()
+		synctest.Test(t, func(t *testing.T) {
+			opener, opens, tf := newReleaseNowOpener()
+			sf := New(opener, 100*time.Millisecond)
+			defer sf.Close()
+
+			// Round 1: latch path. The latch fires inline from
+			// Release; no async work to wait for.
+			_, err := sf.Acquire()
+			require.NoError(t, err)
+			require.NoError(t, sf.ReleaseNow())
+			sf.Release()
+			assert.True(t, tf.closed.Load(), "latch should close FD on refs=0")
+
+			// Round 2: fresh Acquire+Release should observe the
+			// normal grace-timer path (FD still open immediately
+			// after Release; closes only after the grace window).
+			_, err = sf.Acquire()
+			require.NoError(t, err)
+			assert.Equal(t, int32(2), opens.Load(), "Acquire should reopen")
+			sf.Release()
+
+			// FD still open: grace timer is pending.
+			assert.False(t, tf.closed.Load(), "grace timer should be pending after normal Release")
+
+			// Advance past the grace window.
+			time.Sleep(150 * time.Millisecond)
+			synctest.Wait()
+			assert.True(t, tf.closed.Load(), "grace timer should fire")
+		})
+	})
+
+	t.Run("AfterClose_NoOp", func(t *testing.T) {
+		t.Parallel()
+		opener, _, _ := newReleaseNowOpener()
+		sf := New(opener, 0)
+
+		_, err := sf.Acquire()
+		require.NoError(t, err)
+		sf.Release()
+		require.NoError(t, sf.Close())
+
+		// Strict no-op after Close; idempotent under repeat.
+		require.NoError(t, sf.ReleaseNow())
+		require.NoError(t, sf.ReleaseNow())
+	})
+
+	t.Run("Concurrent", func(t *testing.T) {
+		t.Parallel()
+		opener, _, _ := newReleaseNowOpener()
+		sf := New(opener, 10*time.Millisecond)
+		defer sf.Close()
+
+		const goroutines = 32
+		const iters = 64
+
+		var wg sync.WaitGroup
+		for range goroutines {
+			wg.Go(func() {
+				for range iters {
+					_, err := sf.Acquire()
+					if err != nil {
+						return
+					}
+					sf.Release()
+				}
+			})
+		}
+		for range 4 {
+			wg.Go(func() {
+				for range iters {
+					_ = sf.ReleaseNow()
+				}
+			})
+		}
+		wg.Wait()
+	})
 }

--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -21,6 +21,14 @@ const (
 var idxHeader = []byte{255, 't', 'O', 'c'}
 
 // Index represents an index of a packfile.
+//
+// Implementations satisfy a [io.Closer] contract via [Index.Close]:
+// on-disk implementations release file descriptors, pure
+// in-memory implementations return nil. Downstream callers
+// holding their own concrete [Index] implementations must
+// supply a [Close] method to satisfy this interface; a no-op
+// `func (*MyIndex) Close() error { return nil }` is sufficient
+// for in-memory backends.
 type Index interface {
 	// Contains checks whether the given hash is in the index.
 	Contains(h plumbing.Hash) (bool, error)

--- a/plumbing/format/idxfile/lazy_index.go
+++ b/plumbing/format/idxfile/lazy_index.go
@@ -293,6 +293,20 @@ func (s *LazyIndex) Close() error {
 	return errors.Join(s.idx.Close(), s.rev.Close())
 }
 
+// CloseIdleDescriptors releases the idx and rev file descriptors
+// without disabling the [LazyIndex]. The FDs close inline when no
+// readers are active; otherwise each [sharedfile.SharedFile]
+// latches an immediate close on the next refs==0 transition.
+// In-flight readers complete normally; subsequent operations
+// reopen the FDs on demand and resume normal grace-timer
+// behaviour.
+//
+// Returns the joined error of the inline closes; latched closes
+// that fire later are not reported.
+func (s *LazyIndex) CloseIdleDescriptors() error {
+	return errors.Join(s.idx.ReleaseNow(), s.rev.ReleaseNow())
+}
+
 // --- internal helpers; all take an io.ReaderAt so the caller controls
 //     the acquire/release lifecycle. ---
 

--- a/plumbing/format/idxfile/lazy_index_test.go
+++ b/plumbing/format/idxfile/lazy_index_test.go
@@ -400,6 +400,59 @@ func readerAtOpener(data []byte) func() (ReadAtCloser, error) {
 	}
 }
 
+// TestLazyIndexCloseIdleDescriptors verifies that
+// CloseIdleDescriptors releases idx and rev FDs without disabling
+// the index. A subsequent FindHash must succeed and trigger a
+// re-open of both shared files.
+func TestLazyIndexCloseIdleDescriptors(t *testing.T) {
+	t.Parallel()
+
+	idxBytes, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewBufferString(fixtureLarge4GB)))
+	require.NoError(t, err)
+
+	memIdx := new(MemoryIndex)
+	d := NewDecoder(FromBytes(idxBytes), hash.New(crypto.SHA1))
+	require.NoError(t, d.Decode(memIdx))
+
+	revBytes, err := buildTestRevFile(memIdx)
+	require.NoError(t, err)
+
+	var idxOpens, revOpens int
+	openIdx := func() (ReadAtCloser, error) {
+		idxOpens++
+		return nopCloserReaderAt{bytes.NewReader(idxBytes)}, nil
+	}
+	openRev := func() (ReadAtCloser, error) {
+		revOpens++
+		return nopCloserReaderAt{bytes.NewReader(revBytes)}, nil
+	}
+
+	idx, err := NewLazyIndex(openIdx, openRev, memIdx.PackfileChecksum)
+	require.NoError(t, err)
+	defer idx.Close()
+
+	// init counted as one open on each.
+	idxOpensAfterInit, revOpensAfterInit := idxOpens, revOpens
+	require.Equal(t, 1, idxOpensAfterInit)
+	require.Equal(t, 1, revOpensAfterInit)
+
+	// CloseIdleDescriptors drops the cached FDs without disabling.
+	require.NoError(t, idx.CloseIdleDescriptors())
+
+	// Subsequent operation must succeed and trigger fresh opens on
+	// both shared files. Use FindHash on a known fixture offset
+	// (idx and rev both consulted) rather than Contains (idx only).
+	h, err := idx.FindHash(fixtureOffsets[0])
+	require.NoError(t, err)
+	require.False(t, h.IsZero())
+	require.Greater(t, idxOpens, idxOpensAfterInit, "idx FD should have reopened")
+	require.Greater(t, revOpens, revOpensAfterInit, "rev FD should have reopened")
+
+	// CloseIdleDescriptors is idempotent under repeat.
+	require.NoError(t, idx.CloseIdleDescriptors())
+	require.NoError(t, idx.CloseIdleDescriptors())
+}
+
 func BenchmarkScannerFindHash(b *testing.B) {
 	idx, err := fixtureLazyIndex(true)
 	if err != nil {

--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"os"
+	stdsync "sync"
 
 	billy "github.com/go-git/go-billy/v6"
 
@@ -16,6 +17,46 @@ import (
 	"github.com/go-git/go-git/v6/utils/ioutil"
 	"github.com/go-git/go-git/v6/utils/sync"
 )
+
+// probeSize is the byte count for the closed-FD probe. A one-byte
+// ReadAt distinguishes a live descriptor from a closed one without
+// mutating the file's seek cursor; a zero-length read is unusable
+// because some implementations (e.g. [os.File]) return (0, nil) on
+// a closed file.
+const probeSize = 1
+
+// probeBufPool returns the per-call backing array for [probePack].
+// Pooling keeps the read path allocation-free on what is a very hot
+// code path.
+var probeBufPool = stdsync.Pool{
+	New: func() any {
+		var buf [probeSize]byte
+		return &buf
+	},
+}
+
+// probePack tests whether pack is still readable at offset by
+// issuing a [probeSize]-byte [io.ReaderAt.ReadAt]. The error is
+// returned verbatim so any wrapping context (path, syscall) is
+// preserved for the caller; classification is left to
+// [errors.Is]:
+//
+//   - nil means the descriptor is live; the caller may keep using
+//     pack.
+//   - an error matching [os.ErrClosed] means the descriptor has
+//     been closed and the caller should reopen the file.
+//   - any other error is propagated, matching the canonical Git
+//     behaviour in `packfile.c:use_pack`, which does not retry on
+//     transient I/O errors.
+//
+// [io.EOF] indicates the offset is at or past end-of-file, which
+// implies a truncated pack — propagate rather than masking.
+func probePack(pack io.ReaderAt, offset int64) error {
+	buf := probeBufPool.Get().(*[probeSize]byte)
+	defer probeBufPool.Put(buf)
+	_, err := pack.ReadAt(buf[:], offset)
+	return err
+}
 
 // FSObject is an object from the packfile on the filesystem.
 type FSObject struct {
@@ -90,19 +131,17 @@ func (o *FSObject) Reader() (io.ReadCloser, error) {
 	} else {
 		pack = o.pack
 
-		// Probe with a 1-byte ReadAt to detect a closed descriptor
-		// without mutating shared state. A zero-length read is not
-		// usable: some implementations (e.g. [os.File]) return
-		// (0, nil) on a closed file.
-		_, err := pack.ReadAt(make([]byte, 1), o.offset)
-		if err != nil && errors.Is(err, os.ErrClosed) {
+		switch err := probePack(pack, o.offset); {
+		case err == nil:
+			// FD is live; keep using pack.
+		case errors.Is(err, os.ErrClosed):
 			reopened, oerr := o.fs.Open(o.packPath)
 			if oerr != nil {
 				return nil, oerr
 			}
 			pack = reopened
 			file = reopened
-		} else if err != nil && !errors.Is(err, io.EOF) {
+		default:
 			return nil, err
 		}
 	}

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -369,31 +369,21 @@ func (p *Packfile) objectFromHeader(oh *ObjectHeader) (plumbing.EncodedObject, e
 	// If we have filesystem, and the object is not a delta type, return a FSObject.
 	// This avoids having to inflate the object more than once.
 	if !oh.Type.IsDelta() && p.fs != nil {
-		var fsObj *FSObject
+		fsObj := &FSObject{
+			hash:   oh.ID(),
+			offset: oh.ContentOffset,
+			size:   oh.Size,
+			typ:    oh.Type,
+			index:  p.Index,
+			fs:     p.fs,
+			cache:  p.cache,
+		}
 		if p.h != nil {
 			h := p.h
-			fsObj = &FSObject{
-				hash:          oh.ID(),
-				offset:        oh.ContentOffset,
-				size:          oh.Size,
-				typ:           oh.Type,
-				index:         p.Index,
-				fs:            p.fs,
-				cache:         p.cache,
-				acquireRandom: func() (packhandle.RandomReader, error) { return h.OpenRandomReader() },
-			}
+			fsObj.acquireRandom = func() (packhandle.RandomReader, error) { return h.OpenRandomReader() }
 		} else {
-			fsObj = NewFSObject(
-				oh.ID(),
-				oh.Type,
-				oh.ContentOffset,
-				oh.Size,
-				p.Index,
-				p.fs,
-				p.file,
-				p.file.Name(),
-				p.cache,
-			)
+			fsObj.pack = p.file
+			fsObj.packPath = p.file.Name()
 		}
 
 		p.cache.Put(fsObj)

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -3,6 +3,7 @@ package packfile
 import (
 	"bufio"
 	"crypto"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -346,11 +347,7 @@ func (p *Packfile) Close() error {
 			scanErr = p.scanReader.Close()
 			p.scanReader = nil
 		}
-		hErr := p.h.Close()
-		if hErr != nil {
-			return hErr
-		}
-		return scanErr
+		return errors.Join(scanErr, p.h.Close())
 	}
 
 	closer, ok := p.file.(io.Closer)

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -101,6 +101,8 @@ func (p *Packfile) Get(h plumbing.Hash) (plumbing.EncodedObject, error) {
 	}
 	p.m.Lock()
 	defer p.m.Unlock()
+	// Re-check after Lock: Close may have flipped closed and torn
+	// down the scanner between the early Load and the Lock.
 	if p.closed.Load() {
 		return nil, fs.ErrClosed
 	}
@@ -119,6 +121,8 @@ func (p *Packfile) GetByOffset(offset int64) (plumbing.EncodedObject, error) {
 	}
 	p.m.Lock()
 	defer p.m.Unlock()
+	// Re-check after Lock: Close may have flipped closed and torn
+	// down the scanner between the early Load and the Lock.
 	if p.closed.Load() {
 		return nil, fs.ErrClosed
 	}

--- a/plumbing/format/packfile/packfile_options.go
+++ b/plumbing/format/packfile/packfile_options.go
@@ -45,11 +45,20 @@ func WithObjectIDSize(sz int) PackfileOption {
 }
 
 // WithPackHash sets the .pack file's SHA-1 (or SHA-256) checksum.
-// When combined with WithFs, the Packfile routes all .pack file
-// access through a refcounted, grace-period-closing FD owner that
-// reopens the file lazily via the filesystem. Callers that do not
-// set both options fall back to direct access on the file passed
-// to NewPackfile.
+// When combined with [WithFs], the Packfile builds a private,
+// refcounted, grace-period-closing FD owner that reopens the .pack
+// file lazily via the filesystem; the file argument to NewPackfile
+// is closed and replaced by the private owner. Without both
+// options, the file is used as-is and closed by [Packfile.Close].
+//
+// Do not set this option when the file passed to NewPackfile is
+// already a cursor on a pack-handle managed elsewhere (for example,
+// the [billy.File] returned by storage/filesystem/dotgit's
+// OpenPackForReading): wiring it in that case would spin up a
+// second, parallel FD owner per Packfile, sidestepping the
+// caller-owned catalog and its idle-FD release hooks. Such callers
+// should leave the option unset so the cursor wrapper is consumed
+// directly.
 func WithPackHash(h plumbing.Hash) PackfileOption {
 	return func(p *Packfile) {
 		p.packHash = h

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -312,15 +312,34 @@ func (p *Parser) processDelta(oh *ObjectHeader) error {
 	return p.storeOrCache(oh)
 }
 
+// checkDeltaChainDepth verifies that the delta chain rooted at oh
+// stays within [maxDeltaChainDepth] links. The result is cached on
+// [ObjectHeader.chainDepth] so a subsequent walk that crosses the
+// same parent reuses the work — every entry on the chain ends up
+// with its depth set once, which keeps the verification linear in
+// the number of distinct objects rather than quadratic in the
+// chain length. This mirrors the cached `oe->depth` field that
+// upstream Git carries on the object entry in
+// `builtin/pack-objects.c`.
 func checkDeltaChainDepth(oh *ObjectHeader) error {
+	if oh.chainDepth > 0 {
+		return nil
+	}
 	var depth int
 	for current := oh; current != nil && current.isDeltaOnDisk(); current = current.parent {
+		if current.chainDepth > 0 {
+			depth += current.chainDepth
+			if depth > maxDeltaChainDepth {
+				return fmt.Errorf("%w: delta chain depth exceeds %d", ErrMalformedPackfile, maxDeltaChainDepth)
+			}
+			break
+		}
 		depth++
 		if depth > maxDeltaChainDepth {
 			return fmt.Errorf("%w: delta chain depth exceeds %d", ErrMalformedPackfile, maxDeltaChainDepth)
 		}
 	}
-
+	oh.chainDepth = depth
 	return nil
 }
 

--- a/plumbing/format/packfile/types.go
+++ b/plumbing/format/packfile/types.go
@@ -40,6 +40,14 @@ type ObjectHeader struct {
 	parent      *ObjectHeader
 	diskType    plumbing.ObjectType
 	externalRef bool
+
+	// chainDepth caches the result of [checkDeltaChainDepth] for
+	// this header. A positive value is the number of delta links
+	// from this object down to (but not including) the first
+	// non-delta base. Zero means either "not yet computed" or
+	// "this header is not a delta"; both cases collapse to a
+	// constant-time re-check, so the dual meaning is harmless.
+	chainDepth int
 }
 
 // ID returns the object ID.

--- a/plumbing/storer/storer.go
+++ b/plumbing/storer/storer.go
@@ -23,3 +23,15 @@ type Initializer interface {
 type FilesystemStorer interface {
 	Filesystem() billy.Filesystem
 }
+
+// IdleReleaser is implemented by storers that can drop idle
+// file descriptors (or other I/O resources) without becoming
+// unusable. Callers detect via this interface and call
+// [IdleReleaser.CloseIdleDescriptors] at a known quiet point —
+// for example between reconcile bursts.
+//
+// Implementations must remain fully usable after the call;
+// subsequent operations reopen resources on demand.
+type IdleReleaser interface {
+	CloseIdleDescriptors() error
+}

--- a/plumbing/storer/storer_test.go
+++ b/plumbing/storer/storer_test.go
@@ -1,0 +1,36 @@
+package storer
+
+import (
+	"errors"
+	"testing"
+)
+
+// idleReleaserImpl is a stand-in to verify that IdleReleaser has
+// exactly one method, `CloseIdleDescriptors() error`. The test fails
+// to compile if the interface drifts.
+type idleReleaserImpl struct{ err error }
+
+func (i idleReleaserImpl) CloseIdleDescriptors() error { return i.err }
+
+var _ IdleReleaser = idleReleaserImpl{}
+
+func TestIdleReleaserContract(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NilError", func(t *testing.T) {
+		t.Parallel()
+		var r IdleReleaser = idleReleaserImpl{}
+		if err := r.CloseIdleDescriptors(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("ErrorPropagates", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("release-failed")
+		var r IdleReleaser = idleReleaserImpl{err: sentinel}
+		if err := r.CloseIdleDescriptors(); !errors.Is(err, sentinel) {
+			t.Fatalf("expected sentinel error, got %v", err)
+		}
+	})
+}

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -195,9 +195,6 @@ func (d *DotGit) Close() error {
 
 	d.packMap = nil
 
-	if len(phErrs) == 0 {
-		return nil
-	}
 	return errors.Join(phErrs...)
 }
 
@@ -292,8 +289,15 @@ func (d *DotGit) DeleteReflog(name plumbing.ReferenceName) error {
 // NewObjectPack return a writer for a new packfile, it saves the packfile to
 // disk and also generates and save the index for the given packfile.
 func (d *DotGit) NewObjectPack() (*PackWriter, error) {
-	d.cleanPackList()
-	return newPackWrite(d.fs, d.options.ObjectFormat, d.options.WriteReverseIndex)
+	cleanErr := d.cleanPackList()
+	pw, err := newPackWrite(d.fs, d.options.ObjectFormat, d.options.WriteReverseIndex)
+	if err != nil {
+		return nil, errors.Join(cleanErr, err)
+	}
+	if cleanErr != nil {
+		return nil, cleanErr
+	}
+	return pw, nil
 }
 
 // ObjectPacks returns the list of availables packfiles
@@ -568,21 +572,24 @@ func (d *DotGit) CloseIdleDescriptors() error {
 // leave orphaned siblings on disk. A missing .rev is not an error — the
 // reverse index is optional and may have been generated only in memory.
 func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) error {
-	d.cleanPackList()
+	var errs []error
+	if err := d.cleanPackList(); err != nil {
+		errs = append(errs, err)
+	}
 
 	packPath := d.objectPackPath(hash, `pack`)
 	if !t.IsZero() {
 		fi, err := d.fs.Stat(packPath)
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			return errors.Join(errs...)
 		}
 		// too new, skip deletion.
 		if !fi.ModTime().Before(t) {
-			return nil
+			return errors.Join(errs...)
 		}
 	}
 
-	var errs []error
 	for _, ext := range []string{`pack`, `idx`, `rev`} {
 		if err := d.fs.Remove(d.objectPackPath(hash, ext)); err != nil {
 			if ext == `rev` && os.IsNotExist(err) {
@@ -599,7 +606,9 @@ func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) er
 	}
 	d.packHandlesMu.Unlock()
 	if ok {
-		_ = ph.Close()
+		if err := ph.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return errors.Join(errs...)
 }
@@ -780,20 +789,32 @@ func (d *DotGit) hasObject(h plumbing.Hash) error {
 	return nil
 }
 
-func (d *DotGit) cleanPackList() {
+// cleanPackList resets the pack catalog and drops every cached
+// [packhandle.PackHandle]. A pack-set mutation may have
+// invalidated the handles' underlying files, so they cannot
+// safely be reused. Idle readers finish normally; their cursor
+// Close becomes a no-op release.
+//
+// PackHandle.Close owns the underlying sharedfile and LazyIndex
+// FDs, so a close failure here means an FD has not been released.
+// The errors are joined and returned so callers can surface them
+// rather than silently masking I/O failures during cleanup.
+func (d *DotGit) cleanPackList() error {
 	d.packMap = nil
 	d.packList = nil
 
-	// A pack-set mutation may have invalidated any cached handle's
-	// underlying files, so drop them all. Idle readers finish
-	// normally; their cursor Close becomes a no-op release.
 	d.packHandlesMu.Lock()
 	handles := d.packHandles
 	d.packHandles = nil
 	d.packHandlesMu.Unlock()
+
+	var errs []error
 	for _, h := range handles {
-		_ = h.Close()
+		if err := h.Close(); err != nil {
+			errs = append(errs, err)
+		}
 	}
+	return errors.Join(errs...)
 }
 
 func (d *DotGit) genPackList() error {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -515,6 +517,34 @@ func (d *DotGit) packHandle(hash plumbing.Hash) (*packhandle.PackHandle, error) 
 	}
 	d.packHandles[hash] = ph
 	return ph, nil
+}
+
+// walkPackHandles snapshots the [packhandle.PackHandle] catalog
+// under packHandlesMu and invokes fn on each entry with the lock
+// released. The snapshot shortens the critical section so
+// concurrent [DotGit.PackHandle] lookups do not block on slow
+// per-handle work such as file-close syscalls.
+//
+// The catalog is left intact; fn observes the same PackHandle
+// pointers that subsequent lookups return. Callers that want to
+// drain the catalog must do so separately — Close and
+// cleanPackList keep their inline snapshot-with-clear because
+// they need the drain to be atomic with the snapshot.
+//
+// Errors returned by fn are joined; the walk continues past a
+// failing entry so one bad pack does not strand FDs in others.
+func (d *DotGit) walkPackHandles(fn func(*packhandle.PackHandle) error) error {
+	d.packHandlesMu.Lock()
+	handles := slices.Collect(maps.Values(d.packHandles))
+	d.packHandlesMu.Unlock()
+
+	var errs []error
+	for _, h := range handles {
+		if err := fn(h); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // DeleteOldObjectPackAndIndex removes a pack and its index if older than t.

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -522,7 +522,7 @@ func (d *DotGit) packHandle(hash plumbing.Hash) (*packhandle.PackHandle, error) 
 // walkPackHandles snapshots the [packhandle.PackHandle] catalog
 // under packHandlesMu and invokes fn on each entry with the lock
 // released. The snapshot shortens the critical section so
-// concurrent [DotGit.PackHandle] lookups do not block on slow
+// concurrent [DotGit.packHandle] lookups do not block on slow
 // per-handle work such as file-close syscalls.
 //
 // The catalog is left intact; fn observes the same PackHandle
@@ -545,6 +545,21 @@ func (d *DotGit) walkPackHandles(fn func(*packhandle.PackHandle) error) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// CloseIdleDescriptors releases the FDs held by every cached
+// [packhandle.PackHandle] without evicting them from the
+// catalog. The catalog and each PackHandle's cached state
+// (`PackMeta`, `LazyIndex`) survive the call; subsequent
+// operations reopen FDs on demand.
+//
+// Idempotent and safe to call concurrently with other DotGit
+// operations. After [DotGit.Close] the catalog is empty, so the
+// call is a no-op.
+func (d *DotGit) CloseIdleDescriptors() error {
+	return d.walkPackHandles(func(ph *packhandle.PackHandle) error {
+		return ph.CloseIdleDescriptors()
+	})
 }
 
 // DeleteOldObjectPackAndIndex removes a pack and its index if older than t.

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -1513,6 +1513,66 @@ func TestWalkPackHandles_SnapshotsCatalog(t *testing.T) {
 		"walk should visit every snapshot entry, even after mid-walk catalog mutation")
 }
 
+// TestDotGitCloseIdleDescriptors groups the DotGit-layer cases for
+// the catalog walk that releases FDs without evicting the
+// PackHandle entries.
+func TestDotGitCloseIdleDescriptors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("WalksCatalog", func(t *testing.T) {
+		t.Parallel()
+		fs, err := fixtures.Basic().One().DotGit()
+		require.NoError(t, err)
+		d := New(fs)
+		t.Cleanup(func() { _ = d.Close() })
+
+		packs, err := d.ObjectPacks()
+		require.NoError(t, err)
+		require.NotEmpty(t, packs)
+
+		// Populate catalog and capture each PackHandle pointer.
+		before := make(map[plumbing.Hash]*packhandle.PackHandle, len(packs))
+		for _, h := range packs {
+			ph, err := d.packHandle(h)
+			require.NoError(t, err)
+			before[h] = ph
+			// Touch the pack so an FD is actually opened.
+			pr, err := ph.OpenPackReader()
+			require.NoError(t, err)
+			require.NoError(t, pr.Close())
+		}
+
+		require.NoError(t, d.CloseIdleDescriptors())
+
+		// Catalog map is intact and PackHandle pointers are the same.
+		for _, h := range packs {
+			ph, err := d.packHandle(h)
+			require.NoError(t, err)
+			assert.Same(t, before[h], ph,
+				"PackHandle pointer should survive CloseIdleDescriptors")
+		}
+	})
+
+	t.Run("EmptyCatalog", func(t *testing.T) {
+		t.Parallel()
+		fs, err := fixtures.Basic().One().DotGit()
+		require.NoError(t, err)
+		d := New(fs)
+		t.Cleanup(func() { _ = d.Close() })
+		// No packHandle() calls; catalog stays nil.
+		require.NoError(t, d.CloseIdleDescriptors())
+	})
+
+	t.Run("AfterClose_NoOp", func(t *testing.T) {
+		t.Parallel()
+		fs, err := fixtures.Basic().One().DotGit()
+		require.NoError(t, err)
+		d := New(fs)
+		require.NoError(t, d.Close())
+		require.NoError(t, d.CloseIdleDescriptors())
+	})
+}
+
 // TestWalkPackHandles_JoinsErrors verifies that fn errors are
 // joined and returned, but do not stop the walk.
 func TestWalkPackHandles_JoinsErrors(t *testing.T) {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -2,7 +2,9 @@ package dotgit
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -13,6 +15,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
@@ -24,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/go-git/go-git/v6/internal/packhandle"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/storage"
@@ -1421,4 +1425,122 @@ func TestDotGit_HasIncomingObjects_NoRace(t *testing.T) {
 		})
 	}
 	wg.Wait()
+}
+
+// fakePackHandleSource returns a Source whose Open and Size always
+// fail. walkPackHandles never calls these (it only invokes fn on
+// each cached *PackHandle), so the fakes satisfy New without
+// requiring on-disk pack files.
+func fakePackHandleSource() packhandle.Source {
+	return packhandle.Source{
+		Open: func() (packhandle.ReadAtCloser, error) {
+			return nil, errors.New("fake source: not used")
+		},
+		Size: func() (int64, error) {
+			return 0, errors.New("fake source: not used")
+		},
+	}
+}
+
+// newFakePackHandle returns a new *packhandle.PackHandle whose
+// sources all fail when opened. Suitable for tests that only
+// exercise catalog-walk behaviour.
+func newFakePackHandle(t *testing.T, i int) *packhandle.PackHandle {
+	t.Helper()
+	var h plumbing.Hash
+	h.ResetBySize(20) // SHA-1 size
+	_, _ = h.Write(bytes.Repeat([]byte{byte(i + 1)}, 20))
+	src := fakePackHandleSource()
+	ph, err := packhandle.New(packhandle.Sources{Pack: src, Idx: src, Rev: src}, h)
+	require.NoError(t, err)
+	return ph
+}
+
+// seedPackHandles installs n fake PackHandles into d.packHandles
+// under the catalog lock, returning the hashes used as keys.
+func seedPackHandles(t *testing.T, d *DotGit, n int) []plumbing.Hash {
+	t.Helper()
+	d.packHandlesMu.Lock()
+	defer d.packHandlesMu.Unlock()
+	if d.packHandles == nil {
+		d.packHandles = make(map[plumbing.Hash]*packhandle.PackHandle)
+	}
+	hashes := make([]plumbing.Hash, n)
+	for i := range n {
+		var h plumbing.Hash
+		h.ResetBySize(20) // SHA-1 size
+		_, _ = h.Write(bytes.Repeat([]byte{byte(i + 1)}, 20))
+		hashes[i] = h
+		d.packHandles[h] = newFakePackHandle(t, i)
+	}
+	return hashes
+}
+
+// TestWalkPackHandles_SnapshotsCatalog verifies that walkPackHandles
+// iterates a snapshot taken under the lock, so a concurrent mutation
+// of the catalog (e.g. eviction) does not panic or skip entries the
+// snapshot already captured.
+func TestWalkPackHandles_SnapshotsCatalog(t *testing.T) {
+	t.Parallel()
+	fs, err := fixtures.Basic().One().DotGit()
+	require.NoError(t, err)
+	d := New(fs)
+	t.Cleanup(func() { _ = d.Close() })
+
+	const seedN = 3
+	hashes := seedPackHandles(t, d, seedN)
+
+	d.packHandlesMu.Lock()
+	expectedCount := len(d.packHandles)
+	d.packHandlesMu.Unlock()
+	require.GreaterOrEqual(t, expectedCount, seedN,
+		"catalog must hold at least the seeded entries")
+
+	var seen atomic.Int32
+	var evictDone atomic.Bool
+	victim := hashes[0]
+	err = d.walkPackHandles(func(_ *packhandle.PackHandle) error {
+		seen.Add(1)
+		if evictDone.CompareAndSwap(false, true) {
+			d.packHandlesMu.Lock()
+			delete(d.packHandles, victim)
+			d.packHandlesMu.Unlock()
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(expectedCount), seen.Load(),
+		"walk should visit every snapshot entry, even after mid-walk catalog mutation")
+}
+
+// TestWalkPackHandles_JoinsErrors verifies that fn errors are
+// joined and returned, but do not stop the walk.
+func TestWalkPackHandles_JoinsErrors(t *testing.T) {
+	t.Parallel()
+	fs, err := fixtures.Basic().One().DotGit()
+	require.NoError(t, err)
+	d := New(fs)
+	t.Cleanup(func() { _ = d.Close() })
+
+	const seedN = 3
+	_ = seedPackHandles(t, d, seedN)
+
+	d.packHandlesMu.Lock()
+	totalEntries := len(d.packHandles)
+	d.packHandlesMu.Unlock()
+	require.GreaterOrEqual(t, totalEntries, seedN)
+
+	sentinel := errors.New("walk-fn-error")
+	var visits atomic.Int32
+	err = d.walkPackHandles(func(_ *packhandle.PackHandle) error {
+		visits.Add(1)
+		return sentinel
+	})
+	require.Error(t, err)
+	// Every visited entry returns sentinel; errors.Is unwraps the
+	// joined chain and finds it.
+	assert.ErrorIs(t, err, sentinel)
+	// Crucially: the walk did not stop on the first error.
+	assert.Equal(t, int32(totalEntries), visits.Load(),
+		"walk should not stop on first error")
 }

--- a/storage/filesystem/dotgit/openpack.go
+++ b/storage/filesystem/dotgit/openpack.go
@@ -34,6 +34,12 @@ func (d *DotGit) OpenPackForReading(hash plumbing.Hash) (billy.File, error) {
 	if err != nil {
 		return nil, err
 	}
+	// [packhandle.PackReader] is declared as
+	// Reader+Seeker+Closer; ReadAt is not in the interface, so
+	// the assertion is a real runtime check rather than a static
+	// guarantee. The current concrete (cursorReader) satisfies
+	// it; the dynamic assert exists to catch a future PackReader
+	// implementation that does not.
 	ra, ok := pr.(io.ReaderAt)
 	if !ok {
 		_ = pr.Close()

--- a/storage/filesystem/dotgit/openpack.go
+++ b/storage/filesystem/dotgit/openpack.go
@@ -66,10 +66,9 @@ func (d *DotGit) OpenPackForReading(hash plumbing.Hash) (billy.File, error) {
 // snapshot consistent with the cursor's reads should derive size
 // from prior reads rather than re-Stat through this method.
 //
-// The handle holds a [billy.Filesystem] reference only for Stat;
-// it does not retain a pointer back to its parent [DotGit]. That
-// kept the DotGit → cache → PackHandle → readOnlyPackFile cycle
-// open and made the lifetime story harder to reason about.
+// The handle holds a [billy.Filesystem] reference for Stat
+// rather than a back-pointer to [DotGit]; this avoids a
+// DotGit → cache → PackHandle → readOnlyPackFile reference cycle.
 type readOnlyPackFile struct {
 	cursor packhandle.PackReader
 	ra     io.ReaderAt

--- a/storage/filesystem/dotgit/openpack.go
+++ b/storage/filesystem/dotgit/openpack.go
@@ -49,6 +49,16 @@ func (d *DotGit) OpenPackForReading(hash plumbing.Hash) (billy.File, error) {
 }
 
 // readOnlyPackFile adapts a packhandle cursor into a [billy.File].
+//
+// The embedded cursor pins one [sharedfile.SharedFile] reference
+// for the lifetime of this handle: Read, ReadAt, and Seek route
+// through the cursor, so the .pack FD stays live until Close.
+// [readOnlyPackFile.Stat] is the exception — it goes through the
+// filesystem on each call and may report a result that diverges
+// from the cursor's view if the underlying pack was mutated or
+// deleted out from under the handle. Callers that need a
+// snapshot consistent with the cursor's reads should derive size
+// from prior reads rather than re-Stat through this method.
 type readOnlyPackFile struct {
 	cursor packhandle.PackReader
 	ra     io.ReaderAt

--- a/storage/filesystem/dotgit/openpack.go
+++ b/storage/filesystem/dotgit/openpack.go
@@ -44,7 +44,7 @@ func (d *DotGit) OpenPackForReading(hash plumbing.Hash) (billy.File, error) {
 		cursor: pr,
 		ra:     ra,
 		name:   d.objectPackPath(hash, "pack"),
-		dg:     d,
+		fs:     d.fs,
 	}, nil
 }
 
@@ -59,11 +59,16 @@ func (d *DotGit) OpenPackForReading(hash plumbing.Hash) (billy.File, error) {
 // deleted out from under the handle. Callers that need a
 // snapshot consistent with the cursor's reads should derive size
 // from prior reads rather than re-Stat through this method.
+//
+// The handle holds a [billy.Filesystem] reference only for Stat;
+// it does not retain a pointer back to its parent [DotGit]. That
+// kept the DotGit → cache → PackHandle → readOnlyPackFile cycle
+// open and made the lifetime story harder to reason about.
 type readOnlyPackFile struct {
 	cursor packhandle.PackReader
 	ra     io.ReaderAt
 	name   string
-	dg     *DotGit
+	fs     billy.Filesystem
 }
 
 func (f *readOnlyPackFile) Read(p []byte) (int, error) { return f.cursor.Read(p) }
@@ -78,7 +83,7 @@ func (f *readOnlyPackFile) ReadAt(p []byte, off int64) (int, error) {
 }
 
 func (f *readOnlyPackFile) Stat() (fs.FileInfo, error) {
-	return f.dg.fs.Stat(f.name)
+	return f.fs.Stat(f.name)
 }
 
 func (f *readOnlyPackFile) Write(_ []byte) (int, error) { return 0, errReadOnlyPack }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -827,6 +827,64 @@ func (s *ObjectStorage) Close() error {
 	return firstError
 }
 
+// CloseIdleDescriptors releases the FDs held by this
+// [ObjectStorage] and every cached alternate. The object cache,
+// the packfile cache, the alternates cache, and the `s.index`
+// map (with the [idxfile.LazyIndex] entries inside it) all
+// survive — only the file descriptors backing those LazyIndex
+// entries are released.
+//
+// The call fans out across three independent FD owners: the
+// [dotgit.DotGit] `PackHandle` catalog (.pack and the
+// `LazyIndex` inside each `PackHandle`), the ObjectStorage-level
+// idx map (which holds its own LazyIndex per pack, distinct
+// from the one inside the `PackHandle`), and any cached
+// alternate `ObjectStorage`.
+//
+// Idempotent and safe to call concurrently with reads. In-flight
+// reads complete normally; the FDs they hold refcounts on close
+// the instant the last reader releases. After
+// [ObjectStorage.Close] the call is a no-op.
+//
+// Parent storage is released before alternates — a deliberate
+// divergence from Close, which goes alternates-first. The
+// parent-first order favours OS reclaim of this storage's FDs
+// when an alternate's release is slow (e.g. a network FS).
+func (s *ObjectStorage) CloseIdleDescriptors() error {
+	var errs []error
+
+	if err := s.dir.CloseIdleDescriptors(); err != nil {
+		errs = append(errs, err)
+	}
+
+	// ObjectStorage maintains a separate idxfile cache in s.index
+	// (populated by loadIdxFile → loadLazyIndex). LazyIndex
+	// entries own .idx/.rev FDs distinct from those inside the
+	// dotgit PackHandle catalog; they need their own soft-close
+	// fan-out. The storer.IdleReleaser assertion picks up
+	// LazyIndex automatically and silently skips index
+	// implementations that hold no FDs (notably MemoryIndex).
+	s.muI.RLock()
+	for _, idx := range s.index {
+		if r, ok := idx.(storer.IdleReleaser); ok {
+			if err := r.CloseIdleDescriptors(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	s.muI.RUnlock()
+
+	s.muA.RLock()
+	for _, alt := range s.alternates {
+		if err := alt.CloseIdleDescriptors(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	s.muA.RUnlock()
+
+	return errors.Join(errs...)
+}
+
 func hashListAsMap(l []plumbing.Hash) map[plumbing.Hash]struct{} {
 	m := make(map[plumbing.Hash]struct{}, len(l))
 	for _, h := range l {

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -7,11 +7,15 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/osfs"
 	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -832,4 +836,149 @@ func (s *FsSuite) TestObjectStorageAlternatesInitError() {
 	_, err = storage.EncodedObject(plumbing.AnyObject, commitHash)
 	s.Error(err)
 	s.NotErrorIs(err, plumbing.ErrObjectNotFound)
+}
+
+// TestObjectStorageCloseIdleDescriptors groups the cases for the
+// ObjectStorage-layer soft-close.
+func TestObjectStorageCloseIdleDescriptors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("DropsPackFDsButPreservesReadability", func(t *testing.T) {
+		t.Parallel()
+		fixture := fixtures.Basic().One()
+		dir, err := fixture.DotGit()
+		require.NoError(t, err)
+		s := NewStorage(dir, cache.NewObjectLRUDefault())
+		t.Cleanup(func() { _ = s.Close() })
+
+		// Get one hash to read.
+		iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+		require.NoError(t, err)
+		obj1, err := iter.Next()
+		require.NoError(t, err)
+		iter.Close()
+
+		// Read once to warm caches.
+		_, err = s.EncodedObject(plumbing.AnyObject, obj1.Hash())
+		require.NoError(t, err)
+
+		require.NoError(t, s.CloseIdleDescriptors())
+
+		// Second read still works.
+		obj2, err := s.EncodedObject(plumbing.AnyObject, obj1.Hash())
+		require.NoError(t, err)
+		assert.Equal(t, obj1.Hash(), obj2.Hash())
+	})
+
+	t.Run("PreservesIndexMap", func(t *testing.T) {
+		t.Parallel()
+		fixture := fixtures.Basic().One()
+		dir, err := fixture.DotGit()
+		require.NoError(t, err)
+		s := NewStorage(dir, cache.NewObjectLRUDefault())
+		t.Cleanup(func() { _ = s.Close() })
+
+		// Force population of s.index.
+		iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+		require.NoError(t, err)
+		obj1, err := iter.Next()
+		require.NoError(t, err)
+		iter.Close()
+
+		_, err = s.EncodedObject(plumbing.AnyObject, obj1.Hash())
+		require.NoError(t, err)
+
+		s.muI.RLock()
+		idxBefore := make(map[plumbing.Hash]struct{}, len(s.index))
+		for h := range s.index {
+			idxBefore[h] = struct{}{}
+		}
+		s.muI.RUnlock()
+
+		require.NoError(t, s.CloseIdleDescriptors())
+
+		s.muI.RLock()
+		assert.Equal(t, len(idxBefore), len(s.index))
+		for h := range idxBefore {
+			_, ok := s.index[h]
+			assert.True(t, ok, "index entry %s should survive", h)
+		}
+		s.muI.RUnlock()
+	})
+
+	t.Run("TwiceInARow", func(t *testing.T) {
+		t.Parallel()
+		fixture := fixtures.Basic().One()
+		dir, err := fixture.DotGit()
+		require.NoError(t, err)
+		s := NewStorage(dir, cache.NewObjectLRUDefault())
+		t.Cleanup(func() { _ = s.Close() })
+
+		require.NoError(t, s.CloseIdleDescriptors())
+		require.NoError(t, s.CloseIdleDescriptors())
+	})
+
+	t.Run("AfterClose_NoOp", func(t *testing.T) {
+		t.Parallel()
+		fixture := fixtures.Basic().One()
+		dir, err := fixture.DotGit()
+		require.NoError(t, err)
+		s := NewStorage(dir, cache.NewObjectLRUDefault())
+		require.NoError(t, s.Close())
+		require.NoError(t, s.CloseIdleDescriptors())
+		require.NoError(t, s.CloseIdleDescriptors())
+	})
+
+	t.Run("ConcurrentWithReads", func(t *testing.T) {
+		t.Parallel()
+		fixture := fixtures.Basic().One()
+		dir, err := fixture.DotGit()
+		require.NoError(t, err)
+		s := NewStorage(dir, cache.NewObjectLRUDefault())
+		t.Cleanup(func() { _ = s.Close() })
+
+		// Collect a working set of hashes.
+		iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+		require.NoError(t, err)
+		var hashes []plumbing.Hash
+		for range 16 {
+			obj, err := iter.Next()
+			if err != nil {
+				break
+			}
+			hashes = append(hashes, obj.Hash())
+		}
+		iter.Close()
+		require.NotEmpty(t, hashes)
+
+		var wg sync.WaitGroup
+		var failures atomic.Int32
+
+		for range 8 {
+			wg.Go(func() {
+				for _, h := range hashes {
+					obj, err := s.EncodedObject(plumbing.AnyObject, h)
+					if err != nil || obj == nil {
+						failures.Add(1)
+						// Continue rather than return so a single
+						// transient failure does not mask later
+						// reads from this goroutine.
+						continue
+					}
+				}
+			})
+		}
+		for range 4 {
+			wg.Go(func() {
+				for range 16 {
+					if err := s.CloseIdleDescriptors(); err != nil {
+						failures.Add(1)
+					}
+				}
+			})
+		}
+		wg.Wait()
+		assert.Equal(t, int32(0), failures.Load(),
+			"no read or release should fail under concurrent load")
+	})
 }

--- a/storage/filesystem/packhandle_integration_test.go
+++ b/storage/filesystem/packhandle_integration_test.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"io"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sync"
@@ -235,4 +236,133 @@ func TestIntegration_ReindexInvalidatesPackHandles(t *testing.T) {
 	_, err = storage.EncodedObject(plumbing.AnyObject, target)
 	assert.Error(t, err,
 		"EncodedObject should fail after the pack is deleted")
+}
+
+// TestIntegration_CloseIdleDescriptorsDropsAndReopens uses real-process
+// FD counting to verify that CloseIdleDescriptors drops the FDs and
+// the next read reopens. The fixture is copied to a real osfs path so
+// pack/idx opens go through the OS file table (the in-memory
+// embed.FS-backed fixture is not observable via /proc/self/fd or
+// /dev/fd).
+//
+//nolint:paralleltest // process-wide FD count must not race with other tests
+func TestIntegration_CloseIdleDescriptorsDropsAndReopens(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("FD counting: linux/darwin only")
+	}
+	fixture := fixtures.Basic().One()
+	scratchDir := t.TempDir()
+	originalFS, err := fixture.DotGit()
+	require.NoError(t, err)
+	scratchFS := osfs.New(scratchDir)
+	copyDotGit(t, originalFS, scratchFS)
+
+	storage := NewStorage(scratchFS, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = storage.Close() })
+
+	// Warm: read enough objects to open every pack's FDs.
+	iter, err := storage.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	var probe plumbing.Hash
+	for range 8 {
+		obj, err := iter.Next()
+		if err != nil {
+			break
+		}
+		if probe.IsZero() {
+			probe = obj.Hash()
+		}
+	}
+	iter.Close()
+	require.False(t, probe.IsZero(), "fixture must contain at least one object")
+
+	// Touch the object via EncodedObject to ensure pack and idx
+	// sharedFiles have been Acquired and their FDs are open in
+	// the grace window.
+	_, err = storage.EncodedObject(plumbing.AnyObject, probe)
+	require.NoError(t, err)
+
+	warm := openFDCount(t)
+	require.NoError(t, storage.CloseIdleDescriptors())
+
+	// CloseIdleDescriptors closes FDs inline when refs==0 (no
+	// async work to wait for), so the FD count drops before this
+	// call returns.
+	after := openFDCount(t)
+	assert.Less(t, after, warm, "CloseIdleDescriptors should drop FDs")
+
+	// Subsequent reads pay a reopen but succeed.
+	_, err = storage.EncodedObject(plumbing.AnyObject, probe)
+	require.NoError(t, err)
+}
+
+// openFDCount returns the number of open file descriptors for the
+// current process on linux/darwin; skips elsewhere. Uses
+// Readdirnames to avoid the per-entry stat that fails for the
+// listing FD on darwin's /dev/fd.
+func openFDCount(t *testing.T) int {
+	t.Helper()
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("openFDCount: linux/darwin only")
+	}
+	var dir string
+	switch runtime.GOOS {
+	case "linux":
+		dir = "/proc/self/fd"
+	case "darwin":
+		dir = "/dev/fd"
+	}
+	f, err := os.Open(dir)
+	require.NoError(t, err)
+	defer f.Close()
+	names, err := f.Readdirnames(-1)
+	require.NoError(t, err)
+	return len(names)
+}
+
+// copyDotGit copies the essential .git contents from src to dst.
+// Best-effort; sufficient for read-only tests.
+func copyDotGit(t *testing.T, src, dst billy.Filesystem) {
+	t.Helper()
+	for _, p := range []string{"HEAD", "config", "packed-refs"} {
+		copyOne(t, src, dst, p)
+	}
+	copyDir(t, src, dst, "refs")
+	copyDir(t, src, dst, "objects")
+}
+
+func copyOne(t *testing.T, src, dst billy.Filesystem, path string) {
+	t.Helper()
+	rf, err := src.Open(path)
+	if err != nil {
+		return
+	}
+	defer rf.Close()
+	data, err := io.ReadAll(rf)
+	if err != nil {
+		return
+	}
+	_ = dst.MkdirAll(filepath.Dir(path), 0o755)
+	wf, err := dst.Create(path)
+	require.NoError(t, err)
+	defer wf.Close()
+	_, err = wf.Write(data)
+	require.NoError(t, err)
+}
+
+func copyDir(t *testing.T, src, dst billy.Filesystem, dir string) {
+	t.Helper()
+	entries, err := src.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	_ = dst.MkdirAll(dir, 0o755)
+	for _, e := range entries {
+		p := filepath.Join(dir, e.Name())
+		if e.IsDir() {
+			copyDir(t, src, dst, p)
+		} else {
+			copyOne(t, src, dst, p)
+		}
+	}
 }

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
 )
 
@@ -30,6 +31,17 @@ type Storage struct {
 	ModuleStorage
 	ReflogStorage
 }
+
+// Compile-time assertions pin both *Storage and *dotgit.DotGit to
+// [storer.IdleReleaser]. *Storage promotes CloseIdleDescriptors
+// from the embedded [ObjectStorage] via Go's method-set promotion
+// rules; *dotgit.DotGit defines the method directly. A future
+// rename or signature change on either side breaks the build
+// immediately.
+var (
+	_ storer.IdleReleaser = (*Storage)(nil)
+	_ storer.IdleReleaser = (*dotgit.DotGit)(nil)
+)
 
 // Options holds configuration for the storage.
 type Options struct {

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -353,6 +353,22 @@ func TestSupportsExtension(t *testing.T) {
 	}
 }
 
+// TestStorage_ImplementsIdleReleaser pins the public relationship
+// between *Storage and the storer.IdleReleaser interface. The
+// compile-time assertion in storage.go enforces this at build
+// time; the test re-asserts it in test form for visibility, and
+// exercises the no-op path against an empty in-memory FS.
+func TestStorage_ImplementsIdleReleaser(t *testing.T) {
+	t.Parallel()
+	var _ storer.IdleReleaser = (*filesystem.Storage)(nil)
+
+	s := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	assert.NoError(t, s.CloseIdleDescriptors())
+	assert.NoError(t, s.CloseIdleDescriptors())
+}
+
 func getExplicitSHA1(t testing.TB) billy.Filesystem {
 	fs := osfs.New(t.TempDir())
 	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())


### PR DESCRIPTION
Adds an opt-in `CloseIdleDescriptors` surface that drops idle pack file descriptors without invalidating storage state. For long-running processes (servers, daemons) that keep a `Storage` open across idle periods, this enables bounded FD usage on demand without losing the warm `*PackHandle` cache or paying the terminal `Close`-and-reopen cost.

The primitive lives on the unexported `sharedFile` as `releaseNow`: closes the FD inline when no readers are active, otherwise latches "close on next quiescence" so in-flight reads finish normally and the FD drops the instant the last release brings `refs` to zero. The next reader transparently reopens via the source opener. The public surface fans out across three FD owners — `LazyIndex.CloseIdleDescriptors` (idx/rev), `PackHandle.CloseIdleDescriptors` (pack + the cached `LazyIndex` inside the handle), and `ObjectStorage.CloseIdleDescriptors` (`DotGit`'s `PackHandle` catalog, the per-pack `LazyIndex` cache distinct from the one inside the handle, and cached alternates) — with `Storage.CloseIdleDescriptors` promoted from the embedded `ObjectStorage`. The `storer.IdleReleaser` interface exposes this up the stack.

Builds on the PackHandle refcounted FD lifecycle (#2132); prerequisite for the pack hot-path + LRU FD pool work (#2134).