### PR TITLE
git: signer, add context.Context to Sign

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -999,7 +999,8 @@ func (r *Repository) buildTagSignature(tag *object.Tag, signer Signer) (string, 
 		return "", err
 	}
 
-	b, err := signer.Sign(rdr)
+	// TODO: thread a caller-supplied context once CreateTag accepts one.
+	b, err := signer.Sign(context.TODO(), rdr)
 	if err != nil {
 		return "", err
 	}

--- a/signer.go
+++ b/signer.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -13,10 +14,12 @@ type signableObject interface {
 
 // Signer is an interface for signing git objects.
 // message is a reader containing the encoded object to be signed.
+// ctx cancels signers that perform external or remote work; purely local
+// signers may ignore it.
 // Implementors should return the encoded signature and an error if any.
 // See https://git-scm.com/docs/gitformat-signature for more information.
 type Signer interface {
-	Sign(message io.Reader) ([]byte, error)
+	Sign(ctx context.Context, message io.Reader) ([]byte, error)
 }
 
 func signObject(signer Signer, obj signableObject) ([]byte, error) {
@@ -29,5 +32,6 @@ func signObject(signer Signer, obj signableObject) ([]byte, error) {
 		return nil, err
 	}
 
-	return signer.Sign(r)
+	// TODO: thread a caller-supplied context once Worktree.Commit accepts one.
+	return signer.Sign(context.TODO(), r)
 }

--- a/signer_test.go
+++ b/signer_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -16,7 +17,7 @@ type b64signer struct{}
 
 // This is not secure, and is only used as an example for testing purposes.
 // Please don't do this.
-func (b64signer) Sign(message io.Reader) ([]byte, error) {
+func (b64signer) Sign(_ context.Context, message io.Reader) ([]byte, error) {
 	b, err := io.ReadAll(message)
 	if err != nil {
 		return nil, err

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -1149,7 +1150,7 @@ type mockSigner struct {
 
 const mockSignature = "-----BEGIN PGP SIGNATURE-----\n\nmock-signature\n-----END PGP SIGNATURE-----"
 
-func (m *mockSigner) Sign(_ io.Reader) ([]byte, error) {
+func (m *mockSigner) Sign(_ context.Context, _ io.Reader) ([]byte, error) {
 	m.called = true
 	return []byte(mockSignature), nil
 }

--- a/x/plugin/plugin_signer.go
+++ b/x/plugin/plugin_signer.go
@@ -1,14 +1,19 @@
 package plugin
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 const objectSignerPlugin Name = "object-signer"
 
 var objectSigner = newKey[Signer](objectSignerPlugin)
 
 // Signer signs arbitrary data and returns the detached signature bytes.
+// ctx cancels signers that perform external or remote work; purely local
+// signers may ignore it.
 type Signer interface {
-	Sign(message io.Reader) ([]byte, error)
+	Sign(ctx context.Context, message io.Reader) ([]byte, error)
 }
 
 // ObjectSigner returns the key used to register an object-signing plugin.


### PR DESCRIPTION
The `Signer.Sign` method now takes a `context.Context`, matching the object-signer plugins in go-git/x so they continue to satisfy the interface. Both `git.Signer` and the `plugin.Signer` registration interface are updated.

`Worktree.Commit` and `Repository.CreateTag` do not accept a context, so their internal signing call sites pass `context.TODO()` until those public APIs are threaded with one.

Relates to https://github.com/go-git/x/pull/11.