### PR TITLE
plumbing: commitgraph, lightweight traversal Commit and upstream format conformance

### DIFF
--- a/_examples/ls/main.go
+++ b/_examples/ls/main.go
@@ -74,7 +74,11 @@ func main() {
 
 	revs, err := getLastCommitForPaths(commitNode, treePath, paths)
 	CheckIfError(err)
-	for path, rev := range revs {
+	for path, node := range revs {
+		// The commit node only carries traversal fields; load the full
+		// commit object to print its message.
+		rev, err := r.CommitObject(node.ID())
+		CheckIfError(err)
 		// Print one line per file (name hash message)
 		hash := rev.Hash.String()
 		line := strings.Split(rev.Message, "\n")
@@ -155,7 +159,7 @@ func getFileHashes(c commitgraph.CommitNode, treePath string, paths []string) (m
 	return hashes, nil
 }
 
-func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []string) (map[string]*object.Commit, error) {
+func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []string) (map[string]commitgraph.CommitNode, error) {
 	// We do a tree traversal with nodes sorted by commit time
 	heap := binaryheap.NewWith(func(a, b any) int {
 		if a.(*commitAndPaths).commit.CommitTime().Before(b.(*commitAndPaths).commit.CommitTime()) {
@@ -259,15 +263,5 @@ func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []st
 		}
 	}
 
-	// Post-processing
-	result := make(map[string]*object.Commit)
-	for path, commitNode := range resultNodes {
-		var err error
-		result[path], err = commitNode.Commit()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return result, nil
+	return resultNodes, nil
 }

--- a/plumbing/format/commitgraph/chain.go
+++ b/plumbing/format/commitgraph/chain.go
@@ -24,18 +24,25 @@ func OpenChainFile(r io.Reader) ([]string, error) {
 	chain := make([]string, 0, 8)
 	for {
 		line, err := bufRd.ReadSlice('\n')
+		// A final hash that is not newline-terminated is returned by
+		// ReadSlice together with io.EOF; process it before breaking so
+		// the last entry of such a chain file is not silently dropped.
+		if len(line) > 0 {
+			if line[len(line)-1] == '\n' {
+				line = line[:len(line)-1]
+			}
+			hashStr := string(line)
+			if !plumbing.IsHash(hashStr) {
+				return nil, ErrMalformedCommitGraphFile
+			}
+			chain = append(chain, hashStr)
+		}
 		if err != nil {
 			if err == io.EOF {
 				break
 			}
 			return nil, err
 		}
-
-		hashStr := string(line[:len(line)-1])
-		if !plumbing.IsHash(hashStr) {
-			return nil, ErrMalformedCommitGraphFile
-		}
-		chain = append(chain, hashStr)
 	}
 	return chain, nil
 }

--- a/plumbing/format/commitgraph/conformance_test.go
+++ b/plumbing/format/commitgraph/conformance_test.go
@@ -1,0 +1,27 @@
+package commitgraph_test
+
+import (
+	encbin "encoding/binary"
+
+	commitgraph "github.com/go-git/go-git/v6/plumbing/format/commitgraph"
+)
+
+// TestOpenFileIndexRejectsNonMonotonicFanout verifies the OID fanout is
+// validated to be monotonically non-decreasing. Canonical Git:
+// graph_read_oid_fanout rejects "commit-graph fanout values out of order"
+// (commit-graph.c v2.54.0).
+func (s *CommitgraphSuite) TestOpenFileIndexRejectsNonMonotonicFanout() {
+	raw, err := buildSimpleEncoded()
+	s.Require().NoError(err)
+
+	oidfOff, ok := findTOCOffset(raw, []byte("OIDF"))
+	s.Require().True(ok, "OIDF TOC entry not present")
+
+	// The single commit's OID begins with 0xaa, so fanout[0] is 0. Set it
+	// to a value greater than fanout[1] (still 0), breaking monotonicity.
+	encbin.BigEndian.PutUint32(raw[int(oidfOff):], 5)
+
+	_, err = openIndexBytes(raw)
+	s.ErrorIs(err, commitgraph.ErrMalformedCommitGraphFile,
+		"expected ErrMalformedCommitGraphFile for non-monotonic fanout")
+}

--- a/plumbing/format/commitgraph/conformance_test.go
+++ b/plumbing/format/commitgraph/conformance_test.go
@@ -27,6 +27,21 @@ func (s *CommitgraphSuite) TestOpenFileIndexRejectsNonMonotonicFanout() {
 		"expected ErrMalformedCommitGraphFile for non-monotonic fanout")
 }
 
+// TestOpenFileIndexRejectsBadBaseGraphCount verifies the header's base
+// commit-graph count (byte 7) is cross-checked against the actual chain
+// depth: a standalone file must declare zero base graphs.
+func (s *CommitgraphSuite) TestOpenFileIndexRejectsBadBaseGraphCount() {
+	raw, err := buildSimpleEncoded()
+	s.Require().NoError(err)
+
+	// raw[7] is the number-of-base-commit-graphs byte.
+	raw[7] = 1
+
+	_, err = openIndexBytes(raw)
+	s.ErrorIs(err, commitgraph.ErrMalformedCommitGraphFile,
+		"expected ErrMalformedCommitGraphFile when a standalone graph declares base graphs")
+}
+
 // TestOpenChainFileNoTrailingNewline verifies a chain file whose final
 // hash lacks a trailing newline is fully parsed (the last entry must not
 // be silently dropped), and that a normally-terminated file yields the

--- a/plumbing/format/commitgraph/conformance_test.go
+++ b/plumbing/format/commitgraph/conformance_test.go
@@ -1,9 +1,12 @@
 package commitgraph_test
 
 import (
+	"bytes"
 	encbin "encoding/binary"
 	"strings"
+	"time"
 
+	"github.com/go-git/go-git/v6/plumbing"
 	commitgraph "github.com/go-git/go-git/v6/plumbing/format/commitgraph"
 )
 
@@ -40,6 +43,53 @@ func (s *CommitgraphSuite) TestOpenFileIndexRejectsBadBaseGraphCount() {
 	_, err = openIndexBytes(raw)
 	s.ErrorIs(err, commitgraph.ErrMalformedCommitGraphFile,
 		"expected ErrMalformedCommitGraphFile when a standalone graph declares base graphs")
+}
+
+// TestEncodeDecodeSHA256 round-trips a SHA-256 commit-graph through the
+// encoder and reader, exercising the hash-version header byte, the
+// 32-byte OID widths in every chunk, and parent-hash resolution.
+func (s *CommitgraphSuite) TestEncodeDecodeSHA256() {
+	hashA := plumbing.NewHash(strings.Repeat("a", 64))
+	treeA := plumbing.NewHash(strings.Repeat("c", 64))
+	hashB := plumbing.NewHash(strings.Repeat("b", 64))
+	treeB := plumbing.NewHash(strings.Repeat("d", 64))
+	s.Require().Equal(32, hashA.Size(), "test hashes must be SHA-256 sized")
+
+	mem := commitgraph.NewMemoryIndex()
+	mem.Add(hashA, &commitgraph.CommitData{
+		TreeHash:   treeA,
+		Generation: 1,
+		When:       time.Unix(1, 0),
+	})
+	mem.Add(hashB, &commitgraph.CommitData{
+		TreeHash:     treeB,
+		ParentHashes: []plumbing.Hash{hashA},
+		Generation:   2,
+		When:         time.Unix(2, 0),
+	})
+
+	var buf bytes.Buffer
+	s.Require().NoError(commitgraph.NewEncoder(&buf).Encode(mem))
+	raw := buf.Bytes()
+	s.Equal(byte(2), raw[5], "header hash version byte should be 2 (SHA-256)")
+
+	idx, err := openIndexBytes(raw)
+	s.Require().NoError(err)
+	defer idx.Close()
+
+	bIdx, err := idx.GetIndexByHash(hashB)
+	s.Require().NoError(err)
+
+	data, err := idx.GetCommitDataByIndex(bIdx)
+	s.Require().NoError(err)
+	s.Equal(32, data.TreeHash.Size())
+	s.Equal(treeB.String(), data.TreeHash.String())
+	s.Require().Len(data.ParentHashes, 1)
+	s.Equal(hashA.String(), data.ParentHashes[0].String())
+
+	for _, h := range idx.Hashes() {
+		s.Equal(32, h.Size(), "Hashes() must return SHA-256 sized OIDs")
+	}
 }
 
 // TestOpenChainFileNoTrailingNewline verifies a chain file whose final

--- a/plumbing/format/commitgraph/conformance_test.go
+++ b/plumbing/format/commitgraph/conformance_test.go
@@ -2,6 +2,7 @@ package commitgraph_test
 
 import (
 	encbin "encoding/binary"
+	"strings"
 
 	commitgraph "github.com/go-git/go-git/v6/plumbing/format/commitgraph"
 )
@@ -24,4 +25,21 @@ func (s *CommitgraphSuite) TestOpenFileIndexRejectsNonMonotonicFanout() {
 	_, err = openIndexBytes(raw)
 	s.ErrorIs(err, commitgraph.ErrMalformedCommitGraphFile,
 		"expected ErrMalformedCommitGraphFile for non-monotonic fanout")
+}
+
+// TestOpenChainFileNoTrailingNewline verifies a chain file whose final
+// hash lacks a trailing newline is fully parsed (the last entry must not
+// be silently dropped), and that a normally-terminated file yields the
+// same result with no spurious empty entry.
+func (s *CommitgraphSuite) TestOpenChainFileNoTrailingNewline() {
+	h1 := strings.Repeat("a", 40)
+	h2 := strings.Repeat("b", 40)
+
+	chain, err := commitgraph.OpenChainFile(strings.NewReader(h1 + "\n" + h2))
+	s.Require().NoError(err)
+	s.Equal([]string{h1, h2}, chain)
+
+	chain, err = commitgraph.OpenChainFile(strings.NewReader(h1 + "\n" + h2 + "\n"))
+	s.Require().NoError(err)
+	s.Equal([]string{h1, h2}, chain)
 }

--- a/plumbing/format/commitgraph/encoder.go
+++ b/plumbing/format/commitgraph/encoder.go
@@ -13,21 +13,30 @@ import (
 // Encoder writes MemoryIndex structs to an output stream.
 type Encoder struct {
 	io.Writer
+	out  io.Writer
 	hash hash.Hash
 }
 
-// NewEncoder returns a new stream encoder that writes to w.
+// NewEncoder returns a new stream encoder that writes to w. The object
+// format defaults to SHA-1 and is upgraded to SHA-256 by Encode when the
+// index being written holds SHA-256 object IDs.
 func NewEncoder(w io.Writer) *Encoder {
-	// TODO: Support passing an ObjectFormat (sha256)
 	h := hash.New(crypto.SHA1)
-	mw := io.MultiWriter(w, h)
-	return &Encoder{mw, h}
+	return &Encoder{Writer: io.MultiWriter(w, h), out: w, hash: h}
 }
 
 // Encode writes an index into the commit-graph file
 func (e *Encoder) Encode(idx Index) error {
 	// Get all the hashes in the input index
 	hashes := idx.Hashes()
+
+	// Match the index's object format. The encoder defaults to SHA-1;
+	// switch to SHA-256 when the index holds 32-byte object IDs so the
+	// header hash version, OID widths and chunk sizes are all consistent.
+	if len(hashes) > 0 && hashes[0].Size() == crypto.SHA256.Size() {
+		e.hash = hash.New(crypto.SHA256)
+		e.Writer = io.MultiWriter(e.out, e.hash)
+	}
 
 	// Sort the input and prepare helper structures we'll need for encoding
 	hashToIndex, fanout, extraEdgesCount, generationV2OverflowCount := e.prepare(idx, hashes)

--- a/plumbing/format/commitgraph/encoder.go
+++ b/plumbing/format/commitgraph/encoder.go
@@ -14,21 +14,30 @@ import (
 // Encoder writes MemoryIndex structs to an output stream.
 type Encoder struct {
 	io.Writer
+	out  io.Writer
 	hash hash.Hash
 }
 
-// NewEncoder returns a new stream encoder that writes to w.
+// NewEncoder returns a new stream encoder that writes to w. The object
+// format defaults to SHA-1 and is upgraded to SHA-256 by Encode when the
+// index being written holds SHA-256 object IDs.
 func NewEncoder(w io.Writer) *Encoder {
-	// TODO: Support passing an ObjectFormat (sha256)
 	h := hash.New(crypto.SHA1)
-	mw := io.MultiWriter(w, h)
-	return &Encoder{mw, h}
+	return &Encoder{Writer: io.MultiWriter(w, h), out: w, hash: h}
 }
 
 // Encode writes an index into the commit-graph file
 func (e *Encoder) Encode(idx Index) error {
 	// Get all the hashes in the input index
 	hashes := idx.Hashes()
+
+	// Match the index's object format. The encoder defaults to SHA-1;
+	// switch to SHA-256 when the index holds 32-byte object IDs so the
+	// header hash version, OID widths and chunk sizes are all consistent.
+	if len(hashes) > 0 && hashes[0].Size() == crypto.SHA256.Size() {
+		e.hash = hash.New(crypto.SHA256)
+		e.Writer = io.MultiWriter(e.out, e.hash)
+	}
 
 	// Sort the input and prepare helper structures we'll need for encoding
 	hashToIndex, fanout, extraEdgesCount, generationV2OverflowCount, err := e.prepare(idx, hashes)

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/utils/binary"
 )
 
@@ -81,6 +80,14 @@ type fileIndex struct {
 	fileSize              int64
 }
 
+// newHash returns a zero hash sized for this index's object format, so
+// ReadFrom consumes objSize bytes (20 for SHA-1, 32 for SHA-256).
+func (fi *fileIndex) newHash() plumbing.Hash {
+	var h plumbing.Hash
+	h.ResetBySize(fi.objSize)
+	return h
+}
+
 // ReaderAtCloser is an interface that combines io.ReaderAt and io.Closer.
 type ReaderAtCloser interface {
 	io.ReaderAt
@@ -99,7 +106,7 @@ func OpenFileIndexWithParent(reader ReaderAtCloser, parent Index) (Index, error)
 	if reader == nil {
 		return nil, io.ErrUnexpectedEOF
 	}
-	fi := &fileIndex{reader: reader, parent: parent, objSize: config.SHA1Size}
+	fi := &fileIndex{reader: reader, parent: parent}
 
 	if err := fi.verifyFileHeader(); err != nil {
 		return nil, err
@@ -176,9 +183,14 @@ func (fi *fileIndex) verifyFileHeader() error {
 	if header[0] != 1 {
 		return ErrUnsupportedVersion
 	}
-	if (fi.objSize != crypto.SHA1.Size() || header[1] != 1) &&
-		(fi.objSize != crypto.SHA256.Size() || header[1] != 2) {
-		// Unknown hash type / unsupported hash type
+	// header[1] is the hash version: 1 == SHA-1, 2 == SHA-256. It
+	// determines the on-disk OID width used by every subsequent read.
+	switch header[1] {
+	case 1:
+		fi.objSize = crypto.SHA1.Size()
+	case 2:
+		fi.objSize = crypto.SHA256.Size()
+	default:
 		return ErrUnsupportedHash
 	}
 	fi.numChunks = header[2]
@@ -424,7 +436,7 @@ func (fi *fileIndex) readFanout() error {
 
 // GetIndexByHash looks up the provided hash in the commit-graph fanout and returns the index of the commit data for the given hash.
 func (fi *fileIndex) GetIndexByHash(h plumbing.Hash) (uint32, error) {
-	var oid plumbing.Hash
+	oid := fi.newHash()
 
 	// Find the hash in the oid lookup table
 	var low uint32
@@ -483,8 +495,7 @@ func (fi *fileIndex) GetCommitDataByIndex(idx uint32) (*CommitData, error) {
 	offset := fi.offsets[CommitDataChunk] + int64(idx)*int64(fi.objSize+szCommitData)
 	commitDataReader := io.NewSectionReader(fi.reader, offset, int64(fi.objSize+szCommitData))
 
-	// TODO: Add support for SHA256
-	var treeHash plumbing.Hash
+	treeHash := fi.newHash()
 	_, err := treeHash.ReadFrom(commitDataReader)
 	if err != nil {
 		return nil, err
@@ -609,8 +620,9 @@ func (fi *fileIndex) GetHashByIndex(idx uint32) (found plumbing.Hash, err error)
 		return found, ErrMalformedCommitGraphFile
 	}
 
+	found = fi.newHash()
 	offset := fi.offsets[OIDLookupChunk] + int64(idx)*int64(fi.objSize)
-	if _, err := found.ReadFrom(io.NewSectionReader(fi.reader, offset, int64(found.Size()))); err != nil {
+	if _, err := found.ReadFrom(io.NewSectionReader(fi.reader, offset, int64(fi.objSize))); err != nil {
 		return found, err
 	}
 
@@ -639,8 +651,9 @@ func (fi *fileIndex) getHashesFromIndexes(indexes []uint32) ([]plumbing.Hash, er
 			return nil, ErrMalformedCommitGraphFile
 		}
 
+		hashes[i] = fi.newHash()
 		offset := fi.offsets[OIDLookupChunk] + int64(idx)*int64(fi.objSize)
-		if _, err := hashes[i].ReadFrom(io.NewSectionReader(fi.reader, offset, int64(hashes[i].Size()))); err != nil {
+		if _, err := hashes[i].ReadFrom(io.NewSectionReader(fi.reader, offset, int64(fi.objSize))); err != nil {
 			return nil, err
 		}
 	}
@@ -661,9 +674,10 @@ func (fi *fileIndex) Hashes() []plumbing.Hash {
 
 	for i := uint32(0); i < fi.fanout[0xff]; i++ {
 		h := &hashes[i+fi.minimumNumberOfHashes]
-		offset := fi.offsets[OIDLookupChunk] + int64(i)*int64(h.Size())
-		n, err := h.ReadFrom(io.NewSectionReader(fi.reader, offset, int64(h.Size())))
-		if err != nil || n < int64(h.Size()) {
+		*h = fi.newHash()
+		offset := fi.offsets[OIDLookupChunk] + int64(i)*int64(fi.objSize)
+		n, err := h.ReadFrom(io.NewSectionReader(fi.reader, offset, int64(fi.objSize)))
+		if err != nil || n < int64(fi.objSize) {
 			return nil
 		}
 	}

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -389,6 +389,15 @@ func (fi *fileIndex) readFanout() error {
 		if fanoutValue > 0x7fffffff {
 			return ErrMalformedCommitGraphFile
 		}
+		// The fanout is cumulative, so it must be monotonically
+		// non-decreasing. Canonical Git rejects an out-of-order fanout in
+		// graph_read_oid_fanout (commit-graph.c v2.54.0, "commit-graph
+		// fanout values out of order"); mirror that, both to reject
+		// corrupt files and to keep GetIndexByHash's binary search bound
+		// (high = fanout[b]) within the OID lookup chunk.
+		if i > 0 && fanoutValue < fi.fanout[i-1] {
+			return ErrMalformedCommitGraphFile
+		}
 		fi.fanout[i] = fanoutValue
 	}
 	return nil

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -77,6 +77,7 @@ type fileIndex struct {
 	minimumNumberOfHashes uint32
 	objSize               int
 	numChunks             uint8
+	numBaseGraphs         uint8
 	fileSize              int64
 }
 
@@ -102,6 +103,20 @@ func OpenFileIndexWithParent(reader ReaderAtCloser, parent Index) (Index, error)
 
 	if err := fi.verifyFileHeader(); err != nil {
 		return nil, err
+	}
+	// The base-graph count in the header must match the actual chain
+	// depth: zero for a standalone graph, parent-depth+1 within a chain.
+	// Canonical Git cross-checks this when loading a split commit-graph.
+	expectedBaseGraphs := 0
+	if p, ok := parent.(*fileIndex); ok {
+		expectedBaseGraphs = int(p.numBaseGraphs) + 1
+	} else if parent != nil {
+		// Non-fileIndex parent (exotic caller): chain depth is unknown,
+		// so accept whatever the header declares.
+		expectedBaseGraphs = int(fi.numBaseGraphs)
+	}
+	if int(fi.numBaseGraphs) != expectedBaseGraphs {
+		return nil, ErrMalformedCommitGraphFile
 	}
 	if err := fi.verifyFileSize(); err != nil {
 		return nil, err
@@ -167,6 +182,10 @@ func (fi *fileIndex) verifyFileHeader() error {
 		return ErrUnsupportedHash
 	}
 	fi.numChunks = header[2]
+	// header[3] is the number of base commit-graphs (the chain depth
+	// below this file); validated against the actual parent chain in
+	// OpenFileIndexWithParent.
+	fi.numBaseGraphs = header[3]
 
 	return nil
 }

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/utils/binary"
 )
 
@@ -85,6 +84,14 @@ type fileIndex struct {
 	fileSize              int64
 }
 
+// newHash returns a zero hash sized for this index's object format, so
+// ReadFrom consumes objSize bytes (20 for SHA-1, 32 for SHA-256).
+func (fi *fileIndex) newHash() plumbing.Hash {
+	var h plumbing.Hash
+	h.ResetBySize(fi.objSize)
+	return h
+}
+
 // ReaderAtCloser is an interface that combines io.ReaderAt and io.Closer.
 type ReaderAtCloser interface {
 	io.ReaderAt
@@ -103,7 +110,7 @@ func OpenFileIndexWithParent(reader ReaderAtCloser, parent Index) (Index, error)
 	if reader == nil {
 		return nil, io.ErrUnexpectedEOF
 	}
-	fi := &fileIndex{reader: reader, parent: parent, objSize: config.SHA1Size}
+	fi := &fileIndex{reader: reader, parent: parent}
 
 	if err := fi.verifyFileHeader(); err != nil {
 		return nil, err
@@ -180,9 +187,14 @@ func (fi *fileIndex) verifyFileHeader() error {
 	if header[0] != 1 {
 		return ErrUnsupportedVersion
 	}
-	if (fi.objSize != crypto.SHA1.Size() || header[1] != 1) &&
-		(fi.objSize != crypto.SHA256.Size() || header[1] != 2) {
-		// Unknown hash type / unsupported hash type
+	// header[1] is the hash version: 1 == SHA-1, 2 == SHA-256. It
+	// determines the on-disk OID width used by every subsequent read.
+	switch header[1] {
+	case 1:
+		fi.objSize = crypto.SHA1.Size()
+	case 2:
+		fi.objSize = crypto.SHA256.Size()
+	default:
 		return ErrUnsupportedHash
 	}
 	fi.numChunks = header[2]
@@ -428,7 +440,7 @@ func (fi *fileIndex) readFanout() error {
 
 // GetIndexByHash looks up the provided hash in the commit-graph fanout and returns the index of the commit data for the given hash.
 func (fi *fileIndex) GetIndexByHash(h plumbing.Hash) (uint32, error) {
-	var oid plumbing.Hash
+	oid := fi.newHash()
 
 	// Find the hash in the oid lookup table
 	var low uint32
@@ -487,8 +499,7 @@ func (fi *fileIndex) GetCommitDataByIndex(idx uint32) (*CommitData, error) {
 	offset := fi.offsets[CommitDataChunk] + int64(idx)*int64(fi.objSize+szCommitData)
 	commitDataReader := io.NewSectionReader(fi.reader, offset, int64(fi.objSize+szCommitData))
 
-	// TODO: Add support for SHA256
-	var treeHash plumbing.Hash
+	treeHash := fi.newHash()
 	_, err := treeHash.ReadFrom(commitDataReader)
 	if err != nil {
 		return nil, err
@@ -613,8 +624,9 @@ func (fi *fileIndex) GetHashByIndex(idx uint32) (found plumbing.Hash, err error)
 		return found, ErrMalformedCommitGraphFile
 	}
 
+	found = fi.newHash()
 	offset := fi.offsets[OIDLookupChunk] + int64(idx)*int64(fi.objSize)
-	if _, err := found.ReadFrom(io.NewSectionReader(fi.reader, offset, int64(found.Size()))); err != nil {
+	if _, err := found.ReadFrom(io.NewSectionReader(fi.reader, offset, int64(fi.objSize))); err != nil {
 		return found, err
 	}
 
@@ -643,8 +655,9 @@ func (fi *fileIndex) getHashesFromIndexes(indexes []uint32) ([]plumbing.Hash, er
 			return nil, ErrMalformedCommitGraphFile
 		}
 
+		hashes[i] = fi.newHash()
 		offset := fi.offsets[OIDLookupChunk] + int64(idx)*int64(fi.objSize)
-		if _, err := hashes[i].ReadFrom(io.NewSectionReader(fi.reader, offset, int64(hashes[i].Size()))); err != nil {
+		if _, err := hashes[i].ReadFrom(io.NewSectionReader(fi.reader, offset, int64(fi.objSize))); err != nil {
 			return nil, err
 		}
 	}
@@ -665,9 +678,10 @@ func (fi *fileIndex) Hashes() []plumbing.Hash {
 
 	for i := uint32(0); i < fi.fanout[0xff]; i++ {
 		h := &hashes[i+fi.minimumNumberOfHashes]
-		offset := fi.offsets[OIDLookupChunk] + int64(i)*int64(h.Size())
-		n, err := h.ReadFrom(io.NewSectionReader(fi.reader, offset, int64(h.Size())))
-		if err != nil || n < int64(h.Size()) {
+		*h = fi.newHash()
+		offset := fi.offsets[OIDLookupChunk] + int64(i)*int64(fi.objSize)
+		n, err := h.ReadFrom(io.NewSectionReader(fi.reader, offset, int64(fi.objSize)))
+		if err != nil || n < int64(fi.objSize) {
 			return nil
 		}
 	}

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -81,6 +81,7 @@ type fileIndex struct {
 	minimumNumberOfHashes uint32
 	objSize               int
 	numChunks             uint8
+	numBaseGraphs         uint8
 	fileSize              int64
 }
 
@@ -106,6 +107,20 @@ func OpenFileIndexWithParent(reader ReaderAtCloser, parent Index) (Index, error)
 
 	if err := fi.verifyFileHeader(); err != nil {
 		return nil, err
+	}
+	// The base-graph count in the header must match the actual chain
+	// depth: zero for a standalone graph, parent-depth+1 within a chain.
+	// Canonical Git cross-checks this when loading a split commit-graph.
+	expectedBaseGraphs := 0
+	if p, ok := parent.(*fileIndex); ok {
+		expectedBaseGraphs = int(p.numBaseGraphs) + 1
+	} else if parent != nil {
+		// Non-fileIndex parent (exotic caller): chain depth is unknown,
+		// so accept whatever the header declares.
+		expectedBaseGraphs = int(fi.numBaseGraphs)
+	}
+	if int(fi.numBaseGraphs) != expectedBaseGraphs {
+		return nil, ErrMalformedCommitGraphFile
 	}
 	if err := fi.verifyFileSize(); err != nil {
 		return nil, err
@@ -171,6 +186,10 @@ func (fi *fileIndex) verifyFileHeader() error {
 		return ErrUnsupportedHash
 	}
 	fi.numChunks = header[2]
+	// header[3] is the number of base commit-graphs (the chain depth
+	// below this file); validated against the actual parent chain in
+	// OpenFileIndexWithParent.
+	fi.numBaseGraphs = header[3]
 
 	return nil
 }

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -393,6 +393,15 @@ func (fi *fileIndex) readFanout() error {
 		if fanoutValue > 0x7fffffff {
 			return ErrMalformedCommitGraphFile
 		}
+		// The fanout is cumulative, so it must be monotonically
+		// non-decreasing. Canonical Git rejects an out-of-order fanout in
+		// graph_read_oid_fanout (commit-graph.c v2.54.0, "commit-graph
+		// fanout values out of order"); mirror that, both to reject
+		// corrupt files and to keep GetIndexByHash's binary search bound
+		// (high = fanout[b]) within the OID lookup chunk.
+		if i > 0 && fanoutValue < fi.fanout[i-1] {
+			return ErrMalformedCommitGraphFile
+		}
 		fi.fanout[i] = fanoutValue
 	}
 	return nil

--- a/plumbing/object/commitgraph/commit.go
+++ b/plumbing/object/commitgraph/commit.go
@@ -1,0 +1,335 @@
+package commitgraph
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+	gogitsync "github.com/go-git/go-git/v6/utils/sync"
+)
+
+var fixedZones sync.Map // int seconds east of UTC -> *time.Location
+
+// Commit holds the base traversal fields parsed from an encoded commit object.
+// It is a lightweight stand-in for object.Commit, carrying only what commit
+// graph walking needs: tree, parents, and the committer/author timestamps.
+// It is intended to be treated as a read-only value after decode.
+type Commit struct {
+	id           plumbing.Hash
+	treeHash     plumbing.Hash
+	parentHashes []plumbing.Hash
+	when         time.Time
+	authorWhen   time.Time
+}
+
+// ID returns the hash of the commit object.
+func (c *Commit) ID() plumbing.Hash { return c.id }
+
+// Tree returns the hash of the tree referenced by the commit.
+func (c *Commit) Tree() plumbing.Hash { return c.treeHash }
+
+// Parents returns the hashes of the commit's parents.
+func (c *Commit) Parents() []plumbing.Hash { return c.parentHashes }
+
+// When returns the committer timestamp.
+func (c *Commit) When() time.Time { return c.when }
+
+// AuthorWhen returns the author timestamp.
+func (c *Commit) AuthorWhen() time.Time { return c.authorWhen }
+
+// DecodeCommit parses the base traversal fields from an encoded commit object.
+// It reads only up to and including the committer header, which in canonical
+// git commit order precedes any gpgsig/mergetag/extra headers and the message
+// body, so those are never parsed.
+func DecodeCommit(obj plumbing.EncodedObject) (c *Commit, err error) {
+	if obj.Type() != plumbing.CommitObject {
+		return nil, object.ErrUnsupportedObject
+	}
+
+	reader, err := obj.Reader()
+	if err != nil {
+		return nil, fmt.Errorf("open commit reader: %w", err)
+	}
+	defer ioutil.CheckClose(reader, &err)
+
+	c = &Commit{id: obj.Hash()}
+	if err = c.decode(reader); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *Commit) decode(reader io.Reader) error {
+	br := gogitsync.GetBufioReader(reader)
+	defer gogitsync.PutBufioReader(br)
+
+	s := &commitScanner{r: br, commit: c}
+	for state := scanCommitTree; state != nil; {
+		state = state(s)
+	}
+	if s.err != nil {
+		return s.err
+	}
+	if !s.sawTree {
+		return errors.New("malformed commit: missing tree header")
+	}
+	return nil
+}
+
+type commitScanner struct {
+	r       *bufio.Reader
+	commit  *Commit
+	pending []byte
+	err     error
+
+	sawTree bool
+}
+
+type commitState func(*commitScanner) commitState
+
+// readLine returns the next line from the input. atEnd is true when EOF was
+// reached (the returned line may still contain trailing unterminated bytes).
+// Real I/O errors are recorded on the scanner and surfaced via decode's return.
+func (s *commitScanner) readLine() (line []byte, atEnd bool) {
+	if s.pending != nil {
+		line = s.pending
+		s.pending = nil
+		return line, false
+	}
+	line, err := s.r.ReadBytes('\n')
+	switch {
+	case errors.Is(err, io.EOF):
+		return line, true
+	case err != nil:
+		s.err = fmt.Errorf("read commit line: %w", err)
+		return nil, true
+	}
+	return line, false
+}
+
+func (s *commitScanner) pushBack(line []byte) {
+	s.pending = line
+}
+
+func (s *commitScanner) fail(err error) commitState {
+	s.err = err
+	return nil
+}
+
+func scanCommitTree(s *commitScanner) commitState {
+	line, atEnd := s.readLine()
+	if s.err != nil {
+		return nil
+	}
+	if len(line) == 0 || isBlankLine(line) {
+		return s.fail(errors.New("malformed commit: missing tree header"))
+	}
+	key, data := splitHeader(line)
+	if key != "tree" {
+		return s.fail(errors.New("malformed commit: tree header must be first"))
+	}
+	h, ok := hashFromHex(data)
+	if !ok {
+		return s.fail(errors.New("invalid tree hash"))
+	}
+	s.commit.treeHash = h
+	s.sawTree = true
+	if atEnd {
+		return nil
+	}
+	return scanCommitParents
+}
+
+func scanCommitParents(s *commitScanner) commitState {
+	line, atEnd := s.readLine()
+	if s.err != nil {
+		return nil
+	}
+	if len(line) == 0 || isBlankLine(line) {
+		return nil
+	}
+	key, data := splitHeader(line)
+	if key == "parent" {
+		h, ok := hashFromHex(data)
+		if !ok {
+			return s.fail(errors.New("invalid parent hash"))
+		}
+		s.commit.parentHashes = append(s.commit.parentHashes, h)
+		if atEnd {
+			return nil
+		}
+		return scanCommitParents
+	}
+	s.pushBack(line)
+	return scanCommitAuthor
+}
+
+func scanCommitAuthor(s *commitScanner) commitState {
+	line, atEnd := s.readLine()
+	if s.err != nil {
+		return nil
+	}
+	if len(line) == 0 || isBlankLine(line) {
+		return nil
+	}
+	key, data := splitHeader(line)
+	if key == "author" {
+		w, ok := parseWhen(data)
+		if !ok {
+			return s.fail(errors.New("invalid author line"))
+		}
+		s.commit.authorWhen = w
+		if atEnd {
+			return nil
+		}
+		return scanCommitCommitter
+	}
+	s.pushBack(line)
+	return scanCommitCommitter
+}
+
+func scanCommitCommitter(s *commitScanner) commitState {
+	line, _ := s.readLine()
+	if s.err != nil {
+		return nil
+	}
+	if len(line) == 0 || isBlankLine(line) {
+		return nil
+	}
+	key, data := splitHeader(line)
+	if key == "committer" {
+		w, ok := parseWhen(data)
+		if !ok {
+			return s.fail(errors.New("invalid committer line"))
+		}
+		s.commit.when = w
+	}
+	return nil
+}
+
+func isBlankLine(line []byte) bool {
+	return len(line) == 1 && line[0] == '\n'
+}
+
+func splitHeader(line []byte) (string, []byte) {
+	trimmed := bytes.TrimRight(line, "\n")
+	key, value, ok := bytes.Cut(trimmed, []byte{' '})
+	if !ok {
+		return string(trimmed), nil
+	}
+	return string(key), value
+}
+
+// parseWhen extracts the timestamp and timezone from a git signature line.
+func parseWhen(in []byte) (time.Time, bool) {
+	closeBracket := bytes.LastIndexByte(in, '>')
+	if closeBracket < 0 || closeBracket+2 >= len(in) {
+		return time.Time{}, false
+	}
+	tail := in[closeBracket+2:]
+	space := bytes.IndexByte(tail, ' ')
+	if space < 0 {
+		space = len(tail)
+	}
+	ts, ok := parseIntBytes(tail[:space])
+	if !ok {
+		return time.Time{}, false
+	}
+	when := time.Unix(ts, 0).UTC()
+
+	tzStart := space + 1
+	if tzStart+5 > len(tail) {
+		return when, true
+	}
+	offset, ok := parseTimezoneOffset(tail[tzStart : tzStart+5])
+	if !ok {
+		return when, true
+	}
+	return when.In(fixedZone(offset)), true
+}
+
+func parseIntBytes(in []byte) (int64, bool) {
+	if len(in) == 0 {
+		return 0, false
+	}
+	neg := false
+	if in[0] == '-' {
+		neg = true
+		in = in[1:]
+		if len(in) == 0 {
+			return 0, false
+		}
+	}
+	var n int64
+	for _, b := range in {
+		if b < '0' || b > '9' {
+			return 0, false
+		}
+		n = n*10 + int64(b-'0')
+	}
+	if neg {
+		n = -n
+	}
+	return n, true
+}
+
+func parseTimezoneOffset(in []byte) (int, bool) {
+	if len(in) != 5 {
+		return 0, false
+	}
+	sign := 1
+	switch in[0] {
+	case '-':
+		sign = -1
+	case '+':
+	default:
+		return 0, false
+	}
+	hours, ok := parseTwoDigits(in[1], in[2])
+	if !ok {
+		return 0, false
+	}
+	mins, ok := parseTwoDigits(in[3], in[4])
+	if !ok {
+		return 0, false
+	}
+	return sign * ((hours * 60 * 60) + (mins * 60)), true
+}
+
+func parseTwoDigits(a, b byte) (int, bool) {
+	if a < '0' || a > '9' || b < '0' || b > '9' {
+		return 0, false
+	}
+	return int(a-'0')*10 + int(b-'0'), true
+}
+
+func fixedZone(offset int) *time.Location {
+	if z, ok := fixedZones.Load(offset); ok {
+		location, ok := z.(*time.Location)
+		if !ok {
+			return time.FixedZone("", offset)
+		}
+		return location
+	}
+	z := time.FixedZone("", offset)
+	actual, _ := fixedZones.LoadOrStore(offset, z)
+	location, ok := actual.(*time.Location)
+	if !ok {
+		return z
+	}
+	return location
+}
+
+func hashFromHex(in []byte) (plumbing.Hash, bool) {
+	if len(in) != 40 && len(in) != 64 {
+		return plumbing.ZeroHash, false
+	}
+	return plumbing.FromHex(string(in))
+}

--- a/plumbing/object/commitgraph/commit.go
+++ b/plumbing/object/commitgraph/commit.go
@@ -3,6 +3,7 @@ package commitgraph
 import (
 	"bufio"
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -103,10 +104,24 @@ func (s *commitScanner) readLine() (line []byte, atEnd bool) {
 		s.pending = nil
 		return line, false
 	}
-	line, err := s.r.ReadBytes('\n')
+	line, err := s.r.ReadSlice('\n')
 	switch {
 	case errors.Is(err, io.EOF):
 		return line, true
+	case errors.Is(err, bufio.ErrBufferFull):
+		// Line longer than the bufio buffer: fall back to a copy so the
+		// full line is still returned. Rare for commit headers.
+		buf := append([]byte(nil), line...)
+		rest, rerr := s.r.ReadBytes('\n')
+		buf = append(buf, rest...)
+		switch {
+		case errors.Is(rerr, io.EOF):
+			return buf, true
+		case rerr != nil:
+			s.err = fmt.Errorf("read commit line: %w", rerr)
+			return nil, true
+		}
+		return buf, false
 	case err != nil:
 		s.err = fmt.Errorf("read commit line: %w", err)
 		return nil, true
@@ -132,7 +147,7 @@ func scanCommitTree(s *commitScanner) commitState {
 		return s.fail(errors.New("malformed commit: missing tree header"))
 	}
 	key, data := splitHeader(line)
-	if key != "tree" {
+	if string(key) != "tree" {
 		return s.fail(errors.New("malformed commit: tree header must be first"))
 	}
 	h, ok := hashFromHex(data)
@@ -156,7 +171,7 @@ func scanCommitParents(s *commitScanner) commitState {
 		return nil
 	}
 	key, data := splitHeader(line)
-	if key == "parent" {
+	if string(key) == "parent" {
 		h, ok := hashFromHex(data)
 		if !ok {
 			return s.fail(errors.New("invalid parent hash"))
@@ -180,7 +195,7 @@ func scanCommitAuthor(s *commitScanner) commitState {
 		return nil
 	}
 	key, data := splitHeader(line)
-	if key == "author" {
+	if string(key) == "author" {
 		w, ok := parseWhen(data)
 		if !ok {
 			return s.fail(errors.New("invalid author line"))
@@ -204,7 +219,7 @@ func scanCommitCommitter(s *commitScanner) commitState {
 		return nil
 	}
 	key, data := splitHeader(line)
-	if key == "committer" {
+	if string(key) == "committer" {
 		w, ok := parseWhen(data)
 		if !ok {
 			return s.fail(errors.New("invalid committer line"))
@@ -218,13 +233,13 @@ func isBlankLine(line []byte) bool {
 	return len(line) == 1 && line[0] == '\n'
 }
 
-func splitHeader(line []byte) (string, []byte) {
+func splitHeader(line []byte) (key, value []byte) {
 	trimmed := bytes.TrimRight(line, "\n")
-	key, value, ok := bytes.Cut(trimmed, []byte{' '})
+	k, v, ok := bytes.Cut(trimmed, []byte{' '})
 	if !ok {
-		return string(trimmed), nil
+		return trimmed, nil
 	}
-	return string(key), value
+	return k, v
 }
 
 // parseWhen extracts the timestamp and timezone from a git signature line.
@@ -328,8 +343,18 @@ func fixedZone(offset int) *time.Location {
 }
 
 func hashFromHex(in []byte) (plumbing.Hash, bool) {
-	if len(in) != 40 && len(in) != 64 {
+	var raw [32]byte
+	var n int
+	switch len(in) {
+	case 40:
+		n = 20
+	case 64:
+		n = 32
+	default:
 		return plumbing.ZeroHash, false
 	}
-	return plumbing.FromHex(string(in))
+	if _, err := hex.Decode(raw[:n], in); err != nil {
+		return plumbing.ZeroHash, false
+	}
+	return plumbing.FromBytes(raw[:n])
 }

--- a/plumbing/object/commitgraph/commit.go
+++ b/plumbing/object/commitgraph/commit.go
@@ -18,6 +18,15 @@ import (
 
 var fixedZones sync.Map // int seconds east of UTC -> *time.Location
 
+// Header keys are kept as byte slices so the scanner can compare them
+// without converting each scanned line to a string.
+var (
+	headerTree      = []byte("tree")
+	headerParent    = []byte("parent")
+	headerAuthor    = []byte("author")
+	headerCommitter = []byte("committer")
+)
+
 // Commit holds the base traversal fields parsed from an encoded commit object.
 // It is a lightweight stand-in for object.Commit, carrying only what commit
 // graph walking needs: tree, parents, and the committer/author timestamps.
@@ -147,7 +156,7 @@ func scanCommitTree(s *commitScanner) commitState {
 		return s.fail(errors.New("malformed commit: missing tree header"))
 	}
 	key, data := splitHeader(line)
-	if string(key) != "tree" {
+	if !bytes.Equal(key, headerTree) {
 		return s.fail(errors.New("malformed commit: tree header must be first"))
 	}
 	h, ok := hashFromHex(data)
@@ -171,7 +180,7 @@ func scanCommitParents(s *commitScanner) commitState {
 		return nil
 	}
 	key, data := splitHeader(line)
-	if string(key) == "parent" {
+	if bytes.Equal(key, headerParent) {
 		h, ok := hashFromHex(data)
 		if !ok {
 			return s.fail(errors.New("invalid parent hash"))
@@ -195,7 +204,7 @@ func scanCommitAuthor(s *commitScanner) commitState {
 		return nil
 	}
 	key, data := splitHeader(line)
-	if string(key) == "author" {
+	if bytes.Equal(key, headerAuthor) {
 		w, ok := parseWhen(data)
 		if !ok {
 			return s.fail(errors.New("invalid author line"))
@@ -219,7 +228,7 @@ func scanCommitCommitter(s *commitScanner) commitState {
 		return nil
 	}
 	key, data := splitHeader(line)
-	if string(key) == "committer" {
+	if bytes.Equal(key, headerCommitter) {
 		w, ok := parseWhen(data)
 		if !ok {
 			return s.fail(errors.New("invalid committer line"))

--- a/plumbing/object/commitgraph/commit_test.go
+++ b/plumbing/object/commitgraph/commit_test.go
@@ -1,0 +1,123 @@
+package commitgraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+func encodedCommit(t *testing.T, content string) plumbing.EncodedObject {
+	t.Helper()
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.CommitObject)
+	if _, err := obj.Write([]byte(content)); err != nil {
+		t.Fatalf("write commit content: %v", err)
+	}
+	return obj
+}
+
+const (
+	treeHex    = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	parent1Hex = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	parent2Hex = "cccccccccccccccccccccccccccccccccccccccc"
+)
+
+func TestDecodeCommitBaseFields(t *testing.T) {
+	t.Parallel()
+
+	content := "tree " + treeHex + "\n" +
+		"parent " + parent1Hex + "\n" +
+		"parent " + parent2Hex + "\n" +
+		"author Alice <alice@example.com> 1136239445 +0100\n" +
+		"committer Bob <bob@example.com> 1136300000 -0500\n" +
+		"\n" +
+		"commit message body\n"
+
+	obj := encodedCommit(t, content)
+	c, err := DecodeCommit(obj)
+	require.NoError(t, err)
+
+	require.Equal(t, obj.Hash(), c.ID())
+	require.Equal(t, plumbing.NewHash(treeHex), c.Tree())
+	require.Equal(t, []plumbing.Hash{
+		plumbing.NewHash(parent1Hex),
+		plumbing.NewHash(parent2Hex),
+	}, c.Parents())
+
+	require.Equal(t, int64(1136300000), c.When().Unix())
+	_, committerOffset := c.When().Zone()
+	require.Equal(t, -5*60*60, committerOffset)
+
+	require.Equal(t, int64(1136239445), c.AuthorWhen().Unix())
+	_, authorOffset := c.AuthorWhen().Zone()
+	require.Equal(t, 1*60*60, authorOffset)
+}
+
+func TestDecodeCommitRootCommit(t *testing.T) {
+	t.Parallel()
+
+	content := "tree " + treeHex + "\n" +
+		"author Alice <alice@example.com> 1136239445 +0000\n" +
+		"committer Bob <bob@example.com> 1136300000 +0000\n" +
+		"\n" +
+		"root\n"
+
+	c, err := DecodeCommit(encodedCommit(t, content))
+	require.NoError(t, err)
+
+	require.Equal(t, plumbing.NewHash(treeHex), c.Tree())
+	require.Empty(t, c.Parents())
+	require.Equal(t, int64(1136300000), c.When().Unix())
+	require.Equal(t, int64(1136239445), c.AuthorWhen().Unix())
+}
+
+func TestDecodeCommitIgnoresTrailingHeadersAndBody(t *testing.T) {
+	t.Parallel()
+
+	content := "tree " + treeHex + "\n" +
+		"parent " + parent1Hex + "\n" +
+		"author Alice <alice@example.com> 1136239445 +0000\n" +
+		"committer Bob <bob@example.com> 1136300000 +0000\n" +
+		"gpgsig -----BEGIN PGP SIGNATURE-----\n" +
+		" \n" +
+		" iQEcBAABCAAGBQJ...\n" +
+		" -----END PGP SIGNATURE-----\n" +
+		"mergetag object dddddddddddddddddddddddddddddddddddddddd\n" +
+		" type commit\n" +
+		" tag v1\n" +
+		"custom-header some value\n" +
+		"\n" +
+		"message body that must never be parsed\n"
+
+	c, err := DecodeCommit(encodedCommit(t, content))
+	require.NoError(t, err)
+
+	require.Equal(t, plumbing.NewHash(treeHex), c.Tree())
+	require.Equal(t, []plumbing.Hash{plumbing.NewHash(parent1Hex)}, c.Parents())
+	require.Equal(t, int64(1136300000), c.When().Unix())
+	require.Equal(t, int64(1136239445), c.AuthorWhen().Unix())
+}
+
+func TestDecodeCommitRejectsNonCommit(t *testing.T) {
+	t.Parallel()
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.BlobObject)
+	_, _ = obj.Write([]byte("not a commit"))
+
+	_, err := DecodeCommit(obj)
+	require.ErrorIs(t, err, object.ErrUnsupportedObject)
+}
+
+func TestDecodeCommitMissingTree(t *testing.T) {
+	t.Parallel()
+
+	content := "author Alice <alice@example.com> 1136239445 +0000\n" +
+		"committer Bob <bob@example.com> 1136300000 +0000\n"
+
+	_, err := DecodeCommit(encodedCommit(t, content))
+	require.Error(t, err)
+}

--- a/plumbing/object/commitgraph/commit_test.go
+++ b/plumbing/object/commitgraph/commit_test.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -120,4 +121,39 @@ func TestDecodeCommitMissingTree(t *testing.T) {
 
 	_, err := DecodeCommit(encodedCommit(t, content))
 	require.Error(t, err)
+}
+
+func TestDecodeCommitInvalidTreeHash(t *testing.T) {
+	t.Parallel()
+
+	content := "tree zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz\n" +
+		"author Alice <alice@example.com> 1136239445 +0000\n" +
+		"committer Bob <bob@example.com> 1136300000 +0000\n"
+
+	_, err := DecodeCommit(encodedCommit(t, content))
+	require.Error(t, err)
+}
+
+func TestDecodeCommitLongHeaderLines(t *testing.T) {
+	t.Parallel()
+
+	// Names longer than the bufio buffer (4096 bytes) force the line reader
+	// past a single buffered slice; the base fields must still decode.
+	longName := strings.Repeat("a", 9000)
+	content := "tree " + treeHex + "\n" +
+		"parent " + parent1Hex + "\n" +
+		"author " + longName + " <a@example.com> 1136239445 +0100\n" +
+		"committer " + longName + " <b@example.com> 1136300000 -0500\n" +
+		"\n" +
+		"body\n"
+
+	c, err := DecodeCommit(encodedCommit(t, content))
+	require.NoError(t, err)
+
+	require.Equal(t, plumbing.NewHash(treeHex), c.Tree())
+	require.Equal(t, []plumbing.Hash{plumbing.NewHash(parent1Hex)}, c.Parents())
+	require.Equal(t, int64(1136300000), c.When().Unix())
+	_, committerOffset := c.When().Zone()
+	require.Equal(t, -5*60*60, committerOffset)
+	require.Equal(t, int64(1136239445), c.AuthorWhen().Unix())
 }

--- a/plumbing/object/commitgraph/commitnode.go
+++ b/plumbing/object/commitgraph/commitnode.go
@@ -34,8 +34,8 @@ type CommitNode interface {
 	// It combines the contents of the GDA2 and GDO2 sections of the commit-graph
 	// with the commit time portion of the CDAT section.
 	GenerationV2() uint64
-	// Commit returns the full commit object from the node
-	Commit() (*object.Commit, error)
+	// Commit returns the commit traversal fields from the node
+	Commit() (*Commit, error)
 }
 
 // CommitNodeIndex is generic interface encapsulating an index of CommitNode objects

--- a/plumbing/object/commitgraph/commitnode_bench_test.go
+++ b/plumbing/object/commitgraph/commitnode_bench_test.go
@@ -1,0 +1,117 @@
+package commitgraph
+
+import (
+	"path"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	commitgraphfmt "github.com/go-git/go-git/v6/plumbing/format/commitgraph"
+)
+
+var benchHead = plumbing.NewHash("b9d69064b190e7aedccf84731ca1d917871f8a1c")
+
+func benchObjectIndex(b *testing.B) (CommitNodeIndex, func()) {
+	b.Helper()
+	f := fixtures.ByTag("commit-graph").One()
+	storer := unpackRepository(f)
+	return NewObjectCommitNodeIndex(storer), func() { _ = storer.Close() }
+}
+
+func benchGraphIndex(b *testing.B) (CommitNodeIndex, func()) {
+	b.Helper()
+	f := fixtures.ByTag("commit-graph").One()
+	storer := unpackRepository(f)
+	reader, err := storer.Filesystem().Open(path.Join("objects", "info", "commit-graph"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	index, err := commitgraphfmt.OpenFileIndex(reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return NewGraphCommitNodeIndex(index, storer), func() {
+		_ = index.Close()
+		_ = reader.Close()
+		_ = storer.Close()
+	}
+}
+
+func drain(b *testing.B, iter CommitNodeIter) {
+	b.Helper()
+	n := 0
+	err := iter.ForEach(func(c CommitNode) error {
+		n += len(c.ID().String())
+		return nil
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if n == 0 {
+		b.Fatal("walked no commits")
+	}
+}
+
+type walkerFn func(CommitNode, map[plumbing.Hash]bool, []plumbing.Hash) CommitNodeIter
+
+var walkers = []struct {
+	name string
+	fn   walkerFn
+}{
+	{"CTime", NewCommitNodeIterCTime},
+	{"DateOrder", NewCommitNodeIterDateOrder},
+	{"TopoOrder", NewCommitNodeIterTopoOrder},
+	{"AuthorOrder", NewCommitNodeIterAuthorDateOrder},
+}
+
+func BenchmarkObjectIndexGet(b *testing.B) {
+	idx, cleanup := benchObjectIndex(b)
+	defer cleanup()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := idx.Get(benchHead); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkObjectIndexWalk(b *testing.B) {
+	idx, cleanup := benchObjectIndex(b)
+	defer cleanup()
+
+	for _, w := range walkers {
+		b.Run(w.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				head, err := idx.Get(benchHead)
+				if err != nil {
+					b.Fatal(err)
+				}
+				drain(b, w.fn(head, nil, nil))
+			}
+		})
+	}
+}
+
+func BenchmarkGraphIndexWalk(b *testing.B) {
+	idx, cleanup := benchGraphIndex(b)
+	defer cleanup()
+
+	for _, w := range walkers {
+		b.Run(w.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				head, err := idx.Get(benchHead)
+				if err != nil {
+					b.Fatal(err)
+				}
+				drain(b, w.fn(head, nil, nil))
+			}
+		})
+	}
+}

--- a/plumbing/object/commitgraph/commitnode_bench_test.go
+++ b/plumbing/object/commitgraph/commitnode_bench_test.go
@@ -25,10 +25,13 @@ func benchGraphIndex(b *testing.B) (CommitNodeIndex, func()) {
 	storer := unpackRepository(f)
 	reader, err := storer.Filesystem().Open(path.Join("objects", "info", "commit-graph"))
 	if err != nil {
+		_ = storer.Close()
 		b.Fatal(err)
 	}
 	index, err := commitgraphfmt.OpenFileIndex(reader)
 	if err != nil {
+		_ = reader.Close()
+		_ = storer.Close()
 		b.Fatal(err)
 	}
 	return NewGraphCommitNodeIndex(index, storer), func() {

--- a/plumbing/object/commitgraph/commitnode_graph.go
+++ b/plumbing/object/commitgraph/commitnode_graph.go
@@ -59,14 +59,20 @@ func (gci *graphCommitNodeIndex) Get(hash plumbing.Hash) (CommitNode, error) {
 		}
 	}
 
-	// Fallback to loading full commit object
-	commit, err := object.GetCommit(gci.s, hash)
+	// Fallback to loading the commit object
+	obj, err := gci.s.EncodedObject(plumbing.CommitObject, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	commit, err := DecodeCommit(obj)
 	if err != nil {
 		return nil, err
 	}
 
 	return &objectCommitNode{
 		nodeIndex: gci,
+		s:         gci.s,
 		commit:    commit,
 	}, nil
 }
@@ -127,8 +133,13 @@ func (c *graphCommitNode) GenerationV2() uint64 {
 	return c.commitData.GenerationV2
 }
 
-func (c *graphCommitNode) Commit() (*object.Commit, error) {
-	return object.GetCommit(c.gci.s, c.hash)
+func (c *graphCommitNode) Commit() (*Commit, error) {
+	obj, err := c.gci.s.EncodedObject(plumbing.CommitObject, c.hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return DecodeCommit(obj)
 }
 
 func (c *graphCommitNode) String() string {

--- a/plumbing/object/commitgraph/commitnode_object.go
+++ b/plumbing/object/commitgraph/commitnode_object.go
@@ -14,7 +14,8 @@ import (
 // objectCommitNode implements the CommitNode interface.
 type objectCommitNode struct {
 	nodeIndex CommitNodeIndex
-	commit    *object.Commit
+	s         storer.EncodedObjectStorer
+	commit    *Commit
 }
 
 // NewObjectCommitNodeIndex returns CommitNodeIndex implementation that uses
@@ -24,13 +25,19 @@ func NewObjectCommitNodeIndex(s storer.EncodedObjectStorer) CommitNodeIndex {
 }
 
 func (oci *objectCommitNodeIndex) Get(hash plumbing.Hash) (CommitNode, error) {
-	commit, err := object.GetCommit(oci.s, hash)
+	obj, err := oci.s.EncodedObject(plumbing.CommitObject, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	commit, err := DecodeCommit(obj)
 	if err != nil {
 		return nil, err
 	}
 
 	return &objectCommitNode{
 		nodeIndex: oci,
+		s:         oci.s,
 		commit:    commit,
 	}, nil
 }
@@ -44,7 +51,7 @@ type objectCommitNodeIndex struct {
 }
 
 func (c *objectCommitNode) CommitTime() time.Time {
-	return c.commit.Committer.When
+	return c.commit.When()
 }
 
 func (c *objectCommitNode) ID() plumbing.Hash {
@@ -52,11 +59,11 @@ func (c *objectCommitNode) ID() plumbing.Hash {
 }
 
 func (c *objectCommitNode) Tree() (*object.Tree, error) {
-	return c.commit.Tree()
+	return object.GetTree(c.s, c.commit.Tree())
 }
 
 func (c *objectCommitNode) NumParents() int {
-	return c.commit.NumParents()
+	return len(c.commit.Parents())
 }
 
 func (c *objectCommitNode) ParentNodes() CommitNodeIter {
@@ -64,18 +71,18 @@ func (c *objectCommitNode) ParentNodes() CommitNodeIter {
 }
 
 func (c *objectCommitNode) ParentNode(i int) (CommitNode, error) {
-	if i < 0 || i >= len(c.commit.ParentHashes) {
+	if i < 0 || i >= len(c.commit.Parents()) {
 		return nil, object.ErrParentNotFound
 	}
 
 	// Note: It's necessary to go through CommitNodeIndex here to ensure
 	// that if the commit-graph file covers only part of the history we
 	// start using it when that part is reached.
-	return c.nodeIndex.Get(c.commit.ParentHashes[i])
+	return c.nodeIndex.Get(c.commit.Parents()[i])
 }
 
 func (c *objectCommitNode) ParentHashes() []plumbing.Hash {
-	return c.commit.ParentHashes
+	return c.commit.Parents()
 }
 
 func (c *objectCommitNode) Generation() uint64 {
@@ -92,6 +99,6 @@ func (c *objectCommitNode) GenerationV2() uint64 {
 	return math.MaxUint64
 }
 
-func (c *objectCommitNode) Commit() (*object.Commit, error) {
+func (c *objectCommitNode) Commit() (*Commit, error) {
 	return c.commit, nil
 }

--- a/plumbing/object/commitgraph/commitnode_test.go
+++ b/plumbing/object/commitgraph/commitnode_test.go
@@ -102,7 +102,7 @@ func testCommitAndTree(s *CommitNodeSuite, nodeIndex CommitNodeIndex) {
 	s.Equal(merge3commit.ID().String(), merge3node.ID().String())
 	tree, err := merge3node.Tree()
 	s.NoError(err)
-	s.Equal(merge3commit.TreeHash.String(), tree.ID().String())
+	s.Equal(merge3commit.Tree().String(), tree.ID().String())
 }
 
 func (s *CommitNodeSuite) TestObjectGraph() {

--- a/plumbing/object/commitgraph/commitnode_walker_author_order.go
+++ b/plumbing/object/commitgraph/commitnode_walker_author_order.go
@@ -43,9 +43,9 @@ func NewCommitNodeIterAuthorDateOrder(c CommitNode,
 		}
 
 		switch {
-		case rightCommit.Author.When.Before(leftCommit.Author.When):
+		case rightCommit.AuthorWhen().Before(leftCommit.AuthorWhen()):
 			return -1
-		case leftCommit.Author.When.Before(rightCommit.Author.When):
+		case leftCommit.AuthorWhen().Before(rightCommit.AuthorWhen()):
 			return 1
 		}
 		return 0


### PR DESCRIPTION
## Summary

Two related improvements to the commit-graph packages:

  1. **A lightweight `Commit` for graph traversal** (`plumbing/object/commitgraph`),
     replacing the full `*object.Commit` that `CommitNode.Commit()` previously
     returned, plus allocation tuning of its decoder.
  2. **Four commit-graph file-format conformance fixes** (`plumbing/format/commitgraph`),
     aligning the reader/encoder with upstream C Git, including SHA-256 support.

  This does **not** yet wire the commit-graph into `Log`/merge-base/negotiation, it just hardens and slims the existing machinery.

  ## Changes

  ### Lightweight traversal commit
  - New `commitgraph.Commit` carrying only base traversal fields, with a trimmed
    decoder that stops after the committer header (so it never parses gpgsig,
    mergetag or the message body).
  - `CommitNode.Commit()` now returns `*commitgraph.Commit`; `objectCommitNode`
    holds the storer to resolve trees and decodes on demand.
  - Decoder allocation tuning: read header lines in place via `ReadSlice` (with an
    `ErrBufferFull` fallback), decode OIDs straight into a stack array via
    `hex.Decode` + `FromBytes`, and compare header keys as `[]byte` without string
    allocation.

  ### Format conformance (vs upstream commit-graph.c v2.54.0)
  - Reject **non-monotonic OID fanout** (`graph_read_oid_fanout`), which also keeps
    `GetIndexByHash`'s binary-search bound inside the OID lookup chunk.
  - Parse a **chain file whose final line lacks a trailing newline** instead of
    silently dropping the newest graph.
  - Validate the header's **base commit-graph count** against the actual chain depth.
  - **SHA-256 commit-graph support**: derive OID width from the header hash-version
    byte and size every OID read accordingly; the encoder infers SHA-256 from the
    index's hashes and emits a consistent header/widths/chunk sizes.

  ## Performance

  Object-backed commit walking (decode path), `benchstat`, n=6:

  - Per-commit `Get`: **51 → 30 allocs/op (-41%)** cumulatively
    (lightweight struct -30% allocs, decoder tuning a further ~13 allocs).
  - Object-backed walks: ~-39% allocs/op, ~-16% B/op.
  - Pure commit-graph-file walks (CTime/Date/Topo) are unchanged — they never
    decode an object.