### PR TITLE
plumbing: transport/ssh, honor custom host key callbacks

### DIFF
--- a/plumbing/transport/ssh/auth.go
+++ b/plumbing/transport/ssh/auth.go
@@ -17,6 +17,8 @@ import (
 	"github.com/go-git/go-git/v6/utils/trace"
 )
 
+var errNoKnownHostsFiles = errors.New("unable to find any valid known_hosts file, set SSH_KNOWN_HOSTS env variable")
+
 // The names of the auth method implementations.
 const (
 	keyboardInteractiveName = "ssh-keyboard-interactive"
@@ -281,7 +283,7 @@ func filterKnownHostsFiles(files ...string) ([]string, error) {
 	}
 
 	if len(out) == 0 {
-		return nil, fmt.Errorf("unable to find any valid known_hosts file, set SSH_KNOWN_HOSTS env variable")
+		return nil, errNoKnownHostsFiles
 	}
 
 	return out, nil

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -30,8 +30,9 @@ type Options struct {
 	// ClientConfig provides SSH client configuration for each request.
 	// If nil, SSH agent authentication is used with the username from the
 	// URL (falling back to DefaultUsername).
-	// When ClientConfig provides a custom HostKeyCallback, HostKeyAlgorithms
-	// are not inferred from known_hosts; set them explicitly if required.
+	// When ClientConfig provides a custom HostKeyCallback and no
+	// HostKeyAlgorithms, known_hosts is used for algorithm preference when
+	// available, but missing known_hosts files do not fail the connection.
 	ClientConfig func(context.Context, *transport.Request) (*gossh.ClientConfig, error)
 
 	// DialContext is the function used to establish TCP connections.
@@ -78,15 +79,8 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 		return nil, err
 	}
 
-	// Only derive host key algorithms from known_hosts when using the default
-	// callback. A custom callback may not be backed by known_hosts.
-	if config.HostKeyCallback == nil {
-		db, err := newKnownHostsDb(t.knownHostsFiles...)
-		if err != nil {
-			return nil, err
-		}
-		config.HostKeyCallback = db.HostKeyCallback()
-		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
+	if err := t.configureHostKeys(config, hostWithPort); err != nil {
+		return nil, err
 	}
 
 	if len(config.HostKeyAlgorithms) == 0 {
@@ -153,6 +147,28 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 	}
 
 	return conn, nil
+}
+
+func (t *Transport) configureHostKeys(config *gossh.ClientConfig, hostWithPort string) error {
+	if config.HostKeyCallback != nil && len(config.HostKeyAlgorithms) != 0 {
+		return nil
+	}
+
+	db, err := newKnownHostsDb(t.knownHostsFiles...)
+	if err != nil {
+		if config.HostKeyCallback != nil && errors.Is(err, errNoKnownHostsFiles) {
+			return nil
+		}
+		return err
+	}
+
+	if config.HostKeyCallback == nil {
+		config.HostKeyCallback = db.HostKeyCallback()
+	}
+	if len(config.HostKeyAlgorithms) == 0 {
+		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
+	}
+	return nil
 }
 
 func (t *Transport) resolveConfig(ctx context.Context, req *transport.Request) (*gossh.ClientConfig, error) {

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -30,6 +30,8 @@ type Options struct {
 	// ClientConfig provides SSH client configuration for each request.
 	// If nil, SSH agent authentication is used with the username from the
 	// URL (falling back to DefaultUsername).
+	// When ClientConfig provides a custom HostKeyCallback, HostKeyAlgorithms
+	// are not inferred from known_hosts; set them explicitly if required.
 	ClientConfig func(context.Context, *transport.Request) (*gossh.ClientConfig, error)
 
 	// DialContext is the function used to establish TCP connections.
@@ -75,6 +77,8 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 		return nil, err
 	}
 
+	// Only derive host key algorithms from known_hosts when using the default
+	// callback. A custom callback may not be backed by known_hosts.
 	if config.HostKeyCallback == nil {
 		db, err := newKnownHostsDb()
 		if err != nil {
@@ -82,15 +86,13 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 		}
 		config.HostKeyCallback = db.HostKeyCallback()
 		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
-	} else if len(config.HostKeyAlgorithms) == 0 {
-		db, err := newKnownHostsDb()
-		if err != nil {
-			return nil, err
-		}
-		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 	}
 
-	trace.SSH.Printf("ssh: host key algorithms %s", strings.Join(config.HostKeyAlgorithms, ", "))
+	if len(config.HostKeyAlgorithms) == 0 {
+		trace.SSH.Printf("ssh: host key algorithms (default)")
+	} else {
+		trace.SSH.Printf("ssh: host key algorithms %s", strings.Join(config.HostKeyAlgorithms, ", "))
+	}
 
 	client, err := t.dial(ctx, "tcp", hostWithPort, config)
 	if err != nil {

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -49,7 +49,8 @@ type Options struct {
 
 // Transport implements the ssh:// transport protocol.
 type Transport struct {
-	opts Options
+	opts            Options
+	knownHostsFiles []string
 }
 
 // NewTransport creates an SSH transport with the given options.
@@ -80,7 +81,7 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 	// Only derive host key algorithms from known_hosts when using the default
 	// callback. A custom callback may not be backed by known_hosts.
 	if config.HostKeyCallback == nil {
-		db, err := newKnownHostsDb()
+		db, err := newKnownHostsDb(t.knownHostsFiles...)
 		if err != nil {
 			return nil, err
 		}

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -4,11 +4,13 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
@@ -250,6 +252,35 @@ func TestSSHTransport_CustomHostKeyCallbackWithoutKnownHosts(t *testing.T) {
 
 	_, err := tr.Connect(context.Background(), req)
 	require.ErrorIs(t, err, dialErr)
+}
+
+func TestSSHTransport_CustomHostKeyCallbackUsesKnownHostsAlgorithms(t *testing.T) {
+	callbackErr := errors.New("custom callback reached")
+	config := &stdssh.ClientConfig{
+		User: "git",
+		HostKeyCallback: func(string, net.Addr, stdssh.PublicKey) error {
+			return callbackErr
+		},
+	}
+	tr := NewTransport(Options{})
+	tr.knownHostsFiles = []string{writeKnownHostsFile(t, "example.com")}
+
+	require.NoError(t, tr.configureHostKeys(config, "example.com:22"))
+	require.Equal(t, []string{stdssh.KeyAlgoED25519}, config.HostKeyAlgorithms)
+	require.ErrorIs(t, config.HostKeyCallback("", nil, nil), callbackErr)
+}
+
+func writeKnownHostsFile(t *testing.T, host string) string {
+	t.Helper()
+
+	signer, err := stdssh.ParsePrivateKey(testdata.PEMBytes["ed25519"])
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	key := signer.PublicKey()
+	line := fmt.Sprintf("%s %s %s\n", host, key.Type(), base64.StdEncoding.EncodeToString(key.Marshal()))
+	require.NoError(t, os.WriteFile(path, []byte(line), 0o644))
+	return path
 }
 
 func TestSSHTransport_Archive(t *testing.T) {

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -24,6 +25,8 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 )
+
+var knownHostsEnvMu sync.Mutex
 
 func startSSHServer(t *testing.T) *net.TCPAddr {
 	t.Helper()
@@ -221,6 +224,37 @@ func TestSSHTransport_NoConfig(t *testing.T) {
 
 	_, err := tr.Connect(context.Background(), req)
 	require.Error(t, err)
+}
+
+func TestSSHTransport_CustomHostKeyCallbackWithoutKnownHosts(t *testing.T) {
+	knownHostsEnvMu.Lock()
+	t.Cleanup(knownHostsEnvMu.Unlock)
+	t.Setenv("SSH_KNOWN_HOSTS", filepath.Join(t.TempDir(), "missing-known-hosts"))
+
+	dialErr := errors.New("dial reached")
+	tr := NewTransport(Options{
+		ClientConfig: func(_ context.Context, _ *transport.Request) (*stdssh.ClientConfig, error) {
+			return &stdssh.ClientConfig{
+				User:            "git",
+				HostKeyCallback: stdssh.InsecureIgnoreHostKey(),
+			}, nil
+		},
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, dialErr
+		},
+	})
+
+	req := &transport.Request{
+		URL: &url.URL{
+			Scheme: "ssh",
+			Host:   "example.com",
+			Path:   "/repo.git",
+		},
+		Command: "git-upload-pack",
+	}
+
+	_, err := tr.Connect(context.Background(), req)
+	require.ErrorIs(t, err, dialErr)
 }
 
 func TestSSHTransport_Archive(t *testing.T) {

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/transport"
 )
 
-var knownHostsEnvMu sync.Mutex
-
 func startSSHServer(t *testing.T) *net.TCPAddr {
 	t.Helper()
 
@@ -227,10 +225,6 @@ func TestSSHTransport_NoConfig(t *testing.T) {
 }
 
 func TestSSHTransport_CustomHostKeyCallbackWithoutKnownHosts(t *testing.T) {
-	knownHostsEnvMu.Lock()
-	t.Cleanup(knownHostsEnvMu.Unlock)
-	t.Setenv("SSH_KNOWN_HOSTS", filepath.Join(t.TempDir(), "missing-known-hosts"))
-
 	dialErr := errors.New("dial reached")
 	tr := NewTransport(Options{
 		ClientConfig: func(_ context.Context, _ *transport.Request) (*stdssh.ClientConfig, error) {
@@ -243,6 +237,7 @@ func TestSSHTransport_CustomHostKeyCallbackWithoutKnownHosts(t *testing.T) {
 			return nil, dialErr
 		},
 	})
+	tr.knownHostsFiles = []string{filepath.Join(t.TempDir(), "missing-known-hosts")}
 
 	req := &transport.Request{
 		URL: &url.URL{


### PR DESCRIPTION
## Summary

- keep custom `HostKeyCallback` configurations usable when known_hosts files are missing
- preserve known_hosts-derived `HostKeyAlgorithms` for custom callbacks when known_hosts is available and the caller leaves `HostKeyAlgorithms` empty
- clarify SSH trace output when the client uses default host key algorithm negotiation
- avoid process-wide `SSH_KNOWN_HOSTS` mutation in regression tests by injecting known_hosts files through the transport

Fixes #1234

## Validation

- Red check before implementation: `go test ./plumbing/transport/ssh -run TestSSHTransport_CustomHostKeyCallbackWithoutKnownHosts -count=1` failed with `unable to find any valid known_hosts file, set SSH_KNOWN_HOSTS env variable` instead of reaching the dialer
- `go test ./plumbing/transport/ssh -count=1`
- `go test ./plumbing/transport/... -count=1`
- `go test -race ./plumbing/transport/ssh ./plumbing/transport/ssh/knownhosts -count=1`
- `make validate-lint`
- `git diff --check` and `git diff HEAD^ --check`
- Latest review-thread refresh: `go test ./plumbing/transport/ssh` and `git diff --check upstream/main...HEAD`

Also ran `make test`, which executes `go test -race ./...`. The touched SSH/transport packages passed in that run, but the full target failed in the existing local `plumbing/format/gitignore` conformance oracle against Apple Git 2.39.5 for `foo**/bar` matching `foobar`/`foobar/baz`; that package is outside this change.

## AI assistance disclosure

OpenAI GPT-5 assisted with issue/code navigation, drafting the focused tests and patches, and selecting validation commands. I reviewed the final diff and validation output before submitting.