### PR TITLE
storage: filesystem, Clean up empty parent directories on ref removal

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -293,6 +293,10 @@ func (d *DotGit) ReflogWriter(name plumbing.ReferenceName) (billy.File, error) {
 func (d *DotGit) DeleteReflog(name plumbing.ReferenceName) error {
 	p := d.fs.Join(logsPath, string(name))
 	err := d.fs.Remove(p)
+	if err == nil {
+		_ = d.removeEmptyParentDirs(p)
+	}
+
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -1147,6 +1151,9 @@ func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
 	_, err := d.fs.Stat(path)
 	if err == nil {
 		err = d.fs.Remove(path)
+		if err == nil {
+			_ = d.removeEmptyParentDirs(path)
+		}
 		// Drop down to remove it from the packed refs file, too.
 	}
 
@@ -1155,6 +1162,62 @@ func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
 	}
 
 	return d.rewritePackedRefsWithoutRef(name)
+}
+
+func (d *DotGit) removeEmptyParentDirs(path string) error {
+	for {
+		path = filepath.Dir(path)
+		if path == "." || path == "/" {
+			break
+		}
+
+		if d.isProtectedPath(path) {
+			break
+		}
+
+		files, err := d.fs.ReadDir(path)
+		if err != nil {
+			return err
+		}
+
+		if len(files) > 0 {
+			break
+		}
+
+		if err := d.fs.Remove(path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *DotGit) isProtectedPath(p string) bool {
+	// We use ToSlash to ensure we can compare it with our protected list
+	// regardless of the OS separator.
+	p = filepath.ToSlash(p)
+
+	protected := []string{
+		"refs/heads",
+		"refs/tags",
+		"refs/remotes",
+		"logs/refs/heads",
+		"logs/refs/tags",
+		"logs/refs/remotes",
+		"objects/info",
+		"objects/pack",
+		"refs",
+		"logs",
+		"objects",
+	}
+
+	for _, pt := range protected {
+		if p == pt {
+			return true
+		}
+	}
+
+	return false
 }
 
 func refsRecvFunc(refs *[]*plumbing.Reference, seen map[plumbing.ReferenceName]bool) refsRecv {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -90,6 +90,43 @@ func (s *SuiteDotGit) TestInitialize() {
 	s.Require().NoError(err)
 }
 
+func (s *SuiteDotGit) TestRemoveRefAndParentDirs() {
+	fs := s.EmptyFS()
+	dir := New(fs)
+
+	name := plumbing.ReferenceName("refs/heads/bugfix/issue-1")
+	ref := plumbing.NewHashReference(name, plumbing.NewHash("e238dc365d7870404092b774df102d99723ecb65"))
+
+	err := dir.SetRef(ref, nil)
+	s.NoError(err)
+
+	// Check file exists
+	_, err = fs.Stat("refs/heads/bugfix/issue-1")
+	s.NoError(err)
+
+	// Check dir exists
+	_, err = fs.Stat("refs/heads/bugfix")
+	s.NoError(err)
+
+	// Remove ref
+	err = dir.RemoveRef(name)
+	s.NoError(err)
+
+	// Check file is gone
+	_, err = fs.Stat("refs/heads/bugfix/issue-1")
+	s.Error(err)
+
+	// Check dir is gone
+	_, err = fs.Stat("refs/heads/bugfix")
+	s.Error(err)
+
+	// Try to create a ref named refs/heads/bugfix
+	name2 := plumbing.ReferenceName("refs/heads/bugfix")
+	ref2 := plumbing.NewHashReference(name2, plumbing.NewHash("e238dc365d7870404092b774df102d99723ecb65"))
+	err = dir.SetRef(ref2, nil)
+	s.NoError(err)
+}
+
 func (s *SuiteDotGit) TestSetRefs() {
 	fs := s.EmptyFS()
 


### PR DESCRIPTION
When a reference or reflog is removed from the filesystem, empty parent directories are now recursively deleted. This prevents name conflicts where a directory (e.g., 'refs/heads/feature/') would prevent the creation of a reference with the same name.

A protection mechanism ensures that core Git directory scaffolding (like 'refs/heads', 'refs/tags', and 'objects/info') is preserved even when empty, maintaining compatibility with Git standards and repository initialization.

Key changes:
- Implemented `removeEmptyParentDirs` and `isProtectedPath` in `storage/filesystem/dotgit/dotgit.go`.
- Updated `RemoveRef` and `DeleteReflog` to utilize the new cleanup logic.
- Added regression test `TestRemoveRefAndParentDirs` in `storage/filesystem/dotgit/dotgit_test.go`.

This PR fixes #1822 
