### PR TITLE
plumbing: assorted memory optimisations

### DIFF
--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -448,6 +448,7 @@ func (p *Packfile) getMemoryObject(oh *ObjectHeader) (plumbing.EncodedObject, er
 		// duplicate copy of the delta payload.
 		if oh.content == nil {
 			oh.content = gogitsync.GetBytesBuffer()
+			oh.content.Grow(int(oh.Size))
 			err = p.scanner.inflateContent(oh.ContentOffset, oh.content, oh.Size)
 			if err != nil {
 				return nil, fmt.Errorf("cannot inflate content: %w", err)

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -445,18 +445,17 @@ func objectEntry(r *Scanner) (stateFn, error) {
 	}
 	r.crc.Reset()
 
-	b := []byte{0}
-	_, err := r.Read(b)
+	b, err := r.ReadByte()
 	if err != nil {
 		return nil, err
 	}
 
-	typ := packutil.ObjectType(b[0])
+	typ := packutil.ObjectType(b)
 	if !typ.Valid() {
-		return nil, fmt.Errorf("%w: invalid object type: %v", ErrMalformedPackfile, b[0])
+		return nil, fmt.Errorf("%w: invalid object type: %v", ErrMalformedPackfile, b)
 	}
 
-	size, err := packutil.VariableLengthSize(b[0], r)
+	size, err := packutil.VariableLengthSize(b, r)
 	if err != nil {
 		if errors.Is(err, packutil.ErrLengthOverflow) {
 			return nil, fmt.Errorf("%w: %w", ErrMalformedPackfile, err)

--- a/plumbing/object/file.go
+++ b/plumbing/object/file.go
@@ -1,7 +1,6 @@
 package object
 
 import (
-	"bytes"
 	"errors"
 	"io"
 	"strings"
@@ -36,12 +35,12 @@ func (f *File) Contents() (content string, err error) {
 	}
 	defer ioutil.CheckClose(reader, &err)
 
-	buf := new(bytes.Buffer)
-	if _, err := buf.ReadFrom(reader); err != nil {
+	buf := make([]byte, f.Size)
+	if _, err := io.ReadFull(reader, buf); err != nil {
 		return "", err
 	}
 
-	return buf.String(), nil
+	return string(buf), nil
 }
 
 // IsBinary returns if the file is binary or not

--- a/worktree.go
+++ b/worktree.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -1383,23 +1384,25 @@ func findMatchInFiles(fileiter *object.FileIter, treeName string, opts *GrepOpti
 // findMatchInFile takes a single File, worktree name and GrepOptions,
 // and returns a slice of GrepResult containing the result of regex pattern
 // matching in the given file.
-func findMatchInFile(file *object.File, treeName string, opts *GrepOptions) ([]GrepResult, error) {
-	var grepResults []GrepResult
-
-	content, err := file.Contents()
+func findMatchInFile(file *object.File, treeName string, opts *GrepOptions) (grepResults []GrepResult, err error) {
+	reader, err := file.Reader()
 	if err != nil {
 		return grepResults, err
 	}
+	defer ioutil.CheckClose(reader, &err)
 
-	// Split the file content and parse line-by-line.
-	contentByLine := strings.Split(content, "\n")
-	for lineNum, cnt := range contentByLine {
+	lr := bufio.NewScanner(reader)
+
+	lineNum := -1
+	for lr.Scan() {
+		lineNum++
 		addToResult := false
+		cnt := lr.Bytes()
 
 		// Match the patterns and content. Break out of the loop once a
 		// match is found.
 		for _, pattern := range opts.Patterns {
-			if pattern != nil && pattern.MatchString(cnt) {
+			if pattern != nil && pattern.Match(cnt) {
 				// Add to result only if invert match is not enabled.
 				if !opts.InvertMatch {
 					addToResult = true
@@ -1417,10 +1420,13 @@ func findMatchInFile(file *object.File, treeName string, opts *GrepOptions) ([]G
 			grepResults = append(grepResults, GrepResult{
 				FileName:   file.Name,
 				LineNumber: lineNum + 1,
-				Content:    cnt,
+				Content:    string(cnt),
 				TreeName:   treeName,
 			})
 		}
+	}
+	if err := lr.Err(); err != nil {
+		return grepResults, err
 	}
 
 	return grepResults, nil


### PR DESCRIPTION
I noticed there were needless memory allocations in a few places. I only touched paths affected by `git grep` as I was working with that.

<details>

<summary>benchmark function</summary>

```go
package git

import (
	"regexp"
	"testing"
)

func BenchmarkWorktreeGrepRepository(b *testing.B) {
	b.StopTimer()

	r, err := PlainOpen(".")
	if err != nil {
		b.Fatal(err)
	}
	defer func() { _ = r.Close() }()

	w, err := r.Worktree()
	if err != nil {
		b.Fatal(err)
	}

	opts := &GrepOptions{
		Patterns: []*regexp.Regexp{regexp.MustCompile("Gr.*p"), regexp.MustCompile("Grep")},
	}

	b.StartTimer()

	for b.Loop() {
		results, err := w.Grep(opts)
		if err != nil {
			b.Fatal(err)
		}
		if len(results) == 0 {
			b.Fatal("expected grep matches in repository")
		}
	}
}

```

</details>

Benchmark results:

```
$ benchstat bench_before.txt bench_after.txt
goos: darwin
goarch: arm64
pkg: github.com/go-git/go-git/v6
cpu: Apple M4 Pro
                       │ bench_before.txt │          bench_after.txt           │
                       │      sec/op      │   sec/op     vs base               │
WorktreeGrepRepository        92.38m ± 4%   88.73m ± 1%  -3.95% (p=0.000 n=10)

                       │ bench_before.txt │           bench_after.txt            │
                       │       B/op       │     B/op      vs base                │
WorktreeGrepRepository      20.310Mi ± 0%   6.374Mi ± 1%  -68.62% (p=0.000 n=10)

                       │ bench_before.txt │          bench_after.txt           │
                       │    allocs/op     │  allocs/op   vs base               │
WorktreeGrepRepository        71.29k ± 0%   67.00k ± 0%  -6.01% (p=0.000 n=10)
```

So runtime largely unaffected, but allocation volume down in a pretty big way.