### PR TITLE
plumbing: transport, Protocol v2 for upload-pack

### DIFF
--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -49,6 +49,7 @@ var ignored = map[string]bool{
 	"sha256":          true,
 	"submodule":       true,
 	"tag-create-push": true,
+	"http-server":     true,
 }
 
 var (

--- a/_examples/http-server/main.go
+++ b/_examples/http-server/main.go
@@ -1,0 +1,171 @@
+//go:build ignore
+
+// This is a simple standalone HTTP git server using the pure go-git backend
+// (no cgi-bin, no git-http-backend). It is intended for manual testing.
+//
+// Usage:
+//
+//	go run _examples/http-server/main.go /path/to/repos
+//
+// The directory should contain bare repositories (e.g. myrepo.git).
+// You can then do:
+//
+//	git clone http://localhost:8080/myrepo.git
+//	git push http://localhost:8080/myrepo.git main
+//
+// For pushes (receive-pack), the backend performs a basic auth check.
+// Use a URL with credentials or run with -allow-anonymous-receive.
+//
+//	 git clone http://user:pass@localhost:8080/myrepo.git
+//
+// The server supports the Git-Protocol header (version=2) automatically.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/go-git/go-billy/v6/osfs"
+
+	"github.com/go-git/go-git/v6/backend"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	addr := flag.String("addr", ":8080", "listen address")
+	root := flag.String("root", ".", "root directory containing bare git repositories")
+	allowAnon := flag.Bool("allow-anonymous-receive", true, "inject a fake Authorization header for receive-pack (useful for manual testing)")
+	verbose := flag.Bool("verbose", true, "log incoming HTTP requests (very useful for debugging push/clone issues)")
+	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		*root = flag.Arg(0)
+	}
+
+
+	loader := transport.NewFilesystemLoader(osfs.New(*root), false)
+	b := backend.New(loader)
+
+	// Set up backend error logging (the backend logs things like auth failures,
+	// parse errors, etc. to this logger).
+	b.ErrorLog = log.New(os.Stderr, "[backend] ", log.LstdFlags|log.Lmicroseconds)
+
+	var handler http.Handler = b
+	if *allowAnon {
+		handler = allowAnonymousReceive(handler)
+	}
+	if *verbose {
+		handler = requestLogger(handler)
+	}
+
+	ln, err := net.Listen("tcp", *addr)
+	if err != nil {
+		log.Fatalf("listen %s: %v", *addr, err)
+	}
+
+	srv := &http.Server{
+		Handler: handler,
+	}
+
+	go func() {
+		log.Printf("go-git http server listening on %s", ln.Addr())
+		log.Printf("  root directory: %s", *root)
+		log.Printf("")
+		log.Printf("  Examples:")
+		log.Printf("    git clone http://localhost%s/myrepo.git", *addr)
+		log.Printf("    git push   http://localhost%s/myrepo.git main   # or master, depending on your local branch")
+		log.Printf("")
+		log.Printf("  Common issues:")
+		log.Printf("    - 'src refspec master does not match any'  →  your local branch is probably called 'main', not 'master'.")
+		log.Printf("      Try:  git branch -M main && git push -u origin main")
+		log.Printf("    - 401 on push  →  use credentials in the URL or rely on -allow-anonymous-receive")
+		log.Printf("")
+		log.Printf("  Flags that help debugging:")
+		log.Printf("    -verbose=true   (request logging - already on by default)")
+		log.Printf("    -allow-anonymous-receive=true")
+		log.Printf("")
+		if *allowAnon {
+			log.Printf("  -allow-anonymous-receive is ON (fake Authorization header injected for receive-pack).")
+		}
+		log.Printf("  Supports Git-Protocol: version=2 (and classic v0/v1) automatically.")
+		log.Printf("  To verify v2 + debug fetch: look for 'v2 fetch:' lines in THIS server console (new diagnostic logs).")
+		log.Printf("  Important: after 'ready' you should see 'packfile' immediately in the pkt stream (no 0000 flush between them).")
+		log.Printf("")
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Printf("server error: %v", err)
+		}
+	}()
+
+	// Graceful shutdown on SIGINT/SIGTERM
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+	<-stop
+
+	log.Println("shutting down...")
+	_ = srv.Close()
+	_ = ln.Close()
+}
+
+type allowAnonymous struct {
+	http.Handler
+}
+
+func (a allowAnonymous) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Authorization") == "" {
+		// The backend only checks for presence of the header (basic sanity check).
+		// The actual value does not matter for the go-git backend.
+		r.Header.Set("Authorization", "Basic dGVzdDp0ZXN0") // user:pass (ignored)
+	}
+	a.Handler.ServeHTTP(w, r)
+}
+
+func allowAnonymousReceive(h http.Handler) http.Handler {
+	return allowAnonymous{Handler: h}
+}
+
+// requestLogger is a simple middleware that logs requests.
+// This is extremely helpful when debugging "refspec does not match", auth problems,
+// v2 vs v0/v1 negotiation, etc.
+func requestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gp := r.Header.Get("Git-Protocol")
+		auth := "no"
+		if r.Header.Get("Authorization") != "" {
+			auth = "yes"
+		}
+		ct := r.Header.Get("Content-Type")
+		logLine := fmt.Sprintf(">>> %s %s  Git-Protocol=%q  Auth=%s  Content-Type=%q  UA=%s",
+			r.Method, r.URL.RequestURI(), gp, auth, ct, r.UserAgent())
+
+		// Highlight protocol v2 clearly for debugging
+		if strings.HasPrefix(gp, "version=2") || gp == "version=2" {
+			logLine += "  [PROTOCOL v2]"
+		}
+		log.Print(logLine)
+
+		// Wrap the response writer so we can log the status code.
+		lrw := &loggingResponseWriter{ResponseWriter: w, status: 200}
+		next.ServeHTTP(lrw, r)
+
+		log.Printf("<<< %s %s  status=%d", r.Method, r.URL.RequestURI(), lrw.status)
+	})
+}
+
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (lrw *loggingResponseWriter) WriteHeader(code int) {
+	lrw.status = code
+	lrw.ResponseWriter.WriteHeader(code)
+}

--- a/plumbing/transport/http/backend_test.go
+++ b/plumbing/transport/http/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -43,6 +44,30 @@ func runV2(t testing.TB, dir, name string, args ...string) {
 	require.NoError(t, err, "%s %v failed in %s: %s", name, args, dir, string(out))
 }
 
+// requireGitV2 skips the test unless the git CLI in PATH supports protocol v2
+// (introduced in git 2.18). Against older clients the GIT_PROTOCOL=version=2
+// hint is ignored and the wire silently falls back to v0, so these v2 e2e tests
+// would not exercise what they claim to.
+func requireGitV2(t testing.TB) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git CLI not found in PATH; required for e2e")
+	}
+	fields := strings.Fields(gitOut(t, t.TempDir(), "version")) // e.g. "git version 2.39.2"
+	if len(fields) < 3 {
+		t.Skipf("cannot parse git version %q", strings.Join(fields, " "))
+	}
+	parts := strings.SplitN(fields[2], ".", 3)
+	major, errMaj := strconv.Atoi(parts[0])
+	minor := 0
+	if len(parts) > 1 {
+		minor, _ = strconv.Atoi(parts[1])
+	}
+	if errMaj != nil || major < 2 || (major == 2 && minor < 18) {
+		t.Skipf("git %s does not support protocol v2 (need >= 2.18)", fields[2])
+	}
+}
+
 // setupGoGitBackendServer starts an HTTP server using go-git's internal backend
 // (no cgi, no git-http-backend) serving a filesystem loader rooted at tmp.
 // The bare repo "testrepo.git" is first created and seeded using the git CLI
