### PR TITLE
plumbing: format/packfile, allow injecting a custom ObjectSelector

### DIFF
--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -20,12 +20,23 @@ var applyDelta = map[plumbing.ObjectType]bool{
 	plumbing.TreeObject: true,
 }
 
-type deltaSelector struct {
+// DeltaSelector decides which objects in a pack will be encoded as
+// deltas and against which base, using a sliding window over the
+// object set. It is the default object selector used by Encoder.
+//
+// Callers can also run a DeltaSelector ahead of time and feed the
+// result back into an Encoder via WithObjectSelector + a passthrough
+// ObjectSelector, so the pack-write phase can stream output without
+// an internal delay during selection. This is useful when the
+// encoder's writer is something like an HTTP request body where
+// mid-stream stalls trip server timeouts.
+type DeltaSelector struct {
 	storer storer.EncodedObjectStorer
 }
 
-func newDeltaSelector(s storer.EncodedObjectStorer) *deltaSelector {
-	return &deltaSelector{s}
+// NewDeltaSelector returns a DeltaSelector backed by s.
+func NewDeltaSelector(s storer.EncodedObjectStorer) *DeltaSelector {
+	return &DeltaSelector{s}
 }
 
 // ObjectsToPack creates a list of ObjectToPack from the hashes
@@ -33,7 +44,7 @@ func newDeltaSelector(s storer.EncodedObjectStorer) *deltaSelector {
 // internal logic.  `packWindow` specifies the size of the sliding
 // window used to compare objects for delta compression; 0 turns off
 // delta compression entirely.
-func (dw *deltaSelector) ObjectsToPack(
+func (dw *DeltaSelector) ObjectsToPack(
 	hashes []plumbing.Hash,
 	packWindow uint,
 ) ([]*ObjectToPack, error) {
@@ -81,7 +92,7 @@ func (dw *deltaSelector) ObjectsToPack(
 	return otp, nil
 }
 
-func (dw *deltaSelector) objectsToPack(
+func (dw *DeltaSelector) objectsToPack(
 	hashes []plumbing.Hash,
 	packWindow uint,
 ) ([]*ObjectToPack, error) {
@@ -117,7 +128,7 @@ func (dw *deltaSelector) objectsToPack(
 	return objectsToPack, nil
 }
 
-func (dw *deltaSelector) encodedDeltaObject(h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (dw *DeltaSelector) encodedDeltaObject(h plumbing.Hash) (plumbing.EncodedObject, error) {
 	edos, ok := dw.storer.(storer.DeltaObjectStorer)
 	if !ok {
 		return dw.encodedObject(h)
@@ -126,11 +137,11 @@ func (dw *deltaSelector) encodedDeltaObject(h plumbing.Hash) (plumbing.EncodedOb
 	return edos.DeltaObject(plumbing.AnyObject, h)
 }
 
-func (dw *deltaSelector) encodedObject(h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (dw *DeltaSelector) encodedObject(h plumbing.Hash) (plumbing.EncodedObject, error) {
 	return dw.storer.EncodedObject(plumbing.AnyObject, h)
 }
 
-func (dw *deltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error {
+func (dw *DeltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error {
 	m := make(map[plumbing.Hash]*ObjectToPack, len(objectsToPack))
 	for _, otp := range objectsToPack {
 		m[otp.Hash()] = otp
@@ -145,7 +156,7 @@ func (dw *deltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error 
 	return nil
 }
 
-func (dw *deltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*ObjectToPack, otp *ObjectToPack) error {
+func (dw *DeltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*ObjectToPack, otp *ObjectToPack) error {
 	if !otp.Object.Type().IsDelta() {
 		return nil
 	}
@@ -179,7 +190,7 @@ func (dw *deltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*O
 	return nil
 }
 
-func (dw *deltaSelector) restoreOriginal(otp *ObjectToPack) error {
+func (dw *DeltaSelector) restoreOriginal(otp *ObjectToPack) error {
 	if otp.Original != nil {
 		return nil
 	}
@@ -200,7 +211,7 @@ func (dw *deltaSelector) restoreOriginal(otp *ObjectToPack) error {
 
 // undeltify undeltifies an *ObjectToPack by retrieving the original object from
 // the storer and resetting it.
-func (dw *deltaSelector) undeltify(otp *ObjectToPack) error {
+func (dw *DeltaSelector) undeltify(otp *ObjectToPack) error {
 	if err := dw.restoreOriginal(otp); err != nil {
 		return err
 	}
@@ -210,11 +221,11 @@ func (dw *deltaSelector) undeltify(otp *ObjectToPack) error {
 	return nil
 }
 
-func (dw *deltaSelector) sort(objectsToPack []*ObjectToPack) {
+func (dw *DeltaSelector) sort(objectsToPack []*ObjectToPack) {
 	sort.Sort(byTypeAndSize(objectsToPack))
 }
 
-func (dw *deltaSelector) walk(
+func (dw *DeltaSelector) walk(
 	objectsToPack []*ObjectToPack,
 	packWindow uint,
 ) error {
@@ -265,7 +276,7 @@ func (dw *deltaSelector) walk(
 	return nil
 }
 
-func (dw *deltaSelector) tryToDeltify(indexMap map[plumbing.Hash]*deltaIndex, base, target *ObjectToPack) error {
+func (dw *DeltaSelector) tryToDeltify(indexMap map[plumbing.Hash]*deltaIndex, base, target *ObjectToPack) error {
 	// Original object might not be present if we're reusing a delta, so we
 	// ensure it is restored.
 	if err := dw.restoreOriginal(target); err != nil {
@@ -316,7 +327,7 @@ func (dw *deltaSelector) tryToDeltify(indexMap map[plumbing.Hash]*deltaIndex, ba
 	return nil
 }
 
-func (dw *deltaSelector) deltaSizeLimit(targetSize int64, baseDepth int,
+func (dw *DeltaSelector) deltaSizeLimit(targetSize int64, baseDepth int,
 	targetDepth int, targetDelta bool,
 ) int64 {
 	if !targetDelta {

--- a/plumbing/format/packfile/delta_selector_test.go
+++ b/plumbing/format/packfile/delta_selector_test.go
@@ -11,7 +11,7 @@ import (
 
 type DeltaSelectorSuite struct {
 	suite.Suite
-	ds     *deltaSelector
+	ds     *DeltaSelector
 	store  *memory.Storage
 	hashes map[string]plumbing.Hash
 }
@@ -24,7 +24,7 @@ func TestDeltaSelectorSuite(t *testing.T) {
 func (s *DeltaSelectorSuite) SetupTest() {
 	s.store = memory.NewStorage()
 	s.createTestObjects()
-	s.ds = newDeltaSelector(s.store)
+	s.ds = NewDeltaSelector(s.store)
 }
 
 func (s *DeltaSelectorSuite) TestSort() {

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -16,21 +16,64 @@ import (
 	"github.com/go-git/go-git/v6/utils/sync"
 )
 
+// ObjectSelector decides which objects go into a pack and in what
+// order, including any delta relationships. The default selector is
+// *DeltaSelector.
+type ObjectSelector interface {
+	ObjectsToPack(hashes []plumbing.Hash, packWindow uint) ([]*ObjectToPack, error)
+}
+
 // Encoder gets the data from the storage and write it into the writer in PACK
-// format
+// format.
+//
+// The encoder has two selector fields: deltaSelector is the
+// encoder's own *DeltaSelector, used internally for write-phase
+// recovery (e.g. restoreOriginal on cyclic chains). objectSelector is
+// what Encode calls to obtain the object list — by default the same
+// *DeltaSelector, but a caller can override it via WithObjectSelector.
 type Encoder struct {
-	selector *deltaSelector
-	w        *offsetWriter
-	zw       sync.ZlibWriter
-	hasher   hash.Hash
+	deltaSelector  *DeltaSelector
+	objectSelector ObjectSelector
+	w              *offsetWriter
+	zw             sync.ZlibWriter
+	hasher         hash.Hash
 
 	useRefDeltas bool
+}
+
+// EncoderOption configures an Encoder at construction time.
+type EncoderOption func(*Encoder)
+
+// WithObjectSelector overrides the ObjectSelector used by Encode to
+// produce the object list. The default is the encoder's own
+// *DeltaSelector, which runs delta selection synchronously when
+// Encode is called.
+//
+// Supplying a selector that returns a precomputed []*ObjectToPack
+// (typically the result of a prior DeltaSelector.ObjectsToPack call)
+// lets Encode skip the selection step and start writing pack bytes
+// immediately. This is useful when the encoder's writer is something
+// like an HTTP request body where a multi-second mid-stream stall
+// trips server timeouts. The encoder still uses its own internal
+// *DeltaSelector for recovery operations during the write phase
+// (e.g. when a concurrent repack invalidates a chosen delta base),
+// so the storer passed to NewEncoder must remain valid.
+func WithObjectSelector(s ObjectSelector) EncoderOption {
+	return func(e *Encoder) {
+		if s != nil {
+			e.objectSelector = s
+		}
+	}
 }
 
 // NewEncoder creates a new packfile encoder using a specific Writer and
 // EncodedObjectStorer. By default deltas used to generate the packfile will be
 // OFSDeltaObject. To use Reference deltas, set useRefDeltas to true.
-func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool) *Encoder {
+//
+// Optional EncoderOptions configure encoder behavior; see
+// WithObjectSelector for the main use case (precomputed selection for
+// streaming output).
+func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool, opts ...EncoderOption) *Encoder {
 	var of cfgformat.ObjectFormat
 	if c, ok := s.(config.ConfigStorer); ok {
 		cfg, err := c.Config()
@@ -49,24 +92,35 @@ func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool) *E
 	mw := io.MultiWriter(w, h)
 	ow := newOffsetWriter(mw)
 	zw := sync.GetZlibWriter(mw)
-	return &Encoder{
-		selector:     newDeltaSelector(s),
-		w:            ow,
-		zw:           zw,
-		hasher:       h,
-		useRefDeltas: useRefDeltas,
+	sel := NewDeltaSelector(s)
+	e := &Encoder{
+		deltaSelector:  sel,
+		objectSelector: sel,
+		w:              ow,
+		zw:             zw,
+		hasher:         h,
+		useRefDeltas:   useRefDeltas,
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // Encode creates a packfile containing all the objects referenced in
 // hashes and writes it to the writer in the Encoder.  `packWindow`
 // specifies the size of the sliding window used to compare objects
 // for delta compression; 0 turns off delta compression entirely.
+//
+// The object set is produced by the configured ObjectSelector (see
+// WithObjectSelector). The encoder's internal *DeltaSelector is still
+// used for recovery operations during the write phase regardless of
+// the configured selector.
 func (e *Encoder) Encode(
 	hashes []plumbing.Hash,
 	packWindow uint,
 ) (plumbing.Hash, error) {
-	objects, err := e.selector.ObjectsToPack(hashes, packWindow)
+	objects, err := e.objectSelector.ObjectsToPack(hashes, packWindow)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -104,7 +158,7 @@ func (e *Encoder) entry(o *ObjectToPack) (err error) {
 		// (for example due to a concurrent repack) and a different base
 		// was chosen, forcing a cycle. Select something other than a
 		// delta, and write this object.
-		if err := e.selector.restoreOriginal(o); err != nil {
+		if err := e.deltaSelector.restoreOriginal(o); err != nil {
 			return err
 		}
 		o.BackToOriginal()

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -125,6 +125,69 @@ func (s *EncoderSuite) TestDecodeEncodeWithCycleOFS() {
 	s.deltaOverDeltaCyclicTest()
 }
 
+// fixedSelector is a test ObjectSelector that returns a fixed
+// []*ObjectToPack from ObjectsToPack, regardless of its arguments.
+// Mirrors the passthrough pattern callers use after running
+// DeltaSelector.ObjectsToPack ahead of time and feeding the result
+// back via WithObjectSelector.
+type fixedSelector struct{ objects []*ObjectToPack }
+
+func (f fixedSelector) ObjectsToPack(_ []plumbing.Hash, _ uint) ([]*ObjectToPack, error) {
+	return f.objects, nil
+}
+
+// TestWithObjectSelectorMatchesDefault asserts that running delta
+// selection externally and feeding the result back via
+// WithObjectSelector produces a byte-identical pack to the default
+// Encode path. This is the contract callers streaming over slow
+// transports rely on: pre-run selection, then stream the pack without
+// an internal selection delay.
+func (s *EncoderSuite) TestWithObjectSelectorMatchesDefault() {
+	o1 := newObject(plumbing.BlobObject, []byte("hello"))
+	o2 := newObject(plumbing.BlobObject, []byte("hello world"))
+	o3 := newObject(plumbing.BlobObject, []byte("goodbye"))
+	for _, o := range []plumbing.EncodedObject{o1, o2, o3} {
+		_, err := s.store.SetEncodedObject(o)
+		s.NoError(err)
+	}
+	hashes := []plumbing.Hash{o1.Hash(), o2.Hash(), o3.Hash()}
+
+	// Default path: encoder runs selection internally.
+	defaultBuf := bytes.NewBuffer(nil)
+	defaultEnc := NewEncoder(defaultBuf, s.store, false)
+	defaultHash, err := defaultEnc.Encode(hashes, 10)
+	s.NoError(err)
+
+	// Precomputed path: caller runs selection ahead of time, then
+	// feeds the result back via a passthrough ObjectSelector.
+	sel := NewDeltaSelector(s.store)
+	objects, err := sel.ObjectsToPack(hashes, 10)
+	s.NoError(err)
+
+	precomputedBuf := bytes.NewBuffer(nil)
+	precomputedEnc := NewEncoder(precomputedBuf, s.store, false,
+		WithObjectSelector(fixedSelector{objects: objects}))
+	precomputedHash, err := precomputedEnc.Encode(hashes, 10)
+	s.NoError(err)
+
+	s.Equal(defaultHash, precomputedHash)
+	s.Equal(defaultBuf.Bytes(), precomputedBuf.Bytes())
+}
+
+// TestWithObjectSelectorNilPreservesDefault asserts that
+// WithObjectSelector(nil) is a no-op — the encoder keeps its own
+// DeltaSelector. Defensive against callers building options lists
+// conditionally.
+func (s *EncoderSuite) TestWithObjectSelectorNilPreservesDefault() {
+	o := newObject(plumbing.BlobObject, []byte("x"))
+	_, err := s.store.SetEncodedObject(o)
+	s.NoError(err)
+
+	enc := NewEncoder(bytes.NewBuffer(nil), s.store, false, WithObjectSelector(nil))
+	_, err = enc.Encode([]plumbing.Hash{o.Hash()}, 10)
+	s.NoError(err)
+}
+
 func (s *EncoderSuite) simpleDeltaTest() {
 	srcObject := newObject(plumbing.BlobObject, []byte("0"))
 	targetObject := newObject(plumbing.BlobObject, []byte("01"))


### PR DESCRIPTION
## Summary

Adds two related extension points to `packfile.Encoder` so callers can take over delta selection while still using the encoder for the write phase:

- `DeltaSelector` and `NewDeltaSelector` are exported (formerly the unexported `deltaSelector` / `newDeltaSelector`). Behaviour and method set unchanged; this only widens visibility.
- `ObjectSelector` is a new interface (just `ObjectsToPack`), satisfied by `*DeltaSelector` by default.
- `WithObjectSelector` is an `EncoderOption` that overrides which `ObjectSelector` `Encode` calls for the selection step. The encoder's internal `*DeltaSelector` is still used for write-phase recovery (`restoreOriginal` on cyclic chains), so the storer passed to `NewEncoder` must remain valid.
- `PrecomputedSelector` wraps a precomputed `[]*ObjectToPack` as an `ObjectSelector` for the common "run selection ahead, then encode" pattern.
- `NewEncoder` now takes variadic `EncoderOption` values. The existing three-argument call sites are unaffected.

## Motivation

When an `Encoder` writes to a slow or strict transport — e.g. an HTTP request body to a CDN-fronted `git-receive-pack` endpoint — `Encode`'s synchronous selection-then-write shape produces a multi-second window during which no bytes flow. Some CDN edges (we observed this against Cloudflare's git frontend) interpret that as an idle upload and close the connection mid-stream.

With this change a caller can run `DeltaSelector.ObjectsToPack` ahead of time, then invoke `Encode` behind a `PrecomputedSelector` so the write phase starts immediately and streams continuously:

```go
sel := packfile.NewDeltaSelector(store)
objects, _ := sel.ObjectsToPack(hashes, packWindow)  // slow phase, before HTTP body opens

enc := packfile.NewEncoder(w, store, useRefDeltas,
    packfile.WithObjectSelector(packfile.PrecomputedSelector(objects)))
enc.Encode(hashes, packWindow)  // selection step returns instantly; pack bytes stream
```

The same hook is also useful for tests that want to mock or assert on the object set, and for callers exploring alternative selection strategies.

## Discussion

This approach was suggested by @pjbgf in Discord as a cleaner alternative to splitting `Encode` into two new public methods — keeping the `Encoder` API surface unchanged and making the selector the injection point. Filing as a PR per that conversation; happy to iterate.

## Test plan
- [x] `go test ./plumbing/format/packfile/...` — existing tests still pass
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` and `gofmt -l` clean
- [x] New `TestWithObjectSelectorMatchesDefault` asserts the precomputed path produces byte-identical output to the default path
- [x] New `TestWithObjectSelectorNilPreservesDefault` asserts `WithObjectSelector(nil)` is a no-op

## AI disclosure

This change was prepared with assistance from Claude Opus 4.7 — design discussion, code drafting, and tests. Every line was reviewed by me; the `Assisted-by:` trailer is on the commit per AI_POLICY.md.