### PR TITLE
plumbing: transport, Add options and result struct to GetRemoteRefs (3/11)

### DIFF
--- a/internal/server/servers_test.go
+++ b/internal/server/servers_test.go
@@ -71,9 +71,9 @@ func (s *ServerSuite) TestUploadPack() {
 	s.Require().NoError(err)
 	s.T().Cleanup(func() { s.Require().NoError(sess.Close()) })
 
-	refs, err := sess.GetRemoteRefs(context.Background())
+	refs, err := sess.GetRemoteRefs(context.Background(), nil)
 	s.Require().NoError(err)
-	s.Greater(len(refs), 0, "server should advertise refs")
+	s.Greater(len(refs.References), 0, "server should advertise refs")
 }
 
 func (s *ServerSuite) TestUnsupportedService() {

--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -54,9 +54,9 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesEmpty() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	refs, err := conn.GetRemoteRefs(context.TODO())
+	refs, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
-	s.Require().Len(refs, 0)
+	s.Require().Len(refs.References, 0)
 }
 
 // TestAdvertisedReferencesNotExists tests advertised references on a non-existent repo.
@@ -73,11 +73,11 @@ func (s *ReceivePackSuite) TestCallAdvertisedReferenceTwice() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	refs1, err := conn.GetRemoteRefs(context.TODO())
+	refs1, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(refs1)
 
-	refs2, err := conn.GetRemoteRefs(context.TODO())
+	refs2, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().Equal(refs1, refs2)
 }
@@ -89,11 +89,11 @@ func (s *ReceivePackSuite) TestDefaultBranch() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	refs, err := conn.GetRemoteRefs(context.TODO())
+	refs, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	ok := false
 	var ref *plumbing.Reference
