### PR TITLE
Clean sparse checkout directory paths

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -345,8 +345,9 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		return err
 	}
 
-	if len(opts.SparseDirs) > 0 && !opts.SkipSparseDirValidation {
-		if !treeContainsDirs(t, opts.SparseDirs) {
+	sparseDirs := cleanSparseDirs(opts.SparseDirs)
+	if len(sparseDirs) > 0 && !opts.SkipSparseDirValidation {
+		if !treeContainsDirs(t, sparseDirs) {
 			return ErrSparseResetDirectoryNotFound
 		}
 	}
@@ -364,7 +365,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	}
 
 	if opts.Mode == KeepReset {
-		if err := w.checkKeepResetConflicts(prevTree, t, opts.SparseDirs, opts.Files); err != nil {
+		if err := w.checkKeepResetConflicts(prevTree, t, sparseDirs, opts.Files); err != nil {
 			return err
 		}
 	}
@@ -375,7 +376,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 
 	var removedFiles []string
 	if opts.Mode == MixedReset || opts.Mode == MergeReset || opts.Mode == HardReset || opts.Mode == KeepReset {
-		if removedFiles, err = w.resetIndex(t, opts.SparseDirs, opts.Files); err != nil {
+		if removedFiles, err = w.resetIndex(t, sparseDirs, opts.Files); err != nil {
 			return err
 		}
 	}
@@ -393,6 +394,18 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	}
 
 	return nil
+}
+
+func cleanSparseDirs(dirs []string) []string {
+	if len(dirs) == 0 {
+		return nil
+	}
+
+	cleaned := make([]string, len(dirs))
+	for i, dir := range dirs {
+		cleaned[i] = filepath.ToSlash(filepath.Clean(dir))
+	}
+	return cleaned
 }
 
 // treeContainsDirs checks if the given tree contains all the directories.

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -640,6 +640,32 @@ func (s *WorktreeSuite) TestCheckoutSparse() {
 	}
 }
 
+func (s *WorktreeSuite) TestCheckoutSparseRelativeDirs() {
+	fs := memfs.New()
+	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
+		URL:        s.GetBasicLocalRepositoryURL(),
+		NoCheckout: true,
+	})
+	s.NoError(err)
+	defer func() { _ = r.Close() }()
+
+	w, err := r.Worktree()
+	s.NoError(err)
+
+	wantDirs := []string{"go", "json", "php"}
+	s.NoError(w.Checkout(&CheckoutOptions{
+		SparseCheckoutDirectories: []string{"./go", "./json", "./php"},
+	}))
+
+	fis, err := fs.ReadDir("/")
+	s.NoError(err)
+	s.Len(fis, len(wantDirs))
+	for _, fi := range fis {
+		s.True(fi.IsDir())
+		s.Contains(wantDirs, fi.Name())
+	}
+}
+
 func (s *WorktreeSuite) TestCheckoutCRLF() {
 	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
 		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())


### PR DESCRIPTION
Fixes #1506.

Sparse checkout directories are repository-relative paths. `./go` should resolve the same way as `go`, but the reset path used the raw strings for tree validation and index skip-worktree matching.

This cleans the sparse directory list once in `Reset` and reuses it for validation, keep-reset conflict checks, and index updates.

Tested with:
- `go test . -run "TestWorktreeSuite/TestCheckoutSparseRelativeDirs" -count=1 -v`
- `go test . -run "TestWorktreeSuite/Test(CheckoutSparse|CheckoutSparseRelativeDirs|CheckoutForceSparseUntrackedPreserved|ResetSparsely|ResetSparselyInvalidDir|StatusAfterSparseCheckout)$" -count=1 -v`
- `go test . -run "TestWorktreeSuite/TestCheckout" -count=1`