### PR TITLE
plumbing: format/index, sort entries by Name and Stage

### DIFF
--- a/plumbing/format/index/encoder.go
+++ b/plumbing/format/index/encoder.go
@@ -85,7 +85,7 @@ func (e *Encoder) encodeHeader(idx *Index) error {
 }
 
 func (e *Encoder) encodeEntries(idx *Index) error {
-	sort.Sort(byName(idx.Entries))
+	sort.Sort(byNameAndStage(idx.Entries))
 
 	for _, entry := range idx.Entries {
 		if err := e.encodeEntry(idx, entry); err != nil {
@@ -263,8 +263,13 @@ func (e *Encoder) encodeFooter() error {
 	return binary.Write(e.w, e.hash.Sum(nil))
 }
 
-type byName []*Entry
+type byNameAndStage []*Entry
 
-func (l byName) Len() int           { return len(l) }
-func (l byName) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
-func (l byName) Less(i, j int) bool { return l[i].Name < l[j].Name }
+func (l byNameAndStage) Len() int      { return len(l) }
+func (l byNameAndStage) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l byNameAndStage) Less(i, j int) bool {
+	if l[i].Name == l[j].Name {
+		return l[i].Stage < l[j].Stage
+	}
+	return l[i].Name < l[j].Name
+}

--- a/plumbing/format/index/encoder_test.go
+++ b/plumbing/format/index/encoder_test.go
@@ -98,6 +98,65 @@ func TestEncodeLongName(t *testing.T) {
 	assert.Equal(t, uint32(2), output.Entries[1].Size)
 }
 
+func TestEncodeSortedByNameThenStage(t *testing.T) {
+	t.Parallel()
+	idx := &Index{
+		Version: 2,
+		Entries: []*Entry{{
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       "foo",
+			Stage:      TheirMode,
+		}, {
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       "foo",
+			Stage:      OurMode,
+		}, {
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       "foo",
+			Stage:      AncestorMode,
+		}, {
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       "bar",
+			Stage:      Merged,
+		}, {
+			CreatedAt:  time.Now(),
+			ModifiedAt: time.Now(),
+			Name:       "baz",
+			Stage:      OurMode,
+		}},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	e := NewEncoder(buf, crypto.SHA1.New())
+	err := e.Encode(idx)
+	assert.NoError(t, err)
+
+	output := &Index{}
+	d := NewDecoder(buf, crypto.SHA1.New())
+	err = d.Decode(output)
+	assert.NoError(t, err)
+
+	require.Len(t, output.Entries, 5)
+	assert.Equal(t, "bar", output.Entries[0].Name)
+	assert.Equal(t, Merged, output.Entries[0].Stage)
+
+	assert.Equal(t, "baz", output.Entries[1].Name)
+	assert.Equal(t, OurMode, output.Entries[1].Stage)
+
+	assert.Equal(t, "foo", output.Entries[2].Name)
+	assert.Equal(t, AncestorMode, output.Entries[2].Stage)
+
+	assert.Equal(t, "foo", output.Entries[3].Name)
+	assert.Equal(t, OurMode, output.Entries[3].Stage)
+
+	assert.Equal(t, "foo", output.Entries[4].Name)
+	assert.Equal(t, TheirMode, output.Entries[4].Stage)
+}
+
 func TestEncodeV4(t *testing.T) {
 	t.Parallel()
 	idx := &Index{


### PR DESCRIPTION
Per Git index format specification, index entries should be sorted by name, then stage: https://git-scm.com/docs/index-format#_index_entry

Fixes: https://github.com/go-git/go-git/issues/2157