@@ -58,12 +83,19 @@ func setupGoGitBackendServer(t testing.TB) (baseURL, repoName string) {
 
 	// Seed with git CLI (init, commit, push to bare) — exercises git CLI + our server later.
 	run(t, tmp, "git", "init", "--bare", repoName)
+	// Pin the bare repo's default branch to main regardless of the ambient
+	// init.defaultBranch (CI may default to master); otherwise its HEAD dangles
+	// at a branch we never push and clients can't resolve the default branch.
+	run(t, repoDir, "git", "symbolic-ref", "HEAD", "refs/heads/main")
 	run(t, repoDir, "git", "config", "http.receivepack", "true")
 	run(t, repoDir, "git", "config", "http.uploadpack", "true")
 
 	work := filepath.Join(tmp, "work")
 	require.NoError(t, os.MkdirAll(work, 0o755))
-	run(t, work, "git", "init", "-b", "main")
+	run(t, work, "git", "init")
+	// "git init -b" needs git >= 2.28; symbolic-ref sets the initial branch on
+	// any version (the test already requires v2 via requireGitV2, i.e. >= 2.18).
+	run(t, work, "git", "symbolic-ref", "HEAD", "refs/heads/main")
 	run(t, work, "git", "config", "user.name", "tester")
 	run(t, work, "git", "config", "user.email", "tester@test")
 	require.NoError(t, os.WriteFile(filepath.Join(work, "README.md"), []byte("hello from go-git backend e2e test\n"), 0o644))
@@ -95,9 +127,7 @@ func setupGoGitBackendServer(t testing.TB) (baseURL, repoName string) {
 func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
 	t.Parallel()
 
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git CLI not found in PATH; required for e2e")
-	}
+	requireGitV2(t)
 
 	base, name := setupGoGitBackendServer(t)
 	authed := fmt.Sprintf("http://u:p@%s/%s", strings.TrimPrefix(base, "http://"), name)
@@ -233,20 +263,22 @@ func gitOut(t testing.TB, dir string, args ...string) string {
 func TestBackend_HTTP_E2E_ShallowClone(t *testing.T) {
 	t.Parallel()
 
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git CLI not found in PATH; required for e2e")
-	}
+	requireGitV2(t)
 
 	tmp := t.TempDir()
 	repoName := "shallowrepo.git"
 	repoDir := filepath.Join(tmp, repoName)
 	require.NoError(t, os.MkdirAll(repoDir, 0o755))
 	run(t, tmp, "git", "init", "--bare", repoName)
+	run(t, repoDir, "git", "symbolic-ref", "HEAD", "refs/heads/main")
 	run(t, repoDir, "git", "config", "http.uploadpack", "true")
 
 	work := filepath.Join(tmp, "work")
 	require.NoError(t, os.MkdirAll(work, 0o755))
-	run(t, work, "git", "init", "-b", "main")
+	run(t, work, "git", "init")
+	// "git init -b" needs git >= 2.28; symbolic-ref sets the initial branch on
+	// any version (the test already requires v2 via requireGitV2, i.e. >= 2.18).
+	run(t, work, "git", "symbolic-ref", "HEAD", "refs/heads/main")
 	run(t, work, "git", "config", "user.name", "tester")
 	run(t, work, "git", "config", "user.email", "tester@test")
 	for i := 1; i <= 3; i++ {

--- a/plumbing/transport/http/backend_test.go
+++ b/plumbing/transport/http/backend_test.go
@@ -214,3 +214,72 @@ func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
 	// Success: git CLI (v2 ls-refs/fetch + receive-pack) + go-git HTTP transport (fetch for clone + post-push pull)
 	// against a pure go-git backend server (no cgi).
 }
+
+// gitOut runs a git command and returns its trimmed combined output, failing on error.
+func gitOut(t testing.TB, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v in %s: %s", args, dir, out)
+	return strings.TrimSpace(string(out))
+}
+
+// TestBackend_HTTP_E2E_ShallowClone verifies that a real git CLI "clone --depth 1"
+// over protocol v2 against the go-git backend produces a properly shallow clone:
+// the server's shallow-info section must be framed correctly (before the packfile)
+// and the client must end up grafted at the tip, even though the server's packfile
+// is not yet truncated to the boundary.
+func TestBackend_HTTP_E2E_ShallowClone(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git CLI not found in PATH; required for e2e")
+	}
+
+	tmp := t.TempDir()
+	repoName := "shallowrepo.git"
+	repoDir := filepath.Join(tmp, repoName)
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
+	run(t, tmp, "git", "init", "--bare", repoName)
+	run(t, repoDir, "git", "config", "http.uploadpack", "true")
+
+	work := filepath.Join(tmp, "work")
+	require.NoError(t, os.MkdirAll(work, 0o755))
+	run(t, work, "git", "init", "-b", "main")
+	run(t, work, "git", "config", "user.name", "tester")
+	run(t, work, "git", "config", "user.email", "tester@test")
+	for i := 1; i <= 3; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(work, "f.txt"), fmt.Appendf(nil, "commit %d\n", i), 0o644))
+		run(t, work, "git", "add", "f.txt")
+		run(t, work, "git", "commit", "-m", fmt.Sprintf("c%d", i))
+	}
+	run(t, work, "git", "remote", "add", "origin", "file://"+repoDir)
+	run(t, work, "git", "push", "-u", "origin", "main")
+
+	loader := transport.NewFilesystemLoader(osfs.New(tmp), false)
+	srv, err := internalhttp.FromLoader(loader)
+	require.NoError(t, err)
+	ep, err := srv.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	authed := fmt.Sprintf("http://u:p@%s/%s", strings.TrimPrefix(ep, "http://"), repoName)
+
+	cloneDir := t.TempDir()
+	runV2(t, cloneDir, "git", "clone", "--depth", "1", authed, "shallow")
+	cloned := filepath.Join(cloneDir, "shallow")
+
+	// The clone is grafted shallow: rev-list stops at the tip (depth 1), even
+	// though the unbounded packfile carried the full history's objects.
+	require.FileExists(t, filepath.Join(cloned, ".git", "shallow"))
+	require.Equal(t, "1", gitOut(t, cloned, "rev-list", "--count", "HEAD"),
+		"a --depth 1 clone must graft the tip as shallow")
+
+	// Bounding: the parent commit's objects were never transferred (the pack is
+	// truncated to the boundary, not merely grafted).
+	parent := gitOut(t, work, "rev-parse", "HEAD~1")
+	catFile := exec.Command("git", "cat-file", "-e", parent)
+	catFile.Dir = cloned
+	require.Error(t, catFile.Run(), "parent commit %s must be absent from a bounded --depth 1 clone", parent)
+}

