### PR TITLE
worktree: status, Stop at nested git repository boundaries

### DIFF
--- a/utils/merkletrie/change.go
+++ b/utils/merkletrie/change.go
@@ -129,6 +129,10 @@ func (l *Changes) addRecursive(root noder.Path, ctor noderToChangeFn) error {
 		return ErrEmptyFileName
 	}
 
+	if err := detectTraversalBoundary(root); err != nil {
+		return err
+	}
+
 	if !root.IsDir() || isTraversalBoundary(root) {
 		if !root.Skip() {
 			l.Add(ctor(root))
@@ -149,12 +153,25 @@ func (l *Changes) addRecursive(root noder.Path, ctor noderToChangeFn) error {
 			}
 			return err
 		}
+		if !current.Skip() {
+			if err = detectTraversalBoundary(current); err != nil {
+				return err
+			}
+		}
 		if current.Skip() || (current.IsDir() && !isTraversalBoundary(current)) {
 			continue
 		}
 		l.Add(ctor(current))
 	}
 
+	return nil
+}
+
+func detectTraversalBoundary(n noder.Noder) error {
+	if n.IsDir() && !isTraversalBoundary(n) {
+		_, err := n.NumChildren()
+		return err
+	}
 	return nil
 }
 

--- a/utils/merkletrie/change.go
+++ b/utils/merkletrie/change.go
@@ -129,7 +129,7 @@ func (l *Changes) addRecursive(root noder.Path, ctor noderToChangeFn) error {
 		return ErrEmptyFileName
 	}
 
-	if !root.IsDir() {
+	if !root.IsDir() || isTraversalBoundary(root) {
 		if !root.Skip() {
 			l.Add(ctor(root))
 		}
@@ -149,11 +149,24 @@ func (l *Changes) addRecursive(root noder.Path, ctor noderToChangeFn) error {
 			}
 			return err
 		}
-		if current.IsDir() || current.Skip() {
+		if current.Skip() || (current.IsDir() && !isTraversalBoundary(current)) {
 			continue
 		}
 		l.Add(ctor(current))
 	}
 
 	return nil
+}
+
+type traversalBoundary interface {
+	IsTraversalBoundary() bool
+}
+
+func isTraversalBoundary(n noder.Noder) bool {
+	if p, ok := n.(noder.Path); ok && len(p) > 0 {
+		n = p.Last()
+	}
+
+	boundary, ok := n.(traversalBoundary)
+	return ok && boundary.IsTraversalBoundary()
 }

