### PR TITLE
plumbing: packp/capability, Zero-value-safe types and capability cleanup (1/11)

### DIFF
--- a/plumbing/protocol/capability/capability.go
+++ b/plumbing/protocol/capability/capability.go
@@ -266,10 +266,34 @@ const (
 	// Filter if present, fetch-pack may send "filter" commands to request a
 	// partial clone or partial fetch and request that the server omit various objects from the packfile
 	Filter Capability = "filter"
-	// SessionID the server may advertise a session ID that can be used to
-	// identify this process across multiple requests. The client may advertise
-	// its own session ID back to the server as well.
+)
+
+// V2 command capabilities are advertised by the server in protocol v2
+// capability advertisements.
+const (
+	// LsRefs is a v2 command capability indicating the server supports
+	// the ls-refs command for reference discovery.
+	LsRefs Capability = "ls-refs"
+	// FetchCmd is a v2 command capability indicating the server supports
+	// the fetch command. Named FetchCmd to avoid collision with the
+	// transport-level Fetch method.
+	FetchCmd Capability = "fetch"
+	// ObjectInfo is a v2 command capability indicating the server supports
+	// the object-info command.
+	ObjectInfo Capability = "object-info"
+	// BundleURI is a v2 command capability indicating the server supports
+	// the bundle-uri command.
+	BundleURI Capability = "bundle-uri"
+
+	// V2 non-command capabilities.
+	// ServerOption indicates the server supports the server-option capability.
+	ServerOption Capability = "server-option"
+	// SessionID indicates the server supports session-id for correlating
+	// requests and responses in stateless RPC (HTTP).
 	SessionID Capability = "session-id"
+	// WaitForDone is a v2 fetch sub-feature indicating the server supports
+	// the wait-for-done argument in the fetch command.
+	WaitForDone Capability = "wait-for-done"
 )
 
 const userAgent = "go-git/6.x"

