### PR TITLE
plumbing: transport, Refactor server-side Protocol v2 onto packp types (9/11)

### DIFF
--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -21,7 +21,13 @@ import (
 var ErrUpdateReference = errors.New("failed to update ref")
 
 // AdvertiseRefs is a server command that implements the reference
-// discovery phase of the Git transfer protocol.
+// discovery phase of the v0/v1 Git transfer protocol. Protocol v2 advertises
+// capabilities only, via [AdvertiseCapabilities]; the sole reason this function
+// accepts protocol.V2 is the receive-pack fallback: v2 has no push, so when a
+// client requests v2 for receive-pack git ignores it and serves a classic
+// advertisement (builtin/receive-pack.c), while http-backend still suppresses
+// the "# service=..." smart-reply line for the v2 request (http-backend.c
+// get_info_refs). Both behaviours are reproduced below.
 func AdvertiseRefs(
 	_ context.Context,
 	st storage.Storer,
@@ -60,17 +66,7 @@ func AdvertiseRefs(
 		ar.Capabilities.Set(capability.Sideband)
 		ar.Capabilities.Set(capability.NoProgress)
 		ar.Capabilities.Set(capability.Shallow)
-
-		cfg, err := st.Config()
-		var objectformat config.ObjectFormat
-		if err == nil && cfg != nil {
-			objectformat = cfg.Extensions.ObjectFormat
-		}
-
-		if objectformat == config.UnsetObjectFormat {
-			objectformat = config.DefaultObjectFormat
-		}
-		ar.Capabilities.Set(capability.ObjectFormat, objectformat.String())
+		ar.Capabilities.Set(capability.ObjectFormat, objectFormat(st).String())
 	}
 
 	// Set references
@@ -83,7 +79,10 @@ func AdvertiseRefs(
 		return fmt.Errorf("invalid capabilities: %w", err)
 	}
 
-	if smart {
+	// git's http-backend omits the "# service=..." smart reply whenever the
+	// requested protocol is v2, even for receive-pack which then falls back to
+	// a v0 advertisement (http-backend.c get_info_refs).
+	if smart && version != protocol.V2 {
 		smartReply := packp.SmartReply{
 			Service: service,
 		}
@@ -93,63 +92,73 @@ func AdvertiseRefs(
 		}
 	}
 
-	// Emit explicit version packet for V1 (all) and V2 upload-pack.
-	// For HTTP this appears after the "# service=..." smart reply (correct wire order).
-	// For stateful transports (git://, ssh) it appears at the start of the advertisement.
-	if version == protocol.V1 || (version == protocol.V2 && service == UploadPackService) {
+	// V1 prefixes the advertisement with an explicit version packet. For HTTP
+	// this appears after the "# service=..." smart reply (correct wire order);
+	// for stateful transports (git://, ssh) it appears at the start.
+	if version == protocol.V1 {
 		if _, err := pktline.Writef(w, "version %d\n", version); err != nil {
 			return err
 		}
 	}
 
-	if version == protocol.V2 && service == UploadPackService {
-		return writeV2Advertisement(w, st)
-	}
-
 	return ar.Encode(w)
 }
 
-func writeV2Advertisement(w io.Writer, st storage.Storer) error {
-	// Advertise only the v2 commands/features this server implements; refs are
-	// not listed here (clients retrieve them via ls-refs). Advertising a feature
-	// that isn't handled makes clients request it and then mis-handle the reply.
-	//
-	// The fetch "shallow" feature covers the deepen family; only "deepen <n>"
-	// is handled today (deepen-since/-not/-relative are rejected, as in v0/v1).
-	//
-	// TODO: advertise these once implemented:
-	//   - ls-refs=unborn       report an unborn HEAD on an empty repository
-	//   - fetch=filter         partial-clone object filters
-	//   - fetch=ref-in-want    want-ref negotiation
-	//   - fetch=sideband-all   sideband for the entire response, not just the packfile
-	//   - fetch=packfile-uris  offload pack data to out-of-band URIs
-	//   - fetch=wait-for-done  negotiate-only fetch (git fetch --negotiate-only)
-	//   - server-option        process client "server-option" lines
-	//   - object-info          object size/type queries without a fetch
-	caps := make([]string, 0, 4)
-	caps = append(
-		caps,
-		"agent="+capability.DefaultAgent(),
-		"ls-refs",
-		"fetch=shallow",
-	)
+// AdvertiseCapabilities implements the Protocol v2 capability advertisement for
+// the upload-pack service. Unlike the v0/v1 [AdvertiseRefs], it does not list
+// references (clients retrieve them with the ls-refs command) and it does not
+// emit the smart-HTTP "# service=..." prefix: git omits that line for v2
+// (http-backend.c get_info_refs), the response starts directly with the version
+// packet.
+func AdvertiseCapabilities(_ context.Context, st storage.Storer, w io.Writer, service string) error {
+	if service != UploadPackService {
+		return fmt.Errorf("%w: %s", ErrUnsupportedService, service)
+	}
 
-	// object format
-	var objectformat config.ObjectFormat
-	if cfg, err := st.Config(); err == nil && cfg != nil {
-		objectformat = cfg.Extensions.ObjectFormat
+	adv := &packp.CapabilityAdv{
+		Version:      protocol.V2,
+		Capabilities: serverV2Capabilities(st),
 	}
-	if objectformat == config.UnsetObjectFormat {
-		objectformat = config.DefaultObjectFormat
-	}
-	caps = append(caps, "object-format="+objectformat.String())
+	return adv.Encode(w)
+}
 
-	for _, c := range caps {
-		if _, err := pktline.Writef(w, "%s\n", c); err != nil {
-			return err
-		}
+// serverV2Capabilities builds the v2 capabilities this server implements. Only
+// commands and features that are actually handled are advertised: advertising a
+// feature that isn't handled makes clients request it and then mis-handle the
+// reply.
+//
+// The fetch "shallow" feature covers the deepen family; only "deepen <n>" is
+// handled today (deepen-since/-not/-relative are rejected, as in v0/v1).
+//
+// TODO: advertise these once implemented:
+//   - ls-refs=unborn       report an unborn HEAD on an empty repository
+//   - fetch=filter         partial-clone object filters
+//   - fetch=ref-in-want    want-ref negotiation
+//   - fetch=sideband-all   sideband for the entire response, not just the packfile
+//   - fetch=packfile-uris  offload pack data to out-of-band URIs
+//   - fetch=wait-for-done  negotiate-only fetch (git fetch --negotiate-only)
+//   - server-option        process client "server-option" lines
+//   - object-info          object size/type queries without a fetch
+func serverV2Capabilities(st storage.Storer) capability.List {
+	var caps capability.List
+	caps.Set(capability.Agent, capability.DefaultAgent())
+	caps.Set(capability.LsRefs)
+	caps.Set(capability.FetchCmd, "shallow")
+	caps.Set(capability.ObjectFormat, objectFormat(st).String())
+	return caps
+}
+
+// objectFormat returns the repository's configured object format, defaulting to
+// the package default when the config is missing or unset.
+func objectFormat(st storage.Storer) config.ObjectFormat {
+	cfg, err := st.Config()
+	if err != nil || cfg == nil {
+		return config.DefaultObjectFormat
 	}
-	return pktline.WriteFlush(w)
+	if cfg.Extensions.ObjectFormat == config.UnsetObjectFormat {
+		return config.DefaultObjectFormat
+	}
+	return cfg.Extensions.ObjectFormat
 }
 
 func addReferences(st storage.Storer, ar *packp.AdvRefs, addHead bool) error {

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -60,13 +60,17 @@ func UploadPack(
 		v := ProtocolVersion(opts.GitProtocol)
 		switch v {
 		case protocol.V0, protocol.V1, protocol.V2:
-			// V0/V1 share the same classic negotiation format after the
-			// (optional) version line. We only branch for V2 below.
+			// V0/V1 share the classic advertisement; V2 advertises
+			// capabilities only (refs come via ls-refs).
 		default:
 			return fmt.Errorf("%w: %q", ErrUnsupportedVersion, v)
 		}
 
-		if err := AdvertiseRefs(ctx, st, w, UploadPackService, opts.StatelessRPC, v); err != nil {
+		if v == protocol.V2 {
+			if err := AdvertiseCapabilities(ctx, st, w, UploadPackService); err != nil {
+				return fmt.Errorf("advertising v2 capabilities: %w", err)
+			}
+		} else if err := AdvertiseRefs(ctx, st, w, UploadPackService, opts.StatelessRPC, v); err != nil {
 			return fmt.Errorf("advertising references: %w", err)
 		}
 	}
@@ -386,97 +390,64 @@ func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd 
 // It is used when the client requests version=2 via GIT_PROTOCOL.
 func serveUploadPackV2(ctx context.Context, st storage.Storer, rd *bufio.Reader, w io.WriteCloser, opts *UploadPackRequest) error {
 	for {
-		cmd, kvs, args, err := readV2Request(rd)
+		// Peek the command line to choose the argument decoder, then decode the
+		// whole request envelope through packp.CommandRequest (the same type the
+		// client encodes).
+		l, line, err := pktline.PeekLine(rd)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return nil
 			}
 			return err
 		}
-		if cmd == "" {
-			// flush ended the request
+		if l == pktline.Flush {
+			// A lone flush-pkt ends the request.
+			_, _, _ = pktline.ReadLine(rd)
 			return nil
 		}
+
+		cmd := strings.TrimPrefix(strings.TrimSuffix(string(line), "\n"), "command=")
+
+		req := &packp.CommandRequest{}
 		switch cmd {
 		case "ls-refs":
-			if err := serveLsRefsV2(ctx, st, w, kvs, args); err != nil {
-				return err
-			}
-			// For stateless (HTTP) a single command per request; for stateful may continue but clients typically close.
-			if opts.StatelessRPC {
-				return nil
-			}
+			req.Args = &packp.LsRefsArgs{}
 		case "fetch":
-			return serveFetchV2(ctx, st, w, rd, kvs, args, opts)
+			req.Args = &packp.FetchArgs{}
 		default:
 			_, _ = pktline.Writef(w, "error unknown-command %s\n", cmd)
 			_ = pktline.WriteFlush(w)
 			return fmt.Errorf("unsupported v2 command %q", cmd)
 		}
+
+		if err := req.Decode(rd); err != nil {
+			return fmt.Errorf("decoding %s request: %w", cmd, err)
+		}
+
+		switch cmd {
+		case "ls-refs":
+			if err := serveLsRefsV2(ctx, st, w, req.Args.(*packp.LsRefsArgs)); err != nil {
+				return err
+			}
+			// Stateless (HTTP) carries a single command per request; stateful
+			// transports may continue, but clients typically close after.
+			if opts.StatelessRPC {
+				return nil
+			}
+		case "fetch":
+			return serveFetchV2(ctx, st, w, req.Args.(*packp.FetchArgs), opts)
+		}
 	}
 }
 
-// readV2Request reads a v2 command request consisting of:
-//   - command=xxx
-//   - zero or more key=value or agent=... header lines
-//   - delim (0001)
-//   - zero or more argument lines (e.g. "want <oid>", "have <oid>", "done", "peel")
-//   - flush (0000)
+// serveLsRefsV2 responds to a ls-refs command using the decoded arguments.
 //
-// It returns the command name, header kvs (as "k=v" or raw), and the post-delim args.
-func readV2Request(rd *bufio.Reader) (cmd string, kvs, args []string, err error) {
-	seenDelim := false
-	for {
-		l, line, rerr := pktline.ReadLine(rd)
-		if rerr != nil {
-			err = rerr
-			return cmd, kvs, args, err
-		}
-		if l == pktline.Flush {
-			return cmd, kvs, args, nil
-		}
-		if l == pktline.Delim {
-			seenDelim = true
-			continue
-		}
-		s := strings.TrimSuffix(string(line), "\n")
-		if s == "" {
-			continue
-		}
-		if !seenDelim {
-			if after, ok := strings.CutPrefix(s, "command="); ok {
-				cmd = after
-				continue
-			}
-			// header line (agent, object-format, etc)
-			kvs = append(kvs, s)
-			continue
-		}
-		// after delim: args
-		args = append(args, s)
-	}
-}
-
-// serveLsRefsV2 responds to a ls-refs command.
-func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, kvs, args []string) error {
-	_ = kvs // unused for now; could check object-format
-	peel := false
-	symrefs := false
-	// unborn not directly used for listing
-	prefixes := []string{}
-	for _, a := range args {
-		switch a {
-		case "peel":
-			peel = true
-		case "symrefs":
-			symrefs = true
-		default:
-			if after, ok := strings.CutPrefix(a, "ref-prefix "); ok {
-				prefixes = append(prefixes, after)
-			}
-		}
-	}
-
+// The reference lines are encoded by writeV2Ref rather than packp.LsRefsOutput:
+// a v2 HEAD line carries both a resolved object id and a symref-target
+// attribute, which a single plumbing.Reference (hash XOR symbolic) cannot
+// represent. writeV2Ref resolves the symref's hash from the storer, matching
+// upstream git's send_ref.
+func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, args *packp.LsRefsArgs) error {
 	iter, err := st.IterReferences()
 	if err != nil {
 		return err
@@ -489,13 +460,15 @@ func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, kvs, args 
 		return nil
 	})
 
+	prefixes := args.RefPrefixes
+
 	// HEAD is emitted first, but only when it passes the ref-prefix filter,
 	// matching upstream's send_possibly_unborn_head -> send_ref (ls-refs.c),
 	// where HEAD is subject to ref_match like every other ref.
 	for _, r := range refs {
 		if r.Name() == plumbing.HEAD {
 			if len(prefixes) == 0 || refMatchesAnyPrefix(r.Name().String(), prefixes) {
-				if err := writeV2Ref(w, st, r, symrefs, peel); err != nil {
+				if err := writeV2Ref(w, st, r, args.Symrefs, args.Peel); err != nil {
 					return err
 				}
 			}
@@ -510,7 +483,7 @@ func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, kvs, args 
 		if len(prefixes) > 0 && !refMatchesAnyPrefix(r.Name().String(), prefixes) {
 			continue
 		}
-		if err := writeV2Ref(w, st, r, symrefs, peel); err != nil {
+		if err := writeV2Ref(w, st, r, args.Symrefs, args.Peel); err != nil {
 			return err
 		}
 	}
@@ -588,48 +561,32 @@ func peelToNonTag(st storage.Storer, h plumbing.Hash) (plumbing.Hash, bool) {
 	}
 }
 
-// serveFetchV2 handles command=fetch for v2.
-func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *bufio.Reader, kvs, args []string, opts *UploadPackRequest) error {
-	_ = kvs
-	var wants, haves, clientShallows []plumbing.Hash
-	depth := 0
-	done := false
-	for _, a := range args {
-		switch {
-		case strings.HasPrefix(a, "want "):
-			if h := plumbing.NewHash(a[5:]); !h.IsZero() {
-				wants = append(wants, h)
-			}
-		case strings.HasPrefix(a, "have "):
-			if h := plumbing.NewHash(a[5:]); !h.IsZero() {
-				haves = append(haves, h)
-			}
-		case strings.HasPrefix(a, "shallow "):
-			// The client's current shallow boundary; used to scope unshallows.
-			if h := plumbing.NewHash(a[8:]); !h.IsZero() {
-				clientShallows = append(clientShallows, h)
-			}
-		case strings.HasPrefix(a, "deepen "):
-			if _, err := fmt.Sscanf(a, "deepen %d", &depth); err != nil {
-				_ = w.Close()
-				return fmt.Errorf("parsing deepen argument %q: %w", a, err)
-			}
-		case a == "deepen-relative", strings.HasPrefix(a, "deepen-since "), strings.HasPrefix(a, "deepen-not "):
-			// Advertised under "shallow" but not implemented yet, as in v0/v1.
-			// Fail loudly rather than silently ignore an advertised feature.
-			_ = w.Close()
-			return fmt.Errorf("unsupported deepen argument: %q", a)
-		case a == "done":
-			done = true
-		}
+// serveFetchV2 handles command=fetch for v2 using the decoded arguments. The
+// acknowledgments, shallow-info, and packfile-header sections are emitted
+// through packp.FetchOutput; this function streams the packfile data after the
+// header, matching the caller-owned streaming on the client side.
+func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *packp.FetchArgs, opts *UploadPackRequest) error {
+	if args.DeepenRelative || !args.DeepenSince.IsZero() || len(args.DeepenNot) > 0 {
+		// Advertised under "shallow" but not implemented yet, as in v0/v1.
+		// Fail loudly rather than silently ignore an advertised feature.
+		_ = w.Close()
+		return fmt.Errorf("unsupported deepen argument")
 	}
+
+	wants := args.Wants
+	haves := args.Haves
+	clientShallows := args.Shallows
+	depth := args.Deepen
+	done := args.Done
 
 	// No 'want' lines: the client guessed it didn't want anything. Upstream
 	// emits no response at all here (upload-pack.c, UPLOAD_DONE), so write
-	// nothing and just close the stream — no stray flush packet.
+	// nothing and just close the stream, no stray flush packet.
 	if len(wants) == 0 {
 		return w.Close()
 	}
+
+	out := &packp.FetchOutput{}
 
 	// Negotiation (acknowledgments section), per gitprotocol-v2 "fetch":
 	//
@@ -638,54 +595,32 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 	//   - haves and !done -> emit an acknowledgments section. ACK every common
 	//                        object. "ready" is sent only once every want is
 	//                        reachable from the common haves (upstream's
-	//                        ok_to_give_up); then the section ends with a
-	//                        delim-pkt and the packfile follows. Otherwise the
-	//                        section ends with a flush-pkt and NO packfile, and
-	//                        the client negotiates again with more haves (NAK
-	//                        when there is no common object at all).
+	//                        ok_to_give_up); then the packfile follows in the
+	//                        same response. Otherwise the section ends without a
+	//                        packfile and the client negotiates again with more
+	//                        haves (NAK when there is no common object at all).
 	if !done && len(haves) > 0 {
-		if _, err := pktline.Writef(w, "acknowledgments\n"); err != nil {
-			return err
-		}
 		var common []plumbing.Hash
 		for _, h := range haves {
 			if _, err := st.EncodedObject(plumbing.AnyObject, h); err == nil {
 				common = append(common, h)
-				if _, err := pktline.Writef(w, "ACK %s\n", h); err != nil {
-					return err
-				}
 			}
 		}
-		if len(common) == 0 {
-			// No common object at all: NAK and end the section with a flush. No
-			// packfile this round; the client negotiates again with more haves.
-			if _, err := pktline.Writef(w, "NAK\n"); err != nil {
-				return err
-			}
-			if err := pktline.WriteFlush(w); err != nil {
-				return err
-			}
-			return w.Close()
-		}
+		out.Acknowledgments = &packp.Acknowledgments{ACKs: common}
+
 		// "ready" is withheld until every want is reachable from the common
 		// haves (upstream's ok_to_give_up). Declaring it on the first common
 		// have would force single-round negotiation and a larger pack. When not
-		// ready, the ACK'd commons stand but the section ends with a flush so
-		// the client can refine its haves in the next request.
-		if !wantsReachableFromHaves(st, wants, common) {
-			if err := pktline.WriteFlush(w); err != nil {
+		// ready (including no common object at all, which encodes as NAK), the
+		// acknowledgments section stands alone and the client refines its haves
+		// in the next request.
+		if len(common) == 0 || !wantsReachableFromHaves(st, wants, common) {
+			if err := out.Encode(w); err != nil {
 				return err
 			}
 			return w.Close()
 		}
-		// Ready: separate the acknowledgments section from the packfile section
-		// with a delim-pkt (the packfile follows in the same response).
-		if _, err := pktline.Writef(w, "ready\n"); err != nil {
-			return err
-		}
-		if err := pktline.WriteDelim(w); err != nil {
-			return err
-		}
+		out.Acknowledgments.Ready = true
 	}
 
 	// shallow-info section, emitted before the packfile when the client
@@ -694,7 +629,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 	// depth (see shallowBoundaryStorer).
 	//
 	// Note: deepening an already-shallow clone (the client sends its own
-	// "shallow" lines plus haves) is not handled — the haves would exclude the
+	// "shallow" lines plus haves) is not handled, the haves would exclude the
 	// deepened ancestors. Only fresh shallow fetches are bounded here.
 	packSt := st
 	if depth > 0 {
@@ -703,26 +638,27 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 			_ = w.Close()
 			return fmt.Errorf("computing shallow commits: %w", err)
 		}
-		if err := writeV2ShallowInfo(w, &shupd, clientShallows); err != nil {
-			return err
+		out.ShallowInfo = &packp.ShallowInfo{
+			Shallows:   shupd.Shallows,
+			Unshallows: scopeUnshallows(shupd.Unshallows, clientShallows),
 		}
 		packSt = &shallowBoundaryStorer{Storer: st, boundary: shupd.Shallows}
 	}
 
-	// Compute what to send
+	// Compute what to send.
 	objs, err := objectsToUpload(packSt, wants, haves)
 	if err != nil {
 		_ = w.Close()
 		return fmt.Errorf("getting objects to upload: %w", err)
 	}
 
-	// Write packfile section header
-	if _, err := pktline.Writef(w, "packfile\n"); err != nil {
+	// Emit the metadata sections and the "packfile" section header. The client
+	// switches to sideband demux after seeing the header, matching reference git.
+	out.Packfile = true
+	if err := out.Encode(w); err != nil {
 		return err
 	}
 
-	// Send pack data wrapped in sideband (client switches to sideband demux after
-	// seeing the "packfile" marker in v2 fetch response). Matches reference git wire.
 	writer := sideband.NewMuxer(sideband.Sideband64k, w)
 
 	var packWindow uint
@@ -739,12 +675,32 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 		return fmt.Errorf("encoding packfile: %w", err)
 	}
 
-	// Terminate sideband stream and v2 fetch response.
+	// Terminate the sideband stream and the v2 fetch response.
 	if err := pktline.WriteFlush(w); err != nil {
 		return err
 	}
 
 	return w.Close()
+}
+
+// scopeUnshallows restricts the unshallow set to commits the client reported as
+// shallow, so a fresh clone never receives spurious unshallow lines (upstream
+// send_shallow_info).
+func scopeUnshallows(unshallows, clientShallows []plumbing.Hash) []plumbing.Hash {
+	if len(clientShallows) == 0 {
+		return nil
+	}
+	client := make(map[plumbing.Hash]struct{}, len(clientShallows))
+	for _, h := range clientShallows {
+		client[h] = struct{}{}
+	}
+	var scoped []plumbing.Hash
+	for _, h := range unshallows {
+		if _, ok := client[h]; ok {
+			scoped = append(scoped, h)
+		}
+	}
+	return scoped
 }
 
 // shallowBoundaryStorer reports an additional set of shallow commits (the
@@ -767,37 +723,6 @@ func (s *shallowBoundaryStorer) Shallow() ([]plumbing.Hash, error) {
 		return base, nil
 	}
 	return append(append([]plumbing.Hash(nil), base...), s.boundary...), nil
-}
-
-// writeV2ShallowInfo emits the protocol v2 fetch "shallow-info" section: the
-// header, a "shallow <oid>" line per boundary commit and an "unshallow <oid>"
-// line per previously-shallow client commit that is now complete, terminated
-// by a delim-pkt separating it from the packfile section (upstream
-// send_shallow_info). Unshallows are scoped to the client's reported shallow
-// set, so a fresh clone never receives spurious unshallow lines.
-func writeV2ShallowInfo(w io.Writer, upd *packp.ShallowUpdate, clientShallows []plumbing.Hash) error {
-	if _, err := pktline.Writef(w, "shallow-info\n"); err != nil {
-		return err
-	}
-	for _, h := range upd.Shallows {
-		if _, err := pktline.Writef(w, "shallow %s\n", h); err != nil {
-			return err
-		}
-	}
-	if len(clientShallows) > 0 {
-		client := make(map[plumbing.Hash]struct{}, len(clientShallows))
-		for _, h := range clientShallows {
-			client[h] = struct{}{}
-		}
-		for _, h := range upd.Unshallows {
-			if _, ok := client[h]; ok {
-				if _, err := pktline.Writef(w, "unshallow %s\n", h); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return pktline.WriteDelim(w)
 }
 
 // wantsReachableFromHaves reports whether every want is reachable from the set

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -212,6 +212,19 @@ func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV2() {
 	testAdvertise(s.T(), ReceivePack, "version=2", false)
 }
 
+// TestReceivePackAdvertiseV2SmartHTTP verifies the receive-pack fallback when a
+// client requests protocol v2 over smart HTTP. Protocol v2 has no push, so git
+// ignores the request and serves a classic v0 advertisement (no version line),
+// while http-backend still omits the "# service=..." smart reply for the v2
+// request (builtin/receive-pack.c, http-backend.c get_info_refs).
+func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV2SmartHTTP() {
+	adv := testAdvertise(s.T(), ReceivePack, "version=2", true).String()
+	s.NotContains(adv, "# service=")
+	s.NotContains(adv, "version 2")
+	s.NotContains(adv, "version 1")
+	s.Contains(adv, "refs/heads/master")
+}
+
 func (s *ReceivePackServeSuite) TestReceivePackAdvertiseV1() {
 	buf := testAdvertise(s.T(), ReceivePack, "version=1", false)
 	s.Contains(buf.String(), "version 1")

--- a/plumbing/transport/upload_pack_v2_test.go
+++ b/plumbing/transport/upload_pack_v2_test.go
@@ -73,6 +73,7 @@ func TestUploadPackV2AdvertisementCapabilities(t *testing.T) {
 	err := UploadPack(context.TODO(), st, io.NopCloser(bytes.NewBuffer(nil)), ioutil.WriteNopCloser(&out), &UploadPackRequest{
 		GitProtocol:   "version=2",
 		AdvertiseRefs: true,
+		StatelessRPC:  true,
 	})
 	require.NoError(t, err)
 	adv := out.String()
@@ -81,6 +82,13 @@ func TestUploadPackV2AdvertisementCapabilities(t *testing.T) {
 	require.Contains(t, adv, "ls-refs")
 	require.Contains(t, adv, "fetch=shallow")
 	require.Contains(t, adv, "object-format=")
+
+	// git omits the smart-HTTP "# service=..." line for v2 even over HTTP
+	// (http-backend.c get_info_refs): the response starts with the version
+	// packet. Emitting it would diverge from the reference server.
+	require.NotContains(t, adv, "# service=")
+	require.True(t, strings.HasPrefix(adv[4:], "version 2"),
+		"v2 advertisement must start with the version packet, got %q", adv[:32])
 
 	// Capabilities the server does not implement must not be advertised,
 	// otherwise clients request features that are silently dropped or
@@ -232,6 +240,23 @@ func TestUploadPackV2FetchNoWantsEmitsNothing(t *testing.T) {
 	// No want lines: upstream emits no response at all (no stray flush).
 	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{"have " + plumbing.ZeroHash.String()}))
 	require.Empty(t, out)
+}
+
+func TestUploadPackV2LsRefsHeadResolvedOID(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	out := serveUploadPackV2Test(t, st, v2Request(t, "ls-refs", nil, []string{"symrefs"}))
+
+	// Upstream send_ref emits HEAD with its resolved object id and a
+	// symref-target attribute, not a zero id. This is why the server encodes
+	// ls-refs lines directly rather than through packp.LsRefsOutput, whose
+	// symbolic references cannot carry a resolved hash.
+	require.Contains(t, out, head.Hash().String()+" HEAD symref-target:"+head.Name().String())
+	require.NotContains(t, out, plumbing.ZeroHash.String()+" HEAD")
 }
 
 func TestUploadPackV2LsRefsHeadFilteredByPrefix(t *testing.T) {

--- a/plumbing/transport/v2_handshake_test.go
+++ b/plumbing/transport/v2_handshake_test.go
@@ -21,7 +21,7 @@ func TestStreamSessionV2Handshake(t *testing.T) {
 	st := basicV2Storage(t)
 
 	var adv bytes.Buffer
-	require.NoError(t, AdvertiseRefs(context.TODO(), st, &adv, UploadPackService, false, protocol.V2))
+	require.NoError(t, AdvertiseCapabilities(context.TODO(), st, &adv, UploadPackService))
 
 	conn := &testConn{
 		r:     &adv,
@@ -94,7 +94,7 @@ func TestStreamSessionCommandLsRefsEndToEnd(t *testing.T) {
 
 	serveErr := make(chan error, 1)
 	go func() {
-		if err := AdvertiseRefs(context.TODO(), st, serverConn, UploadPackService, false, protocol.V2); err != nil {
+		if err := AdvertiseCapabilities(context.TODO(), st, serverConn, UploadPackService); err != nil {
 			serveErr <- err
 			return
 		}

--- a/plumbing/transport/v2_lsrefs_test.go
+++ b/plumbing/transport/v2_lsrefs_test.go
@@ -43,7 +43,7 @@ func newV2Session(t testing.TB, serve func(serverConn net.Conn) error) *StreamSe
 func serveUploadPackV2Once(st storage.Storer) func(net.Conn) error {
 	return func(serverConn net.Conn) error {
 		defer func() { _ = serverConn.Close() }()
-		if err := AdvertiseRefs(context.TODO(), st, serverConn, UploadPackService, false, protocol.V2); err != nil {
+		if err := AdvertiseCapabilities(context.TODO(), st, serverConn, UploadPackService); err != nil {
 			return err
 		}
 		return serveUploadPackV2(


### PR DESCRIPTION
## Part 9: refactor the server-side Protocol v2 onto packp types

Builds on Part 8 (#2216). The original v2 server (from the upload-pack v2 work) parsed and produced the wire by hand. This part separates the v2 advertisement from v0/v1 and routes the v2 commands through the shared packp types.

### What changed

- `AdvertiseRefs` is now v0/v1 only. A new `AdvertiseCapabilities` writes the v2 capability advertisement through `packp.CapabilityAdv` (no references; clients use ls-refs). `UploadPack` dispatches to it when the negotiated version is 2.
- The v2 advertisement does not emit the smart-HTTP `# service=...` line. git omits it for v2 even over HTTP (http-backend.c `get_info_refs`), so the response starts directly with the version packet. A test locks this in.
- The v2 command dispatcher peeks the command line, sets the matching argument decoder (`packp.LsRefsArgs` or `packp.FetchArgs`), and decodes the request through `packp.CommandRequest`, the same type the client encodes.
- The fetch response (acknowledgments, shallow-info, and the packfile section header) is emitted through `packp.FetchOutput`. The handler streams the packfile after the header, mirroring caller-owned streaming on the client.
- ls-refs lines are still encoded directly. A v2 HEAD line carries both a resolved object id and a symref-target, which a single `plumbing.Reference` (hash XOR symbolic) cannot represent, so `packp.LsRefsOutput` is not used on the server. A test locks in the resolved-HEAD-oid behavior.

### Tests

The existing server v2 suite passes against the refactored code, plus new tests asserting the v2 advertisement omits `# service=` and that HEAD is advertised with its resolved object id and symref-target. The git-CLI-over-v2 HTTP end-to-end test continues to exercise the server.

### Reviewing just this part

https://github.com/aymanbagabas/go-git/compare/gitprotocol-v2-9-http-shared...gitprotocol-v2-8-v2-server

### Notes

Targets `main` (v6). Depends on Part 8 (#2216); merge that first.
