### PR TITLE
*: enforce protocol.allow at transport handshake

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -28,7 +28,10 @@ func ArchiveRemoteContext(ctx context.Context, url string, o *ArchiveOptions) (i
 		return nil, errors.New("remote URL is required")
 	}
 
-	cl, req, err := newClient(url, o.ClientOptions)
+	// nil config: ArchiveRemote has no Repository handle, so the
+	// protocol-policy gate sees only env + built-in defaults — file://
+	// is therefore user-only at the env's default of true.
+	cl, req, err := newClient(url, o.ClientOptions, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -198,6 +199,16 @@ type Config struct {
 		// version string in the initial response from the server.
 		//   2 - Wire protocol version 2.
 		Version protocol.Version
+		// Allow is the fallback policy for protocols that have no
+		// per-scheme entry in AllowByName. Accepts "always", "never",
+		// or "user" (case-insensitive). An empty value means the
+		// built-in defaults apply: http/https/git/ssh -> always,
+		// ext -> never, file and unknown schemes -> user.
+		Allow string
+		// AllowByName holds per-scheme policies, keyed by URL scheme
+		// (e.g. "file", "ssh"). Each value must be one of "always",
+		// "never", or "user"; an empty value defers to Allow.
+		AllowByName map[string]string
 	}
 
 	// Remotes list of repository remotes, the key of the map is the name
@@ -487,6 +498,7 @@ const (
 	gpgSignKey                 = "gpgSign"
 	uploadArchiveSection       = "uploadArchive"
 	allowUnreachableKey        = "allowUnreachable"
+	allowKey                   = "allow"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.
@@ -545,11 +557,11 @@ func (c *Config) unmarshalCore() {
 	c.Core.AutoCRLF = s.Options.Get(autoCRLFKey)
 	c.Core.HooksPath = s.Options.Get(hooksPathKey)
 
-	if parsed := parseConfigBool(s.Options.Get(protectNTFSKey)); parsed.IsSet() {
+	if parsed := ParseConfigBool(s.Options.Get(protectNTFSKey)); parsed.IsSet() {
 		c.Core.ProtectNTFS = parsed
 	}
 
-	if parsed := parseConfigBool(s.Options.Get(protectHFSKey)); parsed.IsSet() {
+	if parsed := ParseConfigBool(s.Options.Get(protectHFSKey)); parsed.IsSet() {
 		c.Core.ProtectHFS = parsed
 	}
 
@@ -720,6 +732,27 @@ func (c *Config) unmarshalProtocol() error {
 			return err
 		}
 		c.Protocol.Version = v
+	}
+
+	if rv := s.Options.Get(allowKey); rv != "" {
+		if err := ValidateProtocolPolicy("protocol.allow", rv); err != nil {
+			return err
+		}
+		c.Protocol.Allow = rv
+	}
+
+	for _, sub := range s.Subsections {
+		rv := sub.Options.Get(allowKey)
+		if rv == "" {
+			continue
+		}
+		if err := ValidateProtocolPolicy("protocol."+sub.Name+".allow", rv); err != nil {
+			return err
+		}
+		if c.Protocol.AllowByName == nil {
+			c.Protocol.AllowByName = make(map[string]string, len(s.Subsections))
+		}
+		c.Protocol.AllowByName[sub.Name] = rv
 	}
 
 	return nil
@@ -990,10 +1023,28 @@ func (c *Config) marshalURLs() {
 }
 
 func (c *Config) marshalProtocol() {
-	// Only marshal protocol section if a version was set.
 	if c.Protocol.Version != DefaultProtocolVersion {
 		s := c.Raw.Section(protocolSection)
 		s.SetOption(versionKey, c.Protocol.Version.String())
+	}
+
+	if c.Protocol.Allow != "" {
+		s := c.Raw.Section(protocolSection)
+		s.SetOption(allowKey, c.Protocol.Allow)
+	}
+
+	if len(c.Protocol.AllowByName) > 0 {
+		s := c.Raw.Section(protocolSection)
+		// Drop existing per-scheme subsections so removed entries do
+		// not linger in the marshalled output.
+		s.Subsections = slices.DeleteFunc(s.Subsections, func(sub *format.Subsection) bool {
+			_, replaced := c.Protocol.AllowByName[sub.Name]
+			return replaced
+		})
+		for name, v := range c.Protocol.AllowByName {
+			sub := s.Subsection(name)
+			sub.SetOption(allowKey, v)
+		}
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1239,3 +1239,19 @@ func TestGPGConfig(t *testing.T) {
 		assert.Equal(t, OptBoolFalse, merged.Commit.GpgSign)
 	})
 }
+
+func TestUnmarshalProtocol_RejectsInvalidAllow(t *testing.T) {
+	t.Parallel()
+	raw := []byte("[protocol]\n\tallow = sometimes\n")
+	cfg := NewConfig()
+	err := cfg.Unmarshal(raw)
+	require.Error(t, err)
+}
+
+func TestUnmarshalProtocol_RejectsInvalidPerSchemeAllow(t *testing.T) {
+	t.Parallel()
+	raw := []byte("[protocol \"file\"]\n\tallow = perhaps\n")
+	cfg := NewConfig()
+	err := cfg.Unmarshal(raw)
+	require.Error(t, err)
+}

--- a/config/optbool.go
+++ b/config/optbool.go
@@ -50,7 +50,7 @@ func (o OptBool) FormatBool() string {
 	return strconv.FormatBool(o.IsTrue())
 }
 
-// parseConfigBool mirrors upstream Git's git_parse_maybe_bool: it
+// ParseConfigBool mirrors upstream Git's git_parse_maybe_bool: it
 // accepts true/yes/on (→ OptBoolTrue) and false/no/off (→
 // OptBoolFalse) case-insensitively, plus any decimal integer (zero
 // → OptBoolFalse, non-zero → OptBoolTrue). Empty or otherwise
@@ -65,7 +65,7 @@ func (o OptBool) FormatBool() string {
 // v2.54.0[1].
 //
 // [1]: https://github.com/git/git/blob/v2.54.0/parse.c#L157-L182
-func parseConfigBool(v string) OptBool {
+func ParseConfigBool(v string) OptBool {
 	switch strings.ToLower(v) {
 	case "true", "yes", "on":
 		return OptBoolTrue

--- a/config/optbool_test.go
+++ b/config/optbool_test.go
@@ -61,8 +61,8 @@ func TestParseConfigBool(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.in, func(t *testing.T) {
 			t.Parallel()
-			got := parseConfigBool(tc.in)
-			assert.Equal(t, tc.want, got, "parseConfigBool(%q)", tc.in)
+			got := ParseConfigBool(tc.in)
+			assert.Equal(t, tc.want, got, "ParseConfigBool(%q)", tc.in)
 		})
 	}
 }

--- a/config/protocolpolicy.go
+++ b/config/protocolpolicy.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Canonical protocol policy values for `protocol.allow` and
+// `protocol.<name>.allow`, matching canonical Git's
+// enum protocol_allow_config[1]. The on-disk form is
+// case-insensitive; these constants give callers the canonical
+// lowercase spelling without forcing them through a typed enum.
+// The empty string means "use the resolution chain" (per-scheme
+// → global → built-in default).
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/transport.c#L1056-L1072
+const (
+	ProtocolNever  = "never"
+	ProtocolUser   = "user"
+	ProtocolAlways = "always"
+)
+
+// ValidateProtocolPolicy returns nil for "always", "never", "user"
+// (case-insensitive) or the empty string; any other value yields
+// an error suitable for surfacing at config-load time. The key is
+// included in the diagnostic to match canonical Git's
+// parse_protocol_config[1].
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/transport.c#L1062-L1072
+func ValidateProtocolPolicy(key, value string) error {
+	switch strings.ToLower(value) {
+	case "", ProtocolNever, ProtocolUser, ProtocolAlways:
+		return nil
+	}
+	return fmt.Errorf("unknown value for %q: %q", key, value)
+}

--- a/config/protocolpolicy_test.go
+++ b/config/protocolpolicy_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestValidateProtocolPolicy(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		value   string
+		wantErr bool
+	}{
+		{"always", false},
+		{"ALWAYS", false},
+		{"never", false},
+		{"user", false},
+		{"User", false},
+		{"", false}, // empty is permitted; means "use the resolution chain"
+		{"sometimes", true},
+		{"alwys", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.value, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateProtocolPolicy("protocol.allow", tc.value)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateProtocolPolicy(%q) err=%v wantErr=%v", tc.value, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/plumbing/client/client.go
+++ b/plumbing/client/client.go
@@ -14,6 +14,7 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 	"golang.org/x/net/proxy"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/plumbing/transport/file"
 	xgit "github.com/go-git/go-git/v6/plumbing/transport/git"
@@ -56,6 +57,9 @@ type options struct {
 	file file.Options
 
 	schemes map[string]transport.Transport
+
+	protocolConfig *config.Config
+	fromUser       *bool
 }
 
 func (o *options) ensureTLS() *tls.Config {
@@ -164,6 +168,32 @@ func WithLoader(l transport.Loader) Option {
 	}
 }
 
+// WithProtocolPolicy wires the repository config consulted by the
+// protocol-policy gate. Reads `protocol.<name>.allow` and
+// `protocol.allow` to decide whether a Handshake or Connect for a
+// given URL scheme is permitted. The config supplied here applies
+// only when the per-request transport.Request.Config is nil.
+//
+// The supplied config must not be mutated after this call —
+// concurrent reads happen on the fetch hot path.
+func WithProtocolPolicy(cfg *config.Config) Option {
+	return func(o *options) {
+		o.protocolConfig = cfg
+	}
+}
+
+// WithUserInitiated pre-populates the user-initiated flag carried
+// into the protocol-policy gate when transport.Request.FromUser is
+// nil. Callers that resolve remote URLs indirectly (e.g. submodule
+// update) pass false; direct user-driven operations either leave
+// the default (nil, which consults GIT_PROTOCOL_FROM_USER and
+// falls back to true) or pass true explicitly.
+func WithUserInitiated(v bool) Option {
+	return func(o *options) {
+		o.fromUser = &v
+	}
+}
+
 // WithTransport registers a custom transport for the given URL scheme.
 // This overrides any built-in transport for that scheme.
 func WithTransport(scheme string, tr transport.Transport) Option {
@@ -195,20 +225,42 @@ func New(opts ...Option) *Client {
 }
 
 // Handshake resolves the transport for the request URL scheme and performs
-// a pack protocol handshake.
+// a pack protocol handshake. Requests are first gated by the protocol
+// policy (see transport.CheckRequest).
+//
+// Policy defaults supplied via WithProtocolPolicy and WithUserInitiated
+// are applied only when the corresponding req.Config / req.FromUser
+// fields are at their zero value. Explicit request fields always win;
+// the request itself is never mutated.
 func (c *Client) Handshake(ctx context.Context, req *transport.Request) (transport.Session, error) {
-	tr, err := c.resolve(req)
+	if req == nil || req.URL == nil {
+		return nil, fmt.Errorf("transport: nil request or URL")
+	}
+	tr, err := c.Transport(req.URL.Scheme)
 	if err != nil {
 		return nil, err
 	}
-	return tr.Handshake(ctx, req)
+	effective := c.requestWithDefaults(req)
+	if err := transport.CheckRequest(effective); err != nil {
+		return nil, err
+	}
+	return tr.Handshake(ctx, effective)
 }
 
 // Connect resolves the transport for the request URL scheme and opens a
 // raw full-duplex connection. Returns ErrConnectUnsupported if the transport
-// does not implement Connector (e.g. HTTP).
+// does not implement Connector (e.g. HTTP). Requests are first gated by the
+// protocol policy (see transport.CheckRequest).
+//
+// Policy defaults supplied via WithProtocolPolicy and WithUserInitiated
+// are applied only when the corresponding req.Config / req.FromUser
+// fields are at their zero value. Explicit request fields always win;
+// the request itself is never mutated.
 func (c *Client) Connect(ctx context.Context, req *transport.Request) (transport.Conn, error) {
-	tr, err := c.resolve(req)
+	if req == nil || req.URL == nil {
+		return nil, fmt.Errorf("transport: nil request or URL")
+	}
+	tr, err := c.Transport(req.URL.Scheme)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +268,28 @@ func (c *Client) Connect(ctx context.Context, req *transport.Request) (transport
 	if !ok {
 		return nil, fmt.Errorf("transport for %s does not support Connect: %w", req.URL.Scheme, transport.ErrConnectUnsupported)
 	}
-	return conn.Connect(ctx, req)
+	effective := c.requestWithDefaults(req)
+	if err := transport.CheckRequest(effective); err != nil {
+		return nil, err
+	}
+	return conn.Connect(ctx, effective)
+}
+
+// requestWithDefaults returns a shallow copy of req with the client's
+// policy defaults applied where the caller left fields at their zero
+// value. The original Request is never mutated.
+func (c *Client) requestWithDefaults(req *transport.Request) *transport.Request {
+	if req == nil {
+		return nil
+	}
+	eff := *req
+	if eff.Config == nil {
+		eff.Config = c.opts.protocolConfig
+	}
+	if eff.FromUser == nil {
+		eff.FromUser = c.opts.fromUser
+	}
+	return &eff
 }
 
 // Transport returns the resolved transport for the given URL scheme.
@@ -232,13 +305,6 @@ func (c *Client) Transport(scheme string) (transport.Transport, error) {
 // Close releases resources held by the client.
 func (c *Client) Close() error {
 	return nil
-}
-
-func (c *Client) resolve(req *transport.Request) (transport.Transport, error) {
-	if req == nil || req.URL == nil {
-		return nil, fmt.Errorf("transport: nil request or URL")
-	}
-	return c.Transport(req.URL.Scheme)
 }
 
 func (c *Client) builtin(scheme string) (transport.Transport, error) {

--- a/plumbing/client/policy_test.go
+++ b/plumbing/client/policy_test.go
@@ -1,0 +1,196 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+// countingTransport records how many times Handshake was invoked so
+// tests can confirm the policy gate fires before transport dispatch.
+type countingTransport struct {
+	calls atomic.Int32
+}
+
+func (t *countingTransport) Handshake(_ context.Context, _ *transport.Request) (transport.Session, error) {
+	t.calls.Add(1)
+	return nil, nil
+}
+
+func newFileRequest(t *testing.T) *transport.Request {
+	t.Helper()
+	u, err := transport.ParseURL("file:///tmp/repo")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return &transport.Request{URL: u}
+}
+
+func TestHandshake_GatesNonUserFileByDefault(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	tr := &countingTransport{}
+	c := New(WithTransport("file", tr))
+	defer c.Close()
+
+	req := newFileRequest(t)
+	req.FromUser = boolPtr(false)
+
+	_, err := c.Handshake(context.Background(), req)
+	if !errors.Is(err, transport.ErrProtocolNotAllowed) {
+		t.Fatalf("Handshake err = %v, want ErrProtocolNotAllowed", err)
+	}
+	if got := tr.calls.Load(); got != 0 {
+		t.Fatalf("transport.Handshake called %d times; want 0", got)
+	}
+}
+
+func TestHandshake_AllowsUserInitiatedFile(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	tr := &countingTransport{}
+	c := New(WithTransport("file", tr))
+	defer c.Close()
+
+	req := newFileRequest(t)
+	req.FromUser = boolPtr(true)
+
+	if _, err := c.Handshake(context.Background(), req); err != nil {
+		t.Fatalf("Handshake err = %v, want nil", err)
+	}
+	if got := tr.calls.Load(); got != 1 {
+		t.Fatalf("transport.Handshake called %d times; want 1", got)
+	}
+}
+
+func TestHandshake_WithProtocolPolicyPopulatesRequest(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	cfg := config.NewConfig()
+	cfg.Protocol.AllowByName = map[string]string{"file": config.ProtocolAlways}
+
+	tr := &countingTransport{}
+	c := New(
+		WithTransport("file", tr),
+		WithProtocolPolicy(cfg),
+	)
+	defer c.Close()
+
+	req := newFileRequest(t)
+	req.FromUser = boolPtr(false)
+
+	if _, err := c.Handshake(context.Background(), req); err != nil {
+		t.Fatalf("Handshake err = %v, want nil (file=always)", err)
+	}
+	if got := tr.calls.Load(); got != 1 {
+		t.Fatalf("transport.Handshake called %d times; want 1", got)
+	}
+}
+
+func TestHandshake_WithFromUserDefault(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	tr := &countingTransport{}
+	c := New(
+		WithTransport("file", tr),
+		WithUserInitiated(false),
+	)
+	defer c.Close()
+
+	req := newFileRequest(t)
+	// Request.FromUser left nil; client option must supply the default.
+
+	_, err := c.Handshake(context.Background(), req)
+	if !errors.Is(err, transport.ErrProtocolNotAllowed) {
+		t.Fatalf("Handshake err = %v, want ErrProtocolNotAllowed", err)
+	}
+}
+
+func TestHandshake_RequestFieldsOverrideClientDefaults(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	tr := &countingTransport{}
+	c := New(
+		WithTransport("file", tr),
+		WithUserInitiated(false),
+	)
+	defer c.Close()
+
+	req := newFileRequest(t)
+	req.FromUser = boolPtr(true)
+
+	if _, err := c.Handshake(context.Background(), req); err != nil {
+		t.Fatalf("Handshake err = %v, want nil (explicit FromUser=true)", err)
+	}
+}
+
+func TestConnect_AppliesProtocolPolicy(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	c := New()
+	defer c.Close()
+
+	req := newFileRequest(t)
+	req.FromUser = boolPtr(false)
+
+	_, err := c.Connect(context.Background(), req)
+	if !errors.Is(err, transport.ErrProtocolNotAllowed) {
+		t.Fatalf("Connect err = %v, want ErrProtocolNotAllowed", err)
+	}
+}
+
+// Client must not leak its option defaults into the caller's
+// Request — a caller reusing the same Request across calls would
+// otherwise carry state across.
+func TestHandshake_DoesNotMutateCallerRequest(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	cfg := config.NewConfig()
+	cfg.Protocol.AllowByName = map[string]string{"file": config.ProtocolAlways}
+
+	tr := &countingTransport{}
+	c := New(
+		WithTransport("file", tr),
+		WithProtocolPolicy(cfg),
+		WithUserInitiated(false),
+	)
+	defer c.Close()
+
+	req := newFileRequest(t)
+	_, err := c.Handshake(context.Background(), req)
+	require.NoError(t, err)
+
+	require.Nil(t, req.Config, "client must not write to req.Config")
+	require.Nil(t, req.FromUser,
+		"client must not write to req.FromUser")
+}

--- a/plumbing/transport/file/file.go
+++ b/plumbing/transport/file/file.go
@@ -61,6 +61,9 @@ func NewTransport(opts Options) *Transport {
 
 // Connect opens a raw connection to the file transport process.
 func (t *Transport) Connect(ctx context.Context, req *transport.Request) (transport.Conn, error) {
+	if err := transport.CheckRequest(req); err != nil {
+		return nil, err
+	}
 	sr, pw, closeAll, err := t.connect(ctx, req)
 	if err != nil {
 		return nil, err

--- a/plumbing/transport/file/handshake.go
+++ b/plumbing/transport/file/handshake.go
@@ -8,6 +8,9 @@ import (
 
 // Handshake implements transport.Transport.
 func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (transport.Session, error) {
+	if err := transport.CheckRequest(req); err != nil {
+		return nil, err
+	}
 	conn, err := t.Connect(ctx, req)
 	if err != nil {
 		return nil, err

--- a/plumbing/transport/file/handshake_test.go
+++ b/plumbing/transport/file/handshake_test.go
@@ -1,0 +1,60 @@
+package file
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+// Direct callers of the file transport must hit the protocol-policy
+// gate without going through plumbing/client. Canonical Git puts
+// the check in every *_open vtable (e.g. transport.c:1205); the Go
+// equivalent puts it at the top of each transport's Handshake and
+// Connect.
+//
+// Reference: https://github.com/git/git/blob/v2.54.0/transport.c#L1146-L1149
+func TestTransport_HandshakeGatesNonUserFile(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	u, err := url.Parse("file:///tmp/repo")
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	_, err = tr.Handshake(context.Background(), &transport.Request{
+		URL:      u,
+		Command:  transport.UploadPackService,
+		FromUser: boolPtr(false),
+	})
+	require.True(t, errors.Is(err, transport.ErrProtocolNotAllowed),
+		"err=%v want ErrProtocolNotAllowed", err)
+}
+
+func TestTransport_ConnectGatesNonUserFile(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	u, err := url.Parse("file:///tmp/repo")
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	_, err = tr.Connect(context.Background(), &transport.Request{
+		URL:      u,
+		Command:  transport.UploadPackService,
+		FromUser: boolPtr(false),
+	})
+	require.True(t, errors.Is(err, transport.ErrProtocolNotAllowed),
+		"err=%v want ErrProtocolNotAllowed", err)
+}

--- a/plumbing/transport/git/git.go
+++ b/plumbing/transport/git/git.go
@@ -39,6 +39,9 @@ func NewTransport(opts Options) *Transport {
 
 // Connect opens a raw connection to the Git protocol server.
 func (t *Transport) Connect(ctx context.Context, req *transport.Request) (transport.Conn, error) {
+	if err := transport.CheckRequest(req); err != nil {
+		return nil, err
+	}
 	host := req.URL.Hostname()
 	port := req.URL.Port()
 	if port == "" {

--- a/plumbing/transport/git/handshake.go
+++ b/plumbing/transport/git/handshake.go
@@ -8,6 +8,9 @@ import (
 
 // Handshake implements transport.Transport.
 func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (transport.Session, error) {
+	if err := transport.CheckRequest(req); err != nil {
+		return nil, err
+	}
 	conn, err := t.Connect(ctx, req)
 	if err != nil {
 		return nil, err

--- a/plumbing/transport/git/handshake_test.go
+++ b/plumbing/transport/git/handshake_test.go
@@ -1,0 +1,57 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+// The built-in default for git:// is ProtocolAlways, so a stock
+// Request would not exercise the gate. Drive it via
+// `protocol.git.allow=never` to verify the gate fires at the
+// transport boundary even when a caller bypasses plumbing/client.
+//
+// Reference: https://github.com/git/git/blob/v2.54.0/transport.c#L1146-L1149
+func TestTransport_HandshakeRespectsProtocolNever(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Protocol.AllowByName = map[string]string{"git": config.ProtocolNever}
+
+	u, err := url.Parse("git://localhost/repo")
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	_, err = tr.Handshake(context.Background(), &transport.Request{
+		URL:     u,
+		Command: transport.UploadPackService,
+		Config:  cfg,
+	})
+	require.True(t, errors.Is(err, transport.ErrProtocolNotAllowed),
+		"err=%v want ErrProtocolNotAllowed", err)
+}
+
+func TestTransport_ConnectRespectsProtocolNever(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Protocol.AllowByName = map[string]string{"git": config.ProtocolNever}
+
+	u, err := url.Parse("git://localhost/repo")
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	_, err = tr.Connect(context.Background(), &transport.Request{
+		URL:     u,
+		Command: transport.UploadPackService,
+		Config:  cfg,
+	})
+	require.True(t, errors.Is(err, transport.ErrProtocolNotAllowed),
+		"err=%v want ErrProtocolNotAllowed", err)
+}

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -22,6 +22,9 @@ import (
 // Handshake implements transport.Transport. GETs /info/refs to discover
 // refs and detects smart vs dumb HTTP.
 func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (transport.Session, error) {
+	if err := transport.CheckRequest(req); err != nil {
+		return nil, err
+	}
 	service := req.Command
 	baseURL := req.URL
 	forceDumb := t.opts.ForceDumb

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -260,4 +261,30 @@ func fetchToStorage(t testing.TB, repoPath string, storage *filesystem.Storage, 
 		Wants: []plumbing.Hash{want},
 	})
 	require.NoError(t, err)
+}
+
+// The built-in default for http:// is ProtocolAlways, so a stock
+// Request would not exercise the gate. Drive it via
+// `protocol.http.allow=never` to verify the gate fires at the
+// transport boundary even when a caller bypasses plumbing/client.
+// HTTP does not implement Connector so only Handshake is tested.
+//
+// Reference: https://github.com/git/git/blob/v2.54.0/transport.c#L1146-L1149
+func TestTransport_HandshakeRespectsProtocolNever(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Protocol.AllowByName = map[string]string{"http": config.ProtocolNever}
+
+	u, err := url.Parse("http://localhost/repo")
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	_, err = tr.Handshake(context.Background(), &transport.Request{
+		URL:     u,
+		Command: transport.UploadPackService,
+		Config:  cfg,
+	})
+	require.True(t, errors.Is(err, transport.ErrProtocolNotAllowed),
+		"err=%v want ErrProtocolNotAllowed", err)
 }

--- a/plumbing/transport/policy.go
+++ b/plumbing/transport/policy.go
@@ -1,0 +1,149 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/go-git/go-git/v6/config"
+)
+
+// ErrProtocolNotAllowed is returned by CheckRequest when the resolved
+// protocol policy denies the request's URL scheme.
+var ErrProtocolNotAllowed = errors.New("transport: protocol not allowed")
+
+// Env vars consulted by the policy gate. Mirror canonical Git's
+// protocol_allow_list and is_transport_allowed in transport.c — see
+// the IsProtocolAllowed comment for the upstream link.
+const (
+	envAllowProtocol = "GIT_ALLOW_PROTOCOL"
+	envProtocolUser  = "GIT_PROTOCOL_FROM_USER"
+)
+
+// DefaultProtocolPolicy returns the built-in policy string for a
+// scheme when no per-scheme or fallback config is set. Matches the
+// fallback table in canonical Git's get_protocol_config.
+func DefaultProtocolPolicy(scheme string) string {
+	switch scheme {
+	case "http", "https", "git", "ssh":
+		return config.ProtocolAlways
+	case "ext":
+		return config.ProtocolNever
+	}
+	return config.ProtocolUser
+}
+
+// IsProtocolAllowed returns (true, nil) when scheme is permitted,
+// (false, nil) when denied by the resolved policy string, and
+// (false, err) when the environment value for
+// GIT_PROTOCOL_FROM_USER is malformed. Malformed
+// protocol.allow / protocol.<name>.allow values are surfaced at
+// config load time (Unmarshal), not here.
+//
+// fromUser carries the user-initiated flag: a non-nil value is taken
+// at face value; nil falls back to GIT_PROTOCOL_FROM_USER (default
+// true), matching canonical Git's transport_check_allowed.
+//
+// GIT_ALLOW_PROTOCOL, when set, replaces every other source: the
+// scheme is allowed iff it appears in the colon-separated list. An
+// empty value denies all schemes, matching canonical Git's
+// protocol_allow_list.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/transport.c#L1037-L1149
+func IsProtocolAllowed(cfg *config.Config, scheme string, fromUser *bool) (bool, error) {
+	if scheme == "" {
+		return false, nil
+	}
+	if list, ok := allowListFromEnv(); ok {
+		return slices.Contains(list, scheme), nil
+	}
+	switch strings.ToLower(resolvePolicy(cfg, scheme)) {
+	case config.ProtocolAlways:
+		return true, nil
+	case config.ProtocolNever:
+		return false, nil
+	case config.ProtocolUser:
+		return resolveFromUser(fromUser)
+	}
+	return false, nil
+}
+
+// CheckRequest gates a Request against the resolved protocol
+// policy. Returns ErrProtocolNotAllowed (wrapped with the scheme)
+// when denied, or a non-nil error other than ErrProtocolNotAllowed
+// when GIT_PROTOCOL_FROM_USER carries a malformed value.
+func CheckRequest(req *Request) error {
+	if req == nil || req.URL == nil {
+		return fmt.Errorf("transport: nil request or URL")
+	}
+	scheme := req.URL.Scheme
+	allowed, err := IsProtocolAllowed(req.Config, scheme, req.FromUser)
+	if err != nil {
+		return fmt.Errorf("transport: %w", err)
+	}
+	if allowed {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrProtocolNotAllowed, scheme)
+}
+
+// resolvePolicy walks protocol.<name>.allow, then protocol.allow,
+// then the built-in default. Returns the resolved policy string; no
+// error path because cfg values were validated at Unmarshal time.
+func resolvePolicy(cfg *config.Config, scheme string) string {
+	if cfg != nil {
+		if v, ok := cfg.Protocol.AllowByName[scheme]; ok && v != "" {
+			return v
+		}
+		if v := cfg.Protocol.Allow; v != "" {
+			return v
+		}
+	}
+	return DefaultProtocolPolicy(scheme)
+}
+
+// allowListFromEnv returns the parsed GIT_ALLOW_PROTOCOL list.
+// Distinguishes "unset" from "set but empty": canonical Git's
+// protocol_allow_list[1] treats the second case as an empty
+// allow-list that denies every scheme.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/transport.c#L1037-L1054
+func allowListFromEnv() ([]string, bool) {
+	v, ok := os.LookupEnv(envAllowProtocol)
+	if !ok {
+		return nil, false
+	}
+	if v == "" {
+		return nil, true
+	}
+	return strings.Split(v, ":"), true
+}
+
+// resolveFromUser implements canonical Git's GIT_PROTOCOL_FROM_USER
+// fallback. An explicit non-nil value wins; nil consults the env,
+// defaulting to true when the env is unset. Empty env value is
+// false (matching git_env_bool[1]). Unparseable env value returns
+// an error so callers see the misconfiguration.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/parse.c#L157-L200
+func resolveFromUser(fu *bool) (bool, error) {
+	if fu != nil {
+		return *fu, nil
+	}
+	v, ok := os.LookupEnv(envProtocolUser)
+	if !ok {
+		return true, nil
+	}
+	if v == "" {
+		// Canonical git_env_bool parses "" via
+		// git_parse_maybe_bool_text as 0 (false).
+		return false, nil
+	}
+	parsed := config.ParseConfigBool(v)
+	if !parsed.IsSet() {
+		return false, fmt.Errorf("bad boolean value %q for %s", v, envProtocolUser)
+	}
+	return parsed.IsTrue(), nil
+}

--- a/plumbing/transport/policy_test.go
+++ b/plumbing/transport/policy_test.go
@@ -1,0 +1,293 @@
+package transport
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/go-git/go-git/v6/config"
+)
+
+func boolPtr(v bool) *bool { return &v }
+
+// Built-in defaults match canonical Git's get_protocol_config fallback
+// table in transport.c.
+func TestDefaultProtocolPolicy(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		scheme string
+		want   string
+	}{
+		{"http", config.ProtocolAlways},
+		{"https", config.ProtocolAlways},
+		{"git", config.ProtocolAlways},
+		{"ssh", config.ProtocolAlways},
+		{"file", config.ProtocolUser},
+		{"ext", config.ProtocolNever},
+		{"unknown-scheme", config.ProtocolUser},
+	}
+	for _, tc := range cases {
+		t.Run(tc.scheme, func(t *testing.T) {
+			t.Parallel()
+			if got := DefaultProtocolPolicy(tc.scheme); got != tc.want {
+				t.Fatalf("DefaultProtocolPolicy(%q) = %v, want %v", tc.scheme, got, tc.want)
+			}
+		})
+	}
+}
+
+// IsProtocolAllowed must follow canonical Git's get_protocol_config +
+// is_transport_allowed precedence: GIT_ALLOW_PROTOCOL overrides
+// everything; otherwise protocol.<name>.allow beats protocol.allow,
+// which beats the built-in default.
+func TestIsProtocolAllowed_Matrix(t *testing.T) {
+	type tc struct {
+		name           string
+		envAllowSet    bool   // when false, GIT_ALLOW_PROTOCOL is unset; envAllow ignored
+		envAllow       string // value to set when envAllowSet is true
+		cfgAllow       string
+		cfgNamed       map[string]string
+		scheme         string
+		fromUser       *bool
+		envFromUserSet bool   // when false, GIT_PROTOCOL_FROM_USER is unset; envFromUser ignored
+		envFromUser    string // value to set when envFromUserSet is true
+		want           bool
+	}
+
+	cases := []tc{
+		// Built-in defaults, user-initiated (env unset → default true).
+		{name: "http default allows", scheme: "http", want: true},
+		{name: "https default allows", scheme: "https", want: true},
+		{name: "git default allows", scheme: "git", want: true},
+		{name: "ssh default allows", scheme: "ssh", want: true},
+		{name: "ext default denies", scheme: "ext", want: false},
+
+		// file scheme: user default. User-initiated allowed, non-user denied.
+		{name: "file default user-initiated allowed", scheme: "file", fromUser: boolPtr(true), want: true},
+		{name: "file default non-user-initiated denied", scheme: "file", fromUser: boolPtr(false), want: false},
+		{name: "file default env-user=0 denied", scheme: "file", envFromUserSet: true, envFromUser: "0", want: false},
+		{name: "file default env-user=1 allowed", scheme: "file", envFromUserSet: true, envFromUser: "1", want: true},
+		{name: "file default env-unset allows", scheme: "file", fromUser: nil, want: true},
+
+		// protocol.<name>.allow overrides built-in.
+		{name: "file always via per-scheme cfg", scheme: "file", cfgNamed: map[string]string{"file": config.ProtocolAlways}, fromUser: boolPtr(false), want: true},
+		{name: "file never via per-scheme cfg", scheme: "file", cfgNamed: map[string]string{"file": config.ProtocolNever}, fromUser: boolPtr(true), want: false},
+		{name: "http never via per-scheme cfg", scheme: "http", cfgNamed: map[string]string{"http": config.ProtocolNever}, want: false},
+
+		// protocol.allow used when per-scheme not set.
+		{name: "ssh never via global cfg", scheme: "ssh", cfgAllow: config.ProtocolNever, want: false},
+		{name: "file always via global cfg", scheme: "file", cfgAllow: config.ProtocolAlways, fromUser: boolPtr(false), want: true},
+		{name: "file user via global cfg", scheme: "file", cfgAllow: config.ProtocolUser, fromUser: boolPtr(false), want: false},
+
+		// per-scheme wins over protocol.allow.
+		{name: "per-scheme always beats global never", scheme: "file", cfgAllow: config.ProtocolNever, cfgNamed: map[string]string{"file": config.ProtocolAlways}, want: true},
+		{name: "per-scheme never beats global always", scheme: "file", cfgAllow: config.ProtocolAlways, cfgNamed: map[string]string{"file": config.ProtocolNever}, want: false},
+
+		// GIT_ALLOW_PROTOCOL takes absolute precedence.
+		{name: "env allow-list permits listed scheme", envAllowSet: true, envAllow: "file:https", scheme: "file", fromUser: boolPtr(false), want: true},
+		{name: "env allow-list denies unlisted scheme", envAllowSet: true, envAllow: "http:https", scheme: "file", fromUser: boolPtr(true), want: false},
+		{name: "env allow-list overrides per-scheme allow", envAllowSet: true, envAllow: "http", cfgNamed: map[string]string{"file": config.ProtocolAlways}, scheme: "file", want: false},
+		{name: "env allow-list overrides per-scheme deny", envAllowSet: true, envAllow: "file", cfgNamed: map[string]string{"file": config.ProtocolNever}, scheme: "file", want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envAllowSet {
+				t.Setenv("GIT_ALLOW_PROTOCOL", tc.envAllow)
+			} else {
+				t.Setenv("GIT_ALLOW_PROTOCOL", "")
+				_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+			}
+			if tc.envFromUserSet {
+				t.Setenv("GIT_PROTOCOL_FROM_USER", tc.envFromUser)
+			} else {
+				t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+				_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+			}
+
+			cfg := config.NewConfig()
+			cfg.Protocol.Allow = tc.cfgAllow
+			cfg.Protocol.AllowByName = tc.cfgNamed
+
+			got, err := IsProtocolAllowed(cfg, tc.scheme, tc.fromUser)
+			if err != nil {
+				t.Fatalf("IsProtocolAllowed(%q, fromUser=%v) unexpected err: %v", tc.scheme, tc.fromUser, err)
+			}
+			if got != tc.want {
+				t.Fatalf("IsProtocolAllowed(%q, fromUser=%v) = %v, want %v",
+					tc.scheme, tc.fromUser, got, tc.want)
+			}
+		})
+	}
+}
+
+// CheckRequest is the gate invoked from Handshake/Connect; it must
+// return ErrProtocolNotAllowed when the resolved policy denies the
+// scheme, and nil otherwise.
+func TestCheckRequest_DefaultDeniesNonUserFile(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	req := mustRequest(t, "file:///tmp/repo")
+	req.FromUser = boolPtr(false)
+
+	err := CheckRequest(req)
+	if !errors.Is(err, ErrProtocolNotAllowed) {
+		t.Fatalf("CheckRequest err = %v, want ErrProtocolNotAllowed", err)
+	}
+}
+
+func TestCheckRequest_AllowsUserInitiatedFile(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	req := mustRequest(t, "file:///tmp/repo")
+	req.FromUser = boolPtr(true)
+
+	if err := CheckRequest(req); err != nil {
+		t.Fatalf("CheckRequest err = %v, want nil", err)
+	}
+}
+
+func TestCheckRequest_HonorsCfgOverride(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	cfg := config.NewConfig()
+	cfg.Protocol.AllowByName = map[string]string{"file": config.ProtocolAlways}
+
+	req := mustRequest(t, "file:///tmp/repo")
+	req.FromUser = boolPtr(false)
+	req.Config = cfg
+
+	if err := CheckRequest(req); err != nil {
+		t.Fatalf("CheckRequest err = %v, want nil (file=always)", err)
+	}
+}
+
+func TestCheckRequest_NilRequest(t *testing.T) {
+	t.Parallel()
+	if err := CheckRequest(nil); err == nil {
+		t.Fatal("CheckRequest(nil) returned nil; want error")
+	}
+}
+
+// Canonical Git's git_env_bool / git_parse_maybe_bool accept
+// "true"/"yes"/"on" → true, "false"/"no"/"off" → false (case-
+// insensitive), integers via strconv (zero → false, non-zero →
+// true), and empty string → false. Unparseable values die.
+//
+// Reference: https://github.com/git/git/blob/v2.54.0/parse.c#L157-L200
+func TestResolveFromUser_CanonicalGrammar(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     string // empty literal means t.Setenv("", "") — see set below
+		set     bool   // whether to call t.Setenv at all
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset uses default true", set: false, want: true},
+		{name: "empty string is false (canonical)", set: true, env: "", want: false},
+		{name: "literal 0 is false", set: true, env: "0", want: false},
+		{name: "literal 1 is true", set: true, env: "1", want: true},
+		{name: "true is true", set: true, env: "true", want: true},
+		{name: "TRUE is true", set: true, env: "TRUE", want: true},
+		{name: "yes is true", set: true, env: "yes", want: true},
+		{name: "on is true", set: true, env: "on", want: true},
+		{name: "false is false", set: true, env: "false", want: false},
+		{name: "FALSE is false", set: true, env: "FALSE", want: false},
+		{name: "no is false", set: true, env: "no", want: false},
+		{name: "off is false", set: true, env: "off", want: false},
+		{name: "negative integer is true", set: true, env: "-1", want: true},
+		{name: "garbage returns error", set: true, env: "maybe", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("GIT_PROTOCOL_FROM_USER", tc.env)
+			} else {
+				t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+				_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+			}
+			got, err := resolveFromUser(nil)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Canonical Git's protocol_allow_list treats `GIT_ALLOW_PROTOCOL=""`
+// (set but empty) as an empty allow-list, denying every scheme.
+// The unset case falls through to the per-scheme / global / default
+// policy resolution.
+//
+// Reference: https://github.com/git/git/blob/v2.54.0/transport.c#L1037-L1054
+func TestIsProtocolAllowed_EmptyAllowListDeniesAll(t *testing.T) {
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	for _, scheme := range []string{"http", "https", "git", "ssh", "file"} { //nolint:paralleltest // mutates process env
+		t.Run(scheme, func(t *testing.T) {
+			got, err := IsProtocolAllowed(nil, scheme, boolPtr(true))
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got {
+				t.Fatalf("scheme %q must be denied when GIT_ALLOW_PROTOCOL is empty", scheme)
+			}
+		})
+	}
+}
+
+// Canonical's string_list_split keeps empty entries, but
+// string_list_has_string only matches non-empty schemes — so leading,
+// trailing, or doubled colons are harmless. Pin that contract.
+//
+// Reference: https://github.com/git/git/blob/v2.54.0/transport.c#L1037-L1054
+func TestIsProtocolAllowed_AllowListEdgeCases(t *testing.T) {
+	cases := []struct {
+		env    string
+		scheme string
+		want   bool
+	}{
+		{env: "file:", scheme: "file", want: true},
+		{env: "file:", scheme: "", want: false},
+		{env: ":file", scheme: "file", want: true},
+		{env: "file::https", scheme: "https", want: true},
+		{env: "file::https", scheme: "file", want: true},
+		{env: "file::https", scheme: "", want: false},
+		{env: "file", scheme: " file", want: false}, // no implicit trim
+	}
+	for _, tc := range cases {
+		t.Run(tc.env+"/"+tc.scheme, func(t *testing.T) {
+			t.Setenv("GIT_ALLOW_PROTOCOL", tc.env)
+			got, err := IsProtocolAllowed(nil, tc.scheme, boolPtr(true))
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("scheme %q with env %q: got %v want %v", tc.scheme, tc.env, got, tc.want)
+			}
+		})
+	}
+}
+
+func mustRequest(t *testing.T, raw string) *Request {
+	t.Helper()
+	u, err := ParseURL(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return &Request{URL: u}
+}

--- a/plumbing/transport/request.go
+++ b/plumbing/transport/request.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"net/url"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 )
 
@@ -18,6 +19,10 @@ import (
 // The repository path is not a field on Request. Adapters derive it from
 // URL.Path, matching how canonical Git handles the relationship for all
 // transport protocols.
+//
+// FromUser and Config feed the protocol-policy gate evaluated by
+// CheckRequest. Config supplies protocol.<name>.allow and protocol.allow;
+// when nil, only env-var policy and built-in defaults apply.
 type Request struct {
 	URL *url.URL
 
@@ -25,4 +30,11 @@ type Request struct {
 	Args    []string
 
 	Protocol protocol.Version
+
+	// FromUser tracks whether this request was initiated directly by
+	// the user. A non-nil value is taken at face value; a nil value
+	// falls back to GIT_PROTOCOL_FROM_USER (default true), matching
+	// canonical Git's transport_check_allowed.
+	FromUser *bool
+	Config   *config.Config
 }

--- a/plumbing/transport/ssh/handshake.go
+++ b/plumbing/transport/ssh/handshake.go
@@ -8,6 +8,9 @@ import (
 
 // Handshake implements transport.Transport.
 func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (transport.Session, error) {
+	if err := transport.CheckRequest(req); err != nil {
+		return nil, err
+	}
 	conn, err := t.Connect(ctx, req)
 	if err != nil {
 		return nil, err

--- a/plumbing/transport/ssh/handshake_test.go
+++ b/plumbing/transport/ssh/handshake_test.go
@@ -1,0 +1,57 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+// The built-in default for ssh:// is ProtocolAlways, so a stock
+// Request would not exercise the gate. Drive it via
+// `protocol.ssh.allow=never` to verify the gate fires at the
+// transport boundary even when a caller bypasses plumbing/client.
+//
+// Reference: https://github.com/git/git/blob/v2.54.0/transport.c#L1146-L1149
+func TestTransport_HandshakeRespectsProtocolNever(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Protocol.AllowByName = map[string]string{"ssh": config.ProtocolNever}
+
+	u, err := url.Parse("ssh://localhost/repo")
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	_, err = tr.Handshake(context.Background(), &transport.Request{
+		URL:     u,
+		Command: transport.UploadPackService,
+		Config:  cfg,
+	})
+	require.True(t, errors.Is(err, transport.ErrProtocolNotAllowed),
+		"err=%v want ErrProtocolNotAllowed", err)
+}
+
+func TestTransport_ConnectRespectsProtocolNever(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewConfig()
+	cfg.Protocol.AllowByName = map[string]string{"ssh": config.ProtocolNever}
+
+	u, err := url.Parse("ssh://localhost/repo")
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	_, err = tr.Connect(context.Background(), &transport.Request{
+		URL:     u,
+		Command: transport.UploadPackService,
+		Config:  cfg,
+	})
+	require.True(t, errors.Is(err, transport.ErrProtocolNotAllowed),
+		"err=%v want ErrProtocolNotAllowed", err)
+}

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -57,6 +57,9 @@ func NewTransport(opts Options) *Transport {
 
 // Connect implements transport.Connector.
 func (t *Transport) Connect(ctx context.Context, req *transport.Request) (transport.Conn, error) {
+	if err := transport.CheckRequest(req); err != nil {
+		return nil, err
+	}
 	conn, err := t.connect(ctx, req)
 	if err != nil {
 		return nil, err

--- a/remote.go
+++ b/remote.go
@@ -65,6 +65,21 @@ func (r *Remote) Config() *config.RemoteConfig {
 	return r.c
 }
 
+// repoConfig returns the storer's loaded config, used to resolve
+// protocol.<name>.allow and protocol.allow for transport policy gating.
+// Returns nil when the storer cannot supply a config; the policy gate
+// then falls back to environment defaults.
+func (r *Remote) repoConfig() *config.Config {
+	if r.s == nil {
+		return nil
+	}
+	cfg, err := r.s.Config()
+	if err != nil {
+		return nil
+	}
+	return cfg
+}
+
 func (r *Remote) String() string {
 	var fetch, push string
 	if len(r.c.URLs) > 0 {
@@ -107,7 +122,7 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		o.RemoteURL = r.c.URLs[len(r.c.URLs)-1]
 	}
 
-	cl, req, err := newClient(o.RemoteURL, o.ClientOptions)
+	cl, req, err := newClient(o.RemoteURL, o.ClientOptions, r.repoConfig())
 	if err != nil {
 		return err
 	}
@@ -372,7 +387,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		o.RemoteURL = r.c.URLs[0]
 	}
 
-	cl, req, err := newClient(o.RemoteURL, o.ClientOptions)
+	cl, req, err := newClient(o.RemoteURL, o.ClientOptions, r.repoConfig())
 	if err != nil {
 		return nil, err
 	}
@@ -537,12 +552,15 @@ func depthChanged(before []plumbing.Hash, s storage.Storer) (bool, error) {
 	return false, nil
 }
 
-func newClient(rawURL string, opts []client.Option) (*client.Client, *transport.Request, error) {
+func newClient(rawURL string, opts []client.Option, cfg *config.Config) (*client.Client, *transport.Request, error) {
 	u, err := transport.ParseURL(rawURL)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	if cfg != nil {
+		opts = append([]client.Option{client.WithProtocolPolicy(cfg)}, opts...)
+	}
 	cl := client.New(opts...)
 	return cl, &transport.Request{URL: u}, nil
 }
@@ -1284,7 +1302,7 @@ func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Refe
 		return nil, ErrEmptyUrls
 	}
 
-	cl, req, err := newClient(r.c.URLs[0], o.ClientOptions)
+	cl, req, err := newClient(r.c.URLs[0], o.ClientOptions, r.repoConfig())
 	if err != nil {
 		return nil, err
 	}

--- a/submodule.go
+++ b/submodule.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/client"
 	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 )
@@ -183,6 +184,38 @@ func (s *Submodule) Repository() (*Repository, error) {
 	return r, nil
 }
 
+// submoduleClientOptions returns the caller's ClientOptions extended
+// with the protocol-policy defaults that apply to submodule fetches:
+// WithUserInitiated(false), so the gate evaluates the fetch as
+// non-user-initiated, and WithProtocolPolicy taken from the
+// submodule's own storer, so its `protocol.<scheme>.allow`
+// resolution governs the clone — matching canonical Git's
+// submodule-subprocess model[1], which reads the subprocess's own
+// local config plus global/system. Callers may flip either bit
+// back by appending their own option later: client.Option
+// resolution is last-wins.
+//
+// Security: a caller can override WithUserInitiated(false)
+// by appending WithUserInitiated(true) to ClientOptions,
+// which re-enables user-only protocols (default for file://) for the
+// submodule fetch. Do so only when the submodule URL is trusted —
+// canonical Git provides no such escape hatch from the `git submodule
+// update` shell wrapper.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/git-submodule.sh#L29-L30
+func (s *Submodule) submoduleClientOptions(subRepo *Repository, opts []client.Option) []client.Option {
+	// Capacity: WithUserInitiated + optional WithProtocolPolicy + caller opts.
+	out := make([]client.Option, 0, len(opts)+2)
+	out = append(out, client.WithUserInitiated(false))
+	if subRepo != nil {
+		if cfg, err := subRepo.Config(); err == nil {
+			out = append(out, client.WithProtocolPolicy(cfg))
+		}
+	}
+	out = append(out, opts...)
+	return out
+}
+
 // defaultRemote returns the remote that relative submodule URLs are
 // resolved against, mirroring canonical Git's repo_default_remote
 // (remote.c) and resolve_relative_url (builtin/submodule--helper.c):
@@ -311,8 +344,23 @@ func (s *Submodule) doRecursiveUpdate(ctx context.Context, r *Repository, o *Sub
 func (s *Submodule) fetchAndCheckout(
 	ctx context.Context, r *Repository, o *SubmoduleUpdateOptions, hash plumbing.Hash,
 ) error {
+	// Submodule URLs are resolved from the worktree's `.gitmodules`
+	// and are not selected directly by the user, so the resulting
+	// fetch is gated by the transport-policy "user" tier. Submodule
+	// fetches must opt out of that tier explicitly; without this the
+	// `protocol.<scheme>.allow=user` default would silently let any
+	// scheme through. Canonical Git models the same constraint by
+	// exporting `GIT_PROTOCOL_FROM_USER=0` from git-submodule.sh[1].
+	// The submodule's own config supplies the
+	// `protocol.<scheme>.allow` resolution, mirroring the subprocess
+	// model where the spawned `git fetch` reads the submodule's local
+	// config plus global/system — not the parent's local config.
+	//
+	// [1]: https://github.com/git/git/blob/v2.54.0/git-submodule.sh#L29-L30
+	subOpts := s.submoduleClientOptions(r, o.ClientOptions)
+
 	if !o.NoFetch {
-		err := r.FetchContext(ctx, &FetchOptions{ClientOptions: o.ClientOptions, Depth: o.Depth})
+		err := r.FetchContext(ctx, &FetchOptions{ClientOptions: subOpts, Depth: o.Depth})
 		if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) {
 			return err
 		}
@@ -332,7 +380,7 @@ func (s *Submodule) fetchAndCheckout(
 			refSpec := config.RefSpec("+" + hash.String() + ":" + hash.String())
 
 			err := r.FetchContext(ctx, &FetchOptions{
-				ClientOptions: o.ClientOptions,
+				ClientOptions: subOpts,
 				RefSpecs:      []config.RefSpec{refSpec},
 				Depth:         o.Depth,
 			})

--- a/submodule_policy_test.go
+++ b/submodule_policy_test.go
@@ -1,0 +1,172 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/format/index"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+)
+
+// Build a small superproject + nested target on disk, where the
+// superproject's .gitmodules pulls the nested repo over file://.
+// Returns the superproject's worktree root and the Submodule handle.
+func setupFileSubmodule(t *testing.T) (*Repository, *Submodule) {
+	t.Helper()
+	t.Setenv("GIT_ALLOW_PROTOCOL", "")
+	_ = os.Unsetenv("GIT_ALLOW_PROTOCOL")
+	t.Setenv("GIT_PROTOCOL_FROM_USER", "")
+	_ = os.Unsetenv("GIT_PROTOCOL_FROM_USER")
+
+	root := t.TempDir()
+	targetDir := filepath.Join(root, "target")
+	parentDir := filepath.Join(root, "parent")
+	require.NoError(t, os.MkdirAll(targetDir, 0o755))
+	require.NoError(t, os.MkdirAll(parentDir, 0o755))
+
+	// Build a small repository that the submodule will point at.
+	tgt, err := PlainInit(targetDir, false)
+	require.NoError(t, err)
+	tgtWT, err := tgt.Worktree()
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(targetDir, "README"), []byte("hello"), 0o644))
+	_, err = tgtWT.Add("README")
+	require.NoError(t, err)
+	tgtHash, err := tgtWT.Commit("init", &CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, tgt.Close())
+
+	// Build a parent repository with a .gitmodules entry pointing at the
+	// target over file://. Commit the gitlink at the recorded hash so
+	// the submodule update has a concrete commit to fetch and check out.
+	parent, err := PlainInit(parentDir, false)
+	require.NoError(t, err)
+	parentWT, err := parent.Worktree()
+	require.NoError(t, err)
+
+	// Normalize the path for the file:// URL: git config treats a
+	// raw Windows backslash (`C:\Users\...`) as the start of an
+	// escape sequence, so the parser rejects it before any submodule
+	// machinery runs. Forward slashes work on every platform.
+	urlPath := filepath.ToSlash(targetDir)
+	if !strings.HasPrefix(urlPath, "/") {
+		urlPath = "/" + urlPath
+	}
+	gitmodules := "[submodule \"sub\"]\n\tpath = sub\n\turl = file://" + urlPath + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(parentDir, ".gitmodules"), []byte(gitmodules), 0o644))
+
+	// Stage the submodule as a gitlink at tgtHash. Add() on the
+	// directory would try to crawl it as a worktree, so we mint the
+	// index entry directly.
+	idx, err := parent.Storer.Index()
+	require.NoError(t, err)
+	idx.Entries = append(idx.Entries, &index.Entry{
+		Name: "sub",
+		Hash: tgtHash,
+		Mode: filemode.Submodule,
+	})
+	require.NoError(t, parent.Storer.SetIndex(idx))
+
+	_, err = parentWT.Add(".gitmodules")
+	require.NoError(t, err)
+	_, err = parentWT.Commit("add submodule", &CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example"},
+	})
+	require.NoError(t, err)
+
+	sm, err := parentWT.Submodule("sub")
+	require.NoError(t, err)
+	require.NoError(t, sm.Init())
+
+	return parent, sm
+}
+
+func TestSubmoduleUpdate_FileSchemeDeniedByDefault(t *testing.T) { //nolint:paralleltest // mutates process env
+	parent, sm := setupFileSubmodule(t)
+	defer func() { _ = parent.Close() }()
+
+	err := sm.UpdateContext(context.Background(), &SubmoduleUpdateOptions{})
+	if !errors.Is(err, transport.ErrProtocolNotAllowed) {
+		t.Fatalf("Update err = %v, want ErrProtocolNotAllowed", err)
+	}
+}
+
+func TestSubmoduleUpdate_FileSchemeAllowedByProtocolConfig(t *testing.T) { //nolint:paralleltest // mutates process env
+	parent, sm := setupFileSubmodule(t)
+	defer func() { _ = parent.Close() }()
+
+	subRepo, err := sm.Repository()
+	require.NoError(t, err)
+	defer func() { _ = subRepo.Close() }()
+
+	cfg, err := subRepo.Config()
+	require.NoError(t, err)
+	cfg.Protocol.AllowByName = map[string]string{"file": config.ProtocolAlways}
+	require.NoError(t, subRepo.Storer.SetConfig(cfg))
+
+	require.NoError(t, sm.UpdateContext(context.Background(), &SubmoduleUpdateOptions{}))
+}
+
+// Canonical Git's submodule subprocess reads its own local config
+// (plus global/system), never the parent's local config. A
+// `protocol.file.allow=always` set on the superproject must not
+// unlock the submodule fetch.
+//
+// Reference: https://github.com/git/git/blob/v2.54.0/git-submodule.sh#L29-L30
+func TestSubmoduleUpdate_ParentPolicyDoesNotGovern(t *testing.T) { //nolint:paralleltest // mutates process env
+	parent, sm := setupFileSubmodule(t)
+	defer func() { _ = parent.Close() }()
+
+	parentCfg, err := parent.Config()
+	require.NoError(t, err)
+	parentCfg.Protocol.AllowByName = map[string]string{"file": config.ProtocolAlways}
+	require.NoError(t, parent.Storer.SetConfig(parentCfg))
+
+	err = sm.UpdateContext(context.Background(), &SubmoduleUpdateOptions{})
+	require.True(t, errors.Is(err, transport.ErrProtocolNotAllowed),
+		"err=%v want ErrProtocolNotAllowed (parent config must not unblock submodule)", err)
+}
+
+func TestSubmoduleUpdate_FileSchemeAllowedByEnv(t *testing.T) {
+	parent, sm := setupFileSubmodule(t)
+	defer func() { _ = parent.Close() }()
+
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file")
+
+	require.NoError(t, sm.UpdateContext(context.Background(), &SubmoduleUpdateOptions{}))
+}
+
+// Confirm the storage helper used above is sound; reading config after
+// SetConfig must round-trip the new keys.
+func TestProtocolPolicyConfigRoundTrip(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	fs := osfs.New(tmp)
+	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+
+	cfg, err := st.Config()
+	require.NoError(t, err)
+	cfg.Protocol.Allow = "user"
+	cfg.Protocol.AllowByName = map[string]string{"file": "always"}
+	require.NoError(t, st.SetConfig(cfg))
+
+	got, err := st.Config()
+	require.NoError(t, err)
+	require.Equal(t, "user", got.Protocol.Allow)
+	require.Equal(t, "always", got.Protocol.AllowByName["file"])
+}


### PR DESCRIPTION
Every `Handshake`/`Connect` now consults `protocol.<name>.allow`, `protocol.allow`, and `GIT_ALLOW_PROTOCOL`, mirroring canonical Git's `is_transport_allowed`[1]. Built-in defaults match upstream:

- `http/https/git/ssh` → `always`
- `ext` → `never`
- `file` and `unknown` → `user`

The `user` tier honours the `GIT_PROTOCOL_FROM_USER` tri-state with canonical bool grammar; the existing `parseConfigBool` helper is exported as `config.ParseConfigBool` and reused.

The gate fires at two layers:

1. Inside `client.Client.Handshake` / `Connect`
2. Inside each built-in transport's `Handshake` / `Connect`; so direct transport callers can't bypass it.

The client never mutates the caller's `*transport.Request`; option defaults are applied on a shallow copy.

`Submodule.fetchAndCheckout` marks its fetch as non-user-initiated and reads the submodule's own storer config, matching canonical's subprocess model[2]. The `file` scheme default is `user`, so a`.gitmodules` entry pointing at a `file://` URL is rejected unless the submodule's own config (or `GIT_ALLOW_PROTOCOL`) re-enables it.

[1]: https://github.com/git/git/blob/v2.54.0/transport.c#L1037-L1149
[2]: https://github.com/git/git/blob/v2.54.0/git-submodule.sh#L29-L30