### PR TITLE
git: repository_extensions, Fix case-mismatched extension whitelist and accept standard extensions

### DIFF
--- a/repository_extensions.go
+++ b/repository_extensions.go
@@ -30,26 +30,43 @@ var (
 	// Some extensions are storage-specific, those are defined by the Storers
 	// themselves by implementing the ExtensionChecker interface.
 	builtinExtensions = map[string]struct{}{
-		// noop does not change git’s behavior at all.
+		// noop does not change git's behavior at all.
 		// It is useful only for testing format-1 compatibility.
 		//
 		// This extension is respected regardless of the
 		// core.repositoryFormatVersion setting.
 		"noop": {},
 
-		// noop-v1 does not change git’s behavior at all.
+		// noop-v1 does not change git's behavior at all.
 		// It is useful only for testing format-1 compatibility.
 		"noop-v1": {},
+
+		// worktreeConfig enables per-worktree configuration,
+		// automatically set by git worktree. go-git does not
+		// change behavior for this extension but must not
+		// reject it.
+		"worktreeconfig": {},
+
+		// partialClone enables partial clone (filter by blob
+		// size, etc.). go-git accepts but does not implement
+		// the partial clone protocol.
+		"partialclone": {},
+
+		// preciousObjects marks the repo as a promisor remote
+		// object store that must not be deleted by gc.
+		"preciousobjects": {},
 	}
 
 	// Some Git extensions were supported upstream before the introduction
 	// of repositoryformatversion. These are the only extensions that can be
 	// enabled while core.repositoryformatversion is unset or set to 0.
+	// Keys must be lowercase to match the output of extensions(), which
+	// normalises extension names with strings.ToLower.
 	extensionsValidForV0 = map[string]struct{}{
 		"noop":            {},
-		"partialClone":    {},
-		"preciousObjects": {},
-		"worktreeConfig":  {},
+		"partialclone":    {},
+		"preciousobjects": {},
+		"worktreeconfig":  {},
 	}
 )
 

--- a/repository_extensions_test.go
+++ b/repository_extensions_test.go
@@ -58,6 +58,42 @@ func TestVerifyExtensions(t *testing.T) {
 			},
 		},
 		{
+			name: "repositoryformatversion=0: allows worktreeConfig (camelCase input)",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_0
+				cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
+			},
+		},
+		{
+			name: "repositoryformatversion=0: allows partialClone (camelCase input)",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_0
+				cfg.Raw.Section("extensions").SetOption("partialClone", "blobmax")
+			},
+		},
+		{
+			name: "repositoryformatversion=0: allows preciousObjects (camelCase input)",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_0
+				cfg.Raw.Section("extensions").SetOption("preciousObjects", "true")
+			},
+		},
+		{
+			name: "repositoryformatversion=0: allows multiple V0 extensions together",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_0
+				cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
+				cfg.Raw.Section("extensions").SetOption("partialClone", "blobmax")
+			},
+		},
+		{
+			name: "repositoryformatversion=1: allows worktreeConfig",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_1
+				cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
+			},
+		},
+		{
 			name: "repositoryformatversion=1: rejects objectformat=sha1", // not supported in go-git/v5
 			setup: func(t *testing.T, cfg *config.Config) {
 				cfg.Core.RepositoryFormatVersion = formatcfg.Version_1


### PR DESCRIPTION
## Description

Fixes #2156

`verifyExtensions` rejects standard Git extensions (`worktreeConfig`, `partialClone`, `preciousObjects`) on V0 repos due to a case mismatch: the `extensionsValidForV0` map used camelCase keys, but `extensions()` normalises all names to lowercase with `strings.ToLower`. The lookup always missed, making these extensions unreachable — only `noop` (already lowercase) worked.

This also affected V1 repos: even with the case fix, these extensions would fail the `builtinExtensions` check since they weren't listed there.

### Changes

- **`repository_extensions.go`**: Lowercase all keys in `extensionsValidForV0` to match the output of `extensions()`. Add `worktreeconfig`, `partialclone`, `preciousobjects` to `builtinExtensions` so they're accepted at any format version.
- **`repository_extensions_test.go`**: Add regression tests that verify camelCase extension input (`worktreeConfig`, `partialClone`, `preciousObjects`) is accepted at V0, and that `worktreeConfig` is accepted at V1.

### Why these extensions are safe to accept

go-git does not need to change behaviour for any of these extensions — it just needs to not reject them:

- **`worktreeConfig`**: Enables per-worktree configuration. Automatically set by `git worktree` tooling. Breaking `PlainOpen` for any repo that has used `git worktree`.
- **`partialClone`**: Enables partial clone (blob filter). go-git can accept the extension without implementing the partial clone protocol.
- **`preciousObjects`**: Marks the repo as a promisor remote object store. No behaviour change needed in go-git.

### Cross-reference

The `main` branch (v6) already has the lowercase keys in `extensionsValidForV0`. This PR backports the same fix plus the `builtinExtensions` additions to `releases/v5.x`.

Assisted-by: Hermes Agent <noreply@hermes.agent>