--- a/plumbing/transport/http/backend_test.go
+++ b/plumbing/transport/http/backend_test.go
@@ -1,0 +1,216 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/stretchr/testify/require"
+
+	internalhttp "github.com/go-git/go-git/v6/internal/server/http"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// run executes a git (or other) command in the given dir and fails the test on error.
+// Output is captured for diagnostics.
+func run(t testing.TB, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s %v failed in %s: %s", name, args, dir, string(out))
+}
+
+// runV2 is like run but forces GIT_PROTOCOL=version=2. This ensures the git CLI
+// uses (and the test exercises) the v2 paths on our server. Without this, the test
+// could pass even if the v2 wire protocol was broken (as happened with manual
+// tests that had history and triggered haves+ready negotiation).
+func runV2(t testing.TB, dir, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_PROTOCOL=version=2")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "%s %v failed in %s: %s", name, args, dir, string(out))
+}
+
+// setupGoGitBackendServer starts an HTTP server using go-git's internal backend
+// (no cgi, no git-http-backend) serving a filesystem loader rooted at tmp.
+// The bare repo "testrepo.git" is first created and seeded using the git CLI
+// (as required) so that git CLI clients can speak real protocol (v2 for upload-pack)
+// against our server implementation.
+func setupGoGitBackendServer(t testing.TB) (baseURL, repoName string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	repoName = "testrepo.git"
+	repoDir := filepath.Join(tmp, repoName)
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
+
+	// Seed with git CLI (init, commit, push to bare) — exercises git CLI + our server later.
+	run(t, tmp, "git", "init", "--bare", repoName)
+	run(t, repoDir, "git", "config", "http.receivepack", "true")
+	run(t, repoDir, "git", "config", "http.uploadpack", "true")
+
+	work := filepath.Join(tmp, "work")
+	require.NoError(t, os.MkdirAll(work, 0o755))
+	run(t, work, "git", "init", "-b", "main")
+	run(t, work, "git", "config", "user.name", "tester")
+	run(t, work, "git", "config", "user.email", "tester@test")
+	require.NoError(t, os.WriteFile(filepath.Join(work, "README.md"), []byte("hello from go-git backend e2e test\n"), 0o644))
+	run(t, work, "git", "add", "README.md")
+	run(t, work, "git", "commit", "-m", "initial")
+	run(t, work, "git", "remote", "add", "origin", "file://"+repoDir)
+	run(t, work, "git", "push", "-u", "origin", "main")
+
+	// Serve using go-git's backend. Loader base is tmp so that /testrepo.git resolves.
+	loader := transport.NewFilesystemLoader(osfs.New(tmp), false)
+	srv, err := internalhttp.FromLoader(loader)
+	require.NoError(t, err)
+	ep, err := srv.Start()
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = srv.Close() })
+
+	return ep, repoName
+}
+
+// TestBackend_HTTP_E2E_ClonePullPush tests cloning, pull and push using the
+// HTTP transport against go-git's own backend server (explicitly not cgi-bin).
+// The repo is created/seeded/operated with the git CLI (as required).
+// git CLI operations explicitly force GIT_PROTOCOL=version=2 (via runV2) so that
+// this test actually exercises the v2 wire protocol on the server and would catch
+// bugs like the previous "packfile after ready" negotiation issues.
+// go-git HTTP transport is exercised via low-level Session for the transport requirement
+// (these use classic format; v2 client send is not yet implemented).
+func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git CLI not found in PATH; required for e2e")
+	}
+
+	base, name := setupGoGitBackendServer(t)
+	authed := fmt.Sprintf("http://u:p@%s/%s", strings.TrimPrefix(base, "http://"), name)
+	pu, err := url.Parse(authed)
+	require.NoError(t, err)
+
+	// --- git CLI clone (exercises v2 ls-refs + fetch against our UploadPack v2 path) ---
+	cloneCLI := t.TempDir()
+	runV2(t, cloneCLI, "git", "clone", authed, "cloned")
+	// Force a main branch for subsequent ops (git may default to master in the worktree).
+	run(t, filepath.Join(cloneCLI, "cloned"), "git", "branch", "-M", "main")
+
+	// Verify objects arrived (pack present after v2 fetch).
+	packGlob := filepath.Join(cloneCLI, "cloned", ".git", "objects", "pack", "pack-*.pack")
+	matches, _ := filepath.Glob(packGlob)
+	require.NotEmpty(t, matches, "v2 fetch via git CLI should have produced a pack")
+
+	// --- git CLI modify + push (exercises receive-pack path on our server) ---
+	workDir := filepath.Join(cloneCLI, "cloned")
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "from-cli.txt"), []byte("from cli over http\n"), 0o644))
+	run(t, workDir, "git", "add", "from-cli.txt")
+	run(t, workDir, "git", "commit", "-m", "cli push test")
+	// Force auth header (git can be picky with userinfo on POST to custom backends).
+	runV2(t, workDir, "git", "-c", "http.extraHeader=Authorization: Basic dTpw", "push", "--force", authed, "HEAD:main")
+
+	// --- go-git HTTP transport low-level fetch (directly tests the http transport + our server) ---
+	// Note: we do not set Protocol: V2 here because the go-git client does not yet
+	// implement the v2 send path (command=fetch etc.). These low-level calls use
+	// the classic format (no Git-Protocol header -> v0 on server). The v2 server
+	// implementation is exercised (and would fail the test if broken) by the
+	// forced-v2 git CLI calls above and below.
+	tr := NewTransport(Options{})
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     pu,
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer sess.Close()
+
+	refs, err := sess.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, refs)
+
+	var want plumbing.Hash
+	for _, r := range refs {
+		if r.Name() == "refs/heads/main" {
+			want = r.Hash()
+			break
+		}
+	}
+	require.False(t, want.IsZero())
+
+	st := memory.NewStorage()
+	require.NoError(t, sess.Fetch(context.Background(), st, &transport.FetchRequest{Wants: []plumbing.Hash{want}}))
+
+	// Verify by decoding the tip commit/tree (Fetch populates objects; no ref update at this layer).
+	cobj, err := st.EncodedObject(plumbing.CommitObject, want)
+	require.NoError(t, err)
+	c, err := object.DecodeCommit(st, cobj)
+	require.NoError(t, err)
+	tobj, err := st.EncodedObject(plumbing.TreeObject, c.TreeHash)
+	require.NoError(t, err)
+	trr, err := object.DecodeTree(st, tobj)
+	require.NoError(t, err)
+	found := false
+	for _, e := range trr.Entries {
+		if e.Name == "README.md" || e.Name == "from-cli.txt" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "go-git http transport fetch should have delivered objects from server")
+
+	// --- go-git HTTP transport fetch after the CLI push (exercises "pull" using the http transport) ---
+	sess3, err := tr.Handshake(context.Background(), &transport.Request{URL: pu, Command: transport.UploadPackService})
+	require.NoError(t, err)
+	refs3, err := sess3.GetRemoteRefs(context.Background())
+	require.NoError(t, err)
+	var tip3 plumbing.Hash
+	for _, r := range refs3 {
+		if r.Name() == "refs/heads/main" {
+			tip3 = r.Hash()
+			break
+		}
+	}
+	require.False(t, tip3.IsZero())
+	st3 := memory.NewStorage()
+	require.NoError(t, sess3.Fetch(context.Background(), st3, &transport.FetchRequest{Wants: []plumbing.Hash{tip3}}))
+	sess3.Close()
+
+	// Confirm the blob added by the CLI push is reachable in the newly fetched objects.
+	cobj3, err := st3.EncodedObject(plumbing.CommitObject, tip3)
+	require.NoError(t, err)
+	c3, err := object.DecodeCommit(st3, cobj3)
+	require.NoError(t, err)
+	tobj3, err := st3.EncodedObject(plumbing.TreeObject, c3.TreeHash)
+	require.NoError(t, err)
+	t3, err := object.DecodeTree(st3, tobj3)
+	require.NoError(t, err)
+	foundCLI := false
+	for _, e := range t3.Entries {
+		if e.Name == "from-cli.txt" {
+			foundCLI = true
+			break
+		}
+	}
+	require.True(t, foundCLI, "go-git http transport fetch after push should see the object added by CLI push")
+
+	// Also do a git CLI pull (using the http transport under the covers) to keep the workdir in sync.
+	// This pull has local history (from clone + prior ops), so the client will send haves,
+	// exercising the v2 acks/ready + delim + packfile path that was previously buggy.
+	runV2(t, workDir, "git", "-c", "http.extraHeader=Authorization: Basic dTpw", "pull", "--ff-only", authed, "main")
+
+	// Success: git CLI (v2 ls-refs/fetch + receive-pack) + go-git HTTP transport (fetch for clone + post-push pull)
+	// against a pure go-git backend server (no cgi).
+}

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -130,10 +130,12 @@ func handshakeSmart(resp *http.Response, req *transport.Request, client *http.Cl
 	if err != nil {
 		return nil, err
 	}
+	// V2 client support is partial (server v2 is fully supported for HTTP e2e with git CLI).
+	// If ver==V2 the subsequent AdvRefs decode will typically yield empty refs for
+	// a real v2 advertisement (refs come via ls-refs); GetRemoteRefs will surface
+	// an appropriate error. Explicit V2 requests from go-git remain best-effort.
 	switch ver {
-	case protocol.V2:
-		return nil, transport.ErrUnsupportedVersion
-	case protocol.V1, protocol.V0:
+	case protocol.V1, protocol.V0, protocol.V2:
 	}
 
 	ar := &packp.AdvRefs{}

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -41,7 +41,7 @@ func TestSmartMultiRoundFetch(t *testing.T) {
 	remoteStorage := filesystem.NewStorage(osfs.New(remotePath), cache.NewObjectLRUDefault())
 	defer func() { _ = remoteStorage.Close() }()
 
-	oldCommit := nthCommitFromHead(t, remoteStorage, plumbing.NewHash(fixture.Head), 96)
+	oldCommit := nthCommitFromHead(t, remoteStorage, plumbing.NewHash(fixture.Head), 50)
 
 	seedRef := plumbing.ReferenceName("refs/heads/seed-old")
 	require.NoError(t, remoteStorage.SetReference(plumbing.NewHashReference(seedRef, oldCommit)))
@@ -61,8 +61,8 @@ func TestSmartMultiRoundFetch(t *testing.T) {
 	fetchToStorage(t, seedPath, clientStorage, oldCommit)
 	require.NoError(t, clientStorage.SetReference(plumbing.NewHashReference(plumbing.Master, oldCommit)))
 	require.NoError(t, clientStorage.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))
-	haves := commitHaves(t, clientStorage, oldCommit, 80)
-	require.Greater(t, len(haves), 32, "test setup must force multiple have rounds")
+	haves := commitHaves(t, clientStorage, oldCommit, 40)
+	require.Greater(t, len(haves), 20, "test setup must force multiple have rounds")
 
 	want := plumbing.NewHash(fixture.Head)
 	require.Error(t, clientStorage.HasEncodedObject(want), "seed client should not already have the remote tip")

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -54,10 +54,10 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 	}
 
 	switch ver {
-	case protocol.V2:
-		_ = conn.Close()
-		return nil, ErrUnsupportedVersion
-	case protocol.V1, protocol.V0:
+	case protocol.V1, protocol.V0, protocol.V2:
+		// V2 is accepted; full client v2 negotiation (ls-refs/fetch commands)
+		// not yet implemented for stream transports. Advertise/decode will
+		// proceed and may result in empty refs for pure v2 servers.
 	}
 
 	ar := &packp.AdvRefs{}

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -45,18 +45,16 @@ func ReceivePack(
 	}
 
 	if opts.AdvertiseRefs || !opts.StatelessRPC {
-		switch version := ProtocolVersion(opts.GitProtocol); version {
-		case protocol.V1:
-			if _, err := pktline.Writef(w, "version %d\n", version); err != nil {
-				return err
-			}
-		// TODO: support version 2
-		case protocol.V0, protocol.V2:
+		v := ProtocolVersion(opts.GitProtocol)
+		switch v {
+		case protocol.V0, protocol.V1, protocol.V2:
+			// version emission (if any) is handled inside AdvertiseRefs for correct
+			// ordering with the HTTP smart-reply prefix when applicable.
 		default:
-			return fmt.Errorf("%w: %q", ErrUnsupportedVersion, version)
+			return fmt.Errorf("%w: %q", ErrUnsupportedVersion, v)
 		}
 
-		if err := AdvertiseRefs(ctx, st, w, ReceivePackService, opts.StatelessRPC); err != nil {
+		if err := AdvertiseRefs(ctx, st, w, ReceivePackService, opts.StatelessRPC, v); err != nil {
 			return err
 		}
 	}
@@ -123,7 +121,7 @@ func ReceivePack(
 	}
 
 	// Report status if the client supports it
-	if !updreq.Capabilities.Supports(capability.ReportStatus) {
+	if !updreq.Capabilities.Supports(capability.ReportStatus) && !updreq.Capabilities.Supports(capability.ReportStatusV2) {
 		return unpackErr
 	}
 

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -114,9 +114,11 @@ func writeV2Advertisement(w io.Writer, st storage.Storer) error {
 	// not listed here (clients retrieve them via ls-refs). Advertising a feature
 	// that isn't handled makes clients request it and then mis-handle the reply.
 	//
+	// The fetch "shallow" feature covers the deepen family; only "deepen <n>"
+	// is handled today (deepen-since/-not/-relative are rejected, as in v0/v1).
+	//
 	// TODO: advertise these once implemented:
 	//   - ls-refs=unborn       report an unborn HEAD on an empty repository
-	//   - fetch=shallow        shallow/deepen (--depth, deepen-since, deepen-not, deepen-relative)
 	//   - fetch=filter         partial-clone object filters
 	//   - fetch=ref-in-want    want-ref negotiation
 	//   - fetch=sideband-all   sideband for the entire response, not just the packfile
@@ -129,7 +131,7 @@ func writeV2Advertisement(w io.Writer, st storage.Storer) error {
 		caps,
 		"agent="+capability.DefaultAgent(),
 		"ls-refs",
-		"fetch",
+		"fetch=shallow",
 	)
 
 	// object format

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -26,6 +28,7 @@ func AdvertiseRefs(
 	w io.Writer,
 	service string,
 	smart bool,
+	version protocol.Version,
 ) error {
 	switch service {
 	case UploadPackService, ReceivePackService:
@@ -90,7 +93,47 @@ func AdvertiseRefs(
 		}
 	}
 
+	// Emit explicit version packet for V1 (all) and V2 upload-pack.
+	// For HTTP this appears after the "# service=..." smart reply (correct wire order).
+	// For stateful transports (git://, ssh) it appears at the start of the advertisement.
+	if version == protocol.V1 || (version == protocol.V2 && service == UploadPackService) {
+		if _, err := pktline.Writef(w, "version %d\n", version); err != nil {
+			return err
+		}
+	}
+
+	if version == protocol.V2 && service == UploadPackService {
+		return writeV2Advertisement(w, st)
+	}
+
 	return ar.Encode(w)
+}
+
+func writeV2Advertisement(w io.Writer, st storage.Storer) error {
+	// Emit protocol v2 capability advertisement (no refs here; use ls-refs to retrieve them).
+	caps := []string{
+		"agent=" + capability.DefaultAgent(),
+		"ls-refs=unborn",
+		"fetch=shallow wait-for-done",
+		"server-option",
+	}
+
+	// object format
+	var objectformat config.ObjectFormat
+	if cfg, err := st.Config(); err == nil && cfg != nil {
+		objectformat = cfg.Extensions.ObjectFormat
+	}
+	if objectformat == config.UnsetObjectFormat {
+		objectformat = config.DefaultObjectFormat
+	}
+	caps = append(caps, "object-format="+objectformat.String())
+
+	for _, c := range caps {
+		if _, err := pktline.Writef(w, "%s\n", c); err != nil {
+			return err
+		}
+	}
+	return pktline.WriteFlush(w)
 }
 
 func addReferences(st storage.Storer, ar *packp.AdvRefs, addHead bool) error {

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -110,14 +110,26 @@ func AdvertiseRefs(
 }
 
 func writeV2Advertisement(w io.Writer, st storage.Storer) error {
-	// Emit protocol v2 capability advertisement (no refs here; use ls-refs to retrieve them).
-	caps := make([]string, 0, 5)
+	// Advertise only the v2 commands/features this server implements; refs are
+	// not listed here (clients retrieve them via ls-refs). Advertising a feature
+	// that isn't handled makes clients request it and then mis-handle the reply.
+	//
+	// TODO: advertise these once implemented:
+	//   - ls-refs=unborn       report an unborn HEAD on an empty repository
+	//   - fetch=shallow        shallow/deepen (--depth, deepen-since, deepen-not, deepen-relative)
+	//   - fetch=filter         partial-clone object filters
+	//   - fetch=ref-in-want    want-ref negotiation
+	//   - fetch=sideband-all   sideband for the entire response, not just the packfile
+	//   - fetch=packfile-uris  offload pack data to out-of-band URIs
+	//   - fetch=wait-for-done  negotiate-only fetch (git fetch --negotiate-only)
+	//   - server-option        process client "server-option" lines
+	//   - object-info          object size/type queries without a fetch
+	caps := make([]string, 0, 4)
 	caps = append(
 		caps,
 		"agent="+capability.DefaultAgent(),
-		"ls-refs=unborn",
-		"fetch=shallow wait-for-done",
-		"server-option",
+		"ls-refs",
+		"fetch",
 	)
 
 	// object format

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -111,12 +111,14 @@ func AdvertiseRefs(
 
 func writeV2Advertisement(w io.Writer, st storage.Storer) error {
 	// Emit protocol v2 capability advertisement (no refs here; use ls-refs to retrieve them).
-	caps := []string{
-		"agent=" + capability.DefaultAgent(),
+	caps := make([]string, 0, 5)
+	caps = append(
+		caps,
+		"agent="+capability.DefaultAgent(),
 		"ls-refs=unborn",
 		"fetch=shallow wait-for-done",
 		"server-option",
-	}
+	)
 
 	// object format
 	var objectformat config.ObjectFormat

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -3,9 +3,12 @@ package transport
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math"
+	"strings"
 
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -17,6 +20,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/revlist"
+	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
@@ -54,18 +58,16 @@ func UploadPack(
 	}
 
 	if opts.AdvertiseRefs || !opts.StatelessRPC {
-		switch version := ProtocolVersion(opts.GitProtocol); version {
-		case protocol.V1:
-			if _, err := pktline.Writef(w, "version %d\n", version); err != nil {
-				return err
-			}
-		// TODO: support version 2
-		case protocol.V0, protocol.V2:
+		v := ProtocolVersion(opts.GitProtocol)
+		switch v {
+		case protocol.V0, protocol.V1, protocol.V2:
+			// V0/V1 share the same classic negotiation format after the
+			// (optional) version line. We only branch for V2 below.
 		default:
-			return fmt.Errorf("%w: %q", ErrUnsupportedVersion, version)
+			return fmt.Errorf("%w: %q", ErrUnsupportedVersion, v)
 		}
 
-		if err := AdvertiseRefs(ctx, st, w, UploadPackService, opts.StatelessRPC); err != nil {
+		if err := AdvertiseRefs(ctx, st, w, UploadPackService, opts.StatelessRPC, v); err != nil {
 			return fmt.Errorf("advertising references: %w", err)
 		}
 	}
@@ -82,6 +84,12 @@ func UploadPack(
 	r = ioutil.NewContextReadCloser(ctx, r)
 
 	rd := bufio.NewReader(r)
+
+	v := ProtocolVersion(opts.GitProtocol)
+	if v == protocol.V2 {
+		return serveUploadPackV2(ctx, st, rd, w, opts)
+	}
+
 	l, _, err := pktline.PeekLine(rd)
 	if err != nil {
 		return fmt.Errorf("peeking line: %w", err)
@@ -373,4 +381,283 @@ func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd 
 	}
 
 	return nil
+}
+
+// serveUploadPackV2 handles the git protocol v2 for upload-pack (fetch/ls-refs).
+// It is used when the client requests version=2 via GIT_PROTOCOL.
+func serveUploadPackV2(ctx context.Context, st storage.Storer, rd *bufio.Reader, w io.WriteCloser, opts *UploadPackRequest) error {
+	for {
+		cmd, kvs, args, err := readV2Request(rd)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		if cmd == "" {
+			// flush ended the request
+			return nil
+		}
+		switch cmd {
+		case "ls-refs":
+			if err := serveLsRefsV2(ctx, st, w, kvs, args); err != nil {
+				return err
+			}
+			// For stateless (HTTP) a single command per request; for stateful may continue but clients typically close.
+			if opts.StatelessRPC {
+				return nil
+			}
+		case "fetch":
+			return serveFetchV2(ctx, st, w, rd, kvs, args, opts)
+		default:
+			_, _ = pktline.Writef(w, "error unknown-command %s\n", cmd)
+			_ = pktline.WriteFlush(w)
+			return fmt.Errorf("unsupported v2 command %q", cmd)
+		}
+	}
+}
+
+// readV2Request reads a v2 command request consisting of:
+//   - command=xxx
+//   - zero or more key=value or agent=... header lines
+//   - delim (0001)
+//   - zero or more argument lines (e.g. "want <oid>", "have <oid>", "done", "peel")
+//   - flush (0000)
+//
+// It returns the command name, header kvs (as "k=v" or raw), and the post-delim args.
+func readV2Request(rd *bufio.Reader) (cmd string, kvs, args []string, err error) {
+	seenDelim := false
+	for {
+		l, line, rerr := pktline.ReadLine(rd)
+		if rerr != nil {
+			err = rerr
+			return
+		}
+		if l == pktline.Flush {
+			return cmd, kvs, args, nil
+		}
+		if l == pktline.Delim {
+			seenDelim = true
+			continue
+		}
+		s := strings.TrimSuffix(string(line), "\n")
+		if s == "" {
+			continue
+		}
+		if !seenDelim {
+			if strings.HasPrefix(s, "command=") {
+				cmd = strings.TrimPrefix(s, "command=")
+				continue
+			}
+			// header line (agent, object-format, etc)
+			kvs = append(kvs, s)
+			continue
+		}
+		// after delim: args
+		args = append(args, s)
+	}
+}
+
+// serveLsRefsV2 responds to a ls-refs command.
+func serveLsRefsV2(ctx context.Context, st storage.Storer, w io.Writer, kvs, args []string) error {
+	_ = kvs // unused for now; could check object-format
+	peel := false
+	symrefs := false
+	// unborn not directly used for listing
+	prefixes := []string{}
+	for _, a := range args {
+		switch a {
+		case "peel":
+			peel = true
+		case "symrefs":
+			symrefs = true
+		default:
+			if strings.HasPrefix(a, "ref-prefix ") {
+				prefixes = append(prefixes, strings.TrimPrefix(a, "ref-prefix "))
+			}
+		}
+	}
+
+	iter, err := st.IterReferences()
+	if err != nil {
+		return err
+	}
+	defer iter.Close()
+
+	var refs []*plumbing.Reference
+	_ = iter.ForEach(func(r *plumbing.Reference) error {
+		refs = append(refs, r)
+		return nil
+	})
+
+	// Always include HEAD first if present (mirrors common behavior)
+	for _, r := range refs {
+		if r.Name() == plumbing.HEAD {
+			if err := writeV2Ref(w, st, r, symrefs, peel); err != nil {
+				return err
+			}
+			break
+		}
+	}
+
+	for _, r := range refs {
+		if r.Name() == plumbing.HEAD {
+			continue
+		}
+		if len(prefixes) > 0 && !refMatchesAnyPrefix(r.Name().String(), prefixes) {
+			continue
+		}
+		if err := writeV2Ref(w, st, r, symrefs, peel); err != nil {
+			return err
+		}
+	}
+
+	return pktline.WriteFlush(w)
+}
+
+func refMatchesAnyPrefix(name string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func writeV2Ref(w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, peel bool) error {
+	var hash plumbing.Hash
+	var target string
+	if r.Type() == plumbing.SymbolicReference {
+		ref, err := storer.ResolveReference(st, r.Target())
+		if err == nil {
+			hash = ref.Hash()
+		}
+		target = r.Target().String()
+	} else {
+		hash = r.Hash()
+	}
+	if hash.IsZero() {
+		return nil
+	}
+	line := fmt.Sprintf("%s %s", hash, r.Name())
+	if symrefs && target != "" {
+		line += " symref-target:" + target
+	}
+	if _, err := pktline.Writef(w, "%s\n", line); err != nil {
+		return err
+	}
+	if peel && r.Name().IsTag() {
+		if tag, err := object.GetTag(st, hash); err == nil {
+			// emit peeled
+			peeled := fmt.Sprintf("%s %s^{}", tag.Target, r.Name())
+			_, _ = pktline.Writef(w, "%s\n", peeled)
+		}
+	}
+	return nil
+}
+
+// serveFetchV2 handles command=fetch for v2.
+func serveFetchV2(ctx context.Context, st storage.Storer, w io.WriteCloser, rd *bufio.Reader, kvs, args []string, opts *UploadPackRequest) error {
+	_ = kvs
+	var wants, haves []plumbing.Hash
+	deepen := 0
+	done := false
+	for _, a := range args {
+		switch {
+		case strings.HasPrefix(a, "want "):
+			if h := plumbing.NewHash(a[5:]); !h.IsZero() {
+				wants = append(wants, h)
+			}
+		case strings.HasPrefix(a, "have "):
+			if h := plumbing.NewHash(a[5:]); !h.IsZero() {
+				haves = append(haves, h)
+			}
+		case strings.HasPrefix(a, "deepen "):
+			fmt.Sscanf(a, "deepen %d", &deepen)
+		case a == "done":
+			done = true
+		}
+	}
+
+	// If nothing wanted, just flush
+	if len(wants) == 0 {
+		_ = pktline.WriteFlush(w)
+		return w.Close()
+	}
+
+	// For v2, if the client sent haves, we must send an acknowledgments section.
+	// If "done" was also present, or the command has ended (0000), we proceed
+	// to send the packfile after "ready". This matches what current git clients
+	// expect during pulls (they may omit "done" on the first fetch command when
+	// they have provided haves and expect the objects in the same response).
+	if !done && len(haves) > 0 {
+		log.Printf("v2 fetch: no 'done' but haves present (%d), sending acknowledgments + ready then will send pack (fallthrough)", len(haves))
+		// send acknowledgments section
+		if _, err := pktline.Writef(w, "acknowledgments\n"); err != nil {
+			return err
+		}
+		// naive: ack any common we have
+		known := map[plumbing.Hash]bool{}
+		for _, h := range haves {
+			if _, err := st.EncodedObject(plumbing.AnyObject, h); err == nil {
+				known[h] = true
+				if _, err := pktline.Writef(w, "ACK %s\n", h); err != nil {
+					return err
+				}
+			}
+		}
+		if len(known) > 0 {
+			_, _ = pktline.Writef(w, "ready\n")
+		}
+		// End the acknowledgments section with a delimiter packet (0001), not a flush.
+		// Per protocol-v2 grammar: [acknowledgments delim-pkt] ... packfile flush-pkt
+		// This tells the client's acks parser that the acks section is complete
+		// (so "packfile" won't be misinterpreted as an ack line), but does *not*
+		// end the overall fetch response, allowing the packfile section to follow
+		// immediately in the same stream. This satisfies both "packfile must appear
+		// after 'ready'" and avoids "unexpected acknowledgment line: 'packfile'".
+		_ = pktline.WriteDelim(w)
+	} else if done {
+		log.Printf("v2 fetch: 'done' seen, will send pack directly")
+	} else {
+		log.Printf("v2 fetch: no haves, sending pack directly (clone-like)")
+	}
+
+	// Compute what to send
+	objs, err := objectsToUpload(st, wants, haves)
+	if err != nil {
+		_ = w.Close()
+		return fmt.Errorf("getting objects to upload: %w", err)
+	}
+
+	// Write packfile section header
+	log.Printf("v2 fetch: writing 'packfile' section (after acks/ready + delim)")
+	if _, err := pktline.Writef(w, "packfile\n"); err != nil {
+		return err
+	}
+
+	// Send pack data wrapped in sideband (client switches to sideband demux after
+	// seeing the "packfile" marker in v2 fetch response). Matches reference git wire.
+	writer := sideband.NewMuxer(sideband.Sideband64k, w)
+
+	var packWindow uint
+	if opts.SkipDeltaCompression {
+		packWindow = 0
+	} else if cfg, cerr := st.Config(); cerr == nil && cfg != nil {
+		packWindow = cfg.Pack.Window
+	} else {
+		packWindow = config.DefaultPackWindow
+	}
+
+	e := packfile.NewEncoder(writer, st, false)
+	if _, err := e.Encode(objs, packWindow); err != nil {
+		return fmt.Errorf("encoding packfile: %w", err)
+	}
+
+	// Terminate sideband stream and v2 fetch response.
+	if err := pktline.WriteFlush(w); err != nil {
+		return err
+	}
+
+	return w.Close()
 }

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"strings"
 
@@ -431,7 +430,7 @@ func readV2Request(rd *bufio.Reader) (cmd string, kvs, args []string, err error)
 		l, line, rerr := pktline.ReadLine(rd)
 		if rerr != nil {
 			err = rerr
-			return
+			return cmd, kvs, args, err
 		}
 		if l == pktline.Flush {
 			return cmd, kvs, args, nil
@@ -445,8 +444,8 @@ func readV2Request(rd *bufio.Reader) (cmd string, kvs, args []string, err error)
 			continue
 		}
 		if !seenDelim {
-			if strings.HasPrefix(s, "command=") {
-				cmd = strings.TrimPrefix(s, "command=")
+			if after, ok := strings.CutPrefix(s, "command="); ok {
+				cmd = after
 				continue
 			}
 			// header line (agent, object-format, etc)
@@ -459,7 +458,7 @@ func readV2Request(rd *bufio.Reader) (cmd string, kvs, args []string, err error)
 }
 
 // serveLsRefsV2 responds to a ls-refs command.
-func serveLsRefsV2(ctx context.Context, st storage.Storer, w io.Writer, kvs, args []string) error {
+func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, kvs, args []string) error {
 	_ = kvs // unused for now; could check object-format
 	peel := false
 	symrefs := false
@@ -472,8 +471,8 @@ func serveLsRefsV2(ctx context.Context, st storage.Storer, w io.Writer, kvs, arg
 		case "symrefs":
 			symrefs = true
 		default:
-			if strings.HasPrefix(a, "ref-prefix ") {
-				prefixes = append(prefixes, strings.TrimPrefix(a, "ref-prefix "))
+			if after, ok := strings.CutPrefix(a, "ref-prefix "); ok {
+				prefixes = append(prefixes, after)
 			}
 		}
 	}
@@ -557,7 +556,7 @@ func writeV2Ref(w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, 
 }
 
 // serveFetchV2 handles command=fetch for v2.
-func serveFetchV2(ctx context.Context, st storage.Storer, w io.WriteCloser, rd *bufio.Reader, kvs, args []string, opts *UploadPackRequest) error {
+func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *bufio.Reader, kvs, args []string, opts *UploadPackRequest) error {
 	_ = kvs
 	var wants, haves []plumbing.Hash
 	deepen := 0
@@ -573,7 +572,7 @@ func serveFetchV2(ctx context.Context, st storage.Storer, w io.WriteCloser, rd *
 				haves = append(haves, h)
 			}
 		case strings.HasPrefix(a, "deepen "):
-			fmt.Sscanf(a, "deepen %d", &deepen)
+			_, _ = fmt.Sscanf(a, "deepen %d", &deepen)
 		case a == "done":
 			done = true
 		}
@@ -590,8 +589,8 @@ func serveFetchV2(ctx context.Context, st storage.Storer, w io.WriteCloser, rd *
 	// to send the packfile after "ready". This matches what current git clients
 	// expect during pulls (they may omit "done" on the first fetch command when
 	// they have provided haves and expect the objects in the same response).
-	if !done && len(haves) > 0 {
-		log.Printf("v2 fetch: no 'done' but haves present (%d), sending acknowledgments + ready then will send pack (fallthrough)", len(haves))
+	switch {
+	case !done && len(haves) > 0:
 		// send acknowledgments section
 		if _, err := pktline.Writef(w, "acknowledgments\n"); err != nil {
 			return err
@@ -617,10 +616,8 @@ func serveFetchV2(ctx context.Context, st storage.Storer, w io.WriteCloser, rd *
 		// immediately in the same stream. This satisfies both "packfile must appear
 		// after 'ready'" and avoids "unexpected acknowledgment line: 'packfile'".
 		_ = pktline.WriteDelim(w)
-	} else if done {
-		log.Printf("v2 fetch: 'done' seen, will send pack directly")
-	} else {
-		log.Printf("v2 fetch: no haves, sending pack directly (clone-like)")
+	case done:
+	default:
 	}
 
 	// Compute what to send
@@ -631,7 +628,6 @@ func serveFetchV2(ctx context.Context, st storage.Storer, w io.WriteCloser, rd *
 	}
 
 	// Write packfile section header
-	log.Printf("v2 fetch: writing 'packfile' section (after acks/ready + delim)")
 	if _, err := pktline.Writef(w, "packfile\n"); err != nil {
 		return err
 	}

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -489,11 +489,15 @@ func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, kvs, args 
 		return nil
 	})
 
-	// Always include HEAD first if present (mirrors common behavior)
+	// HEAD is emitted first, but only when it passes the ref-prefix filter,
+	// matching upstream's send_possibly_unborn_head -> send_ref (ls-refs.c),
+	// where HEAD is subject to ref_match like every other ref.
 	for _, r := range refs {
 		if r.Name() == plumbing.HEAD {
-			if err := writeV2Ref(w, st, r, symrefs, peel); err != nil {
-				return err
+			if len(prefixes) == 0 || refMatchesAnyPrefix(r.Name().String(), prefixes) {
+				if err := writeV2Ref(w, st, r, symrefs, peel); err != nil {
+					return err
+				}
 			}
 			break
 		}
@@ -538,28 +542,56 @@ func writeV2Ref(w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, 
 	if hash.IsZero() {
 		return nil
 	}
+	// Protocol v2 ls-refs grammar:
+	//   ref = obj-id SP refname *(SP ref-attribute) LF
+	//   ref-attribute = (symref | peeled)
+	// Both symref-target and peeled are attributes on the ref's own line
+	// (symref-target first, matching upstream's send_ref ordering), not
+	// separate lines as in the v0/v1 advertisement format.
 	line := fmt.Sprintf("%s %s", hash, r.Name())
 	if symrefs && target != "" {
 		line += " symref-target:" + target
 	}
+	if peel {
+		// Peel any ref whose object is (a chain of) annotated tags, not just
+		// refs/tags/*, and resolve all the way to the underlying non-tag object
+		// — matching upstream's reference_get_peeled_oid (ls-refs.c). Lightweight
+		// tags and branches don't point at tag objects, so they emit no attribute.
+		if peeled, ok := peelToNonTag(st, hash); ok {
+			line += " peeled:" + peeled.String()
+		}
+	}
 	if _, err := pktline.Writef(w, "%s\n", line); err != nil {
 		return err
 	}
-	if peel && r.Name().IsTag() {
-		if tag, err := object.GetTag(st, hash); err == nil {
-			// emit peeled
-			peeled := fmt.Sprintf("%s %s^{}", tag.Target, r.Name())
-			_, _ = pktline.Writef(w, "%s\n", peeled)
-		}
-	}
 	return nil
+}
+
+// peelToNonTag follows annotated-tag objects from h down to the first non-tag
+// object, mirroring upstream's reference_get_peeled_oid. It returns the peeled
+// hash and true when h points at one or more tag objects; false when h is not a
+// tag (a lightweight tag, branch, etc.) so no "peeled" attribute is emitted.
+func peelToNonTag(st storage.Storer, h plumbing.Hash) (plumbing.Hash, bool) {
+	tag, err := object.GetTag(st, h)
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	for {
+		next := tag.Target
+		inner, err := object.GetTag(st, next)
+		if err != nil {
+			// next is a non-tag object (or missing); return it as the peeled
+			// value, as upstream's peel does.
+			return next, true
+		}
+		tag = inner
+	}
 }
 
 // serveFetchV2 handles command=fetch for v2.
 func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *bufio.Reader, kvs, args []string, opts *UploadPackRequest) error {
 	_ = kvs
 	var wants, haves []plumbing.Hash
-	deepen := 0
 	done := false
 	for _, a := range args {
 		switch {
@@ -571,53 +603,73 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 			if h := plumbing.NewHash(a[5:]); !h.IsZero() {
 				haves = append(haves, h)
 			}
-		case strings.HasPrefix(a, "deepen "):
-			_, _ = fmt.Sscanf(a, "deepen %d", &deepen)
 		case a == "done":
 			done = true
 		}
 	}
 
-	// If nothing wanted, just flush
+	// No 'want' lines: the client guessed it didn't want anything. Upstream
+	// emits no response at all here (upload-pack.c, UPLOAD_DONE), so write
+	// nothing and just close the stream — no stray flush packet.
 	if len(wants) == 0 {
-		_ = pktline.WriteFlush(w)
 		return w.Close()
 	}
 
-	// For v2, if the client sent haves, we must send an acknowledgments section.
-	// If "done" was also present, or the command has ended (0000), we proceed
-	// to send the packfile after "ready". This matches what current git clients
-	// expect during pulls (they may omit "done" on the first fetch command when
-	// they have provided haves and expect the objects in the same response).
-	switch {
-	case !done && len(haves) > 0:
-		// send acknowledgments section
+	// Negotiation (acknowledgments section), per gitprotocol-v2 "fetch":
+	//
+	//   - done            -> no acknowledgments section; packfile follows.
+	//   - no haves        -> clone-like; no acknowledgments section; packfile follows.
+	//   - haves and !done -> emit an acknowledgments section. ACK every common
+	//                        object. "ready" is sent only once every want is
+	//                        reachable from the common haves (upstream's
+	//                        ok_to_give_up); then the section ends with a
+	//                        delim-pkt and the packfile follows. Otherwise the
+	//                        section ends with a flush-pkt and NO packfile, and
+	//                        the client negotiates again with more haves (NAK
+	//                        when there is no common object at all).
+	if !done && len(haves) > 0 {
 		if _, err := pktline.Writef(w, "acknowledgments\n"); err != nil {
 			return err
 		}
-		// naive: ack any common we have
-		known := map[plumbing.Hash]bool{}
+		var common []plumbing.Hash
 		for _, h := range haves {
 			if _, err := st.EncodedObject(plumbing.AnyObject, h); err == nil {
-				known[h] = true
+				common = append(common, h)
 				if _, err := pktline.Writef(w, "ACK %s\n", h); err != nil {
 					return err
 				}
 			}
 		}
-		if len(known) > 0 {
-			_, _ = pktline.Writef(w, "ready\n")
+		if len(common) == 0 {
+			// No common object at all: NAK and end the section with a flush. No
+			// packfile this round; the client negotiates again with more haves.
+			if _, err := pktline.Writef(w, "NAK\n"); err != nil {
+				return err
+			}
+			if err := pktline.WriteFlush(w); err != nil {
+				return err
+			}
+			return w.Close()
 		}
-		// End the acknowledgments section with a delimiter packet (0001), not a flush.
-		// Per protocol-v2 grammar: [acknowledgments delim-pkt] ... packfile flush-pkt
-		// This tells the client's acks parser that the acks section is complete
-		// (so "packfile" won't be misinterpreted as an ack line), but does *not*
-		// end the overall fetch response, allowing the packfile section to follow
-		// immediately in the same stream. This satisfies both "packfile must appear
-		// after 'ready'" and avoids "unexpected acknowledgment line: 'packfile'".
-		_ = pktline.WriteDelim(w)
-	case done:
-	default:
+		// "ready" is withheld until every want is reachable from the common
+		// haves (upstream's ok_to_give_up). Declaring it on the first common
+		// have would force single-round negotiation and a larger pack. When not
+		// ready, the ACK'd commons stand but the section ends with a flush so
+		// the client can refine its haves in the next request.
+		if !wantsReachableFromHaves(st, wants, common) {
+			if err := pktline.WriteFlush(w); err != nil {
+				return err
+			}
+			return w.Close()
+		}
+		// Ready: separate the acknowledgments section from the packfile section
+		// with a delim-pkt (the packfile follows in the same response).
+		if _, err := pktline.Writef(w, "ready\n"); err != nil {
+			return err
+		}
+		if err := pktline.WriteDelim(w); err != nil {
+			return err
+		}
 	}
 
 	// Compute what to send
@@ -656,4 +708,71 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 	}
 
 	return w.Close()
+}
+
+// wantsReachableFromHaves reports whether every want is reachable from the set
+// of common haves — upstream's ok_to_give_up (upload-pack.c). A want is anchored
+// when a common have is the want itself or one of its ancestors, i.e. the want
+// can reach a have by walking parents. Tags are peeled to commits first, as the
+// ancestry walk operates on commits. Returns false (keep negotiating) if any
+// want cannot be resolved to a commit or is not yet anchored.
+func wantsReachableFromHaves(st storage.Storer, wants, commonHaves []plumbing.Hash) bool {
+	haveSet := make(map[plumbing.Hash]struct{}, len(commonHaves))
+	haveCommits := make([]*object.Commit, 0, len(commonHaves))
+	for _, h := range commonHaves {
+		haveSet[h] = struct{}{}
+		if c, ok := peelToCommit(st, h); ok {
+			haveCommits = append(haveCommits, c)
+		}
+	}
+
+	for _, wHash := range wants {
+		wc, ok := peelToCommit(st, wHash)
+		if !ok {
+			return false
+		}
+		if _, ok := haveSet[wc.Hash]; ok {
+			continue
+		}
+		anchored := false
+		for _, hc := range haveCommits {
+			if hc.Hash == wc.Hash {
+				anchored = true
+				break
+			}
+			if isAnc, err := hc.IsAncestor(wc); err == nil && isAnc {
+				anchored = true
+				break
+			}
+		}
+		if !anchored {
+			return false
+		}
+	}
+	return true
+}
+
+// peelToCommit resolves h to a commit, following annotated tags. It returns
+// false when h is missing or does not peel to a commit.
+func peelToCommit(st storage.Storer, h plumbing.Hash) (*object.Commit, bool) {
+	obj, err := st.EncodedObject(plumbing.AnyObject, h)
+	if err != nil {
+		return nil, false
+	}
+	switch obj.Type() {
+	case plumbing.CommitObject:
+		c, err := object.GetCommit(st, h)
+		if err != nil {
+			return nil, false
+		}
+		return c, true
+	case plumbing.TagObject:
+		tag, err := object.GetTag(st, h)
+		if err != nil {
+			return nil, false
+		}
+		return peelToCommit(st, tag.Target)
+	default:
+		return nil, false
+	}
 }

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -591,7 +591,8 @@ func peelToNonTag(st storage.Storer, h plumbing.Hash) (plumbing.Hash, bool) {
 // serveFetchV2 handles command=fetch for v2.
 func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *bufio.Reader, kvs, args []string, opts *UploadPackRequest) error {
 	_ = kvs
-	var wants, haves []plumbing.Hash
+	var wants, haves, clientShallows []plumbing.Hash
+	depth := 0
 	done := false
 	for _, a := range args {
 		switch {
@@ -603,6 +604,21 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 			if h := plumbing.NewHash(a[5:]); !h.IsZero() {
 				haves = append(haves, h)
 			}
+		case strings.HasPrefix(a, "shallow "):
+			// The client's current shallow boundary; used to scope unshallows.
+			if h := plumbing.NewHash(a[8:]); !h.IsZero() {
+				clientShallows = append(clientShallows, h)
+			}
+		case strings.HasPrefix(a, "deepen "):
+			if _, err := fmt.Sscanf(a, "deepen %d", &depth); err != nil {
+				_ = w.Close()
+				return fmt.Errorf("parsing deepen argument %q: %w", a, err)
+			}
+		case a == "deepen-relative", strings.HasPrefix(a, "deepen-since "), strings.HasPrefix(a, "deepen-not "):
+			// Advertised under "shallow" but not implemented yet, as in v0/v1.
+			// Fail loudly rather than silently ignore an advertised feature.
+			_ = w.Close()
+			return fmt.Errorf("unsupported deepen argument: %q", a)
 		case a == "done":
 			done = true
 		}
@@ -672,8 +688,29 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 		}
 	}
 
+	// shallow-info section, emitted before the packfile when the client
+	// requested a shallow fetch (e.g. clone --depth N), reusing the v0/v1
+	// boundary computation. The boundary also bounds the packfile to that
+	// depth (see shallowBoundaryStorer).
+	//
+	// Note: deepening an already-shallow clone (the client sends its own
+	// "shallow" lines plus haves) is not handled — the haves would exclude the
+	// deepened ancestors. Only fresh shallow fetches are bounded here.
+	packSt := st
+	if depth > 0 {
+		var shupd packp.ShallowUpdate
+		if err := getShallowCommits(st, wants, depth, &shupd); err != nil {
+			_ = w.Close()
+			return fmt.Errorf("computing shallow commits: %w", err)
+		}
+		if err := writeV2ShallowInfo(w, &shupd, clientShallows); err != nil {
+			return err
+		}
+		packSt = &shallowBoundaryStorer{Storer: st, boundary: shupd.Shallows}
+	}
+
 	// Compute what to send
-	objs, err := objectsToUpload(st, wants, haves)
+	objs, err := objectsToUpload(packSt, wants, haves)
 	if err != nil {
 		_ = w.Close()
 		return fmt.Errorf("getting objects to upload: %w", err)
@@ -708,6 +745,59 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 	}
 
 	return w.Close()
+}
+
+// shallowBoundaryStorer reports an additional set of shallow commits (the
+// per-request boundary) on top of any the repository already has. revlist's
+// object walk stops at shallow commits while still collecting their full trees,
+// so wrapping the storer bounds a shallow fetch's packfile to the requested
+// depth — the boundary commits ship complete, their ancestors are omitted —
+// without the blob loss a plain have-exclusion would cause.
+type shallowBoundaryStorer struct {
+	storage.Storer
+	boundary []plumbing.Hash
+}
+
+func (s *shallowBoundaryStorer) Shallow() ([]plumbing.Hash, error) {
+	base, err := s.Storer.Shallow()
+	if err != nil {
+		return nil, err
+	}
+	if len(s.boundary) == 0 {
+		return base, nil
+	}
+	return append(append([]plumbing.Hash(nil), base...), s.boundary...), nil
+}
+
+// writeV2ShallowInfo emits the protocol v2 fetch "shallow-info" section: the
+// header, a "shallow <oid>" line per boundary commit and an "unshallow <oid>"
+// line per previously-shallow client commit that is now complete, terminated
+// by a delim-pkt separating it from the packfile section (upstream
+// send_shallow_info). Unshallows are scoped to the client's reported shallow
+// set, so a fresh clone never receives spurious unshallow lines.
+func writeV2ShallowInfo(w io.Writer, upd *packp.ShallowUpdate, clientShallows []plumbing.Hash) error {
+	if _, err := pktline.Writef(w, "shallow-info\n"); err != nil {
+		return err
+	}
+	for _, h := range upd.Shallows {
+		if _, err := pktline.Writef(w, "shallow %s\n", h); err != nil {
+			return err
+		}
+	}
+	if len(clientShallows) > 0 {
+		client := make(map[plumbing.Hash]struct{}, len(clientShallows))
+		for _, h := range clientShallows {
+			client[h] = struct{}{}
+		}
+		for _, h := range upd.Unshallows {
+			if _, ok := client[h]; ok {
+				if _, err := pktline.Writef(w, "unshallow %s\n", h); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return pktline.WriteDelim(w)
 }
 
 // wantsReachableFromHaves reports whether every want is reachable from the set

--- a/plumbing/transport/upload_pack_v2_test.go
+++ b/plumbing/transport/upload_pack_v2_test.go
@@ -1,0 +1,210 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+func basicV2Storage(t testing.TB) storage.Storer {
+	t.Helper()
+	return v2StorageFromFixture(t, fixtures.Basic().One())
+}
+
+func v2StorageFromFixture(t testing.TB, f *fixtures.Fixture) storage.Storer {
+	t.Helper()
+	dot, err := f.DotGit(fixtures.WithTargetDir(t.TempDir))
+	require.NoError(t, err)
+	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+// v2Request encodes a protocol-v2 command request: command line, optional
+// header lines, a delim packet, the post-delim argument lines, and a flush.
+func v2Request(t testing.TB, command string, headers, args []string) io.ReadCloser {
+	t.Helper()
+	var buf bytes.Buffer
+	_, err := pktline.Writef(&buf, "command=%s\n", command)
+	require.NoError(t, err)
+	for _, h := range headers {
+		_, err := pktline.Writef(&buf, "%s\n", h)
+		require.NoError(t, err)
+	}
+	require.NoError(t, pktline.WriteDelim(&buf))
+	for _, a := range args {
+		_, err := pktline.Writef(&buf, "%s\n", a)
+		require.NoError(t, err)
+	}
+	require.NoError(t, pktline.WriteFlush(&buf))
+	return io.NopCloser(&buf)
+}
+
+func serveUploadPackV2Test(t testing.TB, st storage.Storer, r io.ReadCloser) string {
+	t.Helper()
+	var out bytes.Buffer
+	err := UploadPack(context.TODO(), st, r, ioutil.WriteNopCloser(&out), &UploadPackRequest{
+		GitProtocol:  "version=2",
+		StatelessRPC: true,
+	})
+	require.NoError(t, err)
+	return out.String()
+}
+
+func TestUploadPackV2AdvertisementCapabilities(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+
+	var out bytes.Buffer
+	err := UploadPack(context.TODO(), st, io.NopCloser(bytes.NewBuffer(nil)), ioutil.WriteNopCloser(&out), &UploadPackRequest{
+		GitProtocol:   "version=2",
+		AdvertiseRefs: true,
+	})
+	require.NoError(t, err)
+	adv := out.String()
+
+	require.Contains(t, adv, "version 2")
+	require.Contains(t, adv, "ls-refs")
+	require.Contains(t, adv, "fetch")
+	require.Contains(t, adv, "object-format=")
+
+	// Capabilities the server does not implement must not be advertised,
+	// otherwise clients request features (e.g. --depth) that are silently
+	// dropped or produce malformed responses.
+	require.NotContains(t, adv, "shallow")
+	require.NotContains(t, adv, "wait-for-done")
+	require.NotContains(t, adv, "unborn")
+	require.NotContains(t, adv, "server-option")
+}
+
+func TestUploadPackV2LsRefsPeeledInline(t *testing.T) {
+	t.Parallel()
+	st := v2StorageFromFixture(t, fixtures.ByTag("tags").One())
+
+	out := serveUploadPackV2Test(t, st, v2Request(t, "ls-refs", nil, []string{"peel"}))
+
+	// Protocol v2 ls-refs encodes the peeled value as a same-line attribute
+	// "peeled:<oid>", not as a separate "<oid> <name>^{}" line (the v0/v1
+	// advertisement format).
+	require.Contains(t, out, "peeled:")
+	require.NotContains(t, out, "^{}")
+}
+
+func TestUploadPackV2FetchCloneNoHaves(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"done",
+	}))
+
+	// No haves: clone-like, no acknowledgments section, packfile follows.
+	require.NotContains(t, out, "acknowledgments")
+	require.Contains(t, out, "packfile")
+}
+
+func TestUploadPackV2FetchReadyWithCommonHave(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"have " + head.Hash().String(),
+	}))
+
+	// A common object is known: acknowledgments section with ACK + ready,
+	// then the packfile. ready must precede packfile.
+	require.Contains(t, out, "acknowledgments")
+	require.Contains(t, out, "ACK "+head.Hash().String())
+	require.Contains(t, out, "ready")
+	require.Contains(t, out, "packfile")
+	require.Less(t, strings.Index(out, "ready"), strings.Index(out, "packfile"),
+		"ready must be emitted before the packfile section")
+}
+
+func TestUploadPackV2FetchCommonButNotReady(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
+	parent := c.ParentHashes[0]
+
+	// want an ancestor, have its descendant (HEAD). HEAD is a known object so it
+	// is ACK'd, but it is not an ancestor of the want, so no want is anchored:
+	// the server must withhold "ready" and end with a flush (no packfile),
+	// mirroring upstream ok_to_give_up.
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + parent.String(),
+		"have " + head.Hash().String(),
+	}))
+
+	require.Contains(t, out, "acknowledgments")
+	require.Contains(t, out, "ACK "+head.Hash().String())
+	require.NotContains(t, out, "ready")
+	require.NotContains(t, out, "packfile")
+}
+
+func TestUploadPackV2FetchNoWantsEmitsNothing(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+
+	// No want lines: upstream emits no response at all (no stray flush).
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{"have " + plumbing.ZeroHash.String()}))
+	require.Empty(t, out)
+}
+
+func TestUploadPackV2LsRefsHeadFilteredByPrefix(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+
+	// With a ref-prefix that excludes HEAD, upstream does not advertise HEAD
+	// (send_ref applies ref_match to HEAD too). No ref ending in HEAD matches
+	// "refs/heads/", so none should appear.
+	out := serveUploadPackV2Test(t, st, v2Request(t, "ls-refs", nil, []string{"ref-prefix refs/heads/"}))
+
+	require.Contains(t, out, "refs/heads/master")
+	require.NotContains(t, out, "HEAD")
+}
+
+func TestUploadPackV2FetchNotReadyContinuesNegotiation(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	// A have the server does not know about: no common base yet, so the
+	// server must NAK and end the acknowledgments section with a flush,
+	// without sending a packfile. Negotiation continues in a later request.
+	unknown := "1111111111111111111111111111111111111111"
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"have " + unknown,
+	}))
+
+	require.Contains(t, out, "acknowledgments")
+	require.Contains(t, out, "NAK")
+	require.NotContains(t, out, "ready")
+	require.NotContains(t, out, "packfile")
+}

--- a/plumbing/transport/upload_pack_v2_test.go
+++ b/plumbing/transport/upload_pack_v2_test.go
@@ -79,13 +79,12 @@ func TestUploadPackV2AdvertisementCapabilities(t *testing.T) {
 
 	require.Contains(t, adv, "version 2")
 	require.Contains(t, adv, "ls-refs")
-	require.Contains(t, adv, "fetch")
+	require.Contains(t, adv, "fetch=shallow")
 	require.Contains(t, adv, "object-format=")
 
 	// Capabilities the server does not implement must not be advertised,
-	// otherwise clients request features (e.g. --depth) that are silently
-	// dropped or produce malformed responses.
-	require.NotContains(t, adv, "shallow")
+	// otherwise clients request features that are silently dropped or
+	// produce malformed responses.
 	require.NotContains(t, adv, "wait-for-done")
 	require.NotContains(t, adv, "unborn")
 	require.NotContains(t, adv, "server-option")
@@ -102,6 +101,66 @@ func TestUploadPackV2LsRefsPeeledInline(t *testing.T) {
 	// advertisement format).
 	require.Contains(t, out, "peeled:")
 	require.NotContains(t, out, "^{}")
+}
+
+func TestUploadPackV2FetchShallowDeepen(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	// A depth-1 fetch: the tip is the shallow boundary. The response carries a
+	// shallow-info section (shallow <tip>) before the packfile.
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"deepen 1",
+		"done",
+	}))
+
+	require.Contains(t, out, "shallow-info")
+	require.Contains(t, out, "shallow "+head.Hash().String())
+	require.Contains(t, out, "packfile")
+	require.Less(t, strings.Index(out, "shallow-info"), strings.Index(out, "packfile"),
+		"shallow-info must precede the packfile section")
+}
+
+func TestObjectsToUploadShallowBounded(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
+	parent := c.ParentHashes[0]
+
+	full, err := objectsToUpload(st, []plumbing.Hash{head.Hash()}, nil)
+	require.NoError(t, err)
+	require.Contains(t, full, parent, "unbounded pack should include the parent commit")
+
+	bounded, err := objectsToUpload(
+		&shallowBoundaryStorer{Storer: st, boundary: []plumbing.Hash{head.Hash()}},
+		[]plumbing.Hash{head.Hash()}, nil,
+	)
+	require.NoError(t, err)
+	require.Contains(t, bounded, head.Hash(), "shallow boundary commit must be included")
+	require.NotContains(t, bounded, parent, "depth-1 pack must exclude the boundary's parent")
+	require.Less(t, len(bounded), len(full), "shallow pack must be smaller than the full pack")
+}
+
+func TestUploadPackV2FetchNoDeepenNoShallowInfo(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"done",
+	}))
+
+	require.NotContains(t, out, "shallow-info")
+	require.Contains(t, out, "packfile")
 }
 
 func TestUploadPackV2FetchCloneNoHaves(t *testing.T) {


### PR DESCRIPTION
I only did ls-refs and fetch command handling. Protocol defaults to v0 when no
Git-Protocol header is sent.

Not sure this is ready as is, we can work on a proper PR to meet the repo standards.

Thanks again.