### PR TITLE
plumbing/transport/http: allow redirects within a custom scheme

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -370,9 +370,12 @@ func (s *session) ModifyEndpointIfRedirect(res *http.Response) error {
 	if !strings.HasSuffix(r.URL.Path, infoRefsPath) {
 		return fmt.Errorf("http redirect: target %q does not end with %s", r.URL.Path, infoRefsPath)
 	}
-	if r.URL.Scheme != "http" && r.URL.Scheme != "https" {
-		return fmt.Errorf("http redirect: unsupported scheme %q", r.URL.Scheme)
-	}
+	// A redirect may not switch to a different scheme; the only permitted
+	// transition is an upgrade from http to https. This blocks SSRF via
+	// protocol escalation (e.g. a redirect from https to file://) without
+	// hardcoding an http/https allowlist, so callers that register a custom
+	// transport under their own scheme can still follow redirects that stay
+	// within that scheme.
 	if r.URL.Scheme != s.endpoint.Protocol &&
 		!(s.endpoint.Protocol == "http" && r.URL.Scheme == "https") {
 		return fmt.Errorf("http redirect: changes scheme from %q to %q", s.endpoint.Protocol, r.URL.Scheme)

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -253,6 +253,9 @@ func (s *ClientSuite) TestModifyEndpointIfRedirect(c *C) {
 			&transport.Endpoint{Protocol: "https"},
 			&transport.Endpoint{Protocol: "https"},
 			".*changes scheme.*"},
+		{"private://pool/foo.git/info/refs",
+			&transport.Endpoint{Protocol: "private", Host: "pool"},
+			&transport.Endpoint{Protocol: "private", Host: "pool", Path: "/foo.git"}, ""},
 	}
 
 	for _, d := range data {


### PR DESCRIPTION
## Problem

`ModifyEndpointIfRedirect` rejects any redirect whose scheme isn't a hardcoded `http` or `https`:

```go
if r.URL.Scheme != "http" && r.URL.Scheme != "https" {
    return fmt.Errorf("http redirect: unsupported scheme %q", r.URL.Scheme)
}
```

This makes redirect handling unusable for callers that register their own transport under a custom scheme via `client.InstallProtocol`. A transport like that can rewrite the request URL to a real backend internally and then surface the original custom-scheme URL back on `resp.Request.URL`, at which point the allowlist trips even though the scheme never actually changed.

This breaks our [Spacelift VCS agent](https://docs.spacelift.io/concepts/vcs-agent-pools), which addresses internal repositories through a `private://` scheme.

## Fix

Drop only the hardcoded `http`/`https` allowlist. The cross-scheme guard immediately below it already does the real work:

```go
if r.URL.Scheme != s.endpoint.Protocol &&
    !(s.endpoint.Protocol == "http" && r.URL.Scheme == "https") {
    return fmt.Errorf("http redirect: changes scheme from %q to %q", ...)
}
```

A redirect can only stay on the endpoint's own scheme or upgrade `http`→`https`. It can never escalate to a protocol the caller didn't start on, so the SSRF protection is preserved:

- `https://` → `file://` / `gopher://` → still blocked (scheme change)
- `http://` → `https://` → still allowed (upgrade)
- `private://` → `private://` → now allowed (same scheme)
- `private://` → `https://` → still blocked (can't escalate)

> [!NOTE]
> `checkRedirect` deliberately keeps its allowlist. It runs at the net/http layer where only real `http`/`https` URLs appear, and it has no cross-scheme guard of its own, so the check still carries SSRF weight there.

Added a test covering a redirect that stays within a custom scheme; the existing `changes scheme` and `unsupported scheme` cases still pass unchanged.


---

> [!NOTE]
> This PR targets `releases/v5.x`. The equivalent fix for `main` is in #2170.
