### PR TITLE
remote: getHavesFromRef, peel tag refs to commits

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -821,12 +821,27 @@ func getHavesFromRef(
 		return nil
 	}
 
-	commit, err := object.GetCommit(s, h)
+	// The pack protocol requires `have <obj-id>` to name a commit, so we
+	// peel annotated-tag refs down to their underlying commit and skip
+	// refs that point at trees or blobs.
+	obj, err := s.EncodedObject(plumbing.AnyObject, h)
 	if err != nil {
-		if !errors.Is(err, plumbing.ErrObjectNotFound) {
-			// Ignore the error if this isn't a commit.
-			haves[ref.Hash()] = true
+		// Object isn't present locally (e.g. shallow clone).
+		return nil
+	}
+	var commit *object.Commit
+	switch obj.Type() {
+	case plumbing.CommitObject:
+		commit, err = object.DecodeCommit(s, obj)
+		if err != nil {
+			return nil
 		}
+	case plumbing.TagObject:
+		commit, err = peelToCommit(s, h)
+		if err != nil || commit == nil {
+			return nil
+		}
+	default:
 		return nil
 	}
 
@@ -854,6 +869,35 @@ func getHavesFromRef(
 	})
 
 	return nil
+}
+
+// maxTagPeelDepth bounds tag-chain peeling in peelToCommit to guard against
+// pathological or cyclic tag-of-tag chains. Real-world annotated tags rarely
+// chain more than once or twice.
+const maxTagPeelDepth = 16
+
+// peelToCommit resolves an object hash that is expected to be reachable
+// through a tag chain down to its underlying commit. It follows
+// Tag.TargetType / Tag.Target through nested annotated tags. If the chain
+// terminates at something other than a commit (a tree or blob), or the
+// chain is missing/malformed, peelToCommit returns (nil, nil) so callers
+// can treat the ref as unadvertisable without surfacing a hard error.
+func peelToCommit(s storage.Storer, h plumbing.Hash) (*object.Commit, error) {
+	for i := 0; i < maxTagPeelDepth; i++ {
+		tag, err := object.GetTag(s, h)
+		if err != nil {
+			return nil, nil
+		}
+		switch tag.TargetType {
+		case plumbing.CommitObject:
+			return object.GetCommit(s, tag.Target)
+		case plumbing.TagObject:
+			h = tag.Target
+		default:
+			return nil, nil
+		}
+	}
+	return nil, nil
 }
 
 func getHaves(

--- a/remote_test.go
+++ b/remote_test.go
@@ -1394,6 +1394,112 @@ func (s *RemoteSuite) TestGetHaves() {
 	s.Len(l, 2)
 }
 
+// storeHavesCommit encodes a Commit with the given message into sto and
+// returns its hash. The commit has no parents and a zero tree, which is
+// sufficient for getHaves negotiation tests because the walker simply stops
+// at missing parents.
+func storeHavesCommit(s *RemoteSuite, sto storage.Storer, message string) plumbing.Hash {
+	when := time.Unix(0, 0).UTC()
+	commit := &object.Commit{
+		Author:    object.Signature{Name: "Author", Email: "author@example.local", When: when},
+		Committer: object.Signature{Name: "Committer", Email: "committer@example.local", When: when},
+		Message:   message,
+	}
+	obj := &plumbing.MemoryObject{}
+	s.Require().NoError(commit.Encode(obj))
+	h, err := sto.SetEncodedObject(obj)
+	s.Require().NoError(err)
+	return h
+}
+
+// storeHavesTag encodes an annotated Tag pointing at target with the given
+// target type and returns its hash.
+func storeHavesTag(s *RemoteSuite, sto storage.Storer, target plumbing.Hash, targetType plumbing.ObjectType, name string) plumbing.Hash {
+	tag := &object.Tag{
+		Name:       name,
+		Tagger:     object.Signature{Name: "Tagger", Email: "tagger@example.local", When: time.Unix(0, 0).UTC()},
+		Message:    name + "\n",
+		TargetType: targetType,
+		Target:     target,
+	}
+	obj := &plumbing.MemoryObject{}
+	s.Require().NoError(tag.Encode(obj))
+	h, err := sto.SetEncodedObject(obj)
+	s.Require().NoError(err)
+	return h
+}
+
+// storeHavesBlob writes a blob of the given content and returns its hash.
+func storeHavesBlob(s *RemoteSuite, sto storage.Storer, content string) plumbing.Hash {
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.BlobObject)
+	_, err := obj.Write([]byte(content))
+	s.Require().NoError(err)
+	h, err := sto.SetEncodedObject(obj)
+	s.Require().NoError(err)
+	return h
+}
+
+func (s *RemoteSuite) TestGetHavesPeelsAnnotatedTag() {
+	sto := memory.NewStorage()
+	commitHash := storeHavesCommit(s, sto, "tagged commit\n")
+	tagHash := storeHavesTag(s, sto, commitHash, plumbing.CommitObject, "v1.0")
+
+	localRefs := []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/tags/v1.0", tagHash.String()),
+	}
+
+	l, err := getHaves(localRefs, memory.NewStorage(), sto, 0)
+	s.NoError(err)
+	s.Contains(l, commitHash)
+	s.NotContains(l, tagHash)
+}
+
+func (s *RemoteSuite) TestGetHavesPeelsNestedAnnotatedTag() {
+	sto := memory.NewStorage()
+	commitHash := storeHavesCommit(s, sto, "deeply tagged commit\n")
+	inner := storeHavesTag(s, sto, commitHash, plumbing.CommitObject, "inner")
+	outer := storeHavesTag(s, sto, inner, plumbing.TagObject, "outer")
+
+	localRefs := []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/tags/outer", outer.String()),
+	}
+
+	l, err := getHaves(localRefs, memory.NewStorage(), sto, 0)
+	s.NoError(err)
+	s.Contains(l, commitHash)
+	s.NotContains(l, inner)
+	s.NotContains(l, outer)
+}
+
+func (s *RemoteSuite) TestGetHavesSkipsTagToBlob() {
+	sto := memory.NewStorage()
+	blobHash := storeHavesBlob(s, sto, "blob contents")
+	tagHash := storeHavesTag(s, sto, blobHash, plumbing.BlobObject, "blob-tag")
+
+	localRefs := []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/tags/blob-tag", tagHash.String()),
+	}
+
+	l, err := getHaves(localRefs, memory.NewStorage(), sto, 0)
+	s.NoError(err)
+	s.Empty(l)
+}
+
+func (s *RemoteSuite) TestGetHavesSkipsTagToMissingObject() {
+	sto := memory.NewStorage()
+	missing := plumbing.NewHash("1111111111111111111111111111111111111111")
+	tagHash := storeHavesTag(s, sto, missing, plumbing.CommitObject, "dangling")
+
+	localRefs := []*plumbing.Reference{
+		plumbing.NewReferenceFromStrings("refs/tags/dangling", tagHash.String()),
+	}
+
+	l, err := getHaves(localRefs, memory.NewStorage(), sto, 0)
+	s.NoError(err)
+	s.Empty(l)
+}
+
 func (s *RemoteSuite) TestList() {
 	repo := fixtures.Basic().One()
 	remote := NewRemote(memory.NewStorage(), &config.RemoteConfig{


### PR DESCRIPTION
The pack protocol requires `have <obj-id>` lines to name commits, but getHavesFromRef previously either advertised non-commit hashes (on storage that distinguishes "wrong type" from "missing") or silently dropped the ref (on storage that returns ErrObjectNotFound for both). Both behaviours are wrong: the first violates the spec and can fail upload-pack on servers that decode haves; the second loses negotiation information for refs that point at annotated tags.

Switch to a type-directed dispatch: read the object as AnyObject, then walk tag chains down to a commit via peelToCommit. Skip refs that resolve to a tree or blob, and skip truly-missing objects (shallow clone case).

Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>