### PR TITLE
git: Lowercase extension names (backport to releases/v5.x)

### DIFF
--- a/repository_extensions.go
+++ b/repository_extensions.go
@@ -45,11 +45,13 @@ var (
 	// Some Git extensions were supported upstream before the introduction
 	// of repositoryformatversion. These are the only extensions that can be
 	// enabled while core.repositoryformatversion is unset or set to 0.
+	// Keys must be lowercase to match the output of extensions(), which
+	// normalises extension names with strings.ToLower.
 	extensionsValidForV0 = map[string]struct{}{
 		"noop":            {},
-		"partialClone":    {},
-		"preciousObjects": {},
-		"worktreeConfig":  {},
+		"partialclone":    {},
+		"preciousobjects": {},
+		"worktreeconfig":  {},
 	}
 )
 


### PR DESCRIPTION
### Backport: lowercase extension names (fixes `worktreeConfig` rejection on v5.x)

This cherry-picks 76c75bb ("git: Lowercase extension names") onto `releases/v5.x`.

#### Problem

Since the strict extension check was added in v5.17.0, opening a repository whose
config enables the `worktreeConfig` extension fails on the current v5.x line:

```
core.repositoryformatversion does not support extension: worktreeconfig
```

`extensions()` normalises extension names with `strings.ToLower`, but
`extensionsValidForV0` (and the lookup in `verifyExtensions`) still used the
camelCase keys `worktreeConfig` / `partialClone` / `preciousObjects`, so the
case-insensitive comparison never matched and the extension was reported as
unsupported. The check inspects the presence of the key, not its value, so
setting `worktreeConfig = false` does not help — only removing the
`[extensions]` section entirely works around it.

Azure DevOps enables `worktreeConfig` by default, so this affects a lot of
real-world repositories. This was already fixed on `main` in 76c75bb but never
landed on `releases/v5.x` (latest tag v5.19.1 still reproduces it). See
go-git/go-git#1943.

#### Change

Cherry-pick of the upstream fix, no modifications.

cc @pjbgf
