### PR TITLE
plumbing: packp/transport, Slice-based AdvRefs and v1 handling (2/11)

### DIFF
--- a/plumbing/protocol/packp/advrefs.go
+++ b/plumbing/protocol/packp/advrefs.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 )
 
@@ -14,6 +15,9 @@ import (
 // advertised-refs message. The zero value is safe to use; References
 // and Shallows can be populated via append.
 type AdvRefs struct {
+	// Version is the protocol version. The only acceptable values are V0 and
+	// V1, any other value is considered invalid.
+	Version protocol.Version
 	// Capabilities are the capabilities.
 	Capabilities capability.List
 	// References are the hash references, including HEAD and peeled refs

--- a/plumbing/protocol/packp/advrefs_decode.go
+++ b/plumbing/protocol/packp/advrefs_decode.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 )
 
@@ -62,6 +64,28 @@ func (a *AdvRefs) Decode(r io.Reader) error {
 	}
 
 	// Check for empty repository (flush packet)
+	if isFlush(line) {
+		return ErrEmptyAdvRefs
+	}
+
+	if line := string(line); strings.HasPrefix(line, "version ") {
+		v, perr := protocol.Parse(line[len("version "):])
+		if perr != nil {
+			return perr
+		}
+		a.Version = v
+
+		if !nextLine() {
+			return err
+		}
+	}
+
+	if a.Version != protocol.V0 && a.Version != protocol.V1 {
+		return decodeError("unsupported protocol version: %d", a.Version)
+	}
+
+	// Check for empty repository (flush packet), which may appear
+	// either as the first line or after the version line.
 	if isFlush(line) {
 		return ErrEmptyAdvRefs
 	}

--- a/plumbing/protocol/packp/advrefs_decode_test.go
+++ b/plumbing/protocol/packp/advrefs_decode_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 )
 
@@ -71,7 +72,7 @@ func (s *AdvRefsDecodeSuite) TestZeroId() {
 	}
 	ar := s.testDecodeOK(payloads)
 	_, err := ar.Head()
-	s.Equal(plumbing.ErrReferenceNotFound, err)
+	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
 func (s *AdvRefsDecodeSuite) testDecodeOK(payloads []string) *AdvRefs {
@@ -127,7 +128,7 @@ func (s *AdvRefsDecodeSuite) TestFirstIsNotHead() {
 	}
 	ar := s.testDecodeOK(payloads)
 	_, err := ar.Head()
-	s.Equal(plumbing.ErrReferenceNotFound, err)
+	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 	refs := make(map[string]plumbing.Hash)
 	for _, ref := range ar.References {
 		refs[ref.Name().String()] = ref.Hash()
@@ -493,6 +494,81 @@ func (s *AdvRefsDecodeSuite) TestEOFRefs() {
 		"00355dc01c595e6c6ec9ccda4f6ffbf614e4d92bb0c7 refs/foo\n",
 	)
 	s.testDecoderErrorMatches(input, ".*invalid pkt-len.*")
+}
+
+func (s *AdvRefsDecodeSuite) TestVersion1Decode() {
+	payloads := []string{
+		"version 1\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00multi_ack thin-pack\n",
+		"",
+	}
+	ar := s.testDecodeOK(payloads)
+	s.Equal(protocol.V1, ar.Version)
+	head, err := ar.Head()
+	s.NoError(err)
+	s.Equal(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), head.Hash())
+}
+
+func (s *AdvRefsDecodeSuite) TestVersion1WithRefsAndShallows() {
+	payloads := []string{
+		"version 1\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00ofs-delta symref=HEAD:refs/heads/master\n",
+		"a6930aaee06755d1bdcfd943fbf614e4d92bb0c7 refs/heads/master\n",
+		"5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c refs/tags/v2.6.11-tree\n",
+		"c39ae07f393806ccf406ef966e9a15afc43cc36a refs/tags/v2.6.11-tree^{}\n",
+		"shallow 1111111111111111111111111111111111111111\n",
+		"",
+	}
+	ar := s.testDecodeOK(payloads)
+	s.Equal(protocol.V1, ar.Version)
+	s.Equal(4, len(ar.References))
+	s.Equal(1, len(ar.Shallows))
+}
+
+func (s *AdvRefsDecodeSuite) TestVersion1EmptyRepo() {
+	payloads := []string{
+		"version 1\n",
+		"0000000000000000000000000000000000000000 capabilities^{}\x00multi_ack thin-pack\n",
+		"",
+	}
+	ar := s.testDecodeOK(payloads)
+	s.Equal(protocol.V1, ar.Version)
+	_, err := ar.Head()
+	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
+}
+
+func (s *AdvRefsDecodeSuite) TestVersion2Unsupported() {
+	payloads := []string{
+		"version 2\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00multi_ack thin-pack\n",
+		"",
+	}
+	r := toPktLines(s.T(), payloads)
+	ar := &AdvRefs{}
+	err := ar.Decode(r)
+	s.Error(err)
+	s.Contains(err.Error(), "unsupported protocol version")
+}
+
+func (s *AdvRefsDecodeSuite) TestVersionUnparseableErrors() {
+	payloads := []string{
+		"version 999\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00multi_ack thin-pack\n",
+		"",
+	}
+	r := toPktLines(s.T(), payloads)
+	ar := &AdvRefs{}
+	err := ar.Decode(r)
+	s.Error(err)
+}
+
+func (s *AdvRefsDecodeSuite) TestVersionNoLineIsV0() {
+	payloads := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00multi_ack thin-pack\n",
+		"",
+	}
+	ar := s.testDecodeOK(payloads)
+	s.Equal(protocol.V0, ar.Version)
 }
 
 func (s *AdvRefsDecodeSuite) TestEOFShallows() {

--- a/plumbing/protocol/packp/advrefs_encode.go
+++ b/plumbing/protocol/packp/advrefs_encode.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 )
 
 // Encode writes the AdvRefs encoding to a writer.
