### PR TITLE
plumbing: format/gitignore, Fix dir-only inclusion matching

### DIFF
--- a/plumbing/format/gitignore/matcher.go
+++ b/plumbing/format/gitignore/matcher.go
@@ -25,6 +25,43 @@ func (m *matcher) Match(path []string, isDir bool) bool {
 		if match := m.patterns[i].Match(path, isDir); match > NoMatch {
 			return match == Exclude
 		}
+		// A directory-only inclusion such as !dir/ matches dir itself,
+		// but it can also reopen descendants ignored only by dir-only rules.
+		if dirOnlyInclusionMatchesAncestor(m.patterns[i], path) {
+			var hasDirOnlyExclusion bool
+			for j := i - 1; j >= 0; j-- {
+				if match := m.patterns[j].Match(path, isDir); match == Exclude {
+					if !isDirOnlyExclusion(m.patterns[j]) {
+						return true
+					}
+					hasDirOnlyExclusion = true
+				}
+			}
+
+			if hasDirOnlyExclusion {
+				return false
+			}
+		}
 	}
 	return false
+}
+
+func dirOnlyInclusionMatchesAncestor(p Pattern, path []string) bool {
+	pattern, ok := p.(*pattern)
+	if !ok || !pattern.dirOnly || !pattern.inclusion {
+		return false
+	}
+
+	for i := 1; i < len(path); i++ {
+		if pattern.Match(path[:i], true) == Include {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isDirOnlyExclusion(p Pattern) bool {
+	pattern, ok := p.(*pattern)
+	return ok && pattern.dirOnly && !pattern.inclusion
 }

--- a/plumbing/format/gitignore/matcher_test.go
+++ b/plumbing/format/gitignore/matcher_test.go
@@ -11,6 +11,40 @@ func (s *MatcherSuite) TestMatcher_Match() {
 	s.False(m.Match([]string{"head", "middle", "volcano"}, false))
 }
 
+func (s *MatcherSuite) TestMatcher_DirOnlyInclusionDoesNotOverrideFilePattern() {
+	ps := []Pattern{
+		ParsePattern("*", nil),
+		ParsePattern("!my-dir/", nil),
+	}
+
+	m := NewMatcher(ps)
+	s.False(m.Match([]string{"my-dir"}, true))
+	s.True(m.Match([]string{"my-dir", "sub", "file.txt"}, false))
+}
+
+func (s *MatcherSuite) TestMatcher_DirOnlyInclusionOverridesDirOnlyExclusion() {
+	ps := []Pattern{
+		ParsePattern("my-dir/", nil),
+		ParsePattern("!my-dir/", nil),
+	}
+
+	m := NewMatcher(ps)
+	s.False(m.Match([]string{"my-dir"}, true))
+	s.False(m.Match([]string{"my-dir", "sub", "file.txt"}, false))
+}
+
+func (s *MatcherSuite) TestMatcher_DirOnlyInclusionKeepsFilePatternExcluded() {
+	ps := []Pattern{
+		ParsePattern("*", nil),
+		ParsePattern("my-dir/", nil),
+		ParsePattern("!my-dir/", nil),
+	}
+
+	m := NewMatcher(ps)
+	s.False(m.Match([]string{"my-dir"}, true))
+	s.True(m.Match([]string{"my-dir", "sub", "file.txt"}, false))
+}
+
 // Test that the "exclude everything except" example
 // from https://git-scm.com/docs/gitignore works
 // (copied below):

--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -471,6 +471,9 @@ func (p *pattern) simpleNameMatch(path []string, isDir bool) bool {
 		if !wildmatch(p.pattern[0], name) {
 			continue
 		}
+		if p.dirOnly && p.inclusion {
+			return isDir && i == len(path)-1
+		}
 		if p.dirOnly && !isDir && i == len(path)-1 {
 			return false
 		}

--- a/plumbing/format/gitignore/pattern_test.go
+++ b/plumbing/format/gitignore/pattern_test.go
@@ -21,6 +21,15 @@ func (s *PatternSuite) TestSimpleMatch_inclusion() {
 	s.Equal(Include, r)
 }
 
+func (s *PatternSuite) TestSimpleMatch_dirOnlyInclusionDoesNotMatchDescendants() {
+	p := ParsePattern("!my-dir/", nil)
+
+	s.Equal(Include, p.Match([]string{"my-dir"}, true))
+	s.Equal(NoMatch, p.Match([]string{"my-dir", "file.txt"}, false))
+	s.Equal(NoMatch, p.Match([]string{"my-dir", "sub"}, true))
+	s.Equal(NoMatch, p.Match([]string{"my-dir", "sub", "file.txt"}, false))
+}
+
 func (s *PatternSuite) TestMatch_domainLonger_mismatch() {
 	p := ParsePattern("value", []string{"head", "middle", "tail"})
 	r := p.Match([]string{"head", "middle"}, false)

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -150,6 +150,32 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	assert.False(t, ok, "untracked file inside an ignored directory must not surface in Status")
 }
 
+func TestStatusIgnoresFileUnderDirectoryOnlyInclusion(t *testing.T) {
+	t.Parallel()
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	write := func(name string, data []byte) {
+		require.NoError(t, wt.Filesystem().MkdirAll(filepath.Dir(name), 0o755))
+		require.NoError(t, util.WriteFile(wt.Filesystem(), name, data, 0o644))
+	}
+
+	write(".gitignore", []byte("*\n!my-dir/\n"))
+	write("my-dir/sub/file.txt", []byte("test\n"))
+
+	st, err := wt.Status()
+	require.NoError(t, err)
+
+	_, ok := st["my-dir/sub/file.txt"]
+	assert.False(t, ok, "file under directory-only inclusion must remain ignored")
+}
+
 func BenchmarkWorktreeStatus(b *testing.B) {
 	b.StopTimer()
 


### PR DESCRIPTION
## Summary

Fixes `.gitignore` handling for directory-only inclusion patterns such as `!my-dir/`.

## What changed

- Added regression coverage for `!my-dir/` not matching files under `my-dir/` when another pattern still ignores them.
- Updated simple gitignore matching so directory-only inclusion patterns only match the directory itself directly.
- Preserved directory-only exclusion behavior by allowing `!dir/` to reopen descendants only when the lower-priority match is a directory-only exclusion.

## Why

Issue #2112 reports that go-git treats `!my-dir/` as if it also included files below that directory. Reference Git still ignores `my-dir/sub/file.txt` when the ignore file contains:

```gitignore
*
!my-dir/
```

## Testing

- `go test ./plumbing/format/gitignore -run 'TestPatternSuite|TestMatcherSuite' -count=1`\n- `go test . -run TestStatus -count=1`\n- `make validate-lint`\n- `git diff --check`\n\nNote: I also ran `go test ./plumbing/format/gitignore` and `make test`; both still fail on the existing `TestConformanceSuite/TestIgnoreDoubleStarPrefix` expectation, which I confirmed was already failing before this change.\n\nFixes #2112\n\nAI assistance disclosure: I used OpenAI Codex to inspect the code path and draft the regression test/fix, then reviewed the final diff and ran the listed tests locally.