### PR TITLE
plumbing: object, don't mask a missing subtree as io.EOF in TreeWalker

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -632,11 +632,11 @@ func NewTreeWalker(t *Tree, recursive bool, seen map[plumbing.Hash]bool) *TreeWa
 // inspection-only callers that need to enumerate raw, unvalidated
 // names can read Tree.Entries directly.
 //
-// In the current implementation any objects which cannot be found in the
-// underlying repository will be skipped automatically. It is possible that this
-// may change in future versions.
+// A recursive walk loads the subtree object behind each directory entry
+// in order to descend into it, and returns the lookup error (e.g.
+// plumbing.ErrObjectNotFound) if it is not available. A non-recursive
+// walk does not load subtree objects.
 func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
-	var obj *Tree
 	for {
 		current := len(w.stack) - 1
 		if current < 0 {
@@ -672,30 +672,23 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 			return name, entry, err
 		}
 
-		if entry.Mode == filemode.Dir {
-			obj, err = GetTree(w.s, entry.Hash)
-		}
-
 		name = simpleJoin(w.base, entry.Name)
 
-		if err != nil {
-			err = io.EOF
-			return name, entry, err
+		// The subtree object is only needed to descend into a directory,
+		// so it is loaded only for a recursive walk; enumerating a tree's
+		// direct entries must not depend on its children being present.
+		if w.recursive && entry.Mode == filemode.Dir {
+			var obj *Tree
+			if obj, err = GetTree(w.s, entry.Hash); err != nil {
+				return name, entry, fmt.Errorf("loading subtree %q: %w", name, err)
+			}
+
+			w.stack = append(w.stack, &treeEntryIter{obj, 0})
+			w.base = name
 		}
 
-		break
-	}
-
-	if !w.recursive {
 		return name, entry, err
 	}
-
-	if obj != nil {
-		w.stack = append(w.stack, &treeEntryIter{obj, 0})
-		w.base = simpleJoin(w.base, entry.Name)
-	}
-
-	return name, entry, err
 }
 
 // Tree returns the tree that the tree walker most recently operated on.

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -497,6 +497,66 @@ func (s *TreeSuite) TestTreeWalkerNextNonRecursive() {
 	s.Equal(8, count)
 }
 
+// TestTreeWalkerMissingSubtree checks that when a directory entry's
+// subtree object is absent from the storer, a non-recursive walk still
+// enumerates all direct entries and a recursive walk surfaces the lookup
+// error.
+func (s *TreeSuite) TestTreeWalkerMissingSubtree() {
+	// a8d315b2 has 8 direct entries; "go" (a39771a7) is its first
+	// directory entry, sorted after the four leading blobs.
+	treeHash := plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")
+	missing := plumbing.NewHash("a39771a7651f97faf5c72e08224d857fc35133db")
+
+	// A storer holding the parent tree object but NOT the "go" subtree.
+	st := memory.NewStorage()
+	src, err := s.Storer.EncodedObject(plumbing.TreeObject, treeHash)
+	s.Require().NoError(err)
+	_, err = st.SetEncodedObject(src)
+	s.Require().NoError(err)
+
+	_, err = st.EncodedObject(plumbing.TreeObject, missing)
+	s.Require().ErrorIs(err, plumbing.ErrObjectNotFound)
+
+	tree, err := GetTree(st, treeHash)
+	s.Require().NoError(err)
+
+	// Non-recursive: every direct entry is enumerated; the missing
+	// subtree is never loaded.
+	var names []string
+	nonRecursive := NewTreeWalker(tree, false, nil)
+	defer nonRecursive.Close()
+	for {
+		name, _, err := nonRecursive.Next()
+		if err == io.EOF {
+			break
+		}
+		s.Require().NoError(err)
+		names = append(names, name)
+	}
+	s.Equal([]string{
+		".gitignore", "CHANGELOG", "LICENSE", "binary.jpg",
+		"go", "json", "php", "vendor",
+	}, names)
+
+	// Recursive: descending into "go" surfaces the lookup error rather
+	// than silently ending the walk.
+	recursive := NewTreeWalker(tree, true, nil)
+	defer recursive.Close()
+	var walkErr error
+	for {
+		_, _, err := recursive.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			walkErr = err
+			break
+		}
+	}
+	s.ErrorIs(walkErr, plumbing.ErrObjectNotFound)
+	s.ErrorContains(walkErr, "go") // the failing entry's path
+}
+
 func (s *TreeSuite) TestPatchContext_ToNil() {
 	commit := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 	tree, err := commit.Tree()


### PR DESCRIPTION
`TreeWalker.Next` loaded the subtree object for every directory entry and rewrote any error from that lookup — including `plumbing.ErrObjectNotFound` — to `io.EOF`. Callers read `io.EOF` as the normal end of entries, so a single missing subtree object silently truncated the walk to the entries sorted before it, returning a partial list with `err == nil`.

This is most damaging via the merkletrie tree noder (`transformChildren`), which Reset, diff, and status build on: if `origin/<branch>` references a subtree object that isn't in the store (e.g. after a shallow fetch), a Reset to that tree silently drops every path sorted at/after the missing directory — turning a missing object into silent data loss instead of an error.

After this change:

- A non-recursive walk no longer loads subtree objects at all. The object is only needed to descend during a recursive walk, so enumerating a tree's direct entries no longer depends on every child being present (also avoids a wasted lookup).

- A recursive walk now returns the real lookup error (e.g. `ErrObjectNotFound`) instead of masking it as `io.EOF`.

Assisted-by: Claude Opus 4.8

---

Pretty sure this bug was what caused the issue in https://github.com/go-git/go-git/issues/1472. Sounds very similar to the problem that led me to this.