### PR TITLE
config: read repositoryformatversion in unmarshalCore

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -329,6 +329,10 @@ func (c *Config) unmarshalCore() {
 	if parsed := parseConfigBool(s.Options.Get(protectHFSKey)); parsed.IsSet() {
 		c.Core.ProtectHFS = parsed
 	}
+
+	if s.Options.Get(repositoryFormatVersionKey) == string(format.Version_1) {
+		c.Core.RepositoryFormatVersion = format.Version_1
+	}
 }
 
 func (c *Config) unmarshalUser() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-billy/v5/util"
 	"github.com/go-git/go-git/v5/plumbing"
+	format "github.com/go-git/go-git/v5/plumbing/format/config"
 	. "gopkg.in/check.v1"
 )
 
@@ -89,6 +90,13 @@ func (s *ConfigSuite) TestUnmarshal(c *C) {
 	c.Assert(cfg.Branches["master"].Merge, Equals, plumbing.ReferenceName("refs/heads/master"))
 	c.Assert(cfg.Branches["master"].Description, Equals, "Add support for branch description.\n\nEdit branch description: git branch --edit-description\n")
 	c.Assert(cfg.Init.DefaultBranch, Equals, "main")
+}
+
+func (s *ConfigSuite) TestUnmarshalRepositoryFormatVersion(c *C) {
+	input := []byte("[core]\n\trepositoryformatversion = 1\n")
+	cfg := NewConfig()
+	c.Assert(cfg.Unmarshal(input), IsNil)
+	c.Assert(cfg.Core.RepositoryFormatVersion, Equals, format.RepositoryFormatVersion(format.Version_1))
 }
 
 func (s *ConfigSuite) TestMarshal(c *C) {
@@ -394,4 +402,3 @@ func (s *ConfigSuite) TestUnmarshalRemotes(c *C) {
 	c.Assert(cfg.Remotes["origin"].URLs[0], Equals, "https://git.sr.ht/~mcepl/go-git")
 	c.Assert(cfg.Remotes["origin"].URLs[1], Equals, "git@git.sr.ht:~mcepl/go-git.git")
 }
-


### PR DESCRIPTION
\`marshalCore\` writes \`core.repositoryformatversion\` when it isn't empty, but \`unmarshalCore\` never set \`Core.RepositoryFormatVersion\` from the parsed section. So on a repo with explicit \`repositoryformatversion=1\` the field loaded as the zero value and \`verifyExtensions\` treated the repo as version 0, which then rejected V1 extensions like \`worktreeConfig\` that the on-disk config clearly enabled.

Mirror of the V6 fix on \`main\` (the read is already there in commit 6923824). Test fails on \`releases/v5.x\` without the change.

fixes #2155