### PR TITLE
DRAFT: feat: add ssh-config 

### DIFF
--- a/internal/transport/test/sshserver.go
+++ b/internal/transport/test/sshserver.go
@@ -1,0 +1,55 @@
+package test
+
+import (
+	"io"
+	"net"
+	"os/exec"
+	"sync"
+	"testing"
+
+	glssh "github.com/gliderlabs/ssh"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh/testdata"
+)
+
+// StartGitSSHServer starts an SSH server that serves git by running the
+// requested git command over the session, accepting any authentication. It
+// returns the listening address; the server is closed on t.Cleanup.
+func StartGitSSHServer(t testing.TB) *net.TCPAddr {
+	t.Helper()
+
+	l := ListenTCP(t)
+	server := &glssh.Server{Handler: func(s glssh.Session) {
+		args := s.Command()
+		if len(args) < 2 {
+			_ = s.Exit(1)
+			return
+		}
+		cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // test server
+		stdout, _ := cmd.StdoutPipe()
+		stdin, _ := cmd.StdinPipe()
+		stderr, _ := cmd.StderrPipe()
+		if err := cmd.Start(); err != nil {
+			_ = s.Exit(1)
+			return
+		}
+		go func() { defer func() { _ = stdin.Close() }(); _, _ = io.Copy(stdin, s) }()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); _, _ = io.Copy(s.Stderr(), stderr) }()
+		go func() { defer wg.Done(); _, _ = io.Copy(s, stdout) }()
+		wg.Wait()
+		if cmd.Wait() != nil {
+			_ = s.Exit(1)
+			return
+		}
+		_ = s.Exit(0)
+	}}
+	require.NoError(t, server.SetOption(glssh.HostKeyPEM(testdata.PEMBytes["ed25519"])))
+
+	done := make(chan struct{})
+	go func() { defer close(done); _ = server.Serve(l) }()
+	t.Cleanup(func() { _ = l.Close(); <-done })
+
+	return l.Addr().(*net.TCPAddr)
+}

--- a/plumbing/client/client.go
+++ b/plumbing/client/client.go
@@ -73,6 +73,21 @@ func WithSSHAuth(a SSHAuth) Option {
 	}
 }
 
