### PR TITLE
plumbing: transport/http, Expose typed auth error for Azure DevOps /_signin redirects

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -85,6 +85,13 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 
 	final := resp.Request.URL
 	if !strings.HasSuffix(final.Path, infoRefsPath) {
+		// Azure DevOps redirects unauthenticated requests for private repos
+		// to /_signin. Treat that as an authentication-required condition
+		// rather than a transport failure so callers can detect it via
+		// errors.Is(err, transport.ErrAuthenticationRequired). See issue #2200.
+		if strings.HasSuffix(final.Path, "/_signin") {
+			return nil, fmt.Errorf("%w: redirect to %q", transport.ErrAuthenticationRequired, final.Path)
+		}
 		return nil, fmt.Errorf(
 			"http transport: redirect target %q does not end with %s",
 			final.Path, infoRefsPath,

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -96,12 +96,13 @@ func TestApplyRedirect(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		baseURL   string
-		finalURL  string
-		wantURL   string
-		wantErr   string
-		noRequest bool
+		name             string
+		baseURL          string
+		finalURL         string
+		wantURL          string
+		wantErr          string
+		wantAuthRequired bool
+		noRequest        bool
 	}{
 		{
 			name:      "no redirect",
@@ -157,6 +158,13 @@ func TestApplyRedirect(t *testing.T) {
 			finalURL: "https://example.com/repo.git",
 			wantErr:  "does not end with",
 		},
+		{
+			name:             "azure devops _signin redirect is auth required",
+			baseURL:          "https://dev.azure.com/org/project/_git/repo",
+			finalURL:         "https://dev.azure.com/org/_signin",
+			wantErr:          "redirect to",
+			wantAuthRequired: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -177,6 +185,10 @@ func TestApplyRedirect(t *testing.T) {
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
+				if tt.wantAuthRequired {
+					assert.True(t, errors.Is(err, transport.ErrAuthenticationRequired),
+						"expected error to wrap transport.ErrAuthenticationRequired")
+				}
 				return
 			}
 


### PR DESCRIPTION
## Summary

Azure DevOps redirects unauthenticated requests for private repositories from `/info/refs` to `/_signin`. go-git previously surfaced this as a generic redirect error:

```
http transport: redirect target "/_signin" does not end with /info/refs
```

That made it impossible for callers to distinguish auth-required from a real transport failure without string-matching the error message.

This change detects a redirect target ending with `/_signin` and wraps the returned error with `transport.ErrAuthenticationRequired`, so callers can use:

```go
errors.Is(err, transport.ErrAuthenticationRequired)
```

As noted by @pjbgf in #2200, we already have forge-specific logic for SSH failures, so adding an equivalent for the Azure DevOps HTTP redirect is consistent.

Closes #2200

## Changes

- `plumbing/transport/http/common.go`: Add `/_signin` detection in `applyRedirect`, wrapping the error with `transport.ErrAuthenticationRequired`.
- `plumbing/transport/http/common_test.go`: Add table-driven test case for the Azure DevOps `/_signin` redirect, asserting `errors.Is(err, transport.ErrAuthenticationRequired)`.

## Verification

Added test case in the existing `TestApplyRedirect` table. Couldn't run `go test` locally (repo requires Go 1.25, environment has 1.19), but the change follows the exact `fmt.Errorf("%w: ...", transport.ErrAuthenticationRequired, ...)` pattern already used in `checkError` for HTTP 401 responses.