### PR TITLE
plumbing/transport/http: allow redirects within a custom scheme

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -74,10 +74,12 @@ const infoRefsPath = "/info/refs"
 // because a mismatch could let a malicious server rewrite the base URL
 // to an unrelated repository.
 //
-// Scheme is validated to prevent SSRF via unsupported protocols (e.g.
-// a redirect to file:// or gopher://). Cross-scheme redirects only
-// permit an upgrade from http to https; downgrades must not influence
-// the session base URL used for subsequent requests.
+// A redirect may not switch to a different scheme; the only permitted
+// transition is an upgrade from http to https. This blocks SSRF via
+// protocol escalation (e.g. a redirect from https to file:// or
+// gopher://) without hardcoding an http/https allowlist, so callers
+// that register a custom transport under their own scheme can still
+// follow redirects that stay within that scheme.
 func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 	if resp.Request == nil {
 		return baseURL, nil
@@ -96,9 +98,6 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 		return baseURL, nil
 	}
 
-	if final.Scheme != "http" && final.Scheme != "https" {
-		return nil, fmt.Errorf("http transport: redirect to unsupported scheme %q", final.Scheme)
-	}
 	if final.Scheme != baseURL.Scheme &&
 		(baseURL.Scheme != "http" || final.Scheme != "https") {
 		return nil, fmt.Errorf(

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -122,10 +122,16 @@ func TestApplyRedirect(t *testing.T) {
 			wantURL:  "https://example.com/repo.git",
 		},
 		{
-			name:     "unsupported scheme",
+			name:     "rejects redirect to a foreign scheme",
 			baseURL:  "https://example.com/repo.git",
 			finalURL: "ftp://evil.com/repo.git/info/refs",
-			wantErr:  "unsupported scheme",
+			wantErr:  "changes scheme",
+		},
+		{
+			name:     "allows redirect within a custom scheme",
+			baseURL:  "private://pool/old-repo.git",
+			finalURL: "private://pool/new-repo.git/info/refs",
+			wantURL:  "private://pool/new-repo.git",
 		},
 		{
 			name:     "tail mismatch",


### PR DESCRIPTION
## Problem

`applyRedirect` rejects any redirect whose final scheme isn't a hardcoded `http` or `https`:

```go
if final.Scheme != "http" && final.Scheme != "https" {
    return nil, fmt.Errorf("http transport: redirect to unsupported scheme %q", final.Scheme)
}
```

This makes redirect handling unusable for callers that register their own transport under a custom scheme via `transport.Register`. A transport like that can rewrite the request URL to a real backend internally and then surface the original custom-scheme URL back on `resp.Request.URL`, at which point the allowlist trips even though the scheme never actually changed.

This breaks our [Spacelift VCS agent](https://docs.spacelift.io/concepts/vcs-agent-pools), which addresses internal repositories through a `private://` scheme.

## Fix

Drop only the hardcoded `http`/`https` allowlist. The cross-scheme guard immediately below it already does the real work:

```go
if final.Scheme != baseURL.Scheme &&
    (baseURL.Scheme != "http" || final.Scheme != "https") {
    return nil, fmt.Errorf("http transport: redirect changes scheme from %q to %q", baseURL.Scheme, final.Scheme)
}
```

A redirect can only stay on the base URL's own scheme or upgrade `http`→`https`. It can never escalate to a protocol the caller didn't start on, so the SSRF protection is preserved:

- `https://` → `file://` / `gopher://` → still blocked (scheme change)
- `http://` → `https://` → still allowed (upgrade)
- `private://` → `private://` → now allowed (same scheme)
- `private://` → `https://` → still blocked (can't escalate)

> [!NOTE]
> `checkRedirect` deliberately keeps its allowlist. It runs at the net/http layer where only real `http`/`https` URLs appear, and it has no cross-scheme guard of its own, so the check still carries SSRF weight there.

The `ftp`-from-`https` case that used to assert `unsupported scheme` now asserts `changes scheme` (the cross-scheme guard catches it), plus a new case covers a redirect that stays within a custom scheme. The `file://` block in `redirect_test.go` is untouched.

---

> [!NOTE]
> This PR targets `main`. The equivalent fix for the `releases/v5.x` line is in #2169.