--- a/utils/merkletrie/doubleiter.go
+++ b/utils/merkletrie/doubleiter.go
@@ -138,8 +138,6 @@ const (
 // Compare returns the comparison between the current elements in the
 // merkletries.
 func (d *doubleIter) compare() (s comparison, err error) {
-	s.sameHash = d.hashEqual(d.from.current, d.to.current)
-
 	fromIsDir := d.from.current.IsDir()
 	toIsDir := d.to.current.IsDir()
 
@@ -159,6 +157,7 @@ func (d *doubleIter) compare() (s comparison, err error) {
 
 	s.fromIsEmptyDir = fromIsDir && fromNumChildren == 0
 	s.toIsEmptyDir = toIsDir && toNumChildren == 0
+	s.sameHash = d.hashEqual(d.from.current, d.to.current)
 
 	return s, err
 }

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -43,6 +43,11 @@ type Options struct {
 	// reported. Requires Index to be set: without an index there is no way
 	// to identify tracked entries, so the matcher is treated as a no-op.
 	IgnoreMatcher gitignore.Matcher
+
+	// DetectNestedRepositories stops traversal at untracked directories
+	// containing a .git entry. It is disabled by default because it requires
+	// an extra lookup for each untracked directory candidate.
+	DetectNestedRepositories bool
 }
 
 // The node represents a file or a directory in a billy.Filesystem. It
@@ -278,7 +283,7 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 
 	if _, isSubmodule := n.submodules[path]; isSubmodule {
 		node.isDir = false
-	} else if isDir && !n.hasTrackedDescendant(path) {
+	} else if isDir && n.detectNestedRepositories() && !n.hasTrackedDescendant(path) {
 		isBoundary, err := n.isNestedGitRepository(path)
 		if err != nil {
 			return nil, err
@@ -290,6 +295,10 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 	}
 
 	return node, nil
+}
+
+func (n *node) detectNestedRepositories() bool {
+	return n.options != nil && n.options.DetectNestedRepositories
 }
 
 func (n *node) hasTrackedDescendant(dir string) bool {

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -165,6 +165,10 @@ func (n *node) IsDir() bool {
 	return n.isDir
 }
 
+func (n *node) IsTraversalBoundary() bool {
+	return n.boundary
+}
+
 func (n *node) Skip() bool {
 	return false
 }
@@ -290,7 +294,6 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 		}
 		if isBoundary {
 			node.boundary = true
-			node.isDir = false
 		}
 	}
 

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -56,9 +56,9 @@ type node struct {
 	idx        *index.Index
 	idxMap     map[string]*index.Entry
 	// trackedDirs holds every directory path that has at least one entry
-	// in the index. It is populated only when IgnoreMatcher is set so the
-	// walker can keep tracked entries even if their parent directory
-	// matches an ignore rule.
+	// in the index. It lets the walker keep tracked entries even if their
+	// parent directory matches an ignore rule, and avoids nested repository
+	// checks for directories already represented by tracked descendants.
 	trackedDirs map[string]struct{}
 
 	options *Options
@@ -67,6 +67,7 @@ type node struct {
 	hash     []byte
 	children []noder.Noder
 	isDir    bool
+	boundary bool
 	mode     os.FileMode
 	size     int64
 	modTime  time.Time
@@ -112,15 +113,13 @@ func NewRootNodeWithOptions(
 			idxMap[entry.Name] = entry
 		}
 
-		if options.IgnoreMatcher != nil {
-			trackedDirs = make(map[string]struct{})
-			for _, entry := range options.Index.Entries {
-				for parent := path.Dir(entry.Name); parent != "." && parent != "/"; parent = path.Dir(parent) {
-					if _, ok := trackedDirs[parent]; ok {
-						break
-					}
-					trackedDirs[parent] = struct{}{}
+		trackedDirs = make(map[string]struct{})
+		for _, entry := range options.Index.Entries {
+			for parent := path.Dir(entry.Name); parent != "." && parent != "/"; parent = path.Dir(parent) {
+				if _, ok := trackedDirs[parent]; ok {
+					break
 				}
+				trackedDirs[parent] = struct{}{}
 			}
 		}
 	}
@@ -182,7 +181,7 @@ func (n *node) NumChildren() (int, error) {
 }
 
 func (n *node) calculateChildren() error {
-	if !n.IsDir() {
+	if !n.IsDir() || n.boundary {
 		return nil
 	}
 
@@ -279,15 +278,26 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 
 	if _, isSubmodule := n.submodules[path]; isSubmodule {
 		node.isDir = false
-	} else if isDir {
+	} else if isDir && !n.hasTrackedDescendant(path) {
 		isBoundary, err := n.isNestedGitRepository(path)
 		if err != nil {
 			return nil, err
 		}
-		node.isDir = !isBoundary
+		if isBoundary {
+			node.boundary = true
+			node.isDir = false
+		}
 	}
 
 	return node, nil
+}
+
+func (n *node) hasTrackedDescendant(dir string) bool {
+	if n.trackedDirs == nil {
+		return false
+	}
+	_, ok := n.trackedDirs[dir]
+	return ok
 }
 
 func (n *node) isNestedGitRepository(dir string) (bool, error) {
@@ -302,6 +312,10 @@ func (n *node) isNestedGitRepository(dir string) (bool, error) {
 }
 
 func (n *node) calculateHash() {
+	if n.boundary {
+		n.hash = plumbing.ZeroHash.Bytes()
+		return
+	}
 	if n.isDir {
 		n.hash = make([]byte, 24)
 		return

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -45,8 +45,7 @@ type Options struct {
 	IgnoreMatcher gitignore.Matcher
 
 	// DetectNestedRepositories stops traversal at untracked directories
-	// containing a .git entry. It is disabled by default because it requires
-	// an extra lookup for each untracked directory candidate.
+	// containing a .git entry.
 	DetectNestedRepositories bool
 }
 
@@ -206,6 +205,11 @@ func (n *node) calculateChildren() error {
 		return err
 	}
 
+	if n.isNestedRepositoryBoundary(files) {
+		n.boundary = true
+		return nil
+	}
+
 	for _, file := range files {
 		if _, ok := ignore[file.Name()]; ok {
 			continue
@@ -287,17 +291,21 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 
 	if _, isSubmodule := n.submodules[path]; isSubmodule {
 		node.isDir = false
-	} else if isDir && n.detectNestedRepositories() && !n.hasTrackedDescendant(path) {
-		isBoundary, err := n.isNestedGitRepository(path)
-		if err != nil {
-			return nil, err
-		}
-		if isBoundary {
-			node.boundary = true
-		}
 	}
 
 	return node, nil
+}
+
+func (n *node) isNestedRepositoryBoundary(files []os.DirEntry) bool {
+	if !n.detectNestedRepositories() || n.path == "" || n.hasTrackedDescendant(n.path) {
+		return false
+	}
+	for _, file := range files {
+		if file.Name() == ".git" {
+			return true
+		}
+	}
+	return false
 }
 
 func (n *node) detectNestedRepositories() bool {
@@ -310,17 +318,6 @@ func (n *node) hasTrackedDescendant(dir string) bool {
 	}
 	_, ok := n.trackedDirs[dir]
 	return ok
-}
-
-func (n *node) isNestedGitRepository(dir string) (bool, error) {
-	_, err := n.fs.Stat(path.Join(dir, ".git"))
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return false, err
 }
 
 func (n *node) calculateHash() {

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -260,6 +260,7 @@ func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
 
 func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 	path := path.Join(n.path, file.Name())
+	isDir := file.IsDir()
 
 	node := &node{
 		fs:          n.fs,
@@ -270,7 +271,7 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 		options:     n.options,
 
 		path:    path,
-		isDir:   file.IsDir(),
+		isDir:   isDir,
 		size:    file.Size(),
 		mode:    file.Mode(),
 		modTime: file.ModTime(),
@@ -278,9 +279,26 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 
 	if _, isSubmodule := n.submodules[path]; isSubmodule {
 		node.isDir = false
+	} else if isDir {
+		isBoundary, err := n.isNestedGitRepository(path)
+		if err != nil {
+			return nil, err
+		}
+		node.isDir = !isBoundary
 	}
 
 	return node, nil
+}
+
+func (n *node) isNestedGitRepository(dir string) (bool, error) {
+	_, err := n.fs.Stat(path.Join(dir, ".git"))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 func (n *node) calculateHash() {

--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -30,6 +30,18 @@ type NoderSuite struct {
 	suite.Suite
 }
 
+type rejectStatFS struct {
+	billy.Filesystem
+	reject string
+}
+
+func (fs *rejectStatFS) Stat(filename string) (os.FileInfo, error) {
+	if filename == fs.reject {
+		return nil, fmt.Errorf("unexpected Stat(%q)", filename)
+	}
+	return fs.Filesystem.Stat(filename)
+}
+
 func TestNoderSuite(t *testing.T) {
 	t.Parallel()
 	suite.Run(t, new(NoderSuite))
@@ -274,6 +286,23 @@ func (s *NoderSuite) TestDetectNestedRepositoryBoundary() {
 	s.Require().NoError(err)
 	s.Equal(merkletrie.Insert, action)
 	s.Equal("nested", changes[0].To.String())
+}
+
+func (s *NoderSuite) TestDetectNestedRepositoryBoundaryUsesDirectoryListing() {
+	base := memfs.New()
+	s.Require().NoError(base.MkdirAll("nested", 0o755))
+	s.Require().NoError(WriteFile(base, "nested/.git", []byte("gitdir: ../.git/worktrees/nested\n"), 0o644))
+	s.Require().NoError(WriteFile(base, "nested/file.txt", []byte("nested\n"), 0o644))
+
+	fs := &rejectStatFS{Filesystem: base, reject: "nested/.git"}
+	root := NewRootNodeWithOptions(fs, nil, Options{DetectNestedRepositories: true})
+	children, err := root.Children()
+	s.Require().NoError(err)
+	s.Require().Len(children, 1)
+
+	grandchildren, err := children[0].Children()
+	s.Require().NoError(err)
+	s.Empty(grandchildren)
 }
 
 func (s *NoderSuite) TestSocket() {

--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -232,6 +232,41 @@ func (s *NoderSuite) TestDiffDirectory() {
 	s.Equal(merkletrie.Modify, a)
 }
 
+func (s *NoderSuite) TestNestedRepositoryDetectionIsOptIn() {
+	fs := memfs.New()
+	s.Require().NoError(fs.MkdirAll("nested", 0o755))
+	s.Require().NoError(WriteFile(fs, "nested/.git", []byte("gitdir: ../.git/worktrees/nested\n"), 0o644))
+	s.Require().NoError(WriteFile(fs, "nested/file.txt", []byte("nested\n"), 0o644))
+
+	root := NewRootNodeWithOptions(fs, nil, Options{})
+	children, err := root.Children()
+	s.Require().NoError(err)
+	s.Require().Len(children, 1)
+	s.True(children[0].IsDir(), "nested repositories should only become boundaries when explicitly requested")
+
+	grandchildren, err := children[0].Children()
+	s.Require().NoError(err)
+	s.Require().Len(grandchildren, 1, ".git is ignored while ordinary children are still walked")
+	s.Equal("file.txt", grandchildren[0].Name())
+}
+
+func (s *NoderSuite) TestDetectNestedRepositoryBoundary() {
+	fs := memfs.New()
+	s.Require().NoError(fs.MkdirAll("nested", 0o755))
+	s.Require().NoError(WriteFile(fs, "nested/.git", []byte("gitdir: ../.git/worktrees/nested\n"), 0o644))
+	s.Require().NoError(WriteFile(fs, "nested/file.txt", []byte("nested\n"), 0o644))
+
+	root := NewRootNodeWithOptions(fs, nil, Options{DetectNestedRepositories: true})
+	children, err := root.Children()
+	s.Require().NoError(err)
+	s.Require().Len(children, 1)
+	s.False(children[0].IsDir(), "nested repository boundary should be file-like so status reports the boundary path")
+
+	grandchildren, err := children[0].Children()
+	s.Require().NoError(err)
+	s.Empty(grandchildren)
+}
+
 func (s *NoderSuite) TestSocket() {
 	if runtime.GOOS == "windows" {
 		s.T().Skip("socket files do not exist on windows")

--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -260,11 +260,20 @@ func (s *NoderSuite) TestDetectNestedRepositoryBoundary() {
 	children, err := root.Children()
 	s.Require().NoError(err)
 	s.Require().Len(children, 1)
-	s.False(children[0].IsDir(), "nested repository boundary should be file-like so status reports the boundary path")
+	s.True(children[0].IsDir(), "nested repository boundary should preserve filesystem directory semantics")
 
 	grandchildren, err := children[0].Children()
 	s.Require().NoError(err)
 	s.Empty(grandchildren)
+
+	changes, err := merkletrie.DiffTree(NewRootNode(memfs.New(), nil), root, IsEquals)
+	s.Require().NoError(err)
+	s.Require().Len(changes, 1, "nested repository boundary should still be reported as an inserted path")
+
+	action, err := changes[0].Action()
+	s.Require().NoError(err)
+	s.Equal(merkletrie.Insert, action)
+	s.Equal("nested", changes[0].To.String())
 }
 
 func (s *NoderSuite) TestSocket() {

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -156,8 +156,9 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 	}
 
 	fsOpts := filesystem.Options{
-		AutoCRLF: cfg.Core.AutoCRLF == "true" || cfg.Core.AutoCRLF == "input",
-		Index:    idx,
+		AutoCRLF:                 cfg.Core.AutoCRLF == "true" || cfg.Core.AutoCRLF == "input",
+		Index:                    idx,
+		DetectNestedRepositories: true,
 	}
 
 	// When ignored changes are to be filtered out, gather the gitignore

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -150,6 +150,41 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	assert.False(t, ok, "untracked file inside an ignored directory must not surface in Status")
 }
 
+func TestStatusTreatsNestedGitFileAsRepositoryBoundary(t *testing.T) {
+	t.Parallel()
+
+	repoDir := t.TempDir()
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	require.NoError(t, util.WriteFile(wt.Filesystem(), "file.txt", []byte("hello\n"), 0o644))
+	_, err = wt.Add("file.txt")
+	require.NoError(t, err)
+
+	sig := &object.Signature{Name: "test", Email: "test@test.com"}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(t, err)
+
+	nestedWorktree := filepath.Join(repoDir, ".worktrees", "feature")
+	require.NoError(t, os.MkdirAll(nestedWorktree, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedWorktree, ".git"), []byte("gitdir: ../../.git/worktrees/feature\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedWorktree, "file.txt"), []byte("nested\n"), 0o644))
+
+	st, err := wt.Status()
+	require.NoError(t, err)
+
+	boundary, ok := st[".worktrees/feature"]
+	require.True(t, ok, "nested git worktree must be reported at its boundary")
+	assert.Equal(t, Untracked, boundary.Worktree)
+
+	_, ok = st[".worktrees/feature/file.txt"]
+	assert.False(t, ok, "Status must not descend into a nested git worktree")
+}
+
 func BenchmarkWorktreeStatus(b *testing.B) {
 	b.StopTimer()
 


### PR DESCRIPTION
## Summary

- Treat directories containing their own `.git` entry as nested repository boundaries during worktree status traversal.
- Add a regression test for a nested worktree-style directory so `Status()` reports the boundary path instead of recursing into files owned by that worktree.

Fixes #1896

## Git compatibility

Checked the same shape against reference Git locally:

```console
$ git status --porcelain --untracked-files=all
?? .worktrees/feature/
```

Git reports the nested worktree boundary and does not list `.worktrees/feature/file.txt`.

## Validation

Passed:

- `go test ./... -run TestStatusTreatsNestedGitFileAsRepositoryBoundary -count=1`
- `go test -race . ./utils/merkletrie/filesystem -run 'TestStatusTreatsNestedGitFileAsRepositoryBoundary|TestStatusReportsModifiedTrackedFileInIgnoredDirectory|TestIgnoredDirIsSkipped|TestSubmoduleInIgnoredDirIsWalked' -count=1`
- `make validate-lint`
- `git diff --check`

Also ran `make test`. The touched packages passed under that run, but the full local run failed in unrelated environment-dependent suites:

- `plumbing/format/gitignore`: conformance oracle disagreed with Apple Git 2.39.5 for `foo**/bar`.
- `plumbing/transport/git`: local git daemon connection setup failed with `context canceled before the port is connectable`.
- `plumbing/transport/ssh`: local SSH tests failed because no valid `known_hosts` file was available.

## AI disclosure

OpenAI GPT-5 assisted with code navigation, drafting the small code/test change, and preparing this PR text. I reviewed the diff and ran the validation above before submitting.
