### PR TITLE
Fix URL insteadOf to use longest match when multiple values exist

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -210,8 +210,8 @@ type Config struct {
 	// equal Branch.Name
 	Branches map[string]*Branch
 	// URLs list of url rewrite rules, if repo url starts with URL.InsteadOf value, it will be replaced with the
-	// key instead.
-	URLs map[string]*URL
+	// URL.Name instead. Ordered by appearance in config file.
+	URLs []*URL
 	// Raw contains the raw information of a config file. The main goal is
 	// preserve the parsed information from the original format, to avoid
 	// dropping unsupported fields.
@@ -326,7 +326,7 @@ func NewConfig() *Config {
 		Remotes:    make(map[string]*RemoteConfig),
 		Submodules: make(map[string]*Submodule),
 		Branches:   make(map[string]*Branch),
-		URLs:       make(map[string]*URL),
+		URLs:       make([]*URL, 0),
 		Raw:        format.New(),
 	}
 
@@ -666,13 +666,14 @@ func (c *Config) unmarshalRemotes() error {
 
 func (c *Config) unmarshalURLs() error {
 	s := c.Raw.Section(urlSection)
+	c.URLs = make([]*URL, 0, len(s.Subsections))
 	for _, sub := range s.Subsections {
 		r := &URL{}
 		if err := r.unmarshal(sub); err != nil {
 			return err
 		}
 
-		c.URLs[r.Name] = r
+		c.URLs = append(c.URLs, r)
 	}
 
 	return nil
@@ -1126,14 +1127,14 @@ func (c *RemoteConfig) IsFirstURLLocal() bool {
 	return url.IsLocalEndpoint(c.URLs[0])
 }
 
-func (c *RemoteConfig) applyURLRules(urlRules map[string]*URL) {
+func (c *RemoteConfig) applyURLRules(urlRules []*URL) {
 	// save original urls
 	originalURLs := make([]string, len(c.URLs))
 	copy(originalURLs, c.URLs)
 
 	for i, url := range c.URLs {
-		if matchingURLRule := findLongestInsteadOfMatch(url, urlRules); matchingURLRule != nil {
-			c.URLs[i] = matchingURLRule.ApplyInsteadOf(c.URLs[i])
+		if rewrittenURL, matched := applyLongestInsteadOfMatch(url, urlRules); matched {
+			c.URLs[i] = rewrittenURL
 			c.insteadOfRulesApplied = true
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -178,10 +178,10 @@ func (s *ConfigSuite) TestMarshal() {
 		Description: "Add support for branch description.\n\nEdit branch description: git branch --edit-description\n",
 	}
 
-	cfg.URLs["ssh://git@github.com/"] = &URL{
+	cfg.URLs = append(cfg.URLs, &URL{
 		Name:       "ssh://git@github.com/",
 		InsteadOfs: []string{"https://github.com/"},
-	}
+	})
 
 	b, err := cfg.Marshal()
 	s.NoError(err)

--- a/config/url.go
+++ b/config/url.go
@@ -54,7 +54,7 @@ func (u *URL) marshal() *format.Subsection {
 	return u.raw
 }
 
-func findLongestInsteadOfMatch(remoteURL string, urls map[string]*URL) *URL {
+func applyLongestInsteadOfMatch(remoteURL string, urls []*URL) (rewrittenURL string, matched bool) {
 	var longestMatch *URL
 	var longestMatchLength int
 
@@ -67,6 +67,7 @@ func findLongestInsteadOfMatch(remoteURL string, urls map[string]*URL) *URL {
 			lengthCurrentInsteadOf := len(currentInsteadOf)
 
 			// according to spec if there is more than one match, take the longest
+			// when lengths are equal, use config file order (first match wins)
 			if longestMatch == nil || longestMatchLength < lengthCurrentInsteadOf {
 				longestMatch = u
 				longestMatchLength = lengthCurrentInsteadOf
@@ -74,16 +75,16 @@ func findLongestInsteadOfMatch(remoteURL string, urls map[string]*URL) *URL {
 		}
 	}
 
-	return longestMatch
+	if longestMatchLength > 0 {
+		return longestMatch.Name + remoteURL[longestMatchLength:], true
+	}
+
+	return remoteURL, false
 }
 
 // ApplyInsteadOf applies the URL rewrite rules to the given URL.
+// When multiple insteadOf values match, the longest match is used.
 func (u *URL) ApplyInsteadOf(url string) string {
-	for _, j := range u.InsteadOfs {
-		if strings.HasPrefix(url, j) {
-			return u.Name + url[len(j):]
-		}
-	}
-
-	return url
+	rewrittenURL, _ := applyLongestInsteadOfMatch(url, []*URL{u})
+	return rewrittenURL
 }

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -34,10 +34,10 @@ func (b *URLSuite) TestMarshal() {
 `)
 
 	cfg := NewConfig()
-	cfg.URLs["ssh://git@github.com/"] = &URL{
+	cfg.URLs = append(cfg.URLs, &URL{
 		Name:       "ssh://git@github.com/",
 		InsteadOfs: []string{"https://github.com/"},
-	}
+	})
 
 	actual, err := cfg.Marshal()
 	b.Nil(err)
@@ -54,10 +54,10 @@ func (b *URLSuite) TestMarshalMultipleInsteadOf() {
 `)
 
 	cfg := NewConfig()
-	cfg.URLs["ssh://git@github.com/"] = &URL{
+	cfg.URLs = append(cfg.URLs, &URL{
 		Name:       "ssh://git@github.com/",
 		InsteadOfs: []string{"https://github.com/", "https://google.com/"},
-	}
+	})
 
 	actual, err := cfg.Marshal()
 	b.NoError(err)
@@ -74,7 +74,9 @@ func (b *URLSuite) TestUnmarshal() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
-	url := cfg.URLs["ssh://git@github.com/"]
+	b.Require().Len(cfg.URLs, 1)
+	url := cfg.URLs[0]
+	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 	b.Equal("https://github.com/", url.InsteadOfs[0])
 }
@@ -90,7 +92,9 @@ func (b *URLSuite) TestUnmarshalMultipleInsteadOf() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(input)
 	b.Nil(err)
-	url := cfg.URLs["ssh://git@github.com/"]
+	b.Require().Len(cfg.URLs, 1)
+	url := cfg.URLs[0]
+	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 
 	b.Equal("ssh://git@github.com/foobar", url.ApplyInsteadOf("https://github.com/foobar"))
@@ -109,7 +113,9 @@ func (b *URLSuite) TestUnmarshalDuplicateUrls() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(input)
 	b.Nil(err)
-	url := cfg.URLs["ssh://git@github.com/"]
+	b.Require().Len(cfg.URLs, 1)
+	url := cfg.URLs[0]
+	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 
 	b.Equal("ssh://git@github.com/foobar", url.ApplyInsteadOf("https://github.com/foobar"))
@@ -126,19 +132,82 @@ func (b *URLSuite) TestApplyInsteadOf() {
 	b.Equal("ssh://github.com/myrepo", urlRule.ApplyInsteadOf("http://github.com/myrepo"))
 }
 
-func (b *URLSuite) TestFindLongestInsteadOfMatch() {
-	urlRules := map[string]*URL{
-		"ssh://github.com": {
+func (b *URLSuite) TestApplyLongestInsteadOfMatch() {
+	urlRules := []*URL{
+		{
 			Name:       "ssh://github.com",
 			InsteadOfs: []string{"http://github.com"},
 		},
-		"ssh://somethingelse.com": {
+		{
 			Name:       "ssh://somethingelse.com",
 			InsteadOfs: []string{"http://github.com/foobar"},
 		},
 	}
 
-	longestURL := findLongestInsteadOfMatch("http://github.com/foobar/bingbash.git", urlRules)
+	rewrittenURL, matched := applyLongestInsteadOfMatch("http://github.com/foobar/bingbash.git", urlRules)
 
-	b.Equal("ssh://somethingelse.com", longestURL.Name)
+	b.True(matched, "Should find a match")
+	b.Equal("ssh://somethingelse.com/bingbash.git", rewrittenURL)
+}
+
+func (b *URLSuite) TestApplyInsteadOfLongestMatchWithinSameURL() {
+	// Test the edge case where a single URL has multiple insteadOf values
+	// and both match the given URL - the longest should win
+	url := &URL{
+		Name: "ssh://git@github.com/",
+		InsteadOfs: []string{
+			"https://github.com/",
+			"https://github.com/enterprise/",
+		},
+	}
+
+	// Both insteadOf values match, but the longer one should be used
+	result := url.ApplyInsteadOf("https://github.com/enterprise/user/repo.git")
+	b.Equal("ssh://git@github.com/user/repo.git", result)
+
+	// Also test with the shorter match
+	result = url.ApplyInsteadOf("https://github.com/user/repo.git")
+	b.Equal("ssh://git@github.com/user/repo.git", result)
+}
+
+func (b *URLSuite) TestApplyInsteadOfLongestMatchIntegration() {
+	// Integration test: verify longest match within a URL's insteadOf list
+	input := []byte(`[url "ssh://git@github.com/"]
+	insteadOf = https://github.com/
+	insteadOf = https://github.com/enterprise/
+[remote "origin"]
+	url = https://github.com/enterprise/user/repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	b.NoError(err)
+
+	// The longer insteadOf should be used
+	origin := cfg.Remotes["origin"]
+	b.NotNil(origin)
+	b.Equal([]string{"ssh://git@github.com/user/repo.git"}, origin.URLs)
+}
+
+func (b *URLSuite) TestApplyInsteadOfDuplicateInsteadOfValues() {
+	// When multiple URLs have the same insteadOf value (same length),
+	// use config file order (first wins), matching git's behavior.
+	input := []byte(`[url "ssh://git@github.com/"]
+	insteadOf = https://github.com/
+[url "git@github.com:"]
+	insteadOf = https://github.com/
+[remote "origin"]
+	url = https://github.com/user/repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	b.NoError(err)
+
+	// First URL in config file should be used
+	origin := cfg.Remotes["origin"]
+	b.NotNil(origin)
+	b.Equal([]string{"ssh://git@github.com/user/repo.git"}, origin.URLs)
 }

--- a/x/plugin/config/static.go
+++ b/x/plugin/config/static.go
@@ -66,19 +66,19 @@ func cloneRemotes(m map[string]*config.RemoteConfig) map[string]*config.RemoteCo
 	return cp
 }
 
-func cloneURLs(m map[string]*config.URL) map[string]*config.URL {
-	if m == nil {
+func cloneURLs(s []*config.URL) []*config.URL {
+	if s == nil {
 		return nil
 	}
-	cp := make(map[string]*config.URL, len(m))
-	for k, v := range m {
+	cp := make([]*config.URL, len(s))
+	for i, v := range s {
 		if v == nil {
-			cp[k] = nil
+			cp[i] = nil
 			continue
 		}
 		cloned := *v
 		cloned.InsteadOfs = cloneSlice(v.InsteadOfs)
-		cp[k] = &cloned
+		cp[i] = &cloned
 	}
 	return cp
 }


### PR DESCRIPTION
## Summary

Fixed a bug in `URL.ApplyInsteadOf()` where it would use the first matching `insteadOf` value instead of the longest one when a single `[url]` section contained multiple `insteadOf` entries that both matched the URL.

This violated git's specification which states: _"When more than one insteadOf strings match a given URL, the longest match is used."_

Additionally fixed a second issue where when multiple URLs had the same `insteadOf` value (tie in length), go-git used random map iteration order instead of config file order like git does.

## The Bugs

### Bug 1: Wrong match within single URL section

When a single `[url]` section has multiple `insteadOf` values that both match a URL, the **longest** match should be used (per git's spec), but the old code used the **first** match:

**Example configuration:**
```gitconfig
[url "ssh://git@github.com/"]
    insteadOf = https://github.com/
    insteadOf = https://github.com/enterprise/
```

**Before (❌ broken):**
```
Input:  https://github.com/enterprise/user/repo.git
Output: ssh://git@github.com/enterprise/user/repo.git
        (incorrectly used first match: https://github.com/)
```

**After (✅ fixed):**
```
Input:  https://github.com/enterprise/user/repo.git  
Output: ssh://git@github.com/user/repo.git
        (correctly used longest match: https://github.com/enterprise/)
```

### Bug 2: Non-deterministic tie-breaking

When multiple URLs have the same `insteadOf` value (tie in length), git uses **config file order** (first wins), but go-git used **random map iteration order**:

**Example configuration:**
```gitconfig
[url "ssh://git@github.com/"]
    insteadOf = https://github.com/
[url "git@github.com:"]
    insteadOf = https://github.com/
```

**Before (❌ non-deterministic):**
```
Result: ssh://git@github.com/user/repo.git  OR  git@github.com:user/repo.git
        (random - depends on map iteration order)
```

**After (✅ deterministic):**
```
Result: ssh://git@github.com/user/repo.git
        (always uses first URL in config file, matching git)
```

## Implementation Changes

- Modified `ApplyInsteadOf()` to find the longest matching `insteadOf` value instead of using the first match
- Optimized `findLongestInsteadOfMatch()` to apply the rewrite in a single pass instead of two, and renamed it to `applyLongestInsteadOfMatch()` to better reflect its behavior
- **Changed `Config.URLs` from `map[string]*URL` to `[]*URL`** to preserve config file order for deterministic tie-breaking (matching git's behavior)
- When multiple URLs have identical `insteadOf` lengths, use config file order (first wins), matching git's behavior exactly
- Updated `x/plugin/config` static plugin's `cloneURLs` to work with slice instead of map
- Added comprehensive tests for these edge cases

## Testing

- ✅ All existing config tests pass
- ✅ Added `TestApplyInsteadOfLongestMatchWithinSameURL` - unit test for bug #1
- ✅ Added `TestApplyInsteadOfLongestMatchIntegration` - integration test with remotes for bug #1
- ✅ Added `TestApplyInsteadOfDuplicateInsteadOfValues` - test for bug #2 (deterministic ordering)
- ✅ Updated `TestApplyLongestInsteadOfMatch` to verify single-pass behavior
- ✅ Verified behavior matches git exactly in all cases

## Related

This fixes edge cases that were not covered by the existing multiple `insteadOf` support added in PR #1410.
