### PR TITLE
plumbing: transport, Run the upload-pack suite across v0/v1/v2 (11/11)

### DIFF
--- a/internal/transport/test/common.go
+++ b/internal/transport/test/common.go
@@ -2,13 +2,54 @@ package test
 
 import (
 	"net"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 )
+
+// GitSupportsV2 reports whether the git binary in PATH supports protocol v2
+// (git >= 2.18). Transports backed by the reference git server use it to skip
+// the v2 suite run on older git, which would silently fall back to v0.
+func GitSupportsV2() bool {
+	out, err := exec.Command("git", "version").Output()
+	if err != nil {
+		return false
+	}
+	fields := strings.Fields(string(out)) // e.g. "git version 2.39.2"
+	if len(fields) < 3 {
+		return false
+	}
+	parts := strings.SplitN(fields[2], ".", 3)
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	minor := 0
+	if len(parts) > 1 {
+		minor, _ = strconv.Atoi(parts[1])
+	}
+	return major > 2 || (major == 2 && minor >= 18)
+}
+
+// UploadPackVersions returns the protocol versions to run the upload-pack suite
+// against. realGit indicates the server is the reference git implementation,
+// whose protocol v2 support depends on the installed git version; v2 is dropped
+// for such servers when the local git is too old.
+func UploadPackVersions(realGit bool) []protocol.Version {
+	versions := []protocol.Version{protocol.V0, protocol.V1}
+	if !realGit || GitSupportsV2() {
+		versions = append(versions, protocol.V2)
+	}
+	return versions
+}
 
 // FixturesFactory returns a function that creates a fixture path.
 func FixturesFactory(base, name string) func() string {

--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
@@ -23,6 +24,7 @@ type UploadPackSuite struct {
 	Endpoint            *url.URL
 	EmptyEndpoint       *url.URL
 	NonExistentEndpoint *url.URL
+	Protocol            protocol.Version
 	Storer              storage.Storer
 	EmptyStorer         storage.Storer
 	NonExistentStorer   storage.Storer
@@ -42,10 +44,16 @@ func (s *UploadPackSuite) packClient() transport.Transport {
 	return s.Transport
 }
 
+// request builds an upload-pack handshake request for the suite's protocol
+// version, so the same suite runs against v0, v1, and v2.
+func (s *UploadPackSuite) request(url *url.URL, command string) *transport.Request {
+	return &transport.Request{URL: url, Command: command, Protocol: s.Protocol}
+}
+
 // TestAdvertisedReferencesEmpty tests advertised references on an empty repo.
 func (s *UploadPackSuite) TestAdvertisedReferencesEmpty() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.EmptyEndpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.EmptyEndpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -57,14 +65,14 @@ func (s *UploadPackSuite) TestAdvertisedReferencesEmpty() {
 // TestAdvertisedReferencesNotExists tests advertised references on a non-existent repo.
 func (s *UploadPackSuite) TestAdvertisedReferencesNotExists() {
 	pc := s.packClient()
-	_, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.NonExistentEndpoint, Command: transport.UploadPackService})
+	_, err := pc.Handshake(context.TODO(), s.request(s.NonExistentEndpoint, transport.UploadPackService))
 	s.Require().Error(err)
 }
 
 // TestCallAdvertisedReferenceTwice tests that calling advertised references twice returns the same result.
 func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -79,13 +87,29 @@ func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice() {
 // TestDefaultBranch tests that the default branch is correctly advertised.
 func (s *UploadPackSuite) TestDefaultBranch() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
 	info, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
+
+	if s.Protocol == protocol.V2 {
+		// v2 reports the default branch via the ls-refs symref-target, surfaced
+		// as a symbolic HEAD reference, not a capability.
+		var head *plumbing.Reference
+		for _, ref := range info.References {
+			if ref.Name() == plumbing.HEAD {
+				head = ref
+			}
+		}
+		s.Require().NotNil(head)
+		s.Require().Equal(plumbing.SymbolicReference, head.Type())
+		s.Require().Equal(plumbing.ReferenceName("refs/heads/master"), head.Target())
+		return
+	}
+
 	symrefs := conn.Capabilities().Get(capability.SymRef)
 	s.Require().Len(symrefs, 1)
 	s.Require().Equal("HEAD:refs/heads/master", symrefs[0])
@@ -94,20 +118,28 @@ func (s *UploadPackSuite) TestDefaultBranch() {
 // TestAdvertisedReferencesFilterUnsupported tests filtering unsupported capabilities.
 func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
 	info, err := conn.GetRemoteRefs(context.TODO(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
+	if s.Protocol == protocol.V2 {
+		// A negotiated v2 session advertises commands (fetch/ls-refs), not the
+		// v0/v1 multi_ack capability. Asserting this confirms the wire really is
+		// v2 rather than a silent fallback.
+		s.Require().True(conn.Capabilities().Supports(capability.FetchCmd))
+		s.Require().False(conn.Capabilities().Supports(capability.MultiACK))
+		return
+	}
 	s.Require().True(conn.Capabilities().Supports(capability.MultiACK))
 }
 
 // TestCapabilities tests that capabilities are correctly reported.
 func (s *UploadPackSuite) TestCapabilities() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -120,7 +152,7 @@ func (s *UploadPackSuite) TestCapabilities() {
 // TestUploadPack tests a basic upload-pack fetch.
 func (s *UploadPackSuite) TestUploadPack() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -141,7 +173,7 @@ func (s *UploadPackSuite) TestUploadPackWithContext() {
 	defer cancel()
 
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -162,7 +194,7 @@ func (s *UploadPackSuite) TestUploadPackWithContextOnRead() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -181,7 +213,7 @@ func (s *UploadPackSuite) TestUploadPackWithContextOnRead() {
 // TestUploadPackFull tests a full upload-pack fetch with advertised references.
 func (s *UploadPackSuite) TestUploadPackFull() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -203,7 +235,7 @@ func (s *UploadPackSuite) TestUploadPackFull() {
 // TestUploadPackInvalidReq tests upload-pack with an invalid request.
 func (s *UploadPackSuite) TestUploadPackInvalidReq() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -217,7 +249,7 @@ func (s *UploadPackSuite) TestUploadPackInvalidReq() {
 // TestUploadPackNoChanges tests upload-pack when there are no changes.
 func (s *UploadPackSuite) TestUploadPackNoChanges() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -247,7 +279,7 @@ func (s *UploadPackSuite) TestUploadPackPartial() {
 
 func (s *UploadPackSuite) testUploadPackFetch(req *transport.FetchRequest, expectedObjects int) {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -264,7 +296,7 @@ func (s *UploadPackSuite) testUploadPackFetch(req *transport.FetchRequest, expec
 // TestFetchError tests that fetching a non-existent object returns an error.
 func (s *UploadPackSuite) TestFetchError() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.UploadPackService})
+	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 

--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -15,6 +16,12 @@ import (
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
+
+// ErrNoChange is returned by FetchV2 when every wanted object is already present
+// in the client's haves and no shallow change was requested, mirroring git's
+// everything_local short-circuit in do_fetch_pack_v2. transport.ErrNoChange
+// aliases this value.
+var ErrNoChange = errors.New("no change")
 
 // Negotiation pacing, mirroring git's fetch-pack.c (INITIAL_FLUSH, LARGE_FLUSH,
 // MAX_IN_VAIN). v2 is stateless per command, so the stateless schedule applies.
@@ -88,6 +95,37 @@ func LsRefs(ctx context.Context, cmd CommandFunc, server capability.List, refPre
 	return out.References, nil
 }
 
+// HasHashRef reports whether refs contains at least one hash (non-symbolic)
+// reference. A v2 ls-refs result with only a symbolic or unborn HEAD and no
+// hash references corresponds to an empty repository, so callers treat the
+// absence of hash references the same as the v0/v1 empty advertisement.
+func HasHashRef(refs []*plumbing.Reference) bool {
+	for _, r := range refs {
+		if r.Type() == plumbing.HashReference {
+			return true
+		}
+	}
+	return false
+}
+
+// wantsLocal reports whether every wanted object is already present in haves, so
+// the fetch has nothing to retrieve.
+func wantsLocal(wants, haves []plumbing.Hash) bool {
+	if len(wants) == 0 {
+		return false
+	}
+	have := make(map[plumbing.Hash]struct{}, len(haves))
+	for _, h := range haves {
+		have[h] = struct{}{}
+	}
+	for _, w := range wants {
+		if _, ok := have[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // FetchRound runs a single fetch command round. When the returned output has
 // Packfile set, packReader is positioned at the first packfile pkt-line so the
 // caller can stream it. If packReader implements io.Closer, Fetch closes it
@@ -105,6 +143,12 @@ type FetchRound func(args *packp.FetchArgs) (out *packp.FetchOutput, packReader 
 // The caller is responsible for validating optional features against the server
 // advertisement (see FetchSupports) before requesting Filter or Depth.
 func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round FetchRound) error {
+	// Everything wanted is already local and no shallow change was requested:
+	// short-circuit before opening negotiation, matching git's everything_local.
+	if req.Depth == 0 && wantsLocal(req.Wants, req.Haves) {
+		return ErrNoChange
+	}
+
 	baseArgs := &packp.FetchArgs{
 		Wants:      req.Wants,
 		OFSDelta:   true,

--- a/plumbing/transport/errors.go
+++ b/plumbing/transport/errors.go
@@ -1,12 +1,16 @@
 package transport
 
-import "errors"
+import (
+	"errors"
+
+	internal "github.com/go-git/go-git/v6/internal/transport"
+)
 
 // Transport errors.
 var (
 	ErrRepositoryNotFound     = errors.New("repository not found")
 	ErrEmptyRemoteRepository  = errors.New("remote repository is empty")
-	ErrNoChange               = errors.New("no change")
+	ErrNoChange               = internal.ErrNoChange
 	ErrAuthenticationRequired = errors.New("authentication required")
 	ErrAuthorizationFailed    = errors.New("authorization failed")
 	ErrEmptyUploadPackRequest = errors.New("empty git-upload-pack given")

--- a/plumbing/transport/file/pack_test.go
+++ b/plumbing/transport/file/pack_test.go
@@ -50,7 +50,14 @@ func setupFilePackEnv(t testing.TB) filePackEnv {
 
 func TestUploadPackSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, new(uploadPackSuite))
+	for _, v := range test.UploadPackVersions(false) {
+		t.Run(v.String(), func(t *testing.T) {
+			t.Parallel()
+			s := new(uploadPackSuite)
+			s.Protocol = v
+			suite.Run(t, s)
+		})
+	}
 }
 
 type uploadPackSuite struct {

--- a/plumbing/transport/git/pack_test.go
+++ b/plumbing/transport/git/pack_test.go
@@ -50,7 +50,14 @@ func TestUploadPackSuite(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip(windowsSkipMsg)
 	}
-	suite.Run(t, new(uploadPackSuite))
+	for _, v := range test.UploadPackVersions(true) {
+		t.Run(v.String(), func(t *testing.T) {
+			t.Parallel()
+			s := new(uploadPackSuite)
+			s.Protocol = v
+			suite.Run(t, s)
+		})
+	}
 }
 
 type uploadPackSuite struct {

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -237,7 +237,7 @@ func (s *smartPackSession) GetRemoteRefs(ctx context.Context, opts *transport.Ge
 		if err != nil {
 			return nil, err
 		}
-		if !forPush && len(refs) == 0 {
+		if !forPush && !internal.HasHashRef(refs) {
 			return nil, transport.ErrEmptyRemoteRepository
 		}
 		return transport.NewRemoteRefs(refs), nil

--- a/plumbing/transport/http/upload_pack_test.go
+++ b/plumbing/transport/http/upload_pack_test.go
@@ -13,7 +13,14 @@ import (
 
 func TestUploadPackSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, new(uploadPackSuite))
+	for _, v := range test.UploadPackVersions(true) {
+		t.Run(v.String(), func(t *testing.T) {
+			t.Parallel()
+			s := new(uploadPackSuite)
+			s.Protocol = v
+			suite.Run(t, s)
+		})
+	}
 }
 
 type uploadPackSuite struct {

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -105,7 +105,7 @@ func (s *StreamSession) GetRemoteRefs(ctx context.Context, opts *GetRemoteRefsOp
 		if err != nil {
 			return nil, err
 		}
-		if !forPush && len(refs) == 0 {
+		if !forPush && !internal.HasHashRef(refs) {
 			return nil, ErrEmptyRemoteRepository
 		}
 		return NewRemoteRefs(refs), nil
@@ -173,7 +173,7 @@ func (s *StreamSession) Push(ctx context.Context, st storage.Storer, req *PushRe
 // server's object-format), so callers only provide the command arguments.
 //
 // Command is only valid on a session that negotiated Protocol v2.
-func (s *StreamSession) Command(_ context.Context, cmd string, req packp.CommandArgs, resp packp.Decoder) error {
+func (s *StreamSession) Command(ctx context.Context, cmd string, req packp.CommandArgs, resp packp.Decoder) error {
 	if s.version != protocol.V2 {
 		return ErrUnsupportedVersion
 	}
@@ -184,12 +184,12 @@ func (s *StreamSession) Command(_ context.Context, cmd string, req packp.Command
 		Args:         req,
 	}
 
-	if err := cr.Encode(s.w); err != nil {
+	if err := cr.Encode(ioutil.NewContextWriter(ctx, s.w)); err != nil {
 		return s.wrapStderr(err)
 	}
 
 	if resp != nil {
-		if err := resp.Decode(s.r); err != nil {
+		if err := resp.Decode(ioutil.NewContextReader(ctx, s.r)); err != nil {
 			return s.wrapStderr(err)
 		}
 	}

--- a/plumbing/transport/ssh/pack_test.go
+++ b/plumbing/transport/ssh/pack_test.go
@@ -62,7 +62,14 @@ func formatSSHHost(addr *net.TCPAddr) string {
 
 func TestUploadPackSuite(t *testing.T) {
 	t.Parallel()
-	suite.Run(t, new(uploadPackSuite))
+	for _, v := range test.UploadPackVersions(true) {
+		t.Run(v.String(), func(t *testing.T) {
+			t.Parallel()
+			s := new(uploadPackSuite)
+			s.Protocol = v
+			suite.Run(t, s)
+		})
+	}
 }
 
 type uploadPackSuite struct {

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
@@ -53,6 +54,9 @@ func handlerSSH(s ssh.Session) {
 	}
 
 	cmd := exec.Command(args[0], args[1:]...)
+	// Forward the SSH session environment (notably GIT_PROTOCOL, which the
+	// client sets via Setenv) so git speaks the requested wire version.
+	cmd.Env = append(os.Environ(), s.Environ()...)
 	stdout, _ := cmd.StdoutPipe()
 	stdin, _ := cmd.StdinPipe()
 	stderr, _ := cmd.StderrPipe()

--- a/plumbing/transport/v2_lsrefs_test.go
+++ b/plumbing/transport/v2_lsrefs_test.go
@@ -101,6 +101,7 @@ func TestV2GetRemoteRefsUnbornHead(t *testing.T) {
 	t.Parallel()
 
 	const unbornTarget = "refs/heads/main"
+	const devHash = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
 
 	serve := func(serverConn net.Conn) (err error) {
 		defer func() { _ = serverConn.Close() }()
@@ -129,7 +130,12 @@ func TestV2GetRemoteRefsUnbornHead(t *testing.T) {
 			return errors.New("server did not receive unborn request")
 		}
 
+		// An unborn HEAD alongside a real branch: HEAD points at a branch with
+		// no commit yet, but the repository is not empty.
 		if _, err := pktline.Writef(w, "unborn HEAD symref-target:%s\n", unbornTarget); err != nil {
+			return err
+		}
+		if _, err := pktline.Writef(w, "%s refs/heads/dev\n", devHash); err != nil {
 			return err
 		}
 		return pktline.WriteFlush(w)
@@ -141,4 +147,37 @@ func TestV2GetRemoteRefsUnbornHead(t *testing.T) {
 	rr, err := s.GetRemoteRefs(context.TODO(), nil)
 	require.NoError(t, err)
 	require.Equal(t, plumbing.ReferenceName(unbornTarget), rr.Unborn)
+}
+
+func TestV2GetRemoteRefsUnbornOnlyIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	serve := func(serverConn net.Conn) (err error) {
+		defer func() { _ = serverConn.Close() }()
+
+		w := serverConn
+		for _, line := range []string{"version 2\n", "agent=test\n", "ls-refs=unborn\n", "object-format=sha1\n"} {
+			if _, err := pktline.WriteString(w, line); err != nil {
+				return err
+			}
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return err
+		}
+
+		req := &packp.CommandRequest{Args: &packp.LsRefsArgs{}}
+		if err := req.Decode(bufio.NewReader(serverConn)); err != nil {
+			return err
+		}
+
+		// Only an unborn HEAD, no hash references: an empty repository.
+		if _, err := pktline.WriteString(w, "unborn HEAD symref-target:refs/heads/main\n"); err != nil {
+			return err
+		}
+		return pktline.WriteFlush(w)
+	}
+
+	s := newV2Session(t, serve)
+	_, err := s.GetRemoteRefs(context.TODO(), nil)
+	require.ErrorIs(t, err, ErrEmptyRemoteRepository)
 }


### PR DESCRIPTION
## Part 11: run the upload-pack suite across v0/v1/v2

Builds on Part 10 (#2217). The shared `UploadPackSuite` ran only the default (v0) path. This part parameterizes it by protocol version and runs it for v0, v1, and v2 on every pack transport (file, git, http, ssh), giving the v2 client end-to-end coverage against both go-git's own server (file) and the reference git server (http via git-http-backend, git:// daemon, ssh).

### What changed

- `UploadPackSuite` gains a `Protocol` field; each transport's entry point runs the suite once per version. Version-specific assertions are made version-aware, and the v2 case positively asserts the negotiated fetch/ls-refs capabilities, so a silent fallback to v0 fails the test rather than passing.
- The ssh test handler forwards the SSH session environment (`GIT_PROTOCOL`) to the spawned git, so ssh genuinely speaks the requested version.

### v2 client fixes surfaced by the suite

Running the suite against the reference git server surfaced two places where the v2 client diverged from the v0/v1 contract, fixed here:

- An ls-refs result with only a symbolic or unborn HEAD and no hash references is an empty repository, so `GetRemoteRefs` returns `ErrEmptyRemoteRepository` like v0/v1. `RemoteRefs.Unborn` is still surfaced when real references coexist.
- `FetchV2` short-circuits with `ErrNoChange` when every want is already local and no shallow change was requested, mirroring git's `everything_local`. The sentinel moves to `internal/transport` and `transport.ErrNoChange` aliases it.

### Reviewing just this part

https://github.com/aymanbagabas/go-git/compare/gitprotocol-v2-10-http-archive...gitprotocol-v2-11-suite-versions

### Notes

Targets `main` (v6). Depends on Part 10 (#2217); merge that first.
