### PR TITLE
git: worktree, fix RemoveGlob on root-level files

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -749,8 +749,10 @@ func (w *Worktree) RemoveGlob(pattern string) error {
 		}
 
 		dir, _ := filepath.Split(file)
-		if err := w.removeEmptyDirectory(dir); err != nil {
-			return err
+		if dir != "" {
+			if err := w.removeEmptyDirectory(dir); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -3399,6 +3399,27 @@ func (s *WorktreeSuite) TestRemoveGlobDirectoryDeleted() {
 	s.Equal(Deleted, status.File("json/long.json").Staging)
 }
 
+func (s *WorktreeSuite) TestRemoveGlobRootFile() {
+	fs := memfs.New()
+	r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+	s.NoError(err)
+
+	err = util.WriteFile(fs, "README", []byte("hello"), 0o644)
+	s.NoError(err)
+
+	w, err := r.Worktree()
+	s.NoError(err)
+
+	_, err = w.Add("README")
+	s.NoError(err)
+
+	err = w.RemoveGlob("*")
+	s.NoError(err)
+
+	_, err = fs.Stat("README")
+	s.True(os.IsNotExist(err))
+}
+
 func (s *WorktreeSuite) TestMove() {
 	fs := memfs.New()
 	w := &Worktree{


### PR DESCRIPTION
Fixes #2143

`RemoveGlob` fails on a root-level file. `RemoveGlob("*")` on a repo with a single file at the root returns `remove: invalid path: ""`.

`filepath.Split` returns an empty dir for a root-level file, so `removeEmptyDirectory` ends up trying to remove the worktree root. I skip the cleanup when there is no parent directory. Files in subdirectories still get their parent cleaned up as before.

Added a test that removes a root-level file.
