### PR TITLE
storage: pack read optimisations and storage-wide LRU FD pool

### DIFF
--- a/internal/packhandle/packhandle.go
+++ b/internal/packhandle/packhandle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v6/internal/sharedfile"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
+	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
 // defaultGracePeriod is the idle window after the last cursor
@@ -69,6 +70,28 @@ type PackHandle struct {
 // [PackHandle.Index] returns [ErrSourceUnconfigured] when either
 // is absent.
 func New(sources Sources, packHash plumbing.Hash) (*PackHandle, error) {
+	return NewWithPool(sources, packHash, nil)
+}
+
+// NewWithPool is like [New] but registers the .pack
+// [sharedfile.SharedFile] with the given [*fdpool.Pool]. The pool
+// governs LRU eviction of the pack FD across many PackHandles so
+// a storage-wide budget bounds the open .pack descriptors. Pass
+// nil for pool to disable pooling (equivalent to [New]).
+//
+// When pool is non-nil the [defaultGracePeriod] timer is inert:
+// the FD stays open and registered with the pool until the LRU
+// evicts it (or [PackHandle.Close] tears it down). When pool is
+// nil the grace timer governs FD lifetime as in [New].
+//
+// Neither this constructor nor the cursor entry points
+// ([PackHandle.OpenPackReader], [PackHandle.OpenRandomReader])
+// accept a [context.Context]. Pack reads are pure ReadAt I/O
+// without cancellation hooks, matching the context-free
+// convention of the storage, plumbing/format, and
+// plumbing/storer layers; callers requiring cancellation
+// enforce it at the call-site in the layer above.
+func NewWithPool(sources Sources, packHash plumbing.Hash, pool *fdpool.Pool) (*PackHandle, error) {
 	if sources.Pack.Open == nil || sources.Pack.Size == nil {
 		return nil, ErrPackSourceRequired
 	}
@@ -78,7 +101,7 @@ func New(sources Sources, packHash plumbing.Hash) (*PackHandle, error) {
 	h := &PackHandle{
 		sources:  sources,
 		packHash: packHash,
-		pack:     sharedfile.New(sources.Pack.Open, defaultGracePeriod),
+		pack:     sharedfile.NewWithPool(sources.Pack.Open, defaultGracePeriod, pool),
 	}
 	h.closeFn = sync.OnceValue(h.doClose)
 	return h, nil

--- a/internal/packhandle/packhandle_bench_test.go
+++ b/internal/packhandle/packhandle_bench_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
@@ -118,6 +119,68 @@ func BenchmarkPackHandleAcquireGrace(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		r, err := ph.OpenPackReader()
+		if err != nil {
+			b.Fatal(err)
+		}
+		off := int64(i) % validRange
+		if _, err := r.(io.ReaderAt).ReadAt(buf, off); err != nil && err != io.EOF {
+			b.Fatal(err)
+		}
+		_ = r.Close()
+	}
+}
+
+// BenchmarkPackHandleAcquireAfterGraceExpiry measures the
+// cold-reopen cost when the SharedFile's grace timer naturally
+// fires between accesses. Each iteration sleeps past the
+// grace window with the timer paused (StopTimer/StartTimer) so
+// only the subsequent OpenPackReader → ReadAt → Close is
+// counted: the timed delta against
+// `BenchmarkPackHandleAcquireGrace` (warm) is one full
+// pack-`SharedFile` reopen including the close that the grace
+// timer fired off-band.
+//
+// At the default `-benchtime=1s` each iteration's mandatory
+// sleep dominates the wall clock, so the testing framework
+// runs the loop body once. Run with `-benchtime=Nx` (e.g.
+// `-benchtime=10x`) to gather a meaningful sample.
+//
+// `BenchmarkPackHandleCloseIdleReopen` exercises the same cold
+// path with the grace timer fast-forwarded via soft-close; this
+// bench is the wall-clock-accurate variant that includes the
+// time.AfterFunc-driven close callback.
+func BenchmarkPackHandleAcquireAfterGraceExpiry(b *testing.B) {
+	ph := newEmbedFixturePackHandle(b)
+	b.Cleanup(func() { _ = ph.Close() })
+
+	packSize := packSizeFromFixture(b)
+	validRange := packSize - 64
+	if validRange <= 0 {
+		b.Fatalf("pack too small: %d bytes", packSize)
+	}
+
+	// Sleep margin past `defaultGracePeriod` (1s in packhandle.go) so
+	// the timer has fired before the next timed iteration starts.
+	const sleep = 1200 * time.Millisecond
+
+	// Warm the SharedFile so the first iteration's sleep covers a
+	// real timer fire rather than the initial open.
+	warm, err := ph.OpenPackReader()
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = warm.Close()
+
+	buf := make([]byte, 64)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		time.Sleep(sleep)
+		b.StartTimer()
+
 		r, err := ph.OpenPackReader()
 		if err != nil {
 			b.Fatal(err)

--- a/internal/sharedfile/sharedfile.go
+++ b/internal/sharedfile/sharedfile.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
 // ReadAtCloser is the interface a SharedFile manages: any
@@ -37,11 +39,18 @@ var ErrClosed = fs.ErrClosed
 //     handed out before Close see [fs.ErrClosed] on the next
 //     read, since the OS-level FD has been released.
 //
+// When constructed with a non-nil [*fdpool.Pool], the grace timer
+// is bypassed at refs==0: the FD stays open and registered, and
+// the pool decides when to evict via [SharedFile.ReleaseNow].
+// This lets a single pool govern the storage-wide FD budget
+// across many SharedFiles.
+//
 // All methods are safe for concurrent use.
 type SharedFile struct {
 	mu          sync.Mutex
 	open        func() (ReadAtCloser, error)
 	gracePeriod time.Duration
+	pool        *fdpool.Pool
 
 	file           ReadAtCloser
 	refs           int
@@ -55,17 +64,30 @@ type SharedFile struct {
 // New returns a new SharedFile that opens files via open and
 // closes the descriptor after gracePeriod of idle time.
 func New(open func() (ReadAtCloser, error), gracePeriod time.Duration) *SharedFile {
-	return &SharedFile{open: open, gracePeriod: gracePeriod}
+	return NewWithPool(open, gracePeriod, nil)
+}
+
+// NewWithPool returns a SharedFile registered with the given
+// [*fdpool.Pool]. The pool governs FD eviction across many
+// SharedFiles via [SharedFile.ReleaseNow]; the grace timer is
+// bypassed at refs==0 so the FD stays open and registered until
+// the pool evicts or [SharedFile.Close] is called. Pass nil for
+// pool to disable pooling (equivalent to [New]).
+func NewWithPool(open func() (ReadAtCloser, error), gracePeriod time.Duration, pool *fdpool.Pool) *SharedFile {
+	return &SharedFile{open: open, gracePeriod: gracePeriod, pool: pool}
 }
 
 // Acquire bumps the refcount and returns the underlying file,
 // opening it via the constructor's open function on first need.
 // Each Acquire must be balanced by exactly one Release.
+//
+// If a pool is configured, every Acquire calls [fdpool.Pool.Touch]
+// after the FD is in hand, which registers the SharedFile on first
+// open and refreshes its LRU position on every subsequent acquire.
 func (s *SharedFile) Acquire() (ReadAtCloser, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.closed {
+		s.mu.Unlock()
 		return nil, ErrClosed
 	}
 
@@ -77,18 +99,34 @@ func (s *SharedFile) Acquire() (ReadAtCloser, error) {
 	if s.file == nil {
 		f, err := s.open()
 		if err != nil {
+			s.mu.Unlock()
 			return nil, err
 		}
 		s.file = f
 	}
 	s.refs++
 	s.gen++
-	return s.file, nil
+	file := s.file
+	pool := s.pool
+	s.mu.Unlock()
+
+	// Touch after releasing s.mu: pool.Touch acquires pool.mu,
+	// and the eviction path acquires Member.mu under pool.mu
+	// release. Keeping Member→Pool as the only lock-acquire
+	// direction avoids the deadlock noted in fdpool.New's docs.
+	if pool != nil {
+		pool.Touch(s)
+	}
+	return file, nil
 }
 
 // Release decrements the refcount. When it reaches zero the
 // grace-period timer is started; the file is closed when the
 // timer fires unless another Acquire happens first.
+//
+// If a pool is configured, the grace timer is skipped at refs==0:
+// the FD stays open and registered. The pool drives the eventual
+// close via [SharedFile.ReleaseNow] when capacity is exceeded.
 func (s *SharedFile) Release() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -111,6 +149,12 @@ func (s *SharedFile) Release() {
 		s.immediateClose = false
 		_ = s.file.Close()
 		s.file = nil
+		return
+	}
+
+	// Pool drives eviction: keep the FD open and registered so the
+	// pool's LRU governs when it closes. No timer.
+	if s.pool != nil {
 		return
 	}
 
@@ -137,11 +181,14 @@ func (s *SharedFile) IsClosed() bool { return s.isClosed.Load() }
 // Close stops any pending grace timer and closes the underlying
 // file synchronously. Subsequent Acquire calls return
 // [ErrClosed]. Close is idempotent.
+//
+// If a pool is configured, the SharedFile is forgotten from the
+// pool's LRU before Close returns, so a racing eviction cannot
+// observe a freed Member.
 func (s *SharedFile) Close() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if s.closed {
+		s.mu.Unlock()
 		return nil
 	}
 	s.closed = true
@@ -157,6 +204,12 @@ func (s *SharedFile) Close() error {
 	if s.file != nil {
 		err = s.file.Close()
 		s.file = nil
+	}
+	pool := s.pool
+	s.mu.Unlock()
+
+	if pool != nil {
+		pool.Forget(s)
 	}
 	return err
 }

--- a/internal/sharedfile/sharedfile.go
+++ b/internal/sharedfile/sharedfile.go
@@ -110,10 +110,11 @@ func (s *SharedFile) Acquire() (ReadAtCloser, error) {
 	pool := s.pool
 	s.mu.Unlock()
 
-	// Touch after releasing s.mu: pool.Touch acquires pool.mu,
-	// and the eviction path acquires Member.mu under pool.mu
-	// release. Keeping Member→Pool as the only lock-acquire
-	// direction avoids the deadlock noted in fdpool.New's docs.
+	// Touch after releasing s.mu: SharedFile never holds s.mu
+	// while calling into the pool (see Acquire and Close), so
+	// the inverse Pool→Member locking via Pinned() during
+	// eviction is deadlock-free. See fdpool/pool.go's eviction
+	// comment for the full invariant.
 	if pool != nil {
 		pool.Touch(s)
 	}
@@ -177,6 +178,26 @@ func (s *SharedFile) Release() {
 // after teardown without depending on the underlying
 // ReadAtCloser's post-Close error semantics.
 func (s *SharedFile) IsClosed() bool { return s.isClosed.Load() }
+
+// Pinned reports whether the SharedFile has active acquirers
+// (refs > 0). Implements [fdpool.Pinnable] so a Pool can prefer
+// unpinned victims when capacity is exceeded; pinned SharedFiles
+// are still evictable as a fallback when every Member is pinned.
+//
+// The reported state is observational — refs may transition the
+// instant Pinned returns. The pool's eviction policy treats the
+// answer as a hint.
+func (s *SharedFile) Pinned() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.refs > 0
+}
+
+// Compile-time assertion that SharedFile satisfies
+// [fdpool.Pinnable]; statically anchors the interface binding
+// so a future signature drift on either side breaks the build
+// rather than degrading to non-Pinnable fallback at runtime.
+var _ fdpool.Pinnable = (*SharedFile)(nil)
 
 // Close stops any pending grace timer and closes the underlying
 // file synchronously. Subsequent Acquire calls return

--- a/internal/sharedfile/sharedfile.go
+++ b/internal/sharedfile/sharedfile.go
@@ -51,6 +51,7 @@ type SharedFile struct {
 	open        func() (ReadAtCloser, error)
 	gracePeriod time.Duration
 	pool        *fdpool.Pool
+	poolHandle  fdpool.Handle // pool's per-Member token; zero until first Touch
 
 	file           ReadAtCloser
 	refs           int
@@ -116,7 +117,7 @@ func (s *SharedFile) Acquire() (ReadAtCloser, error) {
 	// eviction is deadlock-free. See fdpool/pool.go's eviction
 	// comment for the full invariant.
 	if pool != nil {
-		pool.Touch(s)
+		pool.Touch(s, &s.poolHandle)
 	}
 	return file, nil
 }
@@ -230,7 +231,7 @@ func (s *SharedFile) Close() error {
 	s.mu.Unlock()
 
 	if pool != nil {
-		pool.Forget(s)
+		pool.Forget(&s.poolHandle)
 	}
 	return err
 }

--- a/internal/sharedfile/sharedfile_bench_test.go
+++ b/internal/sharedfile/sharedfile_bench_test.go
@@ -3,6 +3,9 @@ package sharedfile
 import (
 	"bytes"
 	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
 // BenchmarkSharedFileAcquireRelease measures the cost of one
@@ -56,5 +59,32 @@ func BenchmarkSharedFileAcquireReleaseLastDrop(b *testing.B) {
 			b.Fatal(err)
 		}
 		sf.Release() // refs drops to 0 every iteration
+	}
+}
+
+// BenchmarkSharedFileAcquireReleaseWithPool measures the
+// Touch-on-Acquire overhead introduced by the pool wiring. The
+// pool capacity exceeds the working set (one member), so every
+// Touch is an LRU hit. Compared to BenchmarkSharedFileAcquire
+// Release this isolates the cost of the pool notification.
+func BenchmarkSharedFileAcquireReleaseWithPool(b *testing.B) {
+	opener := func() (ReadAtCloser, error) {
+		return &memCloser{Reader: bytes.NewReader([]byte("hello"))}, nil
+	}
+	pool := fdpool.New(64)
+	sf := NewWithPool(opener, time.Hour, pool)
+	b.Cleanup(func() { _ = sf.Close() })
+
+	if _, err := sf.Acquire(); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { sf.Release() })
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := sf.Acquire(); err != nil {
+			b.Fatal(err)
+		}
+		sf.Release()
 	}
 }

--- a/internal/sharedfile/sharedfile_pool_test.go
+++ b/internal/sharedfile/sharedfile_pool_test.go
@@ -1,0 +1,157 @@
+package sharedfile
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/x/fdpool"
+)
+
+// TestSharedFile_Pool_TouchesOnAcquire asserts that every
+// successful Acquire updates the pool's LRU — both the first open
+// and subsequent acquires while the FD is already held.
+func TestSharedFile_Pool_TouchesOnAcquire(t *testing.T) {
+	t.Parallel()
+	open, _, _ := newOpener(t, []byte("touch"))
+	pool := fdpool.New(8)
+	sf := NewWithPool(open, time.Hour, pool)
+	defer sf.Close()
+
+	_, err := sf.Acquire()
+	require.NoError(t, err)
+	require.Equal(t, 1, pool.Stats().Active,
+		"first Acquire should register the member")
+
+	_, err = sf.Acquire()
+	require.NoError(t, err)
+	assert.Equal(t, 1, pool.Stats().Active,
+		"subsequent Acquire keeps a single LRU entry")
+	assert.Equal(t, uint64(1), pool.Stats().Hits,
+		"second Touch is an LRU hit")
+
+	sf.Release()
+	sf.Release()
+}
+
+// TestSharedFile_Pool_KeepsFDOpenOnQuiescence asserts that when a
+// pool is wired the FD stays open across refs==0; only the pool's
+// eviction (or terminal Close) releases the FD.
+func TestSharedFile_Pool_KeepsFDOpenOnQuiescence(t *testing.T) {
+	t.Parallel()
+	open, opens, handles := newOpener(t, []byte("keep"))
+	pool := fdpool.New(8)
+	sf := NewWithPool(open, time.Hour, pool)
+	defer sf.Close()
+
+	_, err := sf.Acquire()
+	require.NoError(t, err)
+	sf.Release()
+	require.Len(t, *handles, 1)
+	assert.False(t, (*handles)[0].closed.Load(),
+		"pool-wired SharedFile must keep FD open on refs==0")
+
+	_, err = sf.Acquire()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), opens.Load(),
+		"re-Acquire must reuse the FD held open by the pool")
+	sf.Release()
+}
+
+// TestSharedFile_Pool_Close_Forgets asserts that terminal Close
+// always invokes Forget on a wired pool, regardless of whether
+// references are still active.
+func TestSharedFile_Pool_Close_Forgets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ClosesWithNoRefs", func(t *testing.T) {
+		t.Parallel()
+		open, _, _ := newOpener(t, []byte("noref"))
+		pool := fdpool.New(8)
+		sf := NewWithPool(open, time.Hour, pool)
+
+		_, err := sf.Acquire()
+		require.NoError(t, err)
+		sf.Release()
+		require.NoError(t, sf.Close())
+		assert.Equal(t, 0, pool.Stats().Active,
+			"terminal Close must remove the member from the pool")
+
+		// Repeat Close is idempotent.
+		require.NoError(t, sf.Close())
+		assert.Equal(t, 0, pool.Stats().Active)
+	})
+
+	t.Run("ClosesWithActiveRefs", func(t *testing.T) {
+		t.Parallel()
+		open, _, _ := newOpener(t, []byte("activeref"))
+		pool := fdpool.New(8)
+		sf := NewWithPool(open, time.Hour, pool)
+
+		_, err := sf.Acquire()
+		require.NoError(t, err)
+		require.NoError(t, sf.Close())
+		assert.Equal(t, 0, pool.Stats().Active,
+			"Forget must fire on Close even when refs are still active")
+		sf.Release()
+	})
+}
+
+// TestSharedFile_Pool_EvictionReleasesFD wires a tiny pool and
+// confirms that the LRU eviction path drives the inline FD close
+// via ReleaseNow.
+func TestSharedFile_Pool_EvictionReleasesFD(t *testing.T) {
+	t.Parallel()
+	openA, _, handlesA := newOpener(t, []byte("a"))
+	openB, _, _ := newOpener(t, []byte("b"))
+	pool := fdpool.New(1)
+
+	a := NewWithPool(openA, time.Hour, pool)
+	defer a.Close()
+	b := NewWithPool(openB, time.Hour, pool)
+	defer b.Close()
+
+	_, err := a.Acquire()
+	require.NoError(t, err)
+	a.Release()
+	require.Len(t, *handlesA, 1)
+	require.False(t, (*handlesA)[0].closed.Load(),
+		"a's FD stays open under quiescence")
+
+	_, err = b.Acquire()
+	require.NoError(t, err)
+	b.Release()
+
+	assert.Equal(t, uint64(1), pool.Stats().Evictions,
+		"b's registration should evict a")
+	assert.True(t, (*handlesA)[0].closed.Load(),
+		"evicted member must close its FD")
+}
+
+// TestSharedFile_NoPool_ImmediateClose locks in the pool-less
+// policy: Release with refs==0 closes the FD inline (after the
+// grace timer, which we make short to keep the test fast).
+func TestSharedFile_NoPool_ImmediateClose(t *testing.T) {
+	t.Parallel()
+	open, opens, handles := newOpener(t, []byte("nopool"))
+	sf := New(open, 5*time.Millisecond)
+	defer sf.Close()
+
+	_, err := sf.Acquire()
+	require.NoError(t, err)
+	sf.Release()
+
+	// Wait for the grace timer to fire.
+	assert.Eventually(t, func() bool {
+		return len(*handles) > 0 && (*handles)[0].closed.Load()
+	}, time.Second, 5*time.Millisecond,
+		"pool-less SharedFile must close after grace period")
+
+	_, err = sf.Acquire()
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), opens.Load(),
+		"second Acquire must reopen after grace-period close")
+	sf.Release()
+}

