### PR TITLE
storage: filesystem, fix concurrent access to index map

### DIFF
--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -32,14 +32,17 @@ type ObjectStorage struct {
 	// loaded loose objects.
 	objectCache cache.Object
 
-	dir   *dotgit.DotGit
+	dir *dotgit.DotGit
+
+	// index maps pack file hashes to their decoded indices.
 	index map[plumbing.Hash]idxfile.Index
+	muI   sync.RWMutex // Protects index map
 
 	packList    []plumbing.Hash
 	packListIdx int
-	packfiles   map[plumbing.Hash]*packfile.Packfile
-	muI         sync.RWMutex
-	muP         sync.RWMutex
+	// packfiles caches open packfile handles when KeepDescriptors is enabled.
+	packfiles map[plumbing.Hash]*packfile.Packfile
+	muP       sync.RWMutex // Protects packfiles map and packList
 
 	oh *plumbing.ObjectHasher
 
@@ -207,7 +210,9 @@ func (s *ObjectStorage) requireIndex() error {
 
 // Reindex indexes again all packfiles. Useful if git changed packfiles externally
 func (s *ObjectStorage) Reindex() {
+	s.muI.Lock()
 	s.index = nil
+	s.muI.Unlock()
 }
 
 func (s *ObjectStorage) loadIdxFile(h plumbing.Hash) error {
@@ -306,7 +311,9 @@ func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
 	w.Notify = func(h plumbing.Hash, writer *idxfile.Writer) {
 		index, err := writer.Index()
 		if err == nil {
+			s.muI.Lock()
 			s.index[h] = index
+			s.muI.Unlock()
 		}
 	}
 
@@ -542,7 +549,11 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 	var obj plumbing.EncodedObject
 	var err error
 
-	if s.index != nil {
+	s.muI.RLock()
+	hasIndex := s.index != nil
+	s.muI.RUnlock()
+
+	if hasIndex {
 		obj, err = s.getFromPackfile(h, false)
 		if errors.Is(err, plumbing.ErrObjectNotFound) {
 			obj, err = s.getFromUnpacked(h)
@@ -753,7 +764,16 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
-	for _, index := range s.index {
+
+	// Copy index values into slice while holding lock to avoid races during iteration
+	s.muI.RLock()
+	indices := make([]idxfile.Index, 0, len(s.index))
+	for _, v := range s.index {
+		indices = append(indices, v)
+	}
+	s.muI.RUnlock()
+
+	for _, index := range indices {
 		ei, err := index.Entries()
 		if err != nil {
 			return nil, err
@@ -842,8 +862,11 @@ func (s *ObjectStorage) buildPackfileIters(
 			if err != nil {
 				return nil, err
 			}
+			s.muI.RLock()
+			idx := s.index[h]
+			s.muI.RUnlock()
 			return newPackfileIter(
-				s.dir.Fs(), pack, t, seen, s.index[h],
+				s.dir.Fs(), pack, t, seen, idx,
 				s.objectCache, s.options.KeepDescriptors, h.Size(),
 			)
 		},

--- a/storage/filesystem/object_race_test.go
+++ b/storage/filesystem/object_race_test.go
@@ -1,0 +1,58 @@
+package filesystem
+
+import (
+	"sync"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+)
+
+// TestConcurrentIndexAccess tests that concurrent access to s.index is
+// properly synchronized with mutexes. Without proper mutex protection, this
+// test will trigger race detector failures when run with -race flag.
+//
+// Run with: go test -race -run TestConcurrentIndexAccess ./storage/filesystem/
+func TestConcurrentIndexAccess(t *testing.T) {
+	t.Parallel()
+
+	fixture := fixtures.ByTag("packfile").One()
+	fs, err := fixture.DotGit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	storage := NewStorage(fs, cache.NewObjectLRUDefault())
+	defer func() { _ = storage.Close() }()
+
+	var wg sync.WaitGroup
+
+	// Simulate concurrent operations that access s.index
+	// This should trigger race detector if proper locking isn't in place
+	for range 20 {
+		wg.Add(3)
+
+		// Reader 1: HashesWithPrefix (iterates over s.index)
+		go func() {
+			defer wg.Done()
+			_, _ = storage.HashesWithPrefix([]byte{0x6e})
+		}()
+
+		// Reader 2: EncodedObject (checks s.index != nil)
+		go func() {
+			defer wg.Done()
+			hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+			_, _ = storage.EncodedObject(plumbing.AnyObject, hash)
+		}()
+
+		// Writer: Reindex (sets s.index = nil)
+		go func() {
+			defer wg.Done()
+			storage.Reindex()
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Fix race conditions in ObjectStorage where the `s.index` map was accessed without proper mutex protection in multiple locations.

This PR extracts and focuses on just the index map race fixes from PR #2094. The other fixes in that PR have been superseded by:
- PR #1998 (FSObject.Reader concurrency)
- PR #2131 (DotGit.hasIncomingObjects)

## Changes

**storage/filesystem/object.go:**
- Document `muI` and `muP` mutex fields to clarify what they protect
- `Reindex()`: Add mutex protection around `s.index = nil`
- `PackfileWriter()`: Add mutex protection in Notify callback when writing to `s.index[h]`
- `EncodedObject()`: Add read lock when checking if `s.index != nil`
- `HashesWithPrefix()`: Copy index values to slice while holding lock before iteration
- `buildPackfileIters()`: Add read lock when accessing `s.index[h]` in closure

**storage/filesystem/object_race_test.go** (new):
- Add `TestConcurrentIndexAccess` to reproduce the index map race conditions
- Test simulates concurrent readers (HashesWithPrefix, EncodedObject) and writer (Reindex)
- Run with `go test -race -run TestConcurrentIndexAccess ./storage/filesystem/`

## Note on Test Output

The test may still report race conditions from external dependencies (e.g., memfs package). This is expected - those are separate issues outside the scope of this PR. The s.index races that this PR fixes are now resolved.

## Testing

```bash
# Run the race test
go test -race -run TestConcurrentIndexAccess ./storage/filesystem/

# Run all filesystem tests with race detector
go test -race ./storage/filesystem/... -timeout 5m
```

Supersedes #2094