+// WithSSHConfig configures SSH from an effective config: an Identity (login
+// user and auth methods) and a HostConfig (host key policy, known_hosts and
+// timeout). Build the arguments directly or via the ssh auth builders
+// (ssh.KeyAuth, ssh.AgentAuth).
+func WithSSHConfig(id *xssh.Identity, host *xssh.HostConfig) Option {
+	return func(opts *options) {
+		if host == nil {
+			host = &xssh.HostConfig{}
+		}
+		opts.ssh.ClientConfig = func(ctx context.Context, req *transport.Request) (*gossh.ClientConfig, error) {
+			return host.ClientConfig(ctx, req, id)
+		}
+	}
+}
+
 // WithHTTPAuth sets HTTP authentication. The auth type's Authorizer method
 // is called for each outgoing HTTP request.
 func WithHTTPAuth(a HTTPAuth) Option {

--- a/plumbing/client/example_test.go
+++ b/plumbing/client/example_test.go
@@ -1,0 +1,15 @@
+package client_test
+
+import (
+	"github.com/go-git/go-git/v6/plumbing/client"
+	"github.com/go-git/go-git/v6/plumbing/transport/ssh"
+)
+
+// WithSSHConfig wires a typed Identity and HostConfig into a client.
+func ExampleWithSSHConfig() {
+	host := &ssh.HostConfig{StrictHostKeyChecking: ssh.HostKeyCheckAcceptNew}
+	id := &ssh.Identity{User: "git"} // add auth with ssh.KeyAuth or ssh.AgentAuth
+
+	_ = client.New(client.WithSSHConfig(id, host))
+	// Output:
+}

--- a/plumbing/client/withsshconfig_test.go
+++ b/plumbing/client/withsshconfig_test.go
@@ -1,0 +1,49 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/plumbing/client"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/plumbing/transport/ssh"
+)
+
+// TestWithSSHConfig_UploadPack is a black-box test of WithSSHConfig: it
+// configures SSH through a typed Identity and HostConfig and performs a real
+// upload-pack handshake against an SSH git server.
+func TestWithSSHConfig_UploadPack(t *testing.T) {
+	t.Setenv("SSH_KNOWN_HOSTS", filepath.Join(t.TempDir(), "missing_known_hosts"))
+
+	addr := test.StartGitSSHServer(t)
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath := filepath.ToSlash(repoFS.Root())
+
+	host := &ssh.HostConfig{StrictHostKeyChecking: ssh.HostKeyCheckInsecureIgnore}
+	cl := client.New(client.WithSSHConfig(&ssh.Identity{User: "git"}, host))
+
+	session, err := cl.Handshake(context.Background(), &transport.Request{
+		URL: &url.URL{
+			Scheme: "ssh",
+			User:   url.User("git"),
+			Host:   fmt.Sprintf("localhost:%d", addr.Port),
+			Path:   repoPath,
+		},
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	refs, err := session.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, refs)
+}

--- a/plumbing/transport/ssh/config.go
+++ b/plumbing/transport/ssh/config.go
@@ -1,0 +1,162 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	gossh "golang.org/x/crypto/ssh"
+	xknownhosts "golang.org/x/crypto/ssh/knownhosts"
+
+	transport "github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/utils/trace"
+)
+
+// HostKeyCheck controls how server host keys are verified, mirroring OpenSSH's
+// StrictHostKeyChecking option.
+type HostKeyCheck int
+
+const (
+	// HostKeyCheckKnownHosts verifies the server key against known_hosts and
+	// rejects unknown or changed keys (StrictHostKeyChecking=yes). This is the
+	// zero value and the default.
+	HostKeyCheckKnownHosts HostKeyCheck = iota
+
+	// HostKeyCheckAcceptNew trusts host keys for hosts not yet in known_hosts
+	// but still rejects changed keys for known hosts (accept-new). New keys are
+	// trusted only for the life of the process; they are not written back.
+	HostKeyCheckAcceptNew
+
+	// HostKeyCheckInsecureIgnore disables host key verification entirely
+	// (StrictHostKeyChecking=no).
+	HostKeyCheckInsecureIgnore
+)
+
+// Identity is the authentication identity for an SSH connection: the login user
+// and the auth methods to offer. Build it with [KeyAuth], [KeyAuthBytes] or
+// [AgentAuth], or assemble it directly. An empty User is resolved from the
+// request URL, then [DefaultUsername].
+type Identity struct {
+	User    string
+	Methods []gossh.AuthMethod
+}
+
+// HostConfig is the host verification and connection policy for an SSH
+// connection. Zero-valued fields use the default.
+type HostConfig struct {
+	// StrictHostKeyChecking selects the host key verification policy. It is
+	// ignored when HostKeyCallback is set.
+	StrictHostKeyChecking HostKeyCheck
+
+	// KnownHostsFiles overrides the known_hosts sources (ssh -o
+	// UserKnownHostsFile). Empty uses the defaults (see [NewKnownHostsCallback]).
+	KnownHostsFiles []string
+
+	// HostKeyCallback, when set, verifies the server key directly and takes
+	// precedence over StrictHostKeyChecking and KnownHostsFiles.
+	HostKeyCallback gossh.HostKeyCallback
+
+	// ConnectTimeout bounds the SSH handshake (ssh -o ConnectTimeout).
+	ConnectTimeout time.Duration
+}
+
+// KeyAuth builds an Identity from a PEM-encoded private key file (ssh -i),
+// decrypting it with passphrase when needed.
+func KeyAuth(user, pemFile, passphrase string) (*Identity, error) {
+	pk, err := NewPublicKeysFromFile(user, pemFile, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	return &Identity{User: user, Methods: []gossh.AuthMethod{gossh.PublicKeys(pk.Signer)}}, nil
+}
+
+// KeyAuthBytes builds an Identity from PEM-encoded private key bytes.
+func KeyAuthBytes(user string, pem []byte, passphrase string) (*Identity, error) {
+	pk, err := NewPublicKeys(user, pem, passphrase)
+	if err != nil {
+		return nil, err
+	}
+	return &Identity{User: user, Methods: []gossh.AuthMethod{gossh.PublicKeys(pk.Signer)}}, nil
+}
+
+// AgentAuth builds an Identity backed by the running SSH agent.
+func AgentAuth(user string) (*Identity, error) {
+	pk, err := NewSSHAgentAuth(user)
+	if err != nil {
+		return nil, err
+	}
+	return &Identity{User: pk.User, Methods: []gossh.AuthMethod{gossh.PublicKeysCallback(pk.Callback)}}, nil
+}
+
+// ClientConfig assembles a *gossh.ClientConfig from the host policy and an
+// identity, resolving the login user and the host key callback.
+func (h *HostConfig) ClientConfig(_ context.Context, req *transport.Request, id *Identity) (*gossh.ClientConfig, error) {
+	cb := h.HostKeyCallback
+	if cb == nil {
+		var err error
+		if cb, err = knownHostsCallback(h.StrictHostKeyChecking, h.KnownHostsFiles...); err != nil {
+			return nil, err
+		}
+	}
+
+	cfg := &gossh.ClientConfig{
+		User:            resolveUser(id, req),
+		HostKeyCallback: cb,
+		Timeout:         h.ConnectTimeout,
+	}
+	if id != nil {
+		cfg.Auth = id.Methods
+	}
+	return cfg, nil
+}
+
+// knownHostsCallback builds a HostKeyCallback for the given policy. For
+// HostKeyCheckKnownHosts and HostKeyCheckAcceptNew the keys are read from files
+// (or the default sources when files is empty); HostKeyCheckInsecureIgnore
+// disables verification.
+func knownHostsCallback(check HostKeyCheck, files ...string) (gossh.HostKeyCallback, error) {
+	switch check {
+	case HostKeyCheckInsecureIgnore:
+		return gossh.InsecureIgnoreHostKey(), nil //nolint:gosec // explicit opt-in
+	case HostKeyCheckAcceptNew:
+		cb, err := NewKnownHostsCallback(files...)
+		if err != nil {
+			return nil, err
+		}
+		return acceptNewHostKeyCallback(cb), nil
+	default: // HostKeyCheckKnownHosts
+		return NewKnownHostsCallback(files...)
+	}
+}
+
+func resolveUser(id *Identity, req *transport.Request) string {
+	if id != nil && id.User != "" {
+		return id.User
+	}
+	if req != nil && req.URL != nil && req.URL.User != nil {
+		if u := req.URL.User.Username(); u != "" {
+			return u
+		}
+	}
+	return DefaultUsername
+}
+
+// acceptNewHostKeyCallback wraps a known_hosts callback so hosts not yet present
+// are accepted (and trusted for this process), while changed keys for known
+// hosts are still rejected.
+func acceptNewHostKeyCallback(inner gossh.HostKeyCallback) gossh.HostKeyCallback {
+	return func(hostname string, remote net.Addr, key gossh.PublicKey) error {
+		err := inner(hostname, remote, key)
+		if err == nil {
+			return nil
+		}
+		var keyErr *xknownhosts.KeyError
+		if errors.As(err, &keyErr) && len(keyErr.Want) == 0 {
+			trace.SSH.Printf("ssh: accept-new trusting unknown host %s key %s",
+				hostname, gossh.FingerprintSHA256(key))
+			return nil
+		}
+		return err
+	}
+}

--- a/plumbing/transport/ssh/config_test.go
+++ b/plumbing/transport/ssh/config_test.go
@@ -1,0 +1,135 @@
+package ssh
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gossh "golang.org/x/crypto/ssh"
+	xknownhosts "golang.org/x/crypto/ssh/knownhosts"
+	"golang.org/x/crypto/ssh/testdata"
+
+	transport "github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+func TestKeyAuth(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "id_ed25519")
+	require.NoError(t, os.WriteFile(path, testdata.PEMBytes["ed25519"], 0o600))
+
+	builders := map[string]func() (*Identity, error){
+		"from file":  func() (*Identity, error) { return KeyAuth("git", path, "") },
+		"from bytes": func() (*Identity, error) { return KeyAuthBytes("git", testdata.PEMBytes["ed25519"], "") },
+	}
+	for name, build := range builders {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			id, err := build()
+			require.NoError(t, err)
+			assert.Equal(t, "git", id.User)
+			assert.Len(t, id.Methods, 1)
+		})
+	}
+}
+
+func TestKeyAuth_BadFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := KeyAuth("git", filepath.Join(t.TempDir(), "missing"), "")
+	require.Error(t, err)
+}
+
+func TestHostConfig_ClientConfig(t *testing.T) {
+	t.Parallel()
+
+	h := &HostConfig{
+		StrictHostKeyChecking: HostKeyCheckInsecureIgnore,
+		ConnectTimeout:        5 * time.Second,
+	}
+	id, err := KeyAuthBytes("git", testdata.PEMBytes["ed25519"], "")
+	require.NoError(t, err)
+
+	cfg, err := h.ClientConfig(context.Background(), &transport.Request{}, id)
+	require.NoError(t, err)
+	assert.Equal(t, "git", cfg.User)
+	assert.Len(t, cfg.Auth, 1)
+	assert.NotNil(t, cfg.HostKeyCallback)
+	assert.Equal(t, 5*time.Second, cfg.Timeout)
+}
+
+func TestHostConfig_ClientConfig_ExplicitCallbackWins(t *testing.T) {
+	t.Parallel()
+
+	// StrictHostKeyChecking would otherwise read known_hosts; the explicit
+	// callback must take precedence and avoid any file access.
+	h := &HostConfig{
+		StrictHostKeyChecking: HostKeyCheckKnownHosts,
+		HostKeyCallback:       gossh.InsecureIgnoreHostKey(),
+	}
+
+	cfg, err := h.ClientConfig(context.Background(), &transport.Request{}, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg.HostKeyCallback)
+}
+
+func TestResolveUser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("identity user wins", func(t *testing.T) {
+		t.Parallel()
+		u, _ := url.Parse("ssh://bob@example.com/x.git")
+		assert.Equal(t, "alice", resolveUser(&Identity{User: "alice"}, &transport.Request{URL: u}))
+	})
+
+	t.Run("falls back to url user", func(t *testing.T) {
+		t.Parallel()
+		u, _ := url.Parse("ssh://bob@example.com/x.git")
+		assert.Equal(t, "bob", resolveUser(&Identity{}, &transport.Request{URL: u}))
+	})
+
+	t.Run("falls back to default", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, DefaultUsername, resolveUser(nil, &transport.Request{}))
+	})
+}
+
+func TestAcceptNewHostKeyCallback(t *testing.T) {
+	t.Parallel()
+
+	signer, err := gossh.ParsePrivateKey(testEd25519Key)
+	require.NoError(t, err)
+	key := signer.PublicKey()
+
+	t.Run("accepts unknown host", func(t *testing.T) {
+		t.Parallel()
+		inner := func(string, net.Addr, gossh.PublicKey) error {
+			return &xknownhosts.KeyError{} // empty Want => unknown host
+		}
+		assert.NoError(t, acceptNewHostKeyCallback(inner)("h:22", &net.TCPAddr{}, key))
+	})
+
+	t.Run("rejects changed key for known host", func(t *testing.T) {
+		t.Parallel()
+		changed := &xknownhosts.KeyError{Want: []xknownhosts.KnownKey{{}}}
+		cb := acceptNewHostKeyCallback(func(string, net.Addr, gossh.PublicKey) error {
+			return changed
+		})
+		assert.ErrorIs(t, cb("h:22", &net.TCPAddr{}, key), changed)
+	})
+
+	t.Run("propagates non-knownhosts errors", func(t *testing.T) {
+		t.Parallel()
+		sentinel := assert.AnError
+		cb := acceptNewHostKeyCallback(func(string, net.Addr, gossh.PublicKey) error {
+			return sentinel
+		})
+		assert.ErrorIs(t, cb("h:22", &net.TCPAddr{}, key), sentinel)
+	})
+}

