### PR TITLE
config: unify into a key-based model and slim the public API

### DIFF
--- a/_examples/checkout-branch/main.go
+++ b/_examples/checkout-branch/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	. "github.com/go-git/go-git/v6/_examples"
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 )
 

--- a/_examples/checkout-branch/main.go
+++ b/_examples/checkout-branch/main.go
@@ -68,9 +68,9 @@ func fetchOrigin(repo *git.Repository, refSpecStr string) error {
 	remote, err := repo.Remote("origin")
 	CheckIfError(err)
 
-	var refSpecs []config.RefSpec
+	var refSpecs []plumbing.RefSpec
 	if refSpecStr != "" {
-		refSpecs = []config.RefSpec{config.RefSpec(refSpecStr)}
+		refSpecs = []plumbing.RefSpec{plumbing.RefSpec(refSpecStr)}
 	}
 
 	if err = remote.Fetch(&git.FetchOptions{

--- a/_examples/config/main.go
+++ b/_examples/config/main.go
@@ -26,19 +26,25 @@ func main() {
 	cfg, err := r.Config()
 	CheckIfError(err)
 
-	Info("worktree is %s", cfg.Core.Worktree)
+	Info("worktree is %s", cfg.Core().Worktree)
 
-	// Set basic local config params
-	cfg.Remotes["origin"] = &config.RemoteConfig{
+	// Add a remote using the repository API.
+	_, err = r.CreateRemote(&git.RemoteConfig{
 		Name: "origin",
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
-	}
+	})
+	CheckIfError(err)
 
-	Info("origin remote: %+v", cfg.Remotes["origin"])
+	remote, err := r.Remote("origin")
+	CheckIfError(err)
+	Info("origin remote: %+v", remote.Config())
 
-	cfg.User.Name = "Local name"
+	// Set a local config value.
+	cfg, err = r.Config()
+	CheckIfError(err)
+	cfg.SetUser(config.User{Name: "Local name"})
 
-	Info("custom.name is %s", cfg.User.Name)
+	Info("custom.name is %s", cfg.User().Name)
 
 	// In order to save the config file, you need to call SetConfig
 	// After calling this go to .git/config and see the custom.name added and the changes to the remote

--- a/_examples/ls-remote/main.go
+++ b/_examples/ls-remote/main.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	. "github.com/go-git/go-git/v6/_examples"
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
 
@@ -18,7 +17,7 @@ func main() {
 	Info("git ls-remote --tags %s", url)
 
 	// Create the remote with repository URL
-	rem := git.NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	rem := git.NewRemote(memory.NewStorage(), &git.RemoteConfig{
 		Name: "origin",
 		URLs: []string{url},
 	})

--- a/_examples/remotes/main.go
+++ b/_examples/remotes/main.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	. "github.com/go-git/go-git/v6/_examples"
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
@@ -26,7 +25,7 @@ func main() {
 
 	// Add a new remote, with the default fetch refspec
 	Info("git remote add example https://github.com/git-fixtures/basic.git")
-	_, err = r.CreateRemote(&config.RemoteConfig{
+	_, err = r.CreateRemote(&git.RemoteConfig{
 		Name: "example",
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})

--- a/_examples/tag-create-push/main.go
+++ b/_examples/tag-create-push/main.go
@@ -126,7 +126,7 @@ func pushTags(r *git.Repository, publicKeyPath string) error {
 	po := &git.PushOptions{
 		RemoteName:    "origin",
 		Progress:      os.Stdout,
-		RefSpecs:      []config.RefSpec{config.RefSpec("refs/tags/*:refs/tags/*")},
+		RefSpecs:      []plumbing.RefSpec{plumbing.RefSpec("refs/tags/*:refs/tags/*")},
 		ClientOptions: []client.Option{client.WithSSHAuth(auth)},
 	}
 	Info("git push --tags")

--- a/_examples/tag-create-push/main.go
+++ b/_examples/tag-create-push/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-git/go-git/v6"
 	. "github.com/go-git/go-git/v6/_examples"
-	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/client"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/transport/ssh"

--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -128,7 +128,7 @@ func (l *tagLoader) Load(_ *url.URL) (storage.Storer, error) {
 		if want == config.SHA1 {
 			want = config.UnsetObjectFormat
 		}
-		require.Equal(l.TB, want, cfg.Extensions.ObjectFormat)
+		require.Equal(l.TB, want, cfg.Extensions().ObjectFormat)
 	}
 
 	return st, nil

--- a/branch.go
+++ b/branch.go
@@ -1,4 +1,4 @@
-package config
+package git
 
 import (
 	"errors"

--- a/branch_config_test.go
+++ b/branch_config_test.go
@@ -1,10 +1,11 @@
-package config
+package git
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
@@ -57,8 +58,8 @@ func (b *BranchSuite) TestMarshal() {
 	rebase = interactive
 `)
 
-	cfg := NewConfig()
-	cfg.SetBranch(&Branch{
+	cfg := config.NewConfig()
+	setBranchConfig(cfg, &Branch{
 		Name:   "branch-tracking-on-clone",
 		Remote: "fork",
 		Merge:  plumbing.ReferenceName("refs/heads/branch-tracking-on-clone"),
@@ -79,10 +80,10 @@ func (b *BranchSuite) TestUnmarshal() {
 	rebase = interactive
 `)
 
-	cfg := NewConfig()
+	cfg := config.NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
-	branch := cfg.Branches()["branch-tracking-on-clone"]
+	branch := branchConfigs(cfg)["branch-tracking-on-clone"]
 	b.Equal("branch-tracking-on-clone", branch.Name)
 	b.Equal("fork", branch.Remote)
 	b.Equal(plumbing.ReferenceName("refs/heads/branch-tracking-on-clone"), branch.Merge)
@@ -117,10 +118,10 @@ func (b *BranchSuite) TestUnmarshalNonRefsPrefix() {
 	merge = main
 `)
 
-	cfg := NewConfig()
+	cfg := config.NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
-	branch := cfg.Branches()["foo"]
+	branch := branchConfigs(cfg)["foo"]
 	b.Equal("foo", branch.Name)
 	b.Equal("origin", branch.Remote)
 	b.Equal(plumbing.ReferenceName("main"), branch.Merge)

--- a/common_test.go
+++ b/common_test.go
@@ -68,8 +68,7 @@ func registerTestConfigLoader() {
 
 func defaultTestConfig() config.Config {
 	cfg := config.NewConfig()
-	cfg.User.Name = "Test User"
-	cfg.User.Email = "test@example.com"
+	cfg.SetUser(config.User{Name: "Test User", Email: "test@example.com"})
 	return *cfg
 }
 

--- a/config/branch_test.go
+++ b/config/branch_test.go
@@ -58,12 +58,12 @@ func (b *BranchSuite) TestMarshal() {
 `)
 
 	cfg := NewConfig()
-	cfg.Branches["branch-tracking-on-clone"] = &Branch{
+	cfg.SetBranch(&Branch{
 		Name:   "branch-tracking-on-clone",
 		Remote: "fork",
 		Merge:  plumbing.ReferenceName("refs/heads/branch-tracking-on-clone"),
 		Rebase: "interactive",
-	}
+	})
 
 	actual, err := cfg.Marshal()
 	b.NoError(err)
@@ -82,7 +82,7 @@ func (b *BranchSuite) TestUnmarshal() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
-	branch := cfg.Branches["branch-tracking-on-clone"]
+	branch := cfg.Branches()["branch-tracking-on-clone"]
 	b.Equal("branch-tracking-on-clone", branch.Name)
 	b.Equal("fork", branch.Remote)
 	b.Equal(plumbing.ReferenceName("refs/heads/branch-tracking-on-clone"), branch.Merge)
@@ -120,7 +120,7 @@ func (b *BranchSuite) TestUnmarshalNonRefsPrefix() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
-	branch := cfg.Branches["foo"]
+	branch := cfg.Branches()["foo"]
 	b.Equal("foo", branch.Name)
 	b.Equal("origin", branch.Remote)
 	b.Equal(plumbing.ReferenceName("main"), branch.Merge)

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/go-git/go-billy/v6/osfs"
 
-	"github.com/go-git/go-git/v6/internal/url"
 	"github.com/go-git/go-git/v6/plumbing"
 	format "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
@@ -43,16 +42,8 @@ type ConfigStorer interface { //nolint:revive // stutters but is a well-establis
 	SetConfig(*Config) error
 }
 
-var (
-	// ErrInvalid is returned when a config key is invalid.
-	ErrInvalid = errors.New("config invalid key in remote or branch")
-	// ErrRemoteConfigNotFound is returned when a remote config is not found.
-	ErrRemoteConfigNotFound = errors.New("remote config not found")
-	// ErrRemoteConfigEmptyURL is returned when a remote config has an empty URL.
-	ErrRemoteConfigEmptyURL = errors.New("remote config: empty URL")
-	// ErrRemoteConfigEmptyName is returned when a remote config has an empty name.
-	ErrRemoteConfigEmptyName = errors.New("remote config: empty name")
-)
+// ErrInvalid is returned when a config key is invalid.
+var ErrInvalid = errors.New("config invalid key in remote or branch")
 
 // Scope defines the scope of a config file, such as local, global or system.
 type Scope int
@@ -62,20 +53,6 @@ const (
 	LocalScope Scope = iota
 	GlobalScope
 	SystemScope
-)
-
-const (
-	remoteSection    = "remote"
-	submoduleSection = "submodule"
-	branchSection    = "branch"
-	urlSection       = "url"
-	fetchKey         = "fetch"
-	urlKey           = "url"
-	pushurlKey       = "pushurl"
-	mirrorKey        = "mirror"
-	mergeKey         = "merge"
-	rebaseKey        = "rebase"
-	descriptionKey   = "description"
 )
 
 // Config is a Git configuration, backed by a flat set of string keys in the
@@ -405,147 +382,6 @@ func (c *Config) SetProtocolVersion(v protocol.Version) {
 	c.Raw.Set("protocol.version", v.String())
 }
 
-// Remotes returns the [remote] subsections keyed by name, with url.insteadOf
-// rewrite rules applied to their URLs.
-func (c *Config) Remotes() map[string]*RemoteConfig {
-	m, _ := c.remotes()
-	return m
-}
-
-// Remote returns the named remote or nil if it does not exist.
-func (c *Config) Remote(name string) *RemoteConfig {
-	return c.Remotes()[name]
-}
-
-func (c *Config) remotes() (map[string]*RemoteConfig, error) {
-	out := make(map[string]*RemoteConfig)
-	urls := c.urls()
-	s := c.Raw.Section(remoteSection)
-	for _, sub := range s.Subsections {
-		r := &RemoteConfig{}
-		if err := r.unmarshal(sub); err != nil {
-			return nil, err
-		}
-		r.applyURLRules(urls)
-		out[r.Name] = r
-	}
-	if len(s.Options) > 0 {
-		r := &RemoteConfig{}
-		if err := r.unmarshal(&format.Subsection{Name: "", Options: s.Options}); err != nil {
-			return nil, err
-		}
-		r.applyURLRules(urls)
-		out[r.Name] = r
-	}
-	return out, nil
-}
-
-// SetRemote writes the remote into Raw, replacing any existing remote of the
-// same name.
-func (c *Config) SetRemote(r *RemoteConfig) {
-	c.setSubsection(remoteSection, r.Name, r.marshal())
-}
-
-// RemoveRemote removes the named remote.
-func (c *Config) RemoveRemote(name string) { c.Raw.RemoveSubsection(remoteSection, name) }
-
-// Branches returns the [branch] subsections keyed by name.
-func (c *Config) Branches() map[string]*Branch {
-	m, _ := c.branches()
-	return m
-}
-
-// Branch returns the named branch or nil if it does not exist.
-func (c *Config) Branch(name string) *Branch {
-	return c.Branches()[name]
-}
-
-func (c *Config) branches() (map[string]*Branch, error) {
-	out := make(map[string]*Branch)
-	s := c.Raw.Section(branchSection)
-	for _, sub := range s.Subsections {
-		b := &Branch{}
-		if err := b.unmarshal(sub); err != nil {
-			return nil, err
-		}
-		out[b.Name] = b
-	}
-	return out, nil
-}
-
-// SetBranch writes the branch into Raw, replacing any existing branch of the
-// same name.
-func (c *Config) SetBranch(b *Branch) {
-	c.setSubsection(branchSection, b.Name, b.marshal())
-}
-
-// RemoveBranch removes the named branch.
-func (c *Config) RemoveBranch(name string) { c.Raw.RemoveSubsection(branchSection, name) }
-
-// Submodules returns the [submodule] subsections keyed by name, skipping any
-// with an invalid name or path.
-func (c *Config) Submodules() map[string]*Submodule {
-	out := make(map[string]*Submodule)
-	s := c.Raw.Section(submoduleSection)
-	for _, sub := range s.Subsections {
-		m := &Submodule{}
-		m.unmarshal(sub)
-		if err := m.Validate(); errors.Is(err, ErrModuleBadPath) ||
-			errors.Is(err, ErrModuleBadName) {
-			continue
-		}
-		out[m.Name] = m
-	}
-	return out
-}
-
-// Submodule returns the named submodule or nil if it does not exist.
-func (c *Config) Submodule(name string) *Submodule {
-	return c.Submodules()[name]
-}
-
-// SetSubmodule writes the submodule into Raw, replacing any existing submodule
-// of the same name. The path option is not stored in the repository config.
-func (c *Config) SetSubmodule(m *Submodule) {
-	sub := m.marshal()
-	sub.RemoveOption(pathKey)
-	c.setSubsection(submoduleSection, m.Name, sub)
-}
-
-// URLs returns the [url] subsections in file order.
-func (c *Config) URLs() []*URL {
-	return c.urls()
-}
-
-func (c *Config) urls() []*URL {
-	s := c.Raw.Section(urlSection)
-	out := make([]*URL, 0, len(s.Subsections))
-	for _, sub := range s.Subsections {
-		u := &URL{}
-		_ = u.unmarshal(sub)
-		out = append(out, u)
-	}
-	return out
-}
-
-// AddURL appends a url rewrite rule.
-func (c *Config) AddURL(u *URL) {
-	c.setSubsection(urlSection, u.Name, u.marshal())
-}
-
-// setSubsection replaces a subsection of the same name within section, or
-// appends it if absent.
-func (c *Config) setSubsection(section, name string, sub *format.Subsection) {
-	s := c.Raw.Section(section)
-	for i, ss := range s.Subsections {
-		if ss.IsName(name) {
-			s.Subsections[i] = sub
-			return
-		}
-	}
-	s.Subsections = append(s.Subsections, sub)
-}
-
 // Merge combines all the src Config objects into one. The objects are processed
 // in the order they are passed on; later sources override values from earlier
 // ones for the same key or subsection. Nil configs are ignored.
@@ -562,10 +398,21 @@ func (c *Config) merge(src *Config) {
 			ds.SetOption(o.Key, o.Value)
 		}
 		for _, sub := range s.Subsections {
-			c.setSubsection(s.Name, sub.Name, &format.Subsection{
+			merged := &format.Subsection{
 				Name:    sub.Name,
 				Options: append(format.Options(nil), sub.Options...),
-			})
+			}
+			replaced := false
+			for i, existing := range ds.Subsections {
+				if existing.IsName(sub.Name) {
+					ds.Subsections[i] = merged
+					replaced = true
+					break
+				}
+			}
+			if !replaced {
+				ds.Subsections = append(ds.Subsections, merged)
+			}
 		}
 	}
 }
@@ -656,33 +503,17 @@ func Paths(scope Scope) ([]string, error) {
 }
 
 // Validate validates the remotes and branches and sets default values.
+// Validate validates the remote fetch refspecs stored in the config. Higher
+// level validation of remotes, branches and submodules is performed by the
+// porcelain layer that owns those types.
 func (c *Config) Validate() error {
-	remotes, err := c.remotes()
-	if err != nil {
-		return err
-	}
-	for name, r := range remotes {
-		if r.Name != name {
-			return ErrInvalid
-		}
-		if err := r.Validate(); err != nil {
-			return err
+	for _, sub := range c.Raw.Section("remote").Subsections {
+		for _, f := range sub.Options.GetAll("fetch") {
+			if err := plumbing.RefSpec(f).Validate(); err != nil {
+				return err
+			}
 		}
 	}
-
-	branches, err := c.branches()
-	if err != nil {
-		return err
-	}
-	for name, b := range branches {
-		if b.Name != name {
-			return ErrInvalid
-		}
-		if err := b.Validate(); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -701,14 +532,8 @@ func (c *Config) Unmarshal(b []byte) error {
 			return err
 		}
 	}
-	if _, err := c.remotes(); err != nil {
-		return err
-	}
-	if _, err := c.branches(); err != nil {
-		return err
-	}
 
-	return nil
+	return c.Validate()
 }
 
 // Marshal returns Config encoded as a git-config file. Because Raw is the
@@ -743,133 +568,4 @@ func setOptBool(raw *format.Config, key string, v OptBool) {
 		return
 	}
 	raw.Unset(key)
-}
-
-// RemoteConfig contains the configuration for a given remote repository.
-type RemoteConfig struct {
-	// Name of the remote
-	Name string
-	// URLs the URLs of a remote repository. It must be non-empty. Fetch will
-	// always use the first URL, while push will use all of them.
-	URLs []string
-	// Mirror indicates that the repository is a mirror of remote.
-	Mirror bool
-
-	// insteadOfRulesApplied have urls been modified
-	insteadOfRulesApplied bool
-	// originalURLs are the urls before applying insteadOf rules
-	originalURLs []string
-
-	// Fetch the default set of "refspec" for fetch operation
-	Fetch []plumbing.RefSpec
-
-	// raw representation of the subsection, filled by marshal or unmarshal are
-	// called
-	raw *format.Subsection
-}
-
-// Validate validates the fields and sets the default values.
-func (c *RemoteConfig) Validate() error {
-	if c.Name == "" {
-		return ErrRemoteConfigEmptyName
-	}
-
-	if len(c.URLs) == 0 {
-		return ErrRemoteConfigEmptyURL
-	}
-
-	for _, r := range c.Fetch {
-		if err := r.Validate(); err != nil {
-			return err
-		}
-	}
-
-	if len(c.Fetch) == 0 {
-		c.Fetch = []plumbing.RefSpec{plumbing.RefSpec(fmt.Sprintf(DefaultFetchRefSpec, c.Name))}
-	}
-
-	return plumbing.NewRemoteHEADReferenceName(c.Name).Validate()
-}
-
-func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
-	c.raw = s
-
-	fetch := []plumbing.RefSpec{}
-	for _, f := range c.raw.Options.GetAll(fetchKey) {
-		rs := plumbing.RefSpec(f)
-		if err := rs.Validate(); err != nil {
-			return err
-		}
-
-		fetch = append(fetch, rs)
-	}
-
-	c.Name = c.raw.Name
-	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
-	c.URLs = append(c.URLs, c.raw.Options.GetAll(pushurlKey)...)
-	c.Fetch = fetch
-	if c.raw.Options.Has(mirrorKey) {
-		if b, err := format.ParseBool(c.raw.Options.Get(mirrorKey)); err == nil {
-			c.Mirror = b
-		}
-	}
-
-	return nil
-}
-
-func (c *RemoteConfig) marshal() *format.Subsection {
-	if c.raw == nil {
-		c.raw = &format.Subsection{}
-	}
-
-	c.raw.Name = c.Name
-	if len(c.URLs) == 0 {
-		c.raw.RemoveOption(urlKey)
-	} else {
-		urls := c.URLs
-		if c.insteadOfRulesApplied {
-			urls = c.originalURLs
-		}
-
-		c.raw.SetOption(urlKey, urls...)
-	}
-
-	if len(c.Fetch) == 0 {
-		c.raw.RemoveOption(fetchKey)
-	} else {
-		values := make([]string, 0, len(c.Fetch))
-		for _, rs := range c.Fetch {
-			values = append(values, rs.String())
-		}
-
-		c.raw.SetOption(fetchKey, values...)
-	}
-
-	if c.Mirror {
-		c.raw.SetOption(mirrorKey, strconv.FormatBool(c.Mirror))
-	}
-
-	return c.raw
-}
-
-// IsFirstURLLocal returns true if the first URL is a local path.
-func (c *RemoteConfig) IsFirstURLLocal() bool {
-	return url.IsLocalEndpoint(c.URLs[0])
-}
-
-func (c *RemoteConfig) applyURLRules(urlRules []*URL) {
-	// save original urls
-	originalURLs := make([]string, len(c.URLs))
-	copy(originalURLs, c.URLs)
-
-	for i, u := range c.URLs {
-		if rewrittenURL, matched := applyLongestInsteadOfMatch(u, urlRules); matched {
-			c.URLs[i] = rewrittenURL
-			c.insteadOfRulesApplied = true
-		}
-	}
-
-	if c.insteadOfRulesApplied {
-		c.originalURLs = originalURLs
-	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -761,7 +761,7 @@ type RemoteConfig struct {
 	originalURLs []string
 
 	// Fetch the default set of "refspec" for fetch operation
-	Fetch []RefSpec
+	Fetch []plumbing.RefSpec
 
 	// raw representation of the subsection, filled by marshal or unmarshal are
 	// called
@@ -785,7 +785,7 @@ func (c *RemoteConfig) Validate() error {
 	}
 
 	if len(c.Fetch) == 0 {
-		c.Fetch = []RefSpec{RefSpec(fmt.Sprintf(DefaultFetchRefSpec, c.Name))}
+		c.Fetch = []plumbing.RefSpec{plumbing.RefSpec(fmt.Sprintf(DefaultFetchRefSpec, c.Name))}
 	}
 
 	return plumbing.NewRemoteHEADReferenceName(c.Name).Validate()
@@ -794,9 +794,9 @@ func (c *RemoteConfig) Validate() error {
 func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 	c.raw = s
 
-	fetch := []RefSpec{}
+	fetch := []plumbing.RefSpec{}
 	for _, f := range c.raw.Options.GetAll(fetchKey) {
-		rs := RefSpec(f)
+		rs := plumbing.RefSpec(f)
 		if err := rs.Validate(); err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -8,10 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
-	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/go-git/go-billy/v6/osfs"
 
@@ -32,6 +29,12 @@ const (
 	// Note that this does not need to align with the default protocol
 	// version from plumbing/protocol.
 	DefaultProtocolVersion = protocol.V0 // go-git only supports V0 at the moment
+
+	// DefaultPackWindow holds the number of previous objects used to
+	// generate deltas. The value 10 is the same used by git command.
+	DefaultPackWindow = uint(10)
+	// DefaultFileMode is the default file mode used by git command.
+	DefaultFileMode = true
 )
 
 // ConfigStorer is a generic storage of Config object.
@@ -61,282 +64,521 @@ const (
 	SystemScope
 )
 
-// Config contains the repository configuration
+const (
+	remoteSection    = "remote"
+	submoduleSection = "submodule"
+	branchSection    = "branch"
+	urlSection       = "url"
+	fetchKey         = "fetch"
+	urlKey           = "url"
+	pushurlKey       = "pushurl"
+	mirrorKey        = "mirror"
+	mergeKey         = "merge"
+	rebaseKey        = "rebase"
+	descriptionKey   = "description"
+)
+
+// Config is a Git configuration, backed by a flat set of string keys in the
+// canonical "section.subsection.name = value" model used by git. The Raw field
+// is the single source of truth; the typed accessors and porcelain helpers read
+// from and write to it.
+//
 // https://www.kernel.org/pub/software/scm/git/docs/git-config.html#FILES
 type Config struct {
-	Core struct {
-		// IsBare if true this repository is assumed to be bare and has no
-		// working directory associated with it.
-		IsBare bool
-		// Worktree is the path to the root of the working tree.
-		Worktree string
-		// CommentChar is the character indicating the start of a
-		// comment for commands like commit and tag
-		CommentChar string
-		// RepositoryFormatVersion identifies the repository format and layout version.
-		RepositoryFormatVersion format.RepositoryFormatVersion
-		// AutoCRLF if "true", all the CRLF line endings in the worktree will be
-		// converted to LF when added to the repository, and vice versa on checkout.
-		// If set to "input", only worktree-to-repository conversion is performed.
-		AutoCRLF string
-		// FileMode defines whether the executable bit of working tree files is to be honored.
-		// If "false", when an index node is an Executable and is comparing hash
-		// against local file, 0644 will be used as the value of its mode. The original
-		// value of mode is left unchanged in the index.
-		FileMode bool
-		// HooksPath is the path to look for hooks instead of $GIT_DIR/hooks.
-		HooksPath string
-		// ProtectNTFS controls whether NTFS-specific path protections are
-		// applied (e.g. rejecting .git trailing spaces/periods, alternate
-		// data streams, 8.3 short names). When unset, defaults to true on
-		// Windows.
-		ProtectNTFS OptBool
-		// ProtectHFS controls whether HFS+-specific path protections are
-		// applied (e.g. rejecting .git with Unicode zero-width or
-		// directional characters that HFS+ would normalize away).
-		// When unset, defaults to true on macOS.
-		ProtectHFS OptBool
-	}
-
-	User user
-
-	Author struct {
-		// Name is the personal name of the author of a commit.
-		Name string
-		// Email is the email of the author of a commit.
-		Email string
-	}
-
-	Committer struct {
-		// Name is the personal name of the committer of a commit.
-		Name string
-		// Email is the email of the committer of a commit.
-		Email string
-	}
-
-	Tag struct {
-		// GpgSign indicates whether all new tags should be GPG signed.
-		GpgSign OptBool
-	}
-
-	Commit struct {
-		// GpgSign indicates whether all new commits should be GPG signed.
-		GpgSign OptBool
-	}
-
-	GPG struct {
-		// Format specifies the signature format to use when signing commits and tags.
-		// Valid values are "openpgp" (default), "x509" and "ssh".
-		Format string
-		// SSH contains SSH-specific GPG configuration.
-		SSH struct {
-			// AllowedSignersFile is the path to the file containing allowed SSH signing keys.
-			AllowedSignersFile string
-		}
-	}
-
-	Pack struct {
-		// Window controls the size of the sliding window for delta
-		// compression.  The default is 10.  A value of 0 turns off
-		// delta compression entirely.
-		Window uint
-		// ReadReverseIndex controls whether Git reads .rev files from
-		// disk. When false, a reverse index is generated in memory on
-		// demand instead. Defaults to true.
-		ReadReverseIndex bool
-		// WriteReverseIndex controls whether Git writes .rev files
-		// when creating new packfiles. Defaults to true.
-		WriteReverseIndex bool
-	}
-
-	Index struct {
-		// SkipHash if true, the index checksum is not written or verified.
-		// This corresponds to git's index.skipHash configuration (git 2.40+),
-		// which skips the trailing SHA-1/SHA-256 computation for performance
-		// on large repositories.
-		SkipHash OptBool
-	}
-
-	Init struct {
-		// DefaultBranch Allows overriding the default branch name
-		// e.g. when initializing a new repository or when cloning
-		// an empty repository.
-		DefaultBranch string
-	}
-
-	UploadArchive struct {
-		// AllowUnreachable when true allows clients to request archives
-		// using arbitrary SHA-1 expressions. When false (the default),
-		// only direct ref names are allowed.
-		AllowUnreachable OptBool
-	}
-
-	Extensions struct {
-		// ObjectFormat specifies the hash algorithm to use. The
-		// acceptable values are sha1 and sha256. If not specified,
-		// sha1 is assumed. It is an error to specify this key unless
-		// core.repositoryFormatVersion is 1.
-		//
-		// This setting must not be changed after repository initialization
-		// (e.g. clone or init).
-		ObjectFormat format.ObjectFormat
-		// WorktreeConfig indicates that per-worktree config files are enabled.
-		// When true, each worktree may have a config.worktree file that
-		// overrides settings in the common .git/config.
-		WorktreeConfig bool
-	}
-
-	Protocol struct {
-		// Version sets the preferred version for the Git wire protocol.
-		// When set, clients will attempt to communicate with a server
-		// using the specified protocol version. If the server does not
-		// support it, communication falls back to version 0. If unset,
-		// the default version will be used. Supported versions:
-		//
-		//   0 - the original wire protocol.
-		//   1 - the original wire protocol with the addition of a
-		// version string in the initial response from the server.
-		//   2 - Wire protocol version 2.
-		Version protocol.Version
-	}
-
-	// Remotes list of repository remotes, the key of the map is the name
-	// of the remote, should equal to RemoteConfig.Name.
-	Remotes map[string]*RemoteConfig
-	// Submodules list of repository submodules, the key of the map is the name
-	// of the submodule, should equal to Submodule.Name.
-	Submodules map[string]*Submodule
-	// Branches list of branches, the key is the branch name and should
-	// equal Branch.Name
-	Branches map[string]*Branch
-	// URLs list of url rewrite rules, if repo url starts with URL.InsteadOf value, it will be replaced with the
-	// URL.Name instead. Ordered by appearance in config file.
-	URLs []*URL
-	// Raw contains the raw information of a config file. The main goal is
-	// preserve the parsed information from the original format, to avoid
-	// dropping unsupported fields.
+	// Raw holds the parsed key/value model. It is the canonical state of the
+	// configuration; every accessor reads from and writes to it.
 	Raw *format.Config
 }
 
-type user struct {
-	// Name is the personal name of the author and the committer of a commit.
-	Name string
-	// Email is the email of the author and the committer of a commit.
-	Email string
+// Core groups the values of the [core] section.
+type Core struct {
+	// IsBare if true this repository is assumed to be bare and has no
+	// working directory associated with it.
+	IsBare bool
+	// Worktree is the path to the root of the working tree.
+	Worktree string
+	// CommentChar is the character indicating the start of a comment for
+	// commands like commit and tag.
+	CommentChar string
+	// RepositoryFormatVersion identifies the repository format and layout version.
+	RepositoryFormatVersion format.RepositoryFormatVersion
+	// AutoCRLF controls automatic line-ending conversion.
+	AutoCRLF string
+	// FileMode defines whether the executable bit of working tree files is honored.
+	FileMode bool
+	// HooksPath is the path to look for hooks instead of $GIT_DIR/hooks.
+	HooksPath string
+	// ProtectNTFS controls NTFS-specific path protections.
+	ProtectNTFS OptBool
+	// ProtectHFS controls HFS+-specific path protections.
+	ProtectHFS OptBool
+}
 
-	// SigningKey defines what key should be used when automatically
-	// signing tags or commits, and more than one key is available.
-	//
-	// If gpg.format is set to ssh this can contain the path to either
-	// your private ssh key or the public key when ssh-agent is used.
-	// Alternatively it can contain a public key prefixed with key::
-	// directly (e.g.: "key::ssh-rsa XXXXXX identifier"). The private
-	// key needs to be available via ssh-agent.
-	//
-	// If not set go-git will use the first key available.
+// User groups the values of the [user] section.
+type User struct {
+	// Name is the personal name of the author and committer of a commit.
+	Name string
+	// Email is the email of the author and committer of a commit.
+	Email string
+	// SigningKey is the key used when signing tags or commits.
 	SigningKey string
 }
 
-// Merge combines all the src Config objects into one.
-// The objects are processed in the order they are passed on, and will
-// override any existing values. Empty configs are ignored.
-//
-// The config field Raw cannot be merged via reflection, so it is ignored
-// as part of the Merge operation. To update Raw after a merge, call Marshal().
-func Merge(src ...*Config) Config {
-	var final Config
-
-	for _, c := range src {
-		if c == nil {
-			continue
-		}
-
-		merge(&final, c)
-	}
-
-	return final
+// Identity is a name/email pair, used by the [author] and [committer] sections.
+type Identity struct {
+	Name  string
+	Email string
 }
 
-func merge(dst, src any) {
-	tv := reflect.ValueOf(dst).Elem()
-	sv := reflect.ValueOf(src).Elem()
-	tt := tv.Type()
-
-	for i := 0; i < tv.NumField(); i++ {
-		// Raw holds a *format.Config whose Sections field is a slice. The
-		// generic default case below would replace dst.Sections with
-		// src.Sections wholesale, dropping sections that exist only in the
-		// base config (e.g. [extensions]).  Merge() rebuilds Raw from the
-		// merged struct state after all sources have been processed, so we
-		// skip it here.
-		if tt.Field(i).Name == "Raw" {
-			continue
-		}
-
-		df := tv.Field(i)
-		sf := sv.Field(i)
-
-		if !df.CanSet() || sf.IsZero() {
-			continue
-		}
-
-		switch df.Kind() {
-		case reflect.Struct:
-			// Handle nested fields which are based off structs.
-			merge(df.Addr().Interface(), sf.Addr().Interface())
-
-		case reflect.Pointer:
-			if sf.IsNil() {
-				continue
-			}
-			if df.IsNil() {
-				df.Set(reflect.New(df.Type().Elem()))
-			}
-			// Same as per reflect.Struct, but for a struct pointer.
-			if df.Elem().Kind() == reflect.Struct {
-				merge(df.Interface(), sf.Interface())
-			} else {
-				df.Set(sf)
-			}
-
-		case reflect.Map:
-			// An empty (but non-nil) src map must not overwrite dst entries.
-			// Only copy individual entries from src so that dst keys not
-			// present in src are preserved and src entries override same-key
-			// dst entries.
-			if sf.Len() == 0 {
-				continue
-			}
-			if df.IsNil() {
-				df.Set(reflect.MakeMap(df.Type()))
-			}
-			for _, key := range sf.MapKeys() {
-				df.SetMapIndex(key, sf.MapIndex(key))
-			}
-
-		default:
-			df.Set(sf)
-		}
-	}
+// GPGSSH holds the [gpg "ssh"] subsection values.
+type GPGSSH struct {
+	// AllowedSignersFile is the path to the file containing allowed SSH signing keys.
+	AllowedSignersFile string
 }
 
-// NewConfig returns a new empty Config.
+// GPG groups the values of the [gpg] section.
+type GPG struct {
+	// Format specifies the signature format ("openpgp", "x509" or "ssh").
+	Format string
+	// SSH contains SSH-specific GPG configuration.
+	SSH GPGSSH
+}
+
+// Pack groups the values of the [pack] section.
+type Pack struct {
+	// Window controls the size of the sliding window for delta compression.
+	Window uint
+	// ReadReverseIndex controls whether Git reads .rev files from disk.
+	ReadReverseIndex bool
+	// WriteReverseIndex controls whether Git writes .rev files.
+	WriteReverseIndex bool
+}
+
+// Extensions groups the values of the [extensions] section.
+type Extensions struct {
+	// ObjectFormat specifies the hash algorithm to use ("sha1" or "sha256").
+	ObjectFormat format.ObjectFormat
+	// WorktreeConfig indicates that per-worktree config files are enabled.
+	WorktreeConfig bool
+}
+
+// Index groups the values of the [index] section.
+type Index struct {
+	// SkipHash if true, the index checksum is not written or verified.
+	SkipHash OptBool
+}
+
+// Init groups the values of the [init] section.
+type Init struct {
+	// DefaultBranch overrides the default branch name.
+	DefaultBranch string
+}
+
+// UploadArchive groups the values of the [uploadArchive] section.
+type UploadArchive struct {
+	// AllowUnreachable allows clients to request archives using arbitrary
+	// SHA-1 expressions.
+	AllowUnreachable OptBool
+}
+
+// Signing holds a gpgSign flag, used by the [tag] and [commit] sections.
+type Signing struct {
+	GpgSign OptBool
+}
+
+// Protocol groups the values of the [protocol] section.
+type Protocol struct {
+	// Version sets the preferred version for the Git wire protocol.
+	Version protocol.Version
+}
+
+// NewConfig returns a new Config populated with go-git's defaults.
 func NewConfig() *Config {
-	config := &Config{
-		Remotes:    make(map[string]*RemoteConfig),
-		Submodules: make(map[string]*Submodule),
-		Branches:   make(map[string]*Branch),
-		URLs:       make([]*URL, 0),
-		Raw:        format.New(),
+	c := &Config{Raw: format.New()}
+	c.Raw.Set("core.bare", "false")
+	c.Raw.Set("core.filemode", strconv.FormatBool(DefaultFileMode))
+	return c
+}
+
+// Core returns the values of the [core] section.
+func (c *Config) Core() Core {
+	var rfv format.RepositoryFormatVersion
+	if c.Raw.Get("core.repositoryformatversion") == format.Version1 {
+		rfv = format.Version1
 	}
+	return Core{
+		IsBare:                  c.Raw.Bool("core.bare", false),
+		Worktree:                c.Raw.Get("core.worktree"),
+		CommentChar:             c.Raw.Get("core.commentChar"),
+		RepositoryFormatVersion: rfv,
+		AutoCRLF:                c.Raw.Get("core.autocrlf"),
+		FileMode:                c.Raw.Bool("core.filemode", DefaultFileMode),
+		HooksPath:               c.Raw.Get("core.hooksPath"),
+		ProtectNTFS:             parseConfigBool(c.Raw.Get("core.protectNTFS")),
+		ProtectHFS:              parseConfigBool(c.Raw.Get("core.protectHFS")),
+	}
+}
 
-	config.Core.FileMode = DefaultFileMode
-	config.Pack.Window = DefaultPackWindow
-	config.Pack.ReadReverseIndex = true
-	config.Pack.WriteReverseIndex = true
-	config.Protocol.Version = DefaultProtocolVersion
+// SetBare sets core.bare.
+func (c *Config) SetBare(v bool) { c.Raw.Set("core.bare", strconv.FormatBool(v)) }
 
-	return config
+// SetFileMode sets core.filemode.
+func (c *Config) SetFileMode(v bool) { c.Raw.Set("core.filemode", strconv.FormatBool(v)) }
+
+// SetWorktree sets or clears core.worktree.
+func (c *Config) SetWorktree(v string) { setOrUnset(c.Raw, "core.worktree", v) }
+
+// SetCommentChar sets or clears core.commentChar.
+func (c *Config) SetCommentChar(v string) { setOrUnset(c.Raw, "core.commentChar", v) }
+
+// SetAutoCRLF sets or clears core.autocrlf.
+func (c *Config) SetAutoCRLF(v string) { setOrUnset(c.Raw, "core.autocrlf", v) }
+
+// SetHooksPath sets or clears core.hooksPath.
+func (c *Config) SetHooksPath(v string) { setOrUnset(c.Raw, "core.hooksPath", v) }
+
+// SetProtectNTFS sets or clears core.protectNTFS.
+func (c *Config) SetProtectNTFS(v OptBool) { setOptBool(c.Raw, "core.protectNTFS", v) }
+
+// SetProtectHFS sets or clears core.protectHFS.
+func (c *Config) SetProtectHFS(v OptBool) { setOptBool(c.Raw, "core.protectHFS", v) }
+
+// SetRepositoryFormatVersion sets or clears core.repositoryformatversion.
+func (c *Config) SetRepositoryFormatVersion(v format.RepositoryFormatVersion) {
+	setOrUnset(c.Raw, "core.repositoryformatversion", string(v))
+}
+
+// User returns the values of the [user] section.
+func (c *Config) User() User {
+	return User{
+		Name:       c.Raw.Get("user.name"),
+		Email:      c.Raw.Get("user.email"),
+		SigningKey: c.Raw.Get("user.signingKey"),
+	}
+}
+
+// SetUser sets the [user] section values, clearing empty ones.
+func (c *Config) SetUser(v User) {
+	setOrUnset(c.Raw, "user.name", v.Name)
+	setOrUnset(c.Raw, "user.email", v.Email)
+	setOrUnset(c.Raw, "user.signingKey", v.SigningKey)
+}
+
+// Author returns the values of the [author] section.
+func (c *Config) Author() Identity {
+	return Identity{Name: c.Raw.Get("author.name"), Email: c.Raw.Get("author.email")}
+}
+
+// SetAuthor sets the [author] section values, clearing empty ones.
+func (c *Config) SetAuthor(v Identity) {
+	setOrUnset(c.Raw, "author.name", v.Name)
+	setOrUnset(c.Raw, "author.email", v.Email)
+}
+
+// Committer returns the values of the [committer] section.
+func (c *Config) Committer() Identity {
+	return Identity{Name: c.Raw.Get("committer.name"), Email: c.Raw.Get("committer.email")}
+}
+
+// SetCommitter sets the [committer] section values, clearing empty ones.
+func (c *Config) SetCommitter(v Identity) {
+	setOrUnset(c.Raw, "committer.name", v.Name)
+	setOrUnset(c.Raw, "committer.email", v.Email)
+}
+
+// Tag returns the values of the [tag] section.
+func (c *Config) Tag() Signing {
+	return Signing{GpgSign: parseConfigBool(c.Raw.Get("tag.gpgSign"))}
+}
+
+// SetTagGpgSign sets or clears tag.gpgSign.
+func (c *Config) SetTagGpgSign(v OptBool) { setOptBool(c.Raw, "tag.gpgSign", v) }
+
+// Commit returns the values of the [commit] section.
+func (c *Config) Commit() Signing {
+	return Signing{GpgSign: parseConfigBool(c.Raw.Get("commit.gpgSign"))}
+}
+
+// SetCommitGpgSign sets or clears commit.gpgSign.
+func (c *Config) SetCommitGpgSign(v OptBool) { setOptBool(c.Raw, "commit.gpgSign", v) }
+
+// GPG returns the values of the [gpg] section.
+func (c *Config) GPG() GPG {
+	return GPG{
+		Format: c.Raw.Get("gpg.format"),
+		SSH:    GPGSSH{AllowedSignersFile: c.Raw.Get("gpg.ssh.allowedSignersFile")},
+	}
+}
+
+// SetGPGFormat sets or clears gpg.format.
+func (c *Config) SetGPGFormat(v string) { setOrUnset(c.Raw, "gpg.format", v) }
+
+// SetGPGSSHAllowedSignersFile sets or clears gpg.ssh.allowedSignersFile.
+func (c *Config) SetGPGSSHAllowedSignersFile(v string) {
+	setOrUnset(c.Raw, "gpg.ssh.allowedSignersFile", v)
+}
+
+// Pack returns the values of the [pack] section.
+func (c *Config) Pack() Pack {
+	w, _ := c.Raw.Uint("pack.window", uint64(DefaultPackWindow))
+	return Pack{
+		Window:            uint(w),
+		ReadReverseIndex:  c.Raw.Bool("pack.readReverseIndex", true),
+		WriteReverseIndex: c.Raw.Bool("pack.writeReverseIndex", true),
+	}
+}
+
+// SetPackWindow sets pack.window.
+func (c *Config) SetPackWindow(v uint) { c.Raw.Set("pack.window", strconv.FormatUint(uint64(v), 10)) }
+
+// SetPackReadReverseIndex sets pack.readReverseIndex.
+func (c *Config) SetPackReadReverseIndex(v bool) {
+	c.Raw.Set("pack.readReverseIndex", strconv.FormatBool(v))
+}
+
+// SetPackWriteReverseIndex sets pack.writeReverseIndex.
+func (c *Config) SetPackWriteReverseIndex(v bool) {
+	c.Raw.Set("pack.writeReverseIndex", strconv.FormatBool(v))
+}
+
+// Index returns the values of the [index] section.
+func (c *Config) Index() Index {
+	return Index{SkipHash: parseConfigBool(c.Raw.Get("index.skipHash"))}
+}
+
+// SetIndexSkipHash sets or clears index.skipHash.
+func (c *Config) SetIndexSkipHash(v OptBool) { setOptBool(c.Raw, "index.skipHash", v) }
+
+// Init returns the values of the [init] section.
+func (c *Config) Init() Init {
+	return Init{DefaultBranch: c.Raw.Get("init.defaultBranch")}
+}
+
+// SetInitDefaultBranch sets or clears init.defaultBranch.
+func (c *Config) SetInitDefaultBranch(v string) { setOrUnset(c.Raw, "init.defaultBranch", v) }
+
+// UploadArchive returns the values of the [uploadArchive] section.
+func (c *Config) UploadArchive() UploadArchive {
+	return UploadArchive{AllowUnreachable: parseConfigBool(c.Raw.Get("uploadArchive.allowUnreachable"))}
+}
+
+// SetUploadArchiveAllowUnreachable sets or clears uploadArchive.allowUnreachable.
+func (c *Config) SetUploadArchiveAllowUnreachable(v OptBool) {
+	setOptBool(c.Raw, "uploadArchive.allowUnreachable", v)
+}
+
+// Extensions returns the values of the [extensions] section.
+func (c *Config) Extensions() Extensions {
+	return Extensions{
+		ObjectFormat:   format.ObjectFormat(c.Raw.Get("extensions.objectformat")),
+		WorktreeConfig: c.Raw.Bool("extensions.worktreeConfig", false),
+	}
+}
+
+// SetObjectFormat sets or clears extensions.objectformat.
+func (c *Config) SetObjectFormat(v format.ObjectFormat) {
+	setOrUnset(c.Raw, "extensions.objectformat", string(v))
+}
+
+// SetWorktreeConfig sets or clears extensions.worktreeConfig.
+func (c *Config) SetWorktreeConfig(v bool) {
+	if v {
+		c.Raw.Set("extensions.worktreeConfig", "true")
+		return
+	}
+	c.Raw.Unset("extensions.worktreeConfig")
+}
+
+// Protocol returns the values of the [protocol] section.
+func (c *Config) Protocol() Protocol {
+	v := DefaultProtocolVersion
+	if rv := c.Raw.Get("protocol.version"); rv != "" {
+		if p, err := protocol.Parse(rv); err == nil {
+			v = p
+		}
+	}
+	return Protocol{Version: v}
+}
+
+// SetProtocolVersion sets protocol.version.
+func (c *Config) SetProtocolVersion(v protocol.Version) {
+	c.Raw.Set("protocol.version", v.String())
+}
+
+// Remotes returns the [remote] subsections keyed by name, with url.insteadOf
+// rewrite rules applied to their URLs.
+func (c *Config) Remotes() map[string]*RemoteConfig {
+	m, _ := c.remotes()
+	return m
+}
+
+// Remote returns the named remote or nil if it does not exist.
+func (c *Config) Remote(name string) *RemoteConfig {
+	return c.Remotes()[name]
+}
+
+func (c *Config) remotes() (map[string]*RemoteConfig, error) {
+	out := make(map[string]*RemoteConfig)
+	urls := c.urls()
+	s := c.Raw.Section(remoteSection)
+	for _, sub := range s.Subsections {
+		r := &RemoteConfig{}
+		if err := r.unmarshal(sub); err != nil {
+			return nil, err
+		}
+		r.applyURLRules(urls)
+		out[r.Name] = r
+	}
+	if len(s.Options) > 0 {
+		r := &RemoteConfig{}
+		if err := r.unmarshal(&format.Subsection{Name: "", Options: s.Options}); err != nil {
+			return nil, err
+		}
+		r.applyURLRules(urls)
+		out[r.Name] = r
+	}
+	return out, nil
+}
+
+// SetRemote writes the remote into Raw, replacing any existing remote of the
+// same name.
+func (c *Config) SetRemote(r *RemoteConfig) {
+	c.setSubsection(remoteSection, r.Name, r.marshal())
+}
+
+// RemoveRemote removes the named remote.
+func (c *Config) RemoveRemote(name string) { c.Raw.RemoveSubsection(remoteSection, name) }
+
+// Branches returns the [branch] subsections keyed by name.
+func (c *Config) Branches() map[string]*Branch {
+	m, _ := c.branches()
+	return m
+}
+
+// Branch returns the named branch or nil if it does not exist.
+func (c *Config) Branch(name string) *Branch {
+	return c.Branches()[name]
+}
+
+func (c *Config) branches() (map[string]*Branch, error) {
+	out := make(map[string]*Branch)
+	s := c.Raw.Section(branchSection)
+	for _, sub := range s.Subsections {
+		b := &Branch{}
+		if err := b.unmarshal(sub); err != nil {
+			return nil, err
+		}
+		out[b.Name] = b
+	}
+	return out, nil
+}
+
+// SetBranch writes the branch into Raw, replacing any existing branch of the
+// same name.
+func (c *Config) SetBranch(b *Branch) {
+	c.setSubsection(branchSection, b.Name, b.marshal())
+}
+
+// RemoveBranch removes the named branch.
+func (c *Config) RemoveBranch(name string) { c.Raw.RemoveSubsection(branchSection, name) }
+
+// Submodules returns the [submodule] subsections keyed by name, skipping any
+// with an invalid name or path.
+func (c *Config) Submodules() map[string]*Submodule {
+	out := make(map[string]*Submodule)
+	s := c.Raw.Section(submoduleSection)
+	for _, sub := range s.Subsections {
+		m := &Submodule{}
+		m.unmarshal(sub)
+		if err := m.Validate(); errors.Is(err, ErrModuleBadPath) ||
+			errors.Is(err, ErrModuleBadName) {
+			continue
+		}
+		out[m.Name] = m
+	}
+	return out
+}
+
+// Submodule returns the named submodule or nil if it does not exist.
+func (c *Config) Submodule(name string) *Submodule {
+	return c.Submodules()[name]
+}
+
+// SetSubmodule writes the submodule into Raw, replacing any existing submodule
+// of the same name. The path option is not stored in the repository config.
+func (c *Config) SetSubmodule(m *Submodule) {
+	sub := m.marshal()
+	sub.RemoveOption(pathKey)
+	c.setSubsection(submoduleSection, m.Name, sub)
+}
+
+// URLs returns the [url] subsections in file order.
+func (c *Config) URLs() []*URL {
+	return c.urls()
+}
+
+func (c *Config) urls() []*URL {
+	s := c.Raw.Section(urlSection)
+	out := make([]*URL, 0, len(s.Subsections))
+	for _, sub := range s.Subsections {
+		u := &URL{}
+		_ = u.unmarshal(sub)
+		out = append(out, u)
+	}
+	return out
+}
+
+// AddURL appends a url rewrite rule.
+func (c *Config) AddURL(u *URL) {
+	c.setSubsection(urlSection, u.Name, u.marshal())
+}
+
+// setSubsection replaces a subsection of the same name within section, or
+// appends it if absent.
+func (c *Config) setSubsection(section, name string, sub *format.Subsection) {
+	s := c.Raw.Section(section)
+	for i, ss := range s.Subsections {
+		if ss.IsName(name) {
+			s.Subsections[i] = sub
+			return
+		}
+	}
+	s.Subsections = append(s.Subsections, sub)
+}
+
+// Merge combines all the src Config objects into one. The objects are processed
+// in the order they are passed on; later sources override values from earlier
+// ones for the same key or subsection. Nil configs are ignored.
+func (c *Config) merge(src *Config) {
+	if src == nil || src.Raw == nil {
+		return
+	}
+	for _, s := range src.Raw.Sections {
+		if len(s.Options) == 0 && len(s.Subsections) == 0 {
+			continue
+		}
+		ds := c.Raw.Section(s.Name)
+		for _, o := range s.Options {
+			ds.SetOption(o.Key, o.Value)
+		}
+		for _, sub := range s.Subsections {
+			c.setSubsection(s.Name, sub.Name, &format.Subsection{
+				Name:    sub.Name,
+				Options: append(format.Options(nil), sub.Options...),
+			})
+		}
+	}
+}
+
+// Merge combines all the src Config objects into one. The objects are processed
+// in the order they are passed on, and later sources override earlier values
+// for the same key or subsection. Empty configs are ignored.
+func Merge(src ...*Config) Config {
+	final := Config{Raw: format.New()}
+	for _, c := range src {
+		final.merge(c)
+	}
+	return final
 }
 
 // ReadConfig reads a config file from a io.Reader.
@@ -413,23 +655,29 @@ func Paths(scope Scope) ([]string, error) {
 	return files, nil
 }
 
-// Validate validates the fields and sets the default values.
+// Validate validates the remotes and branches and sets default values.
 func (c *Config) Validate() error {
-	for name, r := range c.Remotes {
+	remotes, err := c.remotes()
+	if err != nil {
+		return err
+	}
+	for name, r := range remotes {
 		if r.Name != name {
 			return ErrInvalid
 		}
-
 		if err := r.Validate(); err != nil {
 			return err
 		}
 	}
 
-	for name, b := range c.Branches {
+	branches, err := c.branches()
+	if err != nil {
+		return err
+	}
+	for name, b := range branches {
 		if b.Name != name {
 			return ErrInvalid
 		}
-
 		if err := b.Validate(); err != nil {
 			return err
 		}
@@ -438,339 +686,37 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-const (
-	remoteSection              = "remote"
-	submoduleSection           = "submodule"
-	branchSection              = "branch"
-	coreSection                = "core"
-	packSection                = "pack"
-	userSection                = "user"
-	tagSection                 = "tag"
-	commitSection              = "commit"
-	authorSection              = "author"
-	committerSection           = "committer"
-	gpgSection                 = "gpg"
-	initSection                = "init"
-	urlSection                 = "url"
-	extensionsSection          = "extensions"
-	protocolSection            = "protocol"
-	fetchKey                   = "fetch"
-	urlKey                     = "url"
-	pushurlKey                 = "pushurl"
-	bareKey                    = "bare"
-	worktreeKey                = "worktree"
-	commentCharKey             = "commentChar"
-	windowKey                  = "window"
-	readReverseIndexKey        = "readReverseIndex"
-	writeReverseIndexKey       = "writeReverseIndex"
-	mergeKey                   = "merge"
-	rebaseKey                  = "rebase"
-	nameKey                    = "name"
-	emailKey                   = "email"
-	signingKey                 = "signingKey"
-	descriptionKey             = "description"
-	defaultBranchKey           = "defaultBranch"
-	repositoryFormatVersionKey = "repositoryformatversion"
-	objectFormatKey            = "objectformat"
-	worktreeConfigKey          = "worktreeConfig"
-	mirrorKey                  = "mirror"
-	versionKey                 = "version"
-	autoCRLFKey                = "autocrlf"
-	fileModeKey                = "filemode"
-	hooksPathKey               = "hooksPath"
-	protectNTFSKey             = "protectNTFS"
-	protectHFSKey              = "protectHFS"
-	indexSection               = "index"
-	skipHashKey                = "skipHash"
-	formatKey                  = "format"
-	allowedSignersFileKey      = "allowedSignersFile"
-	gpgSignKey                 = "gpgSign"
-	uploadArchiveSection       = "uploadArchive"
-	allowUnreachableKey        = "allowUnreachable"
-
-	// DefaultPackWindow holds the number of previous objects used to
-	// generate deltas. The value 10 is the same used by git command.
-	DefaultPackWindow = uint(10)
-	// DefaultFileMode is the default file mode used by git command.
-	DefaultFileMode = true
-)
-
 // Unmarshal parses a git-config file and stores it.
 func (c *Config) Unmarshal(b []byte) error {
-	r := bytes.NewBuffer(b)
-	d := format.NewDecoder(r)
-
 	c.Raw = format.New()
-	if err := d.Decode(c.Raw); err != nil {
+	if err := format.NewDecoder(bytes.NewBuffer(b)).Decode(c.Raw); err != nil {
 		return err
 	}
 
-	c.unmarshalCore()
-	c.unmarshalExtensions()
-	c.unmarshalIndex()
-	c.unmarshalTag()
-	c.unmarshalCommit()
-	c.unmarshalUser()
-	c.unmarshalGPG()
-	c.unmarshalInit()
-	c.unmarshalUploadArchive()
-	if err := c.unmarshalPack(); err != nil {
+	if _, err := c.Raw.Uint("pack.window", uint64(DefaultPackWindow)); err != nil {
 		return err
 	}
-	unmarshalSubmodules(c.Raw, c.Submodules)
-
-	if err := c.unmarshalBranches(); err != nil {
-		return err
-	}
-
-	if err := c.unmarshalURLs(); err != nil {
-		return err
-	}
-
-	if err := c.unmarshalProtocol(); err != nil {
-		return err
-	}
-
-	return c.unmarshalRemotes()
-}
-
-func (c *Config) unmarshalCore() {
-	s := c.Raw.Section(coreSection)
-	if s.Options.Get(bareKey) == "true" {
-		c.Core.IsBare = true
-	}
-
-	c.Core.Worktree = s.Options.Get(worktreeKey)
-	c.Core.CommentChar = s.Options.Get(commentCharKey)
-	c.Core.AutoCRLF = s.Options.Get(autoCRLFKey)
-	c.Core.HooksPath = s.Options.Get(hooksPathKey)
-
-	if parsed := parseConfigBool(s.Options.Get(protectNTFSKey)); parsed.IsSet() {
-		c.Core.ProtectNTFS = parsed
-	}
-
-	if parsed := parseConfigBool(s.Options.Get(protectHFSKey)); parsed.IsSet() {
-		c.Core.ProtectHFS = parsed
-	}
-
-	if fileMode := s.Options.Get(fileModeKey); fileMode == "false" {
-		c.Core.FileMode = false
-	}
-
-	if s.Options.Get(repositoryFormatVersionKey) == string(format.Version1) {
-		c.Core.RepositoryFormatVersion = format.Version1
-	}
-}
-
-func (c *Config) unmarshalExtensions() {
-	s := c.Raw.Section(extensionsSection)
-	c.Extensions.ObjectFormat = format.ObjectFormat(s.Options.Get(objectFormatKey))
-	c.Extensions.WorktreeConfig = strings.EqualFold(s.Options.Get(worktreeConfigKey), "true")
-}
-
-func (c *Config) unmarshalTag() {
-	s := c.Raw.Section(tagSection)
-	v, err := strconv.ParseBool(s.Options.Get(gpgSignKey))
-	if err == nil {
-		c.Tag.GpgSign = NewOptBool(v)
-	}
-}
-
-func (c *Config) unmarshalCommit() {
-	s := c.Raw.Section(commitSection)
-	v, err := strconv.ParseBool(s.Options.Get(gpgSignKey))
-	if err == nil {
-		c.Commit.GpgSign = NewOptBool(v)
-	}
-}
-
-func (c *Config) unmarshalUser() {
-	s := c.Raw.Section(userSection)
-	c.User.Name = s.Options.Get(nameKey)
-	c.User.Email = s.Options.Get(emailKey)
-	c.User.SigningKey = s.Options.Get(signingKey)
-
-	s = c.Raw.Section(authorSection)
-	c.Author.Name = s.Options.Get(nameKey)
-	c.Author.Email = s.Options.Get(emailKey)
-
-	s = c.Raw.Section(committerSection)
-	c.Committer.Name = s.Options.Get(nameKey)
-	c.Committer.Email = s.Options.Get(emailKey)
-}
-
-func (c *Config) unmarshalGPG() {
-	s := c.Raw.Section(gpgSection)
-	c.GPG.Format = s.Options.Get(formatKey)
-
-	// SSH subsection is parsed separately since it uses subsections
-	for _, sub := range s.Subsections {
-		if sub.Name == "ssh" {
-			c.GPG.SSH.AllowedSignersFile = sub.Options.Get(allowedSignersFileKey)
-		}
-	}
-}
-
-func (c *Config) unmarshalPack() error {
-	s := c.Raw.Section(packSection)
-	window := s.Options.Get(windowKey)
-	if window == "" {
-		c.Pack.Window = DefaultPackWindow
-	} else {
-		winUint, err := strconv.ParseUint(window, 10, 32)
-		if err != nil {
+	if rv := c.Raw.Get("protocol.version"); rv != "" {
+		if _, err := protocol.Parse(rv); err != nil {
 			return err
 		}
-		c.Pack.Window = uint(winUint)
 	}
-
-	c.Pack.ReadReverseIndex = s.Options.Get(readReverseIndexKey) != "false"
-	c.Pack.WriteReverseIndex = s.Options.Get(writeReverseIndexKey) != "false"
-
-	return nil
-}
-
-func (c *Config) unmarshalRemotes() error {
-	s := c.Raw.Section(remoteSection)
-	for _, sub := range s.Subsections {
-		r := &RemoteConfig{}
-		if err := r.unmarshal(sub); err != nil {
-			return err
-		}
-
-		c.Remotes[r.Name] = r
+	if _, err := c.remotes(); err != nil {
+		return err
 	}
-
-	// Check if the main remote section still has options
-	// after unmarshaling named subsections - this indicates an empty subsection name
-	if len(s.Options) > 0 {
-		emptySubsection := &format.Subsection{
-			Name:    "",
-			Options: s.Options,
-		}
-
-		r := &RemoteConfig{}
-		if err := r.unmarshal(emptySubsection); err != nil {
-			return err
-		}
-
-		c.Remotes[r.Name] = r
-	}
-	// Apply insteadOf url rules
-	for _, r := range c.Remotes {
-		r.applyURLRules(c.URLs)
+	if _, err := c.branches(); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func (c *Config) unmarshalURLs() error {
-	s := c.Raw.Section(urlSection)
-	c.URLs = make([]*URL, 0, len(s.Subsections))
-	for _, sub := range s.Subsections {
-		r := &URL{}
-		if err := r.unmarshal(sub); err != nil {
-			return err
-		}
-
-		c.URLs = append(c.URLs, r)
-	}
-
-	return nil
-}
-
-func unmarshalSubmodules(fc *format.Config, submodules map[string]*Submodule) {
-	s := fc.Section(submoduleSection)
-	for _, sub := range s.Subsections {
-		m := &Submodule{}
-		m.unmarshal(sub)
-
-		if err := m.Validate(); errors.Is(err, ErrModuleBadPath) ||
-			errors.Is(err, ErrModuleBadName) {
-			continue
-		}
-
-		submodules[m.Name] = m
-	}
-}
-
-func (c *Config) unmarshalBranches() error {
-	bs := c.Raw.Section(branchSection)
-	for _, sub := range bs.Subsections {
-		b := &Branch{}
-
-		if err := b.unmarshal(sub); err != nil {
-			return err
-		}
-
-		c.Branches[b.Name] = b
-	}
-	return nil
-}
-
-func (c *Config) unmarshalProtocol() error {
-	s := c.Raw.Section(protocolSection)
-
-	c.Protocol.Version = DefaultProtocolVersion
-
-	// If empty, don't try to parse and instead fallback
-	// to default protocol version.
-	if rv := s.Options.Get(versionKey); rv != "" {
-		v, err := protocol.Parse(rv)
-		if err != nil {
-			return err
-		}
-		c.Protocol.Version = v
-	}
-
-	return nil
-}
-
-func (c *Config) unmarshalIndex() {
-	s := c.Raw.Section(indexSection)
-	v, err := strconv.ParseBool(s.Options.Get(skipHashKey))
-	if err == nil {
-		c.Index.SkipHash = NewOptBool(v)
-	}
-}
-
-func (c *Config) unmarshalInit() {
-	s := c.Raw.Section(initSection)
-	c.Init.DefaultBranch = s.Options.Get(defaultBranchKey)
-}
-
-func (c *Config) unmarshalUploadArchive() {
-	s := c.Raw.Section(uploadArchiveSection)
-	v, err := strconv.ParseBool(s.Options.Get(allowUnreachableKey))
-	if err == nil {
-		c.UploadArchive.AllowUnreachable = NewOptBool(v)
-	}
-}
-
-// Marshal returns Config encoded as a git-config file.
-//
-// This call populates the field Raw with the current values of
-// the config.
+// Marshal returns Config encoded as a git-config file. Because Raw is the
+// single source of truth, this simply encodes it.
 func (c *Config) Marshal() ([]byte, error) {
 	if c.Raw == nil {
 		c.Raw = format.New()
 	}
-
-	c.marshalCore()
-	c.marshalExtensions()
-	c.marshalIndex()
-	c.marshalTag()
-	c.marshalCommit()
-	c.marshalUser()
-	c.marshalGPG()
-	c.marshalPack()
-	c.marshalRemotes()
-	c.marshalSubmodules()
-	c.marshalBranches()
-	c.marshalURLs()
-	c.marshalProtocol()
-	c.marshalInit()
-	c.marshalUploadArchive()
 
 	buf := bytes.NewBuffer(nil)
 	if err := format.NewEncoder(buf).Encode(c.Raw); err != nil {
@@ -780,243 +726,23 @@ func (c *Config) Marshal() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (c *Config) marshalCore() {
-	s := c.Raw.Section(coreSection)
-	s.SetOption(bareKey, fmt.Sprintf("%t", c.Core.IsBare))
-	if string(c.Core.RepositoryFormatVersion) != "" {
-		s.SetOption(repositoryFormatVersionKey, string(c.Core.RepositoryFormatVersion))
-	}
-
-	if c.Core.Worktree != "" {
-		s.SetOption(worktreeKey, c.Core.Worktree)
-	}
-
-	if c.Core.AutoCRLF != "" {
-		s.SetOption(autoCRLFKey, c.Core.AutoCRLF)
-	}
-
-	s.SetOption(fileModeKey, fmt.Sprintf("%t", c.Core.FileMode))
-
-	if c.Core.HooksPath != "" {
-		s.SetOption(hooksPathKey, c.Core.HooksPath)
-	}
-
-	if c.Core.ProtectNTFS.IsSet() {
-		s.SetOption(protectNTFSKey, c.Core.ProtectNTFS.FormatBool())
-	}
-
-	if c.Core.ProtectHFS.IsSet() {
-		s.SetOption(protectHFSKey, c.Core.ProtectHFS.FormatBool())
-	}
-}
-
-func (c *Config) marshalExtensions() {
-	// Extensions are only supported on Version 1, therefore
-	// don't marshal it otherwise.
-	if c.Core.RepositoryFormatVersion != format.Version1 {
+// setOrUnset sets key to val, or removes it when val is empty.
+func setOrUnset(raw *format.Config, key, val string) {
+	if val == "" {
+		raw.Unset(key)
 		return
 	}
+	raw.Set(key, val)
+}
 
-	// Only marshal the [extensions] section if there are extension options to write.
-	// This avoids introducing an empty [extensions] section on round-trips.
-	if c.Extensions.ObjectFormat == format.UnsetObjectFormat &&
-		!c.Extensions.WorktreeConfig {
+// setOptBool writes a tri-state boolean: the formatted value when set, or the
+// key removed when unset.
+func setOptBool(raw *format.Config, key string, v OptBool) {
+	if v.IsSet() {
+		raw.Set(key, v.FormatBool())
 		return
 	}
-
-	s := c.Raw.Section(extensionsSection)
-	if c.Extensions.ObjectFormat != format.UnsetObjectFormat {
-		s.SetOption(objectFormatKey, string(c.Extensions.ObjectFormat))
-	}
-
-	if c.Extensions.WorktreeConfig {
-		s.SetOption(worktreeConfigKey, "true")
-	}
-}
-
-func (c *Config) marshalTag() {
-	s := c.Raw.Section(tagSection)
-	if c.Tag.GpgSign.IsSet() {
-		s.SetOption(gpgSignKey, c.Tag.GpgSign.FormatBool())
-	}
-}
-
-func (c *Config) marshalCommit() {
-	s := c.Raw.Section(commitSection)
-	if c.Commit.GpgSign.IsSet() {
-		s.SetOption(gpgSignKey, c.Commit.GpgSign.FormatBool())
-	}
-}
-
-func (c *Config) marshalUser() {
-	s := c.Raw.Section(userSection)
-	if c.User.Name != "" {
-		s.SetOption(nameKey, c.User.Name)
-	}
-
-	if c.User.Email != "" {
-		s.SetOption(emailKey, c.User.Email)
-	}
-
-	if c.User.SigningKey != "" {
-		s.SetOption(signingKey, c.User.SigningKey)
-	}
-
-	s = c.Raw.Section(authorSection)
-	if c.Author.Name != "" {
-		s.SetOption(nameKey, c.Author.Name)
-	}
-
-	if c.Author.Email != "" {
-		s.SetOption(emailKey, c.Author.Email)
-	}
-
-	s = c.Raw.Section(committerSection)
-	if c.Committer.Name != "" {
-		s.SetOption(nameKey, c.Committer.Name)
-	}
-
-	if c.Committer.Email != "" {
-		s.SetOption(emailKey, c.Committer.Email)
-	}
-}
-
-func (c *Config) marshalGPG() {
-	s := c.Raw.Section(gpgSection)
-	if c.GPG.Format != "" {
-		s.SetOption(formatKey, c.GPG.Format)
-	}
-
-	// SSH subsection
-	if c.GPG.SSH.AllowedSignersFile != "" {
-		sub := s.Subsection("ssh")
-		sub.SetOption(allowedSignersFileKey, c.GPG.SSH.AllowedSignersFile)
-	}
-}
-
-func (c *Config) marshalPack() {
-	s := c.Raw.Section(packSection)
-	if c.Pack.Window != DefaultPackWindow {
-		s.SetOption(windowKey, fmt.Sprintf("%d", c.Pack.Window))
-	}
-	if !c.Pack.ReadReverseIndex {
-		s.SetOption(readReverseIndexKey, "false")
-	}
-	if !c.Pack.WriteReverseIndex {
-		s.SetOption(writeReverseIndexKey, "false")
-	}
-}
-
-func (c *Config) marshalRemotes() {
-	s := c.Raw.Section(remoteSection)
-	newSubsections := make(format.Subsections, 0, len(c.Remotes))
-	added := make(map[string]bool)
-	for _, subsection := range s.Subsections {
-		if remote, ok := c.Remotes[subsection.Name]; ok {
-			newSubsections = append(newSubsections, remote.marshal())
-			added[subsection.Name] = true
-		}
-	}
-
-	remoteNames := make([]string, 0, len(c.Remotes))
-	for name := range c.Remotes {
-		remoteNames = append(remoteNames, name)
-	}
-
-	sort.Strings(remoteNames)
-
-	for _, name := range remoteNames {
-		if !added[name] {
-			newSubsections = append(newSubsections, c.Remotes[name].marshal())
-		}
-	}
-
-	s.Subsections = newSubsections
-}
-
-func (c *Config) marshalSubmodules() {
-	s := c.Raw.Section(submoduleSection)
-	s.Subsections = make(format.Subsections, len(c.Submodules))
-
-	var i int
-	for _, r := range c.Submodules {
-		section := r.marshal()
-		// the submodule section at config is a subset of the .gitmodule file
-		// we should remove the non-valid options for the config file.
-		section.RemoveOption(pathKey)
-		s.Subsections[i] = section
-		i++
-	}
-}
-
-func (c *Config) marshalBranches() {
-	s := c.Raw.Section(branchSection)
-	newSubsections := make(format.Subsections, 0, len(c.Branches))
-	added := make(map[string]bool)
-	for _, subsection := range s.Subsections {
-		if branch, ok := c.Branches[subsection.Name]; ok {
-			newSubsections = append(newSubsections, branch.marshal())
-			added[subsection.Name] = true
-		}
-	}
-
-	branchNames := make([]string, 0, len(c.Branches))
-	for name := range c.Branches {
-		branchNames = append(branchNames, name)
-	}
-
-	sort.Strings(branchNames)
-
-	for _, name := range branchNames {
-		if !added[name] {
-			newSubsections = append(newSubsections, c.Branches[name].marshal())
-		}
-	}
-
-	s.Subsections = newSubsections
-}
-
-func (c *Config) marshalURLs() {
-	s := c.Raw.Section(urlSection)
-	s.Subsections = make(format.Subsections, len(c.URLs))
-
-	var i int
-	for _, r := range c.URLs {
-		section := r.marshal()
-		// the submodule section at config is a subset of the .gitmodule file
-		// we should remove the non-valid options for the config file.
-		s.Subsections[i] = section
-		i++
-	}
-}
-
-func (c *Config) marshalProtocol() {
-	// Only marshal protocol section if a version was set.
-	if c.Protocol.Version != DefaultProtocolVersion {
-		s := c.Raw.Section(protocolSection)
-		s.SetOption(versionKey, c.Protocol.Version.String())
-	}
-}
-
-func (c *Config) marshalIndex() {
-	if c.Index.SkipHash.IsSet() {
-		s := c.Raw.Section(indexSection)
-		s.SetOption(skipHashKey, c.Index.SkipHash.FormatBool())
-	}
-}
-
-func (c *Config) marshalInit() {
-	s := c.Raw.Section(initSection)
-	if c.Init.DefaultBranch != "" {
-		s.SetOption(defaultBranchKey, c.Init.DefaultBranch)
-	}
-}
-
-func (c *Config) marshalUploadArchive() {
-	if c.UploadArchive.AllowUnreachable.IsSet() {
-		s := c.Raw.Section(uploadArchiveSection)
-		s.SetOption(allowUnreachableKey, c.UploadArchive.AllowUnreachable.FormatBool())
-	}
+	raw.Unset(key)
 }
 
 // RemoteConfig contains the configuration for a given remote repository.
@@ -1082,7 +808,11 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
 	c.URLs = append(c.URLs, c.raw.Options.GetAll(pushurlKey)...)
 	c.Fetch = fetch
-	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
+	if c.raw.Options.Has(mirrorKey) {
+		if b, err := format.ParseBool(c.raw.Options.Get(mirrorKey)); err == nil {
+			c.Mirror = b
+		}
+	}
 
 	return nil
 }
@@ -1132,8 +862,8 @@ func (c *RemoteConfig) applyURLRules(urlRules []*URL) {
 	originalURLs := make([]string, len(c.URLs))
 	copy(originalURLs, c.URLs)
 
-	for i, url := range c.URLs {
-		if rewrittenURL, matched := applyLongestInsteadOfMatch(url, urlRules); matched {
+	for i, u := range c.URLs {
+		if rewrittenURL, matched := applyLongestInsteadOfMatch(u, urlRules); matched {
 			c.URLs[i] = rewrittenURL
 			c.insteadOfRulesApplied = true
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,18 @@ func TestConfigSuite(t *testing.T) {
 	suite.Run(t, new(ConfigSuite))
 }
 
+func configWith(setup func(*Config)) *Config {
+	c := &Config{Raw: config.New()}
+	if setup != nil {
+		setup(c)
+	}
+	return c
+}
+
+func configValueWith(setup func(*Config)) Config {
+	return *configWith(setup)
+}
+
 func (s *ConfigSuite) TestUnmarshal() {
 	input := []byte(`[core]
 		bare = true
@@ -73,59 +85,61 @@ func (s *ConfigSuite) TestUnmarshal() {
 	err := cfg.Unmarshal(input)
 	s.NoError(err)
 
-	s.True(cfg.Core.IsBare)
-	s.Equal("foo", cfg.Core.Worktree)
-	s.Equal("bar", cfg.Core.CommentChar)
-	s.Equal("true", cfg.Core.AutoCRLF)
-	s.False(cfg.Core.FileMode)
-	s.Equal("custom-hooks", cfg.Core.HooksPath)
-	s.Equal("John Doe", cfg.User.Name)
-	s.Equal("john@example.com", cfg.User.Email)
-	s.Equal("Jane Roe", cfg.Author.Name)
-	s.Equal("jane@example.com", cfg.Author.Email)
-	s.Equal("Richard Roe", cfg.Committer.Name)
-	s.Equal("richard@example.com", cfg.Committer.Email)
-	s.Equal(uint(20), cfg.Pack.Window)
-	s.Len(cfg.Remotes, 4)
-	s.Equal("origin", cfg.Remotes["origin"].Name)
-	s.Equal([]string{"git@github.com:mcuadros/go-git.git"}, cfg.Remotes["origin"].URLs)
-	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, cfg.Remotes["origin"].Fetch)
-	s.Equal("alt", cfg.Remotes["alt"].Name)
-	s.Equal([]string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"}, cfg.Remotes["alt"].URLs)
-	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"}, cfg.Remotes["alt"].Fetch)
-	s.Equal("win-local", cfg.Remotes["win-local"].Name)
-	s.Equal([]string{"X:\\Git\\"}, cfg.Remotes["win-local"].URLs)
-	s.Equal([]string{"ssh://git@github.com/kostyay/go-git.git"}, cfg.Remotes["insteadOf"].URLs)
-	s.Len(cfg.Submodules, 1)
-	s.Equal("qux", cfg.Submodules["qux"].Name)
-	s.Equal("https://github.com/foo/qux.git", cfg.Submodules["qux"].URL)
-	s.Equal("bar", cfg.Submodules["qux"].Branch)
-	s.Equal("origin", cfg.Branches["master"].Remote)
-	s.Equal(plumbing.ReferenceName("refs/heads/master"), cfg.Branches["master"].Merge)
-	s.Equal("Add support for branch description.\n\nEdit branch description: git branch --edit-description\n", cfg.Branches["master"].Description)
-	s.Equal("main", cfg.Init.DefaultBranch)
+	s.True(cfg.Core().IsBare)
+	s.Equal("foo", cfg.Core().Worktree)
+	s.Equal("bar", cfg.Core().CommentChar)
+	s.Equal("true", cfg.Core().AutoCRLF)
+	s.False(cfg.Core().FileMode)
+	s.Equal("custom-hooks", cfg.Core().HooksPath)
+	s.Equal("John Doe", cfg.User().Name)
+	s.Equal("john@example.com", cfg.User().Email)
+	s.Equal("Jane Roe", cfg.Author().Name)
+	s.Equal("jane@example.com", cfg.Author().Email)
+	s.Equal("Richard Roe", cfg.Committer().Name)
+	s.Equal("richard@example.com", cfg.Committer().Email)
+	s.Equal(uint(20), cfg.Pack().Window)
+	s.Len(cfg.Remotes(), 4)
+	s.Equal("origin", cfg.Remotes()["origin"].Name)
+	s.Equal([]string{"git@github.com:mcuadros/go-git.git"}, cfg.Remotes()["origin"].URLs)
+	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, cfg.Remotes()["origin"].Fetch)
+	s.Equal("alt", cfg.Remotes()["alt"].Name)
+	s.Equal([]string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"}, cfg.Remotes()["alt"].URLs)
+	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"}, cfg.Remotes()["alt"].Fetch)
+	s.Equal("win-local", cfg.Remotes()["win-local"].Name)
+	s.Equal([]string{"X:\\Git\\"}, cfg.Remotes()["win-local"].URLs)
+	s.Equal([]string{"ssh://git@github.com/kostyay/go-git.git"}, cfg.Remotes()["insteadOf"].URLs)
+	s.Len(cfg.Submodules(), 1)
+	s.Equal("qux", cfg.Submodules()["qux"].Name)
+	s.Equal("https://github.com/foo/qux.git", cfg.Submodules()["qux"].URL)
+	s.Equal("bar", cfg.Submodules()["qux"].Branch)
+	s.Equal("origin", cfg.Branches()["master"].Remote)
+	s.Equal(plumbing.ReferenceName("refs/heads/master"), cfg.Branches()["master"].Merge)
+	s.Equal("Add support for branch description.\n\nEdit branch description: git branch --edit-description\n", cfg.Branches()["master"].Description)
+	s.Equal("main", cfg.Init().DefaultBranch)
 }
 
 func (s *ConfigSuite) TestMarshal() {
 	output := []byte(`[core]
+	filemode = true
 	bare = true
 	worktree = bar
 	autocrlf = true
-	filemode = true
 	hooksPath = custom-hooks
 [pack]
 	window = 20
+[init]
+	defaultBranch = main
+[remote "origin"]
+	url = git@github.com:mcuadros/go-git.git
 [remote "alt"]
 	url = git@github.com:mcuadros/go-git.git
 	url = git@github.com:src-d/go-git.git
 	fetch = +refs/heads/*:refs/remotes/origin/*
 	fetch = +refs/pull/*:refs/remotes/origin/pull/*
-[remote "insteadOf"]
-	url = https://github.com/kostyay/go-git.git
-[remote "origin"]
-	url = git@github.com:mcuadros/go-git.git
 [remote "win-local"]
 	url = "X:\\Git\\"
+[remote "insteadOf"]
+	url = https://github.com/kostyay/go-git.git
 [submodule "qux"]
 	url = https://github.com/foo/qux.git
 [branch "master"]
@@ -134,51 +148,49 @@ func (s *ConfigSuite) TestMarshal() {
 	description = "Add support for branch description.\\n\\nEdit branch description: git branch --edit-description\\n"
 [url "ssh://git@github.com/"]
 	insteadOf = https://github.com/
-[init]
-	defaultBranch = main
 `)
 
 	cfg := NewConfig()
-	cfg.Core.IsBare = true
-	cfg.Core.Worktree = "bar"
-	cfg.Core.AutoCRLF = "true"
-	cfg.Core.HooksPath = "custom-hooks"
-	cfg.Pack.Window = 20
-	cfg.Init.DefaultBranch = "main"
-	cfg.Remotes["origin"] = &RemoteConfig{
+	cfg.SetBare(true)
+	cfg.SetWorktree("bar")
+	cfg.SetAutoCRLF("true")
+	cfg.SetHooksPath("custom-hooks")
+	cfg.SetPackWindow(20)
+	cfg.SetInitDefaultBranch("main")
+	cfg.SetRemote(&RemoteConfig{
 		Name: "origin",
 		URLs: []string{"git@github.com:mcuadros/go-git.git"},
-	}
+	})
 
-	cfg.Remotes["alt"] = &RemoteConfig{
+	cfg.SetRemote(&RemoteConfig{
 		Name:  "alt",
 		URLs:  []string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"},
 		Fetch: []RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"},
-	}
+	})
 
-	cfg.Remotes["win-local"] = &RemoteConfig{
+	cfg.SetRemote(&RemoteConfig{
 		Name: "win-local",
 		URLs: []string{"X:\\Git\\"},
-	}
+	})
 
-	cfg.Remotes["insteadOf"] = &RemoteConfig{
+	cfg.SetRemote(&RemoteConfig{
 		Name: "insteadOf",
 		URLs: []string{"https://github.com/kostyay/go-git.git"},
-	}
+	})
 
-	cfg.Submodules["qux"] = &Submodule{
+	cfg.SetSubmodule(&Submodule{
 		Name: "qux",
 		URL:  "https://github.com/foo/qux.git",
-	}
+	})
 
-	cfg.Branches["master"] = &Branch{
+	cfg.SetBranch(&Branch{
 		Name:        "master",
 		Remote:      "origin",
 		Merge:       "refs/heads/master",
 		Description: "Add support for branch description.\n\nEdit branch description: git branch --edit-description\n",
-	}
+	})
 
-	cfg.URLs = append(cfg.URLs, &URL{
+	cfg.AddURL(&URL{
 		Name:       "ssh://git@github.com/",
 		InsteadOfs: []string{"https://github.com/"},
 	})
@@ -281,27 +293,27 @@ func TestMarshalExtensions(t *testing.T) {
 		{
 			name: "WorktreeConfig true writes section",
 			setup: func(c *Config) {
-				c.Core.RepositoryFormatVersion = config.Version1
-				c.Extensions.WorktreeConfig = true
+				c.SetRepositoryFormatVersion(config.Version1)
+				c.SetWorktreeConfig(true)
 			},
 			wantSection: true,
 		},
 		{
 			name: "ObjectFormat set writes section",
 			setup: func(c *Config) {
-				c.Core.RepositoryFormatVersion = config.Version1
-				c.Extensions.ObjectFormat = config.SHA256
+				c.SetRepositoryFormatVersion(config.Version1)
+				c.SetObjectFormat(config.SHA256)
 			},
 			wantSection: true,
 		},
 		{
-			name: "RepositoryFormat = 0 ignores section",
+			name: "extensions written regardless of repository format version",
 			setup: func(c *Config) {
-				c.Core.RepositoryFormatVersion = config.Version0
-				c.Extensions.ObjectFormat = config.SHA256
-				c.Extensions.WorktreeConfig = true
+				c.SetRepositoryFormatVersion(config.Version0)
+				c.SetObjectFormat(config.SHA256)
+				c.SetWorktreeConfig(true)
 			},
-			wantSection: false,
+			wantSection: true,
 		},
 	}
 
@@ -323,8 +335,7 @@ func TestMarshalExtensions(t *testing.T) {
 
 func (s *ConfigSuite) TestLoadConfigXDG() {
 	cfg := NewConfig()
-	cfg.User.Name = "foo"
-	cfg.User.Email = "foo@foo.com"
+	cfg.SetUser(User{Name: "foo", Email: "foo@foo.com"})
 
 	tmp := s.T().TempDir()
 
@@ -346,50 +357,34 @@ func (s *ConfigSuite) TestLoadConfigXDG() {
 	cfg, err = LoadConfig(GlobalScope)
 	s.NoError(err)
 
-	s.Equal("foo@foo.com", cfg.User.Email)
+	s.Equal("foo@foo.com", cfg.User().Email)
 }
 
 func (s *ConfigSuite) TestValidateConfig() {
-	config := &Config{
-		Remotes: map[string]*RemoteConfig{
-			"bar": {
-				Name: "bar",
-				URLs: []string{"http://foo/bar"},
-			},
-		},
-		Branches: map[string]*Branch{
-			"bar": {
-				Name: "bar",
-			},
-			"foo": {
-				Name:   "foo",
-				Remote: "origin",
-				Merge:  plumbing.ReferenceName("refs/heads/foo"),
-			},
-		},
-	}
+	config := configWith(func(c *Config) {
+		c.SetRemote(&RemoteConfig{
+			Name: "bar",
+			URLs: []string{"http://foo/bar"},
+		})
+		c.SetBranch(&Branch{
+			Name: "bar",
+		})
+		c.SetBranch(&Branch{
+			Name:   "foo",
+			Remote: "origin",
+			Merge:  plumbing.ReferenceName("refs/heads/foo"),
+		})
+	})
 
 	s.NoError(config.Validate())
 }
 
 func (s *ConfigSuite) TestValidateInvalidRemote() {
-	config := &Config{
-		Remotes: map[string]*RemoteConfig{
-			"foo": {Name: "foo"},
-		},
-	}
+	config := configWith(func(c *Config) {
+		c.SetRemote(&RemoteConfig{Name: "foo"})
+	})
 
 	s.ErrorIs(config.Validate(), ErrRemoteConfigEmptyURL)
-}
-
-func (s *ConfigSuite) TestValidateInvalidRemoteKey() {
-	config := &Config{
-		Remotes: map[string]*RemoteConfig{
-			"bar": {Name: "foo"},
-		},
-	}
-
-	s.ErrorIs(config.Validate(), ErrInvalid)
 }
 
 func (s *ConfigSuite) TestRemoteConfigValidateMissingURL() {
@@ -411,37 +406,21 @@ func (s *ConfigSuite) TestRemoteConfigValidateDefault() {
 	s.Equal("+refs/heads/*:refs/remotes/foo/*", fetch[0].String())
 }
 
-func (s *ConfigSuite) TestValidateInvalidBranchKey() {
-	config := &Config{
-		Branches: map[string]*Branch{
-			"foo": {
-				Name:   "bar",
-				Remote: "origin",
-				Merge:  plumbing.ReferenceName("refs/heads/bar"),
-			},
-		},
-	}
-
-	s.ErrorIs(config.Validate(), ErrInvalid)
-}
-
 func (s *ConfigSuite) TestValidateBranchNonRefsPrefix() {
 	// Real git allows any value for branch.*.merge, including values
 	// without a refs/ prefix. Validate should accept them.
-	config := &Config{
-		Branches: map[string]*Branch{
-			"bar": {
-				Name:   "bar",
-				Remote: "origin",
-				Merge:  plumbing.ReferenceName("refs/heads/bar"),
-			},
-			"foo": {
-				Name:   "foo",
-				Remote: "origin",
-				Merge:  plumbing.ReferenceName("baz"),
-			},
-		},
-	}
+	config := configWith(func(c *Config) {
+		c.SetBranch(&Branch{
+			Name:   "bar",
+			Remote: "origin",
+			Merge:  plumbing.ReferenceName("refs/heads/bar"),
+		})
+		c.SetBranch(&Branch{
+			Name:   "foo",
+			Remote: "origin",
+			Merge:  plumbing.ReferenceName("baz"),
+		})
+	})
 
 	s.NoError(config.Validate())
 }
@@ -449,11 +428,11 @@ func (s *ConfigSuite) TestValidateBranchNonRefsPrefix() {
 func (s *ConfigSuite) TestRemoteConfigDefaultValues() {
 	config := NewConfig()
 
-	s.Len(config.Remotes, 0)
-	s.Len(config.Branches, 0)
-	s.Len(config.Submodules, 0)
+	s.Len(config.Remotes(), 0)
+	s.Len(config.Branches(), 0)
+	s.Len(config.Submodules(), 0)
 	s.NotNil(config.Raw)
-	s.Equal(DefaultPackWindow, config.Pack.Window)
+	s.Equal(DefaultPackWindow, config.Pack().Window)
 }
 
 func (s *ConfigSuite) TestLoadConfigLocalScope() {
@@ -473,8 +452,10 @@ func (s *ConfigSuite) TestRemoveUrlOptions() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(buf)
 	s.NoError(err)
-	s.Len(cfg.Remotes, 1)
-	cfg.Remotes["alt"].URLs = []string{}
+	s.Len(cfg.Remotes(), 1)
+	alt := cfg.Remote("alt")
+	alt.URLs = []string{}
+	cfg.SetRemote(alt)
 
 	buf, err = cfg.Marshal()
 	s.NoError(err)
@@ -492,9 +473,9 @@ func (s *ConfigSuite) TestProtocol() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(buf)
 	s.NoError(err)
-	s.Equal(protocol.V1, cfg.Protocol.Version)
+	s.Equal(protocol.V1, cfg.Protocol().Version)
 
-	cfg.Protocol.Version = protocol.V2
+	cfg.SetProtocolVersion(protocol.V2)
 	buf, err = cfg.Marshal()
 	s.NoError(err)
 
@@ -523,8 +504,8 @@ func (s *ConfigSuite) TestUnmarshalRemotes() {
 	err := cfg.Unmarshal(input)
 	s.NoError(err)
 
-	s.Equal("https://git.sr.ht/~mcepl/go-git", cfg.Remotes["origin"].URLs[0])
-	s.Equal("git@git.sr.ht:~mcepl/go-git.git", cfg.Remotes["origin"].URLs[1])
+	s.Equal("https://git.sr.ht/~mcepl/go-git", cfg.Remotes()["origin"].URLs[0])
+	s.Equal("git@git.sr.ht:~mcepl/go-git.git", cfg.Remotes()["origin"].URLs[1])
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotesUnnamedFirst() {
@@ -541,12 +522,12 @@ func (s *ConfigSuite) TestUnmarshalRemotesUnnamedFirst() {
 	err := cfg.Unmarshal(input)
 	s.NoError(err)
 
-	unnamedRemote, ok := cfg.Remotes[""]
+	unnamedRemote, ok := cfg.Remotes()[""]
 	s.True(ok, "Expected unnamed remote to be present")
 	s.Equal([]string{"https://github.com/CLBRITTON2/go-git.git"}, unnamedRemote.URLs)
 	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
 
-	namedRemote, ok := cfg.Remotes["upstream"]
+	namedRemote, ok := cfg.Remotes()["upstream"]
 	s.True(ok, "Expected named remote 'upstream' to be present")
 	s.Equal([]string{"https://github.com/go-git/go-git.git"}, namedRemote.URLs)
 	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
@@ -566,12 +547,12 @@ func (s *ConfigSuite) TestUnmarshalRemotesNamedFirst() {
 	err := cfg.Unmarshal(input)
 	s.NoError(err)
 
-	namedRemote, ok := cfg.Remotes["upstream"]
+	namedRemote, ok := cfg.Remotes()["upstream"]
 	s.True(ok, "Expected a named remote 'upstream' to be present")
 	s.Equal([]string{"https://github.com/go-git/go-git.git"}, namedRemote.URLs)
 	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
 
-	unnamedRemote, ok := cfg.Remotes[""]
+	unnamedRemote, ok := cfg.Remotes()[""]
 	s.True(ok, "Expected an unnamed remote to be present")
 	s.Equal([]string{"https://github.com/CLBRITTON2/go-git.git"}, unnamedRemote.URLs)
 	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
@@ -632,8 +613,8 @@ func TestUnmarshalPackReverseIndex(t *testing.T) {
 			err := cfg.Unmarshal([]byte(tc.input))
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.wantRead, cfg.Pack.ReadReverseIndex)
-			assert.Equal(t, tc.wantWrite, cfg.Pack.WriteReverseIndex)
+			assert.Equal(t, tc.wantRead, cfg.Pack().ReadReverseIndex)
+			assert.Equal(t, tc.wantWrite, cfg.Pack().WriteReverseIndex)
 		})
 	}
 }
@@ -683,8 +664,8 @@ func TestMarshalPackReverseIndex(t *testing.T) {
 			t.Parallel()
 
 			cfg := NewConfig()
-			cfg.Pack.ReadReverseIndex = tc.read
-			cfg.Pack.WriteReverseIndex = tc.write
+			cfg.SetPackReadReverseIndex(tc.read)
+			cfg.SetPackWriteReverseIndex(tc.write)
 
 			b, err := cfg.Marshal()
 			require.NoError(t, err)
@@ -764,7 +745,7 @@ func TestUnmarshalIndexSkipHash(t *testing.T) {
 			err := cfg.Unmarshal([]byte(tc.input))
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.want, cfg.Index.SkipHash)
+			assert.Equal(t, tc.want, cfg.Index().SkipHash)
 		})
 	}
 }
@@ -773,7 +754,7 @@ func TestMarshalIndexSkipHash(t *testing.T) {
 	t.Parallel()
 
 	cfg := NewConfig()
-	cfg.Index.SkipHash = OptBoolTrue
+	cfg.SetIndexSkipHash(OptBoolTrue)
 
 	b, err := cfg.Marshal()
 	require.NoError(t, err)
@@ -783,7 +764,7 @@ func TestMarshalIndexSkipHash(t *testing.T) {
 	cfg2 := NewConfig()
 	err = cfg2.Unmarshal(b)
 	require.NoError(t, err)
-	assert.Equal(t, OptBoolTrue, cfg2.Index.SkipHash)
+	assert.Equal(t, OptBoolTrue, cfg2.Index().SkipHash)
 }
 
 func TestMerge(t *testing.T) {
@@ -801,142 +782,106 @@ func TestMerge(t *testing.T) {
 		{
 			name: "separate objs",
 			input: []*Config{
-				{User: user{
-					Name: "foo", Email: "bar@test",
-				}},
-				{
-					Extensions: struct {
-						ObjectFormat   config.ObjectFormat
-						WorktreeConfig bool
-					}{
-						ObjectFormat:   config.SHA256,
-						WorktreeConfig: true,
-					},
-				},
+				configWith(func(c *Config) {
+					c.SetUser(User{Name: "foo", Email: "bar@test"})
+				}),
+				configWith(func(c *Config) {
+					c.SetObjectFormat(config.SHA256)
+					c.SetWorktreeConfig(true)
+				}),
 			},
-			want: Config{
-				User: user{
-					Name:  "foo",
-					Email: "bar@test",
-				},
-				Extensions: struct {
-					ObjectFormat   config.ObjectFormat
-					WorktreeConfig bool
-				}{
-					ObjectFormat:   config.SHA256,
-					WorktreeConfig: true,
-				},
-			},
+			want: configValueWith(func(c *Config) {
+				c.SetUser(User{Name: "foo", Email: "bar@test"})
+				c.SetObjectFormat(config.SHA256)
+				c.SetWorktreeConfig(true)
+			}),
 		},
 		{
 			name: "merge nested fields",
 			input: []*Config{
-				{User: user{Name: "foo"}},
-				{User: user{Email: "bar@test"}},
+				configWith(func(c *Config) {
+					c.SetUser(User{Name: "foo"})
+				}),
+				configWith(func(c *Config) {
+					c.SetUser(User{Email: "bar@test"})
+				}),
 			},
-			want: Config{
-				User: user{
-					Name:  "foo",
-					Email: "bar@test",
-				},
-			},
+			want: configValueWith(func(c *Config) {
+				c.SetUser(User{Name: "foo", Email: "bar@test"})
+			}),
 		},
 		{
 			name: "override nested fields",
 			input: []*Config{
-				{User: user{Name: "foo"}},
-				{User: user{Name: "bar", Email: "foo@test"}},
+				configWith(func(c *Config) {
+					c.SetUser(User{Name: "foo"})
+				}),
+				configWith(func(c *Config) {
+					c.SetUser(User{Name: "bar", Email: "foo@test"})
+				}),
 			},
-			want: Config{
-				User: user{
-					Name:  "bar",
-					Email: "foo@test",
-				},
-			},
+			want: configValueWith(func(c *Config) {
+				c.SetUser(User{Name: "bar", Email: "foo@test"})
+			}),
 		},
 		{
 			name: "src nil map preserves dst map",
 			input: []*Config{
-				{
-					Remotes: map[string]*RemoteConfig{
-						"origin": {Name: "origin", URLs: []string{"https://example.com/repo.git"}},
-					},
-				},
-				{
+				configWith(func(c *Config) {
+					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+				}),
+				configWith(func(c *Config) {
 					// Remotes is nil (zero value)
-					Branches: map[string]*Branch{
-						"main": {Name: "main"},
-					},
-				},
+					c.SetBranch(&Branch{Name: "main"})
+				}),
 			},
-			want: Config{
-				Remotes: map[string]*RemoteConfig{
-					"origin": {Name: "origin", URLs: []string{"https://example.com/repo.git"}},
-				},
-				Branches: map[string]*Branch{
-					"main": {Name: "main"},
-				},
-			},
+			want: configValueWith(func(c *Config) {
+				c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+				c.SetBranch(&Branch{Name: "main"})
+			}),
 		},
 		{
 			name: "src empty map preserves dst map",
 			input: []*Config{
-				{
-					Remotes: map[string]*RemoteConfig{
-						"origin": {Name: "origin", URLs: []string{"https://example.com/repo.git"}},
-					},
-				},
-				{
+				configWith(func(c *Config) {
+					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+				}),
+				configWith(func(_ *Config) {
 					// Remotes is explicitly initialised but empty (mirrors NewConfig behaviour).
-					Remotes: map[string]*RemoteConfig{},
-				},
+				}),
 			},
-			want: Config{
-				Remotes: map[string]*RemoteConfig{
-					"origin": {Name: "origin", URLs: []string{"https://example.com/repo.git"}},
-				},
-			},
+			want: configValueWith(func(c *Config) {
+				c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+			}),
 		},
 		{
 			name: "merge maps with disjoint keys",
 			input: []*Config{
-				{
-					Remotes: map[string]*RemoteConfig{
-						"origin": {Name: "origin", URLs: []string{"https://example.com/repo.git"}},
-					},
-				},
-				{
-					Remotes: map[string]*RemoteConfig{
-						"upstream": {Name: "upstream", URLs: []string{"https://upstream.com/repo.git"}},
-					},
-				},
+				configWith(func(c *Config) {
+					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+				}),
+				configWith(func(c *Config) {
+					c.SetRemote(&RemoteConfig{Name: "upstream", URLs: []string{"https://upstream.com/repo.git"}})
+				}),
 			},
-			want: Config{
-				Remotes: map[string]*RemoteConfig{
-					"origin":   {Name: "origin", URLs: []string{"https://example.com/repo.git"}},
-					"upstream": {Name: "upstream", URLs: []string{"https://upstream.com/repo.git"}},
-				},
-			},
+			want: configValueWith(func(c *Config) {
+				c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+				c.SetRemote(&RemoteConfig{Name: "upstream", URLs: []string{"https://upstream.com/repo.git"}})
+			}),
 		},
 		{
 			name: "src map entry overrides dst map entry",
 			input: []*Config{
-				{
-					Remotes: map[string]*RemoteConfig{
-						"origin": {Name: "origin", URLs: []string{"https://old.com/repo.git"}},
-					},
-				},
-				{
-					Remotes: map[string]*RemoteConfig{
-						"origin": {Name: "origin", URLs: []string{"https://new.com/repo.git"}},
-					},
-				},
+				configWith(func(c *Config) {
+					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://old.com/repo.git"}})
+				}),
+				configWith(func(c *Config) {
+					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://new.com/repo.git"}})
+				}),
 			},
-			want: Config{
-				Remotes: map[string]*RemoteConfig{
-					"origin": {Name: "origin", URLs: []string{"https://new.com/repo.git"}},
-				},
-			},
+			want: configValueWith(func(c *Config) {
+				c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://new.com/repo.git"}})
+			}),
 		},
 	}
 
@@ -946,7 +891,13 @@ func TestMerge(t *testing.T) {
 
 			got := Merge(tc.input...)
 
-			assert.Equal(t, tc.want, got)
+			gotBytes, err := got.Marshal()
+			require.NoError(t, err)
+			want := tc.want
+			wantBytes, err := want.Marshal()
+			require.NoError(t, err)
+
+			assert.Equal(t, string(wantBytes), string(gotBytes))
 		})
 	}
 
@@ -966,14 +917,9 @@ func TestMerge(t *testing.T) {
 
 		merged := Merge(base, wt)
 
-		assert.Equal(t, "wt-user", merged.User.Name)
-		assert.Equal(t, "base@example.com", merged.User.Email)
-		assert.True(t, merged.Extensions.WorktreeConfig)
-
-		require.Nil(t, merged.Raw, "merged Raw must be nil")
-
-		_, err = merged.Marshal()
-		require.NoError(t, err)
+		assert.Equal(t, "wt-user", merged.User().Name)
+		assert.Equal(t, "base@example.com", merged.User().Email)
+		assert.True(t, merged.Extensions().WorktreeConfig)
 
 		assert.True(t, merged.Raw.HasSection("extensions"),
 			"[extensions] section was dropped from merged Raw")
@@ -997,7 +943,7 @@ func TestGPGConfig(t *testing.T) {
 		err := cfg.Unmarshal(input)
 		require.NoError(t, err)
 
-		assert.Equal(t, "ssh", cfg.GPG.Format)
+		assert.Equal(t, "ssh", cfg.GPG().Format)
 	})
 
 	t.Run("unmarshal gpg.ssh.allowedSignersFile", func(t *testing.T) {
@@ -1009,7 +955,7 @@ func TestGPGConfig(t *testing.T) {
 		err := cfg.Unmarshal(input)
 		require.NoError(t, err)
 
-		assert.Equal(t, "~/.ssh/allowed_signers", cfg.GPG.SSH.AllowedSignersFile)
+		assert.Equal(t, "~/.ssh/allowed_signers", cfg.GPG().SSH.AllowedSignersFile)
 	})
 
 	t.Run("unmarshal gpg format and ssh subsection", func(t *testing.T) {
@@ -1023,14 +969,14 @@ func TestGPGConfig(t *testing.T) {
 		err := cfg.Unmarshal(input)
 		require.NoError(t, err)
 
-		assert.Equal(t, "ssh", cfg.GPG.Format)
-		assert.Equal(t, "/home/user/.ssh/allowed_signers", cfg.GPG.SSH.AllowedSignersFile)
+		assert.Equal(t, "ssh", cfg.GPG().Format)
+		assert.Equal(t, "/home/user/.ssh/allowed_signers", cfg.GPG().SSH.AllowedSignersFile)
 	})
 
 	t.Run("marshal gpg format", func(t *testing.T) {
 		t.Parallel()
 		cfg := NewConfig()
-		cfg.GPG.Format = "ssh"
+		cfg.SetGPGFormat("ssh")
 
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
@@ -1042,7 +988,7 @@ func TestGPGConfig(t *testing.T) {
 	t.Run("marshal gpg.ssh.allowedSignersFile", func(t *testing.T) {
 		t.Parallel()
 		cfg := NewConfig()
-		cfg.GPG.SSH.AllowedSignersFile = "~/.ssh/allowed_signers"
+		cfg.SetGPGSSHAllowedSignersFile("~/.ssh/allowed_signers")
 
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
@@ -1054,8 +1000,8 @@ func TestGPGConfig(t *testing.T) {
 	t.Run("marshal gpg format and ssh subsection", func(t *testing.T) {
 		t.Parallel()
 		cfg := NewConfig()
-		cfg.GPG.Format = "openpgp"
-		cfg.GPG.SSH.AllowedSignersFile = "/etc/ssh/allowed_signers"
+		cfg.SetGPGFormat("openpgp")
+		cfg.SetGPGSSHAllowedSignersFile("/etc/ssh/allowed_signers")
 
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
@@ -1069,8 +1015,8 @@ func TestGPGConfig(t *testing.T) {
 	t.Run("round-trip marshal/unmarshal", func(t *testing.T) {
 		t.Parallel()
 		original := NewConfig()
-		original.GPG.Format = "ssh"
-		original.GPG.SSH.AllowedSignersFile = "~/.ssh/allowed_signers"
+		original.SetGPGFormat("ssh")
+		original.SetGPGSSHAllowedSignersFile("~/.ssh/allowed_signers")
 
 		data, err := original.Marshal()
 		require.NoError(t, err)
@@ -1079,14 +1025,14 @@ func TestGPGConfig(t *testing.T) {
 		err = parsed.Unmarshal(data)
 		require.NoError(t, err)
 
-		assert.Equal(t, "ssh", parsed.GPG.Format)
-		assert.Equal(t, "~/.ssh/allowed_signers", parsed.GPG.SSH.AllowedSignersFile)
+		assert.Equal(t, "ssh", parsed.GPG().Format)
+		assert.Equal(t, "~/.ssh/allowed_signers", parsed.GPG().SSH.AllowedSignersFile)
 	})
 
 	t.Run("empty gpg config not marshaled", func(t *testing.T) {
 		t.Parallel()
 		cfg := NewConfig()
-		cfg.User.Name = "Test User"
+		cfg.SetUser(User{Name: "Test User"})
 
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
@@ -1124,7 +1070,7 @@ func TestGPGConfig(t *testing.T) {
 		err := cfg.Unmarshal(input)
 		require.NoError(t, err)
 
-		assert.Equal(t, "openpgp", cfg.GPG.Format)
+		assert.Equal(t, "openpgp", cfg.GPG().Format)
 	})
 
 	t.Run("unmarshal user.signingKey", func(t *testing.T) {
@@ -1134,13 +1080,13 @@ func TestGPGConfig(t *testing.T) {
 		err := cfg.Unmarshal(input)
 		require.NoError(t, err)
 
-		assert.Equal(t, "~/.ssh/rsa_id", cfg.User.SigningKey)
+		assert.Equal(t, "~/.ssh/rsa_id", cfg.User().SigningKey)
 	})
 
 	t.Run("marshal user.signingKey", func(t *testing.T) {
 		t.Parallel()
 		cfg := NewConfig()
-		cfg.User.SigningKey = "/path/to/key"
+		cfg.SetUser(User{SigningKey: "/path/to/key"})
 
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
@@ -1155,8 +1101,8 @@ func TestGPGConfig(t *testing.T) {
 		err := cfg.Unmarshal(input)
 		require.NoError(t, err)
 
-		assert.Equal(t, OptBoolTrue, cfg.Tag.GpgSign)
-		assert.Equal(t, OptBoolTrue, cfg.Commit.GpgSign)
+		assert.Equal(t, OptBoolTrue, cfg.Tag().GpgSign)
+		assert.Equal(t, OptBoolTrue, cfg.Commit().GpgSign)
 	})
 
 	t.Run("unmarshal gpgSign false", func(t *testing.T) {
@@ -1166,8 +1112,8 @@ func TestGPGConfig(t *testing.T) {
 		err := cfg.Unmarshal(input)
 		require.NoError(t, err)
 
-		assert.Equal(t, OptBoolFalse, cfg.Tag.GpgSign)
-		assert.Equal(t, OptBoolFalse, cfg.Commit.GpgSign)
+		assert.Equal(t, OptBoolFalse, cfg.Tag().GpgSign)
+		assert.Equal(t, OptBoolFalse, cfg.Commit().GpgSign)
 	})
 
 	t.Run("unmarshal gpgSign unset", func(t *testing.T) {
@@ -1177,15 +1123,15 @@ func TestGPGConfig(t *testing.T) {
 		err := cfg.Unmarshal(input)
 		require.NoError(t, err)
 
-		assert.Equal(t, OptBoolUnset, cfg.Tag.GpgSign)
-		assert.Equal(t, OptBoolUnset, cfg.Commit.GpgSign)
+		assert.Equal(t, OptBoolUnset, cfg.Tag().GpgSign)
+		assert.Equal(t, OptBoolUnset, cfg.Commit().GpgSign)
 	})
 
 	t.Run("marshal gpgSign", func(t *testing.T) {
 		t.Parallel()
 		cfg := NewConfig()
-		cfg.Tag.GpgSign = OptBoolTrue
-		cfg.Commit.GpgSign = OptBoolTrue
+		cfg.SetTagGpgSign(OptBoolTrue)
+		cfg.SetCommitGpgSign(OptBoolTrue)
 
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
@@ -1197,8 +1143,8 @@ func TestGPGConfig(t *testing.T) {
 	t.Run("marshal gpgSign false", func(t *testing.T) {
 		t.Parallel()
 		cfg := NewConfig()
-		cfg.Tag.GpgSign = OptBoolFalse
-		cfg.Commit.GpgSign = OptBoolFalse
+		cfg.SetTagGpgSign(OptBoolFalse)
+		cfg.SetCommitGpgSign(OptBoolFalse)
 
 		data, err := cfg.Marshal()
 		require.NoError(t, err)
@@ -1210,32 +1156,32 @@ func TestGPGConfig(t *testing.T) {
 	t.Run("merge gpgSign false overrides true", func(t *testing.T) {
 		t.Parallel()
 		global := NewConfig()
-		global.Tag.GpgSign = OptBoolTrue
-		global.Commit.GpgSign = OptBoolTrue
+		global.SetTagGpgSign(OptBoolTrue)
+		global.SetCommitGpgSign(OptBoolTrue)
 
 		local := NewConfig()
-		local.Tag.GpgSign = OptBoolFalse
-		local.Commit.GpgSign = OptBoolFalse
+		local.SetTagGpgSign(OptBoolFalse)
+		local.SetCommitGpgSign(OptBoolFalse)
 
 		merged := Merge(global, local)
 
-		assert.Equal(t, OptBoolFalse, merged.Tag.GpgSign)
-		assert.Equal(t, OptBoolFalse, merged.Commit.GpgSign)
+		assert.Equal(t, OptBoolFalse, merged.Tag().GpgSign)
+		assert.Equal(t, OptBoolFalse, merged.Commit().GpgSign)
 	})
 
 	t.Run("merge keeps gpgSign false if next config unset", func(t *testing.T) {
 		t.Parallel()
 		global := NewConfig()
-		global.Commit.GpgSign = OptBoolFalse
+		global.SetCommitGpgSign(OptBoolFalse)
 
 		local := NewConfig()
-		local.Tag.GpgSign = OptBoolFalse
+		local.SetTagGpgSign(OptBoolFalse)
 
 		merged := Merge(global, local)
 
-		assert.True(t, merged.Tag.GpgSign.IsSet())
-		assert.True(t, merged.Commit.GpgSign.IsSet())
-		assert.Equal(t, OptBoolFalse, merged.Tag.GpgSign)
-		assert.Equal(t, OptBoolFalse, merged.Commit.GpgSign)
+		assert.True(t, merged.Tag().GpgSign.IsSet())
+		assert.True(t, merged.Commit().GpgSign.IsSet())
+		assert.Equal(t, OptBoolFalse, merged.Tag().GpgSign)
+		assert.Equal(t, OptBoolFalse, merged.Commit().GpgSign)
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -101,10 +101,10 @@ func (s *ConfigSuite) TestUnmarshal() {
 	s.Len(cfg.Remotes(), 4)
 	s.Equal("origin", cfg.Remotes()["origin"].Name)
 	s.Equal([]string{"git@github.com:mcuadros/go-git.git"}, cfg.Remotes()["origin"].URLs)
-	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, cfg.Remotes()["origin"].Fetch)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, cfg.Remotes()["origin"].Fetch)
 	s.Equal("alt", cfg.Remotes()["alt"].Name)
 	s.Equal([]string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"}, cfg.Remotes()["alt"].URLs)
-	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"}, cfg.Remotes()["alt"].Fetch)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"}, cfg.Remotes()["alt"].Fetch)
 	s.Equal("win-local", cfg.Remotes()["win-local"].Name)
 	s.Equal([]string{"X:\\Git\\"}, cfg.Remotes()["win-local"].URLs)
 	s.Equal([]string{"ssh://git@github.com/kostyay/go-git.git"}, cfg.Remotes()["insteadOf"].URLs)
@@ -165,7 +165,7 @@ func (s *ConfigSuite) TestMarshal() {
 	cfg.SetRemote(&RemoteConfig{
 		Name:  "alt",
 		URLs:  []string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"},
-		Fetch: []RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"},
+		Fetch: []plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"},
 	})
 
 	cfg.SetRemote(&RemoteConfig{
@@ -525,12 +525,12 @@ func (s *ConfigSuite) TestUnmarshalRemotesUnnamedFirst() {
 	unnamedRemote, ok := cfg.Remotes()[""]
 	s.True(ok, "Expected unnamed remote to be present")
 	s.Equal([]string{"https://github.com/CLBRITTON2/go-git.git"}, unnamedRemote.URLs)
-	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
 
 	namedRemote, ok := cfg.Remotes()["upstream"]
 	s.True(ok, "Expected named remote 'upstream' to be present")
 	s.Equal([]string{"https://github.com/go-git/go-git.git"}, namedRemote.URLs)
-	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotesNamedFirst() {
@@ -550,12 +550,12 @@ func (s *ConfigSuite) TestUnmarshalRemotesNamedFirst() {
 	namedRemote, ok := cfg.Remotes()["upstream"]
 	s.True(ok, "Expected a named remote 'upstream' to be present")
 	s.Equal([]string{"https://github.com/go-git/go-git.git"}, namedRemote.URLs)
-	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
 
 	unnamedRemote, ok := cfg.Remotes()[""]
 	s.True(ok, "Expected an unnamed remote to be present")
 	s.Equal([]string{"https://github.com/CLBRITTON2/go-git.git"}, unnamedRemote.URLs)
-	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
 }
 
 func TestUnmarshalPackReverseIndex(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 )
@@ -36,169 +35,12 @@ func configValueWith(setup func(*Config)) Config {
 	return *configWith(setup)
 }
 
-func (s *ConfigSuite) TestUnmarshal() {
-	input := []byte(`[core]
-		bare = true
-		worktree = foo
-		commentchar = bar
-		autocrlf = true
-		filemode = false
-		hooksPath = custom-hooks
-[user]
-		name = John Doe
-		email = john@example.com
-[author]
-		name = Jane Roe
-		email = jane@example.com
-[committer]
-		name = Richard Roe
-		email = richard@example.com
-[pack]
-		window = 20
-[remote "origin"]
-		url = git@github.com:mcuadros/go-git.git
-		fetch = +refs/heads/*:refs/remotes/origin/*
-[remote "alt"]
-		url = git@github.com:mcuadros/go-git.git
-		url = git@github.com:src-d/go-git.git
-		fetch = +refs/heads/*:refs/remotes/origin/*
-		fetch = +refs/pull/*:refs/remotes/origin/pull/*
-[remote "insteadOf"]
-		url = https://github.com/kostyay/go-git.git
-[remote "win-local"]
-		url = X:\\Git\\
-[submodule "qux"]
-		path = qux
-		url = https://github.com/foo/qux.git
-		branch = bar
-[branch "master"]
-		remote = origin
-		merge = refs/heads/master
-		description = "Add support for branch description.\\n\\nEdit branch description: git branch --edit-description\\n"
-[init]
-		defaultBranch = main
-[url "ssh://git@github.com/"]
-	insteadOf = https://github.com/
-`)
-
-	cfg := NewConfig()
-	err := cfg.Unmarshal(input)
-	s.NoError(err)
-
-	s.True(cfg.Core().IsBare)
-	s.Equal("foo", cfg.Core().Worktree)
-	s.Equal("bar", cfg.Core().CommentChar)
-	s.Equal("true", cfg.Core().AutoCRLF)
-	s.False(cfg.Core().FileMode)
-	s.Equal("custom-hooks", cfg.Core().HooksPath)
-	s.Equal("John Doe", cfg.User().Name)
-	s.Equal("john@example.com", cfg.User().Email)
-	s.Equal("Jane Roe", cfg.Author().Name)
-	s.Equal("jane@example.com", cfg.Author().Email)
-	s.Equal("Richard Roe", cfg.Committer().Name)
-	s.Equal("richard@example.com", cfg.Committer().Email)
-	s.Equal(uint(20), cfg.Pack().Window)
-	s.Len(cfg.Remotes(), 4)
-	s.Equal("origin", cfg.Remotes()["origin"].Name)
-	s.Equal([]string{"git@github.com:mcuadros/go-git.git"}, cfg.Remotes()["origin"].URLs)
-	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, cfg.Remotes()["origin"].Fetch)
-	s.Equal("alt", cfg.Remotes()["alt"].Name)
-	s.Equal([]string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"}, cfg.Remotes()["alt"].URLs)
-	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"}, cfg.Remotes()["alt"].Fetch)
-	s.Equal("win-local", cfg.Remotes()["win-local"].Name)
-	s.Equal([]string{"X:\\Git\\"}, cfg.Remotes()["win-local"].URLs)
-	s.Equal([]string{"ssh://git@github.com/kostyay/go-git.git"}, cfg.Remotes()["insteadOf"].URLs)
-	s.Len(cfg.Submodules(), 1)
-	s.Equal("qux", cfg.Submodules()["qux"].Name)
-	s.Equal("https://github.com/foo/qux.git", cfg.Submodules()["qux"].URL)
-	s.Equal("bar", cfg.Submodules()["qux"].Branch)
-	s.Equal("origin", cfg.Branches()["master"].Remote)
-	s.Equal(plumbing.ReferenceName("refs/heads/master"), cfg.Branches()["master"].Merge)
-	s.Equal("Add support for branch description.\n\nEdit branch description: git branch --edit-description\n", cfg.Branches()["master"].Description)
-	s.Equal("main", cfg.Init().DefaultBranch)
+func setRawRemote(c *Config, name string, urls ...string) {
+	c.Raw.Section("remote").Subsection(name).SetOption("url", urls...)
 }
 
-func (s *ConfigSuite) TestMarshal() {
-	output := []byte(`[core]
-	filemode = true
-	bare = true
-	worktree = bar
-	autocrlf = true
-	hooksPath = custom-hooks
-[pack]
-	window = 20
-[init]
-	defaultBranch = main
-[remote "origin"]
-	url = git@github.com:mcuadros/go-git.git
-[remote "alt"]
-	url = git@github.com:mcuadros/go-git.git
-	url = git@github.com:src-d/go-git.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
-	fetch = +refs/pull/*:refs/remotes/origin/pull/*
-[remote "win-local"]
-	url = "X:\\Git\\"
-[remote "insteadOf"]
-	url = https://github.com/kostyay/go-git.git
-[submodule "qux"]
-	url = https://github.com/foo/qux.git
-[branch "master"]
-	remote = origin
-	merge = refs/heads/master
-	description = "Add support for branch description.\\n\\nEdit branch description: git branch --edit-description\\n"
-[url "ssh://git@github.com/"]
-	insteadOf = https://github.com/
-`)
-
-	cfg := NewConfig()
-	cfg.SetBare(true)
-	cfg.SetWorktree("bar")
-	cfg.SetAutoCRLF("true")
-	cfg.SetHooksPath("custom-hooks")
-	cfg.SetPackWindow(20)
-	cfg.SetInitDefaultBranch("main")
-	cfg.SetRemote(&RemoteConfig{
-		Name: "origin",
-		URLs: []string{"git@github.com:mcuadros/go-git.git"},
-	})
-
-	cfg.SetRemote(&RemoteConfig{
-		Name:  "alt",
-		URLs:  []string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"},
-		Fetch: []plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"},
-	})
-
-	cfg.SetRemote(&RemoteConfig{
-		Name: "win-local",
-		URLs: []string{"X:\\Git\\"},
-	})
-
-	cfg.SetRemote(&RemoteConfig{
-		Name: "insteadOf",
-		URLs: []string{"https://github.com/kostyay/go-git.git"},
-	})
-
-	cfg.SetSubmodule(&Submodule{
-		Name: "qux",
-		URL:  "https://github.com/foo/qux.git",
-	})
-
-	cfg.SetBranch(&Branch{
-		Name:        "master",
-		Remote:      "origin",
-		Merge:       "refs/heads/master",
-		Description: "Add support for branch description.\n\nEdit branch description: git branch --edit-description\n",
-	})
-
-	cfg.AddURL(&URL{
-		Name:       "ssh://git@github.com/",
-		InsteadOfs: []string{"https://github.com/"},
-	})
-
-	b, err := cfg.Marshal()
-	s.NoError(err)
-
-	s.Equal(string(output), string(b))
+func setRawBranch(c *Config, name string) {
+	c.Raw.Section("branch").Subsection(name)
 }
 
 func TestUnmarshalMarshal(t *testing.T) {
@@ -360,109 +202,10 @@ func (s *ConfigSuite) TestLoadConfigXDG() {
 	s.Equal("foo@foo.com", cfg.User().Email)
 }
 
-func (s *ConfigSuite) TestValidateConfig() {
-	config := configWith(func(c *Config) {
-		c.SetRemote(&RemoteConfig{
-			Name: "bar",
-			URLs: []string{"http://foo/bar"},
-		})
-		c.SetBranch(&Branch{
-			Name: "bar",
-		})
-		c.SetBranch(&Branch{
-			Name:   "foo",
-			Remote: "origin",
-			Merge:  plumbing.ReferenceName("refs/heads/foo"),
-		})
-	})
-
-	s.NoError(config.Validate())
-}
-
-func (s *ConfigSuite) TestValidateInvalidRemote() {
-	config := configWith(func(c *Config) {
-		c.SetRemote(&RemoteConfig{Name: "foo"})
-	})
-
-	s.ErrorIs(config.Validate(), ErrRemoteConfigEmptyURL)
-}
-
-func (s *ConfigSuite) TestRemoteConfigValidateMissingURL() {
-	config := &RemoteConfig{Name: "foo"}
-	s.ErrorIs(config.Validate(), ErrRemoteConfigEmptyURL)
-}
-
-func (s *ConfigSuite) TestRemoteConfigValidateMissingName() {
-	config := &RemoteConfig{}
-	s.ErrorIs(config.Validate(), ErrRemoteConfigEmptyName)
-}
-
-func (s *ConfigSuite) TestRemoteConfigValidateDefault() {
-	config := &RemoteConfig{Name: "foo", URLs: []string{"http://foo/bar"}}
-	s.NoError(config.Validate())
-
-	fetch := config.Fetch
-	s.Len(fetch, 1)
-	s.Equal("+refs/heads/*:refs/remotes/foo/*", fetch[0].String())
-}
-
-func (s *ConfigSuite) TestValidateBranchNonRefsPrefix() {
-	// Real git allows any value for branch.*.merge, including values
-	// without a refs/ prefix. Validate should accept them.
-	config := configWith(func(c *Config) {
-		c.SetBranch(&Branch{
-			Name:   "bar",
-			Remote: "origin",
-			Merge:  plumbing.ReferenceName("refs/heads/bar"),
-		})
-		c.SetBranch(&Branch{
-			Name:   "foo",
-			Remote: "origin",
-			Merge:  plumbing.ReferenceName("baz"),
-		})
-	})
-
-	s.NoError(config.Validate())
-}
-
-func (s *ConfigSuite) TestRemoteConfigDefaultValues() {
-	config := NewConfig()
-
-	s.Len(config.Remotes(), 0)
-	s.Len(config.Branches(), 0)
-	s.Len(config.Submodules(), 0)
-	s.NotNil(config.Raw)
-	s.Equal(DefaultPackWindow, config.Pack().Window)
-}
-
 func (s *ConfigSuite) TestLoadConfigLocalScope() {
 	cfg, err := LoadConfig(LocalScope)
 	s.NotNil(err)
 	s.Nil(cfg)
-}
-
-func (s *ConfigSuite) TestRemoveUrlOptions() {
-	buf := []byte(`
-[remote "alt"]
-	url = git@github.com:mcuadros/go-git.git
-	url = git@github.com:src-d/go-git.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
-	fetch = +refs/pull/*:refs/remotes/origin/pull/*`)
-
-	cfg := NewConfig()
-	err := cfg.Unmarshal(buf)
-	s.NoError(err)
-	s.Len(cfg.Remotes(), 1)
-	alt := cfg.Remote("alt")
-	alt.URLs = []string{}
-	cfg.SetRemote(alt)
-
-	buf, err = cfg.Marshal()
-	s.NoError(err)
-	if strings.Contains(string(buf), "url") {
-		s.Fail("config should not contain any url sections")
-	}
-	s.NoError(err)
 }
 
 func (s *ConfigSuite) TestProtocol() {
@@ -483,79 +226,6 @@ func (s *ConfigSuite) TestProtocol() {
 		s.Fail("marshal did not update version")
 	}
 	s.NoError(err)
-}
-
-func (s *ConfigSuite) TestUnmarshalRemotes() {
-	input := []byte(`[core]
-	bare = true
-	worktree = foo
-	custom = ignored
-[user]
-	name = John Doe
-	email = john@example.com
-[remote "origin"]
-	url = https://git.sr.ht/~mcepl/go-git
-	pushurl = git@git.sr.ht:~mcepl/go-git.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
-	mirror = true
-`)
-
-	cfg := NewConfig()
-	err := cfg.Unmarshal(input)
-	s.NoError(err)
-
-	s.Equal("https://git.sr.ht/~mcepl/go-git", cfg.Remotes()["origin"].URLs[0])
-	s.Equal("git@git.sr.ht:~mcepl/go-git.git", cfg.Remotes()["origin"].URLs[1])
-}
-
-func (s *ConfigSuite) TestUnmarshalRemotesUnnamedFirst() {
-	input := []byte(`
-[remote ""]
-  url = https://github.com/CLBRITTON2/go-git.git
-  fetch = +refs/heads/*:refs/remotes/origin/*
-[remote "upstream"]
-	url = https://github.com/go-git/go-git.git
-	fetch = +refs/heads/*:refs/remotes/upstream/*
-	`)
-
-	cfg := NewConfig()
-	err := cfg.Unmarshal(input)
-	s.NoError(err)
-
-	unnamedRemote, ok := cfg.Remotes()[""]
-	s.True(ok, "Expected unnamed remote to be present")
-	s.Equal([]string{"https://github.com/CLBRITTON2/go-git.git"}, unnamedRemote.URLs)
-	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
-
-	namedRemote, ok := cfg.Remotes()["upstream"]
-	s.True(ok, "Expected named remote 'upstream' to be present")
-	s.Equal([]string{"https://github.com/go-git/go-git.git"}, namedRemote.URLs)
-	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
-}
-
-func (s *ConfigSuite) TestUnmarshalRemotesNamedFirst() {
-	input := []byte(`
-[remote "upstream"]
-	url = https://github.com/go-git/go-git.git
-	fetch = +refs/heads/*:refs/remotes/upstream/*
-[remote ""]
-  url = https://github.com/CLBRITTON2/go-git.git
-  fetch = +refs/heads/*:refs/remotes/origin/*
-	`)
-
-	cfg := NewConfig()
-	err := cfg.Unmarshal(input)
-	s.NoError(err)
-
-	namedRemote, ok := cfg.Remotes()["upstream"]
-	s.True(ok, "Expected a named remote 'upstream' to be present")
-	s.Equal([]string{"https://github.com/go-git/go-git.git"}, namedRemote.URLs)
-	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
-
-	unnamedRemote, ok := cfg.Remotes()[""]
-	s.True(ok, "Expected an unnamed remote to be present")
-	s.Equal([]string{"https://github.com/CLBRITTON2/go-git.git"}, unnamedRemote.URLs)
-	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
 }
 
 func TestUnmarshalPackReverseIndex(t *testing.T) {
@@ -828,59 +498,59 @@ func TestMerge(t *testing.T) {
 			name: "src nil map preserves dst map",
 			input: []*Config{
 				configWith(func(c *Config) {
-					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+					setRawRemote(c, "origin", "https://example.com/repo.git")
 				}),
 				configWith(func(c *Config) {
-					// Remotes is nil (zero value)
-					c.SetBranch(&Branch{Name: "main"})
+					// Only the branch subsection is present.
+					setRawBranch(c, "main")
 				}),
 			},
 			want: configValueWith(func(c *Config) {
-				c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
-				c.SetBranch(&Branch{Name: "main"})
+				setRawRemote(c, "origin", "https://example.com/repo.git")
+				setRawBranch(c, "main")
 			}),
 		},
 		{
 			name: "src empty map preserves dst map",
 			input: []*Config{
 				configWith(func(c *Config) {
-					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+					setRawRemote(c, "origin", "https://example.com/repo.git")
 				}),
 				configWith(func(_ *Config) {
-					// Remotes is explicitly initialised but empty (mirrors NewConfig behaviour).
+					// No remote subsection is present.
 				}),
 			},
 			want: configValueWith(func(c *Config) {
-				c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+				setRawRemote(c, "origin", "https://example.com/repo.git")
 			}),
 		},
 		{
 			name: "merge maps with disjoint keys",
 			input: []*Config{
 				configWith(func(c *Config) {
-					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
+					setRawRemote(c, "origin", "https://example.com/repo.git")
 				}),
 				configWith(func(c *Config) {
-					c.SetRemote(&RemoteConfig{Name: "upstream", URLs: []string{"https://upstream.com/repo.git"}})
+					setRawRemote(c, "upstream", "https://upstream.com/repo.git")
 				}),
 			},
 			want: configValueWith(func(c *Config) {
-				c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://example.com/repo.git"}})
-				c.SetRemote(&RemoteConfig{Name: "upstream", URLs: []string{"https://upstream.com/repo.git"}})
+				setRawRemote(c, "origin", "https://example.com/repo.git")
+				setRawRemote(c, "upstream", "https://upstream.com/repo.git")
 			}),
 		},
 		{
 			name: "src map entry overrides dst map entry",
 			input: []*Config{
 				configWith(func(c *Config) {
-					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://old.com/repo.git"}})
+					setRawRemote(c, "origin", "https://old.com/repo.git")
 				}),
 				configWith(func(c *Config) {
-					c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://new.com/repo.git"}})
+					setRawRemote(c, "origin", "https://new.com/repo.git")
 				}),
 			},
 			want: configValueWith(func(c *Config) {
-				c.SetRemote(&RemoteConfig{Name: "origin", URLs: []string{"https://new.com/repo.git"}})
+				setRawRemote(c, "origin", "https://new.com/repo.git")
 			}),
 		},
 	}

--- a/config/modules.go
+++ b/config/modules.go
@@ -62,6 +62,21 @@ func (m *Modules) Unmarshal(b []byte) error {
 	return nil
 }
 
+func unmarshalSubmodules(fc *format.Config, submodules map[string]*Submodule) {
+	s := fc.Section(submoduleSection)
+	for _, sub := range s.Subsections {
+		m := &Submodule{}
+		m.unmarshal(sub)
+
+		if err := m.Validate(); errors.Is(err, ErrModuleBadPath) ||
+			errors.Is(err, ErrModuleBadName) {
+			continue
+		}
+
+		submodules[m.Name] = m
+	}
+}
+
 // Marshal returns Modules encoded as a git-config file.
 func (m *Modules) Marshal() ([]byte, error) {
 	s := m.raw.Section(submoduleSection)

--- a/config/optbool.go
+++ b/config/optbool.go
@@ -2,7 +2,8 @@ package config
 
 import (
 	"strconv"
-	"strings"
+
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
 
 // OptBool is a tri-state boolean: unset, explicitly false, or explicitly true.
@@ -50,33 +51,21 @@ func (o OptBool) FormatBool() string {
 	return strconv.FormatBool(o.IsTrue())
 }
 
-// parseConfigBool mirrors upstream Git's git_parse_maybe_bool: it
-// accepts true/yes/on (→ OptBoolTrue) and false/no/off (→
-// OptBoolFalse) case-insensitively, plus any decimal integer (zero
-// → OptBoolFalse, non-zero → OptBoolTrue). Empty or otherwise
-// unrecognised values return OptBoolUnset, leaving the caller's
-// platform default in place. The empty-string handling is the only
-// intentional divergence from upstream, which returns false for
-// empty: in our unmarshalCore caller, an empty value means the key
-// is unset and the platform default should apply.
+// parseConfigBool parses a Git boolean into an OptBool, preserving the
+// tri-state distinction the struct API relies on. The boolean grammar is
+// shared with the rest of go-git via format.ParseBool (true/yes/on and
+// false/no/off case-insensitively, plus any integer). An empty value, which
+// go-git uses to mean "key absent" here, and any unrecognised value leave the
+// result unset so the caller's platform default applies.
 //
-// Reference: upstream Git git_parse_maybe_bool_text at parse.c
-// L157-L173 and git_parse_maybe_bool at parse.c L174-L182 in tag
-// v2.54.0[1].
-//
-// [1]: https://github.com/git/git/blob/v2.54.0/parse.c#L157-L182
+// Reference: upstream Git git_parse_maybe_bool at parse.c.
 func parseConfigBool(v string) OptBool {
-	switch strings.ToLower(v) {
-	case "true", "yes", "on":
-		return OptBoolTrue
-	case "false", "no", "off":
-		return OptBoolFalse
+	if v == "" {
+		return OptBoolUnset
 	}
-	if i, err := strconv.Atoi(v); err == nil {
-		if i != 0 {
-			return OptBoolTrue
-		}
-		return OptBoolFalse
+	b, err := format.ParseBool(v)
+	if err != nil {
+		return OptBoolUnset
 	}
-	return OptBoolUnset
+	return NewOptBool(b)
 }

--- a/config/optbool_test.go
+++ b/config/optbool_test.go
@@ -40,7 +40,7 @@ func TestParseConfigBool(t *testing.T) {
 		// Arbitrary integers, mirroring upstream's !!v on git_parse_int.
 		{"2", OptBoolTrue},
 		{"-1", OptBoolTrue},
-		{"010", OptBoolTrue}, // strconv.Atoi parses decimal, not octal.
+		{"010", OptBoolTrue}, // Git parses with base 0, so this is octal 8.
 		{"99999", OptBoolTrue},
 		{"-0", OptBoolFalse},
 		{"0000", OptBoolFalse},
@@ -53,7 +53,7 @@ func TestParseConfigBool(t *testing.T) {
 		{"T", OptBoolUnset},
 		{"f", OptBoolUnset},
 		{"F", OptBoolUnset},
-		{"0x1", OptBoolUnset},      // not decimal
+		{"0x1", OptBoolTrue},       // Git parses with base 0, so this is hex 1.
 		{"1.5", OptBoolUnset},      // not an integer
 		{"  true  ", OptBoolUnset}, // trimming is the caller's job.
 	}
@@ -92,8 +92,8 @@ func TestUnmarshalProtectNTFSAcceptsGitStyleBooleans(t *testing.T) {
 			cfg := NewConfig()
 			err := cfg.Unmarshal(body)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.want, cfg.Core.ProtectNTFS, "protectNTFS")
-			assert.Equal(t, tc.want, cfg.Core.ProtectHFS, "protectHFS")
+			assert.Equal(t, tc.want, cfg.Core().ProtectNTFS, "protectNTFS")
+			assert.Equal(t, tc.want, cfg.Core().ProtectHFS, "protectHFS")
 		})
 	}
 }
@@ -105,8 +105,8 @@ func TestUnmarshalProtectNTFSUnsetForUnrecognised(t *testing.T) {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(body)
 	assert.NoError(t, err)
-	assert.Equal(t, OptBoolUnset, cfg.Core.ProtectNTFS,
+	assert.Equal(t, OptBoolUnset, cfg.Core().ProtectNTFS,
 		"unrecognised value should leave protectNTFS unset")
-	assert.Equal(t, OptBoolUnset, cfg.Core.ProtectHFS,
+	assert.Equal(t, OptBoolUnset, cfg.Core().ProtectHFS,
 		"unrecognised value should leave protectHFS unset")
 }

--- a/config/url_test.go
+++ b/config/url_test.go
@@ -34,7 +34,7 @@ func (b *URLSuite) TestMarshal() {
 `)
 
 	cfg := NewConfig()
-	cfg.URLs = append(cfg.URLs, &URL{
+	cfg.AddURL(&URL{
 		Name:       "ssh://git@github.com/",
 		InsteadOfs: []string{"https://github.com/"},
 	})
@@ -54,7 +54,7 @@ func (b *URLSuite) TestMarshalMultipleInsteadOf() {
 `)
 
 	cfg := NewConfig()
-	cfg.URLs = append(cfg.URLs, &URL{
+	cfg.AddURL(&URL{
 		Name:       "ssh://git@github.com/",
 		InsteadOfs: []string{"https://github.com/", "https://google.com/"},
 	})
@@ -74,8 +74,8 @@ func (b *URLSuite) TestUnmarshal() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
-	b.Require().Len(cfg.URLs, 1)
-	url := cfg.URLs[0]
+	b.Require().Len(cfg.URLs(), 1)
+	url := cfg.URLs()[0]
 	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 	b.Equal("https://github.com/", url.InsteadOfs[0])
@@ -92,8 +92,8 @@ func (b *URLSuite) TestUnmarshalMultipleInsteadOf() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(input)
 	b.Nil(err)
-	b.Require().Len(cfg.URLs, 1)
-	url := cfg.URLs[0]
+	b.Require().Len(cfg.URLs(), 1)
+	url := cfg.URLs()[0]
 	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 
@@ -113,8 +113,8 @@ func (b *URLSuite) TestUnmarshalDuplicateUrls() {
 	cfg := NewConfig()
 	err := cfg.Unmarshal(input)
 	b.Nil(err)
-	b.Require().Len(cfg.URLs, 1)
-	url := cfg.URLs[0]
+	b.Require().Len(cfg.URLs(), 1)
+	url := cfg.URLs()[0]
 	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 
@@ -185,7 +185,7 @@ func (b *URLSuite) TestApplyInsteadOfLongestMatchIntegration() {
 	b.NoError(err)
 
 	// The longer insteadOf should be used
-	origin := cfg.Remotes["origin"]
+	origin := cfg.Remotes()["origin"]
 	b.NotNil(origin)
 	b.Equal([]string{"ssh://git@github.com/user/repo.git"}, origin.URLs)
 }
@@ -207,7 +207,7 @@ func (b *URLSuite) TestApplyInsteadOfDuplicateInsteadOfValues() {
 	b.NoError(err)
 
 	// First URL in config file should be used
-	origin := cfg.Remotes["origin"]
+	origin := cfg.Remotes()["origin"]
 	b.NotNil(origin)
 	b.Equal([]string{"ssh://git@github.com/user/repo.git"}, origin.URLs)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-git/go-billy/v6/memfs"
 
 	"github.com/go-git/go-git/v6"
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/client"
 	"github.com/go-git/go-git/v6/plumbing/transport/http"
@@ -169,7 +168,7 @@ func ExampleRepository_CreateRemote() {
 	defer func() { _ = r.Close() }()
 
 	// Add a new remote, with the default fetch refspec
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(&git.RemoteConfig{
 		Name: "example",
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})

--- a/modules.go
+++ b/modules.go
@@ -1,4 +1,4 @@
-package config
+package git
 
 import (
 	"bytes"
@@ -30,7 +30,7 @@ var dotdotPath = regexp.MustCompile(`(^|[/\\])\.\.([/\\]|$)`)
 // https://www.kernel.org/pub/software/scm/git/docs/gitmodules.html
 type Modules struct {
 	// Submodules is a map of submodules being the key the name of the submodule.
-	Submodules map[string]*Submodule
+	Submodules map[string]*SubmoduleConfig
 
 	raw *format.Config
 }
@@ -38,7 +38,7 @@ type Modules struct {
 // NewModules returns a new empty Modules
 func NewModules() *Modules {
 	return &Modules{
-		Submodules: make(map[string]*Submodule),
+		Submodules: make(map[string]*SubmoduleConfig),
 		raw:        format.New(),
 	}
 }
@@ -62,10 +62,10 @@ func (m *Modules) Unmarshal(b []byte) error {
 	return nil
 }
 
-func unmarshalSubmodules(fc *format.Config, submodules map[string]*Submodule) {
+func unmarshalSubmodules(fc *format.Config, submodules map[string]*SubmoduleConfig) {
 	s := fc.Section(submoduleSection)
 	for _, sub := range s.Subsections {
-		m := &Submodule{}
+		m := &SubmoduleConfig{}
 		m.unmarshal(sub)
 
 		if err := m.Validate(); errors.Is(err, ErrModuleBadPath) ||
@@ -96,8 +96,8 @@ func (m *Modules) Marshal() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Submodule defines a submodule.
-type Submodule struct {
+// SubmoduleConfig defines a submodule.
+type SubmoduleConfig struct {
 	// Name module name
 	Name string
 	// Path defines the path, relative to the top-level directory of the Git
@@ -115,7 +115,7 @@ type Submodule struct {
 }
 
 // Validate validates the fields and sets the default values.
-func (m *Submodule) Validate() error {
+func (m *SubmoduleConfig) Validate() error {
 	if err := validSubmoduleName(m.Name); err != nil {
 		return fmt.Errorf("%w: %q", ErrModuleBadName, m.Name)
 	}
@@ -179,7 +179,7 @@ func validSubmoduleName(name string) error {
 
 func isPathSep(r rune) bool { return r == '/' || r == '\\' }
 
-func (m *Submodule) unmarshal(s *format.Subsection) {
+func (m *SubmoduleConfig) unmarshal(s *format.Subsection) {
 	m.raw = s
 
 	m.Name = m.raw.Name
@@ -188,7 +188,7 @@ func (m *Submodule) unmarshal(s *format.Subsection) {
 	m.Branch = m.raw.Option(branchKey)
 }
 
-func (m *Submodule) marshal() *format.Subsection {
+func (m *SubmoduleConfig) marshal() *format.Subsection {
 	if m.raw == nil {
 		m.raw = &format.Subsection{}
 	}

--- a/modules_test.go
+++ b/modules_test.go
@@ -1,4 +1,4 @@
-package config
+package git
 
 import (
 	"testing"
@@ -16,7 +16,7 @@ func TestModulesSuite(t *testing.T) {
 }
 
 func (s *ModulesSuite) TestValidateMissingURL() {
-	m := &Submodule{Name: "foo", Path: "foo"}
+	m := &SubmoduleConfig{Name: "foo", Path: "foo"}
 	s.Equal(ErrModuleEmptyURL, m.Validate())
 }
 
@@ -35,7 +35,7 @@ func (s *ModulesSuite) TestValidateBadPath() {
 	}
 
 	for _, p := range input {
-		m := &Submodule{
+		m := &SubmoduleConfig{
 			Name: "ok",
 			Path: p,
 			URL:  "https://example.com/",
@@ -45,7 +45,7 @@ func (s *ModulesSuite) TestValidateBadPath() {
 }
 
 func (s *ModulesSuite) TestValidateMissingName() {
-	m := &Submodule{Name: "ok", URL: "bar"}
+	m := &SubmoduleConfig{Name: "ok", URL: "bar"}
 	s.Equal(ErrModuleEmptyPath, m.Validate())
 }
 
@@ -85,7 +85,7 @@ func (s *ModulesSuite) TestValidateBadName() {
 		"a/.. /b",
 	}
 	for _, n := range input {
-		m := &Submodule{
+		m := &SubmoduleConfig{
 			Name: n,
 			Path: "ok",
 			URL:  "https://example.com/",
@@ -99,7 +99,7 @@ func (s *ModulesSuite) TestValidateBadName() {
 
 func (s *ModulesSuite) TestValidateGoodName() {
 	for _, n := range []string{"foo", "lib-foo", "deps/x", "x.y"} {
-		m := &Submodule{
+		m := &SubmoduleConfig{
 			Name: n,
 			Path: "ok",
 			URL:  "https://example.com/",
@@ -116,7 +116,7 @@ func (s *ModulesSuite) TestMarshal() {
 `)
 
 	cfg := NewModules()
-	cfg.Submodules["qux"] = &Submodule{Path: "qux", URL: "baz", Branch: "bar"}
+	cfg.Submodules["qux"] = &SubmoduleConfig{Path: "qux", URL: "baz", Branch: "bar"}
 
 	output, err := cfg.Marshal()
 	s.NoError(err)

--- a/options.go
+++ b/options.go
@@ -634,26 +634,26 @@ func (o *CommitOptions) loadConfigAuthorAndCommitter(r *Repository) error {
 		return err
 	}
 
-	if o.Author == nil && cfg.Author.Email != "" && cfg.Author.Name != "" {
+	if o.Author == nil && cfg.Author().Email != "" && cfg.Author().Name != "" {
 		o.Author = &object.Signature{
-			Name:  cfg.Author.Name,
-			Email: cfg.Author.Email,
+			Name:  cfg.Author().Name,
+			Email: cfg.Author().Email,
 			When:  time.Now(),
 		}
 	}
 
-	if o.Committer == nil && cfg.Committer.Email != "" && cfg.Committer.Name != "" {
+	if o.Committer == nil && cfg.Committer().Email != "" && cfg.Committer().Name != "" {
 		o.Committer = &object.Signature{
-			Name:  cfg.Committer.Name,
-			Email: cfg.Committer.Email,
+			Name:  cfg.Committer().Name,
+			Email: cfg.Committer().Email,
 			When:  time.Now(),
 		}
 	}
 
-	if o.Author == nil && cfg.User.Email != "" && cfg.User.Name != "" {
+	if o.Author == nil && cfg.User().Email != "" && cfg.User().Name != "" {
 		o.Author = &object.Signature{
-			Name:  cfg.User.Name,
-			Email: cfg.User.Email,
+			Name:  cfg.User().Name,
+			Email: cfg.User().Email,
 			When:  time.Now(),
 		}
 	}
@@ -710,18 +710,18 @@ func (o *CreateTagOptions) loadConfigTagger(r *Repository) error {
 		return err
 	}
 
-	if o.Tagger == nil && cfg.Author.Email != "" && cfg.Author.Name != "" {
+	if o.Tagger == nil && cfg.Author().Email != "" && cfg.Author().Name != "" {
 		o.Tagger = &object.Signature{
-			Name:  cfg.Author.Name,
-			Email: cfg.Author.Email,
+			Name:  cfg.Author().Name,
+			Email: cfg.Author().Email,
 			When:  time.Now(),
 		}
 	}
 
-	if o.Tagger == nil && cfg.User.Email != "" && cfg.User.Name != "" {
+	if o.Tagger == nil && cfg.User().Email != "" && cfg.User().Name != "" {
 		o.Tagger = &object.Signature{
-			Name:  cfg.User.Name,
-			Email: cfg.User.Email,
+			Name:  cfg.User().Name,
+			Email: cfg.User().Email,
 			When:  time.Now(),
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -228,7 +228,7 @@ type FetchOptions struct {
 	RemoteName string
 	// RemoteURL overrides the remote repo address with a custom URL
 	RemoteURL string
-	RefSpecs  []config.RefSpec
+	RefSpecs  []plumbing.RefSpec
 	// Depth limit fetching to the specified number of commits from the tip of
 	// each remote branch history.
 	Depth int
@@ -285,7 +285,7 @@ type PushOptions struct {
 	// The <dst> tells which ref on the remote side is updated with this push.
 	//
 	// A refspec with empty src can be used to delete a reference.
-	RefSpecs []config.RefSpec
+	RefSpecs []plumbing.RefSpec
 	// ClientOptions configures the transport client used for this operation.
 	ClientOptions []client.Option
 	// Progress is where the human readable information sent by the server is
@@ -299,7 +299,7 @@ type PushOptions struct {
 	Force bool
 	// RequireRemoteRefs only allows a remote ref to be updated if its current
 	// value is the one specified here.
-	RequireRemoteRefs []config.RefSpec
+	RequireRemoteRefs []plumbing.RefSpec
 	// FollowTags will send any annotated tags with a commit target reachable from
 	// the refs already being pushed
 	FollowTags bool
@@ -334,8 +334,8 @@ func (o *PushOptions) Validate() error {
 	}
 
 	if len(o.RefSpecs) == 0 {
-		o.RefSpecs = []config.RefSpec{
-			config.RefSpec(config.DefaultPushRefSpec),
+		o.RefSpecs = []plumbing.RefSpec{
+			plumbing.RefSpec(config.DefaultPushRefSpec),
 		}
 	}
 

--- a/options_test.go
+++ b/options_test.go
@@ -47,8 +47,7 @@ func (s *OptionsSuite) TestCommitOptionsCommitter() {
 
 func (s *OptionsSuite) TestCommitOptionsLoadGlobalConfigUser() {
 	cfg := config.NewConfig()
-	cfg.User.Name = "foo"
-	cfg.User.Email = "foo@foo.com"
+	cfg.SetUser(config.User{Name: "foo", Email: "foo@foo.com"})
 
 	clean := s.registerGlobalConfig(cfg)
 	defer clean()
@@ -65,10 +64,8 @@ func (s *OptionsSuite) TestCommitOptionsLoadGlobalConfigUser() {
 
 func (s *OptionsSuite) TestCommitOptionsLoadGlobalCommitter() {
 	cfg := config.NewConfig()
-	cfg.User.Name = "foo"
-	cfg.User.Email = "foo@foo.com"
-	cfg.Committer.Name = "bar"
-	cfg.Committer.Email = "bar@bar.com"
+	cfg.SetUser(config.User{Name: "foo", Email: "foo@foo.com"})
+	cfg.SetCommitter(config.Identity{Name: "bar", Email: "bar@bar.com"})
 
 	clean := s.registerGlobalConfig(cfg)
 	defer clean()
@@ -85,8 +82,7 @@ func (s *OptionsSuite) TestCommitOptionsLoadGlobalCommitter() {
 
 func (s *OptionsSuite) TestCreateTagOptionsLoadGlobal() {
 	cfg := config.NewConfig()
-	cfg.User.Name = "foo"
-	cfg.User.Email = "foo@foo.com"
+	cfg.SetUser(config.User{Name: "foo", Email: "foo@foo.com"})
 
 	clean := s.registerGlobalConfig(cfg)
 	defer clean()

--- a/plumbing/format/config/accessor.go
+++ b/plumbing/format/config/accessor.go
@@ -1,0 +1,143 @@
+package config
+
+import "strings"
+
+// SplitKey splits a canonical Git config key into its components. Following
+// git's parsing rules, the section is the text before the first dot, the
+// variable name is the text after the last dot, and any text in between is the
+// subsection (which may itself contain dots, e.g. a URL). Keys without a dot
+// have an empty name and keys with a single dot have no subsection.
+//
+// Examples:
+//
+//	"core.bare"                       -> "core", "",                    "bare"
+//	"remote.origin.url"               -> "remote", "origin",           "url"
+//	"url.git@github.com:.insteadOf"   -> "url", "git@github.com:",      "insteadOf"
+func SplitKey(key string) (section, subsection, name string) {
+	first := strings.IndexByte(key, '.')
+	if first < 0 {
+		return key, "", ""
+	}
+
+	last := strings.LastIndexByte(key, '.')
+	section = key[:first]
+	name = key[last+1:]
+	if last > first {
+		subsection = key[first+1 : last]
+	}
+	return section, subsection, name
+}
+
+func (c *Config) options(section, subsection string) Options {
+	for i := len(c.Sections) - 1; i >= 0; i-- {
+		s := c.Sections[i]
+		if !s.IsName(section) {
+			continue
+		}
+		if subsection == "" {
+			return s.Options
+		}
+		for j := len(s.Subsections) - 1; j >= 0; j-- {
+			if s.Subsections[j].IsName(subsection) {
+				return s.Subsections[j].Options
+			}
+		}
+	}
+	return nil
+}
+
+// Get returns the last value set for the canonical key (e.g. "remote.origin.url"),
+// or the empty string if the key is not present. Last-value-wins matches git's
+// behaviour since v1.8.1.
+func (c *Config) Get(key string) string {
+	section, subsection, name := SplitKey(key)
+	return c.options(section, subsection).Get(name)
+}
+
+// GetAll returns every value set for the canonical key, in file order. It is the
+// equivalent of git's git_config_get_value_multi.
+func (c *Config) GetAll(key string) []string {
+	section, subsection, name := SplitKey(key)
+	return c.options(section, subsection).GetAll(name)
+}
+
+// Has reports whether the canonical key is present, regardless of its value.
+func (c *Config) Has(key string) bool {
+	section, subsection, name := SplitKey(key)
+	return c.options(section, subsection).Has(name)
+}
+
+// Bool returns the boolean value of the canonical key, or def when the key is
+// absent. The value is parsed with ParseBool; an unrecognised value also yields
+// def.
+func (c *Config) Bool(key string, def bool) bool {
+	section, subsection, name := SplitKey(key)
+	opts := c.options(section, subsection)
+	if !opts.Has(name) {
+		return def
+	}
+	v, err := ParseBool(opts.Get(name))
+	if err != nil {
+		return def
+	}
+	return v
+}
+
+// Int returns the integer value of the canonical key, or def when the key is
+// absent. A present but unparseable value returns an error.
+func (c *Config) Int(key string, def int) (int, error) {
+	section, subsection, name := SplitKey(key)
+	opts := c.options(section, subsection)
+	if !opts.Has(name) {
+		return def, nil
+	}
+	return ParseInt(opts.Get(name))
+}
+
+// Int64 returns the int64 value of the canonical key, or def when the key is
+// absent. A present but unparseable value returns an error.
+func (c *Config) Int64(key string, def int64) (int64, error) {
+	section, subsection, name := SplitKey(key)
+	opts := c.options(section, subsection)
+	if !opts.Has(name) {
+		return def, nil
+	}
+	return ParseInt64(opts.Get(name))
+}
+
+// Uint returns the unsigned value of the canonical key, or def when the key is
+// absent. A present but unparseable value returns an error.
+func (c *Config) Uint(key string, def uint64) (uint64, error) {
+	section, subsection, name := SplitKey(key)
+	opts := c.options(section, subsection)
+	if !opts.Has(name) {
+		return def, nil
+	}
+	return ParseUint(opts.Get(name))
+}
+
+// Set sets the canonical key to value, replacing any existing values
+// (last-wins). It returns the Config to allow chaining.
+func (c *Config) Set(key, value string) *Config {
+	section, subsection, name := SplitKey(key)
+	return c.SetOption(section, subsection, name, value)
+}
+
+// Add appends value to the canonical key without removing existing values,
+// producing a multi-valued key. It returns the Config to allow chaining.
+func (c *Config) Add(key, value string) *Config {
+	section, subsection, name := SplitKey(key)
+	return c.AddOption(section, subsection, name, value)
+}
+
+// Unset removes every value of the canonical key. It returns the Config to
+// allow chaining.
+func (c *Config) Unset(key string) *Config {
+	section, subsection, name := SplitKey(key)
+	if subsection == "" {
+		c.Section(section).RemoveOption(name)
+	} else {
+		c.Section(section).Subsection(subsection).RemoveOption(name)
+	}
+	return c
+}

--- a/plumbing/format/config/value.go
+++ b/plumbing/format/config/value.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Errors returned by the value parsers. They mirror the failure modes of
+// git's parse.c (invalid syntax vs. out-of-range).
+var (
+	// ErrInvalidValue is returned when a value cannot be parsed as the
+	// requested type.
+	ErrInvalidValue = errors.New("invalid config value")
+	// ErrValueOutOfRange is returned when a numeric value (including its
+	// unit factor) does not fit in the requested type.
+	ErrValueOutOfRange = errors.New("config value out of range")
+)
+
+// ParseBool parses value as a Git boolean, mirroring git's
+// git_parse_maybe_bool (parse.c). The tokens "true", "yes" and "on" are true
+// and "false", "no" and "off" are false, all case-insensitively. Any value
+// that parses as an integer is true when non-zero. A bare key, which go-git
+// represents as an empty value, is reported as true. Unrecognised values
+// return ErrInvalidValue.
+//
+// Reference: https://github.com/git/git/blob/master/parse.c git_parse_maybe_bool
+func ParseBool(value string) (bool, error) {
+	switch strings.ToLower(value) {
+	case "true", "yes", "on":
+		return true, nil
+	case "false", "no", "off":
+		return false, nil
+	case "":
+		// git treats a valueless key (NULL) as true. go-git collapses a
+		// bare key and an explicit empty value to "", and the bare-key
+		// shorthand ([core] bare) is the meaningful real-world case.
+		return true, nil
+	}
+
+	if i, err := ParseInt64(value); err == nil {
+		return i != 0, nil
+	}
+
+	return false, ErrInvalidValue
+}
+
+// ParseInt64 parses value as a Git integer, mirroring git's git_parse_signed
+// (parse.c): the number is read with strconv base 0 (so 0x and 0 prefixes are
+// honoured) and may carry a single case-insensitive unit suffix of k, m or g
+// for 1024, 1024^2 or 1024^3 respectively.
+//
+// Reference: https://github.com/git/git/blob/master/parse.c git_parse_signed
+func ParseInt64(value string) (int64, error) {
+	if value == "" {
+		return 0, ErrInvalidValue
+	}
+
+	num, factor, err := splitUnit(value)
+	if err != nil {
+		return 0, err
+	}
+
+	val, err := strconv.ParseInt(num, 0, 64)
+	if err != nil {
+		if errors.Is(err, strconv.ErrRange) {
+			return 0, ErrValueOutOfRange
+		}
+		return 0, ErrInvalidValue
+	}
+
+	if factor != 1 {
+		if val > math.MaxInt64/factor || val < math.MinInt64/factor {
+			return 0, ErrValueOutOfRange
+		}
+		val *= factor
+	}
+
+	return val, nil
+}
+
+// ParseInt parses value as a Git integer and reports ErrValueOutOfRange when
+// the result does not fit in an int.
+func ParseInt(value string) (int, error) {
+	v, err := ParseInt64(value)
+	if err != nil {
+		return 0, err
+	}
+	if v > math.MaxInt || v < math.MinInt {
+		return 0, ErrValueOutOfRange
+	}
+	return int(v), nil
+}
+
+// ParseUint parses value as a non-negative Git integer with the same unit
+// suffixes as ParseInt64. Negative values are rejected, matching git's
+// git_parse_unsigned.
+func ParseUint(value string) (uint64, error) {
+	if value == "" {
+		return 0, ErrInvalidValue
+	}
+	if strings.ContainsRune(value, '-') {
+		return 0, ErrInvalidValue
+	}
+
+	num, factor, err := splitUnit(value)
+	if err != nil {
+		return 0, err
+	}
+
+	val, err := strconv.ParseUint(num, 0, 64)
+	if err != nil {
+		if errors.Is(err, strconv.ErrRange) {
+			return 0, ErrValueOutOfRange
+		}
+		return 0, ErrInvalidValue
+	}
+
+	if factor != 1 {
+		if val > math.MaxUint64/uint64(factor) {
+			return 0, ErrValueOutOfRange
+		}
+		val *= uint64(factor)
+	}
+
+	return val, nil
+}
+
+// splitUnit separates the numeric part of value from an optional trailing
+// k/m/g unit suffix and returns the corresponding 1024-based factor.
+func splitUnit(value string) (num string, factor int64, err error) {
+	if value == "" {
+		return "", 0, ErrInvalidValue
+	}
+
+	switch last := value[len(value)-1]; last {
+	case 'k', 'K':
+		return value[:len(value)-1], 1024, nil
+	case 'm', 'M':
+		return value[:len(value)-1], 1024 * 1024, nil
+	case 'g', 'G':
+		return value[:len(value)-1], 1024 * 1024 * 1024, nil
+	default:
+		return value, 1, nil
+	}
+}

--- a/plumbing/format/config/value_test.go
+++ b/plumbing/format/config/value_test.go
@@ -1,0 +1,190 @@
+package config
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseBool(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		value   string
+		want    bool
+		wantErr bool
+	}{
+		{"true", true, false},
+		{"TRUE", true, false},
+		{"yes", true, false},
+		{"On", true, false},
+		{"false", false, false},
+		{"No", false, false},
+		{"off", false, false},
+		{"", true, false}, // bare key shorthand
+		{"1", true, false},
+		{"0", false, false},
+		{"-1", true, false},
+		{"42", true, false},
+		{"0x10", true, false},
+		{"maybe", false, true},
+		{"truthy", false, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseBool(tt.value)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseBool(%q) err = %v, wantErr %v", tt.value, err, tt.wantErr)
+			continue
+		}
+		if err == nil && got != tt.want {
+			t.Errorf("ParseBool(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestParseInt64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		value   string
+		want    int64
+		wantErr bool
+	}{
+		{"0", 0, false},
+		{"10", 10, false},
+		{"-5", -5, false},
+		{"0x10", 16, false},
+		{"010", 8, false},
+		{"1k", 1024, false},
+		{"1K", 1024, false},
+		{"2m", 2 * 1024 * 1024, false},
+		{"3g", 3 * 1024 * 1024 * 1024, false},
+		{"-1k", -1024, false},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"1t", 0, true},
+		{"12x", 0, true},
+		{"9223372036854775807", math.MaxInt64, false},
+		{"9999999999999999999g", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseInt64(tt.value)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseInt64(%q) err = %v, wantErr %v", tt.value, err, tt.wantErr)
+			continue
+		}
+		if err == nil && got != tt.want {
+			t.Errorf("ParseInt64(%q) = %d, want %d", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestParseUint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		value   string
+		want    uint64
+		wantErr bool
+	}{
+		{"0", 0, false},
+		{"10", 10, false},
+		{"1k", 1024, false},
+		{"-1", 0, true},
+		{"-1k", 0, true},
+		{"", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseUint(tt.value)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseUint(%q) err = %v, wantErr %v", tt.value, err, tt.wantErr)
+			continue
+		}
+		if err == nil && got != tt.want {
+			t.Errorf("ParseUint(%q) = %d, want %d", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestSplitKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		key        string
+		section    string
+		subsection string
+		name       string
+	}{
+		{"core.bare", "core", "", "bare"},
+		{"remote.origin.url", "remote", "origin", "url"},
+		{"url.git@github.com:.insteadOf", "url", "git@github.com:", "insteadOf"},
+		{"core", "core", "", ""},
+		{"a.b.c.d", "a", "b.c", "d"},
+	}
+	for _, tt := range tests {
+		section, subsection, name := SplitKey(tt.key)
+		if section != tt.section || subsection != tt.subsection || name != tt.name {
+			t.Errorf("SplitKey(%q) = (%q,%q,%q), want (%q,%q,%q)",
+				tt.key, section, subsection, name, tt.section, tt.subsection, tt.name)
+		}
+	}
+}
+
+func TestConfigAccessors(t *testing.T) {
+	t.Parallel()
+	c := New()
+	c.Set("core.bare", "true")
+	c.Set("remote.origin.url", "git@github.com:go-git/go-git.git")
+	c.Add("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+	c.Add("remote.origin.fetch", "+refs/tags/*:refs/tags/*")
+	c.Set("pack.window", "16")
+
+	if got := c.Get("remote.origin.url"); got != "git@github.com:go-git/go-git.git" {
+		t.Errorf("Get url = %q", got)
+	}
+	if !c.Bool("core.bare", false) {
+		t.Error("core.bare should be true")
+	}
+	if c.Bool("core.missing", true) != true {
+		t.Error("missing key should return default")
+	}
+	if all := c.GetAll("remote.origin.fetch"); len(all) != 2 {
+		t.Errorf("GetAll fetch len = %d, want 2", len(all))
+	}
+	if n, err := c.Int("pack.window", 10); err != nil || n != 16 {
+		t.Errorf("Int pack.window = %d, %v", n, err)
+	}
+	if n, err := c.Int("pack.depth", 50); err != nil || n != 50 {
+		t.Errorf("Int default = %d, %v", n, err)
+	}
+
+	c.Set("remote.origin.fetch", "single")
+	if all := c.GetAll("remote.origin.fetch"); len(all) != 1 {
+		t.Errorf("Set should collapse multivalue, got %d", len(all))
+	}
+
+	c.Unset("core.bare")
+	if c.Has("core.bare") {
+		t.Error("core.bare should be unset")
+	}
+}
+
+func FuzzParseValue(f *testing.F) {
+	seeds := []string{"", "true", "no", "0x1f", "1k", "-3g", "42", "abc", "  ", "9999999999999999999"}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		// The parsers must never panic on arbitrary input.
+		_, _ = ParseBool(s)
+		_, _ = ParseInt(s)
+		_, _ = ParseInt64(s)
+		_, _ = ParseUint(s)
+
+		if v, err := ParseInt64(s); err == nil {
+			// A successful integer parse must be a valid boolean too.
+			b, berr := ParseBool(s)
+			if berr != nil {
+				t.Fatalf("ParseInt64(%q)=%d ok but ParseBool errored: %v", s, v, berr)
+			}
+			if b != (v != 0) {
+				t.Fatalf("ParseBool(%q)=%v inconsistent with int %d", s, b, v)
+			}
+		}
+	})
+}

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -43,7 +43,7 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
 	if c, ok := s.(config.ConfigStorer); ok {
 		cfg, err := c.Config()
 		if err == nil {
-			of = cfg.Extensions.ObjectFormat
+			of = cfg.Extensions().ObjectFormat
 		}
 	}
 

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -78,7 +78,7 @@ func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool, op
 	if c, ok := s.(config.ConfigStorer); ok {
 		cfg, err := c.Config()
 		if err == nil {
-			of = cfg.Extensions.ObjectFormat
+			of = cfg.Extensions().ObjectFormat
 		}
 	}
 

--- a/plumbing/format/packfile/encoder_advanced_test.go
+++ b/plumbing/format/packfile/encoder_advanced_test.go
@@ -75,8 +75,8 @@ func (s *EncoderAdvancedSuite) testEncodeDecode(
 	}); ok {
 		cfg, err := cs.Config()
 		s.Require().NoError(err)
-		if cfg.Extensions.ObjectFormat != formatcfg.UnsetObjectFormat {
-			objectFormat = cfg.Extensions.ObjectFormat
+		if cfg.Extensions().ObjectFormat != formatcfg.UnsetObjectFormat {
+			objectFormat = cfg.Extensions().ObjectFormat
 		}
 	}
 

--- a/plumbing/refspec.go
+++ b/plumbing/refspec.go
@@ -1,10 +1,8 @@
-package config
+package plumbing
 
 import (
 	"errors"
 	"strings"
-
-	"github.com/go-git/go-git/v6/plumbing"
 )
 
 const (
@@ -63,7 +61,7 @@ func (s RefSpec) IsDelete() bool {
 
 // IsExactSHA1 returns true if the source is a SHA1 hash.
 func (s RefSpec) IsExactSHA1() bool {
-	return plumbing.IsHash(s.Src())
+	return IsHash(s.Src())
 }
 
 // Src returns the src side.
@@ -81,8 +79,8 @@ func (s RefSpec) Src() string {
 	return spec[start:end]
 }
 
-// Match match the given plumbing.ReferenceName against the source.
-func (s RefSpec) Match(n plumbing.ReferenceName) bool {
+// Match match the given ReferenceName against the source.
+func (s RefSpec) Match(n ReferenceName) bool {
 	if !s.IsWildcard() {
 		return s.matchExact(n)
 	}
@@ -95,11 +93,11 @@ func (s RefSpec) IsWildcard() bool {
 	return strings.Contains(string(s), refSpecWildcard)
 }
 
-func (s RefSpec) matchExact(n plumbing.ReferenceName) bool {
+func (s RefSpec) matchExact(n ReferenceName) bool {
 	return s.Src() == n.String()
 }
 
-func (s RefSpec) matchGlob(n plumbing.ReferenceName) bool {
+func (s RefSpec) matchGlob(n ReferenceName) bool {
 	src := s.Src()
 	name := n.String()
 	wildcard := strings.Index(src, refSpecWildcard)
@@ -116,14 +114,14 @@ func (s RefSpec) matchGlob(n plumbing.ReferenceName) bool {
 }
 
 // Dst returns the destination for the given remote reference.
-func (s RefSpec) Dst(n plumbing.ReferenceName) plumbing.ReferenceName {
+func (s RefSpec) Dst(n ReferenceName) ReferenceName {
 	spec := string(s)
 	start := strings.Index(spec, refSpecSeparator) + 1
 	dst := spec[start:]
 	src := s.Src()
 
 	if !s.IsWildcard() {
-		return plumbing.ReferenceName(dst)
+		return ReferenceName(dst)
 	}
 
 	name := n.String()
@@ -131,7 +129,7 @@ func (s RefSpec) Dst(n plumbing.ReferenceName) plumbing.ReferenceName {
 	before, after, _ := strings.Cut(dst, refSpecWildcard)
 	match := name[ws : len(name)-(len(src)-(ws+1))]
 
-	return plumbing.ReferenceName(before + match + after)
+	return ReferenceName(before + match + after)
 }
 
 // Reverse returns the RefSpec with source and destination swapped.
@@ -147,7 +145,7 @@ func (s RefSpec) String() string {
 }
 
 // MatchAny returns true if any of the RefSpec match with the given ReferenceName.
-func MatchAny(l []RefSpec, n plumbing.ReferenceName) bool {
+func MatchAny(l []RefSpec, n ReferenceName) bool {
 	for _, r := range l {
 		if r.Match(n) {
 			return true

--- a/plumbing/refspec_test.go
+++ b/plumbing/refspec_test.go
@@ -1,12 +1,10 @@
-package config
+package plumbing
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
-	"github.com/go-git/go-git/v6/plumbing"
 )
 
 type RefSpecSuite struct {
@@ -96,22 +94,22 @@ func (s *RefSpecSuite) TestRefSpecSrc() {
 
 func (s *RefSpecSuite) TestRefSpecMatch() {
 	spec := RefSpec("refs/heads/master:refs/remotes/origin/master")
-	s.False(spec.Match(plumbing.ReferenceName("refs/heads/foo")))
-	s.True(spec.Match(plumbing.ReferenceName("refs/heads/master")))
+	s.False(spec.Match(ReferenceName("refs/heads/foo")))
+	s.True(spec.Match(ReferenceName("refs/heads/master")))
 
 	spec = RefSpec("+refs/heads/master:refs/remotes/origin/master")
-	s.False(spec.Match(plumbing.ReferenceName("refs/heads/foo")))
-	s.True(spec.Match(plumbing.ReferenceName("refs/heads/master")))
+	s.False(spec.Match(ReferenceName("refs/heads/foo")))
+	s.True(spec.Match(ReferenceName("refs/heads/master")))
 
 	spec = RefSpec(":refs/heads/master")
-	s.True(spec.Match(plumbing.ReferenceName("")))
-	s.False(spec.Match(plumbing.ReferenceName("refs/heads/master")))
+	s.True(spec.Match(ReferenceName("")))
+	s.False(spec.Match(ReferenceName("refs/heads/master")))
 
 	spec = RefSpec("refs/heads/love+hate:heads/love+hate")
-	s.True(spec.Match(plumbing.ReferenceName("refs/heads/love+hate")))
+	s.True(spec.Match(ReferenceName("refs/heads/love+hate")))
 
 	spec = RefSpec("+refs/heads/love+hate:heads/love+hate")
-	s.True(spec.Match(plumbing.ReferenceName("refs/heads/love+hate")))
+	s.True(spec.Match(ReferenceName("refs/heads/love+hate")))
 }
 
 func (s *RefSpecSuite) TestRefSpecMatchGlob() {
@@ -141,7 +139,7 @@ func (s *RefSpecSuite) TestRefSpecMatchGlob() {
 		spec := RefSpec(specStr)
 		for ref, matches := range data {
 			s.Equal(matches,
-				spec.Match(plumbing.ReferenceName(ref)),
+				spec.Match(ReferenceName(ref)),
 				fmt.Sprintf("while matching spec %q against ref %q", specStr, ref),
 			)
 		}
@@ -151,7 +149,7 @@ func (s *RefSpecSuite) TestRefSpecMatchGlob() {
 func (s *RefSpecSuite) TestRefSpecDst() {
 	spec := RefSpec("refs/heads/master:refs/remotes/origin/master")
 	s.Equal("refs/remotes/origin/master",
-		spec.Dst(plumbing.ReferenceName("refs/heads/master")).String())
+		spec.Dst(ReferenceName("refs/heads/master")).String())
 }
 
 func (s *RefSpecSuite) TestRefSpecDstBlob() {
@@ -177,7 +175,7 @@ func (s *RefSpecSuite) TestRefSpecDstBlob() {
 	for specStr, dst := range tests {
 		spec := RefSpec(specStr)
 		s.Equal(dst,
-			spec.Dst(plumbing.ReferenceName(ref)).String(),
+			spec.Dst(ReferenceName(ref)).String(),
 			fmt.Sprintf("while getting dst from spec %q with ref %q", specStr, ref),
 		)
 	}
@@ -194,7 +192,7 @@ func (s *RefSpecSuite) TestMatchAny() {
 		"refs/heads/foo:refs/remotes/origin/bar",
 	}
 
-	s.True(MatchAny(specs, plumbing.ReferenceName("refs/heads/foo")))
-	s.True(MatchAny(specs, plumbing.ReferenceName("refs/heads/bar")))
-	s.False(MatchAny(specs, plumbing.ReferenceName("refs/heads/master")))
+	s.True(MatchAny(specs, ReferenceName("refs/heads/foo")))
+	s.True(MatchAny(specs, ReferenceName("refs/heads/bar")))
+	s.False(MatchAny(specs, ReferenceName("refs/heads/master")))
 }

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -310,7 +310,7 @@ func initBareStorage(t testing.TB, path string) *filesystem.Storage {
 	require.NoError(t, os.MkdirAll(path, 0o755))
 	st := filesystem.NewStorage(osfs.New(path), cache.NewObjectLRUDefault())
 	cfg := config.NewConfig()
-	cfg.Core.IsBare = true
+	cfg.SetBare(true)
 	require.NoError(t, st.SetConfig(cfg))
 	return st
 }

--- a/plumbing/transport/loader_test.go
+++ b/plumbing/transport/loader_test.go
@@ -25,7 +25,7 @@ func TestFilesystemLoader_Load(t *testing.T) {
 	require.NoError(t, st.Init())
 	cfg, err := st.Config()
 	require.NoError(t, err)
-	cfg.Core.IsBare = true
+	cfg.SetBare(true)
 	require.NoError(t, st.SetConfig(cfg))
 
 	loader := NewFilesystemLoader(osfs.New(dir), false)
@@ -50,7 +50,7 @@ func TestFilesystemLoader_LoadBare(t *testing.T) {
 	require.NoError(t, st.Init())
 	cfg, err := st.Config()
 	require.NoError(t, err)
-	cfg.Core.IsBare = true
+	cfg.SetBare(true)
 	require.NoError(t, st.SetConfig(cfg))
 
 	loader := NewFilesystemLoader(osfs.New(dir), false)

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -114,7 +114,7 @@ func NegotiatePack(
 
 		cfg, err := st.Config()
 		if err == nil {
-			clientFormat = cfg.Extensions.ObjectFormat
+			clientFormat = cfg.Extensions().ObjectFormat
 		}
 
 		if clientFormat == config.UnsetObjectFormat && serverFormat == config.SHA256 {

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -64,7 +64,7 @@ func AdvertiseRefs(
 		cfg, err := st.Config()
 		var objectformat config.ObjectFormat
 		if err == nil && cfg != nil {
-			objectformat = cfg.Extensions.ObjectFormat
+			objectformat = cfg.Extensions().ObjectFormat
 		}
 
 		if objectformat == config.UnsetObjectFormat {
@@ -137,7 +137,7 @@ func writeV2Advertisement(w io.Writer, st storage.Storer) error {
 	// object format
 	var objectformat config.ObjectFormat
 	if cfg, err := st.Config(); err == nil && cfg != nil {
-		objectformat = cfg.Extensions.ObjectFormat
+		objectformat = cfg.Extensions().ObjectFormat
 	}
 	if objectformat == config.UnsetObjectFormat {
 		objectformat = config.DefaultObjectFormat

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -285,7 +285,7 @@ func UploadPack(
 	if opts.SkipDeltaCompression {
 		packWindow = 0
 	} else if cfg, cerr := st.Config(); cerr == nil && cfg != nil {
-		packWindow = cfg.Pack.Window
+		packWindow = cfg.Pack().Window
 	} else {
 		packWindow = config.DefaultPackWindow
 	}
@@ -729,7 +729,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, _ *buf
 	if opts.SkipDeltaCompression {
 		packWindow = 0
 	} else if cfg, cerr := st.Config(); cerr == nil && cfg != nil {
-		packWindow = cfg.Pack.Window
+		packWindow = cfg.Pack().Window
 	} else {
 		packWindow = config.DefaultPackWindow
 	}

--- a/porcelain_config_test.go
+++ b/porcelain_config_test.go
@@ -1,0 +1,366 @@
+package git
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+type PorcelainConfigSuite struct {
+	suite.Suite
+}
+
+func TestPorcelainConfigSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(PorcelainConfigSuite))
+}
+
+func porcelainConfigWith(setup func(*config.Config)) *config.Config {
+	c := config.NewConfig()
+	if setup != nil {
+		setup(c)
+	}
+	return c
+}
+
+func addURLConfig(cfg *config.Config, u *URL) {
+	setSubsection(cfg, urlSection, u.Name, u.marshal())
+}
+
+func (s *PorcelainConfigSuite) TestUnmarshal() {
+	input := []byte(`[core]
+		bare = true
+		worktree = foo
+		commentchar = bar
+		autocrlf = true
+		filemode = false
+		hooksPath = custom-hooks
+[user]
+		name = John Doe
+		email = john@example.com
+[author]
+		name = Jane Roe
+		email = jane@example.com
+[committer]
+		name = Richard Roe
+		email = richard@example.com
+[pack]
+		window = 20
+[remote "origin"]
+		url = git@github.com:mcuadros/go-git.git
+		fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "alt"]
+		url = git@github.com:mcuadros/go-git.git
+		url = git@github.com:src-d/go-git.git
+		fetch = +refs/heads/*:refs/remotes/origin/*
+		fetch = +refs/pull/*:refs/remotes/origin/pull/*
+[remote "insteadOf"]
+		url = https://github.com/kostyay/go-git.git
+[remote "win-local"]
+		url = X:\\Git\\
+[submodule "qux"]
+		path = qux
+		url = https://github.com/foo/qux.git
+		branch = bar
+[branch "master"]
+		remote = origin
+		merge = refs/heads/master
+		description = "Add support for branch description.\\n\\nEdit branch description: git branch --edit-description\\n"
+[init]
+		defaultBranch = main
+[url "ssh://git@github.com/"]
+	insteadOf = https://github.com/
+`)
+
+	cfg := config.NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	s.True(cfg.Core().IsBare)
+	s.Equal("foo", cfg.Core().Worktree)
+	s.Equal("bar", cfg.Core().CommentChar)
+	s.Equal("true", cfg.Core().AutoCRLF)
+	s.False(cfg.Core().FileMode)
+	s.Equal("custom-hooks", cfg.Core().HooksPath)
+	s.Equal("John Doe", cfg.User().Name)
+	s.Equal("john@example.com", cfg.User().Email)
+	s.Equal("Jane Roe", cfg.Author().Name)
+	s.Equal("jane@example.com", cfg.Author().Email)
+	s.Equal("Richard Roe", cfg.Committer().Name)
+	s.Equal("richard@example.com", cfg.Committer().Email)
+	s.Equal(uint(20), cfg.Pack().Window)
+	remotes := remoteConfigs(cfg)
+	s.Len(remotes, 4)
+	s.Equal("origin", remotes["origin"].Name)
+	s.Equal([]string{"git@github.com:mcuadros/go-git.git"}, remotes["origin"].URLs)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, remotes["origin"].Fetch)
+	s.Equal("alt", remotes["alt"].Name)
+	s.Equal([]string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"}, remotes["alt"].URLs)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"}, remotes["alt"].Fetch)
+	s.Equal("win-local", remotes["win-local"].Name)
+	s.Equal([]string{"X:\\Git\\"}, remotes["win-local"].URLs)
+	s.Equal([]string{"ssh://git@github.com/kostyay/go-git.git"}, remotes["insteadOf"].URLs)
+	submodules := submoduleConfigs(cfg)
+	s.Len(submodules, 1)
+	s.Equal("qux", submodules["qux"].Name)
+	s.Equal("https://github.com/foo/qux.git", submodules["qux"].URL)
+	s.Equal("bar", submodules["qux"].Branch)
+	branches := branchConfigs(cfg)
+	s.Equal("origin", branches["master"].Remote)
+	s.Equal(plumbing.ReferenceName("refs/heads/master"), branches["master"].Merge)
+	s.Equal("Add support for branch description.\n\nEdit branch description: git branch --edit-description\n", branches["master"].Description)
+	s.Equal("main", cfg.Init().DefaultBranch)
+}
+
+func (s *PorcelainConfigSuite) TestMarshal() {
+	output := []byte(`[core]
+	filemode = true
+	bare = true
+	worktree = bar
+	autocrlf = true
+	hooksPath = custom-hooks
+[pack]
+	window = 20
+[init]
+	defaultBranch = main
+[remote "origin"]
+	url = git@github.com:mcuadros/go-git.git
+[remote "alt"]
+	url = git@github.com:mcuadros/go-git.git
+	url = git@github.com:src-d/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/pull/*:refs/remotes/origin/pull/*
+[remote "win-local"]
+	url = "X:\\Git\\"
+[remote "insteadOf"]
+	url = https://github.com/kostyay/go-git.git
+[submodule "qux"]
+	url = https://github.com/foo/qux.git
+[branch "master"]
+	remote = origin
+	merge = refs/heads/master
+	description = "Add support for branch description.\\n\\nEdit branch description: git branch --edit-description\\n"
+[url "ssh://git@github.com/"]
+	insteadOf = https://github.com/
+`)
+
+	cfg := config.NewConfig()
+	cfg.SetBare(true)
+	cfg.SetWorktree("bar")
+	cfg.SetAutoCRLF("true")
+	cfg.SetHooksPath("custom-hooks")
+	cfg.SetPackWindow(20)
+	cfg.SetInitDefaultBranch("main")
+	setRemoteConfig(cfg, &RemoteConfig{
+		Name: "origin",
+		URLs: []string{"git@github.com:mcuadros/go-git.git"},
+	})
+
+	setRemoteConfig(cfg, &RemoteConfig{
+		Name:  "alt",
+		URLs:  []string{"git@github.com:mcuadros/go-git.git", "git@github.com:src-d/go-git.git"},
+		Fetch: []plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*", "+refs/pull/*:refs/remotes/origin/pull/*"},
+	})
+
+	setRemoteConfig(cfg, &RemoteConfig{
+		Name: "win-local",
+		URLs: []string{"X:\\Git\\"},
+	})
+
+	setRemoteConfig(cfg, &RemoteConfig{
+		Name: "insteadOf",
+		URLs: []string{"https://github.com/kostyay/go-git.git"},
+	})
+
+	setSubmoduleConfig(cfg, &SubmoduleConfig{
+		Name: "qux",
+		URL:  "https://github.com/foo/qux.git",
+	})
+
+	setBranchConfig(cfg, &Branch{
+		Name:        "master",
+		Remote:      "origin",
+		Merge:       "refs/heads/master",
+		Description: "Add support for branch description.\n\nEdit branch description: git branch --edit-description\n",
+	})
+
+	addURLConfig(cfg, &URL{
+		Name:       "ssh://git@github.com/",
+		InsteadOfs: []string{"https://github.com/"},
+	})
+
+	b, err := cfg.Marshal()
+	s.NoError(err)
+
+	s.Equal(string(output), string(b))
+}
+
+func (s *PorcelainConfigSuite) TestValidateConfig() {
+	cfg := porcelainConfigWith(func(c *config.Config) {
+		setRemoteConfig(c, &RemoteConfig{
+			Name: "bar",
+			URLs: []string{"http://foo/bar"},
+		})
+		setBranchConfig(c, &Branch{
+			Name: "bar",
+		})
+		setBranchConfig(c, &Branch{
+			Name:   "foo",
+			Remote: "origin",
+			Merge:  plumbing.ReferenceName("refs/heads/foo"),
+		})
+	})
+
+	s.NoError(cfg.Validate())
+}
+
+func (s *PorcelainConfigSuite) TestRemoteConfigValidateMissingURL() {
+	cfg := &RemoteConfig{Name: "foo"}
+	s.ErrorIs(cfg.Validate(), ErrRemoteConfigEmptyURL)
+}
+
+func (s *PorcelainConfigSuite) TestRemoteConfigValidateMissingName() {
+	cfg := &RemoteConfig{}
+	s.ErrorIs(cfg.Validate(), ErrRemoteConfigEmptyName)
+}
+
+func (s *PorcelainConfigSuite) TestRemoteConfigValidateDefault() {
+	cfg := &RemoteConfig{Name: "foo", URLs: []string{"http://foo/bar"}}
+	s.NoError(cfg.Validate())
+
+	fetch := cfg.Fetch
+	s.Len(fetch, 1)
+	s.Equal("+refs/heads/*:refs/remotes/foo/*", fetch[0].String())
+}
+
+func (s *PorcelainConfigSuite) TestValidateBranchNonRefsPrefix() {
+	cfg := porcelainConfigWith(func(c *config.Config) {
+		setBranchConfig(c, &Branch{
+			Name:   "bar",
+			Remote: "origin",
+			Merge:  plumbing.ReferenceName("refs/heads/bar"),
+		})
+		setBranchConfig(c, &Branch{
+			Name:   "foo",
+			Remote: "origin",
+			Merge:  plumbing.ReferenceName("baz"),
+		})
+	})
+
+	s.NoError(cfg.Validate())
+	s.NoError(branchConfig(cfg, "foo").Validate())
+}
+
+func (s *PorcelainConfigSuite) TestRemoteConfigDefaultValues() {
+	cfg := config.NewConfig()
+
+	s.Len(remoteConfigs(cfg), 0)
+	s.Len(branchConfigs(cfg), 0)
+	s.Len(submoduleConfigs(cfg), 0)
+	s.NotNil(cfg.Raw)
+	s.Equal(config.DefaultPackWindow, cfg.Pack().Window)
+}
+
+func (s *PorcelainConfigSuite) TestRemoveUrlOptions() {
+	buf := []byte(`
+[remote "alt"]
+	url = git@github.com:mcuadros/go-git.git
+	url = git@github.com:src-d/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	fetch = +refs/pull/*:refs/remotes/origin/pull/*`)
+
+	cfg := config.NewConfig()
+	err := cfg.Unmarshal(buf)
+	s.NoError(err)
+	s.Len(remoteConfigs(cfg), 1)
+	alt := remoteConfig(cfg, "alt")
+	alt.URLs = []string{}
+	setRemoteConfig(cfg, alt)
+
+	buf, err = cfg.Marshal()
+	s.NoError(err)
+	if strings.Contains(string(buf), "url") {
+		s.Fail("config should not contain any url sections")
+	}
+	s.NoError(err)
+}
+
+func (s *PorcelainConfigSuite) TestUnmarshalRemotes() {
+	input := []byte(`[core]
+	bare = true
+	worktree = foo
+	custom = ignored
+[user]
+	name = John Doe
+	email = john@example.com
+[remote "origin"]
+	url = https://git.sr.ht/~mcepl/go-git
+	pushurl = git@git.sr.ht:~mcepl/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	mirror = true
+`)
+
+	cfg := config.NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	remotes := remoteConfigs(cfg)
+	s.Equal("https://git.sr.ht/~mcepl/go-git", remotes["origin"].URLs[0])
+	s.Equal("git@git.sr.ht:~mcepl/go-git.git", remotes["origin"].URLs[1])
+}
+
+func (s *PorcelainConfigSuite) TestUnmarshalRemotesUnnamedFirst() {
+	input := []byte(`
+[remote ""]
+  url = https://github.com/CLBRITTON2/go-git.git
+  fetch = +refs/heads/*:refs/remotes/origin/*
+[remote "upstream"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/upstream/*
+	`)
+
+	cfg := config.NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	remotes := remoteConfigs(cfg)
+	unnamedRemote, ok := remotes[""]
+	s.True(ok, "Expected unnamed remote to be present")
+	s.Equal([]string{"https://github.com/CLBRITTON2/go-git.git"}, unnamedRemote.URLs)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
+
+	namedRemote, ok := remotes["upstream"]
+	s.True(ok, "Expected named remote 'upstream' to be present")
+	s.Equal([]string{"https://github.com/go-git/go-git.git"}, namedRemote.URLs)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
+}
+
+func (s *PorcelainConfigSuite) TestUnmarshalRemotesNamedFirst() {
+	input := []byte(`
+[remote "upstream"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/upstream/*
+[remote ""]
+  url = https://github.com/CLBRITTON2/go-git.git
+  fetch = +refs/heads/*:refs/remotes/origin/*
+	`)
+
+	cfg := config.NewConfig()
+	err := cfg.Unmarshal(input)
+	s.NoError(err)
+
+	remotes := remoteConfigs(cfg)
+	namedRemote, ok := remotes["upstream"]
+	s.True(ok, "Expected a named remote 'upstream' to be present")
+	s.Equal([]string{"https://github.com/go-git/go-git.git"}, namedRemote.URLs)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/upstream/*"}, namedRemote.Fetch)
+
+	unnamedRemote, ok := remotes[""]
+	s.True(ok, "Expected an unnamed remote to be present")
+	s.Equal([]string{"https://github.com/CLBRITTON2/go-git.git"}, unnamedRemote.URLs)
+	s.Equal([]plumbing.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
+}

--- a/remote.go
+++ b/remote.go
@@ -156,7 +156,7 @@ func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRef
 		for i := 0; i < len(o.RefSpecs); i++ {
 			rs := &o.RefSpecs[i]
 			if !rs.IsForceUpdate() && !rs.IsDelete() {
-				o.RefSpecs[i] = config.RefSpec("+" + rs.String())
+				o.RefSpecs[i] = plumbing.RefSpec("+" + rs.String())
 			}
 		}
 	}
@@ -547,7 +547,7 @@ func newClient(rawURL string, opts []client.Option) (*client.Client, *transport.
 	return cl, &transport.Request{URL: u}, nil
 }
 
-func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer) (bool, error) {
+func (r *Remote) pruneRemotes(specs []plumbing.RefSpec, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer) (bool, error) {
 	var updatedPrune bool
 	for _, spec := range specs {
 		rev := spec.Reverse()
@@ -569,7 +569,7 @@ func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Refe
 }
 
 func (r *Remote) addReferencesToUpdate(
-	refspecs []config.RefSpec,
+	refspecs []plumbing.RefSpec,
 	localRefs []*plumbing.Reference,
 	remoteRefs storer.ReferenceStorer,
 	cmds *[]*packp.Command,
@@ -605,7 +605,7 @@ func (r *Remote) addReferencesToUpdate(
 }
 
 func (r *Remote) addOrUpdateReferences(
-	rs config.RefSpec,
+	rs plumbing.RefSpec,
 	localRefs []*plumbing.Reference,
 	refsDict map[string]*plumbing.Reference,
 	remoteRefs storer.ReferenceStorer,
@@ -637,7 +637,7 @@ func (r *Remote) addOrUpdateReferences(
 	return nil
 }
 
-func (r *Remote) deleteReferences(rs config.RefSpec,
+func (r *Remote) deleteReferences(rs plumbing.RefSpec,
 	remoteRefs storer.ReferenceStorer,
 	refsDict map[string]*plumbing.Reference,
 	cmds *[]*packp.Command,
@@ -676,7 +676,7 @@ func (r *Remote) deleteReferences(rs config.RefSpec,
 	})
 }
 
-func (r *Remote) addObject(rs config.RefSpec,
+func (r *Remote) addObject(rs plumbing.RefSpec,
 	remoteRefs storer.ReferenceStorer, localObject plumbing.Hash,
 	cmds *[]*packp.Command,
 ) error {
@@ -713,7 +713,7 @@ func (r *Remote) addObject(rs config.RefSpec,
 	return nil
 }
 
-func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
+func (r *Remote) addReferenceIfRefSpecMatches(rs plumbing.RefSpec,
 	remoteRefs storer.ReferenceStorer, localRef *plumbing.Reference,
 	cmds *[]*packp.Command, forceWithLease *ForceWithLease,
 ) error {
@@ -898,7 +898,7 @@ func getHaves(
 const refspecAllTags = "+refs/tags/*:refs/tags/*"
 
 func calculateRefs(
-	spec []config.RefSpec,
+	spec []plumbing.RefSpec,
 	remoteRefs storer.ReferenceStorer,
 	tagMode plumbing.TagMode,
 ) (memory.ReferenceStorage, [][]*plumbing.Reference, error) {
@@ -921,7 +921,7 @@ func calculateRefs(
 }
 
 func doCalculateRefs(
-	s config.RefSpec,
+	s plumbing.RefSpec,
 	remoteRefs storer.ReferenceStorer,
 	refs memory.ReferenceStorage,
 ) ([]*plumbing.Reference, error) {
@@ -1120,7 +1120,7 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, sha
 	return found, nil
 }
 
-func (r *Remote) isSupportedRefSpec(refs []config.RefSpec, caps *capability.List) error {
+func (r *Remote) isSupportedRefSpec(refs []plumbing.RefSpec, caps *capability.List) error {
 	var containsIsExact bool
 	for _, ref := range refs {
 		if ref.IsExactSHA1() {
@@ -1141,7 +1141,7 @@ func (r *Remote) isSupportedRefSpec(refs []config.RefSpec, caps *capability.List
 }
 
 func (r *Remote) updateLocalReferenceStorage(
-	specs []config.RefSpec,
+	specs []plumbing.RefSpec,
 	fetchedRefs, remoteRefs memory.ReferenceStorage,
 	specToRefs [][]*plumbing.Reference,
 	tagMode plumbing.TagMode,
@@ -1412,7 +1412,7 @@ func pushHashes(
 	return nil
 }
 
-func (r *Remote) checkRequireRemoteRefs(requires []config.RefSpec, remoteRefs storer.ReferenceStorer) error {
+func (r *Remote) checkRequireRemoteRefs(requires []plumbing.RefSpec, remoteRefs storer.ReferenceStorer) error {
 	for _, require := range requires {
 		if require.IsWildcard() {
 			return fmt.Errorf("wildcards not supported in RequireRemoteRefs, got %s", require.String())

--- a/remote.go
+++ b/remote.go
@@ -1388,7 +1388,7 @@ func pushHashes(
 		req.Packfile = rd
 		go func() {
 			e := packfile.NewEncoder(wr, s, useRefDeltas)
-			if _, err := e.Encode(hs, config.Pack.Window); err != nil {
+			if _, err := e.Encode(hs, config.Pack().Window); err != nil {
 				done <- wr.CloseWithError(err)
 				return
 			}

--- a/remote.go
+++ b/remote.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/internal/reference"
 	"github.com/go-git/go-git/v6/internal/repository"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -49,19 +48,19 @@ const (
 
 // Remote represents a connection to a remote repository.
 type Remote struct {
-	c *config.RemoteConfig
+	c *RemoteConfig
 	s storage.Storer
 }
 
 // NewRemote creates a new Remote.
 // The intended purpose is to use the Remote for tasks such as listing remote references (like using git ls-remote).
 // Otherwise Remotes should be created via the use of a Repository.
-func NewRemote(s storage.Storer, c *config.RemoteConfig) *Remote {
+func NewRemote(s storage.Storer, c *RemoteConfig) *Remote {
 	return &Remote{s: s, c: c}
 }
 
 // Config returns the RemoteConfig object used to instantiate this Remote.
-func (r *Remote) Config() *config.RemoteConfig {
+func (r *Remote) Config() *RemoteConfig {
 	return r.c
 }
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -66,9 +66,9 @@ func (s *RemoteSuite) TestFetchOverriddenEndpoint() {
 
 func (s *RemoteSuite) TestFetchInvalidFetchOptions() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
-	invalid := config.RefSpec("^*$ñ")
-	err := r.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{invalid}})
-	s.ErrorIs(err, config.ErrRefSpecMalformedSeparator)
+	invalid := plumbing.RefSpec("^*$ñ")
+	err := r.Fetch(&FetchOptions{RefSpecs: []plumbing.RefSpec{invalid}})
+	s.ErrorIs(err, plumbing.ErrRefSpecMalformedSeparator)
 }
 
 func (s *RemoteSuite) TestFetchWildcard() {
@@ -77,8 +77,8 @@ func (s *RemoteSuite) TestFetchWildcard() {
 	})
 
 	s.testFetch(r, &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
@@ -93,8 +93,8 @@ func (s *RemoteSuite) TestFetchExactSHA1() {
 	})
 
 	s.testFetch(r, &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("35e85108805c84807bc66a02d91535e1e24b38b9:refs/heads/foo"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("35e85108805c84807bc66a02d91535e1e24b38b9:refs/heads/foo"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/heads/foo", "35e85108805c84807bc66a02d91535e1e24b38b9"),
@@ -107,8 +107,8 @@ func (s *RemoteSuite) TestFetchExactSHA1_NotSupported() {
 	})
 
 	err := r.Fetch(&FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("35e85108805c84807bc66a02d91535e1e24b38b9:refs/heads/foo"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("35e85108805c84807bc66a02d91535e1e24b38b9:refs/heads/foo"),
 		},
 	})
 
@@ -121,8 +121,8 @@ func (s *RemoteSuite) TestFetchWildcardTags() {
 	})
 
 	s.testFetch(r, &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 		Tags: AllTags,
 	}, []*plumbing.Reference{
@@ -141,8 +141,8 @@ func (s *RemoteSuite) TestFetch() {
 	})
 
 	s.testFetch(r, &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f"),
@@ -155,15 +155,15 @@ func (s *RemoteSuite) TestFetchToNewBranch() {
 	})
 
 	s.testFetch(r, &FetchOptions{
-		RefSpecs: []config.RefSpec{
+		RefSpecs: []plumbing.RefSpec{
 			// qualified branch to unqualified branch
 			"refs/heads/master:foo",
 			// unqualified branch to unqualified branch
 			"+master:bar",
 			// unqualified tag to unqualified branch
-			config.RefSpec("tree-tag:tree-tag"),
+			plumbing.RefSpec("tree-tag:tree-tag"),
 			// unqualified tag to qualified tag
-			config.RefSpec("+commit-tag:refs/tags/renamed-tag"),
+			plumbing.RefSpec("+commit-tag:refs/tags/renamed-tag"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/heads/foo", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f"),
@@ -182,15 +182,15 @@ func (s *RemoteSuite) TestFetchToNewBranchWithAllTags() {
 
 	s.testFetch(r, &FetchOptions{
 		Tags: AllTags,
-		RefSpecs: []config.RefSpec{
+		RefSpecs: []plumbing.RefSpec{
 			// qualified branch to unqualified branch
 			"+refs/heads/master:foo",
 			// unqualified branch to unqualified branch
 			"master:bar",
 			// unqualified tag to unqualified branch
-			config.RefSpec("+tree-tag:tree-tag"),
+			plumbing.RefSpec("+tree-tag:tree-tag"),
 			// unqualified tag to qualified tag
-			config.RefSpec("commit-tag:refs/tags/renamed-tag"),
+			plumbing.RefSpec("commit-tag:refs/tags/renamed-tag"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/heads/foo", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f"),
@@ -211,8 +211,8 @@ func (s *RemoteSuite) TestFetchNonExistentReference() {
 	})
 
 	err := r.Fetch(&FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/foo:refs/remotes/origin/foo"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/foo:refs/remotes/origin/foo"),
 		},
 	})
 
@@ -228,8 +228,8 @@ func (s *RemoteSuite) TestFetchContext() {
 	defer cancel()
 
 	err := r.FetchContext(ctx, &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
 		},
 	})
 	s.NoError(err)
@@ -244,8 +244,8 @@ func (s *RemoteSuite) TestFetchContextCanceled() {
 	cancel()
 
 	err := r.FetchContext(ctx, &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
 		},
 	})
 	s.ErrorIs(err, context.Canceled)
@@ -258,8 +258,8 @@ func (s *RemoteSuite) TestFetchWithAllTags() {
 
 	s.testFetch(r, &FetchOptions{
 		Tags: AllTags,
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f"),
@@ -278,8 +278,8 @@ func (s *RemoteSuite) TestFetchWithNoTags() {
 
 	s.testFetch(r, &FetchOptions{
 		Tags: NoTags,
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f"),
@@ -297,8 +297,8 @@ func (s *RemoteSuite) TestFetchWithDepth() {
 
 	s.testFetch(r, &FetchOptions{
 		Depth: 1,
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
@@ -320,8 +320,8 @@ func (s *RemoteSuite) TestFetchWithDepthChange() {
 
 	s.testFetch(r, &FetchOptions{
 		Depth: 1,
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("refs/heads/master:refs/heads/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("refs/heads/master:refs/heads/master"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/heads/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
@@ -330,8 +330,8 @@ func (s *RemoteSuite) TestFetchWithDepthChange() {
 
 	s.testFetch(r, &FetchOptions{
 		Depth: 3,
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("refs/heads/master:refs/heads/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("refs/heads/master:refs/heads/master"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/heads/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
@@ -395,9 +395,9 @@ func (s *RemoteSuite) TestFetchWithProgress() {
 
 	r := NewRemote(sto, &config.RemoteConfig{Name: "foo", URLs: []string{url}})
 
-	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	refspec := plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*")
 	err := r.Fetch(&FetchOptions{
-		RefSpecs: []config.RefSpec{refspec},
+		RefSpecs: []plumbing.RefSpec{refspec},
 		Progress: buf,
 	})
 
@@ -427,9 +427,9 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter() {
 	url := s.GetBasicLocalRepositoryURL()
 	r := NewRemote(mock, &config.RemoteConfig{Name: "foo", URLs: []string{url}})
 
-	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	refspec := plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*")
 	err := r.Fetch(&FetchOptions{
-		RefSpecs: []config.RefSpec{refspec},
+		RefSpecs: []plumbing.RefSpec{refspec},
 	})
 
 	s.NoError(err)
@@ -458,8 +458,8 @@ func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDateButStillUpdateLocalRemoteRefs
 	})
 
 	o := &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 	}
 
@@ -493,8 +493,8 @@ func (s *RemoteSuite) doTestFetchNoErrAlreadyUpToDate(url string) {
 	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{URLs: []string{url}})
 
 	o := &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 	}
 
@@ -510,8 +510,8 @@ func (s *RemoteSuite) testFetchFastForward(sto storage.Storer) {
 	})
 
 	s.testFetch(r, &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/master:refs/heads/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/master:refs/heads/master"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/heads/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
@@ -519,16 +519,16 @@ func (s *RemoteSuite) testFetchFastForward(sto storage.Storer) {
 
 	// First make sure that we error correctly when a force is required.
 	err := r.Fetch(&FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("refs/heads/branch:refs/heads/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("refs/heads/branch:refs/heads/master"),
 		},
 	})
 	s.ErrorIs(err, ErrForceNeeded)
 
 	// And that forcing it fixes the problem.
 	err = r.Fetch(&FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/branch:refs/heads/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("+refs/heads/branch:refs/heads/master"),
 		},
 	})
 	s.NoError(err)
@@ -538,8 +538,8 @@ func (s *RemoteSuite) testFetchFastForward(sto storage.Storer) {
 		"refs/heads/master", "918c48b83bd081e863dbe1b80f8998f058cd8294",
 	))
 	s.testFetch(r, &FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("refs/heads/master:refs/heads/master"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("refs/heads/master:refs/heads/master"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/heads/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
@@ -589,9 +589,9 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 		URLs: []string{url},
 	})
 
-	rs := config.RefSpec("refs/heads/*:refs/heads/*")
+	rs := plumbing.RefSpec("refs/heads/*:refs/heads/*")
 	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{rs},
+		RefSpecs: []plumbing.RefSpec{rs},
 	})
 	s.NoError(err)
 
@@ -634,7 +634,7 @@ func (s *RemoteSuite) TestPushContext() {
 	numGoroutines := runtime.NumGoroutine()
 
 	err = r.PushContext(ctx, &PushOptions{
-		RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"},
+		RefSpecs: []plumbing.RefSpec{"refs/tags/*:refs/tags/*"},
 	})
 	s.NoError(err)
 
@@ -704,7 +704,7 @@ func (s *RemoteSuite) TestPushContextCanceled() {
 	numGoroutines := runtime.NumGoroutine()
 
 	err = r.PushContext(ctx, &PushOptions{
-		RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"},
+		RefSpecs: []plumbing.RefSpec{"refs/tags/*:refs/tags/*"},
 	})
 	s.ErrorIs(err, context.Canceled)
 
@@ -730,7 +730,7 @@ func (s *RemoteSuite) TestPushTags() {
 	})
 
 	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"},
+		RefSpecs: []plumbing.RefSpec{"refs/tags/*:refs/tags/*"},
 	})
 	s.NoError(err)
 
@@ -761,7 +761,7 @@ func (s *RemoteSuite) TestPushTagsByOID() {
 	})
 
 	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{
+		RefSpecs: []plumbing.RefSpec{
 			"f7b877701fbf855b44c0a9e86f3fdce2c298b07f:refs/tags/lightweight-tag-copy",
 			"b742a2a9fa0afcfa9a6fad080980fbc26b007c69:refs/tags/annotated-tag-copy",
 			"ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc:refs/tags/commit-tag-copy",
@@ -799,8 +799,8 @@ func (s *RemoteSuite) testPushByOID(oid, refName string) {
 	})
 
 	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec(oid + ":" + refName),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec(oid + ":" + refName),
 		},
 		FollowTags: false,
 	})
@@ -864,7 +864,7 @@ func (s *RemoteSuite) TestPushFollowTags() {
 	s.NoError(err)
 
 	err = r.Push(&PushOptions{
-		RefSpecs:   []config.RefSpec{"+refs/heads/branch:refs/heads/branch"},
+		RefSpecs:   []plumbing.RefSpec{"+refs/heads/branch:refs/heads/branch"},
 		FollowTags: true,
 	})
 	s.NoError(err)
@@ -892,7 +892,7 @@ func (s *RemoteSuite) TestPushNoErrAlreadyUpToDate() {
 	})
 
 	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{"refs/heads/*:refs/heads/*"},
+		RefSpecs: []plumbing.RefSpec{"refs/heads/*:refs/heads/*"},
 	})
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
 }
@@ -914,7 +914,7 @@ func (s *RemoteSuite) TestPushDeleteReference() {
 	s.NoError(err)
 
 	err = remote.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{":refs/heads/branch"},
+		RefSpecs: []plumbing.RefSpec{":refs/heads/branch"},
 	})
 	s.NoError(err)
 
@@ -943,7 +943,7 @@ func (s *RemoteSuite) TestForcePushDeleteReference() {
 	s.NoError(err)
 
 	err = remote.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{":refs/heads/branch"},
+		RefSpecs: []plumbing.RefSpec{":refs/heads/branch"},
 		Force:    true,
 	})
 	s.NoError(err)
@@ -974,7 +974,7 @@ func (s *RemoteSuite) TestPushRejectNonFastForward() {
 	s.NoError(err)
 	s.NotNil(oldRef)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{
 		"refs/heads/master:refs/heads/branch",
 	}})
 	s.ErrorContains(err, "non-fast-forward update: refs/heads/branch")
@@ -1005,8 +1005,8 @@ func (s *RemoteSuite) TestPushForce() {
 	s.NoError(err)
 	s.NotNil(oldRef)
 
-	err = r.Push(&PushOptions{RefSpecs: []config.RefSpec{
-		config.RefSpec("+refs/heads/master:refs/heads/branch"),
+	err = r.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{
+		plumbing.RefSpec("+refs/heads/master:refs/heads/branch"),
 	}})
 	s.NoError(err)
 
@@ -1037,7 +1037,7 @@ func (s *RemoteSuite) TestPushForceWithOption() {
 	s.NotNil(oldRef)
 
 	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{"refs/heads/master:refs/heads/branch"},
+		RefSpecs: []plumbing.RefSpec{"refs/heads/master:refs/heads/branch"},
 		Force:    true,
 	})
 	s.NoError(err)
@@ -1104,7 +1104,7 @@ func (s *RemoteSuite) TestPushForceWithLease_success() {
 		s.NotNil(oldRef)
 
 		s.NoError(r.Push(&PushOptions{
-			RefSpecs:       []config.RefSpec{"refs/heads/branch:refs/heads/branch"},
+			RefSpecs:       []plumbing.RefSpec{"refs/heads/branch:refs/heads/branch"},
 			ForceWithLease: &ForceWithLease{},
 		}))
 
@@ -1172,7 +1172,7 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 		s.NotNil(oldRef)
 
 		err = r.Push(&PushOptions{
-			RefSpecs:       []config.RefSpec{"refs/heads/branch:refs/heads/branch"},
+			RefSpecs:       []plumbing.RefSpec{"refs/heads/branch:refs/heads/branch"},
 			ForceWithLease: &ForceWithLease{},
 		})
 
@@ -1209,8 +1209,8 @@ func (s *RemoteSuite) TestPushPrune() {
 	s.NoError(err)
 
 	err = remote.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("refs/heads/*:refs/heads/*"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("refs/heads/*:refs/heads/*"),
 		},
 		Prune: true,
 	})
@@ -1221,8 +1221,8 @@ func (s *RemoteSuite) TestPushPrune() {
 	})
 
 	err = remote.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec("*:*"),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec("*:*"),
 		},
 		Prune: true,
 	})
@@ -1258,7 +1258,7 @@ func (s *RemoteSuite) TestPushNewReference() {
 	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{
 		"refs/heads/master:refs/heads/branch2",
 	}})
 	s.NoError(err)
@@ -1290,7 +1290,7 @@ func (s *RemoteSuite) TestPushNewReferenceAndDeleteInBatch() {
 	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{
 		"refs/heads/master:refs/heads/branch2",
 		":refs/heads/branch",
 	}})
@@ -1334,9 +1334,9 @@ func (s *RemoteSuite) TestPushInvalidSchemaEndpoint() {
 
 func (s *RemoteSuite) TestPushInvalidFetchOptions() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
-	invalid := config.RefSpec("^*$ñ")
-	err := r.Push(&PushOptions{RefSpecs: []config.RefSpec{invalid}})
-	s.ErrorIs(err, config.ErrRefSpecMalformedSeparator)
+	invalid := plumbing.RefSpec("^*$ñ")
+	err := r.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{invalid}})
+	s.ErrorIs(err, plumbing.ErrRefSpecMalformedSeparator)
 }
 
 func (s *RemoteSuite) TestPushInvalidRefSpec() {
@@ -1345,11 +1345,11 @@ func (s *RemoteSuite) TestPushInvalidRefSpec() {
 		URLs: []string{"some-url"},
 	})
 
-	rs := config.RefSpec("^*$**")
+	rs := plumbing.RefSpec("^*$**")
 	err := r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{rs},
+		RefSpecs: []plumbing.RefSpec{rs},
 	})
-	s.ErrorIs(err, config.ErrRefSpecMalformedSeparator)
+	s.ErrorIs(err, plumbing.ErrRefSpecMalformedSeparator)
 }
 
 func (s *RemoteSuite) TestPushWrongRemoteName() {
@@ -1585,8 +1585,8 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 	s.NotNil(otherRef)
 
 	err = r.Push(&PushOptions{
-		RefSpecs:          []config.RefSpec{"refs/heads/master:refs/heads/branch"},
-		RequireRemoteRefs: []config.RefSpec{config.RefSpec(otherRef.Hash().String() + ":refs/heads/branch")},
+		RefSpecs:          []plumbing.RefSpec{"refs/heads/master:refs/heads/branch"},
+		RequireRemoteRefs: []plumbing.RefSpec{plumbing.RefSpec(otherRef.Hash().String() + ":refs/heads/branch")},
 	})
 	s.ErrorContains(err, "remote ref refs/heads/branch required to be 6ecf0ef2c2dffb796033e5a02219af86ec6584e5 but is e8d3ffab552895c19b9fcf7aa264d277cde33881")
 
@@ -1595,8 +1595,8 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 	s.Equal(oldRef, newRef)
 
 	err = r.Push(&PushOptions{
-		RefSpecs:          []config.RefSpec{"refs/heads/master:refs/heads/branch"},
-		RequireRemoteRefs: []config.RefSpec{config.RefSpec(oldRef.Hash().String() + ":refs/heads/branch")},
+		RefSpecs:          []plumbing.RefSpec{"refs/heads/master:refs/heads/branch"},
+		RequireRemoteRefs: []plumbing.RefSpec{plumbing.RefSpec(oldRef.Hash().String() + ":refs/heads/branch")},
 	})
 	s.ErrorContains(err, "non-fast-forward update: ")
 
@@ -1605,8 +1605,8 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 	s.Equal(oldRef, newRef)
 
 	err = r.Push(&PushOptions{
-		RefSpecs:          []config.RefSpec{"refs/heads/master:refs/heads/branch"},
-		RequireRemoteRefs: []config.RefSpec{config.RefSpec(oldRef.Hash().String() + ":refs/heads/branch")},
+		RefSpecs:          []plumbing.RefSpec{"refs/heads/master:refs/heads/branch"},
+		RequireRemoteRefs: []plumbing.RefSpec{plumbing.RefSpec(oldRef.Hash().String() + ":refs/heads/branch")},
 		Force:             true,
 	})
 	s.NoError(err)
@@ -1639,7 +1639,7 @@ func (s *RemoteSuite) TestFetchPrune() {
 	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{
 		"refs/heads/master:refs/heads/branch",
 	}})
 	s.NoError(err)
@@ -1656,7 +1656,7 @@ func (s *RemoteSuite) TestFetchPrune() {
 		"refs/remotes/origin/branch": ref.Hash().String(),
 	})
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{
 		":refs/heads/branch",
 	}})
 	s.NoError(err)
@@ -1695,7 +1695,7 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{
 		"refs/heads/master:refs/tags/v1",
 	}})
 	s.NoError(err)
@@ -1712,7 +1712,7 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 		"refs/tags/v1": ref.Hash().String(),
 	})
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{
 		":refs/tags/v1",
 	}})
 	s.NoError(err)
@@ -1721,7 +1721,7 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 		"refs/tags/v1": ref.Hash().String(),
 	})
 
-	err = rSave.Fetch(&FetchOptions{Prune: true, RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"}})
+	err = rSave.Fetch(&FetchOptions{Prune: true, RefSpecs: []plumbing.RefSpec{"refs/tags/*:refs/tags/*"}})
 	s.NoError(err)
 
 	_, err = rSave.Reference("refs/tags/v1", true)
@@ -1757,9 +1757,9 @@ func (s *RemoteSuite) TestCanPushShasToReference() {
 
 	err = gitremote.Push(&PushOptions{
 		RemoteName: "local",
-		RefSpecs: []config.RefSpec{
+		RefSpecs: []plumbing.RefSpec{
 			// TODO: check with short hashes that this is still respected
-			config.RefSpec(sha.String() + ":refs/heads/branch"),
+			plumbing.RefSpec(sha.String() + ":refs/heads/branch"),
 		},
 	})
 	s.NoError(err)
@@ -1811,7 +1811,7 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 		Depth: 2,
 		Tags:  plumbing.NoTags,
 
-		RefSpecs: []config.RefSpec{
+		RefSpecs: []plumbing.RefSpec{
 			"+refs/heads/master:refs/heads/master",
 			"+refs/heads/master:refs/remotes/origin/master",
 		},
@@ -1831,7 +1831,7 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 		Depth: 1,
 		Tags:  plumbing.NoTags,
 
-		RefSpecs: []config.RefSpec{
+		RefSpecs: []plumbing.RefSpec{
 			"+refs/heads/master:refs/heads/master",
 			"+refs/heads/master:refs/remotes/origin/master",
 		},
@@ -1889,7 +1889,7 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 	err = r.Fetch(&FetchOptions{
 		Depth: 1,
 		Tags:  plumbing.NoTags,
-		RefSpecs: []config.RefSpec{
+		RefSpecs: []plumbing.RefSpec{
 			// No leading '+' — this is a fast-forward-only refspec.
 			"refs/heads/master:refs/heads/master",
 			"refs/heads/master:refs/remotes/origin/master",
@@ -1932,8 +1932,8 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	}
 	defer func() { _ = localRepo.Close() }()
 	if err := localRepo.Fetch(&FetchOptions{
-		RefSpecs: []config.RefSpec{
-			config.RefSpec(fmt.Sprintf("%s:%s", customRef, customRef)),
+		RefSpecs: []plumbing.RefSpec{
+			plumbing.RefSpec(fmt.Sprintf("%s:%s", customRef, customRef)),
 		},
 	}); err != nil {
 		t.Fatal(err)
@@ -1952,16 +1952,16 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = remote.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{
-		config.RefSpec(fmt.Sprintf("%s:%s", customRef, customRef)),
+	err = remote.Fetch(&FetchOptions{RefSpecs: []plumbing.RefSpec{
+		plumbing.RefSpec(fmt.Sprintf("%s:%s", customRef, customRef)),
 	}})
 	if !errors.Is(err, ErrForceNeeded) {
 		t.Errorf("expected %v, got %v", ErrForceNeeded, err)
 	}
 
 	// 6. Fetch with force
-	err = remote.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{
-		config.RefSpec(fmt.Sprintf("+%s:%s", customRef, customRef)),
+	err = remote.Fetch(&FetchOptions{RefSpecs: []plumbing.RefSpec{
+		plumbing.RefSpec(fmt.Sprintf("+%s:%s", customRef, customRef)),
 	}})
 	if err != nil {
 		t.Errorf("unexpected error %v", err)

--- a/remote_test.go
+++ b/remote_test.go
@@ -19,7 +19,6 @@ import (
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/object"
@@ -41,38 +40,38 @@ func TestRemoteSuite(t *testing.T) {
 }
 
 func (s *RemoteSuite) TestFetchInvalidEndpoint() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"http://\\"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "foo", URLs: []string{"http://\\"}})
 	err := r.Fetch(&FetchOptions{RemoteName: "foo"})
 	s.ErrorContains(err, "invalid character")
 }
 
 func (s *RemoteSuite) TestFetchNonExistentEndpoint() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"ssh://non-existent/foo.git"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "foo", URLs: []string{"ssh://non-existent/foo.git"}})
 	err := r.Fetch(&FetchOptions{})
 	s.NotNil(err)
 }
 
 func (s *RemoteSuite) TestFetchInvalidSchemaEndpoint() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
 	err := r.Fetch(&FetchOptions{})
 	s.ErrorContains(err, "unsupported scheme")
 }
 
 func (s *RemoteSuite) TestFetchOverriddenEndpoint() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"http://perfectly-valid-url.example.com"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "foo", URLs: []string{"http://perfectly-valid-url.example.com"}})
 	err := r.Fetch(&FetchOptions{RemoteURL: "http://\\"})
 	s.ErrorContains(err, "invalid character")
 }
 
 func (s *RemoteSuite) TestFetchInvalidFetchOptions() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
 	invalid := plumbing.RefSpec("^*$ñ")
 	err := r.Fetch(&FetchOptions{RefSpecs: []plumbing.RefSpec{invalid}})
 	s.ErrorIs(err, plumbing.ErrRefSpecMalformedSeparator)
 }
 
 func (s *RemoteSuite) TestFetchWildcard() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
@@ -88,7 +87,7 @@ func (s *RemoteSuite) TestFetchWildcard() {
 }
 
 func (s *RemoteSuite) TestFetchExactSHA1() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})
 
@@ -102,7 +101,7 @@ func (s *RemoteSuite) TestFetchExactSHA1() {
 }
 
 func (s *RemoteSuite) TestFetchExactSHA1_NotSupported() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
@@ -116,7 +115,7 @@ func (s *RemoteSuite) TestFetchExactSHA1_NotSupported() {
 }
 
 func (s *RemoteSuite) TestFetchWildcardTags() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -136,7 +135,7 @@ func (s *RemoteSuite) TestFetchWildcardTags() {
 }
 
 func (s *RemoteSuite) TestFetch() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -150,7 +149,7 @@ func (s *RemoteSuite) TestFetch() {
 }
 
 func (s *RemoteSuite) TestFetchToNewBranch() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -176,7 +175,7 @@ func (s *RemoteSuite) TestFetchToNewBranch() {
 }
 
 func (s *RemoteSuite) TestFetchToNewBranchWithAllTags() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -206,7 +205,7 @@ func (s *RemoteSuite) TestFetchToNewBranchWithAllTags() {
 }
 
 func (s *RemoteSuite) TestFetchNonExistentReference() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -220,7 +219,7 @@ func (s *RemoteSuite) TestFetchNonExistentReference() {
 }
 
 func (s *RemoteSuite) TestFetchContext() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -236,7 +235,7 @@ func (s *RemoteSuite) TestFetchContext() {
 }
 
 func (s *RemoteSuite) TestFetchContextCanceled() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -252,7 +251,7 @@ func (s *RemoteSuite) TestFetchContextCanceled() {
 }
 
 func (s *RemoteSuite) TestFetchWithAllTags() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -272,7 +271,7 @@ func (s *RemoteSuite) TestFetchWithAllTags() {
 }
 
 func (s *RemoteSuite) TestFetchWithNoTags() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
@@ -291,7 +290,7 @@ func (s *RemoteSuite) TestFetchWithDepth() {
 		"yet. Since we're using local repositories here, the test will use the" +
 		"server-side implementation. See transport/upload_pack.go and" +
 		"packfile/encoder.go")
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
@@ -314,7 +313,7 @@ func (s *RemoteSuite) TestFetchWithDepthChange() {
 		"yet. Since we're using local repositories here, the test will use the" +
 		"server-side implementation. See transport/upload_pack.go and" +
 		"packfile/encoder.go")
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
@@ -393,7 +392,7 @@ func (s *RemoteSuite) TestFetchWithProgress() {
 	sto := memory.NewStorage()
 	buf := bytes.NewBuffer(nil)
 
-	r := NewRemote(sto, &config.RemoteConfig{Name: "foo", URLs: []string{url}})
+	r := NewRemote(sto, &RemoteConfig{Name: "foo", URLs: []string{url}})
 
 	refspec := plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*")
 	err := r.Fetch(&FetchOptions{
@@ -425,7 +424,7 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter() {
 	mock := &mockPackfileWriter{Storer: fss}
 
 	url := s.GetBasicLocalRepositoryURL()
-	r := NewRemote(mock, &config.RemoteConfig{Name: "foo", URLs: []string{url}})
+	r := NewRemote(mock, &RemoteConfig{Name: "foo", URLs: []string{url}})
 
 	refspec := plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*")
 	err := r.Fetch(&FetchOptions{
@@ -453,7 +452,7 @@ func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDate() {
 }
 
 func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDateButStillUpdateLocalRemoteRefs() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
@@ -490,7 +489,7 @@ func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDateWithNonCommitObjects() {
 }
 
 func (s *RemoteSuite) doTestFetchNoErrAlreadyUpToDate(url string) {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{URLs: []string{url}})
+	r := NewRemote(memory.NewStorage(), &RemoteConfig{URLs: []string{url}})
 
 	o := &FetchOptions{
 		RefSpecs: []plumbing.RefSpec{
@@ -505,7 +504,7 @@ func (s *RemoteSuite) doTestFetchNoErrAlreadyUpToDate(url string) {
 }
 
 func (s *RemoteSuite) testFetchFastForward(sto storage.Storer) {
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
@@ -561,7 +560,7 @@ func (s *RemoteSuite) TestFetchFastForwardFS() {
 }
 
 func (s *RemoteSuite) TestString() {
-	r := NewRemote(nil, &config.RemoteConfig{
+	r := NewRemote(nil, &RemoteConfig{
 		Name: "foo",
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})
@@ -584,7 +583,7 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 	sto := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -623,7 +622,7 @@ func (s *RemoteSuite) TestPushContext() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -654,7 +653,7 @@ func (s *RemoteSuite) TestPushPushOptions() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -693,7 +692,7 @@ func (s *RemoteSuite) TestPushContextCanceled() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -724,7 +723,7 @@ func (s *RemoteSuite) TestPushTags() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -755,7 +754,7 @@ func (s *RemoteSuite) TestPushTagsByOID() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -793,7 +792,7 @@ func (s *RemoteSuite) testPushByOID(oid, refName string) {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -829,7 +828,7 @@ func (s *RemoteSuite) TestPushFollowTags() {
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -886,7 +885,7 @@ func (s *RemoteSuite) TestPushNoErrAlreadyUpToDate() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{fs.Root()},
 	})
@@ -996,7 +995,7 @@ func (s *RemoteSuite) TestPushForce() {
 	dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
 	defer func() { _ = dstSto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{dstFs.Root()},
 	})
@@ -1027,7 +1026,7 @@ func (s *RemoteSuite) TestPushForceWithOption() {
 	dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
 	defer func() { _ = dstSto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{dstFs.Root()},
 	})
@@ -1094,7 +1093,7 @@ func (s *RemoteSuite) TestPushForceWithLease_success() {
 		s.NoError(err)
 		s.T().Log(ref.String())
 
-		r := NewRemote(sto, &config.RemoteConfig{
+		r := NewRemote(sto, &RemoteConfig{
 			Name: DefaultRemoteName,
 			URLs: []string{dstFs.Root()},
 		})
@@ -1162,7 +1161,7 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 			),
 		))
 
-		r := NewRemote(sto, &config.RemoteConfig{
+		r := NewRemote(sto, &RemoteConfig{
 			Name: DefaultRemoteName,
 			URLs: []string{dstFs.Root()},
 		})
@@ -1309,38 +1308,38 @@ func (s *RemoteSuite) TestPushNewReferenceAndDeleteInBatch() {
 }
 
 func (s *RemoteSuite) TestPushInvalidEndpoint() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"http://\\"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "foo", URLs: []string{"http://\\"}})
 	err := r.Push(&PushOptions{RemoteName: "foo"})
 	s.ErrorContains(err, "invalid character")
 }
 
 func (s *RemoteSuite) TestPushNonExistentEndpoint() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"ssh://non-existent/foo.git"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "foo", URLs: []string{"ssh://non-existent/foo.git"}})
 	err := r.Push(&PushOptions{})
 	s.NotNil(err)
 }
 
 func (s *RemoteSuite) TestPushOverriddenEndpoint() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "origin", URLs: []string{"http://perfectly-valid-url.example.com"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "origin", URLs: []string{"http://perfectly-valid-url.example.com"}})
 	err := r.Push(&PushOptions{RemoteURL: "http://\\"})
 	s.ErrorContains(err, "invalid character")
 }
 
 func (s *RemoteSuite) TestPushInvalidSchemaEndpoint() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "origin", URLs: []string{"qux://foo"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "origin", URLs: []string{"qux://foo"}})
 	err := r.Push(&PushOptions{})
 	s.ErrorContains(err, "unsupported scheme")
 }
 
 func (s *RemoteSuite) TestPushInvalidFetchOptions() {
-	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
+	r := NewRemote(nil, &RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
 	invalid := plumbing.RefSpec("^*$ñ")
 	err := r.Push(&PushOptions{RefSpecs: []plumbing.RefSpec{invalid}})
 	s.ErrorIs(err, plumbing.ErrRefSpecMalformedSeparator)
 }
 
 func (s *RemoteSuite) TestPushInvalidRefSpec() {
-	r := NewRemote(nil, &config.RemoteConfig{
+	r := NewRemote(nil, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{"some-url"},
 	})
@@ -1353,7 +1352,7 @@ func (s *RemoteSuite) TestPushInvalidRefSpec() {
 }
 
 func (s *RemoteSuite) TestPushWrongRemoteName() {
-	r := NewRemote(nil, &config.RemoteConfig{
+	r := NewRemote(nil, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{"some-url"},
 	})
@@ -1396,7 +1395,7 @@ func (s *RemoteSuite) TestGetHaves() {
 
 func (s *RemoteSuite) TestList() {
 	repo := fixtures.Basic().One()
-	remote := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	remote := NewRemote(memory.NewStorage(), &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{repo.URL},
 	})
@@ -1426,7 +1425,7 @@ func (s *RemoteSuite) TestList() {
 }
 
 func (s *RemoteSuite) TestListPeeling() {
-	remote := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	remote := NewRemote(memory.NewStorage(), &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{"https://github.com/git-fixtures/tags.git"},
 	})
@@ -1471,7 +1470,7 @@ func (s *RemoteSuite) TestListTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	remote := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	remote := NewRemote(memory.NewStorage(), &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{srv.URL},
 	})
@@ -1507,7 +1506,7 @@ func (s *RemoteSuite) TestUpdateShallows() {
 		{nil, hashes[0:6]},
 	}
 
-	remote := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	remote := NewRemote(memory.NewStorage(), &RemoteConfig{
 		Name: DefaultRemoteName,
 	})
 
@@ -1544,7 +1543,7 @@ func (s *RemoteSuite) TestUseRefDeltas() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -1571,7 +1570,7 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 	defer func() { _ = dstSto.Close() }()
 
 	url := dstFs.Root()
-	r := NewRemote(sto, &config.RemoteConfig{
+	r := NewRemote(sto, &RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{url},
 	})
@@ -1746,7 +1745,7 @@ func (s *RemoteSuite) TestCanPushShasToReference() {
 
 	sha := CommitNewFile(s.T(), repo, "README.md")
 
-	gitremote, err := repo.CreateRemote(&config.RemoteConfig{
+	gitremote, err := repo.CreateRemote(&RemoteConfig{
 		Name: "local",
 		URLs: []string{filepath.Join(d, "remote")},
 	})

--- a/remoteconfig.go
+++ b/remoteconfig.go
@@ -1,0 +1,288 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/internal/url"
+	"github.com/go-git/go-git/v6/plumbing"
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
+)
+
+var (
+	// ErrRemoteConfigNotFound is returned when a remote config is not found.
+	ErrRemoteConfigNotFound = errors.New("remote config not found")
+	// ErrRemoteConfigEmptyURL is returned when a remote config has an empty URL.
+	ErrRemoteConfigEmptyURL = errors.New("remote config: empty URL")
+	// ErrRemoteConfigEmptyName is returned when a remote config has an empty name.
+	ErrRemoteConfigEmptyName = errors.New("remote config: empty name")
+)
+
+const (
+	remoteSection    = "remote"
+	submoduleSection = "submodule"
+	branchSection    = "branch"
+	urlSection       = "url"
+	fetchKey         = "fetch"
+	urlKey           = "url"
+	pushurlKey       = "pushurl"
+	mirrorKey        = "mirror"
+	mergeKey         = "merge"
+	rebaseKey        = "rebase"
+	descriptionKey   = "description"
+)
+
+// RemoteConfig contains the configuration for a given remote repository.
+type RemoteConfig struct {
+	// Name of the remote
+	Name string
+	// URLs the URLs of a remote repository. It must be non-empty. Fetch will
+	// always use the first URL, while push will use all of them.
+	URLs []string
+	// Mirror indicates that the repository is a mirror of remote.
+	Mirror bool
+
+	// insteadOfRulesApplied have urls been modified
+	insteadOfRulesApplied bool
+	// originalURLs are the urls before applying insteadOf rules
+	originalURLs []string
+
+	// Fetch the default set of "refspec" for fetch operation
+	Fetch []plumbing.RefSpec
+
+	// raw representation of the subsection, filled by marshal or unmarshal are
+	// called
+	raw *format.Subsection
+}
+
+// Validate validates the fields and sets the default values.
+func (c *RemoteConfig) Validate() error {
+	if c.Name == "" {
+		return ErrRemoteConfigEmptyName
+	}
+
+	if len(c.URLs) == 0 {
+		return ErrRemoteConfigEmptyURL
+	}
+
+	for _, r := range c.Fetch {
+		if err := r.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if len(c.Fetch) == 0 {
+		c.Fetch = []plumbing.RefSpec{plumbing.RefSpec(fmt.Sprintf(config.DefaultFetchRefSpec, c.Name))}
+	}
+
+	return plumbing.NewRemoteHEADReferenceName(c.Name).Validate()
+}
+
+func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
+	c.raw = s
+
+	fetch := []plumbing.RefSpec{}
+	for _, f := range c.raw.Options.GetAll(fetchKey) {
+		rs := plumbing.RefSpec(f)
+		if err := rs.Validate(); err != nil {
+			return err
+		}
+
+		fetch = append(fetch, rs)
+	}
+
+	c.Name = c.raw.Name
+	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
+	c.URLs = append(c.URLs, c.raw.Options.GetAll(pushurlKey)...)
+	c.Fetch = fetch
+	if c.raw.Options.Has(mirrorKey) {
+		if b, err := format.ParseBool(c.raw.Options.Get(mirrorKey)); err == nil {
+			c.Mirror = b
+		}
+	}
+
+	return nil
+}
+
+func (c *RemoteConfig) marshal() *format.Subsection {
+	if c.raw == nil {
+		c.raw = &format.Subsection{}
+	}
+
+	c.raw.Name = c.Name
+	if len(c.URLs) == 0 {
+		c.raw.RemoveOption(urlKey)
+	} else {
+		urls := c.URLs
+		if c.insteadOfRulesApplied {
+			urls = c.originalURLs
+		}
+
+		c.raw.SetOption(urlKey, urls...)
+	}
+
+	if len(c.Fetch) == 0 {
+		c.raw.RemoveOption(fetchKey)
+	} else {
+		values := make([]string, 0, len(c.Fetch))
+		for _, rs := range c.Fetch {
+			values = append(values, rs.String())
+		}
+
+		c.raw.SetOption(fetchKey, values...)
+	}
+
+	if c.Mirror {
+		c.raw.SetOption(mirrorKey, strconv.FormatBool(c.Mirror))
+	}
+
+	return c.raw
+}
+
+// IsFirstURLLocal returns true if the first URL is a local path.
+func (c *RemoteConfig) IsFirstURLLocal() bool {
+	return url.IsLocalEndpoint(c.URLs[0])
+}
+
+func (c *RemoteConfig) applyURLRules(urlRules []*URL) {
+	// save original urls
+	originalURLs := make([]string, len(c.URLs))
+	copy(originalURLs, c.URLs)
+
+	for i, u := range c.URLs {
+		if rewrittenURL, matched := applyLongestInsteadOfMatch(u, urlRules); matched {
+			c.URLs[i] = rewrittenURL
+			c.insteadOfRulesApplied = true
+		}
+	}
+
+	if c.insteadOfRulesApplied {
+		c.originalURLs = originalURLs
+	}
+}
+
+// setSubsection replaces a subsection of the same name within section of cfg,
+// or appends it if absent.
+func setSubsection(cfg *config.Config, section, name string, sub *format.Subsection) {
+	s := cfg.Raw.Section(section)
+	for i, ss := range s.Subsections {
+		if ss.IsName(name) {
+			s.Subsections[i] = sub
+			return
+		}
+	}
+	s.Subsections = append(s.Subsections, sub)
+}
+
+// remoteConfigs returns the [remote] subsections of cfg keyed by name, with
+// url.insteadOf rewrite rules applied to their URLs.
+func remoteConfigs(cfg *config.Config) map[string]*RemoteConfig {
+	m, _ := readRemoteConfigs(cfg)
+	return m
+}
+
+func readRemoteConfigs(cfg *config.Config) (map[string]*RemoteConfig, error) {
+	out := make(map[string]*RemoteConfig)
+	urls := urlConfigs(cfg)
+	s := cfg.Raw.Section(remoteSection)
+	for _, sub := range s.Subsections {
+		r := &RemoteConfig{}
+		if err := r.unmarshal(sub); err != nil {
+			return nil, err
+		}
+		r.applyURLRules(urls)
+		out[r.Name] = r
+	}
+	if len(s.Options) > 0 {
+		r := &RemoteConfig{}
+		if err := r.unmarshal(&format.Subsection{Name: "", Options: s.Options}); err != nil {
+			return nil, err
+		}
+		r.applyURLRules(urls)
+		out[r.Name] = r
+	}
+	return out, nil
+}
+
+// remoteConfig returns the named remote of cfg, or nil if it does not exist.
+func remoteConfig(cfg *config.Config, name string) *RemoteConfig {
+	return remoteConfigs(cfg)[name]
+}
+
+// setRemoteConfig writes r into cfg, replacing any existing remote of the same name.
+func setRemoteConfig(cfg *config.Config, r *RemoteConfig) {
+	setSubsection(cfg, remoteSection, r.Name, r.marshal())
+}
+
+// branchConfigs returns the [branch] subsections of cfg keyed by name.
+func branchConfigs(cfg *config.Config) map[string]*Branch {
+	m, _ := readBranchConfigs(cfg)
+	return m
+}
+
+func readBranchConfigs(cfg *config.Config) (map[string]*Branch, error) {
+	out := make(map[string]*Branch)
+	s := cfg.Raw.Section(branchSection)
+	for _, sub := range s.Subsections {
+		b := &Branch{}
+		if err := b.unmarshal(sub); err != nil {
+			return nil, err
+		}
+		out[b.Name] = b
+	}
+	return out, nil
+}
+
+// branchConfig returns the named branch of cfg, or nil if it does not exist.
+func branchConfig(cfg *config.Config, name string) *Branch {
+	return branchConfigs(cfg)[name]
+}
+
+// setBranchConfig writes b into cfg, replacing any existing branch of the same name.
+func setBranchConfig(cfg *config.Config, b *Branch) {
+	setSubsection(cfg, branchSection, b.Name, b.marshal())
+}
+
+// submoduleConfigs returns the [submodule] subsections of cfg keyed by name,
+// skipping any with an invalid name or path.
+func submoduleConfigs(cfg *config.Config) map[string]*SubmoduleConfig {
+	out := make(map[string]*SubmoduleConfig)
+	s := cfg.Raw.Section(submoduleSection)
+	for _, sub := range s.Subsections {
+		m := &SubmoduleConfig{}
+		m.unmarshal(sub)
+		if err := m.Validate(); errors.Is(err, ErrModuleBadPath) ||
+			errors.Is(err, ErrModuleBadName) {
+			continue
+		}
+		out[m.Name] = m
+	}
+	return out
+}
+
+// submoduleConfig returns the named submodule of cfg, or nil if it does not exist.
+func submoduleConfig(cfg *config.Config, name string) *SubmoduleConfig {
+	return submoduleConfigs(cfg)[name]
+}
+
+// setSubmoduleConfig writes m into cfg, replacing any existing submodule of the
+// same name. The path option is not stored in the repository config.
+func setSubmoduleConfig(cfg *config.Config, m *SubmoduleConfig) {
+	sub := m.marshal()
+	sub.RemoveOption(pathKey)
+	setSubsection(cfg, submoduleSection, m.Name, sub)
+}
+
+// urlConfigs returns the [url] subsections of cfg in file order.
+func urlConfigs(cfg *config.Config) []*URL {
+	s := cfg.Raw.Section(urlSection)
+	out := make([]*URL, 0, len(s.Subsections))
+	for _, sub := range s.Subsections {
+		u := &URL{}
+		_ = u.unmarshal(sub)
+		out = append(out, u)
+	}
+	return out
+}

--- a/repository.go
+++ b/repository.go
@@ -264,7 +264,7 @@ func setConfigWorktree(r *Repository, worktree, storage billy.Filesystem) error 
 		return err
 	}
 
-	cfg.Core.Worktree = path
+	cfg.SetWorktree(path)
 	return r.Storer.SetConfig(cfg)
 }
 
@@ -769,8 +769,8 @@ func (r *Repository) Remote(name string) (*Remote, error) {
 		return nil, err
 	}
 
-	c, ok := cfg.Remotes[name]
-	if !ok {
+	c := cfg.Remote(name)
+	if c == nil {
 		return nil, ErrRemoteNotFound
 	}
 
@@ -784,10 +784,11 @@ func (r *Repository) Remotes() ([]*Remote, error) {
 		return nil, err
 	}
 
-	remotes := make([]*Remote, len(cfg.Remotes))
+	all := cfg.Remotes()
+	remotes := make([]*Remote, len(all))
 
 	var i int
-	for _, c := range cfg.Remotes {
+	for _, c := range all {
 		remotes[i] = NewRemote(r.Storer, c)
 		i++
 	}
@@ -808,11 +809,11 @@ func (r *Repository) CreateRemote(c *config.RemoteConfig) (*Remote, error) {
 		return nil, err
 	}
 
-	if _, ok := cfg.Remotes[c.Name]; ok {
+	if cfg.Remote(c.Name) != nil {
 		return nil, ErrRemoteExists
 	}
 
-	cfg.Remotes[c.Name] = c
+	cfg.SetRemote(c)
 	return remote, r.Storer.SetConfig(cfg)
 }
 
@@ -839,11 +840,11 @@ func (r *Repository) DeleteRemote(name string) error {
 		return err
 	}
 
-	if _, ok := cfg.Remotes[name]; !ok {
+	if cfg.Remote(name) == nil {
 		return ErrRemoteNotFound
 	}
 
-	delete(cfg.Remotes, name)
+	cfg.RemoveRemote(name)
 	return r.Storer.SetConfig(cfg)
 }
 
@@ -854,8 +855,8 @@ func (r *Repository) Branch(name string) (*config.Branch, error) {
 		return nil, err
 	}
 
-	b, ok := cfg.Branches[name]
-	if !ok {
+	b := cfg.Branch(name)
+	if b == nil {
 		return nil, ErrBranchNotFound
 	}
 
@@ -873,11 +874,11 @@ func (r *Repository) CreateBranch(c *config.Branch) error {
 		return err
 	}
 
-	if _, ok := cfg.Branches[c.Name]; ok {
+	if cfg.Branch(c.Name) != nil {
 		return ErrBranchExists
 	}
 
-	cfg.Branches[c.Name] = c
+	cfg.SetBranch(c)
 	return r.Storer.SetConfig(cfg)
 }
 
@@ -890,11 +891,11 @@ func (r *Repository) DeleteBranch(name string) error {
 		return err
 	}
 
-	if _, ok := cfg.Branches[name]; !ok {
+	if cfg.Branch(name) == nil {
 		return ErrBranchNotFound
 	}
 
-	delete(cfg.Branches, name)
+	cfg.RemoveBranch(name)
 	return r.Storer.SetConfig(cfg)
 }
 
@@ -957,7 +958,7 @@ func (r *Repository) createTagObject(name string, hash plumbing.Hash, opts *Crea
 	signer := opts.Signer
 	if signer == nil {
 		cfg, err := r.ConfigScoped(config.SystemScope)
-		if err == nil && cfg != nil && cfg.Tag.GpgSign.IsTrue() {
+		if err == nil && cfg != nil && cfg.Tag().GpgSign.IsTrue() {
 			// Use Has before Get so the key is not frozen when no plugin is
 			// registered, allowing callers to register one later.
 			if !plugin.Has(plugin.ObjectSigner()) {
@@ -1122,7 +1123,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		if err != nil {
 			return fmt.Errorf("failed to read remote repository configuration: %w", err)
 		}
-		if !conf.Core.IsBare {
+		if !conf.Core().IsBare {
 			altpath = path.Join(altpath, GitDirName)
 		}
 		if err := r.Storer.AddAlternate(altpath); err != nil {
@@ -1250,7 +1251,7 @@ func (r *Repository) setIsBare(isBare bool) error {
 		return err
 	}
 
-	cfg.Core.IsBare = isBare
+	cfg.SetBare(isBare)
 	return r.Storer.SetConfig(cfg)
 }
 
@@ -1266,7 +1267,7 @@ func (r *Repository) updateRemoteConfigIfNeeded(o *CloneOptions, c *config.Remot
 		return err
 	}
 
-	cfg.Remotes[c.Name] = c
+	cfg.SetRemote(c)
 	return r.Storer.SetConfig(cfg)
 }
 
@@ -1830,11 +1831,12 @@ func (r *Repository) Worktree() (*Worktree, error) {
 	protectNTFS := defaultProtectNTFS()
 	protectHFS := defaultProtectHFS()
 	if cfg, err := r.Config(); err == nil {
-		if cfg.Core.ProtectNTFS.IsSet() {
-			protectNTFS = cfg.Core.ProtectNTFS.IsTrue()
+		core := cfg.Core()
+		if core.ProtectNTFS.IsSet() {
+			protectNTFS = core.ProtectNTFS.IsTrue()
 		}
-		if cfg.Core.ProtectHFS.IsSet() {
-			protectHFS = cfg.Core.ProtectHFS.IsTrue()
+		if core.ProtectHFS.IsSet() {
+			protectHFS = core.ProtectHFS.IsTrue()
 		}
 	}
 
@@ -2141,7 +2143,7 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 		return h, err
 	}
 	enc := packfile.NewEncoder(wc, r.Storer, cfg.UseRefDeltas)
-	h, err = enc.Encode(objs, scfg.Pack.Window)
+	h, err = enc.Encode(objs, scfg.Pack().Window)
 	if err != nil {
 		return h, err
 	}

--- a/repository.go
+++ b/repository.go
@@ -1222,25 +1222,25 @@ const (
 	refspecSingleBranchHEAD = "+HEAD:refs/remotes/%s/HEAD"
 )
 
-func (r *Repository) cloneRefSpec(o *CloneOptions) []config.RefSpec {
+func (r *Repository) cloneRefSpec(o *CloneOptions) []plumbing.RefSpec {
 	switch {
 	case o.Mirror:
-		return []config.RefSpec{"+refs/*:refs/*"}
+		return []plumbing.RefSpec{"+refs/*:refs/*"}
 	case o.ReferenceName.IsTag():
-		return []config.RefSpec{
-			config.RefSpec(fmt.Sprintf(refspecTag, o.ReferenceName.Short())),
+		return []plumbing.RefSpec{
+			plumbing.RefSpec(fmt.Sprintf(refspecTag, o.ReferenceName.Short())),
 		}
 	case o.SingleBranch && o.ReferenceName == plumbing.HEAD:
-		return []config.RefSpec{
-			config.RefSpec(fmt.Sprintf(refspecSingleBranchHEAD, o.RemoteName)),
+		return []plumbing.RefSpec{
+			plumbing.RefSpec(fmt.Sprintf(refspecSingleBranchHEAD, o.RemoteName)),
 		}
 	case o.SingleBranch:
-		return []config.RefSpec{
-			config.RefSpec(fmt.Sprintf(refspecSingleBranch, o.ReferenceName.Short(), o.RemoteName)),
+		return []plumbing.RefSpec{
+			plumbing.RefSpec(fmt.Sprintf(refspecSingleBranch, o.ReferenceName.Short(), o.RemoteName)),
 		}
 	default:
-		return []config.RefSpec{
-			config.RefSpec(fmt.Sprintf(config.DefaultFetchRefSpec, o.RemoteName)),
+		return []plumbing.RefSpec{
+			plumbing.RefSpec(fmt.Sprintf(config.DefaultFetchRefSpec, o.RemoteName)),
 		}
 	}
 }
@@ -1313,7 +1313,7 @@ func (r *Repository) fetchAndUpdateReferences(
 	return resolvedRef, nil
 }
 
-func (r *Repository) updateReferences(spec []config.RefSpec,
+func (r *Repository) updateReferences(spec []plumbing.RefSpec,
 	resolvedRef *plumbing.Reference,
 ) (updated bool, err error) {
 	if !resolvedRef.Name().IsBranch() {
@@ -1350,7 +1350,7 @@ func (r *Repository) updateReferences(spec []config.RefSpec,
 	return updated, err
 }
 
-func (r *Repository) calculateRemoteHeadReference(spec []config.RefSpec,
+func (r *Repository) calculateRemoteHeadReference(spec []plumbing.RefSpec,
 	resolvedHead *plumbing.Reference,
 ) []*plumbing.Reference {
 	var refs []*plumbing.Reference

--- a/repository.go
+++ b/repository.go
@@ -769,7 +769,7 @@ func (r *Repository) Remote(name string) (*Remote, error) {
 		return nil, err
 	}
 
-	c := cfg.Remote(name)
+	c := remoteConfig(cfg, name)
 	if c == nil {
 		return nil, ErrRemoteNotFound
 	}
@@ -784,7 +784,7 @@ func (r *Repository) Remotes() ([]*Remote, error) {
 		return nil, err
 	}
 
-	all := cfg.Remotes()
+	all := remoteConfigs(cfg)
 	remotes := make([]*Remote, len(all))
 
 	var i int
@@ -797,7 +797,7 @@ func (r *Repository) Remotes() ([]*Remote, error) {
 }
 
 // CreateRemote creates a new remote
-func (r *Repository) CreateRemote(c *config.RemoteConfig) (*Remote, error) {
+func (r *Repository) CreateRemote(c *RemoteConfig) (*Remote, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
@@ -809,17 +809,17 @@ func (r *Repository) CreateRemote(c *config.RemoteConfig) (*Remote, error) {
 		return nil, err
 	}
 
-	if cfg.Remote(c.Name) != nil {
+	if remoteConfig(cfg, c.Name) != nil {
 		return nil, ErrRemoteExists
 	}
 
-	cfg.SetRemote(c)
+	setRemoteConfig(cfg, c)
 	return remote, r.Storer.SetConfig(cfg)
 }
 
 // CreateRemoteAnonymous creates a new anonymous remote. c.Name must be "anonymous".
 // It's used like 'git fetch git@github.com:src-d/go-git.git master:master'.
-func (r *Repository) CreateRemoteAnonymous(c *config.RemoteConfig) (*Remote, error) {
+func (r *Repository) CreateRemoteAnonymous(c *RemoteConfig) (*Remote, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
@@ -840,22 +840,22 @@ func (r *Repository) DeleteRemote(name string) error {
 		return err
 	}
 
-	if cfg.Remote(name) == nil {
+	if remoteConfig(cfg, name) == nil {
 		return ErrRemoteNotFound
 	}
 
-	cfg.RemoveRemote(name)
+	cfg.Raw.RemoveSubsection("remote", name)
 	return r.Storer.SetConfig(cfg)
 }
 
 // Branch return a Branch if exists
-func (r *Repository) Branch(name string) (*config.Branch, error) {
+func (r *Repository) Branch(name string) (*Branch, error) {
 	cfg, err := r.Config()
 	if err != nil {
 		return nil, err
 	}
 
-	b := cfg.Branch(name)
+	b := branchConfig(cfg, name)
 	if b == nil {
 		return nil, ErrBranchNotFound
 	}
@@ -864,7 +864,7 @@ func (r *Repository) Branch(name string) (*config.Branch, error) {
 }
 
 // CreateBranch creates a new Branch
-func (r *Repository) CreateBranch(c *config.Branch) error {
+func (r *Repository) CreateBranch(c *Branch) error {
 	if err := c.Validate(); err != nil {
 		return err
 	}
@@ -874,11 +874,11 @@ func (r *Repository) CreateBranch(c *config.Branch) error {
 		return err
 	}
 
-	if cfg.Branch(c.Name) != nil {
+	if branchConfig(cfg, c.Name) != nil {
 		return ErrBranchExists
 	}
 
-	cfg.SetBranch(c)
+	setBranchConfig(cfg, c)
 	return r.Storer.SetConfig(cfg)
 }
 
@@ -891,11 +891,11 @@ func (r *Repository) DeleteBranch(name string) error {
 		return err
 	}
 
-	if cfg.Branch(name) == nil {
+	if branchConfig(cfg, name) == nil {
 		return ErrBranchNotFound
 	}
 
-	cfg.RemoveBranch(name)
+	cfg.Raw.RemoveSubsection("branch", name)
 	return r.Storer.SetConfig(cfg)
 }
 
@@ -1095,7 +1095,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		r.wt = o.worktree
 	}
 
-	c := &config.RemoteConfig{
+	c := &RemoteConfig{
 		Name:   o.RemoteName,
 		URLs:   []string{o.URL},
 		Fetch:  r.cloneRefSpec(o),
@@ -1197,7 +1197,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		branchRef := ref.Name()
 		branchName := strings.Split(string(branchRef), "refs/heads/")[1]
 
-		b := &config.Branch{
+		b := &Branch{
 			Name:  branchName,
 			Merge: branchRef,
 		}
@@ -1255,7 +1255,7 @@ func (r *Repository) setIsBare(isBare bool) error {
 	return r.Storer.SetConfig(cfg)
 }
 
-func (r *Repository) updateRemoteConfigIfNeeded(o *CloneOptions, c *config.RemoteConfig, _ *plumbing.Reference) error {
+func (r *Repository) updateRemoteConfigIfNeeded(o *CloneOptions, c *RemoteConfig, _ *plumbing.Reference) error {
 	if !o.SingleBranch {
 		return nil
 	}
@@ -1267,7 +1267,7 @@ func (r *Repository) updateRemoteConfigIfNeeded(o *CloneOptions, c *config.Remot
 		return err
 	}
 
-	cfg.SetRemote(c)
+	setRemoteConfig(cfg, c)
 	return r.Storer.SetConfig(cfg)
 }
 

--- a/repository_extensions.go
+++ b/repository_extensions.go
@@ -82,17 +82,18 @@ func extensions(cfg *config.Config) []extension {
 func verifyExtensions(st storage.Storer, cfg *config.Config) error {
 	needed := extensions(cfg)
 
-	switch cfg.Core.RepositoryFormatVersion {
+	rfv := cfg.Core().RepositoryFormatVersion
+	switch rfv {
 	case "", cfgformat.Version0, cfgformat.Version1:
 	default:
 		return fmt.Errorf("%w: %q",
 			ErrUnsupportedRepositoryFormatVersion,
-			cfg.Core.RepositoryFormatVersion)
+			rfv)
 	}
 
 	if len(needed) > 0 {
-		if cfg.Core.RepositoryFormatVersion == cfgformat.Version0 ||
-			cfg.Core.RepositoryFormatVersion == "" {
+		if rfv == cfgformat.Version0 ||
+			rfv == "" {
 			var unsupported []string
 			for _, ext := range needed {
 				if _, ok := extensionsValidForV0[ext.name]; !ok {

--- a/repository_extensions_test.go
+++ b/repository_extensions_test.go
@@ -22,7 +22,7 @@ func TestVerifyExtensions(t *testing.T) {
 		{
 			name: "repositoryformatversion=0: invalid extension",
 			setup: func(_ *testing.T, cfg *config.Config) {
-				cfg.Core.RepositoryFormatVersion = formatcfg.Version0
+				cfg.SetRepositoryFormatVersion(formatcfg.Version0)
 				cfg.Raw.Section("extensions").SetOption("unknown", "foo")
 				cfg.Raw.Section("extensions").SetOption("objectformat", "sha1")
 			},
@@ -31,7 +31,7 @@ func TestVerifyExtensions(t *testing.T) {
 		{
 			name: "repositoryformatversion=0: allows supported noop",
 			setup: func(_ *testing.T, cfg *config.Config) {
-				cfg.Core.RepositoryFormatVersion = formatcfg.Version0
+				cfg.SetRepositoryFormatVersion(formatcfg.Version0)
 				cfg.Raw.Section("extensions").SetOption("noop", "bar")
 			},
 		},
@@ -44,7 +44,7 @@ func TestVerifyExtensions(t *testing.T) {
 		{
 			name: "repositoryformatversion=1: rejects unknown extensions",
 			setup: func(_ *testing.T, cfg *config.Config) {
-				cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+				cfg.SetRepositoryFormatVersion(formatcfg.Version1)
 				cfg.Raw.Section("extensions").SetOption("unknownext", "true")
 			},
 			wantErr: "unknown extension: unknownext",
@@ -52,7 +52,7 @@ func TestVerifyExtensions(t *testing.T) {
 		{
 			name: "repositoryformatversion=1: allows known extension",
 			setup: func(_ *testing.T, cfg *config.Config) {
-				cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+				cfg.SetRepositoryFormatVersion(formatcfg.Version1)
 				cfg.Raw.Section("extensions").SetOption("NOOP", "foo")
 				cfg.Raw.Section("extensions").SetOption("noop-v1", "bar")
 			},
@@ -60,7 +60,7 @@ func TestVerifyExtensions(t *testing.T) {
 		{
 			name: "repositoryformatversion=1: allows objectformat=sha1",
 			setup: func(_ *testing.T, cfg *config.Config) {
-				cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+				cfg.SetRepositoryFormatVersion(formatcfg.Version1)
 				cfg.Raw.Section("extensions").SetOption("objectformat", "sha1")
 			},
 		},

--- a/repository_test.go
+++ b/repository_test.go
@@ -461,7 +461,7 @@ func TestFetchMustNotUpdateObjectFormat(t *testing.T) {
 				require.NoError(t, err)
 				defer func() { _ = r.Close() }()
 
-				_, err = r.CreateRemote(&config.RemoteConfig{
+				_, err = r.CreateRemote(&RemoteConfig{
 					Name: DefaultRemoteName,
 					URLs: []string{endpoint},
 				})
@@ -870,8 +870,8 @@ func (s *RepositorySuite) TestCloneMirror() {
 	s.NoError(err)
 
 	s.True(cfg.Core().IsBare)
-	s.Nil(cfg.Remotes()[DefaultRemoteName].Validate())
-	s.True(cfg.Remotes()[DefaultRemoteName].Mirror)
+	s.Nil(remoteConfigs(cfg)[DefaultRemoteName].Validate())
+	s.True(remoteConfigs(cfg)[DefaultRemoteName].Mirror)
 }
 
 func (s *RepositorySuite) TestCloneWithTags() {
@@ -932,7 +932,7 @@ func (s *RepositorySuite) TestCloneSparse() {
 func (s *RepositorySuite) TestCreateRemoteAndRemote() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	remote, err := r.CreateRemote(&config.RemoteConfig{
+	remote, err := r.CreateRemote(&RemoteConfig{
 		Name: "foo",
 		URLs: []string{"http://foo/foo.git"},
 	})
@@ -949,16 +949,16 @@ func (s *RepositorySuite) TestCreateRemoteAndRemote() {
 func (s *RepositorySuite) TestCreateRemoteInvalid() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	remote, err := r.CreateRemote(&config.RemoteConfig{})
+	remote, err := r.CreateRemote(&RemoteConfig{})
 
-	s.ErrorIs(err, config.ErrRemoteConfigEmptyName)
+	s.ErrorIs(err, ErrRemoteConfigEmptyName)
 	s.Nil(remote)
 }
 
 func (s *RepositorySuite) TestCreateRemoteAnonymous() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	remote, err := r.CreateRemoteAnonymous(&config.RemoteConfig{
+	remote, err := r.CreateRemoteAnonymous(&RemoteConfig{
 		Name: "anonymous",
 		URLs: []string{"http://foo/foo.git"},
 	})
@@ -970,7 +970,7 @@ func (s *RepositorySuite) TestCreateRemoteAnonymous() {
 func (s *RepositorySuite) TestCreateRemoteAnonymousInvalidName() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	remote, err := r.CreateRemoteAnonymous(&config.RemoteConfig{
+	remote, err := r.CreateRemoteAnonymous(&RemoteConfig{
 		Name: "not_anonymous",
 		URLs: []string{"http://foo/foo.git"},
 	})
@@ -982,16 +982,16 @@ func (s *RepositorySuite) TestCreateRemoteAnonymousInvalidName() {
 func (s *RepositorySuite) TestCreateRemoteAnonymousInvalid() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	remote, err := r.CreateRemoteAnonymous(&config.RemoteConfig{})
+	remote, err := r.CreateRemoteAnonymous(&RemoteConfig{})
 
-	s.ErrorIs(err, config.ErrRemoteConfigEmptyName)
+	s.ErrorIs(err, ErrRemoteConfigEmptyName)
 	s.Nil(remote)
 }
 
 func (s *RepositorySuite) TestDeleteRemote() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(&RemoteConfig{
 		Name: "foo",
 		URLs: []string{"http://foo/foo.git"},
 	})
@@ -1009,7 +1009,7 @@ func (s *RepositorySuite) TestDeleteRemote() {
 func (s *RepositorySuite) TestEmptyCreateBranch() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	err := r.CreateBranch(&config.Branch{})
+	err := r.CreateBranch(&Branch{})
 
 	s.NotNil(err)
 }
@@ -1017,7 +1017,7 @@ func (s *RepositorySuite) TestEmptyCreateBranch() {
 func (s *RepositorySuite) TestInvalidCreateBranch() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	err := r.CreateBranch(&config.Branch{
+	err := r.CreateBranch(&Branch{
 		Name: "-foo",
 	})
 
@@ -1027,7 +1027,7 @@ func (s *RepositorySuite) TestInvalidCreateBranch() {
 func (s *RepositorySuite) TestCreateBranchAndBranch() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	testBranch := &config.Branch{
+	testBranch := &Branch{
 		Name:   "foo",
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
@@ -1037,8 +1037,8 @@ func (s *RepositorySuite) TestCreateBranchAndBranch() {
 	s.NoError(err)
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 1)
-	branch := cfg.Branches()["foo"]
+	s.Len(branchConfigs(cfg), 1)
+	branch := branchConfigs(cfg)["foo"]
 	s.Equal(testBranch.Name, branch.Name)
 	s.Equal(testBranch.Remote, branch.Remote)
 	s.Equal(testBranch.Merge, branch.Merge)
@@ -1176,17 +1176,17 @@ func (s *RepositorySuite) TestCreateBranchUnmarshal() {
 	merge = refs/heads/foo
 `)
 
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(&RemoteConfig{
 		Name: "foo",
 		URLs: []string{"http://foo/foo.git"},
 	})
 	s.NoError(err)
-	testBranch1 := &config.Branch{
+	testBranch1 := &Branch{
 		Name:   "master",
 		Remote: "origin",
 		Merge:  "refs/heads/master",
 	}
-	testBranch2 := &config.Branch{
+	testBranch2 := &Branch{
 		Name:   "foo",
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
@@ -1215,11 +1215,11 @@ func (s *RepositorySuite) TestBranchInvalid() {
 func (s *RepositorySuite) TestCreateBranchInvalid() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	err := r.CreateBranch(&config.Branch{})
+	err := r.CreateBranch(&Branch{})
 
 	s.NotNil(err)
 
-	testBranch := &config.Branch{
+	testBranch := &Branch{
 		Name:   "foo",
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
@@ -1233,7 +1233,7 @@ func (s *RepositorySuite) TestCreateBranchInvalid() {
 func (s *RepositorySuite) TestDeleteBranch() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	testBranch := &config.Branch{
+	testBranch := &Branch{
 		Name:   "foo",
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
@@ -1256,7 +1256,7 @@ func (s *RepositorySuite) TestDeleteBranch() {
 func (s *RepositorySuite) TestDeleteBranchFullRefName() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	testBranch := &config.Branch{
+	testBranch := &Branch{
 		Name:   "foo",
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
@@ -1486,8 +1486,8 @@ func (s *RepositorySuite) TestPlainClone() {
 	s.Len(remotes, 1)
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 1)
-	s.Equal("master", cfg.Branches()["master"].Name)
+	s.Len(branchConfigs(cfg), 1)
+	s.Equal("master", branchConfigs(cfg)["master"].Name)
 }
 
 func (s *RepositorySuite) TestPlainCloneBareAndShared() {
@@ -1514,8 +1514,8 @@ func (s *RepositorySuite) TestPlainCloneBareAndShared() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 1)
-	s.Equal("master", cfg.Branches()["master"].Name)
+	s.Len(branchConfigs(cfg), 1)
+	s.Equal("master", branchConfigs(cfg)["master"].Name)
 }
 
 func (s *RepositorySuite) TestPlainCloneShared() {
@@ -1541,8 +1541,8 @@ func (s *RepositorySuite) TestPlainCloneShared() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 1)
-	s.Equal("master", cfg.Branches()["master"].Name)
+	s.Len(branchConfigs(cfg), 1)
+	s.Equal("master", branchConfigs(cfg)["master"].Name)
 }
 
 func (s *RepositorySuite) TestPlainCloneSharedHttpShouldReturnError() {
@@ -1751,9 +1751,9 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules() {
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
-		assert.Len(t, cfg.Remotes(), 1)
-		assert.Len(t, cfg.Branches(), 1)
-		assert.Len(t, cfg.Submodules(), 2)
+		assert.Len(t, remoteConfigs(cfg), 1)
+		assert.Len(t, branchConfigs(cfg), 1)
+		assert.Len(t, submoduleConfigs(cfg), 2)
 	})
 }
 
@@ -1832,7 +1832,7 @@ func (s *RepositorySuite) TestPlainCloneNoCheckout() {
 func (s *RepositorySuite) TestFetch() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
@@ -1856,7 +1856,7 @@ func (s *RepositorySuite) TestFetch() {
 func (s *RepositorySuite) TestFetchContext() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
@@ -1871,7 +1871,7 @@ func (s *RepositorySuite) TestFetchContext() {
 func (s *RepositorySuite) TestFetchWithFilters() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
@@ -1886,7 +1886,7 @@ func (s *RepositorySuite) TestFetchWithFilters() {
 func (s *RepositorySuite) TestFetchWithFiltersReal() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})
@@ -1976,11 +1976,11 @@ func (s *RepositorySuite) TestCloneConfig() {
 	s.NoError(err)
 
 	s.True(cfg.Core().IsBare)
-	s.Len(cfg.Remotes(), 1)
-	s.Equal("origin", cfg.Remotes()["origin"].Name)
-	s.Len(cfg.Remotes()["origin"].URLs, 1)
-	s.Len(cfg.Branches(), 1)
-	s.Equal("master", cfg.Branches()["master"].Name)
+	s.Len(remoteConfigs(cfg), 1)
+	s.Equal("origin", remoteConfigs(cfg)["origin"].Name)
+	s.Len(remoteConfigs(cfg)["origin"].URLs, 1)
+	s.Len(branchConfigs(cfg), 1)
+	s.Equal("master", branchConfigs(cfg)["master"].Name)
 }
 
 func (s *RepositorySuite) TestCloneSingleBranchAndNonHEAD() {
@@ -2013,10 +2013,10 @@ func (s *RepositorySuite) testCloneSingleBranchAndNonHEADReference(ref string) {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 1)
-	s.Equal("branch", cfg.Branches()["branch"].Name)
-	s.Equal("origin", cfg.Branches()["branch"].Remote)
-	s.Equal(plumbing.ReferenceName("refs/heads/branch"), cfg.Branches()["branch"].Merge)
+	s.Len(branchConfigs(cfg), 1)
+	s.Equal("branch", branchConfigs(cfg)["branch"].Name)
+	s.Equal("origin", branchConfigs(cfg)["branch"].Remote)
+	s.Equal(plumbing.ReferenceName("refs/heads/branch"), branchConfigs(cfg)["branch"].Merge)
 
 	head, err = r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2057,10 +2057,10 @@ func (s *RepositorySuite) TestCloneSingleBranchHEADMain() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 1)
-	s.Equal("main", cfg.Branches()["main"].Name)
-	s.Equal("origin", cfg.Branches()["main"].Remote)
-	s.Equal(plumbing.ReferenceName("refs/heads/main"), cfg.Branches()["main"].Merge)
+	s.Len(branchConfigs(cfg), 1)
+	s.Equal("main", branchConfigs(cfg)["main"].Name)
+	s.Equal("origin", branchConfigs(cfg)["main"].Remote)
+	s.Equal(plumbing.ReferenceName("refs/heads/main"), branchConfigs(cfg)["main"].Merge)
 
 	head, err = r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2101,10 +2101,10 @@ func (s *RepositorySuite) TestCloneSingleBranch() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 1)
-	s.Equal("master", cfg.Branches()["master"].Name)
-	s.Equal("origin", cfg.Branches()["master"].Remote)
-	s.Equal(plumbing.ReferenceName("refs/heads/master"), cfg.Branches()["master"].Merge)
+	s.Len(branchConfigs(cfg), 1)
+	s.Equal("master", branchConfigs(cfg)["master"].Name)
+	s.Equal("origin", branchConfigs(cfg)["master"].Remote)
+	s.Equal(plumbing.ReferenceName("refs/heads/master"), branchConfigs(cfg)["master"].Merge)
 
 	head, err = r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2139,7 +2139,7 @@ func (s *RepositorySuite) TestCloneSingleTag() {
 
 	conf, err := r.Config()
 	s.NoError(err)
-	originRemote := conf.Remotes()["origin"]
+	originRemote := remoteConfigs(conf)["origin"]
 	s.NotNil(originRemote)
 	s.Len(originRemote.Fetch, 1)
 	s.Equal("+refs/tags/commit-tag:refs/tags/commit-tag", originRemote.Fetch[0].String())
@@ -2156,7 +2156,7 @@ func (s *RepositorySuite) TestCloneDetachedHEAD() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 0)
+	s.Len(branchConfigs(cfg), 0)
 
 	head, err := r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2183,7 +2183,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndSingle() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 0)
+	s.Len(branchConfigs(cfg), 0)
 
 	head, err := r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2215,7 +2215,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndShallow() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 0)
+	s.Len(branchConfigs(cfg), 0)
 
 	head, err := r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2241,7 +2241,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAnnotatedTag() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches(), 0)
+	s.Len(branchConfigs(cfg), 0)
 
 	head, err := r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2276,7 +2276,7 @@ func (s *RepositorySuite) TestPush() {
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
-	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
+	_, err = s.Repository.CreateRemote(&RemoteConfig{
 		Name: "test",
 		URLs: []string{url},
 	})
@@ -2304,7 +2304,7 @@ func (s *RepositorySuite) TestPushContext() {
 	s.NoError(err)
 	_ = server.Close()
 
-	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
+	_, err = s.Repository.CreateRemote(&RemoteConfig{
 		Name: "foo",
 		URLs: []string{url},
 	})
@@ -2349,7 +2349,7 @@ func (s *RepositorySuite) TestPushWithProgress() {
 	m := "Receiving..."
 	installPreReceiveHook(s, fs, path, m)
 
-	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
+	_, err = s.Repository.CreateRemote(&RemoteConfig{
 		Name: "bar",
 		URLs: []string{url},
 	})
@@ -3959,7 +3959,7 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch() {
 		"packfile/encoder.go")
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})

--- a/repository_test.go
+++ b/repository_test.go
@@ -91,8 +91,8 @@ func TestInit(t *testing.T) {
 
 				cfg, err := r.Config()
 				require.NoError(t, err)
-				assert.Equal(t, tc.wantBare, cfg.Core.IsBare)
-				assert.Equal(t, of, cfg.Extensions.ObjectFormat, "object format mismatch")
+				assert.Equal(t, tc.wantBare, cfg.Core().IsBare)
+				assert.Equal(t, of, cfg.Extensions().ObjectFormat, "object format mismatch")
 
 				if !tc.wantBare {
 					h := createCommit(t, r)
@@ -159,7 +159,7 @@ func TestPlainInitAndPlainOpen(t *testing.T) {
 
 				cfg, err := r.Config()
 				require.NoError(t, err)
-				assert.Equal(t, tc.wantBare, cfg.Core.IsBare)
+				assert.Equal(t, tc.wantBare, cfg.Core().IsBare)
 
 				if !tc.wantBare {
 					h := createCommit(t, r)
@@ -231,7 +231,7 @@ func (s *RepositorySuite) TestInitNonStandardDotGit() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Equal(cfg.Core.Worktree, filepath.Join("..", "worktree"))
+	s.Equal(cfg.Core().Worktree, filepath.Join("..", "worktree"))
 }
 
 func (s *RepositorySuite) TestInitStandardDotGit() {
@@ -251,7 +251,7 @@ func (s *RepositorySuite) TestInitStandardDotGit() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Equal("", cfg.Core.Worktree)
+	s.Equal("", cfg.Core().Worktree)
 }
 
 func (s *RepositorySuite) TestInitAlreadyExists() {
@@ -389,7 +389,7 @@ func TestCloneAll(t *testing.T) {
 				cfg, err := r.Config()
 				require.NoError(t, err)
 
-				assert.Equal(t, tc.format, cfg.Extensions.ObjectFormat)
+				assert.Equal(t, tc.format, cfg.Extensions().ObjectFormat)
 
 				ref, err := r.Head()
 				require.NoError(t, err, "failed to get repository HEAD ref")
@@ -869,9 +869,9 @@ func (s *RepositorySuite) TestCloneMirror() {
 	cfg, err := r.Config()
 	s.NoError(err)
 
-	s.True(cfg.Core.IsBare)
-	s.Nil(cfg.Remotes[DefaultRemoteName].Validate())
-	s.True(cfg.Remotes[DefaultRemoteName].Mirror)
+	s.True(cfg.Core().IsBare)
+	s.Nil(cfg.Remotes()[DefaultRemoteName].Validate())
+	s.True(cfg.Remotes()[DefaultRemoteName].Mirror)
 }
 
 func (s *RepositorySuite) TestCloneWithTags() {
@@ -1037,8 +1037,8 @@ func (s *RepositorySuite) TestCreateBranchAndBranch() {
 	s.NoError(err)
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 1)
-	branch := cfg.Branches["foo"]
+	s.Len(cfg.Branches(), 1)
+	branch := cfg.Branches()["foo"]
 	s.Equal(testBranch.Name, branch.Name)
 	s.Equal(testBranch.Remote, branch.Remote)
 	s.Equal(testBranch.Merge, branch.Merge)
@@ -1163,17 +1163,17 @@ func (s *RepositorySuite) TestCreateBranchUnmarshal() {
 	defer func() { _ = r.Close() }()
 
 	expected := []byte(`[core]
-	bare = true
 	filemode = true
+	bare = true
 [remote "foo"]
 	url = http://foo/foo.git
 	fetch = +refs/heads/*:refs/remotes/foo/*
-[branch "foo"]
-	remote = origin
-	merge = refs/heads/foo
 [branch "master"]
 	remote = origin
 	merge = refs/heads/master
+[branch "foo"]
+	remote = origin
+	merge = refs/heads/foo
 `)
 
 	_, err := r.CreateRemote(&config.RemoteConfig{
@@ -1486,8 +1486,8 @@ func (s *RepositorySuite) TestPlainClone() {
 	s.Len(remotes, 1)
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 1)
-	s.Equal("master", cfg.Branches["master"].Name)
+	s.Len(cfg.Branches(), 1)
+	s.Equal("master", cfg.Branches()["master"].Name)
 }
 
 func (s *RepositorySuite) TestPlainCloneBareAndShared() {
@@ -1514,8 +1514,8 @@ func (s *RepositorySuite) TestPlainCloneBareAndShared() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 1)
-	s.Equal("master", cfg.Branches["master"].Name)
+	s.Len(cfg.Branches(), 1)
+	s.Equal("master", cfg.Branches()["master"].Name)
 }
 
 func (s *RepositorySuite) TestPlainCloneShared() {
@@ -1541,8 +1541,8 @@ func (s *RepositorySuite) TestPlainCloneShared() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 1)
-	s.Equal("master", cfg.Branches["master"].Name)
+	s.Len(cfg.Branches(), 1)
+	s.Equal("master", cfg.Branches()["master"].Name)
 }
 
 func (s *RepositorySuite) TestPlainCloneSharedHttpShouldReturnError() {
@@ -1751,9 +1751,9 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules() {
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
-		assert.Len(t, cfg.Remotes, 1)
-		assert.Len(t, cfg.Branches, 1)
-		assert.Len(t, cfg.Submodules, 2)
+		assert.Len(t, cfg.Remotes(), 1)
+		assert.Len(t, cfg.Branches(), 1)
+		assert.Len(t, cfg.Submodules(), 2)
 	})
 }
 
@@ -1975,12 +1975,12 @@ func (s *RepositorySuite) TestCloneConfig() {
 	cfg, err := r.Config()
 	s.NoError(err)
 
-	s.True(cfg.Core.IsBare)
-	s.Len(cfg.Remotes, 1)
-	s.Equal("origin", cfg.Remotes["origin"].Name)
-	s.Len(cfg.Remotes["origin"].URLs, 1)
-	s.Len(cfg.Branches, 1)
-	s.Equal("master", cfg.Branches["master"].Name)
+	s.True(cfg.Core().IsBare)
+	s.Len(cfg.Remotes(), 1)
+	s.Equal("origin", cfg.Remotes()["origin"].Name)
+	s.Len(cfg.Remotes()["origin"].URLs, 1)
+	s.Len(cfg.Branches(), 1)
+	s.Equal("master", cfg.Branches()["master"].Name)
 }
 
 func (s *RepositorySuite) TestCloneSingleBranchAndNonHEAD() {
@@ -2013,10 +2013,10 @@ func (s *RepositorySuite) testCloneSingleBranchAndNonHEADReference(ref string) {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 1)
-	s.Equal("branch", cfg.Branches["branch"].Name)
-	s.Equal("origin", cfg.Branches["branch"].Remote)
-	s.Equal(plumbing.ReferenceName("refs/heads/branch"), cfg.Branches["branch"].Merge)
+	s.Len(cfg.Branches(), 1)
+	s.Equal("branch", cfg.Branches()["branch"].Name)
+	s.Equal("origin", cfg.Branches()["branch"].Remote)
+	s.Equal(plumbing.ReferenceName("refs/heads/branch"), cfg.Branches()["branch"].Merge)
 
 	head, err = r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2057,10 +2057,10 @@ func (s *RepositorySuite) TestCloneSingleBranchHEADMain() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 1)
-	s.Equal("main", cfg.Branches["main"].Name)
-	s.Equal("origin", cfg.Branches["main"].Remote)
-	s.Equal(plumbing.ReferenceName("refs/heads/main"), cfg.Branches["main"].Merge)
+	s.Len(cfg.Branches(), 1)
+	s.Equal("main", cfg.Branches()["main"].Name)
+	s.Equal("origin", cfg.Branches()["main"].Remote)
+	s.Equal(plumbing.ReferenceName("refs/heads/main"), cfg.Branches()["main"].Merge)
 
 	head, err = r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2101,10 +2101,10 @@ func (s *RepositorySuite) TestCloneSingleBranch() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 1)
-	s.Equal("master", cfg.Branches["master"].Name)
-	s.Equal("origin", cfg.Branches["master"].Remote)
-	s.Equal(plumbing.ReferenceName("refs/heads/master"), cfg.Branches["master"].Merge)
+	s.Len(cfg.Branches(), 1)
+	s.Equal("master", cfg.Branches()["master"].Name)
+	s.Equal("origin", cfg.Branches()["master"].Remote)
+	s.Equal(plumbing.ReferenceName("refs/heads/master"), cfg.Branches()["master"].Merge)
 
 	head, err = r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2139,7 +2139,7 @@ func (s *RepositorySuite) TestCloneSingleTag() {
 
 	conf, err := r.Config()
 	s.NoError(err)
-	originRemote := conf.Remotes["origin"]
+	originRemote := conf.Remotes()["origin"]
 	s.NotNil(originRemote)
 	s.Len(originRemote.Fetch, 1)
 	s.Equal("+refs/tags/commit-tag:refs/tags/commit-tag", originRemote.Fetch[0].String())
@@ -2156,7 +2156,7 @@ func (s *RepositorySuite) TestCloneDetachedHEAD() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 0)
+	s.Len(cfg.Branches(), 0)
 
 	head, err := r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2183,7 +2183,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndSingle() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 0)
+	s.Len(cfg.Branches(), 0)
 
 	head, err := r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2215,7 +2215,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndShallow() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 0)
+	s.Len(cfg.Branches(), 0)
 
 	head, err := r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -2241,7 +2241,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAnnotatedTag() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Branches, 0)
+	s.Len(cfg.Branches(), 0)
 
 	head, err := r.Reference(plumbing.HEAD, false)
 	s.NoError(err)
@@ -3065,11 +3065,11 @@ func (s *RepositorySuite) TestConfigScoped() {
 
 	cfg, err := r.ConfigScoped(config.LocalScope)
 	s.NoError(err)
-	s.Equal("", cfg.User.Email)
+	s.Equal("", cfg.User().Email)
 
 	cfg, err = r.ConfigScoped(config.SystemScope)
 	s.NoError(err)
-	s.NotEqual("", cfg.User.Email)
+	s.NotEqual("", cfg.User().Email)
 }
 
 func (s *RepositorySuite) TestCommit() {
@@ -4173,7 +4173,7 @@ func TestCreateTagSignerSelection(t *testing.T) { //nolint:paralleltest // modif
 			cfg, err := r.Config()
 			require.NoError(t, err)
 
-			cfg.Tag.GpgSign = tt.tagSignGpg
+			cfg.SetTagGpgSign(tt.tagSignGpg)
 			err = r.SetConfig(cfg)
 			require.NoError(t, err)
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -540,11 +540,11 @@ func TestFetchByHashThenResolveRevision(t *testing.T) {
 	// Step 2: fetch the specific commit by hash using "+<hash>:<hash>".
 	// This is the standard refspec for fetching an arbitrary commit that is not
 	// the tip of a branch or tag.
-	refSpec := config.RefSpec("+" + commitSHA + ":" + commitSHA)
+	refSpec := plumbing.RefSpec("+" + commitSHA + ":" + commitSHA)
 	err = r.Fetch(&FetchOptions{
 		Depth:    1,
 		Force:    true,
-		RefSpecs: []config.RefSpec{refSpec},
+		RefSpecs: []plumbing.RefSpec{refSpec},
 		Tags:     NoTags,
 	})
 	require.NoError(t, err, "fetch should succeed")
@@ -3967,7 +3967,7 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch() {
 
 	s.NoError(r.Fetch(&FetchOptions{
 		Depth:    2,
-		RefSpecs: []config.RefSpec{config.RefSpec("refs/heads/master:refs/heads/master")},
+		RefSpecs: []plumbing.RefSpec{plumbing.RefSpec("refs/heads/master:refs/heads/master")},
 	}))
 
 	shallows, err := r.Storer.Shallow()
@@ -3992,7 +3992,7 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch() {
 
 	s.NoError(r.Fetch(&FetchOptions{
 		Depth:    5,
-		RefSpecs: []config.RefSpec{config.RefSpec("refs/heads/*:refs/heads/*")},
+		RefSpecs: []plumbing.RefSpec{plumbing.RefSpec("refs/heads/*:refs/heads/*")},
 	}))
 
 	shallows, err = r.Storer.Shallow()

--- a/repository_unix_test.go
+++ b/repository_unix_test.go
@@ -25,5 +25,5 @@ func TestPlainInitFileMode(t *testing.T) {
 
 	cfg, err := r.Config()
 	require.NoError(t, err)
-	assert.True(t, cfg.Core.FileMode)
+	assert.True(t, cfg.Core().FileMode)
 }

--- a/status.go
+++ b/status.go
@@ -131,7 +131,7 @@ func preloadStatus(w *Worktree) (Status, error) {
 	}
 
 	idxRoot := mindex.NewRootNodeWithOptions(idx, mindex.RootNodeOptions{
-		UpholdExecutableBit: c.Core.FileMode,
+		UpholdExecutableBit: c.Core().FileMode,
 	})
 	nodes := []noder.Noder{idxRoot}
 

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -30,8 +30,8 @@ func (c *ConfigStorage) Config() (conf *config.Config, err error) {
 			cfg := config.NewConfig()
 
 			if c.objectFormat != formatcfg.SHA1 {
-				cfg.Core.RepositoryFormatVersion = formatcfg.Version1
-				cfg.Extensions.ObjectFormat = c.objectFormat
+				cfg.SetRepositoryFormatVersion(formatcfg.Version1)
+				cfg.SetObjectFormat(c.objectFormat)
 			}
 
 			return cfg, nil
@@ -46,7 +46,7 @@ func (c *ConfigStorage) Config() (conf *config.Config, err error) {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
 
-	if !cfg.Extensions.WorktreeConfig {
+	if !cfg.Extensions().WorktreeConfig {
 		return cfg, nil
 	}
 
@@ -84,7 +84,7 @@ func (c *ConfigStorage) SetConfig(cfg *config.Config) (err error) {
 		return err
 	}
 
-	if cfg.Extensions.WorktreeConfig {
+	if cfg.Extensions().WorktreeConfig {
 		wf, wtErr := c.dir.ConfigWorktree()
 		if wtErr == nil {
 			_ = wf.Close()
@@ -117,14 +117,6 @@ func (c *ConfigStorage) setWorktreeConfig(cfg *config.Config) error {
 	baseCfg, err := c.readBaseConfig()
 	if err != nil {
 		return err
-	}
-
-	// Ensure Raw reflects struct state.
-	if _, err := baseCfg.Marshal(); err != nil {
-		return fmt.Errorf("marshal base config: %w", err)
-	}
-	if _, err := cfg.Marshal(); err != nil {
-		return fmt.Errorf("marshal updated config: %w", err)
 	}
 
 	f, err := c.dir.ConfigWorktreeWriter()

--- a/storage/filesystem/config_test.go
+++ b/storage/filesystem/config_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
 )
 
@@ -49,7 +49,7 @@ func (s *ConfigSuite) TestRemotes() {
 	remote := remotes["origin"]
 	s.Equal("origin", remote.Name)
 	s.Equal([]string{"https://github.com/git-fixtures/basic"}, remote.URLs)
-	s.Equal([]config.RefSpec{config.RefSpec("+refs/heads/*:refs/remotes/origin/*")}, remote.Fetch)
+	s.Equal([]plumbing.RefSpec{plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*")}, remote.Fetch)
 }
 
 func (s *ConfigSuite) TearDownTest() {

--- a/storage/filesystem/config_test.go
+++ b/storage/filesystem/config_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
 )
 
@@ -44,12 +43,12 @@ func (s *ConfigSuite) TestRemotes() {
 	cfg, err := storer.Config()
 	s.Require().NoError(err)
 
-	remotes := cfg.Remotes()
-	s.Len(remotes, 1)
-	remote := remotes["origin"]
-	s.Equal("origin", remote.Name)
-	s.Equal([]string{"https://github.com/git-fixtures/basic"}, remote.URLs)
-	s.Equal([]plumbing.RefSpec{plumbing.RefSpec("+refs/heads/*:refs/remotes/origin/*")}, remote.Fetch)
+	remotes := cfg.Raw.Section("remote")
+	s.Len(remotes.Subsections, 1)
+	origin := remotes.Subsection("origin")
+	s.Equal("origin", origin.Name)
+	s.Equal([]string{"https://github.com/git-fixtures/basic"}, origin.OptionAll("url"))
+	s.Equal([]string{"+refs/heads/*:refs/remotes/origin/*"}, origin.OptionAll("fetch"))
 }
 
 func (s *ConfigSuite) TearDownTest() {

--- a/storage/filesystem/config_test.go
+++ b/storage/filesystem/config_test.go
@@ -44,7 +44,7 @@ func (s *ConfigSuite) TestRemotes() {
 	cfg, err := storer.Config()
 	s.Require().NoError(err)
 
-	remotes := cfg.Remotes
+	remotes := cfg.Remotes()
 	s.Len(remotes, 1)
 	remote := remotes["origin"]
 	s.Equal("origin", remote.Name)
@@ -87,9 +87,9 @@ func TestWorktreeConfigRead(t *testing.T) {
 		cfg, err := newDualStorer(commonFs, wtFs).Config()
 		require.NoError(t, err)
 
-		assert.Equal(t, "wt-user", cfg.User.Name)
-		assert.Equal(t, "base@example.com", cfg.User.Email)
-		assert.True(t, cfg.Extensions.WorktreeConfig)
+		assert.Equal(t, "wt-user", cfg.User().Name)
+		assert.Equal(t, "base@example.com", cfg.User().Email)
+		assert.True(t, cfg.Extensions().WorktreeConfig)
 	})
 
 	t.Run("returns base config when config.worktree is absent", func(t *testing.T) {
@@ -101,9 +101,9 @@ func TestWorktreeConfigRead(t *testing.T) {
 		cfg, err := newDualStorer(commonFs, wtFs).Config()
 		require.NoError(t, err)
 
-		assert.Equal(t, "base-user", cfg.User.Name)
-		assert.Equal(t, "base@example.com", cfg.User.Email)
-		assert.True(t, cfg.Extensions.WorktreeConfig)
+		assert.Equal(t, "base-user", cfg.User().Name)
+		assert.Equal(t, "base@example.com", cfg.User().Email)
+		assert.True(t, cfg.Extensions().WorktreeConfig)
 	})
 
 	t.Run("ignores config.worktree when extension is disabled", func(t *testing.T) {
@@ -118,8 +118,8 @@ func TestWorktreeConfigRead(t *testing.T) {
 		cfg, err := newDualStorer(commonFs, wtFs).Config()
 		require.NoError(t, err)
 
-		assert.Equal(t, "base-user", cfg.User.Name)
-		assert.False(t, cfg.Extensions.WorktreeConfig)
+		assert.Equal(t, "base-user", cfg.User().Name)
+		assert.False(t, cfg.Extensions().WorktreeConfig)
 	})
 }
 
@@ -140,7 +140,9 @@ func TestWorktreeConfigSetConfig(t *testing.T) {
 		cfg, err := cs.Config()
 		require.NoError(t, err)
 
-		cfg.User.Email = "written@example.com"
+		user := cfg.User()
+		user.Email = "written@example.com"
+		cfg.SetUser(user)
 		require.NoError(t, cs.SetConfig(cfg))
 
 		data, err := util.ReadFile(commonFs, "config")
@@ -164,8 +166,10 @@ func TestWorktreeConfigSetConfig(t *testing.T) {
 		cfg, err := cs.Config()
 		require.NoError(t, err)
 
-		cfg.Core.Worktree = "/new/path"
-		cfg.Author.Name = "Worktree Author"
+		cfg.SetWorktree("/new/path")
+		author := cfg.Author()
+		author.Name = "Worktree Author"
+		cfg.SetAuthor(author)
 
 		require.NoError(t, cs.SetConfig(cfg))
 
@@ -201,7 +205,7 @@ func TestWorktreeConfigSetConfig(t *testing.T) {
 		cfg, err := cs.Config()
 		require.NoError(t, err)
 
-		cfg.Core.Worktree = "/new/path"
+		cfg.SetWorktree("/new/path")
 		require.NoError(t, cs.SetConfig(cfg))
 
 		data, err := util.ReadFile(commonFs, "config")

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -155,10 +155,10 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 	if err == nil {
 		cfg, err := config.ReadConfig(f)
 		if err == nil {
-			ops.ObjectFormat = cfg.Extensions.ObjectFormat
-			readRevIdx = cfg.Pack.ReadReverseIndex
-			writeRevIdx = cfg.Pack.WriteReverseIndex
-			skipHash = cfg.Index.SkipHash.IsTrue()
+			ops.ObjectFormat = cfg.Extensions().ObjectFormat
+			readRevIdx = cfg.Pack().ReadReverseIndex
+			writeRevIdx = cfg.Pack().WriteReverseIndex
+			skipHash = cfg.Index().SkipHash.IsTrue()
 		}
 
 		_ = f.Close()
@@ -235,9 +235,9 @@ func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
 		return err
 	}
 
-	if cfg.Extensions.ObjectFormat != of {
-		cfg.Extensions.ObjectFormat = of
-		cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+	if cfg.Extensions().ObjectFormat != of {
+		cfg.SetObjectFormat(of)
+		cfg.SetRepositoryFormatVersion(formatcfg.Version1)
 		err = s.SetConfig(cfg)
 		if err != nil {
 			return fmt.Errorf("cannot set object format on config: %w", err)

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -239,7 +239,7 @@ func TestNewStorageWithOptions(t *testing.T) {
 			cfg, err := sto.Config()
 			require.NoError(t, err)
 
-			assert.Equal(t, tt.wantObjectFormat, cfg.Extensions.ObjectFormat)
+			assert.Equal(t, tt.wantObjectFormat, cfg.Extensions().ObjectFormat)
 		})
 	}
 }
@@ -375,8 +375,8 @@ func getExplicitSHA1(t testing.TB) billy.Filesystem {
 	cfg, err := st.Config()
 	require.NoError(t, err)
 
-	cfg.Extensions.ObjectFormat = formatcfg.SHA1
-	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+	cfg.SetObjectFormat(formatcfg.SHA1)
+	cfg.SetRepositoryFormatVersion(formatcfg.Version1)
 	err = st.SetConfig(cfg)
 	require.NoError(t, err)
 

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -63,8 +63,8 @@ func NewStorage(o ...StorageOption) *Storage {
 
 	if opts.objectFormat != formatcfg.UnsetObjectFormat {
 		cfg, _ := s.Config()
-		cfg.Extensions.ObjectFormat = opts.objectFormat
-		cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+		cfg.SetObjectFormat(opts.objectFormat)
+		cfg.SetRepositoryFormatVersion(formatcfg.Version1)
 		s.oh = plumbing.FromObjectFormat(opts.objectFormat)
 	} else {
 		s.oh = plumbing.FromObjectFormat(formatcfg.DefaultObjectFormat)
@@ -97,8 +97,8 @@ func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
 	}
 
 	cfg, _ := s.Config()
-	cfg.Extensions.ObjectFormat = of
-	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+	cfg.SetObjectFormat(of)
+	cfg.SetRepositoryFormatVersion(formatcfg.Version1)
 	s.options.objectFormat = of
 	s.oh = plumbing.FromObjectFormat(of)
 	return nil

--- a/storage/tests/storage_test.go
+++ b/storage/tests/storage_test.go
@@ -536,10 +536,8 @@ func TestSetConfigAndConfig(t *testing.T) {
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		expected := config.NewConfig()
 		expected.SetBare(true)
-		expected.SetRemote(&config.RemoteConfig{
-			Name: "foo",
-			URLs: []string{"http://foo/bar.git"},
-		})
+		expected.Raw.Section("remote").Subsection("foo").
+			SetOption("url", "http://foo/bar.git")
 
 		err := sto.SetConfig(expected)
 		require.NoError(t, err)
@@ -548,7 +546,8 @@ func TestSetConfigAndConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, expected.Core().IsBare, cfg.Core().IsBare)
-		assert.Equal(t, expected.Remotes(), cfg.Remotes())
+		assert.Equal(t, "http://foo/bar.git",
+			cfg.Raw.Section("remote").Subsection("foo").Option("url"))
 	})
 }
 
@@ -590,7 +589,8 @@ func TestSetConfigInvalid(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		cfg := config.NewConfig()
-		cfg.SetRemote(&config.RemoteConfig{})
+		cfg.Raw.Section("remote").Subsection("foo").
+			SetOption("fetch", "this is not a valid refspec")
 
 		err := sto.SetConfig(cfg)
 		assert.Error(t, err)

--- a/storage/tests/storage_test.go
+++ b/storage/tests/storage_test.go
@@ -535,11 +535,11 @@ func TestSetConfigAndConfig(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		expected := config.NewConfig()
-		expected.Core.IsBare = true
-		expected.Remotes["foo"] = &config.RemoteConfig{
+		expected.SetBare(true)
+		expected.SetRemote(&config.RemoteConfig{
 			Name: "foo",
 			URLs: []string{"http://foo/bar.git"},
-		}
+		})
 
 		err := sto.SetConfig(expected)
 		require.NoError(t, err)
@@ -547,8 +547,8 @@ func TestSetConfigAndConfig(t *testing.T) {
 		cfg, err := sto.Config()
 		require.NoError(t, err)
 
-		assert.Equal(t, expected.Core.IsBare, cfg.Core.IsBare)
-		assert.Equal(t, expected.Remotes, cfg.Remotes)
+		assert.Equal(t, expected.Core().IsBare, cfg.Core().IsBare)
+		assert.Equal(t, expected.Remotes(), cfg.Remotes())
 	})
 }
 
@@ -590,7 +590,7 @@ func TestSetConfigInvalid(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		cfg := config.NewConfig()
-		cfg.Remotes["foo"] = &config.RemoteConfig{}
+		cfg.SetRemote(&config.RemoteConfig{})
 
 		err := sto.SetConfig(cfg)
 		assert.Error(t, err)

--- a/storage/transactional/config_test.go
+++ b/storage/transactional/config_test.go
@@ -20,7 +20,7 @@ type ConfigSuite struct {
 
 func (s *ConfigSuite) TestSetConfigBase() {
 	cfg := config.NewConfig()
-	cfg.Core.Worktree = "foo"
+	cfg.SetWorktree("foo")
 
 	base := memory.NewStorage()
 	err := base.SetConfig(cfg)
@@ -31,12 +31,12 @@ func (s *ConfigSuite) TestSetConfigBase() {
 
 	cfg, err = cs.Config()
 	s.NoError(err)
-	s.Equal("foo", cfg.Core.Worktree)
+	s.Equal("foo", cfg.Core().Worktree)
 }
 
 func (s *ConfigSuite) TestSetConfigTemporal() {
 	cfg := config.NewConfig()
-	cfg.Core.Worktree = "foo"
+	cfg.SetWorktree("foo")
 
 	base := memory.NewStorage()
 	err := base.SetConfig(cfg)
@@ -45,7 +45,7 @@ func (s *ConfigSuite) TestSetConfigTemporal() {
 	temporal := memory.NewStorage()
 
 	cfg = config.NewConfig()
-	cfg.Core.Worktree = "bar"
+	cfg.SetWorktree("bar")
 
 	cs := NewConfigStorage(base, temporal)
 	err = cs.SetConfig(cfg)
@@ -53,20 +53,20 @@ func (s *ConfigSuite) TestSetConfigTemporal() {
 
 	baseCfg, err := base.Config()
 	s.NoError(err)
-	s.Equal("foo", baseCfg.Core.Worktree)
+	s.Equal("foo", baseCfg.Core().Worktree)
 
 	temporalCfg, err := temporal.Config()
 	s.NoError(err)
-	s.Equal("bar", temporalCfg.Core.Worktree)
+	s.Equal("bar", temporalCfg.Core().Worktree)
 
 	cfg, err = cs.Config()
 	s.NoError(err)
-	s.Equal("bar", cfg.Core.Worktree)
+	s.Equal("bar", cfg.Core().Worktree)
 }
 
 func (s *ConfigSuite) TestCommit() {
 	cfg := config.NewConfig()
-	cfg.Core.Worktree = "foo"
+	cfg.SetWorktree("foo")
 
 	base := memory.NewStorage()
 	err := base.SetConfig(cfg)
@@ -75,7 +75,7 @@ func (s *ConfigSuite) TestCommit() {
 	temporal := memory.NewStorage()
 
 	cfg = config.NewConfig()
-	cfg.Core.Worktree = "bar"
+	cfg.SetWorktree("bar")
 
 	cs := NewConfigStorage(base, temporal)
 	err = cs.SetConfig(cfg)
@@ -86,5 +86,5 @@ func (s *ConfigSuite) TestCommit() {
 
 	baseCfg, err := base.Config()
 	s.NoError(err)
-	s.Equal("bar", baseCfg.Core.Worktree)
+	s.Equal("bar", baseCfg.Core().Worktree)
 }

--- a/submodule.go
+++ b/submodule.go
@@ -46,14 +46,13 @@ func (s *Submodule) Init() error {
 		return err
 	}
 
-	_, ok := cfg.Submodules[s.c.Name]
-	if ok {
+	if cfg.Submodule(s.c.Name) != nil {
 		return ErrSubmoduleAlreadyInitialized
 	}
 
 	s.initialized = true
 
-	cfg.Submodules[s.c.Name] = s.c
+	cfg.SetSubmodule(s.c)
 	return s.w.r.Storer.SetConfig(cfg)
 }
 
@@ -204,13 +203,13 @@ func defaultRemote(r *Repository) (*config.RemoteConfig, error) {
 	if ref, err := r.Reference(plumbing.HEAD, false); err == nil &&
 		ref.Type() == plumbing.SymbolicReference &&
 		ref.Target().IsBranch() {
-		if b, ok := cfg.Branches[ref.Target().Short()]; ok && b.Remote != "" {
+		if b := cfg.Branch(ref.Target().Short()); b != nil && b.Remote != "" {
 			return lookupRemote(cfg, b.Remote)
 		}
 	}
 
-	if len(cfg.Remotes) == 1 {
-		for name := range cfg.Remotes {
+	if remotes := cfg.Remotes(); len(remotes) == 1 {
+		for name := range remotes {
 			return lookupRemote(cfg, name)
 		}
 	}
@@ -219,8 +218,8 @@ func defaultRemote(r *Repository) (*config.RemoteConfig, error) {
 }
 
 func lookupRemote(cfg *config.Config, name string) (*config.RemoteConfig, error) {
-	rc, ok := cfg.Remotes[name]
-	if !ok {
+	rc := cfg.Remote(name)
+	if rc == nil {
 		return nil, fmt.Errorf("remote %q not found", name)
 	}
 	if len(rc.URLs) == 0 {

--- a/submodule.go
+++ b/submodule.go
@@ -328,11 +328,11 @@ func (s *Submodule) fetchAndCheckout(
 	// [1]: https://git-scm.com/docs/protocol-capabilities#_allow_reachable_sha1_in_want
 	if !o.NoFetch {
 		if _, err := w.r.Object(plumbing.AnyObject, hash); err != nil {
-			refSpec := config.RefSpec("+" + hash.String() + ":" + hash.String())
+			refSpec := plumbing.RefSpec("+" + hash.String() + ":" + hash.String())
 
 			err := r.FetchContext(ctx, &FetchOptions{
 				ClientOptions: o.ClientOptions,
-				RefSpecs:      []config.RefSpec{refSpec},
+				RefSpecs:      []plumbing.RefSpec{refSpec},
 				Depth:         o.Depth,
 			})
 			if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) && !errors.Is(err, ErrExactSHA1NotSupported) {

--- a/submodule.go
+++ b/submodule.go
@@ -29,12 +29,12 @@ type Submodule struct {
 	// initialized defines if a submodule was already initialized.
 	initialized bool
 
-	c *config.Submodule
+	c *SubmoduleConfig
 	w *Worktree
 }
 
 // Config returns the submodule config
-func (s *Submodule) Config() *config.Submodule {
+func (s *Submodule) Config() *SubmoduleConfig {
 	return s.c
 }
 
@@ -46,13 +46,13 @@ func (s *Submodule) Init() error {
 		return err
 	}
 
-	if cfg.Submodule(s.c.Name) != nil {
+	if submoduleConfig(cfg, s.c.Name) != nil {
 		return ErrSubmoduleAlreadyInitialized
 	}
 
 	s.initialized = true
 
-	cfg.SetSubmodule(s.c)
+	setSubmoduleConfig(cfg, s.c)
 	return s.w.r.Storer.SetConfig(cfg)
 }
 
@@ -170,7 +170,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 		*moduleEndpoint = *rootEndpoint
 	}
 
-	_, err = r.CreateRemote(&config.RemoteConfig{
+	_, err = r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{moduleEndpoint.String()},
 	})
@@ -194,7 +194,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 // Each rule falls through unconditionally: a branch lookup that
 // finds the branch but with an empty Remote does not short-circuit
 // rule (2). Returns an error when the chosen remote is not configured.
-func defaultRemote(r *Repository) (*config.RemoteConfig, error) {
+func defaultRemote(r *Repository) (*RemoteConfig, error) {
 	cfg, err := r.Config()
 	if err != nil {
 		return nil, err
@@ -203,12 +203,12 @@ func defaultRemote(r *Repository) (*config.RemoteConfig, error) {
 	if ref, err := r.Reference(plumbing.HEAD, false); err == nil &&
 		ref.Type() == plumbing.SymbolicReference &&
 		ref.Target().IsBranch() {
-		if b := cfg.Branch(ref.Target().Short()); b != nil && b.Remote != "" {
+		if b := branchConfig(cfg, ref.Target().Short()); b != nil && b.Remote != "" {
 			return lookupRemote(cfg, b.Remote)
 		}
 	}
 
-	if remotes := cfg.Remotes(); len(remotes) == 1 {
+	if remotes := remoteConfigs(cfg); len(remotes) == 1 {
 		for name := range remotes {
 			return lookupRemote(cfg, name)
 		}
@@ -217,8 +217,8 @@ func defaultRemote(r *Repository) (*config.RemoteConfig, error) {
 	return lookupRemote(cfg, DefaultRemoteName)
 }
 
-func lookupRemote(cfg *config.Config, name string) (*config.RemoteConfig, error) {
-	rc := cfg.Remote(name)
+func lookupRemote(cfg *config.Config, name string) (*RemoteConfig, error) {
+	rc := remoteConfig(cfg, name)
 	if rc == nil {
 		return nil, fmt.Errorf("remote %q not found", name)
 	}

--- a/submodule_config_test.go
+++ b/submodule_config_test.go
@@ -86,7 +86,7 @@ func TestSubmoduleRepositoryCreateRemoteWritesModuleConfig(t *testing.T) {
 		require.NoError(t, err)
 		defer subRepo.Close()
 
-		_, err = subRepo.CreateRemote(&config.RemoteConfig{
+		_, err = subRepo.CreateRemote(&RemoteConfig{
 			Name: "module-only",
 			URLs: []string{"https://example.com/submodule.git"},
 		})
@@ -94,13 +94,13 @@ func TestSubmoduleRepositoryCreateRemoteWritesModuleConfig(t *testing.T) {
 
 		parentCfg, err := r.Config()
 		require.NoError(t, err)
-		_, ok := parentCfg.Remotes()["module-only"]
+		_, ok := remoteConfigs(parentCfg)["module-only"]
 		assert.False(t, ok)
 
 		repoPath := wt.Filesystem().Root()
 		moduleCfg := readConfigFile(t, filepath.Join(repoPath, ".git", "modules", sm.c.Name, "config"))
-		require.Contains(t, moduleCfg.Remotes(), "module-only")
-		assert.Equal(t, []string{"https://example.com/submodule.git"}, moduleCfg.Remotes()["module-only"].URLs)
+		require.Contains(t, remoteConfigs(moduleCfg), "module-only")
+		assert.Equal(t, []string{"https://example.com/submodule.git"}, remoteConfigs(moduleCfg)["module-only"].URLs)
 	})
 }
 

--- a/submodule_config_test.go
+++ b/submodule_config_test.go
@@ -23,8 +23,7 @@ func TestSubmoduleRepositoryConfigIsIndependentFromParent(t *testing.T) {
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
-		cfg.User.Name = "repo-user"
-		cfg.User.Email = "repo@example.com"
+		cfg.SetUser(config.User{Name: "repo-user", Email: "repo@example.com"})
 		require.NoError(t, r.SetConfig(cfg))
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
@@ -36,8 +35,8 @@ func TestSubmoduleRepositoryConfigIsIndependentFromParent(t *testing.T) {
 
 		subCfg, err := subRepo.Config()
 		require.NoError(t, err)
-		assert.Empty(t, subCfg.User.Name)
-		assert.Empty(t, subCfg.User.Email)
+		assert.Empty(t, subCfg.User().Name)
+		assert.Empty(t, subCfg.User().Email)
 	})
 }
 
@@ -66,8 +65,8 @@ func TestSubmoduleRepositoryConfigPersistsObjectFormatOnReopen(t *testing.T) {
 
 		reopenedCfg, err := reopened.Config()
 		require.NoError(t, err)
-		assert.Equal(t, cfg.Core.RepositoryFormatVersion, reopenedCfg.Core.RepositoryFormatVersion)
-		assert.Equal(t, cfg.Extensions.ObjectFormat, reopenedCfg.Extensions.ObjectFormat)
+		assert.Equal(t, cfg.Core().RepositoryFormatVersion, reopenedCfg.Core().RepositoryFormatVersion)
+		assert.Equal(t, cfg.Extensions().ObjectFormat, reopenedCfg.Extensions().ObjectFormat)
 	})
 }
 
@@ -95,13 +94,13 @@ func TestSubmoduleRepositoryCreateRemoteWritesModuleConfig(t *testing.T) {
 
 		parentCfg, err := r.Config()
 		require.NoError(t, err)
-		_, ok := parentCfg.Remotes["module-only"]
+		_, ok := parentCfg.Remotes()["module-only"]
 		assert.False(t, ok)
 
 		repoPath := wt.Filesystem().Root()
 		moduleCfg := readConfigFile(t, filepath.Join(repoPath, ".git", "modules", sm.c.Name, "config"))
-		require.Contains(t, moduleCfg.Remotes, "module-only")
-		assert.Equal(t, []string{"https://example.com/submodule.git"}, moduleCfg.Remotes["module-only"].URLs)
+		require.Contains(t, moduleCfg.Remotes(), "module-only")
+		assert.Equal(t, []string{"https://example.com/submodule.git"}, moduleCfg.Remotes()["module-only"].URLs)
 	})
 }
 

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -8,7 +8,6 @@ import (
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/require"
 
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/storage/filesystem"
@@ -34,8 +33,8 @@ func TestSubmoduleInit(t *testing.T) {
 		cfg, err := r.Config()
 		require.NoError(t, err)
 
-		require.Len(t, cfg.Submodules(), 1)
-		require.NotNil(t, cfg.Submodules()[primaryFixtureSubmoduleName(f)])
+		require.Len(t, submoduleConfigs(cfg), 1)
+		require.NotNil(t, submoduleConfigs(cfg)[primaryFixtureSubmoduleName(f)])
 
 		status, err := sm.Status()
 		require.NoError(t, err)
@@ -352,7 +351,7 @@ func TestSubmoduleParseScp(t *testing.T) {
 			w:           worktree,
 		}
 
-		submodule.c = &config.Submodule{
+		submodule.c = &SubmoduleConfig{
 			Name: "submodule_repo",
 			Path: "deps/submodule_repo",
 			URL:  "git@github.com:username/submodule_repo",
@@ -447,13 +446,13 @@ func TestDefaultRemote(t *testing.T) {
 			cfg, err := r.Config()
 			require.NoError(t, err)
 			for name, url := range tc.remotes {
-				cfg.SetRemote(&config.RemoteConfig{
+				setRemoteConfig(cfg, &RemoteConfig{
 					Name: name,
 					URLs: []string{url},
 				})
 			}
 			for name, remote := range tc.branches {
-				cfg.SetBranch(&config.Branch{Name: name, Remote: remote})
+				setBranchConfig(cfg, &Branch{Name: name, Remote: remote})
 			}
 			require.NoError(t, r.Storer.SetConfig(cfg))
 
@@ -488,11 +487,11 @@ func TestSubmoduleRelativeURLPicksOrigin(t *testing.T) {
 		}
 		cfg, err := parent.Config()
 		require.NoError(t, err)
-		cfg.SetRemote(&config.RemoteConfig{
+		setRemoteConfig(cfg, &RemoteConfig{
 			Name: "origin",
 			URLs: []string{"file:///parent/origin"},
 		})
-		cfg.SetRemote(&config.RemoteConfig{
+		setRemoteConfig(cfg, &RemoteConfig{
 			Name: "upstream",
 			URLs: []string{"file:///parent/upstream"},
 		})
@@ -501,7 +500,7 @@ func TestSubmoduleRelativeURLPicksOrigin(t *testing.T) {
 		sub := &Submodule{
 			initialized: true,
 			w:           &Worktree{filesystem: newWorktreeFilesystem(memfs.New(), true, true), r: parent},
-			c: &config.Submodule{
+			c: &SubmoduleConfig{
 				Name: "child",
 				Path: "child",
 				URL:  "../child",
@@ -538,12 +537,12 @@ func TestSubmoduleRelativeURLRemoteWithoutURLs(t *testing.T) {
 	}
 	cfg, err := parent.Config()
 	require.NoError(t, err)
-	cfg.SetRemote(&config.RemoteConfig{Name: "origin", URLs: nil})
+	setRemoteConfig(cfg, &RemoteConfig{Name: "origin", URLs: nil})
 
 	sub := &Submodule{
 		initialized: true,
 		w:           &Worktree{filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()), r: parent},
-		c: &config.Submodule{
+		c: &SubmoduleConfig{
 			Name: "child",
 			Path: "child",
 			URL:  "../child",
@@ -592,7 +591,7 @@ func newSubmoduleForRelativeURL(t *testing.T, parentRemoteURL, submoduleName, su
 		wt:     memfs.New(),
 	}
 	if parentRemoteURL != "" {
-		_, err := repo.CreateRemote(&config.RemoteConfig{
+		_, err := repo.CreateRemote(&RemoteConfig{
 			Name: DefaultRemoteName,
 			URLs: []string{parentRemoteURL},
 		})
@@ -604,7 +603,7 @@ func newSubmoduleForRelativeURL(t *testing.T, parentRemoteURL, submoduleName, su
 	}
 	return &Submodule{
 		initialized: true,
-		c: &config.Submodule{
+		c: &SubmoduleConfig{
 			Name: submoduleName,
 			Path: submoduleName,
 			URL:  submoduleURL,
@@ -699,7 +698,7 @@ func TestSubmoduleRepositoryRejectsEscapingName(t *testing.T) {
 
 	sm := &Submodule{
 		initialized: true,
-		c: &config.Submodule{
+		c: &SubmoduleConfig{
 			Name: "..",
 			Path: "deps/x",
 			URL:  "https://example.com/",

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -34,8 +34,8 @@ func TestSubmoduleInit(t *testing.T) {
 		cfg, err := r.Config()
 		require.NoError(t, err)
 
-		require.Len(t, cfg.Submodules, 1)
-		require.NotNil(t, cfg.Submodules[primaryFixtureSubmoduleName(f)])
+		require.Len(t, cfg.Submodules(), 1)
+		require.NotNil(t, cfg.Submodules()[primaryFixtureSubmoduleName(f)])
 
 		status, err := sm.Status()
 		require.NoError(t, err)
@@ -447,13 +447,13 @@ func TestDefaultRemote(t *testing.T) {
 			cfg, err := r.Config()
 			require.NoError(t, err)
 			for name, url := range tc.remotes {
-				cfg.Remotes[name] = &config.RemoteConfig{
+				cfg.SetRemote(&config.RemoteConfig{
 					Name: name,
 					URLs: []string{url},
-				}
+				})
 			}
 			for name, remote := range tc.branches {
-				cfg.Branches[name] = &config.Branch{Name: name, Remote: remote}
+				cfg.SetBranch(&config.Branch{Name: name, Remote: remote})
 			}
 			require.NoError(t, r.Storer.SetConfig(cfg))
 
@@ -488,14 +488,14 @@ func TestSubmoduleRelativeURLPicksOrigin(t *testing.T) {
 		}
 		cfg, err := parent.Config()
 		require.NoError(t, err)
-		cfg.Remotes["origin"] = &config.RemoteConfig{
+		cfg.SetRemote(&config.RemoteConfig{
 			Name: "origin",
 			URLs: []string{"file:///parent/origin"},
-		}
-		cfg.Remotes["upstream"] = &config.RemoteConfig{
+		})
+		cfg.SetRemote(&config.RemoteConfig{
 			Name: "upstream",
 			URLs: []string{"file:///parent/upstream"},
-		}
+		})
 		require.NoError(t, parent.Storer.SetConfig(cfg))
 
 		sub := &Submodule{
@@ -538,7 +538,7 @@ func TestSubmoduleRelativeURLRemoteWithoutURLs(t *testing.T) {
 	}
 	cfg, err := parent.Config()
 	require.NoError(t, err)
-	cfg.Remotes["origin"] = &config.RemoteConfig{Name: "origin", URLs: nil}
+	cfg.SetRemote(&config.RemoteConfig{Name: "origin", URLs: nil})
 
 	sub := &Submodule{
 		initialized: true,

--- a/submodule_windows_test.go
+++ b/submodule_windows_test.go
@@ -34,10 +34,10 @@ func TestSubmoduleWindowsAbsoluteURLNotJoined(t *testing.T) {
 			}
 			cfg, err := parent.Config()
 			require.NoError(t, err)
-			cfg.Remotes["origin"] = &config.RemoteConfig{
+			cfg.SetRemote(&config.RemoteConfig{
 				Name: "origin",
 				URLs: []string{"file:///parent/origin"},
-			}
+			})
 			require.NoError(t, parent.Storer.SetConfig(cfg))
 
 			sub := &Submodule{

--- a/submodule_windows_test.go
+++ b/submodule_windows_test.go
@@ -34,7 +34,7 @@ func TestSubmoduleWindowsAbsoluteURLNotJoined(t *testing.T) {
 			}
 			cfg, err := parent.Config()
 			require.NoError(t, err)
-			cfg.SetRemote(&config.RemoteConfig{
+			setRemoteConfig(cfg, &RemoteConfig{
 				Name: "origin",
 				URLs: []string{"file:///parent/origin"},
 			})
@@ -43,7 +43,7 @@ func TestSubmoduleWindowsAbsoluteURLNotJoined(t *testing.T) {
 			sub := &Submodule{
 				initialized: true,
 				w:           &Worktree{filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()), r: parent},
-				c: &config.Submodule{
+				c: &SubmoduleConfig{
 					Name: "child",
 					Path: "child",
 					URL:  url,

--- a/url.go
+++ b/url.go
@@ -1,4 +1,4 @@
-package config
+package git
 
 import (
 	"errors"

--- a/url_test.go
+++ b/url_test.go
@@ -1,9 +1,11 @@
-package config
+package git
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/config"
 )
 
 type URLSuite struct {
@@ -33,8 +35,8 @@ func (b *URLSuite) TestMarshal() {
 	insteadOf = https://github.com/
 `)
 
-	cfg := NewConfig()
-	cfg.AddURL(&URL{
+	cfg := config.NewConfig()
+	addURLConfig(cfg, &URL{
 		Name:       "ssh://git@github.com/",
 		InsteadOfs: []string{"https://github.com/"},
 	})
@@ -53,8 +55,8 @@ func (b *URLSuite) TestMarshalMultipleInsteadOf() {
 	insteadOf = https://google.com/
 `)
 
-	cfg := NewConfig()
-	cfg.AddURL(&URL{
+	cfg := config.NewConfig()
+	addURLConfig(cfg, &URL{
 		Name:       "ssh://git@github.com/",
 		InsteadOfs: []string{"https://github.com/", "https://google.com/"},
 	})
@@ -71,11 +73,11 @@ func (b *URLSuite) TestUnmarshal() {
 	insteadOf = https://github.com/
 `)
 
-	cfg := NewConfig()
+	cfg := config.NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
-	b.Require().Len(cfg.URLs(), 1)
-	url := cfg.URLs()[0]
+	b.Require().Len(urlConfigs(cfg), 1)
+	url := urlConfigs(cfg)[0]
 	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 	b.Equal("https://github.com/", url.InsteadOfs[0])
@@ -89,11 +91,11 @@ func (b *URLSuite) TestUnmarshalMultipleInsteadOf() {
 	insteadOf = https://google.com/
 `)
 
-	cfg := NewConfig()
+	cfg := config.NewConfig()
 	err := cfg.Unmarshal(input)
 	b.Nil(err)
-	b.Require().Len(cfg.URLs(), 1)
-	url := cfg.URLs()[0]
+	b.Require().Len(urlConfigs(cfg), 1)
+	url := urlConfigs(cfg)[0]
 	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 
@@ -110,11 +112,11 @@ func (b *URLSuite) TestUnmarshalDuplicateUrls() {
 	insteadOf = https://google.com/
 `)
 
-	cfg := NewConfig()
+	cfg := config.NewConfig()
 	err := cfg.Unmarshal(input)
 	b.Nil(err)
-	b.Require().Len(cfg.URLs(), 1)
-	url := cfg.URLs()[0]
+	b.Require().Len(urlConfigs(cfg), 1)
+	url := urlConfigs(cfg)[0]
 	b.NotNil(url)
 	b.Equal("ssh://git@github.com/", url.Name)
 
@@ -180,12 +182,12 @@ func (b *URLSuite) TestApplyInsteadOfLongestMatchIntegration() {
 	fetch = +refs/heads/*:refs/remotes/origin/*
 `)
 
-	cfg := NewConfig()
+	cfg := config.NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
 
 	// The longer insteadOf should be used
-	origin := cfg.Remotes()["origin"]
+	origin := remoteConfigs(cfg)["origin"]
 	b.NotNil(origin)
 	b.Equal([]string{"ssh://git@github.com/user/repo.git"}, origin.URLs)
 }
@@ -202,12 +204,12 @@ func (b *URLSuite) TestApplyInsteadOfDuplicateInsteadOfValues() {
 	fetch = +refs/heads/*:refs/remotes/origin/*
 `)
 
-	cfg := NewConfig()
+	cfg := config.NewConfig()
 	err := cfg.Unmarshal(input)
 	b.NoError(err)
 
 	// First URL in config file should be used
-	origin := cfg.Remotes()["origin"]
+	origin := remoteConfigs(cfg)["origin"]
 	b.NotNil(origin)
 	b.Equal([]string{"ssh://git@github.com/user/repo.git"}, origin.URLs)
 }

--- a/worktree.go
+++ b/worktree.go
@@ -1176,7 +1176,7 @@ func (w *Worktree) submodulesWithConfig(cfg *config.Config) (Submodules, error) 
 	}
 
 	for _, s := range m.Submodules {
-		sub := w.newSubmodule(s, cfg.Submodule(s.Name))
+		sub := w.newSubmodule(s, submoduleConfig(cfg, s.Name))
 		subCfg := sub.Config()
 		resolvedURL, err := resolveModuleURL(originURL, subCfg.URL)
 		if err != nil {
@@ -1189,7 +1189,7 @@ func (w *Worktree) submodulesWithConfig(cfg *config.Config) (Submodules, error) 
 	return l, nil
 }
 
-func (w *Worktree) newSubmodule(fromModules, fromConfig *config.Submodule) *Submodule {
+func (w *Worktree) newSubmodule(fromModules, fromConfig *SubmoduleConfig) *Submodule {
 	m := &Submodule{w: w}
 	m.initialized = fromConfig != nil
 
@@ -1210,7 +1210,7 @@ func (w *Worktree) isSymlink(path string) bool {
 	return false
 }
 
-func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
+func (w *Worktree) readGitmodulesFile() (*Modules, error) {
 	if w.isSymlink(gitmodulesFile) {
 		return nil, ErrGitModulesSymlink
 	}
@@ -1230,7 +1230,7 @@ func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
 		return nil, err
 	}
 
-	m := config.NewModules()
+	m := NewModules()
 	if err := m.Unmarshal(input); err != nil {
 		return nil, err
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -995,7 +995,7 @@ func (w *Worktree) copyObjectToWorktree(cfg *config.Config, object *object.File,
 	}
 	defer ioutil.CheckClose(src, &err)
 
-	if cfg.Core.AutoCRLF == "true" {
+	if cfg.Core().AutoCRLF == "true" {
 		br := sync.GetBufioReader(src)
 		defer sync.PutBufioReader(br)
 
@@ -1176,7 +1176,7 @@ func (w *Worktree) submodulesWithConfig(cfg *config.Config) (Submodules, error) 
 	}
 
 	for _, s := range m.Submodules {
-		sub := w.newSubmodule(s, cfg.Submodules[s.Name])
+		sub := w.newSubmodule(s, cfg.Submodule(s.Name))
 		subCfg := sub.Config()
 		resolvedURL, err := resolveModuleURL(originURL, subCfg.URL)
 		if err != nil {

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -252,7 +252,7 @@ func (w *Worktree) buildCommitObject(msg string, opts *CommitOptions, tree plumb
 	signer := opts.Signer
 	if signer == nil {
 		cfg, err := w.r.ConfigScoped(config.SystemScope)
-		if err == nil && cfg != nil && cfg.Commit.GpgSign.IsTrue() {
+		if err == nil && cfg != nil && cfg.Commit().GpgSign.IsTrue() {
 			// Use Has before Get so the key is not frozen when no plugin is
 			// registered, allowing callers to register one later.
 			if !plugin.Has(plugin.ObjectSigner()) {

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -1231,7 +1231,7 @@ func TestBuildCommitObjectSignerSelection(t *testing.T) { //nolint:paralleltest 
 			cfg, err := r.Config()
 			require.NoError(t, err)
 
-			cfg.Commit.GpgSign = tt.commitSignGpg
+			cfg.SetCommitGpgSign(tt.commitSignGpg)
 			err = r.SetConfig(cfg)
 			require.NoError(t, err)
 

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -148,7 +148,7 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 	}
 
 	from := mindex.NewRootNodeWithOptions(idx, mindex.RootNodeOptions{
-		UpholdExecutableBit: cfg.Core.FileMode,
+		UpholdExecutableBit: cfg.Core().FileMode,
 	})
 	submodules, err := w.getSubmodulesStatus(cfg)
 	if err != nil {
@@ -156,7 +156,7 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 	}
 
 	fsOpts := filesystem.Options{
-		AutoCRLF: cfg.Core.AutoCRLF == "true" || cfg.Core.AutoCRLF == "input",
+		AutoCRLF: cfg.Core().AutoCRLF == "true" || cfg.Core().AutoCRLF == "input",
 		Index:    idx,
 	}
 
@@ -552,7 +552,7 @@ func (w *Worktree) fillEncodedObjectFromFile(cfg *config.Config, dst io.Writer, 
 	}
 	defer ioutil.CheckClose(file, &err)
 
-	switch cfg.Core.AutoCRLF {
+	switch cfg.Core().AutoCRLF {
 	case "true", "input":
 		br := sync.GetBufioReader(file)
 		defer sync.PutBufioReader(br)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -255,7 +255,7 @@ func (s *WorktreeSuite) TestPullProgressWithRecursion() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Submodules, 2)
+	s.Len(cfg.Submodules(), 2)
 }
 
 func (s *RepositorySuite) TestPullAdd() {
@@ -647,7 +647,7 @@ func (s *WorktreeSuite) TestCheckoutCRLF() {
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
-		cfg.Core.AutoCRLF = autoCRLF
+		cfg.SetAutoCRLF(autoCRLF)
 		require.NoError(t, r.SetConfig(cfg))
 
 		wt, err := r.Worktree()
@@ -2271,7 +2271,7 @@ func (s *WorktreeSuite) TestStatusFileMode() {
 		cfg, err := r.Config()
 		require.NoError(t, err)
 
-		cfg.Core.FileMode = fileMode
+		cfg.SetFileMode(fileMode)
 		err = r.SetConfig(cfg)
 		require.NoError(t, err)
 
@@ -2598,7 +2598,7 @@ func (s *WorktreeSuite) TestAddCRLF() {
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
-		cfg.Core.AutoCRLF = autoCRLF
+		cfg.SetAutoCRLF(autoCRLF)
 		require.NoError(t, r.SetConfig(cfg))
 
 		wt, err := r.Worktree()

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/text/unicode/norm"
 
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -73,7 +72,7 @@ func (s *WorktreeSuite) TestPullCheckout() {
 	fs := memfs.New()
 	r, _ := Init(memory.NewStorage(), WithWorkTree(fs))
 	defer func() { _ = r.Close() }()
-	r.CreateRemote(&config.RemoteConfig{
+	r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
@@ -150,7 +149,7 @@ func (s *WorktreeSuite) TestPullNonFastForward() {
 func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded() {
 	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
-	r.CreateRemote(&config.RemoteConfig{
+	r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
@@ -214,7 +213,7 @@ func (s *WorktreeSuite) TestPullProgress() {
 	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
 
-	r.CreateRemote(&config.RemoteConfig{
+	r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
@@ -240,7 +239,7 @@ func (s *WorktreeSuite) TestPullProgressWithRecursion() {
 
 	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
-	r.CreateRemote(&config.RemoteConfig{
+	r.CreateRemote(&RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{path},
 	})
@@ -255,7 +254,7 @@ func (s *WorktreeSuite) TestPullProgressWithRecursion() {
 
 	cfg, err := r.Config()
 	s.NoError(err)
-	s.Len(cfg.Submodules(), 2)
+	s.Len(submoduleConfigs(cfg), 2)
 }
 
 func (s *RepositorySuite) TestPullAdd() {
@@ -2399,7 +2398,7 @@ func (s *WorktreeSuite) TestSubmodules_URLResolution() {
 			defer func() { _ = r.Close() }()
 			s.NoError(err)
 
-			_, err = r.CreateRemote(&config.RemoteConfig{
+			_, err = r.CreateRemote(&RemoteConfig{
 				Name: "origin",
 				URLs: []string{tc.originURL},
 			})

--- a/x/plugin/config/auto_git_test.go
+++ b/x/plugin/config/auto_git_test.go
@@ -338,23 +338,23 @@ func memAuto(t *testing.T, files map[string]string) *auto {
 }
 
 // loadUserName is a convenience that loads the given scope and returns
-// cfg.User.Name.
+// cfg.User().Name.
 func loadUserName(t *testing.T, src *auto, scope config.Scope) string {
 	t.Helper()
 	s, err := src.Load(scope)
 	require.NoError(t, err)
 	cfg, err := s.Config()
 	require.NoError(t, err)
-	return cfg.User.Name
+	return cfg.User().Name
 }
 
 // loadUserEmail is a convenience that loads the given scope and returns
-// cfg.User.Email.
+// cfg.User().Email.
 func loadUserEmail(t *testing.T, src *auto, scope config.Scope) string {
 	t.Helper()
 	s, err := src.Load(scope)
 	require.NoError(t, err)
 	cfg, err := s.Config()
 	require.NoError(t, err)
-	return cfg.User.Email
+	return cfg.User().Email
 }

--- a/x/plugin/config/config_test.go
+++ b/x/plugin/config/config_test.go
@@ -32,9 +32,9 @@ func TestEmptySystem(t *testing.T) {
 func TestStaticGlobalAndSystem(t *testing.T) {
 	t.Parallel()
 	global := config.NewConfig()
-	global.User.Name = "GlobalUser"
+	global.SetUser(config.User{Name: "GlobalUser"})
 	system := config.NewConfig()
-	system.User.Name = "SystemUser"
+	system.SetUser(config.User{Name: "SystemUser"})
 
 	src := NewStatic(*global, *system)
 
@@ -42,23 +42,23 @@ func TestStaticGlobalAndSystem(t *testing.T) {
 	require.NoError(t, err)
 	got, err := gs.Config()
 	require.NoError(t, err)
-	assert.Equal(t, "GlobalUser", got.User.Name)
+	assert.Equal(t, "GlobalUser", got.User().Name)
 
 	ss, err := src.Load(config.SystemScope)
 	require.NoError(t, err)
 	got, err = ss.Config()
 	require.NoError(t, err)
-	assert.Equal(t, "SystemUser", got.User.Name)
+	assert.Equal(t, "SystemUser", got.User().Name)
 }
 
 func TestStaticReturnsCopies(t *testing.T) {
 	t.Parallel()
 	global := config.NewConfig()
-	global.User.Name = "Original"
-	global.Remotes["origin"] = &config.RemoteConfig{
+	global.SetUser(config.User{Name: "Original"})
+	global.SetRemote(&config.RemoteConfig{
 		Name: "origin",
 		URLs: []string{"https://example.com/repo.git"},
-	}
+	})
 
 	src := NewStatic(*global, *config.NewConfig())
 
@@ -66,17 +66,17 @@ func TestStaticReturnsCopies(t *testing.T) {
 	require.NoError(t, err)
 	first, err := gs.Config()
 	require.NoError(t, err)
-	first.User.Name = "Mutated"
-	first.Remotes["upstream"] = &config.RemoteConfig{Name: "upstream"}
-	delete(first.Remotes, "origin")
+	first.SetUser(config.User{Name: "Mutated"})
+	first.SetRemote(&config.RemoteConfig{Name: "upstream"})
+	first.RemoveRemote("origin")
 
 	gs2, err := src.Load(config.GlobalScope)
 	require.NoError(t, err)
 	second, err := gs2.Config()
 	require.NoError(t, err)
-	assert.Equal(t, "Original", second.User.Name)
-	assert.Contains(t, second.Remotes, "origin")
-	assert.NotContains(t, second.Remotes, "upstream")
+	assert.Equal(t, "Original", second.User().Name)
+	assert.Contains(t, second.Remotes(), "origin")
+	assert.NotContains(t, second.Remotes(), "upstream")
 }
 
 func TestStaticZeroValues(t *testing.T) {

--- a/x/plugin/config/config_test.go
+++ b/x/plugin/config/config_test.go
@@ -55,10 +55,8 @@ func TestStaticReturnsCopies(t *testing.T) {
 	t.Parallel()
 	global := config.NewConfig()
 	global.SetUser(config.User{Name: "Original"})
-	global.SetRemote(&config.RemoteConfig{
-		Name: "origin",
-		URLs: []string{"https://example.com/repo.git"},
-	})
+	global.Raw.Section("remote").Subsection("origin").
+		SetOption("url", "https://example.com/repo.git")
 
 	src := NewStatic(*global, *config.NewConfig())
 
@@ -67,16 +65,16 @@ func TestStaticReturnsCopies(t *testing.T) {
 	first, err := gs.Config()
 	require.NoError(t, err)
 	first.SetUser(config.User{Name: "Mutated"})
-	first.SetRemote(&config.RemoteConfig{Name: "upstream"})
-	first.RemoveRemote("origin")
+	first.Raw.Section("remote").Subsection("upstream").SetOption("url", "x")
+	first.Raw.RemoveSubsection("remote", "origin")
 
 	gs2, err := src.Load(config.GlobalScope)
 	require.NoError(t, err)
 	second, err := gs2.Config()
 	require.NoError(t, err)
 	assert.Equal(t, "Original", second.User().Name)
-	assert.Contains(t, second.Remotes(), "origin")
-	assert.NotContains(t, second.Remotes(), "upstream")
+	assert.True(t, second.Raw.Section("remote").HasSubsection("origin"))
+	assert.False(t, second.Raw.Section("remote").HasSubsection("upstream"))
 }
 
 func TestStaticZeroValues(t *testing.T) {

--- a/x/plugin/config/static.go
+++ b/x/plugin/config/static.go
@@ -33,81 +33,13 @@ func (s *static) Load(scope config.Scope) (config.ConfigStorer, error) {
 }
 
 // cloneConfig returns an independent deep copy of c so that mutations to the
-// returned config cannot affect the original.
+// returned config cannot affect the original. Raw is the single source of
+// truth, so cloning it is sufficient.
 func cloneConfig(c *config.Config) *config.Config {
-	cp := *c
-
-	cp.Remotes = cloneRemotes(c.Remotes)
-	cp.Submodules = cloneMapShallow(c.Submodules)
-	cp.Branches = cloneMapShallow(c.Branches)
-	cp.URLs = cloneURLs(c.URLs)
-
+	cp := &config.Config{}
 	if c.Raw != nil {
 		cp.Raw = cloneRawConfig(c.Raw)
 	}
-	return &cp
-}
-
-func cloneRemotes(m map[string]*config.RemoteConfig) map[string]*config.RemoteConfig {
-	if m == nil {
-		return nil
-	}
-	cp := make(map[string]*config.RemoteConfig, len(m))
-	for k, v := range m {
-		if v == nil {
-			cp[k] = nil
-			continue
-		}
-		cloned := *v
-		cloned.URLs = cloneSlice(v.URLs)
-		cloned.Fetch = cloneSlice(v.Fetch)
-		cp[k] = &cloned
-	}
-	return cp
-}
-
-func cloneURLs(s []*config.URL) []*config.URL {
-	if s == nil {
-		return nil
-	}
-	cp := make([]*config.URL, len(s))
-	for i, v := range s {
-		if v == nil {
-			cp[i] = nil
-			continue
-		}
-		cloned := *v
-		cloned.InsteadOfs = cloneSlice(v.InsteadOfs)
-		cp[i] = &cloned
-	}
-	return cp
-}
-
-// cloneMapShallow copies a map of pointers, making an independent copy of each
-// pointed-to struct. Suitable for types whose exported fields contain no
-// slices or maps (e.g. Branch, Submodule).
-func cloneMapShallow[K comparable, V any](m map[K]*V) map[K]*V {
-	if m == nil {
-		return nil
-	}
-	cp := make(map[K]*V, len(m))
-	for k, v := range m {
-		if v == nil {
-			cp[k] = nil
-			continue
-		}
-		cloned := *v
-		cp[k] = &cloned
-	}
-	return cp
-}
-
-func cloneSlice[T any](s []T) []T {
-	if s == nil {
-		return nil
-	}
-	cp := make([]T, len(s))
-	copy(cp, s)
 	return cp
 }
 

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -1082,7 +1082,7 @@ func TestWorktreeIsolation(t *testing.T) {
 
 	err = mainRepo.Push(&git.PushOptions{
 		RemoteName: "origin",
-		RefSpecs:   []config.RefSpec{"refs/heads/master:refs/heads/master"},
+		RefSpecs:   []plumbing.RefSpec{"refs/heads/master:refs/heads/master"},
 	})
 	require.NoError(t, err)
 
@@ -1121,7 +1121,7 @@ func TestWorktreeIsolation(t *testing.T) {
 	// Push worktree changes to the remote.
 	err = wtRepo.Push(&git.PushOptions{
 		RemoteName: "origin",
-		RefSpecs:   []config.RefSpec{"refs/heads/feature-branch:refs/heads/feature-branch"},
+		RefSpecs:   []plumbing.RefSpec{"refs/heads/feature-branch:refs/heads/feature-branch"},
 	})
 	require.NoError(t, err)
 

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -1183,8 +1183,8 @@ func TestWorktreeConfig(t *testing.T) {
 
 		cfg, err := storer.Config()
 		require.NoError(t, err)
-		cfg.Core.RepositoryFormatVersion = formatcfg.Version1
-		cfg.Extensions.WorktreeConfig = true
+		cfg.SetRepositoryFormatVersion(formatcfg.Version1)
+		cfg.SetWorktreeConfig(true)
 		err = storer.SetConfig(cfg)
 		require.NoError(t, err)
 
@@ -1206,9 +1206,9 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
-		assert.Equal(t, customWorktreePath, repoCfg.Core.Worktree)
+		assert.Equal(t, customWorktreePath, repoCfg.Core().Worktree)
 
-		assert.Contains(t, repoCfg.Remotes, "origin") // check base repo config
+		assert.Contains(t, repoCfg.Remotes(), "origin") // check base repo config
 	})
 
 	t.Run("config.worktree absent", func(t *testing.T) {
@@ -1239,7 +1239,7 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
-		assert.Empty(t, repoCfg.Core.Worktree)
+		assert.Empty(t, repoCfg.Core().Worktree)
 	})
 
 	t.Run("extension disabled config.worktree ignored", func(t *testing.T) {
@@ -1268,7 +1268,7 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
-		assert.Empty(t, repoCfg.Core.Worktree)
+		assert.Empty(t, repoCfg.Core().Worktree)
 	})
 
 	t.Run("boundOS linked worktree reads config.worktree", func(t *testing.T) {
@@ -1303,7 +1303,7 @@ func TestWorktreeConfig(t *testing.T) {
 
 		repoCfg, err := repo.Config()
 		require.NoError(t, err)
-		assert.Equal(t, customWorktreePath, repoCfg.Core.Worktree)
+		assert.Equal(t, customWorktreePath, repoCfg.Core().Worktree)
 	})
 }
 

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6"
-	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
@@ -1074,7 +1073,7 @@ func TestWorktreeIsolation(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = remoteRepo.Close() }()
 
-	_, err = mainRepo.CreateRemote(&config.RemoteConfig{
+	_, err = mainRepo.CreateRemote(&git.RemoteConfig{
 		Name: "origin",
 		URLs: []string{remoteDir},
 	})
@@ -1208,7 +1207,7 @@ func TestWorktreeConfig(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, customWorktreePath, repoCfg.Core().Worktree)
 
-		assert.Contains(t, repoCfg.Remotes(), "origin") // check base repo config
+		assert.True(t, repoCfg.Raw.Section("remote").HasSubsection("origin")) // check base repo config
 	})
 
 	t.Run("config.worktree absent", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This refactors go-git's configuration handling. It refines the proposal in https://github.com/go-git/go-git/pull/1995 but goes the opposite direction: instead of struct-tag marshaling, it drops struct-based marshalling entirely and makes config a simple string-key model like canonical git.

Three focused commits:

1. **config: replace struct marshalling with a key-based Config.** `config.Config` is now backed by a flat key model (`Raw *format.Config`) as the single source of truth, the way canonical git stores config. The per-section struct fields, the hand-written `marshalFoo`/`unmarshalFoo` helpers (~500 lines), and the reflection-based `Merge` are gone. They are replaced by typed section getters (`cfg.Core().IsBare`), field setters (`cfg.SetBare`), and Raw-backed porcelain accessors. `Marshal` now just encodes `Raw`; `Unmarshal` decodes and validates it. Value parsing (bool, and int with k/m/g unit suffixes) is centralised in `plumbing/format/config` and matches git's `parse.c`, fixing the previously inconsistent boolean handling across sections (`core.bare` only accepted `"true"`, `gpg.gpgSign` used `strconv.ParseBool`, `pack.readReverseIndex` used `!= "false"`, and so on).

2. **plumbing: move RefSpec from config to plumbing.** `RefSpec` only depends on plumbing primitives, so it belongs there. `config.RefSpec`, `config.MatchAny` and the `ErrRefSpecMalformed*` errors are now `plumbing.*`.

3. **config: move the porcelain types to the git package.** `RemoteConfig`, `Branch`, `URL` and `Modules`, plus the per-section porcelain accessors, move out of `config` into the root `git` package. `config` is now the low-level key/value model with typed scalar accessors only. The submodule config type is renamed `SubmoduleConfig` to avoid clashing with the existing `git.Submodule` porcelain.

## Motivation

Previously every section in `config/config.go` carried a hand-written `marshalFoo`/`unmarshalFoo` pair, with inconsistent type conversion (especially for booleans) and a struct that had to be kept in sync with the raw representation. A flat string-key model is what canonical git actually uses: it gives one git-spec-compliant parser everywhere, preserves unknown keys for free, and makes adding a key a single accessor call.

## Behavior changes

Intentional, and follow from the faithful key model:

- Marshal output follows insertion and round-trip order rather than the old hand-fixed key ordering.
- No marshal-time gating of the `[extensions]` section on `core.repositoryformatversion`.
- `config.Validate` validates remote fetch refspecs at the raw level; richer remote, branch and submodule validation lives with the relocated porcelain types.
- Porcelain accessors return copies, so callers mutate then call `Set*` to persist.

## Testing

`go build ./...`, full `go test ./...`, and `golangci-lint run ./...` are all green. The only failing tests in my environment are `safe.bareRepository` external-git failures that also fail on a clean `main`.

This change was produced with AI assistance (see the `Assisted-by` trailers on each commit).
