### PR TITLE
x: config, add experimental global and system config loaders

### DIFF
--- a/plumbing/format/config/accessor.go
+++ b/plumbing/format/config/accessor.go
@@ -1,0 +1,140 @@
+package config
+
+// This file adds the canonical git "config set" access API on top of the
+// Section/Subsection/Option model: typed getters and setters keyed by a flat
+// "section[.subsection].variable" string, mirroring git's
+// git_configset_get_value, git_configset_get_bool, git_configset_get_int and
+// friends. Reads merge all blocks of a repeated section, with the last value
+// winning, exactly as git does.
+
+// allOptions collects, in file order, the options of every block of the named
+// section (and subsection, when given). git treats repeated [section] blocks as
+// a single logical section, so accessors must look across all of them.
+func (c *Config) allOptions(section, subsection string) Options {
+	var opts Options
+	for _, s := range c.Sections {
+		if !s.IsName(section) {
+			continue
+		}
+		if subsection == "" {
+			opts = append(opts, s.Options...)
+			continue
+		}
+		for _, ss := range s.Subsections {
+			if ss.IsName(subsection) {
+				opts = append(opts, ss.Options...)
+			}
+		}
+	}
+	return opts
+}
+
+// Lookup returns the last value set for the canonical key and whether it was
+// present at all. It is the equivalent of git's git_configset_get_value.
+func (c *Config) Lookup(key string) (string, bool) {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).Lookup(variable)
+}
+
+// Get returns the last value set for the canonical key, or the empty string if
+// the key is absent. Use Lookup to distinguish an absent key from an empty
+// value.
+func (c *Config) Get(key string) string {
+	v, _ := c.Lookup(key)
+	return v
+}
+
+// GetAll returns every value set for the canonical key, in file order. It is
+// the equivalent of git's git_configset_get_value_multi.
+func (c *Config) GetAll(key string) []string {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).GetAll(variable)
+}
+
+// Has reports whether the canonical key is present, regardless of its value.
+func (c *Config) Has(key string) bool {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).Has(variable)
+}
+
+// String returns the string value of the canonical key, or def when the key is
+// absent.
+func (c *Config) String(key, def string) string {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).String(variable, def)
+}
+
+// Bool returns the boolean value of the canonical key, or def when the key is
+// absent. A present but unparseable value returns def together with
+// ErrInvalidBool.
+func (c *Config) Bool(key string, def bool) (bool, error) {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).Bool(variable, def)
+}
+
+// Int returns the integer value of the canonical key, or def when the key is
+// absent. A present but unparseable value returns def together with an error.
+func (c *Config) Int(key string, def int) (int, error) {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).Int(variable, def)
+}
+
+// Int64 returns the int64 value of the canonical key, or def when the key is
+// absent. A present but unparseable value returns def together with an error.
+func (c *Config) Int64(key string, def int64) (int64, error) {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).Int64(variable, def)
+}
+
+// Uint returns the unsigned value of the canonical key, or def when the key is
+// absent. A present but unparseable value returns def together with an error.
+func (c *Config) Uint(key string, def uint) (uint, error) {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).Uint(variable, def)
+}
+
+// Uint64 returns the unsigned 64-bit value of the canonical key, or def when
+// the key is absent. A present but unparseable value returns def together with
+// an error.
+func (c *Config) Uint64(key string, def uint64) (uint64, error) {
+	section, subsection, variable := SplitKey(key)
+	return c.allOptions(section, subsection).Uint64(variable, def)
+}
+
+// Set sets the canonical key to value, replacing any existing values
+// (last-wins). It returns ErrInvalidKey if key is not a valid config key.
+func (c *Config) Set(key, value string) error {
+	if err := ValidateKey(key); err != nil {
+		return err
+	}
+	section, subsection, variable := SplitKey(key)
+	c.SetOption(section, subsection, variable, value)
+	return nil
+}
+
+// Add appends value to the canonical key without removing existing values,
+// producing a multi-valued key. It returns ErrInvalidKey if key is not a valid
+// config key.
+func (c *Config) Add(key, value string) error {
+	if err := ValidateKey(key); err != nil {
+		return err
+	}
+	section, subsection, variable := SplitKey(key)
+	c.AddOption(section, subsection, variable, value)
+	return nil
+}
+
+// Unset removes every value of the canonical key from the section block that
+// holds it. It reports whether anything was removed.
+func (c *Config) Unset(key string) bool {
+	section, subsection, variable := SplitKey(key)
+	if !c.allOptions(section, subsection).Has(variable) {
+		return false
+	}
+	if subsection == "" {
+		c.Section(section).RemoveOption(variable)
+	} else {
+		c.Section(section).Subsection(subsection).RemoveOption(variable)
+	}
+	return true
+}

