### PR TITLE
plumbing: protocol/packp, Handle shallow-clone no-op push in update-request decoder

### DIFF
--- a/plumbing/protocol/packp/updreq_decode.go
+++ b/plumbing/protocol/packp/updreq_decode.go
@@ -118,6 +118,12 @@ func (req *UpdateRequests) Decode(r io.Reader) error {
 		}
 	}
 
+	// A shallow-clone no-op push sends shallow lines followed directly by
+	// a flush with no commands. This is valid per the Git protocol.
+	if length == pktline.Flush {
+		return nil
+	}
+
 	// The first command line must contain capabilities separated by a null byte
 	before, after, ok := bytes.Cut(payload, []byte{0})
 	if !ok {

--- a/plumbing/protocol/packp/updreq_decode_test.go
+++ b/plumbing/protocol/packp/updreq_decode_test.go
@@ -34,6 +34,19 @@ func (s *UpdReqDecodeSuite) TestInvalidPktlines() {
 	s.Regexp(regexp.MustCompile("invalid pkt-len found"), r.Decode(input))
 }
 
+func (s *UpdReqDecodeSuite) TestShallowNoOpPush() {
+	hash := plumbing.NewHash("93e0db17d1f45054b842e7316dd66f94268dc87e")
+
+	payloads := []string{
+		"shallow 93e0db17d1f45054b842e7316dd66f94268dc87e",
+		"",
+	}
+
+	req := s.testDecodeOK(payloads)
+	s.Equal([]plumbing.Hash{hash}, req.Shallows)
+	s.Empty(req.Commands)
+}
+
 func (s *UpdReqDecodeSuite) TestInvalidShadow() {
 	payloads := []string{
 		"shallow",


### PR DESCRIPTION
## What
Fix `UpdateRequests.Decode` to gracefully handle a shallow-clone no-op push
where the client sends shallow lines followed immediately by a flush packet
with no command lines.

## Why
When a standard Git client (git version 2.50.1) pushes from a shallow clone and has no changes to
push, it still writes the update-request body as:
```
shallow \n 0000 (flush)
```

This is valid behaviour from the reference `git` implementation — the client
declares its shallow boundary, then discovers there are no commands to send and
emits a flush. You can reproduce this with:

```bash
git clone --depth=1 <repo-url> shallow-copy
cd shallow-copy
git push origin main   # nothing new to push
```