### PR TITLE
config: url, Add pushInsteadOf support and bring push API closer to Git. Fixes #865.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1025,6 +1025,8 @@ type RemoteConfig struct {
 	// URLs the URLs of a remote repository. It must be non-empty. Fetch will
 	// always use the first URL, while push will use all of them.
 	URLs []string
+	// PushURLs are the explicit push URLs of a remote repository.
+	PushURLs []string
 	// Mirror indicates that the repository is a mirror of remote.
 	Mirror bool
 
@@ -1032,6 +1034,10 @@ type RemoteConfig struct {
 	insteadOfRulesApplied bool
 	// originalURLs are the urls before applying insteadOf rules
 	originalURLs []string
+	// originalPushURLs are the explicit push URLs before applying URL rules.
+	originalPushURLs []string
+	// pushInsteadOfURLs are the push URLs derived from pushInsteadOf rules.
+	pushInsteadOfURLs []string
 
 	// Fetch the default set of "refspec" for fetch operation
 	Fetch []RefSpec
@@ -1079,7 +1085,8 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 
 	c.Name = c.raw.Name
 	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
-	c.URLs = append(c.URLs, c.raw.Options.GetAll(pushurlKey)...)
+	c.PushURLs = append([]string(nil), c.raw.Options.GetAll(pushurlKey)...)
+	c.URLs = append(c.URLs, c.PushURLs...)
 	c.Fetch = fetch
 	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
 
@@ -1092,15 +1099,17 @@ func (c *RemoteConfig) marshal() *format.Subsection {
 	}
 
 	c.raw.Name = c.Name
-	if len(c.URLs) == 0 {
+	urls, pushURLs := c.urlsAndPushURLsForMarshal()
+	if len(urls) == 0 {
 		c.raw.RemoveOption(urlKey)
 	} else {
-		urls := c.URLs
-		if c.insteadOfRulesApplied {
-			urls = c.originalURLs
-		}
-
 		c.raw.SetOption(urlKey, urls...)
+	}
+
+	if len(pushURLs) == 0 {
+		c.raw.RemoveOption(pushurlKey)
+	} else {
+		c.raw.SetOption(pushurlKey, pushURLs...)
 	}
 
 	if len(c.Fetch) == 0 {
@@ -1126,19 +1135,97 @@ func (c *RemoteConfig) IsFirstURLLocal() bool {
 	return url.IsLocalEndpoint(c.URLs[0])
 }
 
+// PushURL returns the URL to use for push operations.
+func (c *RemoteConfig) PushURL() string {
+	// Matches `git remote get-url --push`: an explicit pushurl wins over
+	// pushInsteadOf, which wins over the remote's regular URL.
+	// See https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtpushInsteadOf.
+	if len(c.PushURLs) > 0 {
+		return c.PushURLs[len(c.PushURLs)-1]
+	}
+
+	if len(c.pushInsteadOfURLs) > 0 {
+		return c.pushInsteadOfURLs[len(c.pushInsteadOfURLs)-1]
+	}
+
+	if len(c.URLs) > 0 {
+		return c.URLs[len(c.URLs)-1]
+	}
+
+	return ""
+}
+
 func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
 	// save original urls
 	originalURLs := make([]string, len(c.URLs))
 	copy(originalURLs, c.URLs)
+	originalPushURLs := make([]string, len(c.PushURLs))
+	copy(originalPushURLs, c.PushURLs)
 
-	for i, url := range c.URLs {
-		if matchingURLRule := findLongestInsteadOfMatch(url, urlRules); matchingURLRule != nil {
-			c.URLs[i] = matchingURLRule.ApplyInsteadOf(c.URLs[i])
+	regularURLCount := len(c.URLs) - len(c.PushURLs)
+	if regularURLCount < 0 {
+		regularURLCount = len(c.URLs)
+	}
+
+	for i := 0; i < regularURLCount; i++ {
+		url := c.URLs[i]
+		if matchingURLRule, prefix := findLongestURLMatch(url, urlRules, func(u *URL) []string {
+			return u.InsteadOfs
+		}); matchingURLRule != nil {
+			c.URLs[i] = matchingURLRule.Name + url[len(prefix):]
 			c.insteadOfRulesApplied = true
+		}
+	}
+
+	for i := 0; i < regularURLCount; i++ {
+		url := originalURLs[i]
+		// Git applies pushInsteadOf to the configured fetch URL, not to the
+		// URL after insteadOf rewriting.
+		// I could not find docs for this but I manually tested it. Logic in the source:
+		// https://github.com/git/git/blob/1ff279f3404a482a83fb04c7457e41ab26884aea/remote.c#L616-L621
+		if matchingURLRule, prefix := findLongestURLMatch(url, urlRules, func(u *URL) []string {
+			return u.PushInsteadOfs
+		}); matchingURLRule != nil {
+			if c.pushInsteadOfURLs == nil {
+				c.pushInsteadOfURLs = make([]string, len(c.URLs))
+				copy(c.pushInsteadOfURLs, c.URLs)
+			}
+			c.pushInsteadOfURLs[i] = matchingURLRule.Name + url[len(prefix):]
 		}
 	}
 
 	if c.insteadOfRulesApplied {
 		c.originalURLs = originalURLs
+		c.originalPushURLs = originalPushURLs
 	}
+}
+
+func (c *RemoteConfig) urlsAndPushURLsForMarshal() ([]string, []string) {
+	urls := c.URLs
+	pushURLs := c.PushURLs
+	if c.insteadOfRulesApplied {
+		urls = c.originalURLs
+		pushURLs = c.originalPushURLs
+	}
+
+	if len(pushURLs) > 0 && hasStringSuffix(urls, pushURLs) {
+		urls = urls[:len(urls)-len(pushURLs)]
+	}
+
+	return urls, pushURLs
+}
+
+func hasStringSuffix(values, suffix []string) bool {
+	if len(suffix) > len(values) {
+		return false
+	}
+
+	offset := len(values) - len(suffix)
+	for i := range suffix {
+		if values[offset+i] != suffix[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1038,6 +1038,9 @@ type RemoteConfig struct {
 	originalPushURLs []string
 	// pushInsteadOfURLs are the push URLs derived from pushInsteadOf rules.
 	pushInsteadOfURLs []string
+	// pushURLsAppendedToURLs records that PushURLs were appended to URLs during
+	// unmarshaling for backward compatibility.
+	pushURLsAppendedToURLs bool
 
 	// Fetch the default set of "refspec" for fetch operation
 	Fetch []RefSpec
@@ -1086,7 +1089,10 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 	c.Name = c.raw.Name
 	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
 	c.PushURLs = append([]string(nil), c.raw.Options.GetAll(pushurlKey)...)
-	c.URLs = append(c.URLs, c.PushURLs...)
+	if len(c.PushURLs) > 0 {
+		c.URLs = append(c.URLs, c.PushURLs...)
+		c.pushURLsAppendedToURLs = true
+	}
 	c.Fetch = fetch
 	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
 
@@ -1140,19 +1146,23 @@ func (c *RemoteConfig) PushURL() string {
 	// Matches `git remote get-url --push`: an explicit pushurl wins over
 	// pushInsteadOf, which wins over the remote's regular URL.
 	// See https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtpushInsteadOf.
-	if len(c.PushURLs) > 0 {
-		return c.PushURLs[0]
-	}
-
-	if len(c.pushInsteadOfURLs) > 0 {
-		return c.pushInsteadOfURLs[0]
-	}
-
-	if len(c.URLs) > 0 {
-		return c.URLs[0]
+	if pushURLs := c.pushURLsForPush(); len(pushURLs) > 0 {
+		return pushURLs[0]
 	}
 
 	return ""
+}
+
+func (c *RemoteConfig) pushURLsForPush() []string {
+	if len(c.PushURLs) > 0 {
+		return c.PushURLs
+	}
+
+	if len(c.pushInsteadOfURLs) > 0 {
+		return c.pushInsteadOfURLs
+	}
+
+	return c.URLs
 }
 
 func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
@@ -1208,7 +1218,7 @@ func (c *RemoteConfig) urlsAndPushURLsForMarshal() ([]string, []string) {
 		pushURLs = c.originalPushURLs
 	}
 
-	if len(pushURLs) > 0 && hasStringSuffix(urls, pushURLs) {
+	if c.pushURLsAppendedToURLs && len(pushURLs) > 0 && hasStringSuffix(urls, pushURLs) {
 		urls = urls[:len(urls)-len(pushURLs)]
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1023,7 +1023,8 @@ type RemoteConfig struct {
 	// Name of the remote
 	Name string
 	// URLs the URLs of a remote repository. It must be non-empty. Fetch will
-	// always use the first URL, while push will use all of them.
+	// always use the first URL. Push will use PushURLs when set, otherwise
+	// pushInsteadOf-derived URLs when any match, otherwise all URLs.
 	URLs []string
 	// PushURLs are the explicit push URLs of a remote repository.
 	PushURLs []string

--- a/config/config.go
+++ b/config/config.go
@@ -1180,18 +1180,10 @@ func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
 		regularURLCount -= len(c.PushURLs)
 	}
 
-	rewriteInsteadOf := func(url string) (string, bool) {
-		match, prefix := findLongestURLMatch(url, urlRules, func(u *URL) []string {
-			return u.InsteadOfs
-		})
-		if match == nil {
-			return url, false
-		}
-		return match.Name + url[len(prefix):], true
-	}
-
 	for i, url := range c.URLs {
-		if rewritten, matched := rewriteInsteadOf(url); matched {
+		if rewritten, matched := rewriteLongestURLMatch(url, urlRules, func(u *URL) []string {
+			return u.InsteadOfs
+		}); matched {
 			c.URLs[i] = rewritten
 			c.insteadOfRulesApplied = true
 		}
@@ -1201,7 +1193,9 @@ func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
 		copy(c.PushURLs, c.URLs[regularURLCount:])
 	} else {
 		for i, url := range c.PushURLs {
-			if rewritten, matched := rewriteInsteadOf(url); matched {
+			if rewritten, matched := rewriteLongestURLMatch(url, urlRules, func(u *URL) []string {
+				return u.InsteadOfs
+			}); matched {
 				c.PushURLs[i] = rewritten
 				c.insteadOfRulesApplied = true
 			}
@@ -1214,10 +1208,10 @@ func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
 		// URL after insteadOf rewriting.
 		// I could not find docs for this but I manually tested it. Logic in the source:
 		// https://github.com/git/git/blob/1ff279f3404a482a83fb04c7457e41ab26884aea/remote.c#L616-L621
-		if matchingURLRule, prefix := findLongestURLMatch(url, urlRules, func(u *URL) []string {
+		if rewritten, matched := rewriteLongestURLMatch(url, urlRules, func(u *URL) []string {
 			return u.PushInsteadOfs
-		}); matchingURLRule != nil {
-			c.pushInsteadOfURLs = append(c.pushInsteadOfURLs, matchingURLRule.Name+url[len(prefix):])
+		}); matched {
+			c.pushInsteadOfURLs = append(c.pushInsteadOfURLs, rewritten)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1141,15 +1141,15 @@ func (c *RemoteConfig) PushURL() string {
 	// pushInsteadOf, which wins over the remote's regular URL.
 	// See https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtpushInsteadOf.
 	if len(c.PushURLs) > 0 {
-		return c.PushURLs[len(c.PushURLs)-1]
+		return c.PushURLs[0]
 	}
 
 	if len(c.pushInsteadOfURLs) > 0 {
-		return c.pushInsteadOfURLs[len(c.pushInsteadOfURLs)-1]
+		return c.pushInsteadOfURLs[0]
 	}
 
 	if len(c.URLs) > 0 {
-		return c.URLs[len(c.URLs)-1]
+		return c.URLs[0]
 	}
 
 	return ""
@@ -1163,16 +1163,20 @@ func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
 	copy(originalPushURLs, c.PushURLs)
 
 	regularURLCount := len(c.URLs) - len(c.PushURLs)
-	if regularURLCount < 0 {
+	if !hasStringSuffix(c.URLs, c.PushURLs) {
 		regularURLCount = len(c.URLs)
 	}
 
-	for i := 0; i < regularURLCount; i++ {
+	for i, remoteURL := range c.URLs {
 		url := c.URLs[i]
 		if matchingURLRule, prefix := findLongestURLMatch(url, urlRules, func(u *URL) []string {
 			return u.InsteadOfs
 		}); matchingURLRule != nil {
-			c.URLs[i] = matchingURLRule.Name + url[len(prefix):]
+			rewrittenURL := matchingURLRule.Name + remoteURL[len(prefix):]
+			c.URLs[i] = rewrittenURL
+			if i >= regularURLCount {
+				c.PushURLs[i-regularURLCount] = rewrittenURL
+			}
 			c.insteadOfRulesApplied = true
 		}
 	}
@@ -1186,11 +1190,7 @@ func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
 		if matchingURLRule, prefix := findLongestURLMatch(url, urlRules, func(u *URL) []string {
 			return u.PushInsteadOfs
 		}); matchingURLRule != nil {
-			if c.pushInsteadOfURLs == nil {
-				c.pushInsteadOfURLs = make([]string, len(c.URLs))
-				copy(c.pushInsteadOfURLs, c.URLs)
-			}
-			c.pushInsteadOfURLs[i] = matchingURLRule.Name + url[len(prefix):]
+			c.pushInsteadOfURLs = append(c.pushInsteadOfURLs, matchingURLRule.Name+url[len(prefix):])
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1141,19 +1141,23 @@ func (c *RemoteConfig) IsFirstURLLocal() bool {
 	return url.IsLocalEndpoint(c.URLs[0])
 }
 
-// PushURL returns the URL to use for push operations.
-func (c *RemoteConfig) PushURL() string {
-	// Matches `git remote get-url --push`: an explicit pushurl wins over
-	// pushInsteadOf, which wins over the remote's regular URL.
-	// See https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtpushInsteadOf.
-	if pushURLs := c.pushURLsForPush(); len(pushURLs) > 0 {
+// ResolvedPushURL returns the URL to use for push operations. See
+// ResolvedPushURLs for the full list when more than one push target applies.
+func (c *RemoteConfig) ResolvedPushURL() string {
+	if pushURLs := c.ResolvedPushURLs(); len(pushURLs) > 0 {
 		return pushURLs[0]
 	}
 
 	return ""
 }
 
-func (c *RemoteConfig) pushURLsForPush() []string {
+// ResolvedPushURLs returns every URL that a push should target, after
+// resolving explicit pushurls and pushInsteadOf rewrites. Explicit pushurls
+// take precedence over pushInsteadOf, which takes precedence over the
+// remote's fetch URLs.
+func (c *RemoteConfig) ResolvedPushURLs() []string {
+	// See https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtpushInsteadOf
+	// for docs on the precedence.
 	if len(c.PushURLs) > 0 {
 		return c.PushURLs
 	}
@@ -1166,28 +1170,40 @@ func (c *RemoteConfig) pushURLsForPush() []string {
 }
 
 func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
-	// save original urls
-	originalURLs := make([]string, len(c.URLs))
-	copy(originalURLs, c.URLs)
-	originalPushURLs := make([]string, len(c.PushURLs))
-	copy(originalPushURLs, c.PushURLs)
+	originalURLs := append([]string(nil), c.URLs...)
+	originalPushURLs := append([]string(nil), c.PushURLs...)
 
-	regularURLCount := len(c.URLs) - len(c.PushURLs)
-	if !hasStringSuffix(c.URLs, c.PushURLs) {
-		regularURLCount = len(c.URLs)
+	pushURLsAreURLsSuffix := hasStringSuffix(c.URLs, c.PushURLs)
+	regularURLCount := len(c.URLs)
+	if pushURLsAreURLsSuffix {
+		regularURLCount -= len(c.PushURLs)
 	}
 
-	for i, remoteURL := range c.URLs {
-		url := c.URLs[i]
-		if matchingURLRule, prefix := findLongestURLMatch(url, urlRules, func(u *URL) []string {
+	rewriteInsteadOf := func(url string) (string, bool) {
+		match, prefix := findLongestURLMatch(url, urlRules, func(u *URL) []string {
 			return u.InsteadOfs
-		}); matchingURLRule != nil {
-			rewrittenURL := matchingURLRule.Name + remoteURL[len(prefix):]
-			c.URLs[i] = rewrittenURL
-			if i >= regularURLCount {
-				c.PushURLs[i-regularURLCount] = rewrittenURL
-			}
+		})
+		if match == nil {
+			return url, false
+		}
+		return match.Name + url[len(prefix):], true
+	}
+
+	for i, url := range c.URLs {
+		if rewritten, matched := rewriteInsteadOf(url); matched {
+			c.URLs[i] = rewritten
 			c.insteadOfRulesApplied = true
+		}
+	}
+	if pushURLsAreURLsSuffix {
+		// Keep the appended-pushurls suffix of c.URLs in sync with c.PushURLs.
+		copy(c.PushURLs, c.URLs[regularURLCount:])
+	} else {
+		for i, url := range c.PushURLs {
+			if rewritten, matched := rewriteInsteadOf(url); matched {
+				c.PushURLs[i] = rewritten
+				c.insteadOfRulesApplied = true
+			}
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -569,7 +569,7 @@ func (s *ConfigSuite) TestUnmarshalRemotes() {
 	s.Equal("https://git.sr.ht/~mcepl/go-git", cfg.Remotes["origin"].URLs[0])
 	s.Equal("git@git.sr.ht:~mcepl/go-git.git", cfg.Remotes["origin"].URLs[1])
 	s.Equal([]string{"git@git.sr.ht:~mcepl/go-git.git"}, cfg.Remotes["origin"].PushURLs)
-	s.Equal("git@git.sr.ht:~mcepl/go-git.git", cfg.Remotes["origin"].PushURL())
+	s.Equal("git@git.sr.ht:~mcepl/go-git.git", cfg.Remotes["origin"].ResolvedPushURL())
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOf() {
@@ -588,7 +588,7 @@ func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOf() {
 	remote := cfg.Remotes["origin"]
 	s.Equal([]string{"ssh://fetch.example/repo.git"}, remote.URLs)
 	s.Empty(remote.PushURLs)
-	s.Equal("ssh://push.example/repo.git", remote.PushURL())
+	s.Equal("ssh://push.example/repo.git", remote.ResolvedPushURL())
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotePushURLAppliesInsteadOf() {
@@ -608,7 +608,7 @@ func (s *ConfigSuite) TestUnmarshalRemotePushURLAppliesInsteadOf() {
 	remote := cfg.Remotes["origin"]
 	s.Equal([]string{"ssh://fetch.example/repo.git", "ssh://pushurl.example/repo.git"}, remote.URLs)
 	s.Equal([]string{"ssh://pushurl.example/repo.git"}, remote.PushURLs)
-	s.Equal("ssh://pushurl.example/repo.git", remote.PushURL())
+	s.Equal("ssh://pushurl.example/repo.git", remote.ResolvedPushURL())
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotePushURLReturnsFirstExplicitPushURL() {
@@ -624,7 +624,7 @@ func (s *ConfigSuite) TestUnmarshalRemotePushURLReturnsFirstExplicitPushURL() {
 
 	remote := cfg.Remotes["origin"]
 	s.Equal([]string{"ssh://push1.example/repo.git", "ssh://push2.example/repo.git"}, remote.PushURLs)
-	s.Equal("ssh://push1.example/repo.git", remote.PushURL())
+	s.Equal("ssh://push1.example/repo.git", remote.ResolvedPushURL())
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOfReturnsFirstPushURL() {
@@ -641,7 +641,7 @@ func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOfReturnsFirstPushURL() {
 
 	remote := cfg.Remotes["origin"]
 	s.Equal([]string{"https://example.com/repo.git", "https://unmatched.example/repo.git"}, remote.URLs)
-	s.Equal("ssh://push.example/repo.git", remote.PushURL())
+	s.Equal("ssh://push.example/repo.git", remote.ResolvedPushURL())
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOfLongestMatch() {
@@ -657,7 +657,7 @@ func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOfLongestMatch() {
 	err := cfg.Unmarshal(input)
 	s.NoError(err)
 
-	s.Equal("ssh://long/repo.git", cfg.Remotes["origin"].PushURL())
+	s.Equal("ssh://long/repo.git", cfg.Remotes["origin"].ResolvedPushURL())
 }
 
 func (s *ConfigSuite) TestApplyURLRulesWithIndependentPushURLs() {
@@ -677,6 +677,27 @@ func (s *ConfigSuite) TestApplyURLRulesWithIndependentPushURLs() {
 
 	s.Equal([]string{"ssh://fetch.example/repo.git"}, remote.URLs)
 	s.Equal([]string{"ssh://push.example/repo.git"}, remote.PushURLs)
+}
+
+// When PushURLs is set independently (not appended to URLs via unmarshal),
+// insteadOf rules that match a push URL should still rewrite it — matching
+// git's behavior and the unmarshal-path TestUnmarshalRemotePushURLAppliesInsteadOf.
+func (s *ConfigSuite) TestApplyURLRulesRewritesIndependentPushURLs() {
+	cfg := NewConfig()
+	cfg.Remotes["origin"] = &RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"https://fetch.example/repo.git"},
+		PushURLs: []string{"https://example.com/repo.git"},
+	}
+	cfg.URLs["ssh://rewritten.example/"] = &URL{
+		Name:       "ssh://rewritten.example/",
+		InsteadOfs: []string{"https://example.com/"},
+	}
+
+	remote := cfg.Remotes["origin"]
+	remote.applyURLRules(cfg.URLs)
+
+	s.Equal([]string{"ssh://rewritten.example/repo.git"}, remote.PushURLs)
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotesUnnamedFirst() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -210,6 +210,28 @@ func (s *ConfigSuite) TestMarshalRemotePushURLs() {
 	s.Equal(string(expected), string(actual))
 }
 
+func (s *ConfigSuite) TestMarshalRemotePushURLsDoesNotDropMatchingFetchURL() {
+	expected := []byte(`[core]
+	bare = false
+	filemode = true
+[remote "origin"]
+	url = https://example.com/repo.git
+	url = ssh://example.com/repo.git
+	pushurl = ssh://example.com/repo.git
+`)
+
+	cfg := NewConfig()
+	cfg.Remotes["origin"] = &RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"https://example.com/repo.git", "ssh://example.com/repo.git"},
+		PushURLs: []string{"ssh://example.com/repo.git"},
+	}
+
+	actual, err := cfg.Marshal()
+	s.NoError(err)
+	s.Equal(string(expected), string(actual))
+}
+
 func TestUnmarshalMarshal(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -569,12 +569,46 @@ func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOf() {
 	s.Equal("ssh://push.example/repo.git", remote.PushURL())
 }
 
-func (s *ConfigSuite) TestUnmarshalRemotePushURLIgnoresURLRules() {
+func (s *ConfigSuite) TestUnmarshalRemotePushURLAppliesInsteadOf() {
 	input := []byte(`[remote "origin"]
 	url = https://example.com/repo.git
 	pushurl = https://pushurl.example/repo.git
 [url "ssh://fetch.example/"]
 	insteadOf = https://example.com/
+[url "ssh://pushurl.example/"]
+	insteadOf = https://pushurl.example/
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	remote := cfg.Remotes["origin"]
+	s.Equal([]string{"ssh://fetch.example/repo.git", "ssh://pushurl.example/repo.git"}, remote.URLs)
+	s.Equal([]string{"ssh://pushurl.example/repo.git"}, remote.PushURLs)
+	s.Equal("ssh://pushurl.example/repo.git", remote.PushURL())
+}
+
+func (s *ConfigSuite) TestUnmarshalRemotePushURLReturnsFirstExplicitPushURL() {
+	input := []byte(`[remote "origin"]
+	url = https://example.com/repo.git
+	pushurl = ssh://push1.example/repo.git
+	pushurl = ssh://push2.example/repo.git
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	remote := cfg.Remotes["origin"]
+	s.Equal([]string{"ssh://push1.example/repo.git", "ssh://push2.example/repo.git"}, remote.PushURLs)
+	s.Equal("ssh://push1.example/repo.git", remote.PushURL())
+}
+
+func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOfReturnsFirstPushURL() {
+	input := []byte(`[remote "origin"]
+	url = https://example.com/repo.git
+	url = https://unmatched.example/repo.git
 [url "ssh://push.example/"]
 	pushInsteadOf = https://example.com/
 `)
@@ -584,9 +618,8 @@ func (s *ConfigSuite) TestUnmarshalRemotePushURLIgnoresURLRules() {
 	s.NoError(err)
 
 	remote := cfg.Remotes["origin"]
-	s.Equal([]string{"ssh://fetch.example/repo.git", "https://pushurl.example/repo.git"}, remote.URLs)
-	s.Equal([]string{"https://pushurl.example/repo.git"}, remote.PushURLs)
-	s.Equal("https://pushurl.example/repo.git", remote.PushURL())
+	s.Equal([]string{"https://example.com/repo.git", "https://unmatched.example/repo.git"}, remote.URLs)
+	s.Equal("ssh://push.example/repo.git", remote.PushURL())
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOfLongestMatch() {
@@ -603,6 +636,25 @@ func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOfLongestMatch() {
 	s.NoError(err)
 
 	s.Equal("ssh://long/repo.git", cfg.Remotes["origin"].PushURL())
+}
+
+func (s *ConfigSuite) TestApplyURLRulesWithIndependentPushURLs() {
+	cfg := NewConfig()
+	cfg.Remotes["origin"] = &RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"https://example.com/repo.git"},
+		PushURLs: []string{"ssh://push.example/repo.git"},
+	}
+	cfg.URLs["ssh://fetch.example/"] = &URL{
+		Name:       "ssh://fetch.example/",
+		InsteadOfs: []string{"https://example.com/"},
+	}
+
+	remote := cfg.Remotes["origin"]
+	remote.applyURLRules(cfg.URLs)
+
+	s.Equal([]string{"ssh://fetch.example/repo.git"}, remote.URLs)
+	s.Equal([]string{"ssh://push.example/repo.git"}, remote.PushURLs)
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotesUnnamedFirst() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -189,6 +189,27 @@ func (s *ConfigSuite) TestMarshal() {
 	s.Equal(string(output), string(b))
 }
 
+func (s *ConfigSuite) TestMarshalRemotePushURLs() {
+	expected := []byte(`[core]
+	bare = false
+	filemode = true
+[remote "origin"]
+	url = https://example.com/repo.git
+	pushurl = ssh://example.com/repo.git
+`)
+
+	cfg := NewConfig()
+	cfg.Remotes["origin"] = &RemoteConfig{
+		Name:     "origin",
+		URLs:     []string{"https://example.com/repo.git"},
+		PushURLs: []string{"ssh://example.com/repo.git"},
+	}
+
+	actual, err := cfg.Marshal()
+	s.NoError(err)
+	s.Equal(string(expected), string(actual))
+}
+
 func TestUnmarshalMarshal(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -525,6 +546,63 @@ func (s *ConfigSuite) TestUnmarshalRemotes() {
 
 	s.Equal("https://git.sr.ht/~mcepl/go-git", cfg.Remotes["origin"].URLs[0])
 	s.Equal("git@git.sr.ht:~mcepl/go-git.git", cfg.Remotes["origin"].URLs[1])
+	s.Equal([]string{"git@git.sr.ht:~mcepl/go-git.git"}, cfg.Remotes["origin"].PushURLs)
+	s.Equal("git@git.sr.ht:~mcepl/go-git.git", cfg.Remotes["origin"].PushURL())
+}
+
+func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOf() {
+	input := []byte(`[remote "origin"]
+	url = https://example.com/repo.git
+[url "ssh://fetch.example/"]
+	insteadOf = https://example.com/
+[url "ssh://push.example/"]
+	pushInsteadOf = https://example.com/
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	remote := cfg.Remotes["origin"]
+	s.Equal([]string{"ssh://fetch.example/repo.git"}, remote.URLs)
+	s.Empty(remote.PushURLs)
+	s.Equal("ssh://push.example/repo.git", remote.PushURL())
+}
+
+func (s *ConfigSuite) TestUnmarshalRemotePushURLIgnoresURLRules() {
+	input := []byte(`[remote "origin"]
+	url = https://example.com/repo.git
+	pushurl = https://pushurl.example/repo.git
+[url "ssh://fetch.example/"]
+	insteadOf = https://example.com/
+[url "ssh://push.example/"]
+	pushInsteadOf = https://example.com/
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	remote := cfg.Remotes["origin"]
+	s.Equal([]string{"ssh://fetch.example/repo.git", "https://pushurl.example/repo.git"}, remote.URLs)
+	s.Equal([]string{"https://pushurl.example/repo.git"}, remote.PushURLs)
+	s.Equal("https://pushurl.example/repo.git", remote.PushURL())
+}
+
+func (s *ConfigSuite) TestUnmarshalRemotePushInsteadOfLongestMatch() {
+	input := []byte(`[remote "origin"]
+	url = https://example.com/team/repo.git
+[url "ssh://short/"]
+	pushInsteadOf = https://example.com/
+[url "ssh://long/"]
+	pushInsteadOf = https://example.com/team/
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	s.Equal("ssh://long/repo.git", cfg.Remotes["origin"].PushURL())
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotesUnnamedFirst() {

--- a/config/url.go
+++ b/config/url.go
@@ -86,7 +86,7 @@ func rewriteLongestURLMatch(remoteURL string, urls map[string]*URL, prefixes fun
 		return remoteURL, false
 	}
 
-	return longestMatch.Name + remoteURL[len(longestPrefix):], true
+	return longestMatch.Name + remoteURL[longestMatchLength:], true
 }
 
 // ApplyInsteadOf applies the URL rewrite rules to the given URL.

--- a/config/url.go
+++ b/config/url.go
@@ -96,11 +96,16 @@ func (u *URL) ApplyPushInsteadOf(url string) string {
 }
 
 func (u *URL) apply(url string, prefixes []string) string {
+	var longestPrefix string
 	for _, prefix := range prefixes {
-		if strings.HasPrefix(url, prefix) {
-			return u.Name + url[len(prefix):]
+		if strings.HasPrefix(url, prefix) && len(prefix) > len(longestPrefix) {
+			longestPrefix = prefix
 		}
 	}
 
-	return url
+	if longestPrefix == "" {
+		return url
+	}
+
+	return u.Name + url[len(longestPrefix):]
 }

--- a/config/url.go
+++ b/config/url.go
@@ -60,7 +60,7 @@ func (u *URL) marshal() *format.Subsection {
 	return u.raw
 }
 
-func findLongestURLMatch(remoteURL string, urls map[string]*URL, prefixes func(*URL) []string) (*URL, string) {
+func rewriteLongestURLMatch(remoteURL string, urls map[string]*URL, prefixes func(*URL) []string) (string, bool) {
 	var longestMatch *URL
 	var longestPrefix string
 	var longestMatchLength int
@@ -82,7 +82,11 @@ func findLongestURLMatch(remoteURL string, urls map[string]*URL, prefixes func(*
 		}
 	}
 
-	return longestMatch, longestPrefix
+	if longestMatch == nil {
+		return remoteURL, false
+	}
+
+	return longestMatch.Name + remoteURL[len(longestPrefix):], true
 }
 
 // ApplyInsteadOf applies the URL rewrite rules to the given URL.
@@ -96,16 +100,8 @@ func (u *URL) ApplyPushInsteadOf(url string) string {
 }
 
 func (u *URL) apply(url string, prefixes []string) string {
-	var longestPrefix string
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(url, prefix) && len(prefix) > len(longestPrefix) {
-			longestPrefix = prefix
-		}
-	}
-
-	if longestPrefix == "" {
-		return url
-	}
-
-	return u.Name + url[len(longestPrefix):]
+	rewritten, _ := rewriteLongestURLMatch(url, map[string]*URL{u.Name: u}, func(*URL) []string {
+		return prefixes
+	})
+	return rewritten
 }

--- a/config/url.go
+++ b/config/url.go
@@ -16,6 +16,9 @@ type URL struct {
 	// Any URL that starts with this value will be rewritten to start, instead, with <base>.
 	// When more than one insteadOf strings match a given URL, the longest match is used.
 	InsteadOfs []string
+	// Any URL that starts with this value will be rewritten to start, instead, with <base>
+	// for pushes only. This does not apply when a remote has an explicit pushurl.
+	PushInsteadOfs []string
 
 	// raw representation of the subsection, filled by marshal or unmarshal are
 	// called.
@@ -24,7 +27,7 @@ type URL struct {
 
 // Validate validates fields of branch.
 func (u *URL) Validate() error {
-	if len(u.InsteadOfs) == 0 {
+	if len(u.InsteadOfs) == 0 && len(u.PushInsteadOfs) == 0 {
 		return errURLEmptyInsteadOf
 	}
 
@@ -32,7 +35,8 @@ func (u *URL) Validate() error {
 }
 
 const (
-	insteadOfKey = "insteadOf"
+	insteadOfKey     = "insteadOf"
+	pushInsteadOfKey = "pushInsteadOf"
 )
 
 func (u *URL) unmarshal(s *format.Subsection) error {
@@ -40,6 +44,7 @@ func (u *URL) unmarshal(s *format.Subsection) error {
 
 	u.Name = s.Name
 	u.InsteadOfs = u.raw.OptionAll(insteadOfKey)
+	u.PushInsteadOfs = u.raw.OptionAll(pushInsteadOfKey)
 	return nil
 }
 
@@ -50,38 +55,50 @@ func (u *URL) marshal() *format.Subsection {
 
 	u.raw.Name = u.Name
 	u.raw.SetOption(insteadOfKey, u.InsteadOfs...)
+	u.raw.SetOption(pushInsteadOfKey, u.PushInsteadOfs...)
 
 	return u.raw
 }
 
-func findLongestInsteadOfMatch(remoteURL string, urls map[string]*URL) *URL {
+func findLongestURLMatch(remoteURL string, urls map[string]*URL, prefixes func(*URL) []string) (*URL, string) {
 	var longestMatch *URL
+	var longestPrefix string
 	var longestMatchLength int
 
 	for _, u := range urls {
-		for _, currentInsteadOf := range u.InsteadOfs {
-			if !strings.HasPrefix(remoteURL, currentInsteadOf) {
+		for _, currentPrefix := range prefixes(u) {
+			if !strings.HasPrefix(remoteURL, currentPrefix) {
 				continue
 			}
 
-			lengthCurrentInsteadOf := len(currentInsteadOf)
+			lengthCurrentPrefix := len(currentPrefix)
 
 			// according to spec if there is more than one match, take the longest
-			if longestMatch == nil || longestMatchLength < lengthCurrentInsteadOf {
+			if longestMatch == nil || longestMatchLength < lengthCurrentPrefix {
 				longestMatch = u
-				longestMatchLength = lengthCurrentInsteadOf
+				longestPrefix = currentPrefix
+				longestMatchLength = lengthCurrentPrefix
 			}
 		}
 	}
 
-	return longestMatch
+	return longestMatch, longestPrefix
 }
 
 // ApplyInsteadOf applies the URL rewrite rules to the given URL.
 func (u *URL) ApplyInsteadOf(url string) string {
-	for _, j := range u.InsteadOfs {
-		if strings.HasPrefix(url, j) {
-			return u.Name + url[len(j):]
+	return u.apply(url, u.InsteadOfs)
+}
+
+// ApplyPushInsteadOf applies the push URL rewrite rules to the given URL.
+func (u *URL) ApplyPushInsteadOf(url string) string {
+	return u.apply(url, u.PushInsteadOfs)
+}
+
+func (u *URL) apply(url string, prefixes []string) string {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(url, prefix) {
+			return u.Name + url[len(prefix):]
 		}
 	}
 

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -166,6 +166,24 @@ func (b *URLSuite) TestApplyInsteadOf() {
 	b.Equal("ssh://github.com/myrepo", urlRule.ApplyInsteadOf("http://github.com/myrepo"))
 }
 
+func (b *URLSuite) TestApplyInsteadOfUsesLongestMatch() {
+	urlRule := URL{
+		Name:       "ssh://github.com/",
+		InsteadOfs: []string{"https://example.com/", "https://example.com/team/"},
+	}
+
+	b.Equal("ssh://github.com/repo.git", urlRule.ApplyInsteadOf("https://example.com/team/repo.git"))
+}
+
+func (b *URLSuite) TestApplyPushInsteadOfUsesLongestMatch() {
+	urlRule := URL{
+		Name:           "ssh://github.com/",
+		PushInsteadOfs: []string{"https://example.com/", "https://example.com/team/"},
+	}
+
+	b.Equal("ssh://github.com/repo.git", urlRule.ApplyPushInsteadOf("https://example.com/team/repo.git"))
+}
+
 func (b *URLSuite) TestFindLongestInsteadOfMatch() {
 	urlRules := map[string]*URL{
 		"ssh://github.com": {

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -20,8 +20,13 @@ func (b *URLSuite) TestValidateInsteadOf() {
 		Name:       "ssh://github.com",
 		InsteadOfs: []string{"http://github.com"},
 	}
+	goodPushURL := URL{
+		Name:           "ssh://github.com",
+		PushInsteadOfs: []string{"http://github.com"},
+	}
 	badURL := URL{}
 	b.Nil(goodURL.Validate())
+	b.Nil(goodPushURL.Validate())
 	b.NotNil(badURL.Validate())
 }
 
@@ -64,6 +69,25 @@ func (b *URLSuite) TestMarshalMultipleInsteadOf() {
 	b.Equal(string(expected), string(actual))
 }
 
+func (b *URLSuite) TestMarshalPushInsteadOf() {
+	expected := []byte(`[core]
+	bare = false
+	filemode = true
+[url "ssh://git@github.com/"]
+	pushInsteadOf = https://github.com/
+`)
+
+	cfg := NewConfig()
+	cfg.URLs["ssh://git@github.com/"] = &URL{
+		Name:           "ssh://git@github.com/",
+		PushInsteadOfs: []string{"https://github.com/"},
+	}
+
+	actual, err := cfg.Marshal()
+	b.NoError(err)
+	b.Equal(string(expected), string(actual))
+}
+
 func (b *URLSuite) TestUnmarshal() {
 	input := []byte(`[core]
 	bare = false
@@ -95,6 +119,22 @@ func (b *URLSuite) TestUnmarshalMultipleInsteadOf() {
 
 	b.Equal("ssh://git@github.com/foobar", url.ApplyInsteadOf("https://github.com/foobar"))
 	b.Equal("ssh://git@github.com/foobar", url.ApplyInsteadOf("https://google.com/foobar"))
+}
+
+func (b *URLSuite) TestUnmarshalPushInsteadOf() {
+	input := []byte(`[core]
+	bare = false
+[url "ssh://git@github.com/"]
+	pushInsteadOf = https://github.com/
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	b.NoError(err)
+	url := cfg.URLs["ssh://git@github.com/"]
+	b.Equal("ssh://git@github.com/", url.Name)
+	b.Equal("https://github.com/", url.PushInsteadOfs[0])
+	b.Equal("ssh://git@github.com/foobar", url.ApplyPushInsteadOf("https://github.com/foobar"))
 }
 
 func (b *URLSuite) TestUnmarshalDuplicateUrls() {
@@ -138,7 +178,9 @@ func (b *URLSuite) TestFindLongestInsteadOfMatch() {
 		},
 	}
 
-	longestURL := findLongestInsteadOfMatch("http://github.com/foobar/bingbash.git", urlRules)
+	longestURL, _ := findLongestURLMatch("http://github.com/foobar/bingbash.git", urlRules, func(u *URL) []string {
+		return u.InsteadOfs
+	})
 
 	b.Equal("ssh://somethingelse.com", longestURL.Name)
 }

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -184,7 +184,7 @@ func (b *URLSuite) TestApplyPushInsteadOfUsesLongestMatch() {
 	b.Equal("ssh://github.com/repo.git", urlRule.ApplyPushInsteadOf("https://example.com/team/repo.git"))
 }
 
-func (b *URLSuite) TestFindLongestInsteadOfMatch() {
+func (b *URLSuite) TestRewriteLongestURLMatch() {
 	urlRules := map[string]*URL{
 		"ssh://github.com": {
 			Name:       "ssh://github.com",
@@ -196,9 +196,10 @@ func (b *URLSuite) TestFindLongestInsteadOfMatch() {
 		},
 	}
 
-	longestURL, _ := findLongestURLMatch("http://github.com/foobar/bingbash.git", urlRules, func(u *URL) []string {
+	rewritten, matched := rewriteLongestURLMatch("http://github.com/foobar/bingbash.git", urlRules, func(u *URL) []string {
 		return u.InsteadOfs
 	})
 
-	b.Equal("ssh://somethingelse.com", longestURL.Name)
+	b.True(matched)
+	b.Equal("ssh://somethingelse.com/bingbash.git", rewritten)
 }

--- a/remote.go
+++ b/remote.go
@@ -69,7 +69,7 @@ func (r *Remote) String() string {
 	var fetch, push string
 	if len(r.c.URLs) > 0 {
 		fetch = r.c.URLs[0]
-		push = r.c.PushURL()
+		push = r.c.ResolvedPushURL()
 	}
 
 	return fmt.Sprintf("%s\t%s (fetch)\n%[1]s\t%[3]s (push)", r.c.Name, fetch, push)
@@ -132,18 +132,8 @@ func (r *Remote) pushURLs(remoteURL string) []string {
 		return []string{remoteURL}
 	}
 
-	if len(r.c.PushURLs) > 0 {
-		return r.c.PushURLs
-	}
-
-	if pushURL := r.c.PushURL(); pushURL != "" {
-		if len(r.c.URLs) == 0 || pushURL != r.c.URLs[0] {
-			return []string{pushURL}
-		}
-	}
-
-	if len(r.c.URLs) > 0 {
-		return r.c.URLs
+	if pushURLs := r.c.ResolvedPushURLs(); len(pushURLs) > 0 {
+		return pushURLs
 	}
 
 	return []string{""}

--- a/remote.go
+++ b/remote.go
@@ -69,7 +69,7 @@ func (r *Remote) String() string {
 	var fetch, push string
 	if len(r.c.URLs) > 0 {
 		fetch = r.c.URLs[0]
-		push = r.c.URLs[len(r.c.URLs)-1]
+		push = r.c.PushURL()
 	}
 
 	return fmt.Sprintf("%s\t%s (fetch)\n%[1]s\t%[3]s (push)", r.c.Name, fetch, push)
@@ -104,7 +104,7 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 	}
 
 	if o.RemoteURL == "" && len(r.c.URLs) > 0 {
-		o.RemoteURL = r.c.URLs[len(r.c.URLs)-1]
+		o.RemoteURL = r.c.PushURL()
 	}
 
 	cl, req, err := newClient(o.RemoteURL, o.ClientOptions)

--- a/remote.go
+++ b/remote.go
@@ -103,10 +103,53 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		return fmt.Errorf("remote names don't match: %s != %s", o.RemoteName, r.c.Name)
 	}
 
-	if o.RemoteURL == "" && len(r.c.URLs) > 0 {
-		o.RemoteURL = r.c.PushURL()
+	allUpToDate := true
+	for _, remoteURL := range r.pushURLs(o.RemoteURL) {
+		pushOptions := *o
+		pushOptions.RemoteURL = remoteURL
+		pushOptions.RefSpecs = append([]config.RefSpec(nil), o.RefSpecs...)
+
+		if err := r.pushToURL(ctx, &pushOptions); err != nil {
+			if err == NoErrAlreadyUpToDate {
+				continue
+			}
+
+			return err
+		}
+
+		allUpToDate = false
 	}
 
+	if allUpToDate {
+		return NoErrAlreadyUpToDate
+	}
+
+	return nil
+}
+
+func (r *Remote) pushURLs(remoteURL string) []string {
+	if remoteURL != "" {
+		return []string{remoteURL}
+	}
+
+	if len(r.c.PushURLs) > 0 {
+		return r.c.PushURLs
+	}
+
+	if pushURL := r.c.PushURL(); pushURL != "" {
+		if len(r.c.URLs) == 0 || pushURL != r.c.URLs[0] {
+			return []string{pushURL}
+		}
+	}
+
+	if len(r.c.URLs) > 0 {
+		return r.c.URLs
+	}
+
+	return []string{""}
+}
+
+func (r *Remote) pushToURL(ctx context.Context, o *PushOptions) (err error) {
 	cl, req, err := newClient(o.RemoteURL, o.ClientOptions)
 	if err != nil {
 		return err

--- a/remote_test.go
+++ b/remote_test.go
@@ -682,6 +682,92 @@ func (s *RemoteSuite) TestPushToAllRemoteURLsWhenPushURLsAreUnset() {
 	AssertReferences(s.T(), server2, expected)
 }
 
+// Regression test: when two fetch URLs each match a different pushInsteadOf
+// rule, push must fan out to every rewritten URL rather than just the first.
+func (s *RemoteSuite) TestPushWithMultiplePushInsteadOfFansOut() {
+	pushURL1 := s.T().TempDir()
+	pushServer1, err := PlainInit(pushURL1, true)
+	s.NoError(err)
+	defer func() { _ = pushServer1.Close() }()
+
+	pushURL2 := s.T().TempDir()
+	pushServer2, err := PlainInit(pushURL2, true)
+	s.NoError(err)
+	defer func() { _ = pushServer2.Close() }()
+
+	configText := fmt.Sprintf(`[remote "origin"]
+	url = https://example1.invalid/repo.git
+	url = https://example2.invalid/repo.git
+[url "%s"]
+	pushInsteadOf = https://example1.invalid/repo.git
+[url "%s"]
+	pushInsteadOf = https://example2.invalid/repo.git
+`, pushURL1, pushURL2)
+
+	cfg := config.NewConfig()
+	s.Require().NoError(cfg.Unmarshal([]byte(configText)))
+
+	srcFs, err := fixtures.Basic().One().DotGit()
+	s.Require().NoError(err)
+	sto := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
+
+	r := NewRemote(sto, cfg.Remotes["origin"])
+
+	rs := config.RefSpec("refs/heads/*:refs/heads/*")
+	err = r.Push(&PushOptions{RefSpecs: []config.RefSpec{rs}})
+	s.NoError(err)
+
+	expected := expectedBranchReferences(s.T(), r.s)
+	AssertReferences(s.T(), pushServer1, expected)
+	AssertReferences(s.T(), pushServer2, expected)
+}
+
+// Regression test: when a pushInsteadOf rule rewrites to a value equal to
+// URLs[0], push must still target only the rewritten URL and not fall through
+// to the remaining fetch URLs.
+func (s *RemoteSuite) TestPushWithPushInsteadOfMatchingFirstURL() {
+	pushTarget := s.T().TempDir()
+	pushServer, err := PlainInit(pushTarget, true)
+	s.NoError(err)
+	defer func() { _ = pushServer.Close() }()
+
+	// A real bare repo at a second URL that push should NOT touch.
+	untouched := s.T().TempDir()
+	untouchedServer, err := PlainInit(untouched, true)
+	s.NoError(err)
+	defer func() { _ = untouchedServer.Close() }()
+
+	// URLs[0] == pushTarget, and pushInsteadOf also rewrites URLs[0] -> pushTarget.
+	// So PushURL() returns a value equal to URLs[0].
+	configText := fmt.Sprintf(`[remote "origin"]
+	url = %s
+	url = %s
+[url "%s"]
+	pushInsteadOf = %s
+`, pushTarget, untouched, pushTarget, pushTarget)
+
+	cfg := config.NewConfig()
+	s.Require().NoError(cfg.Unmarshal([]byte(configText)))
+
+	srcFs, err := fixtures.Basic().One().DotGit()
+	s.Require().NoError(err)
+	sto := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
+
+	r := NewRemote(sto, cfg.Remotes["origin"])
+
+	rs := config.RefSpec("refs/heads/*:refs/heads/*")
+	err = r.Push(&PushOptions{RefSpecs: []config.RefSpec{rs}})
+	s.NoError(err)
+
+	expected := expectedBranchReferences(s.T(), r.s)
+	AssertReferences(s.T(), pushServer, expected)
+
+	untouchedRefs := expectedBranchReferences(s.T(), untouchedServer.Storer)
+	s.Empty(untouchedRefs, "second fetch URL should not have been pushed to")
+}
+
 func expectedBranchReferences(t testing.TB, refs storer.ReferenceStorer) map[string]string {
 	t.Helper()
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -775,6 +775,7 @@ func expectedBranchReferences(t testing.TB, refs storer.ReferenceStorer) map[str
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer iter.Close()
 
 	expected := make(map[string]string)
 	err = iter.ForEach(func(ref *plumbing.Reference) error {

--- a/remote_test.go
+++ b/remote_test.go
@@ -612,6 +612,100 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 	AssertReferences(s.T(), server, expected)
 }
 
+func (s *RemoteSuite) TestPushToAllPushURLs() {
+	fetchURL := s.T().TempDir()
+	fetchServer, err := PlainInit(fetchURL, true)
+	s.NoError(err)
+	defer func() { _ = fetchServer.Close() }()
+
+	pushURL1 := s.T().TempDir()
+	pushServer1, err := PlainInit(pushURL1, true)
+	s.NoError(err)
+	defer func() { _ = pushServer1.Close() }()
+
+	pushURL2 := s.T().TempDir()
+	pushServer2, err := PlainInit(pushURL2, true)
+	s.NoError(err)
+	defer func() { _ = pushServer2.Close() }()
+
+	srcFs, err := fixtures.Basic().One().DotGit()
+	s.Require().NoError(err)
+	sto := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		Name:     DefaultRemoteName,
+		URLs:     []string{fetchURL},
+		PushURLs: []string{pushURL1, pushURL2},
+	})
+
+	rs := config.RefSpec("refs/heads/*:refs/heads/*")
+	err = r.Push(&PushOptions{
+		RefSpecs: []config.RefSpec{rs},
+	})
+	s.NoError(err)
+
+	expected := expectedBranchReferences(s.T(), r.s)
+	AssertReferences(s.T(), pushServer1, expected)
+	AssertReferences(s.T(), pushServer2, expected)
+}
+
+func (s *RemoteSuite) TestPushToAllRemoteURLsWhenPushURLsAreUnset() {
+	url1 := s.T().TempDir()
+	server1, err := PlainInit(url1, true)
+	s.NoError(err)
+	defer func() { _ = server1.Close() }()
+
+	url2 := s.T().TempDir()
+	server2, err := PlainInit(url2, true)
+	s.NoError(err)
+	defer func() { _ = server2.Close() }()
+
+	srcFs, err := fixtures.Basic().One().DotGit()
+	s.Require().NoError(err)
+	sto := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	defer func() { _ = sto.Close() }()
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{url1, url2},
+	})
+
+	rs := config.RefSpec("refs/heads/*:refs/heads/*")
+	err = r.Push(&PushOptions{
+		RefSpecs: []config.RefSpec{rs},
+	})
+	s.NoError(err)
+
+	expected := expectedBranchReferences(s.T(), r.s)
+	AssertReferences(s.T(), server1, expected)
+	AssertReferences(s.T(), server2, expected)
+}
+
+func expectedBranchReferences(t testing.TB, refs storer.ReferenceStorer) map[string]string {
+	t.Helper()
+
+	iter, err := refs.IterReferences()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := make(map[string]string)
+	err = iter.ForEach(func(ref *plumbing.Reference) error {
+		if !ref.Name().IsBranch() {
+			return nil
+		}
+
+		expected[ref.Name().String()] = ref.Hash().String()
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return expected
+}
+
 func (s *RemoteSuite) TestPushContext() {
 	url := s.T().TempDir()
 	server, err := PlainInit(url, true)


### PR DESCRIPTION
Parse `url.*.pushInsteadOf` rules and use them when selecting the default push URL. Preserve explicit remote `pushurl` precedence and apply `pushInsteadOf` before normal `insteadOf` rewrites, matching Git behavior.

Assisted-by: Codex 5.5 <noreply@openai.com>
Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: jyn <github@jyn.dev>

This commit is LLM-generated, except that I added the comments. I self-reviewed the tests and they looked ok. I haven't looked too hard at the code.

The original motivation for this PR was a bug in `git-bug` where it would fail when I had `pushInsteadOf` set but not `insteadOf`. It would get an empty string in insteadOf, try to apply the first rewrite I found in the config, and fail because I didn't have any repository forked at that remote. I'm fixing that in a second, but it needs this upstream fix first.

---

New API:
```go
// config/url.go

type URL struct {  // existing
  PushInsteadOfs []string  // new
}

func (u *URL) ApplyPushInsteadOf(url string); // new

// config/config.go

type RemoteConfig struct {  // existing
  PushURLs []string  // new
}

func (c *RemoteConfig) ResolvedPushURL() string;  // new
func (c *RemoteConfig) ResolvedPushURLs() []string; // new
```

Behavior changes:
- `Remote.Push()` now pushes to *all* remotes, not just the first remote, matching git.
- `Remote.String()` now reports `PushURL()` instead of the last URL. Previously these were *usually* the same, but they could diverge if there were multiple `url` fields for the same remote: before, go-git would return the last `url`, now it returns the first. If there is an explicit `pushurl`, the behavior is the same as before.
- `URL.ApplyInsteadOf` now uses the longest prefix instead of the first matching prefix. Longest prefix is Go's behavior, documented here: https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf