### PR TITLE
plumbing: transport, git archive over HTTP (10/11)

### DIFF
--- a/backend/http.go
+++ b/backend/http.go
@@ -32,6 +32,7 @@ var httpServices = []httpService{
 	{regexp.MustCompile(`(.*?)/objects/pack/pack-[0-9a-f]{40,64}\.idx$`), http.MethodGet, (*Backend).handleDumbIdxFile, ""},
 	{regexp.MustCompile("(.*?)/git-upload-pack$"), http.MethodPost, (*Backend).handleServiceRPC, transport.UploadPackService},
 	{regexp.MustCompile("(.*?)/git-receive-pack$"), http.MethodPost, (*Backend).handleServiceRPC, transport.ReceivePackService},
+	{regexp.MustCompile("(.*?)/git-upload-archive$"), http.MethodPost, (*Backend).handleServiceRPC, transport.UploadArchiveService},
 }
 
 // ServeHTTP implements [http.Handler]. It supports both smart and dumb

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -26,12 +26,22 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 	baseURL := req.URL
 	forceDumb := t.opts.ForceDumb
 
+	// git archive over HTTP discovers protocol support through the upload-pack
+	// info/refs endpoint and requires Protocol v2 (remote-curl.c). The archive
+	// request itself is later POSTed to the git-upload-archive endpoint.
+	discoverService := service
+	discoverProtocol := req.Protocol
+	if service == transport.UploadArchiveService {
+		discoverService = transport.UploadPackService
+		discoverProtocol = protocol.V2
+	}
+
 	infoURL, err := url.JoinPath(baseURL.String(), "info/refs")
 	if err != nil {
 		return nil, err
 	}
 	if !forceDumb {
-		infoURL += "?service=" + service
+		infoURL += "?service=" + discoverService
 	}
 
 	// Mark this as the initial request so checkRedirect allows
@@ -45,7 +55,7 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 
 	httpReq.Header.Set("User-Agent", capability.DefaultAgent())
 	if !forceDumb {
-		if gp := transport.GitProtocolEnv(req.Protocol); gp != "" {
+		if gp := transport.GitProtocolEnv(discoverProtocol); gp != "" {
 			httpReq.Header.Set("Git-Protocol", gp)
 		}
 	}
@@ -99,16 +109,16 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 		return handshakeDumb(resp, &sessReq, client, authorizer)
 	}
 
-	expected := fmt.Sprintf("application/x-%s-advertisement", service)
+	expected := fmt.Sprintf("application/x-%s-advertisement", discoverService)
 	isSmart := resp.Header.Get("Content-Type") == expected
 
 	if isSmart {
-		return handshakeSmart(resp, &sessReq, client, authorizer)
+		return handshakeSmart(resp, &sessReq, discoverService, client, authorizer)
 	}
 	return handshakeDumb(resp, &sessReq, client, authorizer)
 }
 
