### PR TITLE
demo: mmap'ed reads

### DIFF
--- a/_examples/merge_base/main.go
+++ b/_examples/merge_base/main.go
@@ -3,9 +3,14 @@ package main
 import (
 	"os"
 
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/osfs"
+
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/storage/filesystem"
 )
 
 type exitCode int
@@ -77,8 +82,23 @@ func main() {
 		}
 	}
 
-	// Open a git repository from current directory
-	repo, err := git.PlainOpen(path)
+	// Build a billy filesystem rooted at the git dir, wrapped to mmap
+	// read-only files. Open the repository with KeepDescriptors so packfile
+	// descriptors are kept open (and thus their mmap regions remain valid)
+	// for the lifetime of the storage.
+	var fs billy.Filesystem = newMmapFS(osfs.New(path))
+	if _, err := fs.Stat(git.GitDirName); err == nil {
+		fs, err = fs.Chroot(git.GitDirName)
+		checkIfError(err, exitCodeCouldNotOpenRepository, "could not chroot into .git")
+	}
+
+	storage := filesystem.NewStorageWithOptions(
+		fs, cache.NewObjectLRUDefault(),
+		filesystem.Options{KeepDescriptors: true},
+	)
+	defer storage.Close()
+
+	repo, err := git.Open(storage, fs)
 	checkIfError(err, exitCodeCouldNotOpenRepository, "not in a git repository")
 	defer func() { _ = repo.Close() }()
 

--- a/_examples/merge_base/mmapfs.go
+++ b/_examples/merge_base/mmapfs.go
@@ -1,0 +1,118 @@
+//go:build darwin || linux
+
+package main
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+
+	"github.com/go-git/go-billy/v6"
+	"golang.org/x/sys/unix"
+)
+
+// mmapFS wraps a billy.Filesystem so that files opened read-only are backed
+// by an mmap'd region instead of regular read syscalls.
+type mmapFS struct {
+	billy.Filesystem
+}
+
+func newMmapFS(fs billy.Filesystem) *mmapFS {
+	return &mmapFS{Filesystem: fs}
+}
+
+func (m *mmapFS) Open(name string) (billy.File, error) {
+	return m.OpenFile(name, os.O_RDONLY, 0)
+}
+
+func (m *mmapFS) OpenFile(name string, flag int, perm fs.FileMode) (billy.File, error) {
+	f, err := m.Filesystem.OpenFile(name, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	if flag&(os.O_WRONLY|os.O_RDWR|os.O_APPEND|os.O_CREATE|os.O_TRUNC) != 0 {
+		return f, nil
+	}
+
+	info, err := f.Stat()
+	if err != nil || info.Size() == 0 || info.IsDir() {
+		return f, err
+	}
+
+	fd, ok := fileDescriptor(f)
+	if !ok {
+		return f, nil
+	}
+
+	data, err := unix.Mmap(int(fd), 0, int(info.Size()), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	return &mmapFile{
+		name:   name,
+		data:   data,
+		reader: bytes.NewReader(data),
+		file:   f,
+		info:   info,
+	}, nil
+}
+
+func (m *mmapFS) Chroot(path string) (billy.Filesystem, error) {
+	sub, err := m.Filesystem.Chroot(path)
+	if err != nil {
+		return nil, err
+	}
+	return &mmapFS{Filesystem: sub}, nil
+}
+
+func fileDescriptor(f billy.File) (uintptr, bool) {
+	type billyFd interface {
+		Fd() (uintptr, bool)
+	}
+	type osFd interface {
+		Fd() uintptr
+	}
+	if bf, ok := f.(billyFd); ok {
+		return bf.Fd()
+	}
+	if of, ok := f.(osFd); ok {
+		return of.Fd(), true
+	}
+	return 0, false
+}
+
+// mmapFile is a read-only billy.File backed by an mmap'd region.
+type mmapFile struct {
+	name   string
+	data   []byte
+	reader *bytes.Reader
+	file   billy.File
+	info   fs.FileInfo
+	closed bool
+}
+
+func (f *mmapFile) Name() string                                 { return f.name }
+func (f *mmapFile) Read(p []byte) (int, error)                   { return f.reader.Read(p) }
+func (f *mmapFile) ReadAt(p []byte, off int64) (int, error)      { return f.reader.ReadAt(p, off) }
+func (f *mmapFile) Seek(offset int64, whence int) (int64, error) { return f.reader.Seek(offset, whence) }
+func (f *mmapFile) Stat() (fs.FileInfo, error)                   { return f.info, nil }
+func (f *mmapFile) Write(p []byte) (int, error)                  { return 0, billy.ErrReadOnly }
+func (f *mmapFile) WriteAt(p []byte, off int64) (int, error)     { return 0, billy.ErrReadOnly }
+func (f *mmapFile) Truncate(size int64) error                    { return billy.ErrReadOnly }
+func (f *mmapFile) Lock() error                                  { return nil }
+func (f *mmapFile) Unlock() error                                { return nil }
+
+func (f *mmapFile) Close() error {
+	if f.closed {
+		return nil
+	}
+	f.closed = true
+	uerr := unix.Munmap(f.data)
+	cerr := f.file.Close()
+	if uerr != nil {
+		return uerr
+	}
+	return cerr
+}


### PR DESCRIPTION
before:

time /tmp/merge-base  ~/vc/linux/.git refs/tags/v7.0 refs/tags/v6.9 a38297e3fb012ddfa7ce0321a7e5a8daeb1872b6

real	0m10.530s
user	0m8.033s
sys	0m3.195s

after:

$ time /tmp/merge-base  ~/vc/linux/.git refs/tags/v7.0 refs/tags/v6.9 a38297e3fb012ddfa7ce0321a7e5a8daeb1872b6

real	0m6.716s
user	0m7.314s
sys	0m0.161s

this change, but osfs.New() with `KeepDescriptors: true`

$ time /tmp/merge-base  ~/vc/linux/.git refs/tags/v7.0 refs/tags/v6.9
a38297e3fb012ddfa7ce0321a7e5a8daeb1872b6

real	0m11.368s
user	0m8.909s
sys	0m3.257s



CGit:

time git  --git-dir ~/vc/linux/.git/ merge-base refs/tags/v6.9 refs/tags/v7.0 a38297e3fb012ddfa7ce0321a7e5a8daeb1872b6

real	0m2.948s
user	0m2.701s
sys	0m0.230s

After packhandle cache (#2132)

time /tmp/merge-base  ~/vc/linux/.git refs/tags/v7.0 refs/tags/v6.9
a38297e3fb012ddfa7ce0321a7e5a8daeb1872b6

real	0m10.596s
user	0m9.272s
sys	0m2.489s

