### PR TITLE
Skip .git root when adding glob matches

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -454,6 +454,10 @@ func (w *Worktree) AddGlob(pattern string) error {
 
 	var saveIndex bool
 	for _, file := range files {
+		if w.isWorktreeMetadataRoot(file) && !w.isWorktreeMetadataRoot(pattern) {
+			continue
+		}
+
 		fi, err := w.filesystem.Lstat(file)
 		if err != nil {
 			return err
@@ -480,6 +484,18 @@ func (w *Worktree) AddGlob(pattern string) error {
 	}
 
 	return nil
+}
+
+func (w *Worktree) isWorktreeMetadataRoot(path string) bool {
+	path = filepath.Clean(path)
+	if filepath.IsAbs(path) {
+		rel, err := filepath.Rel(w.filesystem.Root(), path)
+		if err == nil {
+			path = rel
+		}
+	}
+
+	return filepath.ToSlash(path) == GitDirName
 }
 
 // doAddFile create a new blob from path and update the index, added is true if

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -3022,6 +3022,30 @@ func (s *WorktreeSuite) TestAddGlob() {
 	s.Equal(Unmodified, file.Worktree)
 }
 
+func (s *WorktreeSuite) TestAddGlobSkipsDotGitDirectory() {
+	dir := s.T().TempDir()
+	r, err := PlainInit(dir, false)
+	s.Require().NoError(err)
+	defer func() { _ = r.Close() }()
+
+	err = os.WriteFile(filepath.Join(dir, "newfile"), []byte("hello"), 0o644)
+	s.Require().NoError(err)
+
+	w, err := r.Worktree()
+	s.Require().NoError(err)
+
+	err = w.AddWithOptions(&AddOptions{Glob: "*"})
+	s.Require().NoError(err)
+
+	idx, err := r.Storer.Index()
+	s.Require().NoError(err)
+	s.Require().Len(idx.Entries, 1)
+	s.Equal("newfile", idx.Entries[0].Name)
+
+	err = w.AddWithOptions(&AddOptions{Path: ".git"})
+	s.ErrorContains(err, "invalid path component")
+}
+
 func (s *WorktreeSuite) TestAddFilenameStartingWithDot() {
 	fs := memfs.New()
 	w := &Worktree{


### PR DESCRIPTION
Fixes #2174.

`AddWithOptions(&AddOptions{Glob: "*"})` can include the repository's root `.git` directory when the worktree is backed by the OS filesystem. The protected worktree filesystem rejects that path, so adding ordinary files fails before they can be staged.

This skips only the root `.git` directory when it appears as part of a broader glob expansion. A direct add of `.git` still goes through the existing path validation and returns an error.

Tested with:
- `go test . -run TestWorktreeSuite/TestAddGlobSkipsDotGitDirectory -count=1`
- `go test . -run "TestWorktreeSuite/TestAddGlob" -count=1`
- `go test . -run "TestWorktreeSuite/TestAdd(All|Glob|FilenameStartingWithDot|Directory)" -count=1`

I also tried the root package with the Windows symlink test skipped, but this local checkout still fails unrelated fixture/network-dependent tests with `repository not found`.