-	for _, r := range refs {
+	for _, r := range refs.References {
 		if r.Name() == plumbing.Master {
 			ref = r
 			ok = true
@@ -261,7 +261,7 @@ func (s *ReceivePackSuite) receivePackNoCheck(ep *url.URL,
 	defer func() { s.Require().NoError(conn.Close()) }()
 
 	if callAdvertisedReferences {
-		info, err := conn.GetRemoteRefs(ctx)
+		info, err := conn.GetRemoteRefs(ctx, nil)
 		s.Require().NoError(err, comment)
 		s.Require().NotNil(info, comment)
 	}
@@ -315,11 +315,11 @@ func (s *ReceivePackSuite) checkRemoteReference(ep *url.URL,
 	pc := s.packClient()
 	conn, err := pc.Handshake(ctx, &transport.Request{URL: ep, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
-	ar, err := conn.GetRemoteRefs(ctx)
+	ar, err := conn.GetRemoteRefs(ctx, nil)
 	s.Require().NoError(err, fmt.Sprintf("endpoint: %s", ep.String()))
 	ok := false
 	var ref *plumbing.Reference
-	for _, r := range ar {
+	for _, r := range ar.References {
 		if r.Name() == refName {
 			ref = r
 			ok = true
@@ -348,7 +348,7 @@ func (s *ReceivePackSuite) testSendPackAddReference() {
 	conn, err := pc.Handshake(ctx, &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 
-	refs, err := conn.GetRemoteRefs(ctx)
+	refs, err := conn.GetRemoteRefs(ctx, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(refs)
 	s.Require().NoError(conn.Close())
@@ -371,7 +371,7 @@ func (s *ReceivePackSuite) testSendPackDeleteReference() {
 	s.Require().NoError(err)
 
 	caps := conn.Capabilities()
-	refs, err := conn.GetRemoteRefs(ctx)
+	refs, err := conn.GetRemoteRefs(ctx, nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(refs)
 	s.Require().NoError(conn.Close())

--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -49,7 +49,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesEmpty() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	ar, err := conn.GetRemoteRefs(context.TODO())
+	ar, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().ErrorIs(err, transport.ErrEmptyRemoteRepository)
 	s.Require().Nil(ar)
 }
@@ -68,10 +68,10 @@ func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	ar1, err := conn.GetRemoteRefs(context.TODO())
+	ar1, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(ar1)
-	ar2, err := conn.GetRemoteRefs(context.TODO())
+	ar2, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().Equal(ar1, ar2)
 }
@@ -83,7 +83,7 @@ func (s *UploadPackSuite) TestDefaultBranch() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO())
+	info, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 	symrefs := conn.Capabilities().Get(capability.SymRef)
@@ -98,7 +98,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO())
+	info, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 	s.Require().True(conn.Capabilities().Supports(capability.MultiACK))
@@ -111,7 +111,7 @@ func (s *UploadPackSuite) TestCapabilities() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO())
+	info, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 	s.Require().Len(conn.Capabilities().Get(capability.Agent), 1)
@@ -145,7 +145,7 @@ func (s *UploadPackSuite) TestUploadPackWithContext() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO())
+	info, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 
@@ -166,7 +166,7 @@ func (s *UploadPackSuite) TestUploadPackWithContextOnRead() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO())
+	info, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 
@@ -185,7 +185,7 @@ func (s *UploadPackSuite) TestUploadPackFull() {
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO())
+	info, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 

--- a/plumbing/transport/http/backend_test.go
+++ b/plumbing/transport/http/backend_test.go
@@ -167,12 +167,12 @@ func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
 	require.NoError(t, err)
 	defer sess.Close()
 
-	refs, err := sess.GetRemoteRefs(context.Background())
+	refs, err := sess.GetRemoteRefs(context.Background(), nil)
 	require.NoError(t, err)
-	require.NotEmpty(t, refs)
+	require.NotEmpty(t, refs.References)
 
 	var want plumbing.Hash
-	for _, r := range refs {
+	for _, r := range refs.References {
 		if r.Name() == "refs/heads/main" {
 			want = r.Hash()
 			break
@@ -204,10 +204,10 @@ func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
 	// --- go-git HTTP transport fetch after the CLI push (exercises "pull" using the http transport) ---
 	sess3, err := tr.Handshake(context.Background(), &transport.Request{URL: pu, Command: transport.UploadPackService})
 	require.NoError(t, err)
-	refs3, err := sess3.GetRemoteRefs(context.Background())
+	refs3, err := sess3.GetRemoteRefs(context.Background(), nil)
 	require.NoError(t, err)
 	var tip3 plumbing.Hash
-	for _, r := range refs3 {
+	for _, r := range refs3.References {
 		if r.Name() == "refs/heads/main" {
 			tip3 = r.Hash()
 			break

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
@@ -196,7 +195,7 @@ type smartPackSession struct {
 
 func (s *smartPackSession) Capabilities() *capability.List { return &s.caps }
 
-func (s *smartPackSession) GetRemoteRefs(_ context.Context) ([]*plumbing.Reference, error) {
+func (s *smartPackSession) GetRemoteRefs(_ context.Context, _ *transport.GetRemoteRefsOptions) (*transport.RemoteRefs, error) {
 	if s.refs == nil {
 		return nil, transport.ErrEmptyRemoteRepository
 	}
@@ -208,7 +207,7 @@ func (s *smartPackSession) GetRemoteRefs(_ context.Context) ([]*plumbing.Referen
 	if err != nil {
 		return nil, err
 	}
-	return refs, nil
+	return transport.NewRemoteRefs(refs), nil
 }
 
 func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *transport.FetchRequest) error {
@@ -373,7 +372,7 @@ type dumbPackSession struct {
 
 func (s *dumbPackSession) Capabilities() *capability.List { return &capability.List{} }
 
-func (s *dumbPackSession) GetRemoteRefs(_ context.Context) ([]*plumbing.Reference, error) {
+func (s *dumbPackSession) GetRemoteRefs(_ context.Context, _ *transport.GetRemoteRefsOptions) (*transport.RemoteRefs, error) {
 	if s.refs == nil {
 		return nil, transport.ErrEmptyRemoteRepository
 	}
@@ -381,7 +380,7 @@ func (s *dumbPackSession) GetRemoteRefs(_ context.Context) ([]*plumbing.Referenc
 	if err != nil {
 		return nil, err
 	}
-	return refs, nil
+	return transport.NewRemoteRefs(refs), nil
 }
 
 func (s *dumbPackSession) Fetch(ctx context.Context, st storage.Storer, req *transport.FetchRequest) error {

--- a/plumbing/transport/http/proxy_test.go
+++ b/plumbing/transport/http/proxy_test.go
@@ -55,7 +55,7 @@ func (s *proxySuite) TestAdvertisedReferencesHTTP() {
 	s.Require().NoError(err)
 	defer session.Close()
 
-	info, err := session.GetRemoteRefs(context.Background())
+	info, err := session.GetRemoteRefs(context.Background(), nil)
 	s.NoError(err)
 	s.NotNil(info)
 
@@ -85,7 +85,7 @@ func (s *proxySuite) TestAdvertisedReferencesHTTPS() {
 	s.Require().NoError(err)
 	defer session.Close()
 
-	info, err := session.GetRemoteRefs(context.Background())
+	info, err := session.GetRemoteRefs(context.Background(), nil)
 	s.NoError(err)
 	s.NotNil(info)
 

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -64,7 +64,7 @@ func TestRedirectPath(t *testing.T) {
 	require.NoError(t, err)
 	defer session.Close()
 
-	info, err := session.GetRemoteRefs(context.Background())
+	info, err := session.GetRemoteRefs(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, info)
 }
@@ -109,7 +109,7 @@ func TestRedirectSchema(t *testing.T) {
 	require.NoError(t, err)
 	defer session.Close()
 
-	info, err := session.GetRemoteRefs(context.Background())
+	info, err := session.GetRemoteRefs(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, info)
 }
@@ -162,7 +162,7 @@ func TestRedirectPathWithFetch(t *testing.T) {
 	defer session.Close()
 
 	// Verify that refs are available
-	refs, err := session.GetRemoteRefs(context.Background())
+	refs, err := session.GetRemoteRefs(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, refs)
 
@@ -444,7 +444,7 @@ func fetchWithRedirectedPost(t *testing.T, opts Options) error {
 	require.NoError(t, err)
 	defer session.Close()
 
-	refs, err := session.GetRemoteRefs(context.Background())
+	refs, err := session.GetRemoteRefs(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, refs)
 

--- a/plumbing/transport/pack_session.go
+++ b/plumbing/transport/pack_session.go
@@ -18,8 +18,57 @@ type Transport interface {
 // Session is returned by Transport.Handshake.
 type Session interface {
 	Capabilities() *capability.List
-	GetRemoteRefs(ctx context.Context) ([]*plumbing.Reference, error)
+	GetRemoteRefs(ctx context.Context, opts *GetRemoteRefsOptions) (*RemoteRefs, error)
 	Fetch(ctx context.Context, st storage.Storer, req *FetchRequest) error
 	Push(ctx context.Context, st storage.Storer, req *PushRequest) error
 	Close() error
+}
+
+// GetRemoteRefsOptions configures Session.GetRemoteRefs. A nil pointer
+// requests all references with default behavior, matching git's
+// transport_get_remote_refs(transport, NULL).
+type GetRemoteRefsOptions struct {
+	// RefPrefixes limits the returned references to those matching the
+	// given prefixes. For Protocol v2 these map directly to ls-refs
+	// ref-prefix arguments. For v0/v1 the server always advertises every
+	// reference, so prefixes are ignored.
+	RefPrefixes []string
+}
+
+// RemoteRefs holds the result of Session.GetRemoteRefs. It is a struct so
+// that new output fields can be added without changing the interface.
+type RemoteRefs struct {
+	// References are the advertised references, with HEAD resolved to a
+	// symbolic reference when the server reports a symref target.
+	References []*plumbing.Reference
+	// Unborn is the symref target of HEAD when HEAD points at an unborn
+	// branch. It is empty when HEAD is not unborn or the server does not
+	// report it (v0/v1).
+	Unborn plumbing.ReferenceName
+}
+
+// NewRemoteRefs builds a RemoteRefs from a resolved reference list,
+// detecting an unborn HEAD: a symbolic HEAD whose target has no
+// corresponding hash reference in the advertisement.
+func NewRemoteRefs(refs []*plumbing.Reference) *RemoteRefs {
+	rr := &RemoteRefs{References: refs}
+
+	var headTarget plumbing.ReferenceName
+	hashRefs := make(map[plumbing.ReferenceName]struct{}, len(refs))
+	for _, ref := range refs {
+		switch {
+		case ref.Type() == plumbing.HashReference:
+			hashRefs[ref.Name()] = struct{}{}
+		case ref.Name() == plumbing.HEAD && ref.Type() == plumbing.SymbolicReference:
+			headTarget = ref.Target()
+		}
+	}
+
+	if headTarget != "" {
+		if _, ok := hashRefs[headTarget]; !ok {
+			rr.Unborn = headTarget
+		}
+	}
+
+	return rr
 }

--- a/plumbing/transport/pack_session_test.go
+++ b/plumbing/transport/pack_session_test.go
@@ -1,0 +1,59 @@
+package transport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+func TestNewRemoteRefs(t *testing.T) {
+	t.Parallel()
+
+	head := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+
+	tests := []struct {
+		name       string
+		refs       []*plumbing.Reference
+		wantUnborn plumbing.ReferenceName
+	}{
+		{
+			name:       "no refs",
+			refs:       nil,
+			wantUnborn: "",
+		},
+		{
+			name: "hash refs only",
+			refs: []*plumbing.Reference{
+				plumbing.NewHashReference("refs/heads/main", head),
+			},
+			wantUnborn: "",
+		},
+		{
+			name: "symbolic head with present target is not unborn",
+			refs: []*plumbing.Reference{
+				plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main"),
+				plumbing.NewHashReference("refs/heads/main", head),
+			},
+			wantUnborn: "",
+		},
+		{
+			name: "symbolic head with absent target is unborn",
+			refs: []*plumbing.Reference{
+				plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main"),
+			},
+			wantUnborn: "refs/heads/main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rr := NewRemoteRefs(tt.refs)
+			assert.Equal(t, tt.refs, rr.References)
+			assert.Equal(t, tt.wantUnborn, rr.Unborn)
+		})
+	}
+}

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
@@ -82,8 +81,9 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 // Capabilities implements PackSession.
 func (s *StreamSession) Capabilities() *capability.List { return &s.caps }
 
-// GetRemoteRefs implements PackSession.
-func (s *StreamSession) GetRemoteRefs(_ context.Context) ([]*plumbing.Reference, error) {
+// GetRemoteRefs implements Session. For v0/v1 the server advertises every
+// reference during the handshake, so opts is ignored.
+func (s *StreamSession) GetRemoteRefs(_ context.Context, _ *GetRemoteRefsOptions) (*RemoteRefs, error) {
 	if s.refs == nil {
 		return nil, ErrEmptyRemoteRepository
 	}
@@ -96,7 +96,7 @@ func (s *StreamSession) GetRemoteRefs(_ context.Context) ([]*plumbing.Reference,
 	if err != nil {
 		return nil, err
 	}
-	return refs, nil
+	return NewRemoteRefs(refs), nil
 }
 
 // Fetch implements PackSession.

--- a/remote.go
+++ b/remote.go
@@ -119,12 +119,12 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 	}
 	defer ioutil.CheckClose(sess, &err)
 
-	rRefs, err := sess.GetRemoteRefs(ctx)
+	rRefs, err := sess.GetRemoteRefs(ctx, nil)
 	if err != nil {
 		return err
 	}
 
-	remoteRefs := referenceStorageFromRefs(rRefs, true)
+	remoteRefs := referenceStorageFromRefs(rRefs.References, true)
 	if err := r.checkRequireRemoteRefs(o.RequireRemoteRefs, remoteRefs); err != nil {
 		return err
 	}
@@ -388,12 +388,12 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		return nil, err
 	}
 
-	rRefs, err := sess.GetRemoteRefs(ctx)
+	rRefs, err := sess.GetRemoteRefs(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	remoteRefs := referenceStorageFromRefs(rRefs, true)
+	remoteRefs := referenceStorageFromRefs(rRefs.References, true)
 	localRefs, err := reference.References(r.s)
 	if err != nil {
 		return nil, err
@@ -1297,13 +1297,13 @@ func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Refe
 
 	defer ioutil.CheckClose(sess, &err)
 
-	allRefs, err := sess.GetRemoteRefs(ctx)
+	allRefs, err := sess.GetRemoteRefs(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var resultRefs []*plumbing.Reference
-	for _, ref := range allRefs {
+	for _, ref := range allRefs.References {
 		isPeeled := strings.HasSuffix(ref.Name().String(), peeledSuffix)
 		switch o.PeelingOption {
 		case IgnorePeeled:


### PR DESCRIPTION
## Part 3 of 11: GetRemoteRefs options and result struct

Third of the Protocol v2 series. Builds on Part 2 (#2207).

### What changes

`Session.GetRemoteRefs` now takes a nullable `*GetRemoteRefsOptions` and
returns a `*RemoteRefs`, following git's `transport_get_remote_refs`:

- `GetRemoteRefsOptions` carries only `RefPrefixes`, which map to the
  Protocol v2 ls-refs `ref-prefix` arguments. They are ignored for v0/v1,
  where the server advertises every reference.
- `RemoteRefs.References` holds the advertised refs and `RemoteRefs.Unborn`
  reports the symref target of an unborn HEAD.

`Unborn` is output only: git sends the ls-refs `unborn` argument whenever the
server supports it rather than gating it behind a request flag. An unborn HEAD
is modeled as a symbolic reference whose target has no corresponding hash
reference, so no new reference type is required.

Existing callers, including the #2188 HTTP backend test, are updated to the
new signature.

### Reviewing just this part

https://github.com/aymanbagabas/go-git/compare/gitprotocol-v2-2-transport...gitprotocol-v2-3-getremoterefs

### Notes

- Targets `main` (v6). Built and tested green. Squashed.

Depends on Part 2 (#2207); merge that first.


