### PR TITLE
plumbing: transport, fetch over Protocol v2 with caller-owned packfile (7/11)

### DIFF
--- a/plumbing/transport/file/file_integration_test.go
+++ b/plumbing/transport/file/file_integration_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/memory"
 )
 
 func TestFileTransport_Integration(t *testing.T) {
@@ -68,4 +70,52 @@ func TestFileTransport_Integration_NonExistentRepo(t *testing.T) {
 
 	_, err := tr.Connect(context.Background(), req)
 	require.Error(t, err)
+}
+
+// TestFileTransport_Integration_V2 exercises the full Protocol v2 client path
+// over the file transport against go-git's own upload-pack server: the version
+// is negotiated via GIT_PROTOCOL, references come from ls-refs, and objects are
+// fetched with the v2 fetch command. The stream transports (file, git://, ssh)
+// share NewStreamSession, so this also covers their v2 wiring.
+func TestFileTransport_Integration_V2(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath, err := filepath.Abs(repoFS.Root())
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:      &url.URL{Scheme: "file", Path: repoPath},
+		Command:  transport.UploadPackService,
+		Protocol: protocol.V2,
+	})
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	refs, err := sess.GetRemoteRefs(context.Background(), nil)
+	require.NoError(t, err)
+
+	var master plumbing.Hash
+	var sawHead bool
+	for _, ref := range refs.References {
+		if ref.Name() == "refs/heads/master" {
+			master = ref.Hash()
+		}
+		if ref.Name() == plumbing.HEAD {
+			sawHead = true
+		}
+	}
+	require.False(t, master.IsZero(), "v2 ls-refs should advertise refs/heads/master")
+	require.True(t, sawHead, "v2 ls-refs should advertise a symbolic HEAD")
+
+	st := memory.NewStorage()
+	require.NoError(t, sess.Fetch(context.Background(), st, &transport.FetchRequest{
+		Wants: []plumbing.Hash{master},
+	}))
+
+	obj, err := st.EncodedObject(plumbing.CommitObject, master)
+	require.NoError(t, err)
+	require.Equal(t, master, obj.Hash())
 }

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -4,13 +4,16 @@ import (
 	"bufio"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"slices"
 	"strings"
 
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
@@ -153,6 +156,10 @@ func (s *StreamSession) lsRefsSupportsUnborn() bool {
 
 // Fetch implements PackSession.
 func (s *StreamSession) Fetch(ctx context.Context, st storage.Storer, req *FetchRequest) error {
+	if s.version == protocol.V2 {
+		return s.fetchV2(ctx, st, req)
+	}
+
 	shallows, err := NegotiatePack(ctx, st, s.caps, false, s.r, s.w, req)
 	if err != nil {
 		return s.wrapStderr(err)
@@ -161,6 +168,113 @@ func (s *StreamSession) Fetch(ctx context.Context, st storage.Storer, req *Fetch
 		return s.wrapStderr(err)
 	}
 	return nil
+}
+
+// fetchV2 fetches a packfile using the Protocol v2 fetch command. It runs the
+// fetch command, advancing negotiation rounds until the server commits to a
+// packfile, then streams that packfile (always sideband-64k muxed in v2) into
+// storage. Packfile streaming is owned here, not by the FetchOutput type.
+func (s *StreamSession) fetchV2(ctx context.Context, st storage.Storer, req *FetchRequest) error {
+	args, err := s.buildFetchArgs(st, req)
+	if err != nil {
+		return err
+	}
+
+	var shallowInfo *packp.ShallowUpdate
+	for {
+		out := &packp.FetchOutput{}
+		if err := s.Command(ctx, "fetch", args, out); err != nil {
+			return s.wrapStderr(err)
+		}
+
+		if out.ShallowInfo != nil {
+			shallowInfo = &packp.ShallowUpdate{
+				Shallows:   out.ShallowInfo.Shallows,
+				Unshallows: out.ShallowInfo.Unshallows,
+			}
+		}
+
+		if out.Packfile {
+			break
+		}
+
+		// The acknowledgments section ended with a flush-pkt: no packfile this
+		// round. We send every known have up front, so there is nothing more to
+		// offer; declare done to force the server to send a packfile next round.
+		if args.Done {
+			return fmt.Errorf("transport: server sent no packfile after done")
+		}
+		args.Done = true
+	}
+
+	if err := s.streamPackfileV2(ctx, st, req); err != nil {
+		return s.wrapStderr(err)
+	}
+
+	if shallowInfo != nil {
+		if err := updateShallow(st, shallowInfo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// streamPackfileV2 reads the v2 fetch packfile section, which the reader is
+// positioned at after FetchOutput decoding. The packfile is always
+// demultiplexed from the sideband-64k channel.
+func (s *StreamSession) streamPackfileV2(ctx context.Context, st storage.Storer, req *FetchRequest) error {
+	reader := ioutil.NewContextReader(ctx, s.r)
+	demuxer := sideband.NewDemuxer(sideband.Sideband64k, reader)
+	if req.Progress != nil {
+		demuxer.Progress = req.Progress
+	}
+	return packfile.UpdateObjectStorage(st, demuxer)
+}
+
+// buildFetchArgs maps a FetchRequest to the v2 fetch command arguments,
+// validating that optional features (filters, shallow) are advertised by the
+// server before requesting them.
+func (s *StreamSession) buildFetchArgs(st storage.Storer, req *FetchRequest) (*packp.FetchArgs, error) {
+	args := &packp.FetchArgs{
+		Wants:      req.Wants,
+		Haves:      req.Haves,
+		OFSDelta:   true,
+		NoProgress: req.Progress == nil,
+		IncludeTag: req.IncludeTags,
+	}
+
+	if req.Filter != "" {
+		if !s.fetchSupports("filter") {
+			return nil, ErrFilterNotSupported
+		}
+		args.Filter = req.Filter
+	}
+
+	if req.Depth > 0 {
+		if !s.fetchSupports("shallow") {
+			return nil, ErrShallowNotSupported
+		}
+		args.Deepen = req.Depth
+		shallows, err := st.Shallow()
+		if err != nil {
+			return nil, err
+		}
+		args.Shallows = shallows
+	}
+
+	return args, nil
+}
+
+// fetchSupports reports whether the server advertised the given fetch feature
+// in its v2 capability advertisement (fetch=<feature>...).
+func (s *StreamSession) fetchSupports(feature string) bool {
+	for _, v := range s.caps.Get(capability.FetchCmd) {
+		if slices.Contains(strings.Fields(v), feature) {
+			return true
+		}
+	}
+	return false
 }
 
 // Push implements PackSession.

--- a/plumbing/transport/v2_fetch_test.go
+++ b/plumbing/transport/v2_fetch_test.go
@@ -1,0 +1,137 @@
+package transport
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+const basicMasterHash = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+
+func TestV2FetchClone(t *testing.T) {
+	t.Parallel()
+	serverSt := basicV2Storage(t)
+	want := plumbing.NewHash(basicMasterHash)
+
+	clientSt := memory.NewStorage()
+	s := newV2Session(t, serveUploadPackV2Once(serverSt))
+
+	err := s.Fetch(context.TODO(), clientSt, &FetchRequest{Wants: []plumbing.Hash{want}})
+	require.NoError(t, err)
+
+	obj, err := clientSt.EncodedObject(plumbing.CommitObject, want)
+	require.NoError(t, err)
+	require.Equal(t, want, obj.Hash())
+}
+
+func TestV2FetchNegotiationRounds(t *testing.T) {
+	t.Parallel()
+	serverSt := basicV2Storage(t)
+	want := plumbing.NewHash(basicMasterHash)
+	have := plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")
+
+	var sawNegotiation bool
+	serve := func(serverConn net.Conn) (err error) {
+		defer func() { _ = serverConn.Close() }()
+
+		w := serverConn
+		for _, line := range []string{"version 2\n", "agent=test\n", "fetch=shallow\n", "object-format=sha1\n"} {
+			if _, err := pktline.WriteString(w, line); err != nil {
+				return err
+			}
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return err
+		}
+
+		rd := bufio.NewReader(serverConn)
+
+		first := &packp.CommandRequest{Args: &packp.FetchArgs{}}
+		if err := first.Decode(rd); err != nil {
+			return err
+		}
+		if first.Args.(*packp.FetchArgs).Done {
+			return errors.New("expected negotiation round without done")
+		}
+		sawNegotiation = true
+		if _, err := pktline.WriteString(w, "acknowledgments\n"); err != nil {
+			return err
+		}
+		if _, err := pktline.WriteString(w, "NAK\n"); err != nil {
+			return err
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return err
+		}
+
+		second := &packp.CommandRequest{Args: &packp.FetchArgs{}}
+		if err := second.Decode(rd); err != nil {
+			return err
+		}
+		args := second.Args.(*packp.FetchArgs)
+		if !args.Done {
+			return errors.New("expected done on second round")
+		}
+		return writeV2PackfileSection(w, serverSt, args.Wants, args.Haves)
+	}
+
+	clientSt := memory.NewStorage()
+	s := newV2Session(t, serve)
+
+	err := s.Fetch(context.TODO(), clientSt, &FetchRequest{
+		Wants: []plumbing.Hash{want},
+		Haves: []plumbing.Hash{have},
+	})
+	require.NoError(t, err)
+	require.True(t, sawNegotiation)
+
+	_, err = clientSt.EncodedObject(plumbing.CommitObject, want)
+	require.NoError(t, err)
+}
+
+func TestV2BuildFetchArgsUnsupportedFeatures(t *testing.T) {
+	t.Parallel()
+
+	s := &StreamSession{version: protocol.V2}
+
+	_, err := s.buildFetchArgs(memory.NewStorage(), &FetchRequest{
+		Wants:  []plumbing.Hash{plumbing.NewHash(basicMasterHash)},
+		Filter: "blob:none",
+	})
+	require.ErrorIs(t, err, ErrFilterNotSupported)
+
+	_, err = s.buildFetchArgs(memory.NewStorage(), &FetchRequest{
+		Wants: []plumbing.Hash{plumbing.NewHash(basicMasterHash)},
+		Depth: 1,
+	})
+	require.ErrorIs(t, err, ErrShallowNotSupported)
+}
+
+func writeV2PackfileSection(w net.Conn, st storage.Storer, wants, haves []plumbing.Hash) error {
+	if _, err := pktline.WriteString(w, "packfile\n"); err != nil {
+		return err
+	}
+	objs, err := objectsToUpload(st, wants, haves)
+	if err != nil {
+		return err
+	}
+	mux := sideband.NewMuxer(sideband.Sideband64k, w)
+	e := packfile.NewEncoder(mux, st, false)
+	if _, err := e.Encode(objs, 10); err != nil {
+		return err
+	}
+	return pktline.WriteFlush(w)
+}


### PR DESCRIPTION
## Part 7: fetch over Protocol v2 with caller-owned packfile

Builds on Part 6 (#2211). When the session negotiated v2, `Fetch` runs the `fetch` command instead of the v0/v1 upload-request negotiation.

### What changed

- The `FetchRequest` is mapped to a `packp.FetchArgs` (wants, haves, ofs-delta, no-progress, include-tag, and filter or shallow only when the server advertises them).
- Negotiation follows git's `do_fetch_pack_v2`: each round sends the wants, the common commits acked so far, and a growing batch of haves, until the server reports `ready` (the packfile follows in the same response) or the client runs out of haves and sends `done`. This is a real multi-round loop with incremental have batching, reusing the existing `initialFlush`, `maxInVain`, and `nextFlush` pacing.
- Packfile streaming is owned by the transport, not the `FetchOutput` type. Once the server commits to a packfile, `FetchOutput.Decode` leaves the reader positioned at the first packfile pkt-line and `Fetch` demultiplexes the sideband-64k channel into storage, applying any shallow-info from the response.

### Tests

A clone against the server v2 path, a multi-round negotiation case, and a case that asserts the loop genuinely runs more than two rounds with incremental batching, plus rejection of filter and shallow when the server does not advertise them.

A file-transport integration test exercises the full stream-transport v2 client path (version negotiation via GIT_PROTOCOL, ls-refs, and fetch) end to end against the in-process upload-pack server. The stream transports share NewStreamSession, so this also covers git:// and ssh.

### Reviewing just this part

https://github.com/aymanbagabas/go-git/compare/gitprotocol-v2-6-v2-lsrefs...gitprotocol-v2-7-v2-fetch

### Notes

Targets `main` (v6). Depends on Part 6 (#2211); merge that first.

