### PR TITLE
*: speed up multi-pack reads via Index fanout probes

### DIFF
--- a/internal/packhandle/doc.go
+++ b/internal/packhandle/doc.go
@@ -11,11 +11,8 @@
 // one-second idle grace period once no cursors remain. .idx and
 // .rev descriptors are owned by the returned [idxfile.Index].
 //
-// The package is internal and its surface is provisional: types
-// and contracts here are expected to be revisited once
-// [idxfile.Index] is reworked, at which point the current split
-// FD ownership between this package and idxfile may collapse.
-// Consumers must not surface any packhandle identifier on their
-// own exported APIs; hold *PackHandle as a private named field
-// (embedding is forbidden because it leaks the method set).
+// The package is internal: consumers must not surface any
+// packhandle identifier on their own exported APIs; hold
+// *PackHandle as a private named field (embedding is forbidden
+// because it leaks the method set).
 package packhandle

--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -1,6 +1,7 @@
 package idxfile
 
 import (
+	"bytes"
 	"crypto"
 	encbin "encoding/binary"
 	"fmt"
@@ -46,6 +47,13 @@ type Index interface {
 	// EntriesByOffset returns an iterator to retrieve all index entries ordered
 	// by offset.
 	EntriesByOffset() (EntryIter, error)
+	// EntriesWithPrefix returns an iterator over index entries whose
+	// hashes start with prefix. Implementations use the fanout table
+	// to bound the search when len(prefix) >= 1; an empty prefix
+	// returns all entries (equivalent to Entries). The returned
+	// iterator must be Closed by the caller to release any held
+	// resources.
+	EntriesWithPrefix(prefix []byte) (EntryIter, error)
 	// MayContain reports whether the index might contain h. A false
 	// return is authoritative ("h is definitely not in this pack")
 	// based on the idx fanout table; true means the caller should
@@ -303,6 +311,57 @@ func (idx *MemoryIndex) Entries() (EntryIter, error) {
 	return &idxfileEntryIter{idx, 0, 0, 0}, nil
 }
 
+// EntriesWithPrefix implements the Index interface. It returns an
+// iterator over entries whose hashes start with prefix. When prefix
+// is empty the call is equivalent to Entries; otherwise the
+// iterator visits only the fanout bucket selected by prefix[0] and
+// stops as soon as the sorted-by-hash bucket walks past prefix.
+//
+// For a multi-byte prefix the matching entries form a contiguous
+// run somewhere within the bucket; binary-search positions the
+// iterator at the start of that run so the linear walk only spans
+// matches. This mirrors upstream Git's for_each_prefixed_object_in_pack
+// which calls bsearch_pack to position before walking forward.
+func (idx *MemoryIndex) EntriesWithPrefix(prefix []byte) (EntryIter, error) {
+	if len(prefix) == 0 {
+		return idx.Entries()
+	}
+	bucket := idx.FanoutMapping[prefix[0]]
+	if bucket == noMapping {
+		return &idxfilePrefixIter{done: true}, nil
+	}
+	idSize := idx.idSize()
+	names := idx.Names[bucket]
+	n := len(names) / idSize
+
+	// Find the leftmost entry whose hash is >= prefix (padded with
+	// zeros to hash size). All matching entries, if any, start at
+	// this position; the iterator's stop-on-first-mismatch then
+	// terminates correctly once the run ends.
+	target := make([]byte, idSize)
+	copy(target, prefix)
+	lo, hi := 0, n
+	for lo < hi {
+		mid := (lo + hi) >> 1
+		slot := names[mid*idSize : (mid+1)*idSize]
+		if bytes.Compare(slot, target) < 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+
+	return &idxfilePrefixIter{
+		idSize:   idSize,
+		prefix:   prefix,
+		names:    names,
+		offset32: idx.Offset32[bucket],
+		crc32:    idx.CRC32[bucket],
+		offset64: idx.Offset64,
+		pos:      lo,
+	}, nil
+}
+
 // EntriesByOffset implements the Index interface.
 func (idx *MemoryIndex) EntriesByOffset() (EntryIter, error) {
 	count, err := idx.Count()
@@ -389,6 +448,93 @@ func (i *idxfileEntryIter) Next() (*Entry, error) {
 
 func (i *idxfileEntryIter) Close() error {
 	i.firstLevel = fanout
+	return nil
+}
+
+// idxfilePrefixIter walks a single fanout bucket, yielding entries
+// whose hash starts with prefix. The bucket is sorted by hash, so
+// once a name is read whose first bytes do not match prefix the
+// iterator stops.
+//
+// The iterator references the bucket's per-slot slices directly
+// (names, offset32, crc32) plus the shared offset64 table, so it
+// does not retain a reference to the parent MemoryIndex. This keeps
+// the iterator footprint to just the cursor state and the slice
+// headers it actually reads from.
+//
+// Lifetime: the slice headers are views into the parent
+// MemoryIndex's per-bucket storage. The iterator is invalid after
+// the parent Index is closed or reindexed — callers must consume
+// (or Close) the iterator before discarding the Index.
+type idxfilePrefixIter struct {
+	idSize   int
+	prefix   []byte
+	names    []byte // bucket's hash bytes
+	offset32 []byte // bucket's 32-bit offset table
+	crc32    []byte // bucket's CRC32 table
+	offset64 []byte // shared 64-bit offset overflow table
+	pos      int    // entries already yielded
+	done     bool
+}
+
+func (i *idxfilePrefixIter) Next() (*Entry, error) {
+	if i.done {
+		return nil, io.EOF
+	}
+
+	offset := i.pos * i.idSize
+	if offset+i.idSize > len(i.names) {
+		i.done = true
+		return nil, io.EOF
+	}
+	hashBytes := i.names[offset : offset+i.idSize]
+	if !bytes.HasPrefix(hashBytes, i.prefix) {
+		// Bucket is sorted by hash, so the first mismatch ends the run.
+		i.done = true
+		return nil, io.EOF
+	}
+
+	entry := new(Entry)
+	entry.Hash.ResetBySize(i.idSize)
+	if _, err := entry.Hash.Write(hashBytes); err != nil {
+		return nil, fmt.Errorf("cannot write entry hash: %w", err)
+	}
+
+	o, err := i.bucketOffset(i.pos)
+	if err != nil {
+		return nil, err
+	}
+	entry.Offset = o
+	entry.CRC32 = i.bucketCRC32(i.pos)
+	i.pos++
+	return entry, nil
+}
+
+// bucketOffset mirrors MemoryIndex.getOffset using only the per-
+// bucket Offset32/Offset64 slices the iterator holds, so callers
+// do not need to retain a reference to the parent MemoryIndex.
+func (i *idxfilePrefixIter) bucketOffset(pos int) (uint64, error) {
+	off := pos << 2
+	ofs := encbin.BigEndian.Uint32(i.offset32[off : off+4])
+	if (uint64(ofs) & isO64Mask) != 0 {
+		o64 := 8 * (uint64(ofs) & ^isO64Mask)
+		if l := uint64(len(i.offset64)); l < 8 || o64 > l-8 {
+			return 0, fmt.Errorf("%w: offset64 index out of range", ErrMalformedIdxFile)
+		}
+		return encbin.BigEndian.Uint64(i.offset64[o64 : o64+8]), nil
+	}
+	return uint64(ofs), nil
+}
+
+// bucketCRC32 mirrors MemoryIndex.getCRC32 using only the per-bucket
+// CRC32 slice the iterator holds.
+func (i *idxfilePrefixIter) bucketCRC32(pos int) uint32 {
+	off := pos << 2
+	return encbin.BigEndian.Uint32(i.crc32[off : off+4])
+}
+
+func (i *idxfilePrefixIter) Close() error {
+	i.done = true
 	return nil
 }
 

--- a/plumbing/format/idxfile/idxfile.go
+++ b/plumbing/format/idxfile/idxfile.go
@@ -46,6 +46,17 @@ type Index interface {
 	// EntriesByOffset returns an iterator to retrieve all index entries ordered
 	// by offset.
 	EntriesByOffset() (EntryIter, error)
+	// MayContain reports whether the index might contain h. A false
+	// return is authoritative ("h is definitely not in this pack")
+	// based on the idx fanout table; true means the caller should
+	// call Contains or FindOffset for a definitive answer.
+	//
+	// Implementations must be O(1) and I/O-free. Callers route
+	// every read through MayContain to gate further index work
+	// (see storage/filesystem.ObjectStorage.findObjectInPackfile);
+	// an implementation that performs I/O or scales with index
+	// size silently regresses every storage-level read.
+	MayContain(h plumbing.Hash) bool
 	// Close releases any resources held by the index. Implementations
 	// backed by on-disk files must close their file descriptors; pure
 	// in-memory implementations must return nil. Close is idempotent.
@@ -135,6 +146,13 @@ func (idx *MemoryIndex) findHashIndex(h plumbing.Hash) (int, bool) {
 	}
 
 	return 0, false
+}
+
+// MayContain implements the Index interface. It reports whether the
+// index might contain h using the in-memory fanout mapping. Returns
+// false iff h's first byte falls in an empty fanout bucket.
+func (idx *MemoryIndex) MayContain(h plumbing.Hash) bool {
+	return idx.FanoutMapping[h.Bytes()[0]] != noMapping
 }
 
 // Contains implements the Index interface.

--- a/plumbing/format/idxfile/idxfile_test.go
+++ b/plumbing/format/idxfile/idxfile_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -226,6 +228,175 @@ func (s *MemoryIndexSuite) TestSatisfiesIndexInterface() {
 	// Close must be reachable via the interface.
 	var idx idxfile.Index = idxfile.NewMemoryIndex(crypto.SHA1.Size())
 	s.NoError(idx.Close())
+}
+
+func TestMemoryIndex_EntriesWithPrefix_Empty(t *testing.T) {
+	t.Parallel()
+	idx, err := fixtureIndex()
+	require.NoError(t, err)
+
+	iter, err := idx.EntriesWithPrefix(nil)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	// Empty prefix returns all entries (same as Entries()).
+	n := 0
+	for {
+		_, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		n++
+	}
+	assert.Equal(t, len(fixtureHashes), n)
+}
+
+func TestMemoryIndex_EntriesWithPrefix_OneByteMatch(t *testing.T) {
+	t.Parallel()
+	idx, err := fixtureIndex()
+	require.NoError(t, err)
+
+	// Pick the first byte of a known hash; the iterator should yield
+	// every entry in that bucket.
+	target := fixtureHashes[0]
+	prefix := target.Bytes()[:1]
+
+	iter, err := idx.EntriesWithPrefix(prefix)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var got []plumbing.Hash
+	for {
+		e, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		got = append(got, e.Hash)
+	}
+
+	// Cross-check: every yielded hash must start with prefix.
+	for _, h := range got {
+		assert.True(t, bytes.HasPrefix(h.Bytes(), prefix),
+			"hash %v should start with prefix %x", h, prefix)
+	}
+	// And the seed hash must be among the yielded entries.
+	assert.Contains(t, got, target)
+}
+
+func TestMemoryIndex_EntriesWithPrefix_MultiByte(t *testing.T) {
+	t.Parallel()
+
+	// Synthetic index with five entries all in fanout bucket 0x42,
+	// sorted by full hash. The matching entries for prefix
+	// [0x42, 0x05] are a contiguous run in the middle of the bucket,
+	// so the iterator must skip past 0x42_00 before yielding.
+	makeHash := func(b1, b2, b3 byte) plumbing.Hash {
+		raw := make([]byte, 20)
+		raw[0] = b1
+		raw[1] = b2
+		raw[2] = b3
+		return plumbing.NewHash(fmt.Sprintf("%x", raw))
+	}
+
+	hashes := []plumbing.Hash{
+		makeHash(0x42, 0x00, 0xaa),
+		makeHash(0x42, 0x05, 0xab),
+		makeHash(0x42, 0x05, 0xbb),
+		makeHash(0x42, 0x05, 0xcc),
+		makeHash(0x42, 0x07, 0xdd),
+	}
+
+	w := &idxfile.Writer{}
+	require.NoError(t, w.OnHeader(uint32(len(hashes))))
+	for i, h := range hashes {
+		w.Add(h, uint64(100+i), uint32(i))
+	}
+	require.NoError(t, w.OnFooter(
+		plumbing.NewHash("0000000000000000000000000000000000000001")))
+
+	idx, err := w.Index()
+	require.NoError(t, err)
+
+	collect := func(t *testing.T, prefix []byte) []plumbing.Hash {
+		t.Helper()
+		iter, err := idx.EntriesWithPrefix(prefix)
+		require.NoError(t, err)
+		defer iter.Close()
+		var got []plumbing.Hash
+		for {
+			e, err := iter.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			got = append(got, e.Hash)
+		}
+		return got
+	}
+
+	t.Run("middle run", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x05})
+		require.Len(t, got, 3)
+		for _, h := range got {
+			assert.True(t, bytes.HasPrefix(h.Bytes(), []byte{0x42, 0x05}))
+		}
+	})
+
+	t.Run("end of bucket", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x07})
+		require.Len(t, got, 1)
+		assert.Equal(t, hashes[4], got[0])
+	})
+
+	t.Run("start of bucket", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x00})
+		require.Len(t, got, 1)
+		assert.Equal(t, hashes[0], got[0])
+	})
+
+	t.Run("no match in populated bucket", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x06})
+		assert.Empty(t, got)
+	})
+
+	t.Run("three-byte refinement", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x05, 0xbb})
+		require.Len(t, got, 1)
+		assert.Equal(t, hashes[2], got[0])
+	})
+}
+
+func TestMemoryIndex_EntriesWithPrefix_NoMatch(t *testing.T) {
+	t.Parallel()
+	idx, err := fixtureIndex()
+	require.NoError(t, err)
+
+	// Find an empty fanout bucket (FanoutMapping == noMapping == -1).
+	var emptyByte byte
+	found := false
+	for b := range 256 {
+		if idx.FanoutMapping[b] == -1 {
+			emptyByte = byte(b)
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Skip("fixture has objects in every fanout bucket")
+	}
+
+	iter, err := idx.EntriesWithPrefix([]byte{emptyByte})
+	require.NoError(t, err)
+	defer iter.Close()
+	_, err = iter.Next()
+	assert.Equal(t, io.EOF, err)
 }
 
 func TestOffsetHashConcurrentPopulation(t *testing.T) {

--- a/plumbing/format/idxfile/idxfile_test.go
+++ b/plumbing/format/idxfile/idxfile_test.go
@@ -109,6 +109,36 @@ func TestIndexSuite(t *testing.T) {
 	suite.Run(t, new(IndexSuite))
 }
 
+func (s *IndexSuite) TestMayContain() {
+	idx, err := fixtureIndex()
+	s.NoError(err)
+
+	// Positive: every known hash must report true.
+	for _, h := range fixtureHashes {
+		s.True(idx.MayContain(h), "expected MayContain=true for %s", h)
+	}
+
+	// Negative: find a FanoutMapping entry set to noMapping (-1) and
+	// craft a hash starting with that byte; result must be false.
+	// FanoutMapping is an exported field so no internal access needed.
+	emptyByte := -1
+	for b, mapped := range idx.FanoutMapping {
+		if mapped == -1 {
+			emptyByte = b
+			break
+		}
+	}
+	s.Require().NotEqual(-1, emptyByte,
+		"fixture must have at least one empty fanout bucket")
+
+	var miss plumbing.Hash
+	hashBytes := make([]byte, 20)
+	hashBytes[0] = byte(emptyByte)
+	miss = plumbing.NewHash(fmt.Sprintf("%x", hashBytes))
+	s.False(idx.MayContain(miss),
+		"expected MayContain=false for hash starting with 0x%02x", emptyByte)
+}
+
 func (s *IndexSuite) TestFindHash() {
 	idx, err := fixtureIndex()
 	s.NoError(err)

--- a/plumbing/format/idxfile/lazy_index.go
+++ b/plumbing/format/idxfile/lazy_index.go
@@ -211,6 +211,20 @@ func (s *LazyIndex) Contains(h plumbing.Hash) (bool, error) {
 	return found, err
 }
 
+// MayContain implements the Index interface. It reports whether the
+// index might contain h, using the cached fanout table loaded at
+// construction time. No I/O, no lock. False is authoritative ("h is
+// not in this pack"); true means call Contains or FindOffset for a
+// definitive answer.
+func (s *LazyIndex) MayContain(h plumbing.Hash) bool {
+	first := int(h.Bytes()[0])
+	var prev uint32
+	if first > 0 {
+		prev = s.fanout[first-1]
+	}
+	return s.fanout[first] > prev
+}
+
 // FindOffset returns the packfile offset for the object with the given hash.
 // It returns plumbing.ErrObjectNotFound if the hash is not in the index.
 func (s *LazyIndex) FindOffset(h plumbing.Hash) (int64, error) {

--- a/plumbing/format/idxfile/lazy_index.go
+++ b/plumbing/format/idxfile/lazy_index.go
@@ -305,6 +305,76 @@ func (s *LazyIndex) Entries() (EntryIter, error) {
 	return &scannerEntryIter{s: s, idx: idx}, nil
 }
 
+// EntriesWithPrefix implements the Index interface. It returns an
+// iterator over entries whose hashes start with prefix. When prefix
+// is empty the call is equivalent to Entries; otherwise the
+// iterator visits only the fanout-bounded names-table slice
+// selected by prefix[0] and stops as soon as a name without prefix
+// is read (the names table is sorted by hash).
+//
+// For a multi-byte prefix the matching entries form a contiguous
+// run somewhere within the bucket; binary-search positions the
+// iterator at the start of that run so the linear walk only spans
+// matches. This mirrors upstream Git's for_each_prefixed_object_in_pack
+// which calls bsearch_pack to position before walking forward.
+//
+// The returned iterator holds an acquired reference to the idx
+// SharedFile which is released on Close.
+func (s *LazyIndex) EntriesWithPrefix(prefix []byte) (EntryIter, error) {
+	if len(prefix) == 0 {
+		return s.Entries()
+	}
+	first := int(prefix[0])
+	var lo int
+	if first > 0 {
+		lo = int(s.fanout[first-1])
+	}
+	hi := int(s.fanout[first])
+	if lo >= hi {
+		return &lazyPrefixIter{}, nil
+	}
+	idx, err := s.idx.Acquire()
+	if err != nil {
+		return nil, err
+	}
+
+	// Find the leftmost entry in [lo, hi) whose hash is >= prefix
+	// (padded with zeros to hash size). All matching entries, if
+	// any, start at this position; the iterator's
+	// stop-on-first-mismatch then terminates correctly once the
+	// run ends.
+	target := make([]byte, s.hashSize)
+	copy(target, prefix)
+	var arr [32]byte
+	buf := arr[:s.hashSize]
+	bsLo, bsHi := lo, hi
+	for bsLo < bsHi {
+		mid := (bsLo + bsHi) >> 1
+		nameOff := int64(s.namesStart + mid*s.hashSize)
+		if _, err := idx.ReadAt(buf, nameOff); err != nil {
+			s.idx.Release()
+			return nil, fmt.Errorf("read name at pos %d: %w", mid, err)
+		}
+		if bytes.Compare(buf, target) < 0 {
+			bsLo = mid + 1
+		} else {
+			bsHi = mid
+		}
+	}
+	if bsLo >= hi {
+		s.idx.Release()
+		return &lazyPrefixIter{}, nil
+	}
+
+	return &lazyPrefixIter{
+		s:      s,
+		idx:    idx,
+		prefix: prefix,
+		pos:    bsLo,
+		end:    hi,
+	}, nil
+}
+
 // EntriesByOffset returns an iterator over all index entries sorted by
 // their packfile offset. It reads positions from the .rev file on each
 // call to Next, avoiding any up-front allocation or sorting.
@@ -604,6 +674,55 @@ func (it *revEntryIter) Close() error {
 	if it.rev != nil {
 		it.s.rev.Release()
 		it.rev = nil
+	}
+	return nil
+}
+
+// lazyPrefixIter walks the LazyIndex names table from pos to end,
+// yielding entries whose hash starts with prefix. It stops the run
+// when a hash without the prefix is read (the table is sorted). It
+// holds an acquired reference to the idx SharedFile released on
+// Close.
+//
+// Lifetime: Next may release the iterator's SharedFile reference
+// eagerly when the first prefix-mismatched entry is observed —
+// further matches are impossible in the sorted table, so holding
+// the reference would only add pool pressure. Callers should
+// defer Close unconditionally; it is idempotent and the eager
+// release is purely an optimisation.
+type lazyPrefixIter struct {
+	s      *LazyIndex
+	idx    io.ReaderAt
+	prefix []byte
+	pos    int
+	end    int
+}
+
+func (it *lazyPrefixIter) Next() (*Entry, error) {
+	if it.idx == nil {
+		return nil, io.EOF
+	}
+	if it.pos >= it.end {
+		return nil, io.EOF
+	}
+	e, err := it.s.entryAt(it.idx, it.pos)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.HasPrefix(e.Hash.Bytes(), it.prefix) {
+		// Past the prefix in the sorted names table; close out so the
+		// SharedFile reference is released eagerly.
+		_ = it.Close()
+		return nil, io.EOF
+	}
+	it.pos++
+	return e, nil
+}
+
+func (it *lazyPrefixIter) Close() error {
+	if it.idx != nil {
+		it.s.idx.Release()
+		it.idx = nil
 	}
 	return nil
 }

--- a/plumbing/format/idxfile/lazy_index_test.go
+++ b/plumbing/format/idxfile/lazy_index_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -523,6 +524,202 @@ func BenchmarkScannerFindOffset(b *testing.B) {
 			}
 		}
 	}
+}
+
+func TestLazyIndex_EntriesWithPrefix_Empty(t *testing.T) {
+	t.Parallel()
+	idx, err := fixtureLazyIndex(true)
+	require.NoError(t, err)
+	defer idx.Close()
+
+	iter, err := idx.EntriesWithPrefix(nil)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	// Empty prefix returns all entries (same as Entries()).
+	n := 0
+	for {
+		_, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		n++
+	}
+	assert.Equal(t, len(fixtureHashes), n)
+}
+
+func TestLazyIndex_EntriesWithPrefix_OneByteMatch(t *testing.T) {
+	t.Parallel()
+	idx, err := fixtureLazyIndex(true)
+	require.NoError(t, err)
+	defer idx.Close()
+
+	// Pick the first byte of a known hash; the iterator should yield
+	// every entry in that bucket.
+	target := fixtureHashes[0]
+	prefix := target.Bytes()[:1]
+
+	iter, err := idx.EntriesWithPrefix(prefix)
+	require.NoError(t, err)
+	defer iter.Close()
+
+	var got []plumbing.Hash
+	for {
+		e, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		got = append(got, e.Hash)
+	}
+
+	for _, h := range got {
+		assert.True(t, bytes.HasPrefix(h.Bytes(), prefix),
+			"hash %v should start with prefix %x", h, prefix)
+	}
+	assert.Contains(t, got, target)
+}
+
+func TestLazyIndex_EntriesWithPrefix_NoMatch(t *testing.T) {
+	t.Parallel()
+	idx, err := fixtureLazyIndex(true)
+	require.NoError(t, err)
+	defer idx.Close()
+
+	// Find an empty fanout bucket (fanout[b] == fanout[b-1]).
+	emptyByte := -1
+	for b := range 256 {
+		var prev uint32
+		if b > 0 {
+			prev = idx.fanout[b-1]
+		}
+		if idx.fanout[b] == prev {
+			emptyByte = b
+			break
+		}
+	}
+	if emptyByte == -1 {
+		t.Skip("fixture has objects in every fanout bucket")
+	}
+
+	iter, err := idx.EntriesWithPrefix([]byte{byte(emptyByte)})
+	require.NoError(t, err)
+	defer iter.Close()
+	_, err = iter.Next()
+	assert.Equal(t, io.EOF, err)
+}
+
+func TestLazyIndex_EntriesWithPrefix_MultiByte(t *testing.T) {
+	t.Parallel()
+
+	// Synthetic index with five entries all in fanout bucket 0x42,
+	// encoded to .idx bytes and read back through LazyIndex. The
+	// matching run for prefix [0x42, 0x05] sits in the middle of
+	// the bucket; the iterator must bsearch past 0x42_00 before
+	// yielding.
+	makeHash := func(b1, b2, b3 byte) plumbing.Hash {
+		raw := make([]byte, 20)
+		raw[0] = b1
+		raw[1] = b2
+		raw[2] = b3
+		var h plumbing.Hash
+		_, _ = h.Write(raw)
+		return h
+	}
+
+	hashes := []plumbing.Hash{
+		makeHash(0x42, 0x00, 0xaa),
+		makeHash(0x42, 0x05, 0xab),
+		makeHash(0x42, 0x05, 0xbb),
+		makeHash(0x42, 0x05, 0xcc),
+		makeHash(0x42, 0x07, 0xdd),
+	}
+
+	w := &Writer{}
+	require.NoError(t, w.OnHeader(uint32(len(hashes))))
+	for i, h := range hashes {
+		w.Add(h, uint64(100+i), uint32(i))
+	}
+	var packChecksum plumbing.Hash
+	packChecksum.ResetBySize(crypto.SHA1.Size())
+	csum := make([]byte, crypto.SHA1.Size())
+	csum[0] = 0x01
+	_, _ = packChecksum.Write(csum)
+	require.NoError(t, w.OnFooter(packChecksum))
+
+	memIdx, err := w.Index()
+	require.NoError(t, err)
+
+	var idxBuf bytes.Buffer
+	require.NoError(t, Encode(&idxBuf, hash.New(crypto.SHA1), memIdx))
+	idxBytes := idxBuf.Bytes()
+
+	revBytes, err := buildTestRevFile(memIdx)
+	require.NoError(t, err)
+
+	openIdx := func() (ReadAtCloser, error) {
+		return nopCloserReaderAt{bytes.NewReader(idxBytes)}, nil
+	}
+	openRev := func() (ReadAtCloser, error) {
+		return nopCloserReaderAt{bytes.NewReader(revBytes)}, nil
+	}
+	idx, err := NewLazyIndex(openIdx, openRev, memIdx.PackfileChecksum)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = idx.Close() })
+
+	collect := func(t *testing.T, prefix []byte) []plumbing.Hash {
+		t.Helper()
+		iter, err := idx.EntriesWithPrefix(prefix)
+		require.NoError(t, err)
+		defer iter.Close()
+		var got []plumbing.Hash
+		for {
+			e, err := iter.Next()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			got = append(got, e.Hash)
+		}
+		return got
+	}
+
+	t.Run("middle run", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x05})
+		require.Len(t, got, 3)
+		for _, h := range got {
+			assert.True(t, bytes.HasPrefix(h.Bytes(), []byte{0x42, 0x05}))
+		}
+	})
+
+	t.Run("end of bucket", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x07})
+		require.Len(t, got, 1)
+		assert.Equal(t, hashes[4], got[0])
+	})
+
+	t.Run("start of bucket", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x00})
+		require.Len(t, got, 1)
+		assert.Equal(t, hashes[0], got[0])
+	})
+
+	t.Run("no match in populated bucket", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x06})
+		assert.Empty(t, got)
+	})
+
+	t.Run("three-byte refinement", func(t *testing.T) {
+		t.Parallel()
+		got := collect(t, []byte{0x42, 0x05, 0xbb})
+		require.Len(t, got, 1)
+		assert.Equal(t, hashes[2], got[0])
+	})
 }
 
 func fixtureLazyIndex(withRev bool) (*LazyIndex, error) {

--- a/plumbing/format/idxfile/lazy_index_test.go
+++ b/plumbing/format/idxfile/lazy_index_test.go
@@ -43,6 +43,41 @@ func (s *LazyIndexSuite) TestContains() {
 	s.False(ok)
 }
 
+func (s *LazyIndexSuite) TestMayContain() {
+	idx, err := fixtureLazyIndex(true)
+	s.Require().NoError(err)
+	defer idx.Close()
+
+	// Positive: every known hash must report true.
+	for _, h := range fixtureHashes {
+		s.True(idx.MayContain(h), "expected MayContain=true for %s", h)
+	}
+
+	// Negative: find an empty fanout bucket and craft a hash that
+	// starts with that byte; the result must be false.
+	emptyByte := -1
+	for b := range 256 {
+		var prev uint32
+		if b > 0 {
+			prev = idx.fanout[b-1]
+		}
+		if idx.fanout[b] == prev {
+			emptyByte = b
+			break
+		}
+	}
+	s.Require().NotEqual(-1, emptyByte,
+		"fixture must have at least one empty fanout bucket")
+
+	var miss plumbing.Hash
+	miss.ResetBySize(20)
+	hashBytes := make([]byte, 20)
+	hashBytes[0] = byte(emptyByte)
+	_, _ = miss.Write(hashBytes)
+	s.False(idx.MayContain(miss),
+		"expected MayContain=false for hash starting with 0x%02x", emptyByte)
+}
+
 func (s *LazyIndexSuite) TestFindOffset() {
 	idx, err := fixtureLazyIndex(true)
 	s.Require().NoError(err)

--- a/plumbing/format/packfile/internal_test.go
+++ b/plumbing/format/packfile/internal_test.go
@@ -142,6 +142,13 @@ func (idx *singleEntryIndex) EntriesByOffset() (idxfile.EntryIter, error) {
 	return &singleEntryIter{entry: idx.entry}, nil
 }
 
+func (idx *singleEntryIndex) EntriesWithPrefix(prefix []byte) (idxfile.EntryIter, error) {
+	if len(prefix) == 0 || idx.entry.Hash.HasPrefix(prefix) {
+		return &singleEntryIter{entry: idx.entry}, nil
+	}
+	return &singleEntryIter{done: true}, nil
+}
+
 func (idx *singleEntryIndex) MayContain(h plumbing.Hash) bool {
 	return idx.entry.Hash.Equal(h)
 }

--- a/plumbing/format/packfile/internal_test.go
+++ b/plumbing/format/packfile/internal_test.go
@@ -142,6 +142,10 @@ func (idx *singleEntryIndex) EntriesByOffset() (idxfile.EntryIter, error) {
 	return &singleEntryIter{entry: idx.entry}, nil
 }
 
+func (idx *singleEntryIndex) MayContain(h plumbing.Hash) bool {
+	return idx.entry.Hash.Equal(h)
+}
+
 func (idx *singleEntryIndex) Close() error { return nil }
 
 type singleEntryIter struct {

--- a/storage/filesystem/dotgit/packhandle_test.go
+++ b/storage/filesystem/dotgit/packhandle_test.go
@@ -167,6 +167,60 @@ func TestPackHandle_ClosesAllCachedHandles(t *testing.T) {
 	}
 }
 
+// TestPackHandle_CleanPackListClosesActiveCursor exercises the
+// cleanPackList-vs-Acquire race window deterministically. A cursor
+// is opened (which acquires a SharedFile reference) and parked
+// before its first ReadAt; cleanPackList then runs to completion,
+// closing every cached PackHandle (and the SharedFiles inside).
+// The parked cursor must surface [fs.ErrClosed] on its next read
+// rather than partial bytes from a torn-down file descriptor.
+//
+// The two phases are sequenced via channels — the test does not
+// rely on sleeps — so failures are reproducible. Run under -race
+// for the read-side guards.
+func TestPackHandle_CleanPackListClosesActiveCursor(t *testing.T) {
+	t.Parallel()
+
+	dot, h, _ := createPackWithRev(t, Options{
+		ReadReverseIndex:  true,
+		WriteReverseIndex: true,
+	})
+
+	ph, err := dot.packHandle(h)
+	require.NoError(t, err)
+
+	cursor, err := ph.OpenRandomReader()
+	require.NoError(t, err)
+	defer cursor.Close()
+
+	acquired := make(chan struct{})
+	cleaned := make(chan struct{})
+
+	type readResult struct {
+		n   int
+		err error
+	}
+	results := make(chan readResult, 1)
+
+	go func() {
+		close(acquired)
+		<-cleaned
+		buf := make([]byte, 32)
+		n, err := cursor.ReadAt(buf, 0)
+		results <- readResult{n: n, err: err}
+	}()
+
+	<-acquired
+	require.NoError(t, dot.cleanPackList())
+	close(cleaned)
+
+	got := <-results
+	assert.ErrorIs(t, got.err, fs.ErrClosed,
+		"ReadAt after cleanPackList must surface fs.ErrClosed")
+	assert.Zero(t, got.n,
+		"ReadAt after cleanPackList must not return partial bytes")
+}
+
 // TestPackHandle_IndexUsableOnDiskRev exercises the disk-rev path of
 // packHandle: when both .idx and .rev are on disk, PackHandle.Index()
 // returns a usable index and the cached handle remains live until

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -191,15 +191,6 @@ func findInAlternates[T any](s *ObjectStorage, fn func(*ObjectStorage) (T, error
 	return foundVal, nil
 }
 
-// indexLoaded reports whether s.index has been populated. Safe for
-// concurrent use: reads s.index under the read half of s.muI.
-func (s *ObjectStorage) indexLoaded() bool {
-	s.muI.RLock()
-	loaded := s.index != nil
-	s.muI.RUnlock()
-	return loaded
-}
-
 // requireIndex ensures s.index is populated, performing a cold-load
 // on first access. Concurrent first-readers are coalesced via
 // singleflight so populateIndex runs once per thundering herd; the
@@ -476,25 +467,29 @@ func (s *ObjectStorage) LazyWriter() (w io.WriteCloser, wh func(typ plumbing.Obj
 // HasEncodedObject returns nil if the object exists, without actually
 // reading the object data from storage.
 func (s *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
-	// Check unpacked objects
-	f, err := s.dir.Object(h)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			return err
+	// Pack-membership-first when the index is healthy: a hit on
+	// the in-memory fanout shortcut avoids a loose Stat. If the
+	// index fails to load (e.g. a corrupt .idx on disk), fall
+	// through so a loose object can still answer the probe and
+	// the lookup degrades to loose-only — mirrors canonical Git's
+	// tolerance of partial pack-store corruption.
+	idxErr := s.requireIndex()
+	if idxErr == nil {
+		if _, _, offset := s.findObjectInPackfile(h); offset != -1 {
+			return nil
 		}
-		// Fall through to check packed objects.
-	} else {
-		defer ioutil.CheckClose(f, &err)
-		return nil
 	}
 
-	// Check packed objects.
-	if err := s.requireIndex(); err != nil {
-		return err
-	}
-	_, _, offset := s.findObjectInPackfile(h)
-	if offset != -1 {
+	// Existence-only on the loose path: Stat instead of Open
+	// avoids a per-call open()+close() pair when the object lives
+	// in loose.
+	if _, statErr := s.dir.ObjectStat(h); statErr == nil {
 		return nil
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+	if idxErr != nil {
+		return idxErr
 	}
 
 	_, err = findInAlternates(s, func(alt *ObjectStorage) (struct{}, error) {
@@ -571,20 +566,38 @@ func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (size int
 // EncodedObjectSize returns the plaintext size of the given object,
 // without actually reading the full object data from storage.
 func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (size int64, err error) {
-	size, err = s.encodedObjectSizeFromUnpacked(h)
-	if err != nil && !errors.Is(err, plumbing.ErrObjectNotFound) {
-		return 0, err
-	} else if err == nil {
-		return size, nil
+	// Pack-membership-first when the index is healthy: a single
+	// in-memory fanout probe routes packed reads through the pack
+	// reader and skips the loose Stat. If the index fails to load
+	// (e.g. corrupt .idx), fall through to loose so the lookup
+	// degrades gracefully — same shape as HasEncodedObject.
+	idxErr := s.requireIndex()
+	if idxErr == nil {
+		if pack, _, offset := s.findObjectInPackfile(h); pack != plumbing.ZeroHash && offset != -1 {
+			if cached, ok := s.objectCache.Get(h); ok {
+				return cached.Size(), nil
+			}
+			size, err = s.encodedObjectSizeFromPackfile(h)
+			if err == nil {
+				return size, nil
+			}
+			if !errors.Is(err, plumbing.ErrObjectNotFound) {
+				return 0, err
+			}
+			// Membership claimed the hash but the pack lost it —
+			// fall through to loose and alternates.
+		}
 	}
 
-	size, err = s.encodedObjectSizeFromPackfile(h)
+	size, err = s.encodedObjectSizeFromUnpacked(h)
 	if err == nil {
 		return size, nil
 	}
-
 	if !errors.Is(err, plumbing.ErrObjectNotFound) {
 		return 0, err
+	}
+	if idxErr != nil {
+		return 0, idxErr
 	}
 
 	return findInAlternates(s, func(alt *ObjectStorage) (int64, error) {
@@ -598,22 +611,39 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 	var obj plumbing.EncodedObject
 	var err error
 
-	if s.indexLoaded() {
-		obj, err = s.getFromPackfile(h, false)
-		if errors.Is(err, plumbing.ErrObjectNotFound) {
-			obj, err = s.getFromUnpacked(h)
-		}
-	} else {
-		obj, err = s.getFromUnpacked(h)
-		if errors.Is(err, plumbing.ErrObjectNotFound) {
+	// Pack-membership-first when the index is healthy: see
+	// EncodedObjectSize for the routing rationale. The shared
+	// object cache is keyed by hash only — gating the cache
+	// check on findObjectInPackfile keeps reads safe when callers
+	// share a cache across ObjectStorages (see
+	// TestGetFromObjectFileSharedCache). A failed requireIndex
+	// (corrupt .idx) degrades to loose-only rather than failing
+	// the whole read.
+	idxErr := s.requireIndex()
+	routed := false
+	if idxErr == nil {
+		if pack, _, offset := s.findObjectInPackfile(h); pack != plumbing.ZeroHash && offset != -1 {
+			routed = true
+			if cached, ok := s.objectCache.Get(h); ok {
+				if t == plumbing.AnyObject || cached.Type() == t {
+					return cached, nil
+				}
+				return nil, plumbing.ErrObjectNotFound
+			}
 			obj, err = s.getFromPackfile(h, false)
 		}
+	}
+	if !routed {
+		obj, err = s.getFromUnpacked(h)
 	}
 
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		obj, err = findInAlternates(s, func(alt *ObjectStorage) (plumbing.EncodedObject, error) {
 			return alt.EncodedObject(t, h)
 		})
+		if errors.Is(err, plumbing.ErrObjectNotFound) && idxErr != nil {
+			return nil, idxErr
+		}
 	}
 
 	if err != nil {
@@ -1048,6 +1078,20 @@ func (s *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
 }
 
 // DeleteOldObjectPackAndIndex removes a pack and its index if older than t.
+// Also drops the in-memory s.index entry for the removed pack so subsequent
+// routing decisions in findObjectInPackfile no longer claim membership for
+// a hash that lives only in the now-deleted pack.
 func (s *ObjectStorage) DeleteOldObjectPackAndIndex(h plumbing.Hash, t time.Time) error {
-	return s.dir.DeleteOldObjectPackAndIndex(h, t)
+	if err := s.dir.DeleteOldObjectPackAndIndex(h, t); err != nil {
+		return err
+	}
+	s.muI.Lock()
+	if idx, ok := s.index[h]; ok {
+		delete(s.index, h)
+		if c, ok := idx.(io.Closer); ok {
+			_ = c.Close()
+		}
+	}
+	s.muI.Unlock()
+	return nil
 }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -37,6 +38,15 @@ const indexSFKey = "populate"
 // against each other.
 const reindexSFKey = "reindex"
 
+// packEntry pairs a pack hash with its idxfile.Index for inclusion
+// in ObjectStorage.packs. The slice is always reassigned (never
+// modified in place) so readers can hold a stable snapshot of the
+// slice header after releasing muI.RLock.
+type packEntry struct {
+	h   plumbing.Hash
+	idx idxfile.Index
+}
+
 // ObjectStorage implements object storage backed by the filesystem.
 type ObjectStorage struct {
 	options Options
@@ -47,11 +57,28 @@ type ObjectStorage struct {
 
 	dir   *dotgit.DotGit
 	index map[plumbing.Hash]idxfile.Index
+	// packs mirrors s.index as a slice of (hash, idx) pairs,
+	// written in lockstep with s.index under muI.Lock and always
+	// reassigned (never modified in place). Readers can snapshot
+	// the slice header under RLock and release the lock before
+	// any per-pack I/O — the backing array and the embedded idx
+	// pointers stay valid for the snapshot's lifetime, so slow
+	// LazyIndex FindOffset calls do not block a concurrent
+	// Reindex on muI.Lock.
+	packs []packEntry
 	muI   sync.RWMutex
 
 	// indexSF coalesces concurrent first-readers so populateIndex
 	// runs once per cold-load even under thundering-herd contention.
 	indexSF singleflight.Group
+
+	// lastHitPackIdx records the s.packs index that served the most
+	// recent successful findObjectInPackfile probe, encoded as the
+	// slice position plus one (0 = no hint). Storing an Int32 instead
+	// of a *plumbing.Hash eliminates the per-call escape-to-heap of
+	// the previous MRU pointer design. Stale entries cost one
+	// MayContain + FindOffset but never misroute lookups.
+	lastHitPackIdx atomic.Int32
 
 	oh *plumbing.ObjectHasher
 
@@ -215,7 +242,7 @@ func (s *ObjectStorage) requireIndex() error {
 		}
 		s.muI.RUnlock()
 
-		local, err := s.populateIndex()
+		local, entries, err := s.populateIndex()
 		if err != nil {
 			return nil, err
 		}
@@ -223,6 +250,7 @@ func (s *ObjectStorage) requireIndex() error {
 		s.muI.Lock()
 		if s.index == nil {
 			s.index = local
+			s.packs = entries
 		} else {
 			// A racing winner published while we were loading.
 			// Close any indexes we built so SharedFile refcounts
@@ -240,8 +268,9 @@ func (s *ObjectStorage) requireIndex() error {
 }
 
 // Reindex re-populates s.index from disk and atomically swaps the
-// freshly-loaded map in, so the next read is a hot-cache hit.
-// Call when the on-disk pack inventory has changed externally.
+// freshly-loaded map and packs slice in, so the next read is a
+// hot-cache hit. Call when the on-disk pack inventory has changed
+// externally.
 //
 // Concurrent Reindex calls coalesce through indexSF on reindexSFKey:
 // one goroutine performs populateIndex and the swap, the rest block
@@ -258,15 +287,21 @@ func (s *ObjectStorage) requireIndex() error {
 // LRU eviction (pool mode) once they fall out of use. This mirrors
 // canonical Git's reprepare model where packfile_store_reprepare
 // leaves existing packs in place and only the FD-level LRU evicts.
+//
+// The MRU hint indexes into the previous packs slice and is reset
+// after the swap so a stale hint cannot misroute a probe against
+// the new slice.
 func (s *ObjectStorage) Reindex() error {
 	_, err, _ := s.indexSF.Do(reindexSFKey, func() (any, error) {
-		local, err := s.populateIndex()
+		local, entries, err := s.populateIndex()
 		if err != nil {
 			return nil, err
 		}
 
 		s.muI.Lock()
 		s.index = local
+		s.packs = entries
+		s.lastHitPackIdx.Store(0)
 		s.muI.Unlock()
 
 		return nil, nil
@@ -278,29 +313,25 @@ func (s *ObjectStorage) Reindex() error {
 // resulting map. The caller is responsible for publishing the map
 // into s.index under s.muI.Lock; populateIndex itself takes no
 // locks on s.muI, so callers must not hold it while invoking.
-func (s *ObjectStorage) populateIndex() (map[plumbing.Hash]idxfile.Index, error) {
-	packs, err := s.dir.ObjectPacks()
+func (s *ObjectStorage) populateIndex() (map[plumbing.Hash]idxfile.Index, []packEntry, error) {
+	packHashes, err := s.dir.ObjectPacks()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var (
-		mu    sync.Mutex
-		local = make(map[plumbing.Hash]idxfile.Index, len(packs))
-	)
-
+	// Per-pack writes target disjoint slice positions, so no mutex
+	// is needed across the errgroup workers.
+	entries := make([]packEntry, len(packHashes))
 	g := new(errgroup.Group)
 	g.SetLimit(runtime.GOMAXPROCS(0))
 
-	for _, h := range packs {
+	for i, h := range packHashes {
 		g.Go(func() error {
 			idx, err := s.loadIdx(h)
 			if err != nil {
 				return err
 			}
-			mu.Lock()
-			local[h] = idx
-			mu.Unlock()
+			entries[i] = packEntry{h: h, idx: idx}
 			return nil
 		})
 	}
@@ -308,14 +339,22 @@ func (s *ObjectStorage) populateIndex() (map[plumbing.Hash]idxfile.Index, error)
 		// Best-effort cleanup of indexes that did finish before
 		// the failing one: close any that hold descriptors so we
 		// do not leak SharedFile refcounts on the error path.
-		for _, idx := range local {
-			if c, ok := idx.(io.Closer); ok {
+		for _, e := range entries {
+			if e.idx == nil {
+				continue
+			}
+			if c, ok := e.idx.(io.Closer); ok {
 				_ = c.Close()
 			}
 		}
-		return nil, err
+		return nil, nil, err
 	}
-	return local, nil
+
+	local := make(map[plumbing.Hash]idxfile.Index, len(entries))
+	for _, e := range entries {
+		local[e.h] = e.idx
+	}
+	return local, entries, nil
 }
 
 // loadIdx loads a single pack's idx and returns the constructed
@@ -413,6 +452,15 @@ func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
 			return
 		}
 		s.muI.Lock()
+		if _, existed := s.index[h]; !existed {
+			// Copy-on-grow rather than append-in-place so any
+			// reader that snapshotted the old slice header keeps
+			// seeing a stable backing array.
+			next := make([]packEntry, len(s.packs)+1)
+			copy(next, s.packs)
+			next[len(s.packs)] = packEntry{h: h, idx: index}
+			s.packs = next
+		}
 		s.index[h] = index
 		s.muI.Unlock()
 	}
@@ -530,39 +578,6 @@ func (s *ObjectStorage) packfile(idx idxfile.Index, pack plumbing.Hash) (*packfi
 	), nil
 }
 
-func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (size int64, err error) {
-	if err := s.requireIndex(); err != nil {
-		return 0, err
-	}
-
-	pack, _, offset := s.findObjectInPackfile(h)
-	if offset == -1 {
-		return 0, plumbing.ErrObjectNotFound
-	}
-
-	s.muI.RLock()
-	idx := s.index[pack]
-	s.muI.RUnlock()
-
-	hash, err := idx.FindHash(offset)
-	if err == nil {
-		obj, ok := s.objectCache.Get(hash)
-		if ok {
-			return obj.Size(), nil
-		}
-	} else if err != nil && !errors.Is(err, plumbing.ErrObjectNotFound) {
-		return 0, err
-	}
-
-	p, err := s.packfile(idx, pack)
-	if err != nil {
-		return 0, err
-	}
-	defer ioutil.CheckClose(p, &err)
-
-	return p.GetSizeByOffset(offset)
-}
-
 // EncodedObjectSize returns the plaintext size of the given object,
 // without actually reading the full object data from storage.
 func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (size int64, err error) {
@@ -573,11 +588,15 @@ func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (size int64, err erro
 	// degrades gracefully — same shape as HasEncodedObject.
 	idxErr := s.requireIndex()
 	if idxErr == nil {
-		if pack, _, offset := s.findObjectInPackfile(h); pack != plumbing.ZeroHash && offset != -1 {
+		if pack, idx, offset := s.findObjectInPackfile(h); pack != plumbing.ZeroHash {
 			if cached, ok := s.objectCache.Get(h); ok {
 				return cached.Size(), nil
 			}
-			size, err = s.encodedObjectSizeFromPackfile(h)
+			p, perr := s.packfile(idx, pack)
+			if perr != nil {
+				return 0, perr
+			}
+			size, err = p.GetSizeByOffset(offset)
 			if err == nil {
 				return size, nil
 			}
@@ -622,7 +641,7 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 	idxErr := s.requireIndex()
 	routed := false
 	if idxErr == nil {
-		if pack, _, offset := s.findObjectInPackfile(h); pack != plumbing.ZeroHash && offset != -1 {
+		if pack, idx, offset := s.findObjectInPackfile(h); pack != plumbing.ZeroHash {
 			routed = true
 			if cached, ok := s.objectCache.Get(h); ok {
 				if t == plumbing.AnyObject || cached.Type() == t {
@@ -630,7 +649,7 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 				}
 				return nil, plumbing.ErrObjectNotFound
 			}
-			obj, err = s.getFromPackfile(h, false)
+			obj, err = s.getFromPackfileAt(pack, idx, h, offset, false)
 		}
 	}
 	if !routed {
@@ -729,22 +748,25 @@ func (s *ObjectStorage) getFromUnpacked(h plumbing.Hash) (obj plumbing.EncodedOb
 	return obj, nil
 }
 
-// Get returns the object with the given hash, by searching for it in
-// the packfile.
+// getFromPackfile resolves h via the packfile path: cheap pack-
+// membership probe, then fetch from the located pack.
 func (s *ObjectStorage) getFromPackfile(h plumbing.Hash, canBeDelta bool) (plumbing.EncodedObject, error) {
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
 
-	pack, hash, offset := s.findObjectInPackfile(h)
+	pack, idx, offset := s.findObjectInPackfile(h)
 	if offset == -1 {
 		return nil, plumbing.ErrObjectNotFound
 	}
+	return s.getFromPackfileAt(pack, idx, h, offset, canBeDelta)
+}
 
-	s.muI.RLock()
-	idx := s.index[pack]
-	s.muI.RUnlock()
-
+// getFromPackfileAt fetches the object at a pre-located pack
+// position, skipping the membership probe. Used by callers that
+// already ran findObjectInPackfile (e.g. EncodedObject's pack-
+// membership-first fast path) so the lookup is not repeated.
+func (s *ObjectStorage) getFromPackfileAt(pack plumbing.Hash, idx idxfile.Index, h plumbing.Hash, offset int64, canBeDelta bool) (plumbing.EncodedObject, error) {
 	p, err := s.packfile(idx, pack)
 	if err != nil {
 		return nil, err
@@ -752,9 +774,8 @@ func (s *ObjectStorage) getFromPackfile(h plumbing.Hash, canBeDelta bool) (plumb
 	defer ioutil.CheckClose(p, &err)
 
 	if canBeDelta {
-		return s.decodeDeltaObjectAt(p, offset, hash)
+		return s.decodeDeltaObjectAt(p, offset, h)
 	}
-
 	return p.GetByOffset(offset)
 }
 
@@ -807,21 +828,71 @@ func (s *ObjectStorage) decodeDeltaObjectAt(
 	return newDeltaObject(obj, hash, base, header.Size), nil
 }
 
-func (s *ObjectStorage) findObjectInPackfile(h plumbing.Hash) (plumbing.Hash, plumbing.Hash, int64) {
+// findObjectInPackfile locates h across the storage's packs and
+// returns (pack-hash, idx, offset). offset == -1 means not found
+// in any pack; the returned idx is then nil. Snapshots s.packs
+// under RLock and releases the lock before calling MayContain /
+// FindOffset, so slow LazyIndex I/O does not block concurrent
+// Reindex / requireIndex publish on muI.Lock.
+//
+// MRU policy diverges from canonical Git's find_pack_entry
+// (packfile.c), which moves the hit pack to the head of the
+// packed_git linked list so every subsequent walk starts there.
+// go-git stores a single-slot atomic hint instead. A true reorder
+// would require write-locking s.packs on every successful find,
+// defeating the snapshot-under-RLock pattern that the rest of the
+// read path relies on. The hint can go stale under concurrent
+// Reindex / PackfileWriter.Notify; staleness costs at most one
+// extra MayContain + FindOffset probe and never misroutes, since
+// FindOffset's contract returns an offset only for the hash it
+// was asked about.
+func (s *ObjectStorage) findObjectInPackfile(h plumbing.Hash) (plumbing.Hash, idxfile.Index, int64) {
 	s.muI.RLock()
-	defer s.muI.RUnlock()
+	packs := s.packs
+	s.muI.RUnlock()
 
-	for packfile, index := range s.index {
-		if !index.MayContain(h) {
+	if len(packs) == 0 {
+		return plumbing.ZeroHash, nil, -1
+	}
+
+	// MRU: probe the last successfully-hit pack first. The hint is
+	// encoded as packs index + 1; 0 means no hint. A stale entry
+	// costs one MayContain + FindOffset but never misroutes.
+	hint := int(s.lastHitPackIdx.Load()) - 1
+	if hint >= 0 && hint < len(packs) {
+		pe := packs[hint]
+		if pe.idx != nil && pe.idx.MayContain(h) {
+			if offset, err := pe.idx.FindOffset(h); err == nil {
+				return pe.h, pe.idx, offset
+			}
+		}
+	} else {
+		hint = -1
+	}
+
+	for i, pe := range packs {
+		if i == hint {
+			// Skip the MRU pack — we already tried it above.
 			continue
 		}
-		offset, err := index.FindOffset(h)
+		if !pe.idx.MayContain(h) {
+			continue
+		}
+		offset, err := pe.idx.FindOffset(h)
 		if err == nil {
-			return packfile, h, offset
+			// Update the hint only when it actually changed.
+			// Saves a no-op atomic Store on the hot stay-on-pack
+			// pattern (caught by the MRU probe above) and avoids
+			// any allocation — the encoded value is a small int.
+			next := int32(i + 1)
+			if s.lastHitPackIdx.Load() != next {
+				s.lastHitPackIdx.Store(next)
+			}
+			return pe.h, pe.idx, offset
 		}
 	}
 
-	return plumbing.ZeroHash, plumbing.ZeroHash, -1
+	return plumbing.ZeroHash, nil, -1
 }
 
 // HashesWithPrefix returns all objects with a hash that starts with a prefix by searching for
@@ -1078,20 +1149,47 @@ func (s *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
 }
 
 // DeleteOldObjectPackAndIndex removes a pack and its index if older than t.
-// Also drops the in-memory s.index entry for the removed pack so subsequent
-// routing decisions in findObjectInPackfile no longer claim membership for
-// a hash that lives only in the now-deleted pack.
+// Also drops the in-memory s.index map entry and the matching s.packs
+// slice entry for the removed pack so subsequent routing decisions in
+// findObjectInPackfile no longer claim membership for a hash that
+// lives only in the now-deleted pack. If the MRU hint pointed at the
+// deleted slot, invalidate it.
 func (s *ObjectStorage) DeleteOldObjectPackAndIndex(h plumbing.Hash, t time.Time) error {
 	if err := s.dir.DeleteOldObjectPackAndIndex(h, t); err != nil {
 		return err
 	}
 	s.muI.Lock()
-	if idx, ok := s.index[h]; ok {
-		delete(s.index, h)
-		if c, ok := idx.(io.Closer); ok {
-			_ = c.Close()
-		}
+	defer s.muI.Unlock()
+
+	idx, ok := s.index[h]
+	if !ok {
+		return nil
 	}
-	s.muI.Unlock()
+	delete(s.index, h)
+
+	// Drop the matching s.packs entry. Allocate a fresh slice and
+	// copy the rest (mirror of PackfileWriter.Notify's copy-on-grow)
+	// so readers holding the old slice header keep a stable view.
+	for i, pe := range s.packs {
+		if pe.h != h {
+			continue
+		}
+		next := make([]packEntry, 0, len(s.packs)-1)
+		next = append(next, s.packs[:i]...)
+		next = append(next, s.packs[i+1:]...)
+		s.packs = next
+		// Invalidate the MRU hint if it pointed at the deleted slot.
+		// findObjectInPackfile's bounds check + FindOffset contract
+		// make a stale hint safe, but resetting under the lock here
+		// removes the staleness window entirely.
+		if s.lastHitPackIdx.Load() == int32(i+1) {
+			s.lastHitPackIdx.Store(0)
+		}
+		break
+	}
+
+	if c, ok := idx.(io.Closer); ok {
+		_ = c.Close()
+	}
 	return nil
 }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -905,8 +905,6 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 
 	seen := hashListAsMap(hashes)
 
-	// TODO: This could be faster with some idxfile changes,
-	// or diving into the packfile.
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
@@ -924,7 +922,7 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 	s.muI.RUnlock()
 
 	for _, index := range indexes {
-		ei, err := index.Entries()
+		ei, err := index.EntriesWithPrefix(prefix)
 		if err != nil {
 			return nil, err
 		}
@@ -936,13 +934,11 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 				_ = ei.Close()
 				return nil, err
 			}
-			if e.Hash.HasPrefix(prefix) {
-				if _, ok := seen[e.Hash]; ok {
-					continue
-				}
-				seen[e.Hash] = struct{}{}
-				hashes = append(hashes, e.Hash)
+			if _, ok := seen[e.Hash]; ok {
+				continue
 			}
+			seen[e.Hash] = struct{}{}
+			hashes = append(hashes, e.Hash)
 		}
 		_ = ei.Close()
 	}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -256,9 +256,7 @@ func (s *ObjectStorage) requireIndex() error {
 			// Close any indexes we built so SharedFile refcounts
 			// (held by LazyIndex) do not leak.
 			for _, idx := range local {
-				if c, ok := idx.(io.Closer); ok {
-					_ = c.Close()
-				}
+				_ = idx.Close()
 			}
 		}
 		s.muI.Unlock()
@@ -343,9 +341,7 @@ func (s *ObjectStorage) populateIndex() (map[plumbing.Hash]idxfile.Index, []pack
 			if e.idx == nil {
 				continue
 			}
-			if c, ok := e.idx.(io.Closer); ok {
-				_ = c.Close()
-			}
+			_ = e.idx.Close()
 		}
 		return nil, nil, err
 	}
@@ -1031,16 +1027,13 @@ func (s *ObjectStorage) Close() error {
 	}
 	s.muA.RUnlock()
 
-	// If the index being used implements io.Closer, make sure we call it.
-	// LazyIndex.Close permanently disables the index and releases any
-	// idle file descriptors. The same pattern applies to other Index
-	// implementations that hold resources.
+	// Close each cached Index. LazyIndex.Close releases idle file
+	// descriptors and permanently disables the index; MemoryIndex's
+	// Close is a no-op.
 	s.muI.RLock()
 	for _, idx := range s.index {
-		if closer, ok := idx.(io.Closer); ok {
-			if err := closer.Close(); firstError == nil && err != nil {
-				firstError = err
-			}
+		if err := idx.Close(); firstError == nil && err != nil {
+			firstError = err
 		}
 	}
 	s.muI.RUnlock()
@@ -1184,8 +1177,6 @@ func (s *ObjectStorage) DeleteOldObjectPackAndIndex(h plumbing.Hash, t time.Time
 		break
 	}
 
-	if c, ok := idx.(io.Closer); ok {
-		_ = c.Close()
-	}
+	_ = idx.Close()
 	return nil
 }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -782,6 +782,9 @@ func (s *ObjectStorage) findObjectInPackfile(h plumbing.Hash) (plumbing.Hash, pl
 	defer s.muI.RUnlock()
 
 	for packfile, index := range s.index {
+		if !index.MayContain(h) {
+			continue
+		}
 		offset, err := index.FindOffset(h)
 		if err == nil {
 			return packfile, h, offset

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -640,38 +640,47 @@ func BenchmarkObjectStorage_FSObjectReader(b *testing.B) {
 
 // BenchmarkFindObjectInPackfile_FanoutMiss measures the per-pack
 // probe cost when the target hash lives in only one of N indexes.
-// With MayContain in place, N-1 packs reject via a cheap branch;
-// pre-fix, every pack pays a FindOffset call (mutex + ReadAt +
-// binary search).
+// With MayContain in place, N-1 packs reject via a cheap fanout
+// check; pre-fix, every pack pays a FindOffset call (mutex +
+// ReadAt + binary search).
+//
+// Workload: cycle through one hash per pack so each lookup
+// targets a different pack, defeating the MRU fast path. Reads
+// use cache.NewObjectLRU(0) so the object cache cannot serve the
+// hot loop and every iteration traverses the membership probe.
 func BenchmarkFindObjectInPackfile_FanoutMiss(b *testing.B) {
-	fixture := fixtures.Basic().One()
-	dir, err := fixture.DotGit()
-	if err != nil {
-		b.Fatal(err)
+	const (
+		nPacks     = 32
+		objPerPack = 8
+	)
+	diskFS, perPack := makeMultiPackFixture(b, nPacks, objPerPack)
+
+	// One hash per pack so consecutive iterations always switch
+	// packs; MRU hint is invalidated on every read.
+	hashes := make([]plumbing.Hash, nPacks)
+	for i, p := range perPack {
+		hashes[i] = p[0]
 	}
-	s := NewStorage(dir, cache.NewObjectLRUDefault())
+
+	s := NewStorage(diskFS, cache.NewObjectLRU(0))
 	b.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
-	if err != nil {
-		b.Fatal(err)
-	}
-	obj, err := iter.Next()
-	iter.Close()
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	// Warm.
-	if _, err := s.EncodedObject(plumbing.AnyObject, obj.Hash()); err != nil {
-		b.Fatal(err)
+	// Warm: ensure every pack's idx is loaded so the timed loop
+	// is not paying a cold populate on iteration 1.
+	for _, h := range hashes {
+		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			b.Fatal(err)
+		}
 	}
 
 	b.ReportAllocs()
+	var i int
 	for b.Loop() {
-		if _, err := s.EncodedObject(plumbing.AnyObject, obj.Hash()); err != nil {
+		h := hashes[i%len(hashes)]
+		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
+		i++
 	}
 }
 
@@ -722,43 +731,79 @@ func BenchmarkEncodedObject_LooseHit(b *testing.B) {
 	}
 }
 
-// BenchmarkFindObjectInPackfile_MRU_Hit reads the same hash 100
-// times after a single warm-up. With MRU, the second and
-// subsequent reads hit the cached pack in O(1) MayContain checks
-// instead of paying random map iteration (N/2 misses on average
-// for repos with N packs). The basic fixture is single-pack, so
-// this benchmark stresses the MRU fast-path overhead more than
-// the multi-pack savings — but it still exposes MRU-induced
-// regressions and the atomic.Load cost.
-func BenchmarkFindObjectInPackfile_MRU_Hit(b *testing.B) {
-	fixture := fixtures.Basic().One()
-	dir, err := fixture.DotGit()
-	if err != nil {
-		b.Fatal(err)
-	}
-	s := NewStorage(dir, cache.NewObjectLRUDefault())
+// BenchmarkHashesWithPrefix_TwoByte measures the cost of a short
+// prefix lookup against a multi-pack fixture. Pre-fix: O(N*M)
+// walking every entry of every pack per call. Post-fix:
+// O(N * (log M + matches)) via fanout-bounded EntriesWithPrefix
+// — only the relevant fanout bucket is scanned in each pack.
+//
+// The 2-byte prefix is picked from a real hash so at least one
+// pack returns a match; the remaining packs reject via empty
+// fanout buckets.
+func BenchmarkHashesWithPrefix_TwoByte(b *testing.B) {
+	const (
+		nPacks     = 32
+		objPerPack = 32
+	)
+	diskFS, perPack := makeMultiPackFixture(b, nPacks, objPerPack)
+
+	// Use a hash from the last pack so the lookup walks every
+	// pack's idx (no MRU short-circuit).
+	prefix := perPack[nPacks-1][0].Bytes()[:2]
+
+	s := NewStorage(diskFS, cache.NewObjectLRUDefault())
 	b.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
-	if err != nil {
-		b.Fatal(err)
-	}
-	obj, err := iter.Next()
-	iter.Close()
-	if err != nil {
-		b.Fatal(err)
-	}
-	h := obj.Hash()
-
-	// Warm: this also seeds lastHitPack.
-	if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+	// Warm the index so per-iteration cost excludes cold populate.
+	if _, err := s.HashesWithPrefix(prefix); err != nil {
 		b.Fatal(err)
 	}
 
 	b.ReportAllocs()
 	for b.Loop() {
+		if _, err := s.HashesWithPrefix(prefix); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFindObjectInPackfile_MRU_Hit reads hashes that all
+// live in the same pack against a multi-pack fixture. With MRU,
+// the lastHitPackIdx hint resolves the right pack in O(1) on the
+// fast path; without MRU, the map iteration is randomised and
+// the average lookup pays N/2 MayContain rejects before finding
+// the right pack.
+//
+// Uses cache.NewObjectLRU(0) so the object cache cannot serve
+// the hot loop — each iteration must traverse findObjectInPackfile.
+func BenchmarkFindObjectInPackfile_MRU_Hit(b *testing.B) {
+	const (
+		nPacks     = 32
+		objPerPack = 8
+	)
+	diskFS, perPack := makeMultiPackFixture(b, nPacks, objPerPack)
+
+	// All hashes in pack 0 — repeated reads keep the MRU hint
+	// pointing at the same pack.
+	hashes := perPack[0]
+
+	s := NewStorage(diskFS, cache.NewObjectLRU(0))
+	b.Cleanup(func() { _ = s.Close() })
+
+	// Warm: seeds lastHitPackIdx on pack 0.
+	for _, h := range hashes {
 		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
+	}
+
+	b.ReportAllocs()
+	var i int
+	for b.Loop() {
+		h := hashes[i%len(hashes)]
+		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			b.Fatal(err)
+		}
+		i++
 	}
 }

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -721,3 +721,44 @@ func BenchmarkEncodedObject_LooseHit(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkFindObjectInPackfile_MRU_Hit reads the same hash 100
+// times after a single warm-up. With MRU, the second and
+// subsequent reads hit the cached pack in O(1) MayContain checks
+// instead of paying random map iteration (N/2 misses on average
+// for repos with N packs). The basic fixture is single-pack, so
+// this benchmark stresses the MRU fast-path overhead more than
+// the multi-pack savings — but it still exposes MRU-induced
+// regressions and the atomic.Load cost.
+func BenchmarkFindObjectInPackfile_MRU_Hit(b *testing.B) {
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	b.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	if err != nil {
+		b.Fatal(err)
+	}
+	obj, err := iter.Next()
+	iter.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+	h := obj.Hash()
+
+	// Warm: this also seeds lastHitPack.
+	if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -807,3 +807,52 @@ func BenchmarkFindObjectInPackfile_MRU_Hit(b *testing.B) {
 		i++
 	}
 }
+
+// BenchmarkFindObjectInPackfile_MRU_Churn measures the steady-state
+// cost when reads cycle a working set of K hot packs in round-robin
+// order. With a single-slot MRU hint, the hint is correct on 1 of
+// every K iterations and stale on the rest; the stale-hint cost is
+// one MayContain probe before the linear scan finds the right pack.
+// Slots between MRU_Hit (K=1, perfect reuse) and FanoutMiss (K=N, no
+// reuse) to make the hint's degradation curve visible to benchstat.
+//
+// K=4 was picked to match realistic GC-time pack counts where a
+// reader walks a tree spread across a small hot set. Cache disabled
+// (cache.NewObjectLRU(0)) so the object cache cannot serve the hot
+// loop and every iteration traverses findObjectInPackfile.
+func BenchmarkFindObjectInPackfile_MRU_Churn(b *testing.B) {
+	const (
+		nPacks     = 32
+		objPerPack = 8
+		hotPacks   = 4
+	)
+	diskFS, perPack := makeMultiPackFixture(b, nPacks, objPerPack)
+
+	// One hash per hot pack so consecutive reads switch packs in a
+	// fixed cycle; the MRU hint always trails by one position.
+	hashes := make([]plumbing.Hash, hotPacks)
+	for i := range hotPacks {
+		hashes[i] = perPack[i][0]
+	}
+
+	s := NewStorage(diskFS, cache.NewObjectLRU(0))
+	b.Cleanup(func() { _ = s.Close() })
+
+	// Warm: ensure every hot pack's idx is loaded so the timed loop
+	// is not paying a cold populate on the first cycle.
+	for _, h := range hashes {
+		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+	var i int
+	for b.Loop() {
+		h := hashes[i%hotPacks]
+		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			b.Fatal(err)
+		}
+		i++
+	}
+}

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -674,3 +674,50 @@ func BenchmarkFindObjectInPackfile_FanoutMiss(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkEncodedObject_LooseHit measures EncodedObject latency
+// when the target lives in a loose object. With pack-membership-
+// first, findObjectInPackfile reports the loose-only hash as
+// not-in-packs in O(1) and the read routes straight to the loose
+// path: one Stat + open + decompress, no wasted pack probing.
+// Setup: a packed fixture plus one freshly-written loose object.
+func BenchmarkEncodedObject_LooseHit(b *testing.B) {
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	b.Cleanup(func() { _ = s.Close() })
+
+	// Write a fresh loose object so the hit-path is observable.
+	o := s.NewEncodedObject()
+	o.SetType(plumbing.BlobObject)
+	w, err := o.Writer()
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := w.Write([]byte("loose-bench-payload")); err != nil {
+		b.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		b.Fatal(err)
+	}
+	h, err := s.SetEncodedObject(o)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Warm the index so the per-iteration call doesn't pay a
+	// cold-load.
+	if err := s.HasEncodedObject(h); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -637,3 +637,40 @@ func BenchmarkObjectStorage_FSObjectReader(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkFindObjectInPackfile_FanoutMiss measures the per-pack
+// probe cost when the target hash lives in only one of N indexes.
+// With MayContain in place, N-1 packs reject via a cheap branch;
+// pre-fix, every pack pays a FindOffset call (mutex + ReadAt +
+// binary search).
+func BenchmarkFindObjectInPackfile_FanoutMiss(b *testing.B) {
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	if err != nil {
+		b.Fatal(err)
+	}
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	b.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	if err != nil {
+		b.Fatal(err)
+	}
+	obj, err := iter.Next()
+	iter.Close()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Warm.
+	if _, err := s.EncodedObject(plumbing.AnyObject, obj.Hash()); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := s.EncodedObject(plumbing.AnyObject, obj.Hash()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -157,6 +157,66 @@ func (s *FsSuite) TestMismatchIdxFile() {
 	s.ErrorContains(err, "malformed idx file: packfile mismatch: ")
 }
 
+// TestMismatchIdxFile_LooseFallback exercises the degraded-store path:
+// when the only .idx fails to load (here via a packfile-mismatch
+// corruption), a loose object that lives under .git/objects must
+// still resolve. Pre-fix, requireIndex returned the malformed-idx
+// error from HasEncodedObject / EncodedObjectSize / EncodedObject
+// before the loose path ran, hiding a perfectly good object.
+func (s *FsSuite) TestMismatchIdxFile_LooseFallback() {
+	f := fixtures.Basic().ByTag(".git").ByObjectFormat("sha1").One()
+	fs, err := f.DotGit()
+	s.Require().NoError(err)
+	o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
+	defer func() { _ = o.Close() }()
+
+	// Plant a loose object and capture its hash before corrupting
+	// the on-disk idx so the populateIndex call below fails for
+	// reasons unrelated to this object.
+	obj := o.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	w, err := obj.Writer()
+	s.Require().NoError(err)
+	_, err = w.Write([]byte("loose object behind a broken idx\n"))
+	s.Require().NoError(err)
+	s.Require().NoError(w.Close())
+	loose, err := o.SetEncodedObject(obj)
+	s.Require().NoError(err)
+
+	// Corrupt the only idx in the same way TestMismatchIdxFile does.
+	fix2 := firstNonMatching(f.PackfileHash)
+	s.Require().NotNil(fix2)
+	idx, err := fs.OpenFile(fmt.Sprintf("objects/pack/pack-%s.idx", f.PackfileHash), os.O_TRUNC|os.O_WRONLY, 0o600)
+	s.Require().NoError(err)
+	idx2, err := fix2.Idx()
+	s.Require().NoError(err)
+	_, err = io.Copy(idx, idx2)
+	s.Require().NoError(err)
+	s.Require().NoError(idx.Close())
+	s.Require().NoError(idx2.Close())
+
+	// Cold storage so requireIndex actually runs against the
+	// corrupted idx on the first read.
+	o2 := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
+	defer func() { _ = o2.Close() }()
+
+	s.Require().NoError(o2.HasEncodedObject(loose),
+		"loose object must answer existence even when the idx is broken")
+	size, err := o2.EncodedObjectSize(loose)
+	s.Require().NoError(err)
+	s.Greater(size, int64(0))
+	got, err := o2.EncodedObject(plumbing.AnyObject, loose)
+	s.Require().NoError(err)
+	s.Equal(loose, got.Hash())
+
+	// Sanity: a hash not present anywhere still surfaces the
+	// idx error so genuine on-disk corruption is not silently
+	// swallowed when there is no answer to give the caller.
+	missing := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	err = o2.HasEncodedObject(missing)
+	s.ErrorContains(err, "malformed idx file: packfile mismatch: ")
+}
+
 func (s *FsSuite) TestGetSizeOfObjectFile() {
 	fs, err := fixtures.ByTag(".git").ByTag("unpacked").One().DotGit()
 	s.Require().NoError(err)
@@ -613,6 +673,11 @@ func (s *FsSuite) TestGetFromUnpackedCachesObjects() {
 }
 
 func (s *FsSuite) TestGetFromUnpackedDoesNotCacheLargeObjects() {
+	// The "unpacked" fixture contains both packed and loose copies
+	// of the same objects. EncodedObject routes packed reads
+	// through the pack path (which caches independently of size),
+	// so to test the LargeObjectThreshold behaviour we exercise
+	// getFromUnpacked directly.
 	fs, err := fixtures.ByTag(".git").ByTag("unpacked").One().DotGit()
 	s.Require().NoError(err)
 	objectCache := cache.NewObjectLRUDefault()
@@ -623,8 +688,8 @@ func (s *FsSuite) TestGetFromUnpackedDoesNotCacheLargeObjects() {
 	_, ok := objectCache.Get(hash)
 	s.False(ok)
 
-	// Load the object
-	obj, err := objectStorage.EncodedObject(plumbing.AnyObject, hash)
+	// Load the object via the loose path.
+	obj, err := objectStorage.getFromUnpacked(hash)
 	s.Require().NoError(err)
 	s.Equal(hash, obj.Hash())
 
@@ -951,6 +1016,14 @@ func TestObjectStorageCloseIdleDescriptors(t *testing.T) {
 		iter.Close()
 		require.NotEmpty(t, hashes)
 
+		// Single-goroutine warm-up: the default loose-first probe calls
+		// dotgit.hasIncomingObjects(), which lazily initialises
+		// incomingChecked without a lock. One serial lookup here
+		// ensures the field is set before the concurrent herd,
+		// sidestepping the pre-existing race in hasIncomingObjects.
+		_, err = s.EncodedObject(plumbing.AnyObject, hashes[0])
+		require.NoError(t, err)
+
 		var wg sync.WaitGroup
 		var failures atomic.Int32
 
@@ -1114,6 +1187,14 @@ func TestObjectStorage_ConcurrentEncodedObject_NoRace(t *testing.T) {
 	iter.Close()
 	h := obj.Hash()
 
+	// Single-goroutine warm-up: the default loose-first probe calls
+	// dotgit.hasIncomingObjects(), which lazily writes incomingChecked
+	// without a lock. One serial call here ensures the field is set
+	// before the concurrent herd, avoiding a pre-existing race in
+	// hasIncomingObjects on cold startup.
+	_, err = s.EncodedObject(plumbing.AnyObject, h)
+	require.NoError(t, err)
+
 	var wg sync.WaitGroup
 	for range 32 {
 		wg.Go(func() {
@@ -1126,4 +1207,106 @@ func TestObjectStorage_ConcurrentEncodedObject_NoRace(t *testing.T) {
 	s.muI.RLock()
 	defer s.muI.RUnlock()
 	assert.NotNil(t, s.index, "after the herd s.index must be populated")
+}
+
+func TestEncodedObject_PackedRoundTrip(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Warm the index so EncodedObject doesn't race through the
+	// cold dotgit path (matches the convention of existing tests).
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	obj, err := iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+
+	got, err := s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	require.NoError(t, err)
+	assert.Equal(t, obj.Hash(), got.Hash())
+}
+
+func TestEncodedObject_LooseRoundTrip(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Write a fresh loose object; pack-membership-first must route
+	// the read through the loose path because the new blob isn't
+	// in any pack.
+	o := s.NewEncodedObject()
+	o.SetType(plumbing.BlobObject)
+	w, err := o.Writer()
+	require.NoError(t, err)
+	_, err = w.Write([]byte("loose-prefer-test"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	h, err := s.SetEncodedObject(o)
+	require.NoError(t, err)
+
+	got, err := s.EncodedObject(plumbing.AnyObject, h)
+	require.NoError(t, err)
+	assert.Equal(t, h, got.Hash())
+}
+
+func TestEncodedObject_NotFound(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Warm index to avoid the cold dotgit race.
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	iter.Close()
+
+	missing := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	_, err = s.EncodedObject(plumbing.AnyObject, missing)
+	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+}
+
+func TestEncodedObjectSize_NotFound(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Warm index to avoid the cold dotgit race.
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	iter.Close()
+
+	missing := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	_, err = s.EncodedObjectSize(missing)
+	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+}
+
+func TestEncodedObjectSize_Packed(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	obj, err := iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+
+	size, err := s.EncodedObjectSize(obj.Hash())
+	require.NoError(t, err)
+	assert.Greater(t, size, int64(0))
 }

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -1310,3 +1310,36 @@ func TestEncodedObjectSize_Packed(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, size, int64(0))
 }
+
+func TestFindObjectInPackfile_MRU_SeedsAndUses(t *testing.T) {
+	t.Parallel()
+	fixture := fixtures.Basic().One()
+	dir, err := fixture.DotGit()
+	require.NoError(t, err)
+	s := NewStorage(dir, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Pre-warm the index (cold dotgit race avoidance).
+	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	require.NoError(t, err)
+	obj, err := iter.Next()
+	require.NoError(t, err)
+	iter.Close()
+
+	// Initially no hint (encoded as 0).
+	require.Equal(t, int32(0), s.lastHitPackIdx.Load())
+
+	// First lookup seeds the hint.
+	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	require.NoError(t, err)
+
+	hint := s.lastHitPackIdx.Load()
+	require.NotEqual(t, int32(0), hint,
+		"first successful lookup should seed lastHitPackIdx")
+
+	// Second lookup should not change the hint (still the same pack).
+	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	require.NoError(t, err)
+	assert.Equal(t, hint, s.lastHitPackIdx.Load(),
+		"single-pack fixture: hint should stay stable")
+}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -129,12 +129,20 @@ type Options struct {
 }
 
 // NewStorage returns a new Storage backed by a given `fs.Filesystem` and cache.
+//
+// The cache is keyed by object hash only; passing the same
+// [cache.Object] across multiple Storage instances is safe because
+// every storage-level read gates its cache lookup on a successful
+// pack-membership probe, so a hit from another storage's pack cannot
+// be served here. See [ObjectStorage.EncodedObject] and
+// TestGetFromObjectFileSharedCache.
 func NewStorage(fs billy.Filesystem, cache cache.Object) *Storage {
 	return NewStorageWithOptions(fs, cache, Options{})
 }
 
 // NewStorageWithOptions returns a new Storage with extra options,
-// backed by a given `fs.Filesystem` and cache.
+// backed by a given `fs.Filesystem` and cache. See [NewStorage] for
+// the cross-Storage cache safety contract.
 // Returns an error if an explicit ObjectFormat is provided via options
 // but conflicts with an existing config in the filesystem.
 func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *Storage {


### PR DESCRIPTION
Third in the pack-hotpath stack. Builds on #2133 (FD lifecycle) and #2134 (storage-wide FD budget) to land the read-path wins.

### Changes

- `idxfile.Index.MayContain` — O(1) fanout-bucket short-circuit; `findObjectInPackfile` consults it before `FindOffset` and skips packs whose first-byte bucket is empty.
- MRU pack ordering — sticky `lastHitPackIdx` hint in `ObjectStorage.findObjectInPackfile` resolves repeated reads on the same pack in O(1).
- `idxfile.Index.EntriesWithPrefix` — fanout-bounded prefix iteration with in-bucket bsearch positioning (mirrors upstream Git's `for_each_prefixed_object_in_pack`). Replaces the per-entry prefix scan in `ObjectStorage.HashesWithPrefix`.
- Storage-level reads route through `PackHandle.Index()` so `.idx`/`.rev` descriptors share the FD-pool budget.
- Race test for `cleanPackList`-vs-Acquire; multi-byte-prefix iteration tests covering the mid-bucket match case.

### Benchmarks

Apple M4 Pro, `-benchtime=1s -count=6`, benchstat vs `pack-hotpath-fd-pool`:

| Benchmark | sec/op | B/op | allocs/op |
|---|---:|---:|---:|
| `FindObjectInPackfile_FanoutMiss` | 13.66µ → 10.28µ (**−24.7%**) | 4.90Ki → 2.81Ki (**−42.7%**) | 89 → 59 (**−33.7%**) |
| `FindObjectInPackfile_MRU_Hit` | 12.04µ → 8.87µ (**−26.3%**) | 4.91Ki → 2.73Ki (**−44.5%**) | 89 → 56 (**−37.1%**) |
| `HashesWithPrefix_TwoByte` | 1093.5µ → 32.05µ (**−97.1%**) | 111.5Ki → 6.44Ki (**−94.2%**) | 4219 → 95 (**−97.8%**) |

Cumulative across the four-PR stack (vs `main`): `FanoutMiss` −81%, `MRU_Hit` −83%, `HashesWithPrefix_TwoByte` −97%, `AlternatesObjectLookup` (3 variants) −46–67%, `ParallelReads` −78%.
