### PR TITLE
plumbing: format/index, accept empty trailing checksum on decode

### DIFF
--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -378,6 +378,15 @@ func (d *Decoder) readChecksum(expected []byte) error {
 		return err
 	}
 
+	// A null (all-zero) trailing hash means the checksum was skipped when
+	// the index was written (git's index.skipHash, 2.40+). Upstream git
+	// disables verification in this case, so match that even when the
+	// caller did not opt in via WithSkipHash.
+	if h.IsZero() {
+		trace.Internal.Printf("index: null trailing checksum, skipping verification")
+		return nil
+	}
+
 	if d.skipHash {
 		trace.Internal.Printf("index: skipping checksum verification (skipHash)")
 		return nil

--- a/plumbing/format/index/decoder_test.go
+++ b/plumbing/format/index/decoder_test.go
@@ -466,13 +466,15 @@ func TestDecodeSkipHash(t *testing.T) {
 			_, err = buf.Write(make([]byte, hashSize))
 			require.NoError(t, err)
 
-			// Without SkipHash, decoding must fail (checksum mismatch).
+			// A null (all-zero) trailing checksum is accepted without
+			// opting in, matching git's index.skipHash read behaviour.
 			out := &Index{}
 			d := NewDecoder(bytes.NewReader(buf.Bytes()), tc.hash.New())
 			err = d.Decode(out)
-			assert.ErrorIs(t, err, ErrInvalidChecksum)
+			require.NoError(t, err)
+			assert.Len(t, out.Entries, 1)
 
-			// With SkipHash, decoding must succeed.
+			// WithSkipHash also decodes successfully.
 			out = &Index{}
 			d = NewDecoder(bytes.NewReader(buf.Bytes()), tc.hash.New(), WithSkipHash())
 			err = d.Decode(out)

--- a/plumbing/format/index/encoder_test.go
+++ b/plumbing/format/index/encoder_test.go
@@ -262,11 +262,13 @@ func TestEncodeSkipHash(t *testing.T) {
 			checksum := raw[len(raw)-hashSize:]
 			assert.Equal(t, make([]byte, hashSize), checksum)
 
-			// A normal decoder must reject the null checksum.
+			// A normal decoder accepts the null checksum, matching git's
+			// index.skipHash read behaviour.
 			output := &Index{}
 			d := NewDecoder(bytes.NewReader(raw), tc.hash.New())
 			err = d.Decode(output)
-			assert.ErrorIs(t, err, ErrInvalidChecksum)
+			require.NoError(t, err)
+			assert.EqualExportedValues(t, idx, output)
 
 			// A skipHash decoder must accept it and recover the entries.
 			output = &Index{}


### PR DESCRIPTION
Git writes an all-zero trailing hash when `index.skipHash` is enabled (git 2.40+, also turned on by feature.manyFiles). On read, upstream git disables checksum verification when the trailing hash is empty, so an index written this way is decoded without error.

go-git only skipped verification when the caller explicitly passed `WithSkipHash`, so opening a repository whose index was written with `index.skipHash` failed with `ErrInvalidChecksum`. Detect the empty trailing hash in `readChecksum` and skip verification regardless of the option. With this changes go-git can then read an index that was generated with `index.skipHash=true`, regardless of the current value of that setting.  

This matches git's behaviour as per below which comes from the upstream refs that follows:

> we disable this check if the trailing hash is all zeroes.

Refs:
- https://lore.kernel.org/git/5fb4b5a36ac806f3ee07a614bcb93df2c430507c.1670433958.git.gitgitgadget@gmail.com/
- https://patchwork.kernel.org/project/git/patch/c8a2fd3a470e1c12a7b182854874f63ed25b9992.1670862677.git.gitgitgadget@gmail.com/


Fixes https://github.com/go-git/go-git/issues/1868.