-func handshakeSmart(resp *http.Response, req *transport.Request, client *http.Client, authorizer func(*http.Request) error) (transport.Session, error) {
+func handshakeSmart(resp *http.Response, req *transport.Request, discoverService string, client *http.Client, authorizer func(*http.Request) error) (transport.Session, error) {
 	defer resp.Body.Close() //nolint:errcheck
 	rd := bufio.NewReader(resp.Body)
 
@@ -121,7 +131,7 @@ func handshakeSmart(resp *http.Response, req *transport.Request, client *http.Cl
 		if err := reply.Decode(rd); err != nil {
 			return nil, err
 		}
-		if reply.Service != req.Command {
+		if reply.Service != discoverService {
 			return nil, fmt.Errorf("unexpected service name: %w", transport.ErrInvalidResponse)
 		}
 	}
@@ -129,6 +139,11 @@ func handshakeSmart(resp *http.Response, req *transport.Request, client *http.Cl
 	ver, err := transport.DiscoverVersion(rd)
 	if err != nil {
 		return nil, err
+	}
+
+	// git archive over HTTP is only available when the server speaks v2.
+	if req.Command == transport.UploadArchiveService && ver != protocol.V2 {
+		return nil, transport.ErrArchiveUnsupported
 	}
 
 	if ver == protocol.V2 {
@@ -196,6 +211,7 @@ func handshakeDumb(resp *http.Response, req *transport.Request, client *http.Cli
 var (
 	_ transport.Session   = (*smartPackSession)(nil)
 	_ transport.Commander = (*smartPackSession)(nil)
+	_ transport.Archiver  = (*smartPackSession)(nil)
 )
 
 type smartPackSession struct {
@@ -355,6 +371,40 @@ func (s *smartPackSession) Push(ctx context.Context, st storage.Storer, req *tra
 }
 
 func (s *smartPackSession) Close() error { return nil }
+
+// Archive implements transport.Archiver. git archive over HTTP is a v2-only,
+// stateless operation (remote-curl.c): the archive request is POSTed to the
+// git-upload-archive endpoint and the response carries the ACK/NACK and the
+// sideband-encoded archive stream.
+func (s *smartPackSession) Archive(ctx context.Context, req *transport.ArchiveRequest) (io.ReadCloser, error) {
+	if s.version != protocol.V2 {
+		return nil, transport.ErrArchiveUnsupported
+	}
+
+	rt := &httpRequester{session: s, ctx: ctx}
+	body := &httpArchiveBody{req: rt}
+	archive, err := transport.Archive(ctx, rt, body, req)
+	if err != nil {
+		_ = body.Close()
+		return nil, err
+	}
+	return archive, nil
+}
+
+// httpArchiveBody adapts an httpRequester to the io.ReadCloser the archive
+// client reads from: reads come from the POST response body, and Close closes
+// that body. The paired httpRequester is passed to transport.Archive as the
+// writer, whose Close fires the POST.
+type httpArchiveBody struct{ req *httpRequester }
+
+func (b *httpArchiveBody) Read(p []byte) (int, error) { return b.req.Read(p) }
+
+func (b *httpArchiveBody) Close() error {
+	if b.req.resp != nil {
+		return b.req.resp.Body.Close()
+	}
+	return nil
+}
 
 // httpRequester buffers writes and fires a POST on first Read or Close.
 type httpRequester struct {

--- a/plumbing/transport/http/v2_client_test.go
+++ b/plumbing/transport/http/v2_client_test.go
@@ -1,8 +1,12 @@
 package http
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"strings"
 	"testing"
@@ -72,4 +76,49 @@ func TestBackend_HTTP_V2_GoGitClient(t *testing.T) {
 		require.True(t, strings.HasPrefix(r.Name().String(), "refs/heads/"),
 			"ref-prefix filter should drop %s", r.Name())
 	}
+}
+
+// TestBackend_HTTP_V2_Archive exercises git archive over HTTP, which is a
+// v2-only operation: the go-git client discovers v2 via upload-pack and POSTs
+// the archive request to git-upload-archive against go-git's own backend.
+func TestBackend_HTTP_V2_Archive(t *testing.T) {
+	t.Parallel()
+	requireGitV2(t)
+
+	base, name := setupGoGitBackendServer(t)
+	pu, err := url.Parse(fmt.Sprintf("http://u:p@%s/%s", strings.TrimPrefix(base, "http://"), name))
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     pu,
+		Command: transport.UploadArchiveService,
+	})
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	archiver, ok := sess.(transport.Archiver)
+	require.True(t, ok, "session should implement Archiver")
+
+	rc, err := archiver.Archive(context.Background(), &transport.ArchiveRequest{
+		Args: []string{"--format=tar", "main"},
+	})
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	tarR := tar.NewReader(bytes.NewReader(data))
+	var names []string
+	for {
+		hdr, err := tarR.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	require.Contains(t, names, "README.md")
 }


### PR DESCRIPTION
## Part 10: git archive over HTTP

Builds on Part 9 (#2213). With the v2 HTTP session in place, this part adds git archive over HTTP, which git only supports over v2 (remote-curl.c `stateless_connect`).

### What changed

- The HTTP handshake discovers protocol support through the upload-pack info/refs endpoint when the command is upload-archive, and forces Protocol v2 for that discovery (git only attempts HTTP archive in v2 mode, so the caller does not need to set it). If the server does not speak v2, the handshake returns `ErrArchiveUnsupported`.
- The session that comes back implements `Archiver`. `smartPackSession.Archive` POSTs the archive request to the git-upload-archive endpoint and reads the ACK/NACK and the sideband-encoded archive stream from the response.
- The server backend routes POST git-upload-archive to the existing upload-archive handler.

This mirrors canonical git: `remote-curl.c` discovers via `git-upload-pack`, requires v2, and POSTs to `git-upload-archive` without resending the capability listing.

### Tests

An end-to-end test runs git archive over HTTP through the go-git client (without setting Protocol explicitly) against go-git's own backend and verifies the resulting tar.

### Reviewing just this part

https://github.com/aymanbagabas/go-git/compare/gitprotocol-v2-8-v2-server...gitprotocol-v2-10-http-archive

### Notes

Targets `main` (v6). Depends on Part 9 (#2213); merge that first.
