### PR TITLE
plumbing: object, skip path validation in tree diff walk

### DIFF
--- a/plumbing/object/difftree_test.go
+++ b/plumbing/object/difftree_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"testing"
@@ -8,6 +9,7 @@ import (
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -385,4 +387,120 @@ func (s *DiffTreeSuite) TestIssue279() {
 		mode: filemode.Deprecated,
 	}
 	s.NotEqual(bb.Hash(), b.Hash())
+}
+
+// DiffTree computes a diff in memory and never materialises entry names into a
+// worktree, so it must not reject trees whose entry names contain bytes that
+// upstream Git's verify_path accepts — a control character such as a newline is
+// a valid pathname byte on disk (only '/' and NUL are forbidden in a tree entry
+// name). The path-safety validation in TreeWalker.Next is for callers that hand
+// names to the filesystem; the diff walk opts out of it.
+func TestDiffTreeAllowsControlCharInPath(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	blob := storeTestObject(t, st, plumbing.BlobObject, []byte("IO.puts(\"hi\")\n"))
+
+	const ctrlName = "foo\n.exs"
+	empty := storeTestTree(t, st, nil)
+	withFile := storeTestTree(t, st, []TreeEntry{
+		{Name: ctrlName, Mode: filemode.Regular, Hash: blob},
+	})
+
+	from, err := GetTree(st, empty)
+	if err != nil {
+		t.Fatalf("GetTree(empty) = %v", err)
+	}
+	to, err := GetTree(st, withFile)
+	if err != nil {
+		t.Fatalf("GetTree(withFile) = %v", err)
+	}
+
+	changes, err := DiffTree(from, to)
+	if err != nil {
+		t.Fatalf("DiffTree on a tree with a control-char path = %v; want nil", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("len(changes) = %d, want 1", len(changes))
+	}
+	if got := changes[0].To.Name; got != ctrlName {
+		t.Fatalf("change name = %q, want %q", got, ctrlName)
+	}
+}
+
+// The diff walk opting out of path validation must not weaken the default
+// TreeWalker, which materialising callers (archive, FileIter) rely on to reject
+// names that are unsafe to write to disk.
+func TestTreeWalkerValidatesControlCharByDefault(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	blob := storeTestObject(t, st, plumbing.BlobObject, []byte("x\n"))
+	withFile := storeTestTree(t, st, []TreeEntry{
+		{Name: "foo\n.exs", Mode: filemode.Regular, Hash: blob},
+	})
+	tree, err := GetTree(st, withFile)
+	if err != nil {
+		t.Fatalf("GetTree = %v", err)
+	}
+
+	w := NewTreeWalker(tree, true, nil)
+	defer w.Close()
+	_, _, err = w.Next()
+	if !errors.Is(err, pathutil.ErrInvalidPath) {
+		t.Fatalf("TreeWalker.Next error = %v, want pathutil.ErrInvalidPath", err)
+	}
+}
+
+func storeTestObject(t *testing.T, st storer.EncodedObjectStorer, typ plumbing.ObjectType, content []byte) plumbing.Hash {
+	t.Helper()
+	o := st.NewEncodedObject()
+	o.SetType(typ)
+	w, err := o.Writer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	h, err := st.SetEncodedObject(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+// storeTestTree writes a raw tree object, bypassing Tree.Encode's Validate gate
+// so a tree with an otherwise-rejected entry name can be created — mirroring how
+// such a tree arrives off the wire and is read back via the permissive Decode.
+func storeTestTree(t *testing.T, st storer.EncodedObjectStorer, entries []TreeEntry) plumbing.Hash {
+	t.Helper()
+	o := st.NewEncodedObject()
+	o.SetType(plumbing.TreeObject)
+	w, err := o.Writer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if _, err := fmt.Fprintf(w, "%o %s", e.Mode, e.Name); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte{0x00}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := e.Hash.WriteTo(w); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	h, err := st.SetEncodedObject(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -598,6 +598,13 @@ type TreeWalker struct {
 	recursive bool
 	seen      map[plumbing.Hash]bool
 
+	// skipPathValidation disables the pathutil.ValidTreePath check in Next.
+	// It is set by inspection-only callers (e.g. the diff treeNoder) that
+	// never funnel entry names into the filesystem and must enumerate trees
+	// faithfully, including entries with names upstream Git accepts but that
+	// are unsafe to materialise (control characters, `.git`-shaped names).
+	skipPathValidation bool
+
 	s storer.EncodedObjectStorer
 	t *Tree
 }
@@ -630,7 +637,7 @@ func NewTreeWalker(t *Tree, recursive bool, seen map[plumbing.Hash]bool) *TreeWa
 // HFS+/NTFS variants, Windows reserved names, and traversal sequences.
 // A malformed entry stops the walk with the validator's error;
 // inspection-only callers that need to enumerate raw, unvalidated
-// names can read Tree.Entries directly.
+// names can read Tree.Entries directly or set skipPathValidation.
 //
 // In the current implementation any objects which cannot be found in the
 // underlying repository will be skipped automatically. It is possible that this
@@ -668,8 +675,10 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 			continue
 		}
 
-		if err := pathutil.ValidTreePath(entry.Name); err != nil {
-			return name, entry, err
+		if !w.skipPathValidation {
+			if err := pathutil.ValidTreePath(entry.Name); err != nil {
+				return name, entry, err
+			}
 		}
 
 		if entry.Mode == filemode.Dir {

--- a/plumbing/object/treenoder.go
+++ b/plumbing/object/treenoder.go
@@ -106,6 +106,12 @@ func transformChildren(t *Tree) ([]noder.Noder, error) {
 	ret := make([]noder.Noder, 0, len(t.Entries))
 
 	walker := NewTreeWalker(t, false, nil) // don't recurse
+	// The diff walk is read-only and never materialises entry names into the
+	// filesystem, so it must enumerate the tree faithfully — including entries
+	// with names that are unsafe to check out but valid per upstream Git (e.g.
+	// control characters). Path safety is enforced at materialisation
+	// boundaries (FindEntry, TreeEntryFile, archive, FileIter), not here.
+	walker.skipPathValidation = true
 	// don't defer walker.Close() for efficiency reasons.
 	for {
 		_, e, err = walker.Next()


### PR DESCRIPTION
`DiffTree` walks each tree through `treeNoder.Children -> transformChildren -> TreeWalker.Next`, which validated every entry name with `pathutil.ValidTreePath`. That validator rejects control characters and .git-shaped names so that callers materialising entries into a worktree or archive stay safe. `DiffTree` does neither: it computes a diff in memory and never writes a name to disk.

The effect was that a diff over a tree containing an entry name upstream Git accepts — e.g. one with an embedded newline, which verify_path permits since only '/' and NUL are forbidden in a path component — failed the whole diff with "invalid path: contains control character" instead of reporting the change.

Add an unexported `skipPathValidation` flag to `TreeWalker` and set it for the diff walk so the tree is enumerated faithfully. The flag defaults to off, so the materialising callers (`archive`, `FileIter`, `FindEntry`, `TreeEntryFile`) keep validating exactly as before.

Follow-up from #2105.