@@ -16,6 +17,16 @@ import (
 // references and shallows are written in alphabetical order, except for
 // peeled references that always follow their corresponding references.
 func (a *AdvRefs) Encode(w io.Writer) error {
+	switch a.Version {
+	case protocol.V0:
+	case protocol.V1:
+		if _, err := pktline.Writef(w, "version %d\n", a.Version); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported protocol version: %d", a.Version)
+	}
+
 	// Find HEAD or use first ref
 	firstName, firstHash := a.firstRef()
 

--- a/plumbing/protocol/packp/advrefs_encode_test.go
+++ b/plumbing/protocol/packp/advrefs_encode_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 )
 
@@ -230,4 +231,95 @@ func (s *AdvRefsEncodeSuite) TestErrorTooLong() {
 	var buf bytes.Buffer
 	err := ar.Encode(&buf)
 	s.Regexp(regexp.MustCompile(".*payload is too long.*"), err)
+}
+
+func (s *AdvRefsEncodeSuite) TestVersion0NoVersionLine() {
+	ar := &AdvRefs{
+		Version: protocol.V0,
+		References: []*plumbing.Reference{
+			plumbing.NewHashReference(plumbing.HEAD, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")),
+		},
+	}
+
+	expected := pktlines(s.T(),
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00\n",
+		"",
+	)
+
+	testEncode(s, ar, expected)
+}
+
+func (s *AdvRefsEncodeSuite) TestVersion1WritesVersionLine() {
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	ar := &AdvRefs{
+		Version: protocol.V1,
+		References: []*plumbing.Reference{
+			plumbing.NewHashReference(plumbing.HEAD, hash),
+		},
+	}
+
+	expected := pktlines(s.T(),
+		"version 1\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00\n",
+		"",
+	)
+
+	testEncode(s, ar, expected)
+}
+
+func (s *AdvRefsEncodeSuite) TestVersion1WithRefsAndShallows() {
+	capabilities := capability.List{}
+	capabilities.Add(capability.OFSDelta)
+	capabilities.Add(capability.SymRef, "HEAD:refs/heads/master")
+
+	shallows := []plumbing.Hash{
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("2222222222222222222222222222222222222222"),
+	}
+
+	ar := &AdvRefs{
+		Version:      protocol.V1,
+		Capabilities: capabilities,
+		References: []*plumbing.Reference{
+			plumbing.NewHashReference(plumbing.HEAD, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")),
+			plumbing.NewHashReference("refs/heads/master", plumbing.NewHash("a6930aaee06755d1bdcfd943fbf614e4d92bb0c7")),
+		},
+		Shallows: shallows,
+	}
+
+	expected := pktlines(s.T(),
+		"version 1\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00ofs-delta symref=HEAD:refs/heads/master\n",
+		"a6930aaee06755d1bdcfd943fbf614e4d92bb0c7 refs/heads/master\n",
+		"shallow 1111111111111111111111111111111111111111\n",
+		"shallow 2222222222222222222222222222222222222222\n",
+		"",
+	)
+
+	testEncode(s, ar, expected)
+}
+
+func (s *AdvRefsEncodeSuite) TestVersion2Unsupported() {
+	ar := &AdvRefs{
+		Version: protocol.V2,
+	}
+
+	var buf bytes.Buffer
+	err := ar.Encode(&buf)
+	s.Error(err)
+	s.Contains(err.Error(), "unsupported protocol version")
+}
+
+func (s *AdvRefsEncodeSuite) TestVersion1EmptyRepo() {
+	ar := &AdvRefs{
+		Version: protocol.V1,
+	}
+
+	expected := pktlines(s.T(),
+		"version 1\n",
+		"0000000000000000000000000000000000000000 capabilities^{}\x00\n",
+		"",
+	)
+
+	testEncode(s, ar, expected)
 }

--- a/plumbing/protocol/packp/advrefs_test.go
+++ b/plumbing/protocol/packp/advrefs_test.go
@@ -383,3 +383,67 @@ func (s *AdvRefsDecodeEncodeSuite) TestAllSmartBug() {
 
 	s.test(input, expected, false)
 }
+
+func (s *AdvRefsDecodeEncodeSuite) TestVersion1RoundTrip() {
+	input := []string{
+		"version 1\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00symref=HEAD:/refs/heads/master ofs-delta multi_ack\n",
+		"a6930aaee06755d1bdcfd943fbf614e4d92bb0c7 refs/heads/master\n",
+		"5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c refs/tags/v2.6.11-tree\n",
+		"c39ae07f393806ccf406ef966e9a15afc43cc36a refs/tags/v2.6.11-tree^{}\n",
+		"shallow 1111111111111111111111111111111111111111\n",
+		"shallow 2222222222222222222222222222222222222222\n",
+		"",
+	}
+
+	expected := []string{
+		"version 1\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00symref=HEAD:/refs/heads/master ofs-delta multi_ack\n",
+		"a6930aaee06755d1bdcfd943fbf614e4d92bb0c7 refs/heads/master\n",
+		"5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c refs/tags/v2.6.11-tree\n",
+		"c39ae07f393806ccf406ef966e9a15afc43cc36a refs/tags/v2.6.11-tree^{}\n",
+		"shallow 1111111111111111111111111111111111111111\n",
+		"shallow 2222222222222222222222222222222222222222\n",
+		"",
+	}
+
+	s.test(input, expected, false)
+}
+
+func (s *AdvRefsDecodeEncodeSuite) TestVersion1EmptyRepoRoundTrip() {
+	input := []string{
+		"version 1\n",
+		"0000000000000000000000000000000000000000 capabilities^{}\x00report-status\n",
+		"",
+	}
+
+	expected := []string{
+		"version 1\n",
+		"0000000000000000000000000000000000000000 capabilities^{}\x00report-status\n",
+		"",
+	}
+
+	s.test(input, expected, true)
+}
+
+func (s *AdvRefsDecodeEncodeSuite) TestVersion1SmartRoundTrip() {
+	input := []string{
+		"# service=git-upload-pack\n",
+		"",
+		"version 1\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00symref=HEAD:/refs/heads/master ofs-delta multi_ack\n",
+		"a6930aaee06755d1bdcfd943fbf614e4d92bb0c7 refs/heads/master\n",
+		"",
+	}
+
+	expected := []string{
+		"# service=git-upload-pack\n",
+		"",
+		"version 1\n",
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00symref=HEAD:/refs/heads/master ofs-delta multi_ack\n",
+		"a6930aaee06755d1bdcfd943fbf614e4d92bb0c7 refs/heads/master\n",
+		"",
+	}
+
+	s.test(input, expected, false)
+}

--- a/plumbing/transport/version.go
+++ b/plumbing/transport/version.go
@@ -11,6 +11,9 @@ import (
 // DiscoverVersion reads the first pktline from the reader to determine the
 // protocol version. This is used by the client to determine the protocol
 // version of the server.
+//
+// Note that the discovered version is not consumed from the reader, so the
+// caller can read it again after discovering the version.
 func DiscoverVersion(r ioutil.ReadPeeker) (protocol.Version, error) {
 	ver := protocol.V0
 	_, pktb, err := pktline.PeekLine(r)
@@ -20,10 +23,6 @@ func DiscoverVersion(r ioutil.ReadPeeker) (protocol.Version, error) {
 
 	pkt := strings.TrimSpace(string(pktb))
 	if strings.HasPrefix(pkt, "version ") {
-		// Consume the version packet
-		if _, _, err := pktline.ReadLine(r); err != nil {
-			return ver, err
-		}
 		if v, _ := protocol.Parse(pkt[8:]); v > ver {
 			ver = protocol.Version(v)
 		}


### PR DESCRIPTION
## Part 2 of 11: slice-based AdvRefs and v1 handling

Second of the Protocol v2 series. Builds on Part 1 (#2206).

### What changes

- Migrate `AdvRefs` from a map to a slice of references, preserving wire
  order, and simplify its encoder and decoder.
- Move Protocol version 1 handling into `AdvRefs`, so version detection and
  the v1 advertisement live with the advertised-refs type rather than being
  spread across the session code.

No new wire features.

### Reviewing just this part

https://github.com/go-git/go-git/compare/gitprotocol-v2-1-packp...gitprotocol-v2-2-transport

### Notes

- Targets `main` (v6). Built and tested green. Squashed.

Depends on Part 1 (#2206); merge that first.





---
_Recreated as a same-repo stacked PR (supersedes #2207)._