--- a/internal/sharedfile/sharedfile_pool_test.go
+++ b/internal/sharedfile/sharedfile_pool_test.go
@@ -1,6 +1,8 @@
 package sharedfile
 
 import (
+	"bytes"
+	"sync"
 	"testing"
 	"time"
 
@@ -154,4 +156,73 @@ func TestSharedFile_NoPool_ImmediateClose(t *testing.T) {
 	assert.Equal(t, int64(2), opens.Load(),
 		"second Acquire must reopen after grace-period close")
 	sf.Release()
+}
+
+// TestSharedFile_Pool_ReadsDuringEviction stresses the refcount +
+// immediateClose latch contract under sustained concurrent I/O.
+// N reader goroutines do Acquire → ReadAt → verify bytes → Release
+// in a tight loop while M evictor goroutines fire ReleaseNow
+// concurrently. The refcount guarantees the FD is valid for the
+// duration of a held Acquire; ReleaseNow with refs > 0 must latch
+// immediateClose rather than close the FD out from under the
+// reader. A successful ReadAt confirms the latch worked.
+func TestSharedFile_Pool_ReadsDuringEviction(t *testing.T) {
+	t.Parallel()
+
+	payload := []byte("PACKfile-bytes-for-ReadAt-mid-eviction-stress")
+	open, _, _ := newOpener(t, payload)
+
+	pool := fdpool.New(8)
+	sf := NewWithPool(open, time.Hour, pool)
+	defer sf.Close()
+
+	const (
+		readers     = 16
+		evictors    = 4
+		readsPerGo  = 256
+		evictsPerGo = 128
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(readers + evictors)
+
+	for range readers {
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, len(payload))
+			for range readsPerGo {
+				f, err := sf.Acquire()
+				if err != nil {
+					t.Errorf("Acquire: %v", err)
+					return
+				}
+				n, err := f.ReadAt(buf, 0)
+				if err != nil {
+					t.Errorf("ReadAt: %v", err)
+					sf.Release()
+					return
+				}
+				if n != len(payload) || !bytes.Equal(buf, payload) {
+					t.Errorf("ReadAt returned wrong bytes: got %q", buf[:n])
+					sf.Release()
+					return
+				}
+				sf.Release()
+			}
+		}()
+	}
+
+	for range evictors {
+		go func() {
+			defer wg.Done()
+			for range evictsPerGo {
+				if err := sf.ReleaseNow(); err != nil {
+					t.Errorf("ReleaseNow: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/plumbing/format/idxfile/lazy_index.go
+++ b/plumbing/format/idxfile/lazy_index.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v6/internal/sharedfile"
 	"github.com/go-git/go-git/v6/plumbing"
 	gsync "github.com/go-git/go-git/v6/utils/sync"
+	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
 const defaultCloseGracePeriod = time.Second
@@ -66,6 +67,29 @@ var _ Index = (*LazyIndex)(nil)
 // are shared across concurrent readers and released automatically when
 // idle.
 func NewLazyIndex(openIdx, openRev func() (ReadAtCloser, error), packHash plumbing.Hash) (*LazyIndex, error) {
+	return NewLazyIndexWithPool(openIdx, openRev, packHash, nil)
+}
+
+// NewLazyIndexWithPool is like [NewLazyIndex] but registers the
+// idx and rev [sharedfile.SharedFile]s with the given
+// [*fdpool.Pool]. The pool governs LRU eviction across many
+// LazyIndexes so a storage-wide FD budget covers the .idx and
+// .rev descriptors. Pass nil to disable pooling (equivalent to
+// [NewLazyIndex]).
+//
+// When pool is non-nil the [defaultCloseGracePeriod] timer is
+// inert: each FD stays open and registered with the pool until
+// the LRU evicts it (or [LazyIndex.Close] tears it down). When
+// pool is nil the grace timer governs FD lifetime as in
+// [NewLazyIndex].
+//
+// Neither this constructor nor the [Index] methods accept a
+// [context.Context]. Index lookups are pure ReadAt I/O without
+// cancellation hooks, matching the context-free convention of
+// the storage, plumbing/format, and plumbing/storer layers;
+// callers requiring cancellation enforce it at the call-site
+// in the layer above.
+func NewLazyIndexWithPool(openIdx, openRev func() (ReadAtCloser, error), packHash plumbing.Hash, pool *fdpool.Pool) (*LazyIndex, error) {
 	if openIdx == nil {
 		return nil, errors.New("idx opener is nil")
 	}
@@ -74,8 +98,8 @@ func NewLazyIndex(openIdx, openRev func() (ReadAtCloser, error), packHash plumbi
 	}
 
 	s := &LazyIndex{
-		idx: sharedfile.New(openIdx, defaultCloseGracePeriod),
-		rev: sharedfile.New(openRev, defaultCloseGracePeriod),
+		idx: sharedfile.NewWithPool(openIdx, defaultCloseGracePeriod, pool),
+		rev: sharedfile.NewWithPool(openRev, defaultCloseGracePeriod, pool),
 	}
 
 	if err := s.init(packHash); err != nil {

--- a/plumbing/format/idxfile/lazy_index_test.go
+++ b/plumbing/format/idxfile/lazy_index_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/hash"
+	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
 type LazyIndexSuite struct {
@@ -563,4 +564,68 @@ func buildTestRevFile(idx *MemoryIndex) ([]byte, error) {
 	// LazyIndex doesn't validate the rev trailer).
 	buf.Write(make([]byte, crypto.SHA1.Size()*2))
 	return buf.Bytes(), nil
+}
+
+// TestLazyIndex_WithPool_EvictionAndReopen verifies that
+// NewLazyIndexWithPool registers both idx and rev SharedFiles
+// with the pool, that exceeding capacity triggers eviction, and
+// that a subsequent read against an evicted LazyIndex reopens its
+// FDs via the stored openers without error.
+func TestLazyIndex_WithPool_EvictionAndReopen(t *testing.T) {
+	t.Parallel()
+	idxBytes, err := io.ReadAll(base64.NewDecoder(base64.StdEncoding, bytes.NewBufferString(fixtureLarge4GB)))
+	require.NoError(t, err)
+
+	memIdx := new(MemoryIndex)
+	d := NewDecoder(FromBytes(idxBytes), hash.New(crypto.SHA1))
+	require.NoError(t, d.Decode(memIdx))
+
+	revBytes, err := buildTestRevFile(memIdx)
+	require.NoError(t, err)
+
+	openIdx := func() (ReadAtCloser, error) {
+		return nopCloserReaderAt{bytes.NewReader(idxBytes)}, nil
+	}
+	openRev := func() (ReadAtCloser, error) {
+		return nopCloserReaderAt{bytes.NewReader(revBytes)}, nil
+	}
+
+	// Capacity 2: a single LazyIndex registers idx + rev = 2
+	// members. Constructing two LazyIndexes forces eviction on the
+	// second construction.
+	pool := fdpool.New(2)
+	first, err := NewLazyIndexWithPool(openIdx, openRev, memIdx.PackfileChecksum, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = first.Close() })
+
+	// init() Acquires idx and rev, reads headers, then Releases.
+	// Both SharedFiles are pool-registered with refs == 0.
+	require.Equal(t, 2, pool.Stats().Active,
+		"first LazyIndex should register idx and rev SharedFiles")
+
+	second, err := NewLazyIndexWithPool(openIdx, openRev, memIdx.PackfileChecksum, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = second.Close() })
+
+	// Second LazyIndex Acquire/Release forced evictions on the
+	// first LazyIndex's SharedFiles (since they were the LRU
+	// tail with refs == 0).
+	got := pool.Stats()
+	require.Equal(t, uint64(2), got.Evictions,
+		"both of first LazyIndex's SharedFiles (idx + rev) should be evicted")
+
+	// Now read through the (potentially) evicted first LazyIndex.
+	// FindHash exercises both SharedFiles (idx and rev) so the
+	// reopen-on-closed-FD path is verified for both openers.
+	iter, err := memIdx.Entries()
+	require.NoError(t, err)
+	defer iter.Close()
+	entry, err := iter.Next()
+	require.NoError(t, err)
+
+	gotHash, err := first.FindHash(int64(entry.Offset))
+	require.NoError(t, err,
+		"FindHash on an evicted LazyIndex must transparently reopen both idx and rev")
+	require.Equal(t, entry.Hash, gotHash,
+		"FindHash must return the same hash MemoryIndex has at this offset")
 }

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -31,6 +31,7 @@ import (
 	plumbhash "github.com/go-git/go-git/v6/plumbing/hash"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
+	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
 const (
@@ -107,6 +108,11 @@ type Options struct {
 	// WriteReverseIndex controls whether .rev files are written when
 	// creating new packfiles. Defaults to true.
 	WriteReverseIndex bool
+	// Pool, when non-nil, governs the LRU eviction of file
+	// descriptors held by [packhandle.PackHandle] instances
+	// constructed by this DotGit. Nil disables pooling for the
+	// pack-FD lifecycle (grace-period close on quiescence).
+	Pool *fdpool.Pool
 }
 
 // The DotGit type represents a local git repository on disk. This
@@ -511,7 +517,7 @@ func (d *DotGit) packHandle(hash plumbing.Hash) (*packhandle.PackHandle, error) 
 		},
 	}
 
-	ph, err := packhandle.New(sources, hash)
+	ph, err := packhandle.NewWithPool(sources, hash, d.options.Pool)
 	if err != nil {
 		return nil, err
 	}
@@ -1529,7 +1535,17 @@ func (d *DotGit) Alternates() ([]*DotGit, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cannot chroot %q: %w", path, err)
 		}
-		alternates = append(alternates, New(afs))
+		// Inherit the parent DotGit's ObjectFormat so the alternate
+		// reads and writes hashes at the same width as the
+		// repository it serves. Inherit the FD pool too so the
+		// storage-wide budget covers alternate packs and idxes.
+		// Other Options keep their defaults from New.
+		alternates = append(alternates, NewWithOptions(afs, Options{
+			ObjectFormat:      d.options.ObjectFormat,
+			ReadReverseIndex:  true,
+			WriteReverseIndex: true,
+			Pool:              d.options.Pool,
+		}))
 	}
 
 	if err = scanner.Err(); err != nil {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -112,6 +112,12 @@ type Options struct {
 	// descriptors held by [packhandle.PackHandle] instances
 	// constructed by this DotGit. Nil disables pooling for the
 	// pack-FD lifecycle (grace-period close on quiescence).
+	//
+	// The Pool field's API stability tracks [fdpool.Pool]'s, not
+	// this package's. Per the x/ package policy, the fdpool API
+	// may change without following semantic versioning; consumers
+	// reading this field should treat it as experimental on the
+	// same timeline.
 	Pool *fdpool.Pool
 }
 

--- a/storage/filesystem/multipack_fixture_test.go
+++ b/storage/filesystem/multipack_fixture_test.go
@@ -1,0 +1,99 @@
+package filesystem
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/osfs"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// makeMultiPackFixture builds a fresh .git directory containing
+// nPacks independent packfiles, each holding objPerPack distinct
+// blob objects. Returns the filesystem rooted at .git and a slice
+// of per-pack hash lists so callers can construct workloads that
+// target specific access patterns (e.g. read one hash from each
+// pack to exercise MRU pack ordering, or read a working set
+// larger than the FD pool capacity to force eviction churn).
+//
+// Object content is deterministic per (pack, index) and globally
+// unique across the fixture; deltas are disabled at encode time
+// so every object resolves with a single offset lookup.
+//
+// The fixture is built using only the public DotGit + go-git
+// internal APIs; no production code paths are touched.
+func makeMultiPackFixture(tb testing.TB, nPacks, objPerPack int) (billy.Filesystem, [][]plumbing.Hash) {
+	tb.Helper()
+
+	diskFS := osfs.New(tb.TempDir())
+	dg := dotgit.New(diskFS)
+	if err := dg.Initialize(); err != nil {
+		tb.Fatalf("initialize dotgit: %v", err)
+	}
+
+	perPack := make([][]plumbing.Hash, nPacks)
+	for p := range nPacks {
+		// Stage this pack's objects in an in-memory storage so the
+		// on-disk repo only ends up with packs (no stray loose
+		// objects from the staging step).
+		stage := memory.NewStorage()
+		hashes := make([]plumbing.Hash, objPerPack)
+		for i := range objPerPack {
+			o := stage.NewEncodedObject()
+			o.SetType(plumbing.BlobObject)
+			w, err := o.Writer()
+			if err != nil {
+				tb.Fatalf("object writer: %v", err)
+			}
+			// Padding ensures each object has non-trivial body so
+			// the pack has realistic per-entry overhead and the
+			// idx fanout buckets distribute reasonably.
+			content := fmt.Sprintf("pack-%d-obj-%d-%s", p, i, strings.Repeat("x", 64))
+			if _, err := w.Write([]byte(content)); err != nil {
+				tb.Fatalf("write content: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				tb.Fatalf("close writer: %v", err)
+			}
+			h, err := stage.SetEncodedObject(o)
+			if err != nil {
+				tb.Fatalf("stage object: %v", err)
+			}
+			hashes[i] = h
+		}
+		perPack[p] = hashes
+
+		// Encode the staged objects into a pack stream. window=0
+		// disables delta compression — bench fixtures want every
+		// read to resolve in a single offset lookup.
+		var buf bytes.Buffer
+		enc := packfile.NewEncoder(&buf, stage, false)
+		if _, err := enc.Encode(hashes, 0); err != nil {
+			tb.Fatalf("encode pack %d: %v", p, err)
+		}
+
+		// Stream the encoded pack into the on-disk repo via the
+		// PackWriter; this writes both the .pack and the .idx,
+		// matching what `git index-pack` produces.
+		pw, err := dg.NewObjectPack()
+		if err != nil {
+			tb.Fatalf("new object pack %d: %v", p, err)
+		}
+		if _, err := io.Copy(pw, &buf); err != nil {
+			tb.Fatalf("copy pack %d: %v", p, err)
+		}
+		if err := pw.Close(); err != nil {
+			tb.Fatalf("close pack %d: %v", p, err)
+		}
+	}
+
+	return diskFS, perPack
+}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
@@ -24,6 +25,18 @@ import (
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
+// indexSFKey is the singleflight key used by [ObjectStorage.requireIndex]
+// to coalesce concurrent first-readers around a single populateIndex
+// scan. The literal value is opaque; only its uniqueness within
+// indexSF matters.
+const indexSFKey = "populate"
+
+// reindexSFKey is the singleflight key used by [ObjectStorage.Reindex]
+// to collapse concurrent rescans. Kept distinct from indexSFKey so a
+// cold first-load and an externally-driven rescan do not deduplicate
+// against each other.
+const reindexSFKey = "reindex"
+
 // ObjectStorage implements object storage backed by the filesystem.
 type ObjectStorage struct {
 	options Options
@@ -35,6 +48,10 @@ type ObjectStorage struct {
 	dir   *dotgit.DotGit
 	index map[plumbing.Hash]idxfile.Index
 	muI   sync.RWMutex
+
+	// indexSF coalesces concurrent first-readers so populateIndex
+	// runs once per cold-load even under thundering-herd contention.
+	indexSF singleflight.Group
 
 	oh *plumbing.ObjectHasher
 
@@ -183,6 +200,11 @@ func (s *ObjectStorage) indexLoaded() bool {
 	return loaded
 }
 
+// requireIndex ensures s.index is populated, performing a cold-load
+// on first access. Concurrent first-readers are coalesced via
+// singleflight so populateIndex runs once per thundering herd; the
+// winning goroutine publishes the local map under s.muI.Lock and
+// joiners block in singleflight.Do until the in-flight call returns.
 func (s *ObjectStorage) requireIndex() error {
 	s.muI.RLock()
 	if s.index != nil {
@@ -191,54 +213,133 @@ func (s *ObjectStorage) requireIndex() error {
 	}
 	s.muI.RUnlock()
 
-	s.muI.Lock()
-	defer s.muI.Unlock()
-
-	// Re-check after upgrading to write lock: a concurrent goroutine
-	// may have built the index between our RUnlock and Lock above.
-	if s.index != nil {
-		return nil
-	}
-
-	s.index = make(map[plumbing.Hash]idxfile.Index)
-	packs, err := s.dir.ObjectPacks()
-	if err != nil {
-		return err
-	}
-
-	for _, h := range packs {
-		if err := s.loadIdxFile(h); err != nil {
-			return err
+	_, err, _ := s.indexSF.Do(indexSFKey, func() (any, error) {
+		// Re-check inside the singleflight window: a racing winner
+		// may have already published, in which case there is
+		// nothing for this caller to do.
+		s.muI.RLock()
+		if s.index != nil {
+			s.muI.RUnlock()
+			return nil, nil
 		}
-	}
+		s.muI.RUnlock()
 
-	return nil
-}
+		local, err := s.populateIndex()
+		if err != nil {
+			return nil, err
+		}
 
-// Reindex indexes again all packfiles. Useful if git changed packfiles externally
-func (s *ObjectStorage) Reindex() {
-	s.index = nil
-}
-
-func (s *ObjectStorage) loadIdxFile(h plumbing.Hash) error {
-	if s.options.UseInMemoryIdx {
-		return s.loadMemoryIndex(h)
-	}
-
-	// Use LazyIndex on a best-effort basis.
-	if idx, err := s.loadLazyIndex(h); err == nil {
-		// If an index already exists, and implements io.Closer, try to close it.
-		if i, found := s.index[h]; found && i != nil {
-			if closer, ok := i.(io.Closer); ok {
-				_ = closer.Close()
+		s.muI.Lock()
+		if s.index == nil {
+			s.index = local
+		} else {
+			// A racing winner published while we were loading.
+			// Close any indexes we built so SharedFile refcounts
+			// (held by LazyIndex) do not leak.
+			for _, idx := range local {
+				if c, ok := idx.(io.Closer); ok {
+					_ = c.Close()
+				}
 			}
 		}
+		s.muI.Unlock()
+		return nil, nil
+	})
+	return err
+}
 
-		s.index[h] = idx
-		return nil
+// Reindex re-populates s.index from disk and atomically swaps the
+// freshly-loaded map in, so the next read is a hot-cache hit.
+// Call when the on-disk pack inventory has changed externally.
+//
+// Concurrent Reindex calls coalesce through indexSF on reindexSFKey:
+// one goroutine performs populateIndex and the swap, the rest block
+// in singleflight.Do and observe the same outcome. Without this the
+// callers would each scan the disk and race to publish, producing
+// duplicate I/O.
+//
+// populateIndex runs before the swap so s.index is never nil during
+// Reindex: a concurrent PackfileWriter.Notify can rely on s.index
+// being a writable map under muI.Lock. Previously-cached LazyIndex
+// entries are not closed here; in-flight readers that borrowed an
+// entry before the swap keep using it, and the underlying
+// SharedFile FDs close via the grace timer (no-pool mode) or fdpool
+// LRU eviction (pool mode) once they fall out of use. This mirrors
+// canonical Git's reprepare model where packfile_store_reprepare
+// leaves existing packs in place and only the FD-level LRU evicts.
+func (s *ObjectStorage) Reindex() error {
+	_, err, _ := s.indexSF.Do(reindexSFKey, func() (any, error) {
+		local, err := s.populateIndex()
+		if err != nil {
+			return nil, err
+		}
+
+		s.muI.Lock()
+		s.index = local
+		s.muI.Unlock()
+
+		return nil, nil
+	})
+	return err
+}
+
+// populateIndex loads every pack's idx in parallel and returns the
+// resulting map. The caller is responsible for publishing the map
+// into s.index under s.muI.Lock; populateIndex itself takes no
+// locks on s.muI, so callers must not hold it while invoking.
+func (s *ObjectStorage) populateIndex() (map[plumbing.Hash]idxfile.Index, error) {
+	packs, err := s.dir.ObjectPacks()
+	if err != nil {
+		return nil, err
 	}
 
-	return s.loadMemoryIndex(h)
+	var (
+		mu    sync.Mutex
+		local = make(map[plumbing.Hash]idxfile.Index, len(packs))
+	)
+
+	g := new(errgroup.Group)
+	g.SetLimit(runtime.GOMAXPROCS(0))
+
+	for _, h := range packs {
+		g.Go(func() error {
+			idx, err := s.loadIdx(h)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			local[h] = idx
+			mu.Unlock()
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		// Best-effort cleanup of indexes that did finish before
+		// the failing one: close any that hold descriptors so we
+		// do not leak SharedFile refcounts on the error path.
+		for _, idx := range local {
+			if c, ok := idx.(io.Closer); ok {
+				_ = c.Close()
+			}
+		}
+		return nil, err
+	}
+	return local, nil
+}
+
+// loadIdx loads a single pack's idx and returns the constructed
+// idxfile.Index. It does not mutate s.index; callers are
+// responsible for installation.
+func (s *ObjectStorage) loadIdx(h plumbing.Hash) (idxfile.Index, error) {
+	if !s.options.UseInMemoryIdx {
+		// Use LazyIndex on a best-effort basis; fall through to
+		// MemoryIndex if construction fails (e.g. a malformed
+		// .rev file), matching the legacy loadIdxFile path.
+		if idx, err := s.loadLazyIndex(h); err == nil {
+			return idx, nil
+		}
+	}
+	return s.loadMemoryIndexValue(h)
 }
 
 func (s *ObjectStorage) loadLazyIndex(h plumbing.Hash) (*idxfile.LazyIndex, error) {
@@ -252,10 +353,13 @@ func (s *ObjectStorage) loadLazyIndex(h plumbing.Hash) (*idxfile.LazyIndex, erro
 	return idxfile.NewLazyIndex(openIdx, openRev, h)
 }
 
-func (s *ObjectStorage) loadMemoryIndex(h plumbing.Hash) (err error) {
+// loadMemoryIndexValue decodes a pack's idx into a MemoryIndex and
+// returns it. Unlike the now-removed loadMemoryIndex helper it does
+// not write into s.index; the caller installs the returned value.
+func (s *ObjectStorage) loadMemoryIndexValue(h plumbing.Hash) (idx idxfile.Index, err error) {
 	f, err := s.dir.ObjectPackIdx(h)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer ioutil.CheckClose(f, &err)
@@ -270,16 +374,15 @@ func (s *ObjectStorage) loadMemoryIndex(h plumbing.Hash) (err error) {
 	idxf := idxfile.NewMemoryIndex(h.Size())
 	d := idxfile.NewDecoder(f, hasher)
 	if err = d.Decode(idxf); err != nil {
-		return err
+		return nil, err
 	}
 
 	if idxf.PackfileChecksum != h {
-		return fmt.Errorf("%w: packfile mismatch: target is %q not %q",
+		return nil, fmt.Errorf("%w: packfile mismatch: target is %q not %q",
 			idxfile.ErrMalformedIdxFile, idxf.PackfileChecksum.String(), h.String())
 	}
 
-	s.index[h] = idxf
-	return err
+	return idxf, err
 }
 
 // RawObjectWriter returns a writer for a new loose object of the given type and size.

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -315,9 +315,12 @@ func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
 
 	w.Notify = func(h plumbing.Hash, writer *idxfile.Writer) {
 		index, err := writer.Index()
-		if err == nil {
-			s.index[h] = index
+		if err != nil {
+			return
 		}
+		s.muI.Lock()
+		s.index[h] = index
+		s.muI.Unlock()
 	}
 
 	return w, nil

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -350,7 +350,7 @@ func (s *ObjectStorage) loadLazyIndex(h plumbing.Hash) (*idxfile.LazyIndex, erro
 		return s.dir.OpenPackRev(h)
 	}
 
-	return idxfile.NewLazyIndex(openIdx, openRev, h)
+	return idxfile.NewLazyIndexWithPool(openIdx, openRev, h, s.options.Pool)
 }
 
 // loadMemoryIndexValue decodes a pack's idx into a MemoryIndex and

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -808,7 +808,20 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
-	for _, index := range s.index {
+	// Snapshot the index map under muI.RLock so the iteration
+	// below is safe against a concurrent Reindex swap or a
+	// PackfileWriter.Notify insert. The borrowed LazyIndex values
+	// stay alive for the duration of the loop via this slice; the
+	// underlying SharedFile FDs are governed by their refcount and
+	// the fdpool, not by removal from s.index.
+	s.muI.RLock()
+	indexes := make([]idxfile.Index, 0, len(s.index))
+	for _, idx := range s.index {
+		indexes = append(indexes, idx)
+	}
+	s.muI.RUnlock()
+
+	for _, index := range indexes {
 		ei, err := index.Entries()
 		if err != nil {
 			return nil, err

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -444,7 +444,10 @@ func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (size int
 		return 0, plumbing.ErrObjectNotFound
 	}
 
+	s.muI.RLock()
 	idx := s.index[pack]
+	s.muI.RUnlock()
+
 	hash, err := idx.FindHash(offset)
 	if err == nil {
 		obj, ok := s.objectCache.Get(hash)
@@ -791,8 +794,11 @@ func (s *ObjectStorage) buildPackfileIters(
 			if err != nil {
 				return nil, err
 			}
+			s.muI.RLock()
+			idx := s.index[h]
+			s.muI.RUnlock()
 			return newPackfileIter(
-				s.dir.Fs(), pack, t, seen, s.index[h],
+				s.dir.Fs(), pack, t, seen, idx,
 				s.objectCache, false, h.Size(),
 			)
 		},

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -16,13 +16,15 @@ import (
 	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
-// BenchmarkAlternatesObjectLookup measures object lookup performance when using
-// alternates. This benchmark tests the improvement from caching alternate
-// ObjectStorage instances.
+// BenchmarkAlternatesObjectLookup measures object lookup performance
+// when using alternates. Setup mirrors what PlainClone(Shared:true)
+// produces in the public API: a work .git that points at a template
+// via objects/info/alternates. We can't call PlainClone here due to
+// an import cycle (repository.go imports storage/filesystem), so we
+// build the alternate manually and construct a Storage via
+// NewStorageWithOptions — the same path PlainClone takes. This is
+// what wires the FD pool through to the alternate's PackHandles.
 func BenchmarkAlternatesObjectLookup(b *testing.B) {
-	// Setup: Create a shared clone using alternates
-	// Note: We can't use PlainClone with Shared:true here due to import cycle
-	// (repository.go imports storage/filesystem), so we set up alternates manually.
 	baseDir := b.TempDir()
 
 	templateFs, err := fixtures.Basic().ByTag(".git").One().DotGit(
@@ -46,9 +48,9 @@ func BenchmarkAlternatesObjectLookup(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	dg := dotgit.NewWithOptions(workFs, dotgit.Options{AlternatesFS: rootFs})
-	storage := NewObjectStorage(dg, cache.NewObjectLRUDefault())
-	b.Cleanup(func() { storage.Close() })
+	storage := NewStorageWithOptions(workFs, cache.NewObjectLRUDefault(),
+		Options{AlternatesFS: rootFs})
+	b.Cleanup(func() { _ = storage.Close() })
 
 	commitHashes := []plumbing.Hash{
 		plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
+	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
 // BenchmarkAlternatesObjectLookup measures object lookup performance when using
@@ -337,4 +338,211 @@ func BenchmarkObjectStorage_ReindexThenRead(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+// BenchmarkObjectStorage_ParallelReads measures concurrent
+// EncodedObject throughput. The packed read path takes muI as
+// RLock so independent goroutines do not serialise on the lock.
+// Run with -cpu=1,2,4,8 to see the throughput curve scale.
+func BenchmarkObjectStorage_ParallelReads(b *testing.B) {
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	b.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	if err != nil {
+		b.Fatal(err)
+	}
+	var hashes []plumbing.Hash
+	for range 32 {
+		obj, err := iter.Next()
+		if err != nil {
+			break
+		}
+		hashes = append(hashes, obj.Hash())
+	}
+	iter.Close()
+	if len(hashes) == 0 {
+		b.Fatal("fixture must have objects")
+	}
+
+	if _, err := s.EncodedObject(plumbing.AnyObject, hashes[0]); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		var i int64
+		for pb.Next() {
+			h := hashes[i%int64(len(hashes))]
+			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+}
+
+// BenchmarkStorage_PoolPressure measures end-to-end read latency
+// at two pool capacities. DefaultCapacity holds every fixture FD
+// warm; CapacityOne is the worst-case shape where pack, idx, and
+// rev sharedFiles all contend for one LRU slot and FDs reopen on
+// every read.
+//
+// The basic fixture is small enough that the object cache may
+// serve hot reads without touching the FD layer; for a precise
+// FD-churn measurement use a larger fixture or invalidate the
+// cache between iterations.
+// BenchmarkStorage_PoolPressure measures the FD-pool's effect on
+// read latency across two regimes. A 32-pack fixture is read with
+// a working set wide enough that the object cache cannot serve the
+// hot loop: the bench uses cache.NewObjectLRU(0) so every read
+// traverses the index and pack FD layers. Each sub-benchmark
+// injects its own [*fdpool.Pool] and asserts against
+// [fdpool.Stats.Evictions] at end-of-bench, guarding against
+// silent regressions where the expected pool behaviour stops
+// happening.
+//
+//	NoChurn  cap = 256, fixture FDs (~96) fit comfortably
+//	Churn    cap =   8, every Touch evicts a member
+//
+// Comparing the two sub-benchmarks isolates the eviction +
+// reopen tax. The bench fails loud if Churn does not actually
+// evict, or NoChurn unexpectedly does — keeping the bench honest
+// across future code paths.
+func BenchmarkStorage_PoolPressure(b *testing.B) {
+	const (
+		nPacks     = 32
+		objPerPack = 8
+	)
+	diskFS, perPack := makeMultiPackFixture(b, nPacks, objPerPack)
+
+	// Flatten into a working set spanning every pack so reads cycle
+	// across all FDs and the pool's eviction policy is exercised
+	// uniformly rather than against a hot subset.
+	var hashes []plumbing.Hash
+	for _, p := range perPack {
+		hashes = append(hashes, p...)
+	}
+
+	run := func(b *testing.B, capacity int, wantChurn bool) {
+		pool := fdpool.New(capacity)
+		s := NewStorageWithOptions(diskFS, cache.NewObjectLRU(0), Options{
+			Pool: pool,
+		})
+		b.Cleanup(func() { _ = s.Close() })
+
+		// Warm-up: ensure every pack's idx + rev is loaded into
+		// s.index so the timed loop is not paying a cold populate
+		// on iteration 1.
+		for _, h := range hashes {
+			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+				b.Fatal(err)
+			}
+		}
+		startEvictions := pool.Stats().Evictions
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		var i int
+		for b.Loop() {
+			h := hashes[i%len(hashes)]
+			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+		b.StopTimer()
+
+		gotEvictions := pool.Stats().Evictions - startEvictions
+		switch {
+		case wantChurn && gotEvictions == 0:
+			b.Fatalf("cap=%d ws=%d: expected pool churn, observed 0 evictions; "+
+				"bench no longer exercises the pool", capacity, len(hashes))
+		case !wantChurn && gotEvictions > 0:
+			b.Fatalf("cap=%d ws=%d: expected steady-state, observed %d evictions; "+
+				"working set should fit in pool", capacity, len(hashes), gotEvictions)
+		}
+	}
+
+	b.Run("NoChurn", func(b *testing.B) { run(b, 256, false) })
+	b.Run("Churn", func(b *testing.B) { run(b, 8, true) })
+}
+
+// BenchmarkStorage_PackHandleCacheContention exercises the
+// [dotgit.DotGit] packHandlesMu by running NumCPU goroutines
+// against a 32-pack fixture, with each goroutine cycling through
+// every pack so independent reads still meet on the cache lock.
+// The pool is sized generously so FD churn does not mask the
+// lookup-mutex cost. Compared against
+// `BenchmarkStorage_PackHandleCacheContention/Serial`, the
+// per-iteration delta is the contended-mutex overhead a sharded
+// cache would aim to remove.
+//
+// Run with `-cpu=1,2,4,8` to see how the contended path scales —
+// if the parallel curve flattens early, packHandlesMu is the
+// bottleneck and sharding the map is worth pursuing.
+func BenchmarkStorage_PackHandleCacheContention(b *testing.B) {
+	const (
+		nPacks     = 32
+		objPerPack = 8
+	)
+	diskFS, perPack := makeMultiPackFixture(b, nPacks, objPerPack)
+
+	hashes := make([]plumbing.Hash, 0, nPacks*objPerPack)
+	for _, p := range perPack {
+		hashes = append(hashes, p...)
+	}
+
+	newStorage := func(b *testing.B) *Storage {
+		b.Helper()
+		s := NewStorageWithOptions(diskFS, cache.NewObjectLRU(0), Options{
+			Pool: fdpool.New(256),
+		})
+		b.Cleanup(func() { _ = s.Close() })
+
+		// Warm-up: populate the dotgit packHandles map and every
+		// LazyIndex so the timed loop measures only the cache
+		// lookup + read, not first-touch index loads.
+		for _, h := range hashes {
+			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+				b.Fatal(err)
+			}
+		}
+		return s
+	}
+
+	b.Run("Serial", func(b *testing.B) {
+		s := newStorage(b)
+		b.ReportAllocs()
+		b.ResetTimer()
+		var i int
+		for b.Loop() {
+			h := hashes[i%len(hashes)]
+			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+
+	b.Run("Parallel", func(b *testing.B) {
+		s := newStorage(b)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			var i int
+			for pb.Next() {
+				h := hashes[i%len(hashes)]
+				if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+					b.Fatal(err)
+				}
+				i++
+			}
+		})
+	})
 }

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -266,3 +266,75 @@ func benchWarmPack(b *testing.B, fs billy.Filesystem) {
 		return // warm the first pack only
 	}
 }
+
+// BenchmarkObjectStorage_ColdEncodedObject measures end-to-end
+// first-read latency on a freshly-constructed Storage against a
+// multi-pack fixture. Each iteration pays the populateIndex
+// cold-load (which loads every pack's idx in parallel via
+// errgroup) plus the per-object decode for a single read.
+//
+// Storage construction is in the timed window because b.Loop
+// forbids stopping the timer at iteration boundaries; the cost
+// is bounded (a struct alloc + dotgit pointer setup, no I/O) and
+// the multi-pack fixture ensures populateIndex is the dominant
+// per-iteration cost rather than the decode.
+//
+// The parallel-vs-serial populateIndex win is a property of the
+// code (errgroup.SetLimit(GOMAXPROCS)) — to quantify it use
+// benchstat against a baseline recording on main; in-bench -cpu
+// scaling is masked by the per-iteration decode cost.
+func BenchmarkObjectStorage_ColdEncodedObject(b *testing.B) {
+	const (
+		nPacks     = 32
+		objPerPack = 8
+	)
+	diskFS, perPack := makeMultiPackFixture(b, nPacks, objPerPack)
+
+	// Pick a hash from the last pack so the lookup actually
+	// iterates s.packs rather than hitting whichever pack happens
+	// to be first in the (randomised) map iteration order.
+	target := perPack[nPacks-1][0]
+
+	b.ReportAllocs()
+	for b.Loop() {
+		s := NewStorage(diskFS, cache.NewObjectLRUDefault())
+		if _, err := s.EncodedObject(plumbing.AnyObject, target); err != nil {
+			b.Fatal(err)
+		}
+		_ = s.Close()
+	}
+}
+
+// BenchmarkObjectStorage_ReindexThenRead measures Reindex + read.
+// Pre-fix: Reindex returns fast but the next read pays the cold
+// bootstrap. Post-fix: Reindex pre-warms s.index synchronously so
+// the next read is hot.
+func BenchmarkObjectStorage_ReindexThenRead(b *testing.B) {
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	b.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	if err != nil {
+		b.Fatal(err)
+	}
+	obj, err := iter.Next()
+	iter.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := s.Reindex(); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := s.EncodedObject(plumbing.AnyObject, obj.Hash()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -982,3 +982,148 @@ func TestObjectStorageCloseIdleDescriptors(t *testing.T) {
 			"no read or release should fail under concurrent load")
 	})
 }
+
+// TestObjectStorage_PopulateIndex_FirstReadHotMap asserts that the
+// first observable read leaves s.index populated, i.e. requireIndex
+// publishes the local map into the shared field under the lock.
+func TestObjectStorage_PopulateIndex_FirstReadHotMap(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	obj, err := iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+
+	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	require.NoError(t, err)
+
+	s.muI.RLock()
+	defer s.muI.RUnlock()
+	assert.NotNil(t, s.index, "first read should publish s.index")
+	assert.NotEmpty(t, s.index, "fixture must contribute at least one pack")
+}
+
+// TestObjectStorage_ReindexPrewarms verifies that Reindex leaves
+// s.index in a hot, non-nil state so the next read does not pay a
+// cold-load. The pre-Phase-3 implementation niled s.index and
+// deferred reload to the next read.
+func TestObjectStorage_ReindexPrewarms(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	obj, err := iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+
+	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	require.NoError(t, err)
+
+	require.NoError(t, s.Reindex())
+
+	// Reindex must synchronously re-populate s.index.
+	s.muI.RLock()
+	idxPopulated := len(s.index) > 0
+	s.muI.RUnlock()
+	assert.True(t, idxPopulated,
+		"Reindex should leave s.index pre-warmed for the next read")
+
+	// And the next read should still succeed.
+	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	require.NoError(t, err)
+}
+
+// TestObjectStorage_ConcurrentReindex_NoRace runs many concurrent
+// Reindex calls against the same Storage and asserts that the
+// singleflight wrapper keeps the operation safe: every call returns
+// nil, s.index stays non-empty and consistent throughout, and reads
+// after the herd still succeed. Without singleflight the goroutines
+// would each populate independently and race on the map swap,
+// producing duplicate disk I/O and a window where a reader could
+// observe a partially-published map.
+func TestObjectStorage_ConcurrentReindex_NoRace(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Pre-warm so a concurrent reader can RLock muI without first
+	// racing requireIndex against the Reindex herd.
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	obj, err := iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+	h := obj.Hash()
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			assert.NoError(t, s.Reindex())
+		})
+	}
+	// A few readers in parallel exercise the muI.RLock fast-path
+	// during the Reindex herd.
+	for range 8 {
+		wg.Go(func() {
+			_, err := s.EncodedObject(plumbing.AnyObject, h)
+			assert.NoError(t, err)
+		})
+	}
+	wg.Wait()
+
+	s.muI.RLock()
+	assert.NotEmpty(t, s.index, "after the Reindex herd s.index must be populated")
+	s.muI.RUnlock()
+
+	_, err = s.EncodedObject(plumbing.AnyObject, h)
+	require.NoError(t, err, "reads after the Reindex herd must still succeed")
+}
+
+// TestObjectStorage_ConcurrentEncodedObject_NoRace slams many
+// goroutines at the same storage and verifies the read path is
+// race-free under -race. The map is pre-warmed by IterEncodedObjects
+// before the herd, so the herd exercises the RLock fast-path of
+// requireIndex (singleflight coalescing is exercised separately by
+// the cold-load benchmark).
+func TestObjectStorage_ConcurrentEncodedObject_NoRace(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	obj, err := iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+	h := obj.Hash()
+
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			_, err := s.EncodedObject(plumbing.AnyObject, h)
+			assert.NoError(t, err)
+		})
+	}
+	wg.Wait()
+
+	s.muI.RLock()
+	defer s.muI.RUnlock()
+	assert.NotNil(t, s.index, "after the herd s.index must be populated")
+}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -16,10 +16,10 @@ import (
 	"github.com/go-git/go-git/v6/x/fdpool"
 )
 
-// defaultMaxOpenDescriptors is the FD pool capacity selected when
-// [Options.MaxOpenDescriptors] is zero. It accommodates roughly 85
-// concurrently-hot packs (3 FDs per pack: pack + idx + rev).
-const defaultMaxOpenDescriptors = 256
+// defaultPoolCapacity is the FD pool capacity selected when
+// [Options.Pool] is nil. It accommodates roughly 85 concurrently-hot
+// packs (3 FDs per pack: pack + idx + rev).
+const defaultPoolCapacity = 256
 
 // Storage is an implementation of git.Storer that stores data on disk in the
 // standard git format (this is, the .git directory). Zero values of this type
@@ -54,38 +54,6 @@ type Options struct {
 	// ExclusiveAccess means that the filesystem is not modified externally
 	// while the repo is open.
 	ExclusiveAccess bool
-	// MaxOpenDescriptors is the capacity of the storage-wide LRU FD
-	// pool. The pool bounds the read-side .pack/.idx/.rev file
-	// descriptors across the entire Storage. When a Storage exceeds
-	// this capacity, the least-recently-used `sharedFile`'s FD is
-	// closed (via `sharedFile.ReleaseNow`) and reopens on the next
-	// read. Pack-write FDs ([PackWriter]) are short-lived and not
-	// pooled.
-	//
-	// Zero (the default) selects [defaultMaxOpenDescriptors] (256),
-	// which accommodates roughly 85 concurrently-hot packs (3 FDs
-	// per pack: pack + idx + rev). The 256 default assumes go-git
-	// is responsible for the dominant share of FDs in the process;
-	// applications running other FD-heavy subsystems (network
-	// servers, large connection pools) should size this against
-	// their full FD budget rather than rely on the default.
-	// Negative values disable pooling: pool-less sharedFiles fall
-	// back to their grace-period close on quiescence.
-	//
-	// The field name is reused from a pre-v6 option that capped
-	// concurrently-open packs without an eviction policy; the v6
-	// pool governs the same FD-budget concern with LRU eviction
-	// across all .pack/.idx/.rev descriptors. The v5
-	// KeepDescriptors flag (which pinned every pack FD open) is
-	// removed; callers migrating from it can leave this field at
-	// zero for the LRU default.
-	//
-	// To request mmap-backed read FDs (read-only, where the
-	// platform supports it) construct the underlying billy
-	// filesystem with [github.com/go-git/go-billy/v6/osfs.WithMmap]
-	// before handing it to [NewStorageWithOptions]. The pool
-	// governs that file equally whether it is FD- or mmap-backed.
-	MaxOpenDescriptors int
 	// LargeObjectThreshold maximum object size (in bytes) that will be read in to memory.
 	// If left unset or set to 0 there is no limit
 	LargeObjectThreshold int64
@@ -113,24 +81,44 @@ type Options struct {
 	// If left as nil, a default stat-based implementation is created automatically.
 	IndexCache IndexCache
 
-	// Pool, when non-nil, replaces the per-Storage FD pool that
-	// NewStorageWithOptions would otherwise construct. Multiple
-	// Storages sharing a pool share a single bounded FD budget
-	// across the process — useful when a single process opens
-	// many Storages and wants the FD budget bounded process-wide
-	// rather than per Storage (servers handling concurrent
-	// requests, batch tools iterating many repositories, etc.).
-	// When non-nil, MaxOpenDescriptors is ignored (the shared
-	// pool's existing capacity governs).
+	// Pool governs LRU eviction of the read-side .pack/.idx/.rev
+	// file descriptors that this Storage opens. When a Storage
+	// exceeds the pool capacity the least-recently-used SharedFile
+	// is closed (via ReleaseNow) and reopens on the next read.
+	// Pack-write FDs ([PackWriter]) are short-lived and are not
+	// pooled.
 	//
-	// To share a pool across Storage instances, construct the
-	// pool explicitly and pass it via this field to
+	// A nil Pool selects a per-Storage pool sized at the package
+	// default (currently 256 entries, accommodating roughly 85
+	// concurrently-hot packs at 3 FDs per pack). The default
+	// assumes go-git owns the dominant share of FDs in the
+	// process; applications running other FD-heavy subsystems
+	// (network servers, large connection pools) should construct
+	// a pool sized against their full FD budget and pass it here
+	// rather than rely on the default.
+	//
+	// Sharing one Pool across multiple Storages bounds the FD
+	// budget process-wide rather than per Storage — useful for
+	// servers handling concurrent per-request repositories or
+	// batch tools iterating many repos. Construct the pool with
+	// [fdpool.New], pass it via this field to
 	// [NewStorageWithOptions], then open repositories with
 	// [git.Open], [git.Clone], or [git.Init] using the resulting
 	// Storer. The path-based wrappers (all Plain* functions:
 	// PlainOpen, PlainClone, PlainInit) construct their own
 	// Storage internally and so do not accept an injected pool;
 	// that is by design.
+	//
+	// To disable pooling, pass [fdpool.New](0) (or any non-positive
+	// capacity): the resulting no-op Pool causes pool-less
+	// SharedFiles to fall back to their grace-period close on
+	// quiescence.
+	//
+	// To request mmap-backed read FDs (read-only, where the
+	// platform supports it) construct the underlying billy
+	// filesystem with [github.com/go-git/go-billy/v6/osfs.WithMmap]
+	// before handing it to [NewStorageWithOptions]. The pool
+	// governs that file equally whether it is FD- or mmap-backed.
 	//
 	// The Pool field's API stability tracks [fdpool.Pool]'s, not
 	// this package's. Per the x/ package policy, the fdpool API
@@ -170,18 +158,12 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 
 	hasher := plumbing.NewHasher(ops.ObjectFormat, plumbing.AnyObject, 0)
 
-	// Construct the FD pool unless the caller injected one. Zero
-	// MaxOpenDescriptors selects the default capacity; negative
-	// capacity yields a no-op pool whose Touch and Forget are
-	// no-ops, so pool-less sharedFiles fall back to their grace
-	// timer on quiescence.
+	// Construct a per-Storage FD pool at the package default
+	// capacity unless the caller injected one. Pass a non-positive-
+	// capacity Pool via Options.Pool to disable pooling.
 	pool := ops.Pool
 	if pool == nil {
-		poolCap := ops.MaxOpenDescriptors
-		if poolCap == 0 {
-			poolCap = defaultMaxOpenDescriptors
-		}
-		pool = fdpool.New(poolCap)
+		pool = fdpool.New(defaultPoolCapacity)
 	}
 
 	dirOps := dotgit.Options{

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -55,17 +55,36 @@ type Options struct {
 	// while the repo is open.
 	ExclusiveAccess bool
 	// MaxOpenDescriptors is the capacity of the storage-wide LRU FD
-	// pool. The pool bounds the number of open .pack/.idx/.rev file
+	// pool. The pool bounds the read-side .pack/.idx/.rev file
 	// descriptors across the entire Storage. When a Storage exceeds
-	// this capacity, the least-recently-used [sharedFile]'s FD is
-	// closed (via [sharedFile.ReleaseNow]) and reopens on the next
-	// read.
+	// this capacity, the least-recently-used `sharedFile`'s FD is
+	// closed (via `sharedFile.ReleaseNow`) and reopens on the next
+	// read. Pack-write FDs ([PackWriter]) are short-lived and not
+	// pooled.
 	//
 	// Zero (the default) selects [defaultMaxOpenDescriptors] (256),
 	// which accommodates roughly 85 concurrently-hot packs (3 FDs
-	// per pack: pack + idx + rev). Negative values disable pooling:
-	// pool-less sharedFiles fall back to their grace-period close
-	// on quiescence.
+	// per pack: pack + idx + rev). The 256 default assumes go-git
+	// is responsible for the dominant share of FDs in the process;
+	// applications running other FD-heavy subsystems (network
+	// servers, large connection pools) should size this against
+	// their full FD budget rather than rely on the default.
+	// Negative values disable pooling: pool-less sharedFiles fall
+	// back to their grace-period close on quiescence.
+	//
+	// The field name is reused from a pre-v6 option that capped
+	// concurrently-open packs without an eviction policy; the v6
+	// pool governs the same FD-budget concern with LRU eviction
+	// across all .pack/.idx/.rev descriptors. The v5
+	// KeepDescriptors flag (which pinned every pack FD open) is
+	// removed; callers migrating from it can leave this field at
+	// zero for the LRU default.
+	//
+	// To request mmap-backed read FDs (read-only, where the
+	// platform supports it) construct the underlying billy
+	// filesystem with [github.com/go-git/go-billy/v6/osfs.WithMmap]
+	// before handing it to [NewStorageWithOptions]. The pool
+	// governs that file equally whether it is FD- or mmap-backed.
 	MaxOpenDescriptors int
 	// LargeObjectThreshold maximum object size (in bytes) that will be read in to memory.
 	// If left unset or set to 0 there is no limit
@@ -97,10 +116,27 @@ type Options struct {
 	// Pool, when non-nil, replaces the per-Storage FD pool that
 	// NewStorageWithOptions would otherwise construct. Multiple
 	// Storages sharing a pool share a single bounded FD budget
-	// across the process — useful for GitOps controllers and
-	// other applications that spawn many short-lived Storages
-	// concurrently. When non-nil, MaxOpenDescriptors is ignored
-	// (the shared pool's existing capacity governs).
+	// across the process — useful when a single process opens
+	// many Storages and wants the FD budget bounded process-wide
+	// rather than per Storage (servers handling concurrent
+	// requests, batch tools iterating many repositories, etc.).
+	// When non-nil, MaxOpenDescriptors is ignored (the shared
+	// pool's existing capacity governs).
+	//
+	// To share a pool across Storage instances, construct the
+	// pool explicitly and pass it via this field to
+	// [NewStorageWithOptions], then open repositories with
+	// [git.Open], [git.Clone], or [git.Init] using the resulting
+	// Storer. The path-based wrappers (all Plain* functions:
+	// PlainOpen, PlainClone, PlainInit) construct their own
+	// Storage internally and so do not accept an injected pool;
+	// that is by design.
+	//
+	// The Pool field's API stability tracks [fdpool.Pool]'s, not
+	// this package's. Per the x/ package policy, the fdpool API
+	// may change without following semantic versioning; consumers
+	// reading this field should treat it as experimental on the
+	// same timeline.
 	Pool *fdpool.Pool
 }
 

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -13,7 +13,13 @@ import (
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
+	"github.com/go-git/go-git/v6/x/fdpool"
 )
+
+// defaultMaxOpenDescriptors is the FD pool capacity selected when
+// [Options.MaxOpenDescriptors] is zero. It accommodates roughly 85
+// concurrently-hot packs (3 FDs per pack: pack + idx + rev).
+const defaultMaxOpenDescriptors = 256
 
 // Storage is an implementation of git.Storer that stores data on disk in the
 // standard git format (this is, the .git directory). Zero values of this type
@@ -48,6 +54,19 @@ type Options struct {
 	// ExclusiveAccess means that the filesystem is not modified externally
 	// while the repo is open.
 	ExclusiveAccess bool
+	// MaxOpenDescriptors is the capacity of the storage-wide LRU FD
+	// pool. The pool bounds the number of open .pack/.idx/.rev file
+	// descriptors across the entire Storage. When a Storage exceeds
+	// this capacity, the least-recently-used [sharedFile]'s FD is
+	// closed (via [sharedFile.ReleaseNow]) and reopens on the next
+	// read.
+	//
+	// Zero (the default) selects [defaultMaxOpenDescriptors] (256),
+	// which accommodates roughly 85 concurrently-hot packs (3 FDs
+	// per pack: pack + idx + rev). Negative values disable pooling:
+	// pool-less sharedFiles fall back to their grace-period close
+	// on quiescence.
+	MaxOpenDescriptors int
 	// LargeObjectThreshold maximum object size (in bytes) that will be read in to memory.
 	// If left unset or set to 0 there is no limit
 	LargeObjectThreshold int64
@@ -74,6 +93,15 @@ type Options struct {
 	// IndexCache provides an optional cache implementation for index data.
 	// If left as nil, a default stat-based implementation is created automatically.
 	IndexCache IndexCache
+
+	// Pool, when non-nil, replaces the per-Storage FD pool that
+	// NewStorageWithOptions would otherwise construct. Multiple
+	// Storages sharing a pool share a single bounded FD budget
+	// across the process — useful for GitOps controllers and
+	// other applications that spawn many short-lived Storages
+	// concurrently. When non-nil, MaxOpenDescriptors is ignored
+	// (the shared pool's existing capacity governs).
+	Pool *fdpool.Pool
 }
 
 // NewStorage returns a new Storage backed by a given `fs.Filesystem` and cache.
@@ -106,12 +134,27 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 
 	hasher := plumbing.NewHasher(ops.ObjectFormat, plumbing.AnyObject, 0)
 
+	// Construct the FD pool unless the caller injected one. Zero
+	// MaxOpenDescriptors selects the default capacity; negative
+	// capacity yields a no-op pool whose Touch and Forget are
+	// no-ops, so pool-less sharedFiles fall back to their grace
+	// timer on quiescence.
+	pool := ops.Pool
+	if pool == nil {
+		poolCap := ops.MaxOpenDescriptors
+		if poolCap == 0 {
+			poolCap = defaultMaxOpenDescriptors
+		}
+		pool = fdpool.New(poolCap)
+	}
+
 	dirOps := dotgit.Options{
 		ExclusiveAccess:   ops.ExclusiveAccess,
 		AlternatesFS:      ops.AlternatesFS,
 		ObjectFormat:      ops.ObjectFormat,
 		ReadReverseIndex:  readRevIdx,
 		WriteReverseIndex: writeRevIdx,
+		Pool:              pool,
 	}
 	dir := dotgit.NewWithOptions(fs, dirOps)
 

--- a/storage/filesystem/storage_pool_test.go
+++ b/storage/filesystem/storage_pool_test.go
@@ -133,16 +133,17 @@ func TestStorage_FDPool_SharedAcrossStorages(t *testing.T) {
 		"shared pool should track FDs across all storages")
 }
 
-// TestStorage_FDPool_Disabled verifies negative MaxOpenDescriptors
-// yields a working Storage: pool-less sharedFiles fall back to the
-// grace-period close on quiescence, reads still succeed.
+// TestStorage_FDPool_Disabled verifies that injecting a no-op Pool
+// (capacity <= 0) yields a working Storage: pool-less SharedFiles
+// fall back to the grace-period close on quiescence, reads still
+// succeed.
 func TestStorage_FDPool_Disabled(t *testing.T) {
 	t.Parallel()
 	fixture := fixtures.Basic().One()
 	dir, err := fixture.DotGit()
 	require.NoError(t, err)
 	s := filesystem.NewStorageWithOptions(dir, cache.NewObjectLRUDefault(),
-		filesystem.Options{MaxOpenDescriptors: -1})
+		filesystem.Options{Pool: fdpool.New(0)})
 	t.Cleanup(func() { _ = s.Close() })
 
 	iter, err := s.IterEncodedObjects(plumbing.AnyObject)

--- a/storage/filesystem/storage_pool_test.go
+++ b/storage/filesystem/storage_pool_test.go
@@ -1,0 +1,152 @@
+package filesystem_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/x/fdpool"
+)
+
+// TestStorage_FDPool_PoolIsUsed verifies that an injected pool is
+// wired through to PackHandle SharedFiles. After a read the pool's
+// Active count must be > 0.
+func TestStorage_FDPool_PoolIsUsed(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+
+	pool := fdpool.New(256)
+	s := filesystem.NewStorageWithOptions(dir, cache.NewObjectLRUDefault(),
+		filesystem.Options{Pool: pool})
+	t.Cleanup(func() { _ = s.Close() })
+
+	assert.Equal(t, 0, pool.Stats().Active)
+
+	// Trigger a read; this opens at least the .pack and .idx.
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	obj, err := iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	require.NoError(t, err)
+
+	assert.Greater(t, pool.Stats().Active, 0,
+		"after a read, pool should have active SharedFiles")
+}
+
+// TestStorage_FDPool_AlternatesShareParentPool verifies that when a
+// Storage has alternates, the alternate DotGit's PackHandles register
+// with the parent's FD pool, so the storage-wide FD budget covers
+// the whole repo plus its alternates rather than just the primary.
+func TestStorage_FDPool_AlternatesShareParentPool(t *testing.T) {
+	t.Parallel()
+
+	// Set up: a primary work .git that points at a template via the
+	// alternates file. Mirrors the BenchmarkAlternatesObjectLookup
+	// pattern, but exercises the Storage construction path so the
+	// pool is wired.
+	baseDir := t.TempDir()
+	templateFs, err := fixtures.Basic().ByTag(".git").One().DotGit(
+		fixtures.WithTargetDir(func() string { return baseDir }))
+	require.NoError(t, err)
+
+	workDotGit := filepath.Join(baseDir, "work", ".git")
+	alternatesDir := filepath.Join(workDotGit, "objects", "info")
+	require.NoError(t, os.MkdirAll(alternatesDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(alternatesDir, "alternates"),
+		[]byte(templateFs.Root()+"/objects\n"),
+		0o644,
+	))
+
+	rootFs := osfs.New(baseDir)
+	workFs, err := rootFs.Chroot(filepath.Join("work", ".git"))
+	require.NoError(t, err)
+
+	pool := fdpool.New(256)
+	s := filesystem.NewStorageWithOptions(workFs, cache.NewObjectLRUDefault(),
+		filesystem.Options{AlternatesFS: rootFs, Pool: pool})
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Force a lookup that misses on the (empty) primary and falls
+	// through to the alternate.
+	probe := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	_, err = s.EncodedObject(plumbing.AnyObject, probe)
+	require.NoError(t, err)
+
+	// The alternate's PackHandle SharedFiles registered with our
+	// pool, so Active reflects the alternate FDs even though the
+	// primary itself has no packs.
+	assert.Greater(t, pool.Stats().Active, 0,
+		"alternate's SharedFiles must register with the parent pool")
+}
+
+// TestStorage_FDPool_SharedAcrossStorages verifies that callers
+// can inject one *fdpool.Pool into multiple Storages so the FD
+// budget is bounded process-wide rather than per-Storage. This
+// is the pattern GitOps controllers (e.g. Flux) need when they
+// spawn many short-lived Storages concurrently.
+func TestStorage_FDPool_SharedAcrossStorages(t *testing.T) {
+	t.Parallel()
+
+	shared := fdpool.New(128)
+
+	for i := range 3 {
+		fixture := fixtures.Basic().One()
+		dir, err := fixture.DotGit()
+		require.NoError(t, err)
+		s := filesystem.NewStorageWithOptions(dir, cache.NewObjectLRUDefault(),
+			filesystem.Options{Pool: shared})
+
+		// Trigger a read so the storage registers its SharedFiles
+		// in the shared pool.
+		iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+		require.NoError(t, err)
+		obj, err := iter.Next()
+		require.NoError(t, err)
+		iter.Close()
+		_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+		require.NoError(t, err)
+
+		assert.Greater(t, shared.Stats().Active, 0,
+			"storage %d should have registered FDs in the shared pool", i)
+
+		t.Cleanup(func() { _ = s.Close() })
+	}
+
+	// After all three storages have read, the shared pool tracks
+	// FDs from all of them.
+	assert.Equal(t, 128, shared.Stats().Capacity)
+	assert.Greater(t, shared.Stats().Active, 0,
+		"shared pool should track FDs across all storages")
+}
+
+// TestStorage_FDPool_Disabled verifies negative MaxOpenDescriptors
+// yields a working Storage: pool-less sharedFiles fall back to the
+// grace-period close on quiescence, reads still succeed.
+func TestStorage_FDPool_Disabled(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := filesystem.NewStorageWithOptions(dir, cache.NewObjectLRUDefault(),
+		filesystem.Options{MaxOpenDescriptors: -1})
+	t.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	_, err = iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+}

--- a/storage/filesystem/storage_pool_test.go
+++ b/storage/filesystem/storage_pool_test.go
@@ -94,9 +94,10 @@ func TestStorage_FDPool_AlternatesShareParentPool(t *testing.T) {
 
 // TestStorage_FDPool_SharedAcrossStorages verifies that callers
 // can inject one *fdpool.Pool into multiple Storages so the FD
-// budget is bounded process-wide rather than per-Storage. This
-// is the pattern GitOps controllers (e.g. Flux) need when they
-// spawn many short-lived Storages concurrently.
+// budget is bounded process-wide rather than per-Storage —
+// useful for servers handling concurrent per-request
+// repositories, batch tools iterating many repos, or any
+// process that opens many Storages concurrently.
 func TestStorage_FDPool_SharedAcrossStorages(t *testing.T) {
 	t.Parallel()
 

--- a/x/fdpool/pool.go
+++ b/x/fdpool/pool.go
@@ -1,0 +1,160 @@
+// Package fdpool implements a fixed-capacity LRU cache of
+// resources that own a file descriptor. The pool is used by
+// storage/filesystem to bound the number of open .pack/.idx/.rev
+// descriptors across a Storage. Members register on first FD
+// acquire and report subsequent acquires via Touch; when the LRU
+// length exceeds the configured capacity, the least-recently-
+// touched Member is evicted via Member.ReleaseNow.
+//
+// A zero or negative capacity yields a no-op pool: Touch and
+// Forget do nothing, never evict, and Stats reports the raw
+// capacity value. This lets callers wire the pool unconditionally
+// even when pooling is disabled.
+package fdpool
+
+import (
+	"container/list"
+	"sync"
+)
+
+// Member is the interface a pool entry must implement. The pool
+// holds Member references in an internal LRU list and calls
+// ReleaseNow on the tail Member when capacity is exceeded.
+//
+// Implementations must be comparable (typically a pointer-receiver
+// type), since Members are used as keys in the pool's internal
+// O(1)-lookup map.
+//
+// ReleaseNow must close the underlying FD without permanently
+// invalidating the Member: a subsequent acquire from the Member's
+// owner should reopen and re-register (via Touch) automatically.
+// Returning an error is fine; the pool discards it and continues,
+// since eviction is best-effort.
+type Member interface {
+	ReleaseNow() error
+}
+
+// Stats captures a snapshot of the pool's runtime state. The
+// values are observational — they may change immediately after
+// Stats returns.
+type Stats struct {
+	// Capacity is the configured maximum number of Members the
+	// pool will keep without evicting. <= 0 means the pool is a
+	// no-op.
+	Capacity int
+	// Active is the current number of registered Members.
+	Active int
+	// Hits is the cumulative count of Touch calls that targeted
+	// an already-registered Member (cache hit).
+	Hits uint64
+	// Evictions is the cumulative count of Members evicted via
+	// ReleaseNow because capacity was exceeded.
+	Evictions uint64
+}
+
+// Pool is a fixed-capacity LRU of Members. The zero value is not
+// usable; construct via New.
+type Pool struct {
+	mu        sync.Mutex
+	capacity  int
+	lru       *list.List // front = MRU, back = LRU; values are Member
+	elements  map[Member]*list.Element
+	hits      uint64
+	evictions uint64
+}
+
+// New constructs a Pool with the given capacity. capacity <= 0
+// returns a Pool whose Touch and Forget are no-ops and that never
+// evicts; callers may use New(0) to disable pooling without
+// special-casing the call sites.
+func New(capacity int) *Pool {
+	if capacity <= 0 {
+		return &Pool{capacity: capacity}
+	}
+	return &Pool{
+		capacity: capacity,
+		lru:      list.New(),
+		elements: make(map[Member]*list.Element, capacity),
+	}
+}
+
+// Touch reports an FD-active transition on m: either the first
+// acquire (m is newly registered) or a subsequent acquire on an
+// already-registered Member (m moves to MRU front). If the
+// resulting active count exceeds the capacity, the LRU tail is
+// evicted via Member.ReleaseNow. Eviction never targets m itself.
+//
+// Touch is safe to call from multiple goroutines.
+func (p *Pool) Touch(m Member) {
+	if p.capacity <= 0 || m == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if elem, ok := p.elements[m]; ok {
+		p.lru.MoveToFront(elem)
+		p.hits++
+		return
+	}
+	elem := p.lru.PushFront(m)
+	p.elements[m] = elem
+
+	// Evict the LRU tail if we exceeded capacity. The eviction
+	// target cannot be m (we just inserted it at the front) so
+	// this never evicts the caller's own Member.
+	if p.lru.Len() > p.capacity {
+		tail := p.lru.Back()
+		if tail != nil {
+			victim := tail.Value.(Member)
+			p.lru.Remove(tail)
+			delete(p.elements, victim)
+			p.evictions++
+			// Release the lock while calling ReleaseNow to avoid
+			// a lock-ordering hazard against the Member's own
+			// mutex (SharedFile.mu in the real wiring). Callers
+			// take p.mu briefly; the pool releases p.mu before
+			// touching member locks, so Member→Pool is the only
+			// direction of lock acquisition.
+			p.mu.Unlock()
+			_ = victim.ReleaseNow()
+			p.mu.Lock()
+		}
+	}
+}
+
+// Forget removes m from the LRU without invoking ReleaseNow.
+// Used when m is permanently closed by its owner.
+//
+// Forget is idempotent: calling it on a Member that was never
+// registered, or that has already been Forgotten, is a no-op.
+func (p *Pool) Forget(m Member) {
+	if p.capacity <= 0 || m == nil {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if elem, ok := p.elements[m]; ok {
+		p.lru.Remove(elem)
+		delete(p.elements, m)
+	}
+}
+
+// Stats returns a snapshot of the pool's current statistics.
+// Counters are monotonic; subtraction across two Stats snapshots
+// yields per-interval rates.
+func (p *Pool) Stats() Stats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var active int
+	if p.lru != nil {
+		active = p.lru.Len()
+	}
+	return Stats{
+		Capacity:  p.capacity,
+		Active:    active,
+		Hits:      p.hits,
+		Evictions: p.evictions,
+	}
+}

--- a/x/fdpool/pool.go
+++ b/x/fdpool/pool.go
@@ -17,13 +17,9 @@ import (
 	"sync"
 )
 
-// Member is the interface a pool entry must implement. The pool
-// holds Member references in an internal LRU list and calls
-// ReleaseNow on the tail Member when capacity is exceeded.
-//
-// Implementations must be comparable (typically a pointer-receiver
-// type), since Members are used as keys in the pool's internal
-// O(1)-lookup map.
+// Member is the interface a pool entry must implement. On eviction
+// the Pool calls ReleaseNow on the Member; the per-Member
+// registration token is the [Handle] the caller passes alongside.
 //
 // ReleaseNow must close the underlying FD without permanently
 // invalidating the Member: a subsequent acquire from the Member's
@@ -48,6 +44,34 @@ type Member interface {
 // first release.
 type Pinnable interface {
 	Pinned() bool
+}
+
+// Handle is the per-Member registration token that the Pool uses
+// to locate a Member in its internal LRU. Each Member instance
+// owns exactly one Handle and passes a pointer to it alongside
+// the Member on every [Pool.Touch] and [Pool.Forget] call.
+//
+// The zero value is valid and reports "not yet registered". The
+// Pool reads and writes Handle fields exclusively under its
+// internal mutex; callers must not touch them directly.
+//
+// Using a per-Member Handle (rather than the Member itself as a
+// map key) removes the implicit "Member must be comparable"
+// requirement that an internal map[Member]*list.Element would
+// impose — a Member with a non-comparable concrete type would
+// otherwise panic on registration.
+type Handle struct {
+	elem *list.Element
+}
+
+// entry is the per-Member record stored in the LRU list. Holding
+// a back-pointer to the Member's Handle lets eviction clear
+// h.elem before invoking ReleaseNow, so a concurrent re-Touch on
+// the evicted Member observes h.elem == nil and re-registers
+// cleanly.
+type entry struct {
+	m Member
+	h *Handle
 }
 
 // Stats captures a snapshot of the pool's runtime state. The
@@ -87,8 +111,7 @@ type Stats struct {
 type Pool struct {
 	mu               sync.Mutex
 	capacity         int
-	lru              *list.List // front = MRU, back = LRU; values are Member
-	elements         map[Member]*list.Element
+	lru              *list.List // front = MRU, back = LRU; values are *entry
 	hits             uint64
 	evictions        uint64
 	evictionFailures uint64
@@ -106,31 +129,31 @@ func New(capacity int) *Pool {
 	return &Pool{
 		capacity: capacity,
 		lru:      list.New(),
-		elements: make(map[Member]*list.Element, capacity),
 	}
 }
 
 // Touch reports an FD-active transition on m: either the first
 // acquire (m is newly registered) or a subsequent acquire on an
-// already-registered Member (m moves to MRU front). If the
-// resulting active count exceeds the capacity, the LRU tail is
-// evicted via Member.ReleaseNow. Eviction never targets m itself.
+// already-registered Member (m moves to MRU front). The Handle h
+// identifies m in the LRU; the same h must be passed on every
+// Touch/Forget for the same Member. If the resulting active count
+// exceeds the capacity, the LRU tail is evicted via
+// Member.ReleaseNow. Eviction never targets m itself.
 //
 // Touch is safe to call from multiple goroutines.
-func (p *Pool) Touch(m Member) {
-	if p.capacity <= 0 || m == nil {
+func (p *Pool) Touch(m Member, h *Handle) {
+	if p.capacity <= 0 || m == nil || h == nil {
 		return
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if elem, ok := p.elements[m]; ok {
-		p.lru.MoveToFront(elem)
+	if h.elem != nil {
+		p.lru.MoveToFront(h.elem)
 		p.hits++
 		return
 	}
-	elem := p.lru.PushFront(m)
-	p.elements[m] = elem
+	h.elem = p.lru.PushFront(&entry{m: m, h: h})
 
 	// Evict if we exceeded capacity. Two-pass victim selection:
 	// walk the LRU back-to-front and prefer the LRU-most Member
@@ -144,9 +167,9 @@ func (p *Pool) Touch(m Member) {
 	// the caller's own Member.
 	if p.lru.Len() > p.capacity {
 		var victimElem *list.Element
-		for e := p.lru.Back(); e != nil && e != elem; e = e.Prev() {
-			m := e.Value.(Member)
-			if pn, ok := m.(Pinnable); !ok || !pn.Pinned() {
+		for e := p.lru.Back(); e != nil && e != h.elem; e = e.Prev() {
+			ent := e.Value.(*entry)
+			if pn, ok := ent.m.(Pinnable); !ok || !pn.Pinned() {
 				victimElem = e
 				break
 			}
@@ -156,16 +179,23 @@ func (p *Pool) Touch(m Member) {
 			victimElem = p.lru.Back()
 		}
 		if victimElem != nil {
-			victim := victimElem.Value.(Member)
+			victimEnt := victimElem.Value.(*entry)
 			p.lru.Remove(victimElem)
-			delete(p.elements, victim)
+			// Clear the victim's Handle before dropping p.mu so a
+			// concurrent re-Touch on the same Member observes
+			// h.elem == nil and re-registers cleanly. Without
+			// this clear the re-Touch would call MoveToFront on
+			// the removed element (a no-op in container/list),
+			// silently leaving the Member unregistered while its
+			// Handle still claimed it was.
+			victimEnt.h.elem = nil
 			p.evictions++
 			// Release the lock while calling ReleaseNow to avoid
 			// a lock-ordering hazard against the Member's own
 			// mutex (SharedFile.mu in the real wiring). The rule
 			// is: Member calls into Pool only after releasing
 			// Member.mu (see SharedFile.Acquire and Close). The
-			// new Pool→Member call through Pinned above is
+			// Pool→Member call through Pinned above is
 			// deadlock-free because no Member call holds s.mu
 			// while waiting for p.mu.
 			//
@@ -175,7 +205,7 @@ func (p *Pool) Touch(m Member) {
 			// elsewhere (e.g. packhandle.doClose) and is recorded
 			// here so the asymmetry doesn't read as an oversight.
 			p.mu.Unlock()
-			err := victim.ReleaseNow()
+			err := victimEnt.m.ReleaseNow()
 			p.mu.Lock()
 			if err != nil {
 				p.evictionFailures++
@@ -184,22 +214,25 @@ func (p *Pool) Touch(m Member) {
 	}
 }
 
-// Forget removes m from the LRU without invoking ReleaseNow.
-// Used when m is permanently closed by its owner.
+// Forget removes the Handle's Member from the LRU without invoking
+// ReleaseNow. Used when the Member is permanently closed by its
+// owner.
 //
-// Forget is idempotent: calling it on a Member that was never
-// registered, or that has already been Forgotten, is a no-op.
-func (p *Pool) Forget(m Member) {
-	if p.capacity <= 0 || m == nil {
+// Forget is idempotent: calling it with a Handle that was never
+// registered, or that has already been Forgotten or evicted, is a
+// no-op.
+func (p *Pool) Forget(h *Handle) {
+	if p.capacity <= 0 || h == nil {
 		return
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if elem, ok := p.elements[m]; ok {
-		p.lru.Remove(elem)
-		delete(p.elements, m)
+	if h.elem == nil {
+		return
 	}
+	p.lru.Remove(h.elem)
+	h.elem = nil
 }
 
 // Stats returns a snapshot of the pool's current statistics.

--- a/x/fdpool/pool.go
+++ b/x/fdpool/pool.go
@@ -34,6 +34,22 @@ type Member interface {
 	ReleaseNow() error
 }
 
+// Pinnable is an optional Member-side interface that the Pool
+// consults during eviction. When evicting because capacity is
+// exceeded, the Pool walks the LRU back-to-front and skips
+// Members whose Pinned reports true; if every Member is pinned,
+// the Pool falls back to evicting the LRU tail unconditionally.
+// This matches canonical Git's find_lru_pack policy
+// (packfile.c:482-530), where the in-use preference is a hint
+// rather than a guarantee.
+//
+// Members that do not implement Pinnable are treated as unpinned,
+// preserving the unconditional-LRU behaviour from the pool's
+// first release.
+type Pinnable interface {
+	Pinned() bool
+}
+
 // Stats captures a snapshot of the pool's runtime state. The
 // values are observational — they may change immediately after
 // Stats returns.
@@ -56,6 +72,14 @@ type Stats struct {
 	// regardless); the counter exists so operators can distinguish
 	// clean evictions from those that hit a Close error.
 	EvictionFailures uint64
+	// PinnedSkips is the cumulative count of Pinnable Members the
+	// eviction walk skipped because Pinned() reported true. The
+	// counter is incremented in both cases: when an unpinned
+	// victim was eventually found further forward, and when every
+	// Member was pinned and the walk fell back to evicting the
+	// LRU tail anyway. Useful for spotting churn under sustained
+	// concurrent load.
+	PinnedSkips uint64
 }
 
 // Pool is a fixed-capacity LRU of Members. The zero value is not
@@ -68,6 +92,7 @@ type Pool struct {
 	hits             uint64
 	evictions        uint64
 	evictionFailures uint64
+	pinnedSkips      uint64
 }
 
 // New constructs a Pool with the given capacity. capacity <= 0
@@ -107,22 +132,42 @@ func (p *Pool) Touch(m Member) {
 	elem := p.lru.PushFront(m)
 	p.elements[m] = elem
 
-	// Evict the LRU tail if we exceeded capacity. The eviction
-	// target cannot be m (we just inserted it at the front) so
-	// this never evicts the caller's own Member.
+	// Evict if we exceeded capacity. Two-pass victim selection:
+	// walk the LRU back-to-front and prefer the LRU-most Member
+	// whose Pinnable.Pinned reports false; fall back to evicting
+	// the LRU tail unconditionally if every Member is pinned.
+	// Matches canonical Git's find_lru_pack (packfile.c:482-530).
+	// Members that do not implement Pinnable are treated as
+	// unpinned, preserving the unconditional-LRU behaviour from
+	// the pool's first release. The eviction target cannot be m
+	// (we just inserted it at the front) so this never evicts
+	// the caller's own Member.
 	if p.lru.Len() > p.capacity {
-		tail := p.lru.Back()
-		if tail != nil {
-			victim := tail.Value.(Member)
-			p.lru.Remove(tail)
+		var victimElem *list.Element
+		for e := p.lru.Back(); e != nil && e != elem; e = e.Prev() {
+			m := e.Value.(Member)
+			if pn, ok := m.(Pinnable); !ok || !pn.Pinned() {
+				victimElem = e
+				break
+			}
+			p.pinnedSkips++
+		}
+		if victimElem == nil {
+			victimElem = p.lru.Back()
+		}
+		if victimElem != nil {
+			victim := victimElem.Value.(Member)
+			p.lru.Remove(victimElem)
 			delete(p.elements, victim)
 			p.evictions++
 			// Release the lock while calling ReleaseNow to avoid
 			// a lock-ordering hazard against the Member's own
-			// mutex (SharedFile.mu in the real wiring). Callers
-			// take p.mu briefly; the pool releases p.mu before
-			// touching member locks, so Member→Pool is the only
-			// direction of lock acquisition.
+			// mutex (SharedFile.mu in the real wiring). The rule
+			// is: Member calls into Pool only after releasing
+			// Member.mu (see SharedFile.Acquire and Close). The
+			// new Pool→Member call through Pinned above is
+			// deadlock-free because no Member call holds s.mu
+			// while waiting for p.mu.
 			//
 			// ReleaseNow's error is intentionally discarded per
 			// the Member contract above: eviction is best-effort.
@@ -173,5 +218,6 @@ func (p *Pool) Stats() Stats {
 		Hits:             p.hits,
 		Evictions:        p.evictions,
 		EvictionFailures: p.evictionFailures,
+		PinnedSkips:      p.pinnedSkips,
 	}
 }

--- a/x/fdpool/pool.go
+++ b/x/fdpool/pool.go
@@ -50,17 +50,24 @@ type Stats struct {
 	// Evictions is the cumulative count of Members evicted via
 	// ReleaseNow because capacity was exceeded.
 	Evictions uint64
+	// EvictionFailures is the cumulative count of evictions whose
+	// Member.ReleaseNow returned a non-nil error. The eviction
+	// itself still completes (the Member is removed from the LRU
+	// regardless); the counter exists so operators can distinguish
+	// clean evictions from those that hit a Close error.
+	EvictionFailures uint64
 }
 
 // Pool is a fixed-capacity LRU of Members. The zero value is not
 // usable; construct via New.
 type Pool struct {
-	mu        sync.Mutex
-	capacity  int
-	lru       *list.List // front = MRU, back = LRU; values are Member
-	elements  map[Member]*list.Element
-	hits      uint64
-	evictions uint64
+	mu               sync.Mutex
+	capacity         int
+	lru              *list.List // front = MRU, back = LRU; values are Member
+	elements         map[Member]*list.Element
+	hits             uint64
+	evictions        uint64
+	evictionFailures uint64
 }
 
 // New constructs a Pool with the given capacity. capacity <= 0
@@ -123,8 +130,11 @@ func (p *Pool) Touch(m Member) {
 			// elsewhere (e.g. packhandle.doClose) and is recorded
 			// here so the asymmetry doesn't read as an oversight.
 			p.mu.Unlock()
-			_ = victim.ReleaseNow()
+			err := victim.ReleaseNow()
 			p.mu.Lock()
+			if err != nil {
+				p.evictionFailures++
+			}
 		}
 	}
 }
@@ -158,9 +168,10 @@ func (p *Pool) Stats() Stats {
 		active = p.lru.Len()
 	}
 	return Stats{
-		Capacity:  p.capacity,
-		Active:    active,
-		Hits:      p.hits,
-		Evictions: p.evictions,
+		Capacity:         p.capacity,
+		Active:           active,
+		Hits:             p.hits,
+		Evictions:        p.evictions,
+		EvictionFailures: p.evictionFailures,
 	}
 }

--- a/x/fdpool/pool.go
+++ b/x/fdpool/pool.go
@@ -116,6 +116,12 @@ func (p *Pool) Touch(m Member) {
 			// take p.mu briefly; the pool releases p.mu before
 			// touching member locks, so Member→Pool is the only
 			// direction of lock acquisition.
+			//
+			// ReleaseNow's error is intentionally discarded per
+			// the Member contract above: eviction is best-effort.
+			// This contrasts with the errors.Join pattern used
+			// elsewhere (e.g. packhandle.doClose) and is recorded
+			// here so the asymmetry doesn't read as an oversight.
 			p.mu.Unlock()
 			_ = victim.ReleaseNow()
 			p.mu.Lock()

--- a/x/fdpool/pool_bench_test.go
+++ b/x/fdpool/pool_bench_test.go
@@ -7,9 +7,11 @@ import (
 
 // benchMember is a stub Member for pool benchmarks. ReleaseNow
 // increments a counter so the eviction sanity checks can verify
-// the pool called it at least once (or not at all).
+// the pool called it at least once (or not at all). The embedded
+// Handle is the Pool's per-Member registration token.
 type benchMember struct {
 	releases atomic.Int32
+	h        Handle
 }
 
 func (m *benchMember) ReleaseNow() error {
@@ -34,13 +36,14 @@ func BenchmarkFDPool_WorkingSetFitsInPool(b *testing.B) {
 	// Warm: insert all members once so subsequent iterations hit
 	// the MoveToFront (cache-hit) path exclusively.
 	for _, m := range members {
-		p.Touch(m)
+		p.Touch(m, &m.h)
 	}
 
 	b.ReportAllocs()
 	var i int
 	for b.Loop() {
-		p.Touch(members[i%wset])
+		m := members[i%wset]
+		p.Touch(m, &m.h)
 		i++
 	}
 
@@ -76,7 +79,8 @@ func BenchmarkFDPool_Eviction_WorkingSetExceedsPool(b *testing.B) {
 	b.ReportAllocs()
 	var i int
 	for b.Loop() {
-		p.Touch(members[i%wset])
+		m := members[i%wset]
+		p.Touch(m, &m.h)
 		i++
 	}
 

--- a/x/fdpool/pool_bench_test.go
+++ b/x/fdpool/pool_bench_test.go
@@ -45,9 +45,16 @@ func BenchmarkFDPool_WorkingSetFitsInPool(b *testing.B) {
 	}
 
 	// Sanity: no evictions should have occurred during the timed
-	// section (capacity >> working set).
-	if got := p.Stats().Evictions; got != 0 {
-		b.Fatalf("unexpected evictions: %d", got)
+	// section (capacity >> working set), and Active must never
+	// exceed capacity — a regression where Touch lets the LRU
+	// grow past the cap would slip silently past the evictions
+	// check alone.
+	stats := p.Stats()
+	if stats.Evictions != 0 {
+		b.Fatalf("unexpected evictions: %d", stats.Evictions)
+	}
+	if stats.Active > capacity {
+		b.Fatalf("active %d exceeds capacity %d", stats.Active, capacity)
 	}
 }
 
@@ -74,8 +81,15 @@ func BenchmarkFDPool_Eviction_WorkingSetExceedsPool(b *testing.B) {
 	}
 
 	// Sanity: we must have evicted members given working set >
-	// capacity and round-robin access with no re-Touches.
-	if got := p.Stats().Evictions; got == 0 {
+	// capacity and round-robin access with no re-Touches; and
+	// Active must respect capacity throughout — a regression where
+	// Touch lets the LRU grow past the cap would slip silently
+	// past the evictions check alone.
+	stats := p.Stats()
+	if stats.Evictions == 0 {
 		b.Fatal("expected evictions under exceeded working set")
+	}
+	if stats.Active > capacity {
+		b.Fatalf("active %d exceeds capacity %d", stats.Active, capacity)
 	}
 }

--- a/x/fdpool/pool_bench_test.go
+++ b/x/fdpool/pool_bench_test.go
@@ -1,0 +1,81 @@
+package fdpool
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+// benchMember is a stub Member for pool benchmarks. ReleaseNow
+// increments a counter so the eviction sanity checks can verify
+// the pool called it at least once (or not at all).
+type benchMember struct {
+	releases atomic.Int32
+}
+
+func (m *benchMember) ReleaseNow() error {
+	m.releases.Add(1)
+	return nil
+}
+
+// BenchmarkFDPool_WorkingSetFitsInPool measures Touch hot-path
+// cost when no eviction fires. The pool's capacity exceeds the
+// working set, so every Touch either inserts (first time) or
+// re-Touches an existing entry — neither path calls ReleaseNow.
+func BenchmarkFDPool_WorkingSetFitsInPool(b *testing.B) {
+	const capacity = 64
+	const wset = 16
+
+	p := New(capacity)
+	members := make([]*benchMember, wset)
+	for i := range members {
+		members[i] = &benchMember{}
+	}
+
+	// Warm: insert all members once so subsequent iterations hit
+	// the MoveToFront (cache-hit) path exclusively.
+	for _, m := range members {
+		p.Touch(m)
+	}
+
+	b.ReportAllocs()
+	var i int
+	for b.Loop() {
+		p.Touch(members[i%wset])
+		i++
+	}
+
+	// Sanity: no evictions should have occurred during the timed
+	// section (capacity >> working set).
+	if got := p.Stats().Evictions; got != 0 {
+		b.Fatalf("unexpected evictions: %d", got)
+	}
+}
+
+// BenchmarkFDPool_Eviction_WorkingSetExceedsPool measures Touch
+// cost when every new insert triggers an eviction. The working set
+// is 2x the pool capacity and is accessed in strict round-robin
+// order, so no Member is ever re-Touched before it falls off the
+// LRU tail — every iteration is an insert followed by an eviction.
+func BenchmarkFDPool_Eviction_WorkingSetExceedsPool(b *testing.B) {
+	const capacity = 16
+	const wset = 32 // 2x capacity: every Touch is a fresh insert + eviction
+
+	p := New(capacity)
+	members := make([]*benchMember, wset)
+	for i := range members {
+		members[i] = &benchMember{}
+	}
+
+	b.ReportAllocs()
+	var i int
+	for b.Loop() {
+		p.Touch(members[i%wset])
+		i++
+	}
+
+	// Sanity: we must have evicted members given working set >
+	// capacity and round-robin access with no re-Touches.
+	if got := p.Stats().Evictions; got == 0 {
+		b.Fatal("expected evictions under exceeded working set")
+	}
+}

--- a/x/fdpool/pool_test.go
+++ b/x/fdpool/pool_test.go
@@ -39,7 +39,7 @@ func TestPool_ZeroCapacity_NoOp(t *testing.T) {
 		"ReleaseNow must not be invoked on a no-op pool")
 
 	got := p.Stats()
-	require.Equal(t, Stats{Capacity: 0, Active: 0, Hits: 0, Evictions: 0}, got)
+	require.Equal(t, Stats{Capacity: 0, Active: 0, Hits: 0, Evictions: 0, EvictionFailures: 0}, got)
 }
 
 func TestPool_NegativeCapacity_NoOp(t *testing.T) {
@@ -308,4 +308,41 @@ func TestPool_ConcurrentTouch(t *testing.T) {
 	}
 	require.Equal(t, int32(got.Evictions), totalReleased,
 		"sum of ReleaseNow calls must equal Evictions")
+}
+
+// failingMember returns a sentinel error from ReleaseNow so
+// TestPool_EvictionFailureCounted can assert the pool recorded the
+// failure in Stats.EvictionFailures.
+type failingMember struct{}
+
+func (failingMember) ReleaseNow() error {
+	return errReleaseNowFailed
+}
+
+var errReleaseNowFailed = fakeError("release now failed")
+
+type fakeError string
+
+func (e fakeError) Error() string { return string(e) }
+
+// TestPool_EvictionFailureCounted verifies that a non-nil error
+// return from a Member's ReleaseNow bumps Stats.EvictionFailures
+// once per failed eviction. Stats.Evictions still counts the
+// eviction itself — failure does not retract the LRU/map update.
+func TestPool_EvictionFailureCounted(t *testing.T) {
+	t.Parallel()
+	p := New(1)
+
+	// Insert a failing member, then insert a clean one to trigger
+	// eviction of the failing tail.
+	failing := failingMember{}
+	clean := &fakeMember{}
+	p.Touch(failing)
+	p.Touch(clean)
+
+	got := p.Stats()
+	require.Equal(t, uint64(1), got.Evictions,
+		"eviction should still count")
+	require.Equal(t, uint64(1), got.EvictionFailures,
+		"failing ReleaseNow should bump EvictionFailures")
 }

--- a/x/fdpool/pool_test.go
+++ b/x/fdpool/pool_test.go
@@ -346,3 +346,115 @@ func TestPool_EvictionFailureCounted(t *testing.T) {
 	require.Equal(t, uint64(1), got.EvictionFailures,
 		"failing ReleaseNow should bump EvictionFailures")
 }
+
+// pinnableMember is a Member that also implements Pinnable so the
+// pool's two-pass eviction can be exercised independently of the
+// SharedFile wiring.
+type pinnableMember struct {
+	released atomic.Int32
+	pinned   atomic.Bool
+}
+
+func (m *pinnableMember) ReleaseNow() error {
+	m.released.Add(1)
+	return nil
+}
+
+func (m *pinnableMember) Pinned() bool {
+	return m.pinned.Load()
+}
+
+func (m *pinnableMember) releaseCount() int32 {
+	return m.released.Load()
+}
+
+// TestPool_EvictsUnpinnedFirst verifies that Touch's eviction
+// walks the LRU back-to-front and prefers an unpinned victim,
+// leaving pinned LRU members alone when an unpinned candidate
+// exists further forward.
+func TestPool_EvictsUnpinnedFirst(t *testing.T) {
+	t.Parallel()
+	p := New(2)
+
+	pinned := &pinnableMember{}
+	pinned.pinned.Store(true)
+	unpinned := &pinnableMember{}
+
+	// Insert order: pinned (LRU tail), unpinned (head).
+	p.Touch(pinned)
+	p.Touch(unpinned)
+
+	// One more Touch triggers eviction. The LRU tail (pinned) must
+	// be skipped in favour of unpinned, even though unpinned is
+	// further forward in the list.
+	overflow := &pinnableMember{}
+	p.Touch(overflow)
+
+	require.Equal(t, int32(0), pinned.releaseCount(),
+		"pinned member must not be evicted while an unpinned candidate exists")
+	require.Equal(t, int32(1), unpinned.releaseCount(),
+		"unpinned LRU candidate should be the evicted victim")
+
+	got := p.Stats()
+	require.Equal(t, uint64(1), got.Evictions)
+	require.Equal(t, uint64(1), got.PinnedSkips,
+		"the walk past pinned should be counted")
+}
+
+// TestPool_AllPinned_FallsBackToLRU verifies that when every
+// Member is pinned, Touch falls back to evicting the LRU tail
+// anyway — matching canonical Git's find_lru_pack policy
+// (packfile.c:482-530) where the inuse_cnt preference is a
+// soft hint, not a guarantee.
+func TestPool_AllPinned_FallsBackToLRU(t *testing.T) {
+	t.Parallel()
+	p := New(2)
+
+	tail := &pinnableMember{}
+	tail.pinned.Store(true)
+	head := &pinnableMember{}
+	head.pinned.Store(true)
+
+	p.Touch(tail) // LRU tail
+	p.Touch(head) // MRU front
+
+	overflow := &pinnableMember{}
+	p.Touch(overflow)
+
+	require.Equal(t, int32(1), tail.releaseCount(),
+		"with all members pinned, LRU tail must still be evicted")
+	require.Equal(t, int32(0), head.releaseCount(),
+		"MRU front must not be evicted ahead of LRU tail")
+
+	got := p.Stats()
+	require.Equal(t, uint64(1), got.Evictions)
+	require.Equal(t, uint64(2), got.PinnedSkips,
+		"both pinned members should appear in the walk count")
+}
+
+// TestPool_MemberWithoutPinnable_PreservesLRU verifies that
+// Members that do not implement the optional Pinnable interface
+// receive unconditional-LRU eviction (the pre-Pinnable behaviour).
+// fakeMember does not implement Pinnable; the LRU tail must be
+// evicted regardless of any inflight state.
+func TestPool_MemberWithoutPinnable_PreservesLRU(t *testing.T) {
+	t.Parallel()
+	p := New(2)
+
+	tail := &fakeMember{}
+	head := &fakeMember{}
+	p.Touch(tail)
+	p.Touch(head)
+
+	overflow := &fakeMember{}
+	p.Touch(overflow)
+
+	require.Equal(t, int32(1), tail.releaseCount(),
+		"LRU tail must be evicted when Member does not implement Pinnable")
+	require.Equal(t, int32(0), head.releaseCount())
+
+	got := p.Stats()
+	require.Equal(t, uint64(1), got.Evictions)
+	require.Equal(t, uint64(0), got.PinnedSkips,
+		"non-Pinnable Members must not appear in the walk count")
+}

--- a/x/fdpool/pool_test.go
+++ b/x/fdpool/pool_test.go
@@ -10,9 +10,11 @@ import (
 
 // fakeMember is a stub Member that records how many times
 // ReleaseNow has been invoked. The counter uses sync/atomic so
-// the concurrent test can assert on it without racing.
+// the concurrent test can assert on it without racing. The
+// embedded Handle is the Pool's per-Member registration token.
 type fakeMember struct {
 	released atomic.Int32
+	h        Handle
 }
 
 func (f *fakeMember) ReleaseNow() error {
@@ -31,9 +33,9 @@ func TestPool_ZeroCapacity_NoOp(t *testing.T) {
 
 	// Touch and Forget must be no-ops; in particular Touch must
 	// not call ReleaseNow on its own argument.
-	p.Touch(m)
-	p.Touch(m)
-	p.Forget(m)
+	p.Touch(m, &m.h)
+	p.Touch(m, &m.h)
+	p.Forget(&m.h)
 
 	require.Equal(t, int32(0), m.releaseCount(),
 		"ReleaseNow must not be invoked on a no-op pool")
@@ -47,8 +49,8 @@ func TestPool_NegativeCapacity_NoOp(t *testing.T) {
 	p := New(-5)
 	m := &fakeMember{}
 
-	p.Touch(m)
-	p.Forget(m)
+	p.Touch(m, &m.h)
+	p.Forget(&m.h)
 
 	require.Equal(t, int32(0), m.releaseCount())
 	got := p.Stats()
@@ -59,9 +61,12 @@ func TestPool_NegativeCapacity_NoOp(t *testing.T) {
 func TestPool_NilMember_NoOp(t *testing.T) {
 	t.Parallel()
 	p := New(2)
-	// Should not panic.
-	p.Touch(nil)
+	// Should not panic for either nil Member or nil Handle.
+	p.Touch(nil, nil)
+	var h Handle
+	p.Touch(nil, &h)
 	p.Forget(nil)
+	p.Forget(&h)
 
 	got := p.Stats()
 	require.Equal(t, 2, got.Capacity)
@@ -74,11 +79,11 @@ func TestPool_Capacity1_EvictsOnInsert(t *testing.T) {
 	m1 := &fakeMember{}
 	m2 := &fakeMember{}
 
-	p.Touch(m1)
+	p.Touch(m1, &m1.h)
 	require.Equal(t, int32(0), m1.releaseCount())
 	require.Equal(t, 1, p.Stats().Active)
 
-	p.Touch(m2)
+	p.Touch(m2, &m2.h)
 	// m1 must be evicted exactly once; m2 stays.
 	require.Equal(t, int32(1), m1.releaseCount(),
 		"m1 must be evicted exactly once when m2 is inserted")
@@ -97,7 +102,7 @@ func TestPool_WorkingSetWithinCapacity_NoEviction(t *testing.T) {
 	members := make([]*fakeMember, capacity)
 	for i := range members {
 		members[i] = &fakeMember{}
-		p.Touch(members[i])
+		p.Touch(members[i], &members[i].h)
 	}
 
 	// All four registered, no evictions yet.
@@ -113,7 +118,7 @@ func TestPool_WorkingSetWithinCapacity_NoEviction(t *testing.T) {
 	// Re-Touch existing members: should register as Hits and
 	// produce no evictions.
 	for _, m := range members {
-		p.Touch(m)
+		p.Touch(m, &m.h)
 	}
 	got = p.Stats()
 	require.Equal(t, capacity, got.Active)
@@ -131,26 +136,26 @@ func TestPool_OldestEvictsFirst(t *testing.T) {
 	m3 := &fakeMember{}
 	m4 := &fakeMember{}
 
-	p.Touch(m1)
-	p.Touch(m2)
-	p.Touch(m3)
+	p.Touch(m1, &m1.h)
+	p.Touch(m2, &m2.h)
+	p.Touch(m3, &m3.h)
 
 	// LRU order from MRU to LRU: m3, m2, m1.
 	// Inserting m4 evicts m1.
-	p.Touch(m4)
+	p.Touch(m4, &m4.h)
 	require.Equal(t, int32(1), m1.releaseCount(), "m1 should evict first")
 	require.Equal(t, int32(0), m2.releaseCount())
 	require.Equal(t, int32(0), m3.releaseCount())
 	require.Equal(t, int32(0), m4.releaseCount())
 
 	// Now Touch m2 to make it MRU; LRU is m3.
-	p.Touch(m2)
+	p.Touch(m2, &m2.h)
 	require.Equal(t, uint64(1), p.Stats().Hits)
 
 	// Insert a fresh m5; m3 should evict next (m2 is MRU, m4 is
 	// middle, m3 is LRU).
 	m5 := &fakeMember{}
-	p.Touch(m5)
+	p.Touch(m5, &m5.h)
 	require.Equal(t, int32(1), m3.releaseCount(),
 		"after re-touching m2 the LRU tail is m3, which must evict")
 	require.Equal(t, int32(0), m2.releaseCount())
@@ -170,7 +175,7 @@ func TestPool_EvictionNeverTargetsJustTouched(t *testing.T) {
 	members := make([]*fakeMember, total)
 	for i := range members {
 		members[i] = &fakeMember{}
-		p.Touch(members[i])
+		p.Touch(members[i], &members[i].h)
 	}
 
 	// Exactly the oldest member (m0) must be evicted. The
@@ -188,24 +193,52 @@ func TestPool_EvictionNeverTargetsJustTouched(t *testing.T) {
 	require.Equal(t, uint64(1), got.Evictions)
 }
 
+// TestPool_EvictedMemberReregistersCleanly asserts that after the
+// Pool evicts a Member, a subsequent Touch on the same Member
+// re-registers it: the LRU contains the Member again and Active
+// reflects it. This exercises the eviction path's clearing of
+// victim.h.elem under p.mu; without that clear, the re-Touch would
+// see h.elem != nil and call MoveToFront on the removed element,
+// silently leaving the Member unregistered while its Handle claimed
+// otherwise.
+func TestPool_EvictedMemberReregistersCleanly(t *testing.T) {
+	t.Parallel()
+	p := New(1)
+	a := &fakeMember{}
+	b := &fakeMember{}
+
+	p.Touch(a, &a.h)
+	p.Touch(b, &b.h) // evicts a
+	require.Equal(t, int32(1), a.releaseCount(), "a must have been evicted")
+	require.Equal(t, 1, p.Stats().Active)
+
+	// Re-Touch the evicted member; it must register fresh.
+	p.Touch(a, &a.h) // evicts b
+	require.Equal(t, int32(1), b.releaseCount(), "b must now be the evicted tail")
+	require.Equal(t, 1, p.Stats().Active,
+		"after re-Touch the evicted member must be back in the LRU")
+	require.Equal(t, uint64(0), p.Stats().Hits,
+		"the re-Touch must register fresh, not record as a hit")
+}
+
 func TestPool_Forget_Idempotent(t *testing.T) {
 	t.Parallel()
 	p := New(4)
 
 	// Forget on a never-registered Member: no-op, no panic.
 	never := &fakeMember{}
-	p.Forget(never)
+	p.Forget(&never.h)
 	require.Equal(t, int32(0), never.releaseCount())
 	require.Equal(t, 0, p.Stats().Active)
 
 	// Register, Forget, and Forget again.
 	m := &fakeMember{}
-	p.Touch(m)
+	p.Touch(m, &m.h)
 	require.Equal(t, 1, p.Stats().Active)
-	p.Forget(m)
+	p.Forget(&m.h)
 	require.Equal(t, 0, p.Stats().Active)
 	// Double Forget is a no-op.
-	p.Forget(m)
+	p.Forget(&m.h)
 	require.Equal(t, 0, p.Stats().Active)
 
 	// Forget must not call ReleaseNow.
@@ -220,11 +253,11 @@ func TestPool_Forget_FreesSlotForNewInsert(t *testing.T) {
 	m2 := &fakeMember{}
 	m3 := &fakeMember{}
 
-	p.Touch(m1)
-	p.Touch(m2)
-	p.Forget(m1)
+	p.Touch(m1, &m1.h)
+	p.Touch(m2, &m2.h)
+	p.Forget(&m1.h)
 	// Active dropped to 1, so inserting m3 fits without eviction.
-	p.Touch(m3)
+	p.Touch(m3, &m3.h)
 	require.Equal(t, int32(0), m1.releaseCount(),
 		"Forget must not release; m1 must remain unreleased")
 	require.Equal(t, int32(0), m2.releaseCount())
@@ -242,10 +275,10 @@ func TestPool_Stats_Snapshot(t *testing.T) {
 	m2 := &fakeMember{}
 	m3 := &fakeMember{}
 
-	p.Touch(m1)
-	p.Touch(m2)
-	p.Touch(m1) // hit
-	p.Touch(m3) // evicts m2
+	p.Touch(m1, &m1.h)
+	p.Touch(m2, &m2.h)
+	p.Touch(m1, &m1.h) // hit
+	p.Touch(m3, &m3.h) // evicts m2
 
 	got := p.Stats()
 	require.Equal(t, 2, got.Capacity)
@@ -280,9 +313,9 @@ func TestPool_ConcurrentTouch(t *testing.T) {
 			// different offset.
 			for i := range iters {
 				m := pool[(seed+i)%members]
-				p.Touch(m)
+				p.Touch(m, &m.h)
 				if i%17 == 0 {
-					p.Forget(m)
+					p.Forget(&m.h)
 				}
 			}
 		}(g)
@@ -312,10 +345,16 @@ func TestPool_ConcurrentTouch(t *testing.T) {
 
 // failingMember returns a sentinel error from ReleaseNow so
 // TestPool_EvictionFailureCounted can assert the pool recorded the
-// failure in Stats.EvictionFailures.
-type failingMember struct{}
+// failure in Stats.EvictionFailures. The embedded []byte makes the
+// concrete type non-comparable on purpose: the Handle-based
+// registration must accept Members the Go runtime cannot use as a
+// map key.
+type failingMember struct {
+	_ []byte // forces non-comparable concrete type
+	h Handle
+}
 
-func (failingMember) ReleaseNow() error {
+func (*failingMember) ReleaseNow() error {
 	return errReleaseNowFailed
 }
 
@@ -328,17 +367,22 @@ func (e fakeError) Error() string { return string(e) }
 // TestPool_EvictionFailureCounted verifies that a non-nil error
 // return from a Member's ReleaseNow bumps Stats.EvictionFailures
 // once per failed eviction. Stats.Evictions still counts the
-// eviction itself — failure does not retract the LRU/map update.
+// eviction itself — failure does not retract the LRU update.
+//
+// The failing Member is deliberately a non-comparable concrete
+// type; pre-Handle the map[Member]*list.Element registration would
+// panic at hash time. Asserting clean registration here doubles as
+// regression cover for that hazard.
 func TestPool_EvictionFailureCounted(t *testing.T) {
 	t.Parallel()
 	p := New(1)
 
 	// Insert a failing member, then insert a clean one to trigger
 	// eviction of the failing tail.
-	failing := failingMember{}
+	failing := &failingMember{}
 	clean := &fakeMember{}
-	p.Touch(failing)
-	p.Touch(clean)
+	p.Touch(failing, &failing.h)
+	p.Touch(clean, &clean.h)
 
 	got := p.Stats()
 	require.Equal(t, uint64(1), got.Evictions,
@@ -353,6 +397,7 @@ func TestPool_EvictionFailureCounted(t *testing.T) {
 type pinnableMember struct {
 	released atomic.Int32
 	pinned   atomic.Bool
+	h        Handle
 }
 
 func (m *pinnableMember) ReleaseNow() error {
@@ -381,14 +426,14 @@ func TestPool_EvictsUnpinnedFirst(t *testing.T) {
 	unpinned := &pinnableMember{}
 
 	// Insert order: pinned (LRU tail), unpinned (head).
-	p.Touch(pinned)
-	p.Touch(unpinned)
+	p.Touch(pinned, &pinned.h)
+	p.Touch(unpinned, &unpinned.h)
 
 	// One more Touch triggers eviction. The LRU tail (pinned) must
 	// be skipped in favour of unpinned, even though unpinned is
 	// further forward in the list.
 	overflow := &pinnableMember{}
-	p.Touch(overflow)
+	p.Touch(overflow, &overflow.h)
 
 	require.Equal(t, int32(0), pinned.releaseCount(),
 		"pinned member must not be evicted while an unpinned candidate exists")
@@ -415,11 +460,11 @@ func TestPool_AllPinned_FallsBackToLRU(t *testing.T) {
 	head := &pinnableMember{}
 	head.pinned.Store(true)
 
-	p.Touch(tail) // LRU tail
-	p.Touch(head) // MRU front
+	p.Touch(tail, &tail.h) // LRU tail
+	p.Touch(head, &head.h) // MRU front
 
 	overflow := &pinnableMember{}
-	p.Touch(overflow)
+	p.Touch(overflow, &overflow.h)
 
 	require.Equal(t, int32(1), tail.releaseCount(),
 		"with all members pinned, LRU tail must still be evicted")
@@ -443,11 +488,11 @@ func TestPool_MemberWithoutPinnable_PreservesLRU(t *testing.T) {
 
 	tail := &fakeMember{}
 	head := &fakeMember{}
-	p.Touch(tail)
-	p.Touch(head)
+	p.Touch(tail, &tail.h)
+	p.Touch(head, &head.h)
 
 	overflow := &fakeMember{}
-	p.Touch(overflow)
+	p.Touch(overflow, &overflow.h)
 
 	require.Equal(t, int32(1), tail.releaseCount(),
 		"LRU tail must be evicted when Member does not implement Pinnable")

--- a/x/fdpool/pool_test.go
+++ b/x/fdpool/pool_test.go
@@ -1,0 +1,311 @@
+package fdpool
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMember is a stub Member that records how many times
+// ReleaseNow has been invoked. The counter uses sync/atomic so
+// the concurrent test can assert on it without racing.
+type fakeMember struct {
+	released atomic.Int32
+}
+
+func (f *fakeMember) ReleaseNow() error {
+	f.released.Add(1)
+	return nil
+}
+
+func (f *fakeMember) releaseCount() int32 {
+	return f.released.Load()
+}
+
+func TestPool_ZeroCapacity_NoOp(t *testing.T) {
+	t.Parallel()
+	p := New(0)
+	m := &fakeMember{}
+
+	// Touch and Forget must be no-ops; in particular Touch must
+	// not call ReleaseNow on its own argument.
+	p.Touch(m)
+	p.Touch(m)
+	p.Forget(m)
+
+	require.Equal(t, int32(0), m.releaseCount(),
+		"ReleaseNow must not be invoked on a no-op pool")
+
+	got := p.Stats()
+	require.Equal(t, Stats{Capacity: 0, Active: 0, Hits: 0, Evictions: 0}, got)
+}
+
+func TestPool_NegativeCapacity_NoOp(t *testing.T) {
+	t.Parallel()
+	p := New(-5)
+	m := &fakeMember{}
+
+	p.Touch(m)
+	p.Forget(m)
+
+	require.Equal(t, int32(0), m.releaseCount())
+	got := p.Stats()
+	require.Equal(t, -5, got.Capacity)
+	require.Equal(t, 0, got.Active)
+}
+
+func TestPool_NilMember_NoOp(t *testing.T) {
+	t.Parallel()
+	p := New(2)
+	// Should not panic.
+	p.Touch(nil)
+	p.Forget(nil)
+
+	got := p.Stats()
+	require.Equal(t, 2, got.Capacity)
+	require.Equal(t, 0, got.Active)
+}
+
+func TestPool_Capacity1_EvictsOnInsert(t *testing.T) {
+	t.Parallel()
+	p := New(1)
+	m1 := &fakeMember{}
+	m2 := &fakeMember{}
+
+	p.Touch(m1)
+	require.Equal(t, int32(0), m1.releaseCount())
+	require.Equal(t, 1, p.Stats().Active)
+
+	p.Touch(m2)
+	// m1 must be evicted exactly once; m2 stays.
+	require.Equal(t, int32(1), m1.releaseCount(),
+		"m1 must be evicted exactly once when m2 is inserted")
+	require.Equal(t, int32(0), m2.releaseCount())
+
+	got := p.Stats()
+	require.Equal(t, 1, got.Capacity)
+	require.Equal(t, 1, got.Active)
+	require.Equal(t, uint64(1), got.Evictions)
+}
+
+func TestPool_WorkingSetWithinCapacity_NoEviction(t *testing.T) {
+	t.Parallel()
+	const capacity = 4
+	p := New(capacity)
+	members := make([]*fakeMember, capacity)
+	for i := range members {
+		members[i] = &fakeMember{}
+		p.Touch(members[i])
+	}
+
+	// All four registered, no evictions yet.
+	got := p.Stats()
+	require.Equal(t, capacity, got.Active)
+	require.Equal(t, uint64(0), got.Evictions)
+	require.Equal(t, uint64(0), got.Hits)
+	for i, m := range members {
+		require.Equalf(t, int32(0), m.releaseCount(),
+			"member %d unexpectedly released", i)
+	}
+
+	// Re-Touch existing members: should register as Hits and
+	// produce no evictions.
+	for _, m := range members {
+		p.Touch(m)
+	}
+	got = p.Stats()
+	require.Equal(t, capacity, got.Active)
+	require.Equal(t, uint64(0), got.Evictions)
+	require.Equal(t, uint64(capacity), got.Hits)
+}
+
+func TestPool_OldestEvictsFirst(t *testing.T) {
+	t.Parallel()
+	const capacity = 3
+	p := New(capacity)
+
+	m1 := &fakeMember{}
+	m2 := &fakeMember{}
+	m3 := &fakeMember{}
+	m4 := &fakeMember{}
+
+	p.Touch(m1)
+	p.Touch(m2)
+	p.Touch(m3)
+
+	// LRU order from MRU to LRU: m3, m2, m1.
+	// Inserting m4 evicts m1.
+	p.Touch(m4)
+	require.Equal(t, int32(1), m1.releaseCount(), "m1 should evict first")
+	require.Equal(t, int32(0), m2.releaseCount())
+	require.Equal(t, int32(0), m3.releaseCount())
+	require.Equal(t, int32(0), m4.releaseCount())
+
+	// Now Touch m2 to make it MRU; LRU is m3.
+	p.Touch(m2)
+	require.Equal(t, uint64(1), p.Stats().Hits)
+
+	// Insert a fresh m5; m3 should evict next (m2 is MRU, m4 is
+	// middle, m3 is LRU).
+	m5 := &fakeMember{}
+	p.Touch(m5)
+	require.Equal(t, int32(1), m3.releaseCount(),
+		"after re-touching m2 the LRU tail is m3, which must evict")
+	require.Equal(t, int32(0), m2.releaseCount())
+	require.Equal(t, int32(0), m4.releaseCount())
+	require.Equal(t, int32(0), m5.releaseCount())
+
+	got := p.Stats()
+	require.Equal(t, capacity, got.Active)
+	require.Equal(t, uint64(2), got.Evictions)
+}
+
+func TestPool_EvictionNeverTargetsJustTouched(t *testing.T) {
+	t.Parallel()
+	const capacity = 4
+	p := New(capacity)
+	const total = capacity + 1
+	members := make([]*fakeMember, total)
+	for i := range members {
+		members[i] = &fakeMember{}
+		p.Touch(members[i])
+	}
+
+	// Exactly the oldest member (m0) must be evicted. The
+	// just-touched m4 (members[capacity]) and every other recent
+	// member must remain.
+	require.Equal(t, int32(1), members[0].releaseCount(),
+		"only the oldest member must evict")
+	for i := 1; i < total; i++ {
+		require.Equalf(t, int32(0), members[i].releaseCount(),
+			"member %d must not be evicted (it is more recent than the LRU tail)", i)
+	}
+
+	got := p.Stats()
+	require.Equal(t, capacity, got.Active)
+	require.Equal(t, uint64(1), got.Evictions)
+}
+
+func TestPool_Forget_Idempotent(t *testing.T) {
+	t.Parallel()
+	p := New(4)
+
+	// Forget on a never-registered Member: no-op, no panic.
+	never := &fakeMember{}
+	p.Forget(never)
+	require.Equal(t, int32(0), never.releaseCount())
+	require.Equal(t, 0, p.Stats().Active)
+
+	// Register, Forget, and Forget again.
+	m := &fakeMember{}
+	p.Touch(m)
+	require.Equal(t, 1, p.Stats().Active)
+	p.Forget(m)
+	require.Equal(t, 0, p.Stats().Active)
+	// Double Forget is a no-op.
+	p.Forget(m)
+	require.Equal(t, 0, p.Stats().Active)
+
+	// Forget must not call ReleaseNow.
+	require.Equal(t, int32(0), m.releaseCount(),
+		"Forget must not invoke ReleaseNow")
+}
+
+func TestPool_Forget_FreesSlotForNewInsert(t *testing.T) {
+	t.Parallel()
+	p := New(2)
+	m1 := &fakeMember{}
+	m2 := &fakeMember{}
+	m3 := &fakeMember{}
+
+	p.Touch(m1)
+	p.Touch(m2)
+	p.Forget(m1)
+	// Active dropped to 1, so inserting m3 fits without eviction.
+	p.Touch(m3)
+	require.Equal(t, int32(0), m1.releaseCount(),
+		"Forget must not release; m1 must remain unreleased")
+	require.Equal(t, int32(0), m2.releaseCount())
+	require.Equal(t, int32(0), m3.releaseCount())
+
+	got := p.Stats()
+	require.Equal(t, 2, got.Active)
+	require.Equal(t, uint64(0), got.Evictions)
+}
+
+func TestPool_Stats_Snapshot(t *testing.T) {
+	t.Parallel()
+	p := New(2)
+	m1 := &fakeMember{}
+	m2 := &fakeMember{}
+	m3 := &fakeMember{}
+
+	p.Touch(m1)
+	p.Touch(m2)
+	p.Touch(m1) // hit
+	p.Touch(m3) // evicts m2
+
+	got := p.Stats()
+	require.Equal(t, 2, got.Capacity)
+	require.Equal(t, 2, got.Active)
+	require.Equal(t, uint64(1), got.Hits)
+	require.Equal(t, uint64(1), got.Evictions)
+	require.Equal(t, int32(0), m1.releaseCount())
+	require.Equal(t, int32(1), m2.releaseCount())
+	require.Equal(t, int32(0), m3.releaseCount())
+}
+
+func TestPool_ConcurrentTouch(t *testing.T) {
+	t.Parallel()
+	const capacity = 16
+	const members = 32
+	const goroutines = 8
+	const iters = 500
+
+	p := New(capacity)
+	pool := make([]*fakeMember, members)
+	for i := range pool {
+		pool[i] = &fakeMember{}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(seed int) {
+			defer wg.Done()
+			// Deterministic interleaving per-goroutine: each
+			// goroutine walks the member ring starting at a
+			// different offset.
+			for i := range iters {
+				m := pool[(seed+i)%members]
+				p.Touch(m)
+				if i%17 == 0 {
+					p.Forget(m)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	got := p.Stats()
+	require.Equal(t, capacity, got.Capacity)
+	// Active must never exceed capacity.
+	require.LessOrEqualf(t, got.Active, capacity,
+		"active %d exceeded capacity %d", got.Active, capacity)
+	// We must have evicted at least once given working set >
+	// capacity.
+	require.Greater(t, got.Evictions, uint64(0),
+		"expected at least one eviction under contention")
+
+	// Every ReleaseNow recorded across all members should match
+	// the eviction counter exactly: ReleaseNow is called once
+	// per eviction.
+	var totalReleased int32
+	for _, m := range pool {
+		totalReleased += m.releaseCount()
+	}
+	require.Equal(t, int32(got.Evictions), totalReleased,
+		"sum of ReleaseNow calls must equal Evictions")
+}


### PR DESCRIPTION
This PR primarily addresses resource hygiene and concurrent correctness: bounded FDs across a Storage (and across multiple Storages via `Options.Pool`), `*fdpool.Pool.Stats()` for observability, and four `s.index` race fixes. Read-path performance changes are minimal — measured against `main` with `benchstat (-count=6, -benchtime=1s)`:

- Allocations reduced 14% geomean, up to 47% on hot read paths (ParallelReads, AlternatesObjectLookup/EncodedObject). Lower GC pressure.
- Alternates lookup latency -59% (with variance caveats; replication recommended).
- Flat throughput on the primary read path (ParallelReads).
- Single-pack ReindexThenRead is +14% slower (cost of singleflight ceremony when there's no parallelisation benefit to capture).