--- a/plumbing/format/config/accessor_test.go
+++ b/plumbing/format/config/accessor_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestConfigAccessors(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if err := c.Set("core.bare", "true"); err != nil {
+		t.Fatalf("Set core.bare: %v", err)
+	}
+	if err := c.Set("remote.origin.url", "git@github.com:go-git/go-git.git"); err != nil {
+		t.Fatalf("Set url: %v", err)
+	}
+	if err := c.Add("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+		t.Fatalf("Add fetch: %v", err)
+	}
+	if err := c.Add("remote.origin.fetch", "+refs/tags/*:refs/tags/*"); err != nil {
+		t.Fatalf("Add fetch: %v", err)
+	}
+	_ = c.Set("pack.window", "16")
+
+	if got := c.Get("remote.origin.url"); got != "git@github.com:go-git/go-git.git" {
+		t.Errorf("Get url = %q", got)
+	}
+	if b, err := c.Bool("core.bare", false); err != nil || !b {
+		t.Errorf("Bool core.bare = %v, %v", b, err)
+	}
+	if b, _ := c.Bool("core.missing", true); !b {
+		t.Error("missing bool should return default")
+	}
+	if all := c.GetAll("remote.origin.fetch"); len(all) != 2 {
+		t.Errorf("GetAll fetch len = %d, want 2", len(all))
+	}
+	if n, err := c.Int("pack.window", 10); err != nil || n != 16 {
+		t.Errorf("Int pack.window = %d, %v", n, err)
+	}
+	if n, err := c.Int("pack.depth", 50); err != nil || n != 50 {
+		t.Errorf("Int default = %d, %v", n, err)
+	}
+	if s := c.String("user.name", "nobody"); s != "nobody" {
+		t.Errorf("String default = %q", s)
+	}
+
+	if _, ok := c.Lookup("core.bare"); !ok {
+		t.Error("Lookup core.bare should be present")
+	}
+	if _, ok := c.Lookup("core.nope"); ok {
+		t.Error("Lookup core.nope should be absent")
+	}
+
+	_ = c.Set("remote.origin.fetch", "single")
+	if all := c.GetAll("remote.origin.fetch"); len(all) != 1 {
+		t.Errorf("Set should collapse multivalue, got %d", len(all))
+	}
+
+	if !c.Unset("core.bare") {
+		t.Error("Unset core.bare should report removal")
+	}
+	if c.Has("core.bare") {
+		t.Error("core.bare should be unset")
+	}
+	if c.Unset("core.bare") {
+		t.Error("Unset of absent key should report false")
+	}
+}
+
+func TestConfigAccessorMergesRepeatedSections(t *testing.T) {
+	t.Parallel()
+	c := New()
+	c.Section("core").AddOption("bare", "false")
+	c.Sections = append(c.Sections, &Section{
+		Name:    "core",
+		Options: Options{&Option{Key: "bare", Value: "true"}},
+	})
+
+	if got := c.Get("core.bare"); got != "true" {
+		t.Errorf("Get core.bare across blocks = %q, want last value true", got)
+	}
+	if all := c.GetAll("core.bare"); len(all) != 2 {
+		t.Errorf("GetAll core.bare = %v, want 2 values", all)
+	}
+	if b, err := c.Bool("core.bare", false); err != nil || !b {
+		t.Errorf("Bool merged = %v, %v", b, err)
+	}
+}
+
+func TestConfigAccessorInvalidKey(t *testing.T) {
+	t.Parallel()
+	c := New()
+	if err := c.Set("core", "x"); !errors.Is(err, ErrInvalidKey) {
+		t.Errorf("Set invalid key err = %v, want ErrInvalidKey", err)
+	}
+	if err := c.Add("core.1bad", "x"); !errors.Is(err, ErrInvalidKey) {
+		t.Errorf("Add invalid key err = %v, want ErrInvalidKey", err)
+	}
+}
+
+func TestConfigBoolInvalidValue(t *testing.T) {
+	t.Parallel()
+	c := New()
+	_ = c.Set("core.bare", "notabool")
+	b, err := c.Bool("core.bare", true)
+	if !errors.Is(err, ErrInvalidBool) {
+		t.Errorf("Bool err = %v, want ErrInvalidBool", err)
+	}
+	if !b {
+		t.Error("Bool should return the default on parse error")
+	}
+}

