### PR TITLE
plumbing: protocol/packp, handle shallow-only no-op push in UpdateRequests.Decode

### DIFF
--- a/plumbing/protocol/packp/updreq_decode.go
+++ b/plumbing/protocol/packp/updreq_decode.go
@@ -118,6 +118,12 @@ func (req *UpdateRequests) Decode(r io.Reader) error {
 		}
 	}
 
+	// A shallow-only no-op push (e.g. from a shallow clone with nothing to push)
+	// sends shallow lines followed immediately by a flush packet with no commands.
+	if length == pktline.Flush {
+		return nil
+	}
+
 	// The first command line must contain capabilities separated by a null byte
 	before, after, ok := bytes.Cut(payload, []byte{0})
 	if !ok {
@@ -160,7 +166,12 @@ func (req *UpdateRequests) Decode(r io.Reader) error {
 		return errMalformedRequest("unexpected data after flush")
 	}
 
-	return validateUpdateRequests(req)
+	for _, c := range req.Commands {
+		if err := c.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func parseCommand(b []byte) (*Command, error) {

--- a/plumbing/protocol/packp/updreq_decode.go
+++ b/plumbing/protocol/packp/updreq_decode.go
@@ -118,9 +118,11 @@ func (req *UpdateRequests) Decode(r io.Reader) error {
 		}
 	}
 
-	// A shallow-only no-op push (e.g. from a shallow clone with nothing to push)
-	// sends shallow lines followed immediately by a flush packet with no commands.
-	if length == pktline.Flush {
+	// A shallow-only no-op push (shallow lines followed immediately by a
+	// flush, with no commands) is a valid empty request, e.g. from a shallow
+	// clone with nothing to push. A bare flush with no shallows is still
+	// treated as malformed.
+	if length == pktline.Flush && len(req.Shallows) > 0 {
 		return nil
 	}
 
@@ -166,12 +168,7 @@ func (req *UpdateRequests) Decode(r io.Reader) error {
 		return errMalformedRequest("unexpected data after flush")
 	}
 
-	for _, c := range req.Commands {
-		if err := c.validate(); err != nil {
-			return err
-		}
-	}
-	return nil
+	return validateUpdateRequests(req)
 }
 
 func parseCommand(b []byte) (*Command, error) {

--- a/plumbing/protocol/packp/updreq_decode_test.go
+++ b/plumbing/protocol/packp/updreq_decode_test.go
@@ -316,6 +316,36 @@ func (s *UpdReqDecodeSuite) testDecodeOK(payloads []string) *UpdateRequests {
 	return r
 }
 
+func (s *UpdReqDecodeSuite) TestShallowNoOpPush() {
+	hash1 := plumbing.NewHash("1ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+
+	expected := &UpdateRequests{}
+	expected.Shallows = []plumbing.Hash{hash1}
+
+	payloads := []string{
+		"shallow 1ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"",
+	}
+
+	s.testDecodeOkExpected(expected, payloads)
+}
+
+func (s *UpdReqDecodeSuite) TestShallowNoOpPushMultipleShallows() {
+	hash1 := plumbing.NewHash("1ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	hash2 := plumbing.NewHash("2ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+
+	expected := &UpdateRequests{}
+	expected.Shallows = []plumbing.Hash{hash1, hash2}
+
+	payloads := []string{
+		"shallow 1ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"shallow 2ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"",
+	}
+
+	s.testDecodeOkExpected(expected, payloads)
+}
+
 func (s *UpdReqDecodeSuite) TestMultipleShallowLines() {
 	hash1 := plumbing.NewHash("0c22e5ae8f25b3b070c9cad6e998ab388c636091")
 	hash2 := plumbing.NewHash("1a129f5ef8baf66eaf9fc391c8104d0e7d6f95f5")

--- a/plumbing/protocol/packp/updreq_decode_test.go
+++ b/plumbing/protocol/packp/updreq_decode_test.go
@@ -346,6 +346,13 @@ func (s *UpdReqDecodeSuite) TestShallowNoOpPushMultipleShallows() {
 	s.testDecodeOkExpected(expected, payloads)
 }
 
+func (s *UpdReqDecodeSuite) TestBareFlushNoShallowsIsMalformed() {
+	payloads := []string{
+		"",
+	}
+	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "capabilities delimiter not found")
+}
+
 func (s *UpdReqDecodeSuite) TestMultipleShallowLines() {
 	hash1 := plumbing.NewHash("0c22e5ae8f25b3b070c9cad6e998ab388c636091")
 	hash2 := plumbing.NewHash("1a129f5ef8baf66eaf9fc391c8104d0e7d6f95f5")


### PR DESCRIPTION
## Summary

When a shallow clone runs `git push` with nothing to push, the Git client
sends shallow lines followed immediately by a flush packet — with no
command lines. `UpdateRequests.Decode` unconditionally tried to parse the
flush as a command line containing a capabilities delimiter (`\x00`),
causing a **"capabilities delimiter not found"** error.

### Git protocol reference

The [pack-protocol spec](https://git-scm.com/docs/pack-protocol) defines
the receive-pack update request grammar as:

```
update-requests   =  *shallow ( command-list | push-cert )

command-list      =  PKT-LINE(command NUL capability-list)
                     *PKT-LINE(command)
                     flush-pkt
```

The grammar requires either a `command-list` or a `push-cert` after
shallow lines — it does **not** explicitly account for the case where a
client sends shallow lines followed directly by a flush-pkt with no
commands.

However, in practice this is exactly what the reference `git` client does.

### Evidence from `git/git` source

**Client side — [`send-pack.c`](https://github.com/git/git/blob/master/send-pack.c):**

[Line 681](https://github.com/git/git/blob/master/send-pack.c#L681):
shallow lines are written unconditionally for shallow repos:

```c
if (!args->dry_run)
    advertise_shallow_grafts_buf(r, &req_buf);
```

Lines 689–708: command lines are only written for refs that need updating
(the loop may produce zero commands, leaving `cmds_sent == 0`).

[Lines 721–724](https://github.com/git/git/blob/master/send-pack.c#L721-L724):
the buffer is still flushed and sent when the repo is shallow, even if no
commands were generated:

```c
if (!args->dry_run && (cmds_sent || is_repository_shallow(r))) {
    packet_buf_flush(&req_buf);
    send_sideband(out, -1, req_buf.buf, req_buf.len, LARGE_PACKET_MAX);
}
```

The condition `cmds_sent || is_repository_shallow(r)` means that when a
shallow repository has nothing to push, the client still sends the shallow
lines + flush packet with zero command lines.

**Server side — [`builtin/receive-pack.c`](https://github.com/git/git/blob/master/builtin/receive-pack.c):**

[`read_head_info()`](https://github.com/git/git/blob/master/builtin/receive-pack.c#L2201-L2287)
(line 2201) parses shallow lines and commands:

```c
static struct command *read_head_info(struct packet_reader *reader,
                                     struct oid_array *shallow)
{
    struct command *commands = NULL;
    struct command **p = &commands;
    for (;;) {
        if (packet_reader_read(reader) != PACKET_READ_NORMAL)  // L2209: flush → break
            break;

        if (reader->pktlen > 8 && starts_with(reader->line, "shallow ")) {  // L2212
            ...
            oid_array_append(shallow, &oid);  // L2217
            continue;
        }
        ...
        p = queue_command(p, reader->line, linelen);  // L2281
    }
    return commands;  // NULL when no commands were received
}
```

[Line 2694](https://github.com/git/git/blob/master/builtin/receive-pack.c#L2694):
NULL commands → the entire command-processing block is skipped:

```c
if ((commands = read_head_info(&reader, &shallow))) {
    ...
}
```

The reference server handles this gracefully: `read_head_info` returns
`NULL`, the outer `if` is false, and the push completes as a no-op.
go-git should do the same.

### Reproduction

1. Create a bare repository and serve it via go-git's `receive-pack`.
2. Clone it with `--depth 1` to produce a shallow clone.
3. Without making any local commits, run `git push` from the shallow clone.

go-git crashes with `capabilities delimiter not found`.

### Fix

- Add an early return when a `flush-pkt` is encountered after shallow
  lines but before any commands, treating it as a valid empty push.
- Relax end-of-decode validation to allow empty commands during decode
  (encode-time validation via `Encode` still requires at least one command).

## Test plan

- `TestShallowNoOpPush` — single shallow + flush, no commands.
- `TestShallowNoOpPushMultipleShallows` — two shallow lines + flush, no commands.
- Existing tests continue to pass (`go test ./plumbing/protocol/packp/...`).

Assisted-by: Cursor Agent <cursoragent@cursor.com>