--- a/plumbing/transport/ssh/connect_test.go
+++ b/plumbing/transport/ssh/connect_test.go
@@ -1,0 +1,46 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+// TestSSHTransport_ExplicitCallbackNoKnownHosts verifies that a caller-supplied
+// HostKeyCallback with no HostKeyAlgorithms does not require a known_hosts file:
+// the transport must negotiate default algorithms instead of failing. The
+// caller has taken ownership of host verification via the callback.
+func TestSSHTransport_ExplicitCallbackNoKnownHosts(t *testing.T) {
+	t.Setenv("SSH_KNOWN_HOSTS", filepath.Join(t.TempDir(), "missing_known_hosts"))
+
+	addr := startSSHServer(t)
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath := filepath.ToSlash(repoFS.Root())
+
+	tr := NewTransport(sshClientOptions())
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL: &url.URL{
+			Scheme: "ssh",
+			User:   url.User("git"),
+			Host:   fmt.Sprintf("localhost:%d", addr.Port),
+			Path:   repoPath,
+		},
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	refs, err := session.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, refs)
+}

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -83,11 +83,11 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 		config.HostKeyCallback = db.HostKeyCallback()
 		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 	} else if len(config.HostKeyAlgorithms) == 0 {
-		db, err := newKnownHostsDb()
-		if err != nil {
-			return nil, err
+		// Constrain the algorithms to the pinned host keys when known_hosts is
+		// available; otherwise negotiate defaults rather than failing.
+		if db, err := newKnownHostsDb(); err == nil {
+			config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 		}
-		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 	}
 
 	trace.SSH.Printf("ssh: host key algorithms %s", strings.Join(config.HostKeyAlgorithms, ", "))


### PR DESCRIPTION
A PR suggestion to solve the issue discussed in https://github.com/go-git/go-git/discussions/1207:

The problem a some missing go-git ssh-config-wireup to support the common enterprise case of needing to  Proxy SSH through an HTTP CONNECT/SOCKS proxy. A common setup when wanting to use ssh to github over their https url, when ssh is totally blocked, and enterprise also has an mandatory proxy for the https-calls.

So, I think we don't need to support GIT_SSH_COMMAND as I used it the discussion examples for 1207, as basically is just a caller to the underlying ssh impl anyway. This PR is much simpler, and more in line with existing go-git idioms.

A small ssh-config and as the ProxyCommand (in the 1207-discussion) is just "tunnel SSH through an HTTP CONNECT proxy to reach
  ssh.github.com:443." go-git already supports that,
  existing client.WithProxyURL (HTTP CONNECT + SOCKS via golang.org/x/net/proxy:


 Also one extra commit in this, with an explicit HostKeyCallback (e.g. InsecureIgnoreHostKey)
  and no known_hosts file present,  Transport.connect now falls back to default negotiation, instead of erroring. If this papercut is wrong/out of scope i'll just remove it.
  