--- a/plumbing/format/config/configset.go
+++ b/plumbing/format/config/configset.go
@@ -1,0 +1,154 @@
+package config
+
+// ConfigSet provides read-only flat-key access across multiple sources in
+// precedence order, the way git's config_set composes several configuration
+// files (system, global, local, ...) into one effective view. The first source
+// has the highest precedence. Because ConfigSet itself is a Getter, sets nest:
+// a per-scope ConfigSet can be one source of a larger effective view.
+//
+// A ConfigSet never mutates its sources and is not encodable: it is a Getter
+// but not a Setter, and is not accepted by Encoder. It is purely a read view,
+// so the writable one-file Config keeps accurate per-file semantics while
+// effective, multi-source resolution is an explicit, separate concept. A
+// ConfigSet observes later mutations to its underlying sources, since it holds
+// references rather than copies of their contents.
+type ConfigSet struct { //nolint:revive // "config set" mirrors git's config_set terminology
+	sources []Getter // highest precedence first
+}
+
+// NewConfigSet returns a ConfigSet over the given sources, highest precedence
+// first. Nil sources are ignored, and the slice is copied so later mutation of
+// the argument does not affect the set.
+func NewConfigSet(sources ...Getter) *ConfigSet {
+	srcs := make([]Getter, 0, len(sources))
+	for _, s := range sources {
+		if s != nil {
+			srcs = append(srcs, s)
+		}
+	}
+	return &ConfigSet{sources: srcs}
+}
+
+// Sources returns the sources that make up the set, highest precedence first.
+func (s *ConfigSet) Sources() []Getter {
+	return append([]Getter(nil), s.sources...)
+}
+
+// Lookup returns the highest-precedence value set for the canonical key and
+// whether it was present in any source.
+func (s *ConfigSet) Lookup(key string) (string, bool) {
+	for _, c := range s.sources {
+		if v, ok := c.Lookup(key); ok {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// Get returns the highest-precedence value for the canonical key, or the empty
+// string if it is not present in any source.
+func (s *ConfigSet) Get(key string) string {
+	v, _ := s.Lookup(key)
+	return v
+}
+
+// GetAll returns every value set for the canonical key across all sources, in
+// ascending precedence order (lowest-precedence source first), matching git's
+// git config --get-all ordering across files.
+func (s *ConfigSet) GetAll(key string) []string {
+	var all []string
+	for i := len(s.sources) - 1; i >= 0; i-- {
+		all = append(all, s.sources[i].GetAll(key)...)
+	}
+	return all
+}
+
+// Has reports whether the canonical key is present in any source.
+func (s *ConfigSet) Has(key string) bool {
+	_, ok := s.Lookup(key)
+	return ok
+}
+
+// String returns the highest-precedence string value of the canonical key, or
+// def when it is absent from every source.
+func (s *ConfigSet) String(key, def string) string {
+	if v, ok := s.Lookup(key); ok {
+		return v
+	}
+	return def
+}
+
+// Bool returns the highest-precedence boolean value of the canonical key, or
+// def when it is absent. A present but unparseable value returns def together
+// with ErrInvalidBool.
+func (s *ConfigSet) Bool(key string, def bool) (bool, error) {
+	v, ok := s.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	b, err := ParseBool(v)
+	if err != nil {
+		return def, err
+	}
+	return b, nil
+}
+
+// Int returns the highest-precedence integer value of the canonical key, or def
+// when it is absent. A present but unparseable value returns def together with
+// an error.
+func (s *ConfigSet) Int(key string, def int) (int, error) {
+	v, ok := s.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	i, err := ParseInt(v)
+	if err != nil {
+		return def, err
+	}
+	return i, nil
+}
+
+// Int64 returns the highest-precedence int64 value of the canonical key, or def
+// when it is absent. A present but unparseable value returns def together with
+// an error.
+func (s *ConfigSet) Int64(key string, def int64) (int64, error) {
+	v, ok := s.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	i, err := ParseInt64(v)
+	if err != nil {
+		return def, err
+	}
+	return i, nil
+}
+
+// Uint returns the highest-precedence unsigned value of the canonical key, or
+// def when it is absent. A present but unparseable value returns def together
+// with an error.
+func (s *ConfigSet) Uint(key string, def uint) (uint, error) {
+	v, ok := s.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	u, err := ParseUint(v)
+	if err != nil {
+		return def, err
+	}
+	return u, nil
+}
+
+// Uint64 returns the highest-precedence unsigned 64-bit value of the canonical
+// key, or def when it is absent. A present but unparseable value returns def
+// together with an error.
+func (s *ConfigSet) Uint64(key string, def uint64) (uint64, error) {
+	v, ok := s.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	u, err := ParseUint64(v)
+	if err != nil {
+		return def, err
+	}
+	return u, nil
+}

--- a/plumbing/format/config/configset_test.go
+++ b/plumbing/format/config/configset_test.go
@@ -1,0 +1,94 @@
+package config
+
+import "testing"
+
+func mustSet(t *testing.T, c *Config, key, value string) {
+	t.Helper()
+	if err := c.Set(key, value); err != nil {
+		t.Fatalf("Set(%q): %v", key, err)
+	}
+}
+
+func TestConfigSet(t *testing.T) {
+	t.Parallel()
+	system := New()
+	mustSet(t, system, "core.editor", "vi")
+	mustSet(t, system, "pack.window", "20")
+
+	global := New()
+	mustSet(t, global, "user.name", "Ayman")
+	mustSet(t, global, "pack.window", "50") // overrides system
+
+	local := New()
+	mustSet(t, local, "core.bare", "true")
+
+	// Highest precedence first: local, global, system.
+	set := NewConfigSet(local, global, system)
+
+	if got := set.String("core.editor", ""); got != "vi" { // from system
+		t.Errorf("core.editor = %q, want vi", got)
+	}
+	if got := set.String("user.name", ""); got != "Ayman" { // from global
+		t.Errorf("user.name = %q, want Ayman", got)
+	}
+	if b, err := set.Bool("core.bare", false); err != nil || !b { // from local
+		t.Errorf("core.bare = %v, %v, want true", b, err)
+	}
+	if n, err := set.Int("pack.window", 0); err != nil || n != 50 { // global wins over system
+		t.Errorf("pack.window = %d, %v, want 50 (global over system)", n, err)
+	}
+	if _, ok := set.Lookup("core.missing"); ok {
+		t.Error("Lookup core.missing should be absent")
+	}
+	if set.Has("core.missing") {
+		t.Error("Has core.missing should be false")
+	}
+}
+
+func TestConfigSetGetAllAccumulates(t *testing.T) {
+	t.Parallel()
+	system := New()
+	_ = system.Add("safe.directory", "/system")
+	global := New()
+	_ = global.Add("safe.directory", "/global")
+	local := New()
+	_ = local.Add("safe.directory", "/local")
+
+	set := NewConfigSet(local, global, system)
+
+	// Ascending precedence: lowest (system) first.
+	got := set.GetAll("safe.directory")
+	want := []string{"/system", "/global", "/local"}
+	if len(got) != len(want) {
+		t.Fatalf("GetAll = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("GetAll = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestConfigSetIgnoresNilAndIsImmutable(t *testing.T) {
+	t.Parallel()
+	a := New()
+	mustSet(t, a, "user.name", "A")
+
+	srcs := []Getter{a, nil}
+	set := NewConfigSet(srcs...)
+
+	if set.String("user.name", "") != "A" {
+		t.Error("nil source should be ignored")
+	}
+
+	// Mutating the original argument slice must not affect the set.
+	b := New()
+	mustSet(t, b, "user.name", "B")
+	srcs[0] = b
+	if set.String("user.name", "") != "A" {
+		t.Error("ConfigSet must copy its source slice")
+	}
+	if got := set.Sources(); len(got) != 1 {
+		t.Errorf("Sources() len = %d, want 1 (nil ignored)", len(got))
+	}
+}

--- a/plumbing/format/config/interface.go
+++ b/plumbing/format/config/interface.go
@@ -1,0 +1,20 @@
+package config
+
+var (
+	_ Getter = (*Config)(nil)
+	_ Getter = (*ConfigSet)(nil)
+)
+
+// Getter is a read-only, flat-key view of git configuration. A single parsed
+// file (*Config), an effective multi-source view (*ConfigSet), and any
+// caller-supplied source all satisfy it, so they can be layered together with
+// NewConfigSet. It is the minimal primitive the typed accessors build on:
+// Lookup resolves the winning value, GetAll the full multi-valued history.
+type Getter interface {
+	// Lookup returns the value set for the canonical key and whether it was
+	// present at all.
+	Lookup(key string) (string, bool)
+	// GetAll returns every value set for the canonical key, in ascending
+	// precedence order (oldest/lowest first).
+	GetAll(key string) []string
+}

--- a/plumbing/format/config/key.go
+++ b/plumbing/format/config/key.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrInvalidKey is returned when a config key is not a valid
+// "section[.subsection].variable" key as understood by git.
+var ErrInvalidKey = errors.New("config: invalid key")
+
+// SplitKey splits a canonical git config key into its components. Following
+// git's parsing rules, the section is the text before the first dot, the
+// variable name is the text after the last dot, and any text in between is the
+// subsection (which may itself contain dots, e.g. a URL). Keys without a dot
+// yield an empty variable, and keys with a single dot have no subsection.
+//
+// SplitKey performs no validation; use IsValidKey or ValidateKey for that.
+//
+//	"core.bare"                     -> "core", "",              "bare"
+//	"remote.origin.url"             -> "remote", "origin",      "url"
+//	"url.git@github.com:.insteadOf" -> "url", "git@github.com:", "insteadOf"
+func SplitKey(key string) (section, subsection, variable string) {
+	first := strings.IndexByte(key, '.')
+	if first < 0 {
+		return key, "", ""
+	}
+
+	last := strings.LastIndexByte(key, '.')
+	section = key[:first]
+	variable = key[last+1:]
+	if last > first {
+		subsection = key[first+1 : last]
+	}
+	return section, subsection, variable
+}
+
+// IsValidKey reports whether key is a valid git config key, equivalent to git's
+// git_config_key_is_valid.
+func IsValidKey(key string) bool {
+	return ValidateKey(key) == nil
+}
+
+// ValidateKey checks that key is a valid "section[.subsection].variable" key
+// and returns ErrInvalidKey otherwise. It mirrors git's do_parse_config_key:
+// the section and variable names may contain only alphanumeric characters and
+// '-', the variable name must start with a letter, and the subsection (if any)
+// may contain any character except a newline.
+//
+// Reference: https://github.com/git/git/blob/master/config.c (do_parse_config_key)
+func ValidateKey(key string) error {
+	last := strings.LastIndexByte(key, '.')
+	if last <= 0 || last == len(key)-1 {
+		return ErrInvalidKey
+	}
+
+	first := strings.IndexByte(key, '.')
+	section := key[:first]
+	subsection := ""
+	if last > first {
+		subsection = key[first+1 : last]
+	}
+	variable := key[last+1:]
+
+	if !validName(section) || !validVariable(variable) {
+		return ErrInvalidKey
+	}
+	if strings.ContainsRune(subsection, '\n') {
+		return ErrInvalidKey
+	}
+	return nil
+}
+
+// isKeyChar reports whether c is allowed in a section or variable name,
+// matching git's iskeychar (ASCII alphanumeric or '-').
+func isKeyChar(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-'
+}
+
+func isAlpha(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+// validName reports whether name is a valid section or non-leading variable
+// component: non-empty and composed only of key characters.
+func validName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if !isKeyChar(name[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// validVariable reports whether name is a valid variable name: it must be a
+// valid name and start with a letter.
+func validVariable(name string) bool {
+	return validName(name) && isAlpha(name[0])
+}

--- a/plumbing/format/config/key_test.go
+++ b/plumbing/format/config/key_test.go
@@ -1,0 +1,79 @@
+package config
+
+import "testing"
+
+func TestSplitKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		key        string
+		section    string
+		subsection string
+		variable   string
+	}{
+		{"core.bare", "core", "", "bare"},
+		{"remote.origin.url", "remote", "origin", "url"},
+		{"url.git@github.com:.insteadOf", "url", "git@github.com:", "insteadOf"},
+		// A subsection may contain dots (e.g. a URL); git keeps everything
+		// between the first and last dot as the subsection.
+		{"url.https://github.com/.insteadOf", "url", "https://github.com/", "insteadOf"},
+		// Quotes are config-file header syntax, not key syntax: in a flat key
+		// they are literal subsection characters, exactly as git treats them
+		// (git config 'remote."origin".url' writes [remote "\"origin\""]).
+		{`remote."origin".url`, "remote", `"origin"`, "url"},
+		{"core", "core", "", ""},
+		{"a.b.c.d", "a", "b.c", "d"},
+	}
+	for _, tt := range tests {
+		section, subsection, variable := SplitKey(tt.key)
+		if section != tt.section || subsection != tt.subsection || variable != tt.variable {
+			t.Errorf("SplitKey(%q) = (%q,%q,%q), want (%q,%q,%q)",
+				tt.key, section, subsection, variable, tt.section, tt.subsection, tt.variable)
+		}
+	}
+}
+
+func TestIsValidKey(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		{"core.bare", true},
+		{"remote.origin.url", true},
+		{"core.auto-crlf", true},
+		{"url.https://github.com/.insteadOf", true},
+		{"core", false},               // no section/variable separator
+		{"core.", false},              // empty variable
+		{".bare", false},              // empty section
+		{"core.1abc", false},          // variable must start with a letter
+		{"co re.bare", false},         // space in section
+		{"core.ba re", false},         // space in variable
+		{"core.bar=baz", false},       // '=' in variable
+		{"url.a\nb.insteadOf", false}, // newline in subsection
+	}
+	for _, tt := range tests {
+		if got := IsValidKey(tt.key); got != tt.want {
+			t.Errorf("IsValidKey(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+func FuzzKey(f *testing.F) {
+	for _, s := range []string{"core.bare", "remote.origin.url", "a.b.c.d", "", ".", "x", "a.\n.b"} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		// Neither function may panic on arbitrary input.
+		_ = IsValidKey(s)
+		section, subsection, variable := SplitKey(s)
+
+		// A valid key must round-trip through SplitKey into non-empty
+		// section and variable.
+		if IsValidKey(s) {
+			if section == "" || variable == "" {
+				t.Fatalf("valid key %q split to empty section/variable (%q,%q,%q)",
+					s, section, subsection, variable)
+			}
+		}
+	})
+}

--- a/plumbing/format/config/option.go
+++ b/plumbing/format/config/option.go
@@ -78,6 +78,96 @@ func (opts Options) GetAll(key string) []string {
 	return result
 }
 
+// Lookup returns the last value for key and whether the key was present at all.
+// Unlike Get it lets callers distinguish an absent key from a key with an empty
+// value.
+func (opts Options) Lookup(key string) (string, bool) {
+	for i := len(opts) - 1; i >= 0; i-- {
+		if opts[i].IsKey(key) {
+			return opts[i].Value, true
+		}
+	}
+	return "", false
+}
+
+// String returns the value for key, or def when key is absent.
+func (opts Options) String(key, def string) string {
+	if v, ok := opts.Lookup(key); ok {
+		return v
+	}
+	return def
+}
+
+// Bool returns the boolean value of key, or def when key is absent. A present
+// but unparseable value returns def together with ErrInvalidBool.
+func (opts Options) Bool(key string, def bool) (bool, error) {
+	v, ok := opts.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	b, err := ParseBool(v)
+	if err != nil {
+		return def, err
+	}
+	return b, nil
+}
+
+// Int returns the integer value of key, or def when key is absent. A present
+// but unparseable value returns def together with an error.
+func (opts Options) Int(key string, def int) (int, error) {
+	v, ok := opts.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	i, err := ParseInt(v)
+	if err != nil {
+		return def, err
+	}
+	return i, nil
+}
+
+// Int64 returns the int64 value of key, or def when key is absent. A present
+// but unparseable value returns def together with an error.
+func (opts Options) Int64(key string, def int64) (int64, error) {
+	v, ok := opts.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	i, err := ParseInt64(v)
+	if err != nil {
+		return def, err
+	}
+	return i, nil
+}
+
+// Uint returns the unsigned value of key, or def when key is absent. A present
+// but unparseable value returns def together with an error.
+func (opts Options) Uint(key string, def uint) (uint, error) {
+	v, ok := opts.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	u, err := ParseUint(v)
+	if err != nil {
+		return def, err
+	}
+	return u, nil
+}
+
+// Uint64 returns the unsigned 64-bit value of key, or def when key is absent. A
+// present but unparseable value returns def together with an error.
+func (opts Options) Uint64(key string, def uint64) (uint64, error) {
+	v, ok := opts.Lookup(key)
+	if !ok {
+		return def, nil
+	}
+	u, err := ParseUint64(v)
+	if err != nil {
+		return def, err
+	}
+	return u, nil
+}
+
 func (opts Options) withoutOption(key string) Options {
 	result := Options{}
 	for _, o := range opts {

--- a/plumbing/format/config/option_test.go
+++ b/plumbing/format/config/option_test.go
@@ -53,3 +53,34 @@ func (s *OptionSuite) TestOption_IsKey() {
 	s.False((&Option{Key: "key"}).IsKey(""))
 	s.False((&Option{Key: ""}).IsKey("key"))
 }
+
+func TestOptionsTypedAccessors(t *testing.T) {
+	t.Parallel()
+	opts := Options{
+		&Option{Key: "bare", Value: "yes"},
+		&Option{Key: "window", Value: "1k"},
+		&Option{Key: "name", Value: "value"},
+	}
+
+	if v, ok := opts.Lookup("bare"); !ok || v != "yes" {
+		t.Errorf("Lookup bare = %q, %v", v, ok)
+	}
+	if _, ok := opts.Lookup("missing"); ok {
+		t.Error("Lookup missing should be absent")
+	}
+	if b, err := opts.Bool("bare", false); err != nil || !b {
+		t.Errorf("Bool bare = %v, %v", b, err)
+	}
+	if b, _ := opts.Bool("missing", true); !b {
+		t.Error("Bool missing should return default")
+	}
+	if n, err := opts.Int("window", 0); err != nil || n != 1024 {
+		t.Errorf("Int window = %d, %v", n, err)
+	}
+	if s := opts.String("name", "def"); s != "value" {
+		t.Errorf("String name = %q", s)
+	}
+	if s := opts.String("missing", "def"); s != "def" {
+		t.Errorf("String default = %q", s)
+	}
+}

--- a/plumbing/format/config/value.go
+++ b/plumbing/format/config/value.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"errors"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Errors returned by the value parsers. They mirror the failure modes of git's
+// parse.c: a value that is syntactically not of the requested type, or a
+// numeric value (including its unit factor) that does not fit the target type.
+var (
+	// ErrInvalidBool is returned when a value cannot be parsed as a git boolean.
+	ErrInvalidBool = errors.New("config: invalid boolean value")
+	// ErrInvalidNumber is returned when a value cannot be parsed as a git integer.
+	ErrInvalidNumber = errors.New("config: invalid numeric value")
+	// ErrValueOutOfRange is returned when a numeric value does not fit the
+	// requested type.
+	ErrValueOutOfRange = errors.New("config: numeric value out of range")
+)
+
+// ParseBool parses value as a git boolean, mirroring git_parse_maybe_bool in
+// git's parse.c. The tokens "true", "yes" and "on" are true and "false", "no"
+// and "off" are false, all case-insensitively. Any value that parses as an
+// integer is true when non-zero. An empty value is treated as true: go-git
+// stores a valueless ("bare") key such as "[core] bare" with an empty value,
+// and that shorthand means true. Unrecognised values return ErrInvalidBool.
+//
+// Reference: https://github.com/git/git/blob/master/parse.c (git_parse_maybe_bool)
+func ParseBool(value string) (bool, error) {
+	switch strings.ToLower(value) {
+	case "true", "yes", "on":
+		return true, nil
+	case "false", "no", "off":
+		return false, nil
+	case "":
+		return true, nil
+	}
+
+	if i, err := ParseInt64(value); err == nil {
+		return i != 0, nil
+	}
+
+	return false, ErrInvalidBool
+}
+
+// ParseInt64 parses value as a git integer, mirroring git_parse_signed in git's
+// parse.c: the number is read with strconv base 0 (so 0x hexadecimal and 0
+// octal prefixes are honoured) and may carry a single case-insensitive unit
+// suffix of k, m or g for 1024, 1024^2 or 1024^3 respectively.
+//
+// Reference: https://github.com/git/git/blob/master/parse.c (git_parse_signed)
+func ParseInt64(value string) (int64, error) {
+	num, factor, err := splitUnit(value)
+	if err != nil {
+		return 0, err
+	}
+
+	val, err := strconv.ParseInt(num, 0, 64)
+	if err != nil {
+		return 0, numericError(err)
+	}
+
+	if factor != 1 {
+		if val > math.MaxInt64/factor || val < math.MinInt64/factor {
+			return 0, ErrValueOutOfRange
+		}
+		val *= factor
+	}
+
+	return val, nil
+}
+
+// ParseInt parses value as a git integer and reports ErrValueOutOfRange when
+// the result does not fit in an int.
+func ParseInt(value string) (int, error) {
+	v, err := ParseInt64(value)
+	if err != nil {
+		return 0, err
+	}
+	if v > math.MaxInt || v < math.MinInt {
+		return 0, ErrValueOutOfRange
+	}
+	return int(v), nil
+}
+
+// ParseUint64 parses value as a non-negative git integer with the same unit
+// suffixes as ParseInt64. Negative values are rejected, mirroring
+// git_parse_unsigned.
+//
+// Reference: https://github.com/git/git/blob/master/parse.c (git_parse_unsigned)
+func ParseUint64(value string) (uint64, error) {
+	if strings.ContainsRune(value, '-') {
+		return 0, ErrInvalidNumber
+	}
+
+	num, factor, err := splitUnit(value)
+	if err != nil {
+		return 0, err
+	}
+
+	val, err := strconv.ParseUint(num, 0, 64)
+	if err != nil {
+		return 0, numericError(err)
+	}
+
+	if factor != 1 {
+		ufactor := uint64(factor)
+		if val > math.MaxUint64/ufactor {
+			return 0, ErrValueOutOfRange
+		}
+		val *= ufactor
+	}
+
+	return val, nil
+}
+
+// ParseUint parses value as a non-negative git integer and reports
+// ErrValueOutOfRange when the result does not fit in a uint.
+func ParseUint(value string) (uint, error) {
+	v, err := ParseUint64(value)
+	if err != nil {
+		return 0, err
+	}
+	if v > math.MaxUint {
+		return 0, ErrValueOutOfRange
+	}
+	return uint(v), nil
+}
+
+// splitUnit separates the numeric part of value from an optional trailing
+// k/m/g unit suffix and returns the corresponding 1024-based factor.
+func splitUnit(value string) (num string, factor int64, err error) {
+	if value == "" {
+		return "", 0, ErrInvalidNumber
+	}
+
+	switch value[len(value)-1] {
+	case 'k', 'K':
+		return value[:len(value)-1], 1024, nil
+	case 'm', 'M':
+		return value[:len(value)-1], 1024 * 1024, nil
+	case 'g', 'G':
+		return value[:len(value)-1], 1024 * 1024 * 1024, nil
+	default:
+		return value, 1, nil
+	}
+}
+
+func numericError(err error) error {
+	if errors.Is(err, strconv.ErrRange) {
+		return ErrValueOutOfRange
+	}
+	return ErrInvalidNumber
+}

--- a/plumbing/format/config/value_test.go
+++ b/plumbing/format/config/value_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseBool(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		value   string
+		want    bool
+		wantErr bool
+	}{
+		{"true", true, false},
+		{"TRUE", true, false},
+		{"yes", true, false},
+		{"On", true, false},
+		{"false", false, false},
+		{"No", false, false},
+		{"off", false, false},
+		{"", true, false}, // bare-key shorthand
+		{"1", true, false},
+		{"0", false, false},
+		{"-1", true, false},
+		{"42", true, false},
+		{"0x10", true, false},
+		{"0x0", false, false},
+		{"010", true, false},
+		{"maybe", false, true},
+		{"t", false, true},
+		{"f", false, true},
+		{"truthy", false, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseBool(tt.value)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseBool(%q) err = %v, wantErr %v", tt.value, err, tt.wantErr)
+			continue
+		}
+		if err == nil && got != tt.want {
+			t.Errorf("ParseBool(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestParseInt64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		value   string
+		want    int64
+		wantErr bool
+	}{
+		{"0", 0, false},
+		{"10", 10, false},
+		{"-5", -5, false},
+		{"0x10", 16, false},
+		{"010", 8, false}, // base 0: octal
+		{"1k", 1024, false},
+		{"1K", 1024, false},
+		{"2m", 2 * 1024 * 1024, false},
+		{"3g", 3 * 1024 * 1024 * 1024, false},
+		{"-1k", -1024, false},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"1t", 0, true},
+		{"12x", 0, true},
+		{"9223372036854775807", math.MaxInt64, false},
+		{"9999999999999999999g", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseInt64(tt.value)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseInt64(%q) err = %v, wantErr %v", tt.value, err, tt.wantErr)
+			continue
+		}
+		if err == nil && got != tt.want {
+			t.Errorf("ParseInt64(%q) = %d, want %d", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestParseUint64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		value   string
+		want    uint64
+		wantErr bool
+	}{
+		{"0", 0, false},
+		{"10", 10, false},
+		{"1k", 1024, false},
+		{"-1", 0, true},
+		{"-1k", 0, true},
+		{"", 0, true},
+	}
+	for _, tt := range tests {
+		got, err := ParseUint64(tt.value)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseUint64(%q) err = %v, wantErr %v", tt.value, err, tt.wantErr)
+			continue
+		}
+		if err == nil && got != tt.want {
+			t.Errorf("ParseUint64(%q) = %d, want %d", tt.value, got, tt.want)
+		}
+	}
+}
+
+func FuzzParseValue(f *testing.F) {
+	for _, s := range []string{"", "true", "no", "0x1f", "1k", "-3g", "42", "abc", "  ", "9999999999999999999"} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		// The parsers must never panic on arbitrary input.
+		_, _ = ParseBool(s)
+		_, _ = ParseInt(s)
+		_, _ = ParseInt64(s)
+		_, _ = ParseUint(s)
+		_, _ = ParseUint64(s)
+
+		if v, err := ParseInt64(s); err == nil {
+			// A value that parses as an integer must parse as a bool too,
+			// and agree on truthiness.
+			b, berr := ParseBool(s)
+			if berr != nil {
+				t.Fatalf("ParseInt64(%q)=%d ok but ParseBool errored: %v", s, v, berr)
+			}
+			if b != (v != 0) {
+				t.Fatalf("ParseBool(%q)=%v inconsistent with int %d", s, b, v)
+			}
+		}
+	})
+}

--- a/x/config/config.go
+++ b/x/config/config.go
@@ -1,0 +1,169 @@
+// Package xconfig is an experimental, opt-in layer over
+// plumbing/format/config for reading git's global and system configuration
+// files. It is NOT used by go-git's repository core, which deals only with the
+// local repository config; callers that want git-like effective resolution
+// compose these sources explicitly with config.NewConfigSet.
+//
+// Path resolution and the environment variables that override it follow git
+// (GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM, GIT_CONFIG_NOSYSTEM, XDG_CONFIG_HOME),
+// matching the conventions of x/plugin/config. Includes (include.path,
+// includeIf.*) and command-line (-c) configuration are NOT resolved, and the
+// defaults git applies inline at use sites are not modelled here.
+package xconfig
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	config "github.com/go-git/go-git/v6/plumbing/format/config"
+)
+
+// Git environment variables that override config file paths, matching git and
+// x/plugin/config.
+const (
+	envGitConfigGlobal   = "GIT_CONFIG_GLOBAL"
+	envGitConfigSystem   = "GIT_CONFIG_SYSTEM"
+	envGitConfigNoSystem = "GIT_CONFIG_NOSYSTEM"
+	envXDGConfigHome     = "XDG_CONFIG_HOME"
+)
+
+// GlobalConfig loads the user-level ("global") git configuration as one
+// effective, read-only view, highest precedence first, following git's rules:
+//
+//   - GIT_CONFIG_GLOBAL, when set to a non-empty path, is the only file read
+//     and replaces both ~/.gitconfig and the XDG file. When set to "", global
+//     config is disabled and an empty set is returned.
+//   - Otherwise ~/.gitconfig and the XDG file ($XDG_CONFIG_HOME/git/config,
+//     defaulting per platform) are layered, with ~/.gitconfig winning.
+//
+// Missing files are skipped; a file that exists but fails to parse returns an
+// error. The returned set is non-nil even when empty.
+func GlobalConfig() (*config.ConfigSet, error) {
+	if path, ok := os.LookupEnv(envGitConfigGlobal); ok {
+		if path == "" {
+			return config.NewConfigSet(), nil
+		}
+		return loadConfigSet([]string{path})
+	}
+	return loadConfigSet(globalPaths())
+}
+
+// SystemConfig loads the system-level git configuration as a read-only view,
+// following git's rules:
+//
+//   - GIT_CONFIG_NOSYSTEM, when truthy, disables system config entirely.
+//   - GIT_CONFIG_SYSTEM, when set to a non-empty path, is the only file read.
+//     When set to "", system config is disabled.
+//   - Otherwise the platform's default path (/etc/gitconfig on Unix) is used.
+//
+// Missing files are skipped; a parse error is returned. The returned set is
+// non-nil even when empty.
+func SystemConfig() (*config.ConfigSet, error) {
+	if isNoSystem() {
+		return config.NewConfigSet(), nil
+	}
+	if path, ok := os.LookupEnv(envGitConfigSystem); ok {
+		if path == "" {
+			return config.NewConfigSet(), nil
+		}
+		return loadConfigSet([]string{path})
+	}
+	return loadConfigSet(systemPaths())
+}
+
+// globalPaths returns the default global config paths, highest precedence
+// first. git reads the XDG file before ~/.gitconfig and layers them, so
+// ~/.gitconfig wins; both are read (they are not mutually exclusive).
+func globalPaths() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+
+	var paths []string
+	if home != "" {
+		paths = append(paths, filepath.Join(home, ".gitconfig"))
+	}
+	if xdg := xdgConfigPath(home); xdg != "" {
+		paths = append(paths, xdg)
+	}
+	return paths
+}
+
+// xdgConfigPath returns the XDG git config file path, consulting
+// XDG_CONFIG_HOME with platform-specific fallbacks.
+func xdgConfigPath(home string) string {
+	if xdg := os.Getenv(envXDGConfigHome); xdg != "" {
+		return filepath.Join(xdg, "git", "config")
+	}
+	if runtime.GOOS == "windows" {
+		if appData := os.Getenv("APPDATA"); appData != "" {
+			return filepath.Join(appData, "git", "config")
+		}
+		return ""
+	}
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "git", "config")
+}
+
+// systemPaths returns the candidate system config paths for the platform.
+func systemPaths() []string {
+	if runtime.GOOS == "windows" {
+		if pf := os.Getenv("PROGRAMFILES"); pf != "" {
+			return []string{filepath.Join(pf, "Git", "etc", "gitconfig")}
+		}
+		return nil
+	}
+	return []string{"/etc/gitconfig"}
+}
+
+// isNoSystem reports whether GIT_CONFIG_NOSYSTEM is set to a truthy value,
+// matching git's case-insensitive boolean parsing.
+func isNoSystem() bool {
+	v := os.Getenv(envGitConfigNoSystem)
+	if v == "" {
+		return false
+	}
+	switch strings.ToLower(v) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// loadConfigSet parses each existing path into a Config, in the given order,
+// and returns them as one read-only ConfigSet (highest precedence first).
+// Missing files are skipped; any other open error or a parse error is returned.
+func loadConfigSet(paths []string) (*config.ConfigSet, error) {
+	var sources []config.Getter
+	for _, p := range paths {
+		f, err := os.Open(p)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+
+		c := config.New()
+		decErr := config.NewDecoder(f).Decode(c)
+		closeErr := f.Close()
+		if decErr != nil {
+			return nil, fmt.Errorf("xconfig: parse %s: %w", p, decErr)
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+
+		sources = append(sources, c)
+	}
+	return config.NewConfigSet(sources...), nil
+}

--- a/x/config/config_test.go
+++ b/x/config/config_test.go
@@ -1,0 +1,193 @@
+package xconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// unsetGitConfigEnv clears the GIT_CONFIG_* overrides so a test exercises pure
+// path resolution, restoring any prior values when it finishes.
+func unsetGitConfigEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{envGitConfigGlobal, envGitConfigSystem, envGitConfigNoSystem} {
+		if v, ok := os.LookupEnv(k); ok {
+			t.Cleanup(func() { _ = os.Setenv(k, v) })
+			_ = os.Unsetenv(k)
+		}
+	}
+}
+
+func TestLoadConfigSetSkipsMissingAndErrorsOnParse(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	ok := filepath.Join(dir, "ok")
+	writeFile(t, ok, "[user]\n\tname = Jane\n")
+	missing := filepath.Join(dir, "missing")
+
+	got, err := loadConfigSet([]string{missing, ok})
+	if err != nil {
+		t.Fatalf("loadConfigSet: %v", err)
+	}
+	if n := len(got.Sources()); n != 1 {
+		t.Fatalf("loaded %d sources, want 1 (missing skipped)", n)
+	}
+	if got.Get("user.name") != "Jane" {
+		t.Errorf("user.name = %q", got.Get("user.name"))
+	}
+
+	bad := filepath.Join(dir, "bad")
+	writeFile(t, bad, "this is not = valid [ git config")
+	if _, err := loadConfigSet([]string{bad}); err == nil {
+		t.Error("loadConfigSet should error on a malformed file")
+	}
+}
+
+func TestGlobalConfigLayersHomeAndXDG(t *testing.T) {
+	unsetGitConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(envXDGConfigHome, filepath.Join(home, "xdg"))
+
+	writeFile(t, filepath.Join(home, ".gitconfig"), "[user]\n\tname = FromHome\n")
+	writeFile(t, filepath.Join(home, "xdg", "git", "config"), "[user]\n\tname = FromXDG\n\temail = xdg@example.com\n")
+
+	set, err := GlobalConfig()
+	if err != nil {
+		t.Fatalf("GlobalConfig: %v", err)
+	}
+	if n := len(set.Sources()); n != 2 {
+		t.Fatalf("GlobalConfig sources = %d, want 2 (home and XDG layered)", n)
+	}
+	if got := set.String("user.name", ""); got != "FromHome" {
+		t.Errorf("user.name = %q, want FromHome (~/.gitconfig wins)", got)
+	}
+	if got := set.String("user.email", ""); got != "xdg@example.com" {
+		t.Errorf("user.email = %q, want xdg value (layered, not mutually exclusive)", got)
+	}
+}
+
+func TestGlobalConfigEnvOverride(t *testing.T) {
+	unsetGitConfigEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(envXDGConfigHome, filepath.Join(home, "xdg"))
+	writeFile(t, filepath.Join(home, ".gitconfig"), "[user]\n\tname = FromHome\n")
+	writeFile(t, filepath.Join(home, "xdg", "git", "config"), "[user]\n\temail = xdg@example.com\n")
+
+	alt := filepath.Join(home, "alt", "gitconfig")
+	writeFile(t, alt, "[user]\n\tname = FromAlt\n")
+
+	t.Run("non-empty path replaces home and XDG", func(t *testing.T) {
+		t.Setenv(envGitConfigGlobal, alt)
+		set, err := GlobalConfig()
+		if err != nil {
+			t.Fatalf("GlobalConfig: %v", err)
+		}
+		if got := set.String("user.name", ""); got != "FromAlt" {
+			t.Errorf("user.name = %q, want FromAlt", got)
+		}
+		if set.Has("user.email") {
+			t.Error("user.email should be absent: GIT_CONFIG_GLOBAL replaces XDG too")
+		}
+	})
+
+	t.Run("empty value disables global", func(t *testing.T) {
+		t.Setenv(envGitConfigGlobal, "")
+		set, err := GlobalConfig()
+		if err != nil {
+			t.Fatalf("GlobalConfig: %v", err)
+		}
+		if n := len(set.Sources()); n != 0 {
+			t.Errorf("sources = %d, want 0 (global disabled)", n)
+		}
+		if set.Has("user.name") {
+			t.Error("global config should be disabled")
+		}
+	})
+}
+
+func TestSystemConfigEnv(t *testing.T) {
+	unsetGitConfigEnv(t)
+	home := t.TempDir()
+	sys := filepath.Join(home, "sys", "gitconfig")
+	writeFile(t, sys, "[core]\n\tsomething = sys\n")
+
+	t.Run("GIT_CONFIG_SYSTEM points at a file", func(t *testing.T) {
+		t.Setenv(envGitConfigSystem, sys)
+		set, err := SystemConfig()
+		if err != nil {
+			t.Fatalf("SystemConfig: %v", err)
+		}
+		if got := set.String("core.something", ""); got != "sys" {
+			t.Errorf("core.something = %q, want sys", got)
+		}
+	})
+
+	t.Run("GIT_CONFIG_SYSTEM empty disables system", func(t *testing.T) {
+		t.Setenv(envGitConfigSystem, "")
+		set, err := SystemConfig()
+		if err != nil {
+			t.Fatalf("SystemConfig: %v", err)
+		}
+		if n := len(set.Sources()); n != 0 {
+			t.Errorf("sources = %d, want 0 (system disabled)", n)
+		}
+	})
+
+	t.Run("GIT_CONFIG_NOSYSTEM skips system even with GIT_CONFIG_SYSTEM set", func(t *testing.T) {
+		t.Setenv(envGitConfigSystem, sys)
+		t.Setenv(envGitConfigNoSystem, "1")
+		set, err := SystemConfig()
+		if err != nil {
+			t.Fatalf("SystemConfig: %v", err)
+		}
+		if set.Has("core.something") {
+			t.Error("GIT_CONFIG_NOSYSTEM should skip system config")
+		}
+	})
+}
+
+func TestIsNoSystem(t *testing.T) { //nolint:paralleltest // mutates process environment
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"FALSE", false},
+		{"no", false},
+		{"off", false},
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"anything", true},
+	}
+	for _, tc := range cases {
+		t.Setenv(envGitConfigNoSystem, tc.val)
+		if got := isNoSystem(); got != tc.want {
+			t.Errorf("isNoSystem(%q) = %v, want %v", tc.val, got, tc.want)
+		}
+	}
+}
+
+func TestSystemConfigSkipsMissing(t *testing.T) { //nolint:paralleltest // mutates process environment
+	unsetGitConfigEnv(t)
+	// The platform's default system file may or may not exist; either way this
+	// must not error.
+	if _, err := SystemConfig(); err != nil {
+		t.Fatalf("SystemConfig: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Experimental follow-up to the canonical config work in https://github.com/go-git/go-git/pull/2221 (this PR stacks on it; the `Getter`/`ConfigSet` commit belongs to that PR and drops out once it merges).

It adds opt-in loaders for git's user- and system-level configuration files, the explicit pieces for *effective* (multi-source) config resolution that are deliberately kept out of the repository core. The repository core stays local-config only.

### `x/config` (package `xconfig`, experimental)

Loaders that read git's global and system config files and return each scope as a read-only `config.ConfigSet`, which callers compose for git-like effective resolution:

```go
globalSet, _ := xconfig.GlobalConfig() // ~/.gitconfig layered over the XDG file
systemSet, _ := xconfig.SystemConfig() // /etc/gitconfig (platform-aware)

eff := config.NewConfigSet(local, globalSet, systemSet)
window, _ := eff.Int("pack.window", 10 /* call-site default */)
```

Path resolution follows git, including the environment variables that override it, all verified against the reference `git` implementation:

- `GIT_CONFIG_GLOBAL` selects a single global file (replacing both `~/.gitconfig` and the XDG file), or disables global config when empty.
- `GIT_CONFIG_SYSTEM` selects a single system file, or disables system config when empty.
- `GIT_CONFIG_NOSYSTEM` skips system config entirely.
- `XDG_CONFIG_HOME` locates the XDG file, with platform fallbacks (Windows `APPDATA`/`PROGRAMFILES`).

The default global scope layers `~/.gitconfig` over the XDG file (both are read, `~/.gitconfig` wins), matching git rather than treating them as mutually exclusive. Missing files are skipped; a malformed file is a hard error. Includes (`include.path`/`includeIf`), command-line `-c`, and inline defaults are intentionally out of scope.

## Notes

- A `DefaultConfig()` source was intentionally left out. Git's defaults are call-site defaults (the typed getters already take a default value), and modelling them as a config source would make `Has` report unconfigured keys as present. Defaults stay behavior-local exported constants, like the existing `DefaultObjectFormat`.
- This is part of the foundation that will eventually replace `Repository.ConfigScoped`, which flattens scopes into one `*Config` and loses provenance. That migration is a separate change; this PR does not touch `ConfigScoped`.

This change was produced with AI assistance (see the `Assisted-by` trailer on the commit).