--- a/plumbing/protocol/capability/capability_test.go
+++ b/plumbing/protocol/capability/capability_test.go
@@ -2,24 +2,38 @@ package capability
 
 import (
 	"fmt"
+	"os"
 	"strings"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
-func TestDefaultAgent(t *testing.T) {
-	t.Setenv("GO_GIT_USER_AGENT_EXTRA", "")
+func (s *SuiteCapabilities) TestDefaultAgent() {
+	defer restoreEnv("GO_GIT_USER_AGENT_EXTRA")()
+	os.Unsetenv("GO_GIT_USER_AGENT_EXTRA")
 	ua := DefaultAgent()
-	assert.Equal(t, userAgent, ua)
+	s.Equal(userAgent, ua)
 }
 
-func TestEnvAgent(t *testing.T) {
-	t.Setenv("GO_GIT_USER_AGENT_EXTRA", "abc xyz")
+func (s *SuiteCapabilities) TestEnvAgent() {
+	defer restoreEnv("GO_GIT_USER_AGENT_EXTRA")()
+	os.Setenv("GO_GIT_USER_AGENT_EXTRA", "abc xyz")
 	ua := DefaultAgent()
-	assert.Equal(t, fmt.Sprintf("%s %s", userAgent, "abc xyz"), ua)
+	s.Equal(fmt.Sprintf("%s %s", userAgent, "abc xyz"), ua)
+}
+
+// restoreEnv captures the current value of key and returns a function that
+// restores it, so a test can mutate the variable without leaking into other
+// tests. The capability suite runs with t.Parallel, which rules out t.Setenv.
+func restoreEnv(key string) func() {
+	old, had := os.LookupEnv(key)
+	return func() {
+		if had {
+			_ = os.Setenv(key, old)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	}
 }
 
 func (s *SuiteCapabilities) TestValidate() {

--- a/plumbing/protocol/capability/list.go
+++ b/plumbing/protocol/capability/list.go
@@ -2,14 +2,11 @@ package capability
 
 import (
 	"bytes"
-	"fmt"
-	"strings"
 )
 
 // List represents a list of capabilities. The zero value is safe to use;
-// the internal map is lazily initialized on first write.
-//
-// Note that the List is not thread safe.
+// the internal map is lazily initialized on first write. List is not safe for
+// concurrent use.
 type List struct {
 	m    map[string]*entry
 	sort []string
@@ -37,22 +34,41 @@ func DecodeList(raw []byte, l *List) {
 	}
 
 	raw = bytes.TrimSpace(raw)
-
 	if len(raw) == 0 {
 		return
 	}
 
-	for data := range bytes.SplitSeq(raw, []byte{' '}) {
-		pair := bytes.SplitN(data, []byte{'='}, 2)
+	for len(raw) > 0 {
+		var chunk []byte
+		if i := bytes.IndexByte(raw, ' '); i >= 0 {
+			chunk = raw[:i]
+			raw = raw[i+1:]
+		} else {
+			chunk = raw
+			raw = nil
+		}
 
-		c := string(pair[0])
-		if len(pair) == 1 {
-			l.Add(c)
+		if len(chunk) == 0 {
 			continue
 		}
 
-		l.Add(c, string(pair[1]))
+		if before, after, ok := bytes.Cut(chunk, []byte{'='}); ok {
+			l.Add(string(before), string(after))
+		} else {
+			l.Add(string(chunk))
+		}
 	}
+}
+
+// EncodeList encodes the List into a v0/v1 space-separated capability string.
+// This is the format used in advertise-refs, upload-request, and
+// update-request messages.
+func EncodeList(l *List) []byte {
+	if l == nil {
+		return nil
+	}
+	b, _ := l.MarshalText()
+	return b
 }
 
 // Get returns the values for a capability
@@ -135,24 +151,50 @@ func (l *List) All() []string {
 	return cs
 }
 
-// String generates the capabilities strings, the capabilities are sorted in
-// insertion order
-func (l *List) String() string {
-	var o []string
+// MarshalText implements encoding.TextMarshaler.
+func (l *List) MarshalText() ([]byte, error) {
+	return l.AppendText(nil)
+}
+
+// AppendText implements encoding.TextAppender.
+func (l *List) AppendText(b []byte) ([]byte, error) {
+	first := true
 	for _, key := range l.sort {
 		if l.m == nil {
 			continue
 		}
 		c := l.m[key]
 		if len(c.Values) == 0 {
-			o = append(o, key)
+			if !first {
+				b = append(b, ' ')
+			}
+			first = false
+			b = append(b, key...)
 			continue
 		}
 
 		for _, value := range c.Values {
-			o = append(o, fmt.Sprintf("%s=%s", key, value))
+			if !first {
+				b = append(b, ' ')
+			}
+			first = false
+			b = append(b, key...)
+			b = append(b, '=')
+			b = append(b, value...)
 		}
 	}
+	return b, nil
+}
 
-	return strings.Join(o, " ")
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (l *List) UnmarshalText(text []byte) error {
+	DecodeList(text, l)
+	return nil
+}
+
+// String generates the capabilities strings, the capabilities are sorted in
+// insertion order.
+func (l *List) String() string {
+	b, _ := l.MarshalText()
+	return string(b)
 }

--- a/plumbing/protocol/capability/list_test.go
+++ b/plumbing/protocol/capability/list_test.go
@@ -21,203 +21,103 @@ func (s *SuiteCapabilities) TestIsEmpty() {
 }
 
 func (s *SuiteCapabilities) TestDecode() {
-	cases := []struct {
-		name         string
-		add          [][]string
-		wantLen      int
-		wantGet      map[string][]string
-		wantSupports []string
-		wantIsEmpty  bool
-	}{
-		{
-			name:        "empty",
-			wantIsEmpty: true,
-		},
-		{
-			name: "symref and thin-pack",
-			add: [][]string{
-				{SymRef, "foo", "qux"},
-				{ThinPack},
-			},
-			wantLen: 2,
-			wantGet: map[string][]string{
-				SymRef:   {"foo", "qux"},
-				ThinPack: nil,
-			},
-		},
-		{
-			name: "with leading space",
-			add: [][]string{
-				{ReportStatus},
-			},
-			wantLen: 1,
-			wantSupports: []string{
-				ReportStatus,
-			},
-		},
-		{
-			name: "with equal in argument",
-			add: [][]string{
-				{Agent, "foo=bar"},
-			},
-			wantLen: 1,
-			wantGet: map[string][]string{
-				Agent: {"foo=bar"},
-			},
-		},
-		{
-			name: "unknown capability",
-			add: [][]string{
-				{"foo"},
-			},
-			wantSupports: []string{
-				"foo",
-			},
-		},
-		{
-			name: "unknown capability with argument",
-			add: [][]string{
-				{"oldref", "HEAD:refs/heads/v2"},
-				{ThinPack},
-			},
-			wantLen: 2,
-			wantGet: map[string][]string{
-				"oldref": {"HEAD:refs/heads/v2"},
-				ThinPack: nil,
-			},
-		},
-		{
-			name: "unknown capability with multiple arguments",
-			add: [][]string{
-				{"foo", "HEAD:refs/heads/v2", "HEAD:refs/heads/v1"},
-				{ThinPack},
-			},
-			wantLen: 2,
-			wantGet: map[string][]string{
-				"foo":    {"HEAD:refs/heads/v2", "HEAD:refs/heads/v1"},
-				ThinPack: nil,
-			},
-		},
-	}
+	caps := &List{}
+	// symref=foo symref=qux thin-pack
+	caps.Add("symref", "foo", "qux")
+	caps.Add("thin-pack")
 
-	for _, tc := range cases {
-		s.Run(tc.name, func() {
-			caps := &List{}
-			for _, args := range tc.add {
-				caps.Add(args[0], args[1:]...)
-			}
+	s.Len(caps.m, 2)
+	s.Equal([]string{"foo", "qux"}, caps.Get(SymRef))
+	s.Nil(caps.Get(ThinPack))
+}
 
-			if tc.wantLen > 0 {
-				s.Len(caps.m, tc.wantLen)
-			}
-			if tc.wantIsEmpty {
-				s.True(caps.IsEmpty())
-			}
-			for name, want := range tc.wantGet {
-				if want == nil {
-					s.Nil(caps.Get(name))
-				} else {
-					s.Equal(want, caps.Get(name))
-				}
-			}
-			for _, name := range tc.wantSupports {
-				s.True(caps.Supports(name))
-			}
-		})
-	}
+func (s *SuiteCapabilities) TestDecodeWithLeadingSpace() {
+	caps := &List{}
+	caps.Add("report-status")
+
+	s.Len(caps.m, 1)
+	s.True(caps.Supports(ReportStatus))
+}
+
+func (s *SuiteCapabilities) TestDecodeEmpty() {
+	caps := &List{}
+	s.Equal(&List{}, caps)
+}
+
+func (s *SuiteCapabilities) TestDecodeWithEqual() {
+	caps := &List{}
+	caps.Add("agent", "foo=bar")
+
+	s.Len(caps.m, 1)
+	s.Equal([]string{"foo=bar"}, caps.Get(Agent))
+}
+
+func (s *SuiteCapabilities) TestDecodeWithUnknownCapability() {
+	caps := &List{}
+	caps.Add("foo")
+	s.True(caps.Supports("foo"))
+}
+
+func (s *SuiteCapabilities) TestDecodeWithUnknownCapabilityWithArgument() {
+	caps := &List{}
+	caps.Add("oldref", "HEAD:refs/heads/v2")
+	caps.Add("thin-pack")
+
+	s.Len(caps.m, 2)
+	s.Equal([]string{"HEAD:refs/heads/v2"}, caps.Get("oldref"))
+	s.Nil(caps.Get(ThinPack))
+}
+
+func (s *SuiteCapabilities) TestDecodeWithUnknownCapabilityWithMultipleArgument() {
+	caps := &List{}
+	caps.Add("foo", "HEAD:refs/heads/v2", "HEAD:refs/heads/v1")
+	caps.Add("thin-pack")
+
+	s.Len(caps.m, 2)
+	s.Equal([]string{"HEAD:refs/heads/v2", "HEAD:refs/heads/v1"}, caps.Get("foo"))
+	s.Nil(caps.Get(ThinPack))
 }
 
 func (s *SuiteCapabilities) TestString() {
-	cases := []struct {
-		name       string
-		set        [][]string
-		wantString string
-	}{
-		{
-			name: "sorted output",
-			set: [][]string{
-				{Agent, "bar"},
-				{SymRef, "foo:qux"},
-				{ThinPack},
-			},
-			wantString: "agent=bar symref=foo:qux thin-pack",
-		},
-	}
+	caps := &List{}
+	caps.Set(Agent, "bar")
+	caps.Set(SymRef, "foo:qux")
+	caps.Set(ThinPack)
 
-	for _, tc := range cases {
-		s.Run(tc.name, func() {
-			caps := &List{}
-			for _, args := range tc.set {
-				caps.Set(args[0], args[1:]...)
-			}
+	s.Equal("agent=bar symref=foo:qux thin-pack", caps.String())
+}
 
-			s.Equal(tc.wantString, caps.String())
-		})
-	}
+func (s *SuiteCapabilities) TestStringSort() {
+	caps := &List{}
+	caps.Set(Agent, "bar")
+	caps.Set(SymRef, "foo:qux")
+	caps.Set(ThinPack)
+
+	s.Equal("agent=bar symref=foo:qux thin-pack", caps.String())
 }
 
 func (s *SuiteCapabilities) TestSet() {
-	cases := []struct {
-		name       string
-		add        [][]string
-		set        [][]string
-		wantLen    int
-		wantGet    map[string][]string
-		wantString string
-	}{
-		{
-			name: "overwrites add",
-			add: [][]string{
-				{SymRef, "foo", "qux"},
-			},
-			set: [][]string{
-				{SymRef, "bar"},
-			},
-			wantLen: 1,
-			wantGet: map[string][]string{
-				SymRef: {"bar"},
-			},
-		},
-		{
-			name: "with argument",
-			set: [][]string{
-				{Agent, "bar"},
-			},
-			wantGet: map[string][]string{
-				Agent: {"bar"},
-			},
-		},
-		{
-			name: "duplicate set keeps last",
-			set: [][]string{
-				{Agent, "baz"},
-				{Agent, "bar"},
-			},
-			wantString: "agent=bar",
-		},
-	}
+	caps := &List{}
+	caps.Add(SymRef, "foo", "qux")
+	caps.Set(SymRef, "bar")
 
-	for _, tc := range cases {
-		s.Run(tc.name, func() {
-			caps := &List{}
-			for _, args := range tc.add {
-				caps.Add(args[0], args[1:]...)
-			}
-			for _, args := range tc.set {
-				caps.Set(args[0], args[1:]...)
-			}
+	s.Len(caps.m, 1)
+	s.Equal([]string{"bar"}, caps.Get(SymRef))
+}
 
-			if tc.wantLen > 0 {
-				s.Len(caps.m, tc.wantLen)
-			}
-			for name, want := range tc.wantGet {
-				s.Equal(want, caps.Get(name))
-			}
-			if tc.wantString != "" {
-				s.Equal(tc.wantString, caps.String())
-			}
-		})
-	}
+func (s *SuiteCapabilities) TestSetEmpty() {
+	caps := &List{}
+	caps.Set(Agent, "bar")
+
+	s.Len(caps.Get(Agent), 1)
+}
+
+func (s *SuiteCapabilities) TestSetDuplicate() {
+	caps := &List{}
+	caps.Set(Agent, "baz")
+	caps.Set(Agent, "bar")
+
+	s.Equal("agent=bar", caps.String())
 }
 
 func (s *SuiteCapabilities) TestGetEmpty() {

--- a/plumbing/protocol/packp/advrefs_decode_test.go
+++ b/plumbing/protocol/packp/advrefs_decode_test.go
@@ -71,7 +71,7 @@ func (s *AdvRefsDecodeSuite) TestZeroId() {
 	}
 	ar := s.testDecodeOK(payloads)
 	_, err := ar.Head()
-	s.ErrorIs(plumbing.ErrReferenceNotFound, err)
+	s.Equal(plumbing.ErrReferenceNotFound, err)
 }
 
 func (s *AdvRefsDecodeSuite) testDecodeOK(payloads []string) *AdvRefs {


### PR DESCRIPTION
## Part 1 of 11: zero-value-safe packp and capability types

First of an eleven-part series implementing Protocol v2. This part carries no
new wire features; it reshapes the `capability` and `packp` types so the rest
of the series can build on a cleaner base. It targets `main` and is compatible
with the existing v2 upload-pack work (#2188), which is adapted to the new
APIs in later parts.

### What changes

capability:
- `List` is zero-value safe with lazy initialization; `NewList` is removed.
- `Capability` is a plain `string` alias.
- `List.Decode` is replaced by `DecodeList`, and `List` gains text
  marshaling/unmarshaling.
- `Validate` and its v0/v1 capability checks are kept, matching upstream git.

packp:
- Zero-value constructors are removed in favor of zero-value-safe structs.
- `Depth` becomes a concrete `DepthRequest` struct with deepen-prefixed
  fields, with depth validation against git.
- A shallow-only no-op push decodes as a valid empty request.

### Notes

- Targets `main` (v6). Built and tested green.
- Squashed into a single reviewable commit.

Part of the Protocol v2 series. Parts 2-11 build on this branch.


