### PR TITLE
plumbing: packp, Protocol v2 wire types with caller-owned packfile streaming (4/11)

### DIFF
--- a/plumbing/protocol/packp/capability_adv.go
+++ b/plumbing/protocol/packp/capability_adv.go
@@ -1,0 +1,96 @@
+package packp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+)
+
+// CapabilityAdv represents a protocol v2 server capability advertisement.
+// It includes the version line and the capability lines that follow it.
+//
+// In protocol v2, the server sends:
+//
+//	version 2\n
+//	agent=git/2.45.0\n
+//	ls-refs=unborn\n
+//	fetch=shallow wait-for-done filter\n
+//	0000
+//
+// Capabilities are one per line in "key" or "key=value" format,
+// terminated by a flush packet. This differs from v0/v1 where
+// capabilities are space-separated after a NUL byte on the first ref line.
+type CapabilityAdv struct {
+	// Version is the protocol version. Decode sets this to V2.
+	// Encode writes the version line when Version is V2.
+	Version protocol.Version
+	// Capabilities is the parsed list of server capabilities.
+	Capabilities capability.List
+}
+
+// Decode reads a v2 capability advertisement from a pkt-line stream.
+// It expects the stream to start with the "version 2\n" line,
+// followed by capability lines (one per line), terminated by a flush packet.
+func (ca *CapabilityAdv) Decode(r io.Reader) error {
+	// Read version line first.
+	l, line, err := pktline.ReadLine(r)
+	if err != nil {
+		return err
+	}
+	if l < 4 || line == nil {
+		return errInvalidVersionLine
+	}
+
+	line = bytes.TrimSuffix(line, []byte("\n"))
+	if !bytes.HasPrefix(line, []byte("version ")) {
+		return errInvalidVersionLine
+	}
+
+	v, err := protocol.Parse(string(line[8:]))
+	if err != nil {
+		return err
+	}
+
+	if v != protocol.V2 {
+		return fmt.Errorf("unsupported protocol version in capability advertisement: %s", v)
+	}
+
+	ca.Version = v
+
+	// Read capability lines until flush.
+	length, err := DecodeListV2(r, &ca.Capabilities)
+	if err != nil {
+		return fmt.Errorf("decoding capability list: %w", err)
+	}
+	if length != pktline.Flush {
+		return fmt.Errorf("expected flush-pkt after capability list, got %04x", length)
+	}
+	return nil
+}
+
+// Encode writes a v2 capability advertisement to a pkt-line stream.
+// It writes the "version N\n" line (where N is ca.Version), then each
+// capability on its own line, and terminates with a flush packet.
+// Encode returns an error if ca.Version is not V2.
+func (ca *CapabilityAdv) Encode(w io.Writer) error {
+	if ca.Version != protocol.V2 {
+		return fmt.Errorf("unsupported protocol version for capability advertisement: %s", ca.Version)
+	}
+
+	if _, err := pktline.Writef(w, "version %d\n", ca.Version); err != nil {
+		return err
+	}
+
+	if err := EncodeListV2(w, &ca.Capabilities); err != nil {
+		return err
+	}
+
+	return pktline.WriteFlush(w)
+}
+
+var errInvalidVersionLine = errors.New("capability advertisement must start with version line")

--- a/plumbing/protocol/packp/capability_adv_test.go
+++ b/plumbing/protocol/packp/capability_adv_test.go
@@ -1,0 +1,168 @@
+package packp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+)
+
+func TestCapabilityAdvDecode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic capabilities", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "version 2\n")
+		pktline.WriteString(&buf, "agent=git/2.45.0\n")
+		pktline.WriteString(&buf, "ls-refs=unborn\n")
+		pktline.WriteString(&buf, "fetch=shallow wait-for-done filter\n")
+		pktline.WriteString(&buf, "server-option\n")
+		pktline.WriteString(&buf, "object-format=sha1\n")
+		pktline.WriteFlush(&buf)
+
+		ca := &CapabilityAdv{}
+		assert.NoError(t, ca.Decode(&buf))
+		assert.Equal(t, protocol.V2, ca.Version)
+		assert.True(t, ca.Capabilities.Supports(capability.Agent))
+		assert.Equal(t, []string{"git/2.45.0"}, ca.Capabilities.Get(capability.Agent))
+		assert.True(t, ca.Capabilities.Supports(capability.LsRefs))
+		assert.Equal(t, []string{"unborn"}, ca.Capabilities.Get(capability.LsRefs))
+		assert.True(t, ca.Capabilities.Supports(capability.FetchCmd))
+		assert.Equal(t, []string{"shallow", "wait-for-done", "filter"}, ca.Capabilities.Get(capability.FetchCmd))
+		assert.True(t, ca.Capabilities.Supports(capability.ServerOption))
+		assert.True(t, ca.Capabilities.Supports(capability.ObjectFormat))
+		assert.Equal(t, []string{"sha1"}, ca.Capabilities.Get(capability.ObjectFormat))
+	})
+
+	t.Run("capability without value", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "version 2\n")
+		pktline.WriteString(&buf, "agent=git/2.0.0\n")
+		pktline.WriteString(&buf, "ls-refs\n")
+		pktline.WriteFlush(&buf)
+
+		ca := &CapabilityAdv{}
+		assert.NoError(t, ca.Decode(&buf))
+		assert.True(t, ca.Capabilities.Supports(capability.Agent))
+		assert.True(t, ca.Capabilities.Supports(capability.LsRefs))
+		assert.Nil(t, ca.Capabilities.Get(capability.LsRefs))
+	})
+
+	t.Run("empty advertisement", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "version 2\n")
+		pktline.WriteFlush(&buf)
+
+		ca := &CapabilityAdv{}
+		assert.NoError(t, ca.Decode(&buf))
+		assert.Equal(t, protocol.V2, ca.Version)
+		assert.True(t, ca.Capabilities.IsEmpty())
+	})
+
+	t.Run("preserves existing capabilities", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "version 2\n")
+		pktline.WriteString(&buf, "ls-refs\n")
+		pktline.WriteFlush(&buf)
+
+		caps := capability.List{}
+		caps.Add(capability.Agent, "test/1.0")
+		ca := &CapabilityAdv{Capabilities: caps}
+		assert.NoError(t, ca.Decode(&buf))
+		assert.Equal(t, []string{"test/1.0"}, ca.Capabilities.Get(capability.Agent))
+		assert.True(t, ca.Capabilities.Supports(capability.LsRefs))
+	})
+}
+
+func TestCapabilityAdvEncode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("basic capabilities", func(t *testing.T) {
+		t.Parallel()
+		caps := capability.List{}
+		caps.Add(capability.Agent, "git/2.45.0")
+		caps.Add(capability.LsRefs, "unborn")
+		caps.Add(capability.FetchCmd, "shallow", "wait-for-done", "filter")
+		caps.Add(capability.ServerOption)
+		caps.Add(capability.ObjectFormat, "sha1")
+
+		ca := &CapabilityAdv{
+			Version:      protocol.V2,
+			Capabilities: caps,
+		}
+
+		var buf bytes.Buffer
+		assert.NoError(t, ca.Encode(&buf))
+
+		got := &CapabilityAdv{}
+		assert.NoError(t, got.Decode(&buf))
+		assert.Equal(t, protocol.V2, got.Version)
+		assert.Equal(t, []string{"git/2.45.0"}, got.Capabilities.Get(capability.Agent))
+		assert.Equal(t, []string{"unborn"}, got.Capabilities.Get(capability.LsRefs))
+		assert.Equal(t, []string{"shallow", "wait-for-done", "filter"}, got.Capabilities.Get(capability.FetchCmd))
+		assert.True(t, got.Capabilities.Supports(capability.ServerOption))
+		assert.Equal(t, []string{"sha1"}, got.Capabilities.Get(capability.ObjectFormat))
+	})
+
+	t.Run("empty capabilities", func(t *testing.T) {
+		t.Parallel()
+		ca := &CapabilityAdv{
+			Version:      protocol.V2,
+			Capabilities: capability.List{},
+		}
+
+		var buf bytes.Buffer
+		assert.NoError(t, ca.Encode(&buf))
+
+		got := &CapabilityAdv{}
+		assert.NoError(t, got.Decode(&buf))
+		assert.Equal(t, protocol.V2, got.Version)
+		assert.True(t, got.Capabilities.IsEmpty())
+	})
+
+	t.Run("encode produces version line first", func(t *testing.T) {
+		t.Parallel()
+		caps := capability.List{}
+		caps.Add(capability.Agent, "go-git/6.x")
+		ca := &CapabilityAdv{
+			Version:      protocol.V2,
+			Capabilities: caps,
+		}
+
+		var buf bytes.Buffer
+		assert.NoError(t, ca.Encode(&buf))
+
+		l, line, err := pktline.ReadLine(&buf)
+		assert.NoError(t, err)
+		assert.True(t, l >= 4)
+		assert.Equal(t, "version 2\n", string(line))
+	})
+
+	t.Run("capability without values", func(t *testing.T) {
+		t.Parallel()
+		caps := capability.List{}
+		caps.Add(capability.LsRefs)
+		caps.Add(capability.ServerOption)
+		ca := &CapabilityAdv{
+			Version:      protocol.V2,
+			Capabilities: caps,
+		}
+
+		var buf bytes.Buffer
+		assert.NoError(t, ca.Encode(&buf))
+
+		got := &CapabilityAdv{}
+		assert.NoError(t, got.Decode(&buf))
+		assert.True(t, got.Capabilities.Supports(capability.LsRefs))
+		assert.Nil(t, got.Capabilities.Get(capability.LsRefs))
+		assert.True(t, got.Capabilities.Supports(capability.ServerOption))
+	})
+}

--- a/plumbing/protocol/packp/command.go
+++ b/plumbing/protocol/packp/command.go
@@ -1,0 +1,117 @@
+package packp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+)
+
+// CommandArgs is the interface for v2 command-specific arguments.
+type CommandArgs interface {
+	Encoder
+	Decoder
+}
+
+// CommandRequest represents a v2 command request.
+//
+// Wire format:
+//
+//	request = empty-request | command-request
+//	empty-request = flush-pkt
+//	command-request = command
+//	    capability-list
+//	    delim-pkt
+//	    command-args
+//	    flush-pkt
+//	command = PKT-LINE("command=" key LF)
+//	command-args = *command-specific-arg
+//
+// An empty Command encodes as an empty request (a single flush-pkt).
+// On decode, a flush-pkt as the first packet leaves Command empty.
+type CommandRequest struct {
+	Command      string
+	Capabilities capability.List
+	Args         CommandArgs
+}
+
+// Encode writes the command request to w.
+// If Command is empty, it writes a single flush-pkt (empty request).
+func (c *CommandRequest) Encode(w io.Writer) error {
+	if c.Command == "" {
+		return pktline.WriteFlush(w)
+	}
+
+	if _, err := pktline.Writef(w, "command=%s\n", c.Command); err != nil {
+		return err
+	}
+
+	if err := EncodeListV2(w, &c.Capabilities); err != nil {
+		return err
+	}
+
+	if err := pktline.WriteDelim(w); err != nil {
+		return err
+	}
+
+	if c.Args != nil {
+		if err := c.Args.Encode(w); err != nil {
+			return err
+		}
+	}
+
+	return pktline.WriteFlush(w)
+}
+
+// Decode reads a command request from r.
+// If the first packet is a flush-pkt, Command is left empty (empty request).
+func (c *CommandRequest) Decode(r io.Reader) error {
+	c.Command = ""
+	c.Capabilities = capability.List{}
+
+	length, line, err := pktline.ReadLine(r)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+
+	if length == pktline.Flush {
+		return nil
+	}
+
+	line = bytes.TrimSuffix(line, []byte("\n"))
+	const prefix = "command="
+	if !bytes.HasPrefix(line, []byte(prefix)) {
+		return fmt.Errorf("expected command line, got %q", string(line))
+	}
+	c.Command = string(line[len(prefix):])
+
+	// Read capabilities until delim-pkt.
+	length, err = DecodeListV2(r, &c.Capabilities)
+	if err != nil {
+		return err
+	}
+	if length != pktline.Delim {
+		return fmt.Errorf("expected delim-pkt after capabilities, got %04x", length)
+	}
+
+	// Read command args until flush-pkt.
+	if c.Args != nil {
+		return c.Args.Decode(r)
+	}
+
+	// No args decoder — consume the flush-pkt.
+	length, _, err = pktline.ReadLine(r)
+	if err != nil {
+		return err
+	}
+	if length != pktline.Flush {
+		return fmt.Errorf("expected flush-pkt after empty args, got %04x", length)
+	}
+	return nil
+}

--- a/plumbing/protocol/packp/command_test.go
+++ b/plumbing/protocol/packp/command_test.go
@@ -1,0 +1,173 @@
+package packp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+)
+
+func TestCommandRequestEncodeEmpty(t *testing.T) {
+	t.Parallel()
+
+	cmd := &CommandRequest{}
+	var buf bytes.Buffer
+	require.NoError(t, cmd.Encode(&buf))
+
+	length, _, err := pktline.ReadLine(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, pktline.Flush, length)
+}
+
+func TestCommandRequestEncodeWithArgs(t *testing.T) {
+	t.Parallel()
+
+	cmd := &CommandRequest{
+		Command: "fetch",
+		Capabilities: func() capability.List {
+			var caps capability.List
+			caps.Add(capability.Agent, "go-git/6.x")
+			caps.Add(capability.ObjectFormat, "sha1")
+			return caps
+		}(),
+		Args: &FetchArgs{
+			Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+			Done:  true,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.Encode(&buf))
+
+	// Verify structure: command, caps, delim, args, flush
+	l, line, err := pktline.ReadLine(&buf)
+	require.NoError(t, err)
+	require.True(t, l >= 4)
+	assert.Equal(t, "command=fetch\n", string(line))
+
+	l, line, err = pktline.ReadLine(&buf)
+	require.NoError(t, err)
+	require.True(t, l >= 4)
+	assert.Equal(t, "agent=go-git/6.x\n", string(line))
+
+	l, line, err = pktline.ReadLine(&buf)
+	require.NoError(t, err)
+	require.True(t, l >= 4)
+	assert.Equal(t, "object-format=sha1\n", string(line))
+
+	l, _, err = pktline.ReadLine(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, pktline.Delim, l)
+
+	l, line, err = pktline.ReadLine(&buf)
+	require.NoError(t, err)
+	require.True(t, l >= 4)
+	assert.Equal(t, "want 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n", string(line))
+
+	l, _, err = pktline.ReadLine(&buf)
+	require.NoError(t, err)
+	require.True(t, l >= 4)
+
+	l, _, err = pktline.ReadLine(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, pktline.Flush, l)
+}
+
+func TestCommandRequestDecodeEmpty(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	pktline.WriteFlush(&buf)
+
+	cmd := &CommandRequest{}
+	require.NoError(t, cmd.Decode(&buf))
+	assert.Empty(t, cmd.Command)
+	assert.True(t, cmd.Capabilities.IsEmpty())
+}
+
+func TestCommandRequestDecodeWithArgs(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	pktline.WriteString(&buf, "command=fetch\n")
+	pktline.WriteString(&buf, "agent=go-git/6.x\n")
+	pktline.WriteString(&buf, "object-format=sha1\n")
+	pktline.WriteDelim(&buf)
+	pktline.Writef(&buf, "want %s\n", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	pktline.WriteString(&buf, "done\n")
+	pktline.WriteFlush(&buf)
+
+	cmd := &CommandRequest{Args: &FetchArgs{}}
+	require.NoError(t, cmd.Decode(&buf))
+	assert.Equal(t, "fetch", cmd.Command)
+	assert.True(t, cmd.Capabilities.Supports(capability.Agent))
+	assert.True(t, cmd.Capabilities.Supports(capability.ObjectFormat))
+
+	args, ok := cmd.Args.(*FetchArgs)
+	require.True(t, ok)
+	assert.Len(t, args.Wants, 1)
+	assert.True(t, args.Done)
+}
+
+func TestCommandRequestDecodeNoArgs(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	pktline.WriteString(&buf, "command=ls-refs\n")
+	pktline.WriteString(&buf, "agent=go-git/6.x\n")
+	pktline.WriteDelim(&buf)
+	pktline.WriteFlush(&buf)
+
+	cmd := &CommandRequest{}
+	require.NoError(t, cmd.Decode(&buf))
+	assert.Equal(t, "ls-refs", cmd.Command)
+	assert.True(t, cmd.Capabilities.Supports(capability.Agent))
+	assert.Nil(t, cmd.Args)
+}
+
+func TestCommandRequestRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cmd := &CommandRequest{
+		Command: "fetch",
+		Capabilities: func() capability.List {
+			var caps capability.List
+			caps.Add(capability.Agent, "go-git/6.x")
+			return caps
+		}(),
+		Args: &FetchArgs{
+			Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+			Done:  true,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cmd.Encode(&buf))
+
+	got := &CommandRequest{Args: &FetchArgs{}}
+	require.NoError(t, got.Decode(&buf))
+	assert.Equal(t, cmd.Command, got.Command)
+	assert.Equal(t, cmd.Capabilities.Get(capability.Agent), got.Capabilities.Get(capability.Agent))
+
+	args, ok := got.Args.(*FetchArgs)
+	require.True(t, ok)
+	assert.Equal(t, []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")}, args.Wants)
+	assert.True(t, args.Done)
+}
+
+func TestCommandRequestDecodeInvalidLine(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	pktline.WriteString(&buf, "not-a-command\n")
+
+	cmd := &CommandRequest{}
+	err := cmd.Decode(&buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected command line")
+}

--- a/plumbing/protocol/packp/fetch.go
+++ b/plumbing/protocol/packp/fetch.go
@@ -1,0 +1,694 @@
+package packp
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+// FetchArgs represents the arguments for the v2 fetch command.
+type FetchArgs struct {
+	// Wants is the list of object IDs the client wants.
+	Wants []plumbing.Hash
+	// Haves is the list of object IDs the client already has.
+	Haves []plumbing.Hash
+	// Done indicates the client is done sending wants and haves.
+	// If false, the client may send additional want/have lines
+	// in subsequent request rounds (stateful transport only).
+	Done bool
+	// ThinPack requests a thin pack if the server supports it.
+	ThinPack bool
+	// NoProgress requests that the server suppress progress messages.
+	NoProgress bool
+	// IncludeTag requests that the server include tag objects.
+	IncludeTag bool
+	// OFSDelta requests that the server use OFS_DELTA objects.
+	OFSDelta bool
+	// Shallows is the list of shallow object IDs the client has.
+	Shallows []plumbing.Hash
+	// Deepen specifies the number of depth commits to fetch.
+	Deepen int
+	// DeepenRelative indicates that deepen is relative to the shallow boundary.
+	DeepenRelative bool
+	// DeepenSince specifies a time-based depth constraint.
+	DeepenSince time.Time
+	// DeepenNot specifies references to exclude from the shallow boundary.
+	DeepenNot []string
+
+	// Filter specifies a partial clone filter.
+	Filter Filter
+	// WaitForDone indicates that the client will wait for the server to send a
+	// done acknowledgment before sending additional want/have lines.
+	WaitForDone bool
+}
+
+// Encode writes the v2 fetch command arguments to a writer.
+// Each argument is written as a separate pkt-line.
+// The caller is responsible for writing the delim-pkt before and
+// the flush-pkt after these arguments.
+func (r *FetchArgs) Encode(w io.Writer) error {
+	if len(r.Wants) == 0 {
+		return fmt.Errorf("empty wants provided")
+	}
+
+	wants := append([]plumbing.Hash(nil), r.Wants...)
+	plumbing.HashesSort(wants)
+	for _, h := range wants {
+		if _, err := pktline.Writef(w, "want %s\n", h); err != nil {
+			return fmt.Errorf("encoding want %q: %s", h, err)
+		}
+	}
+
+	haves := append([]plumbing.Hash(nil), r.Haves...)
+	plumbing.HashesSort(haves)
+	for _, h := range haves {
+		if _, err := pktline.Writef(w, "have %s\n", h); err != nil {
+			return fmt.Errorf("encoding have %q: %s", h, err)
+		}
+	}
+
+	if r.Done {
+		if _, err := pktline.WriteString(w, "done\n"); err != nil {
+			return fmt.Errorf("encoding done: %s", err)
+		}
+	}
+
+	if r.ThinPack {
+		if _, err := pktline.WriteString(w, "thin-pack\n"); err != nil {
+			return fmt.Errorf("encoding thin-pack: %s", err)
+		}
+	}
+
+	if r.NoProgress {
+		if _, err := pktline.WriteString(w, "no-progress\n"); err != nil {
+			return fmt.Errorf("encoding no-progress: %s", err)
+		}
+	}
+
+	if r.IncludeTag {
+		if _, err := pktline.WriteString(w, "include-tag\n"); err != nil {
+			return fmt.Errorf("encoding include-tag: %s", err)
+		}
+	}
+
+	if r.OFSDelta {
+		if _, err := pktline.WriteString(w, "ofs-delta\n"); err != nil {
+			return fmt.Errorf("encoding ofs-delta: %s", err)
+		}
+	}
+
+	shallows := append([]plumbing.Hash(nil), r.Shallows...)
+	plumbing.HashesSort(shallows)
+	for _, h := range shallows {
+		if _, err := pktline.Writef(w, "shallow %s\n", h); err != nil {
+			return fmt.Errorf("encoding shallow %q: %s", h, err)
+		}
+	}
+
+	if r.Deepen > 0 {
+		if _, err := pktline.Writef(w, "deepen %d\n", r.Deepen); err != nil {
+			return fmt.Errorf("encoding deepen %d: %s", r.Deepen, err)
+		}
+	}
+
+	if r.DeepenRelative {
+		// deepen-relative is a flag: the depth is carried by the "deepen <n>"
+		// line above. Matches git's fetch-pack.c (packet "deepen-relative\n").
+		if _, err := pktline.WriteString(w, "deepen-relative\n"); err != nil {
+			return fmt.Errorf("encoding deepen-relative: %s", err)
+		}
+	}
+
+	if !r.DeepenSince.IsZero() {
+		if _, err := pktline.Writef(w, "deepen-since %d\n", r.DeepenSince.UTC().Unix()); err != nil {
+			return fmt.Errorf("encoding deepen-since %s: %s", r.DeepenSince, err)
+		}
+	}
+
+	for _, ref := range r.DeepenNot {
+		if _, err := pktline.Writef(w, "deepen-not %s\n", ref); err != nil {
+			return fmt.Errorf("encoding deepen-not %s: %s", ref, err)
+		}
+	}
+
+	if r.Filter != "" {
+		if _, err := pktline.Writef(w, "filter %s\n", r.Filter); err != nil {
+			return fmt.Errorf("encoding filter %s: %s", r.Filter, err)
+		}
+	}
+
+	if r.WaitForDone {
+		if _, err := pktline.WriteString(w, "wait-for-done\n"); err != nil {
+			return fmt.Errorf("encoding wait-for-done: %s", err)
+		}
+	}
+
+	return nil
+}
+
+// Decode reads v2 fetch command arguments from a reader until a flush-pkt
+// is encountered. The caller is responsible for reading the delim-pkt
+// and command header before calling Decode.
+func (r *FetchArgs) Decode(rd io.Reader) error {
+	for {
+		l, pkt, err := pktline.ReadLine(rd)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		if l == pktline.Flush || l == pktline.Delim {
+			return nil
+		}
+
+		line := strings.TrimSpace(string(pkt))
+		if len(line) == 0 {
+			return nil
+		}
+
+		switch {
+		case strings.HasPrefix(line, "want "):
+			h, ok := parseFullHash(line[5:])
+			if !ok {
+				return fmt.Errorf("malformed want hash: %q", line[5:])
+			}
+			r.Wants = append(r.Wants, h)
+
+		case strings.HasPrefix(line, "have "):
+			h, ok := parseFullHash(line[5:])
+			if !ok {
+				return fmt.Errorf("malformed have hash: %q", line[5:])
+			}
+			r.Haves = append(r.Haves, h)
+
+		case line == "done":
+			r.Done = true
+
+		case line == "thin-pack":
+			r.ThinPack = true
+
+		case line == "no-progress":
+			r.NoProgress = true
+
+		case line == "include-tag":
+			r.IncludeTag = true
+
+		case line == "ofs-delta":
+			r.OFSDelta = true
+
+		case strings.HasPrefix(line, "shallow "):
+			h, ok := parseFullHash(line[8:])
+			if !ok {
+				return fmt.Errorf("malformed shallow hash: %q", line[8:])
+			}
+			r.Shallows = append(r.Shallows, h)
+
+		case line == "deepen-relative":
+			r.DeepenRelative = true
+
+		case strings.HasPrefix(line, "deepen-relative "):
+			// Legacy/lenient: the depth belongs to "deepen <n>"; the argument
+			// here is ignored. git only ever sends the bare flag.
+			r.DeepenRelative = true
+
+		case strings.HasPrefix(line, "deepen-since "):
+			secs, e := strconv.ParseInt(line[13:], 10, 64)
+			if e != nil {
+				return fmt.Errorf("malformed deepen-since: %q", line)
+			}
+			r.DeepenSince = time.Unix(secs, 0).UTC()
+
+		case strings.HasPrefix(line, "deepen-not "):
+			r.DeepenNot = append(r.DeepenNot, line[11:])
+
+		case strings.HasPrefix(line, "deepen "):
+			n, e := strconv.Atoi(line[7:])
+			if e != nil {
+				return fmt.Errorf("malformed deepen: %q", line)
+			}
+			r.Deepen = n
+
+		case strings.HasPrefix(line, "filter "):
+			r.Filter = Filter(line[7:])
+
+		case line == "wait-for-done":
+			r.WaitForDone = true
+		}
+	}
+}
+
+// Acknowledgments represents the server response to a v2 fetch command's
+// acknowledgments section. It is used by the transport layer to determine
+// which objects the server has in common with the client.
+type Acknowledgments struct {
+	// ACKs is the list of common object IDs acknowledged by the server.
+	// Empty list means the server found no common objects (NAK).
+	ACKs []plumbing.Hash
+	// Ready indicates the server is ready to send a packfile after the
+	// acknowledgments section. For stream transports, ready is implied and
+	// this field is always true.
+	Ready bool
+}
+
+// ShallowInfo represents the server response to a v2 fetch command's
+// shallow-info section. It is used by the transport layer to update the
+// client's shallow boundary after a fetch.
+type ShallowInfo struct {
+	// Shallows is the list of shallow object IDs sent by the server.
+	Shallows []plumbing.Hash
+	// Unshallows is the list of object IDs that are no longer shallow.
+	Unshallows []plumbing.Hash
+}
+
+// WantedRefs represents the server response to a v2 fetch command's
+// wanted-refs section. It is used by the transport layer to determine which
+// references the server wants the client to have.
+type WantedRefs struct {
+	// Refs is the list of references sent by the server.
+	Refs []*plumbing.Reference
+}
+
+// PackfileURIs represents the server response to a v2 fetch command's
+// packfile-uris section. It is used by the transport layer to determine which
+// alternate URIs the server suggests for fetching the packfile.
+type PackfileURIs struct {
+	// URIs is the list of alternate URIs the server suggests for fetching the
+	// packfile.
+	URIs []string
+}
+
+// FetchOutput represents the server response to a v2 fetch command.
+//
+// The response has explicit sections separated by delim-pkt:
+//
+//	acknowledgments\n
+//	ACK <oid>\n
+//	ready\n
+//	0001
+//	shallow-info\n
+//	shallow <oid>\n
+//	0001
+//	packfile\n
+//	<sideband packfile data>
+//	0000
+//
+// For HTTP, the transport layer consumes response-end (0002) after Decode returns.
+type FetchOutput struct {
+	// Acknowledgments indicates the server sent an acknowledgments section.
+	Acknowledgments *Acknowledgments
+	// ShallowInfo indicates the server sent a shallow-info section.
+	ShallowInfo *ShallowInfo
+	// WantedRefs indicates the server sent a wanted-refs section.
+	WantedRefs *WantedRefs
+	// PackfileURIs indicates the server sent a packfile-uris section.
+	PackfileURIs *PackfileURIs
+	// Packfile reports whether a packfile section follows the metadata
+	// sections. When true, Decode leaves the reader positioned at the first
+	// packfile pkt-line so the caller can stream it, and Encode writes the
+	// "packfile" section header so the caller can write the packfile data.
+	// When false, the response is a negotiation round
+	// (acknowledgments flush-pkt) that carries no packfile.
+	Packfile bool
+}
+
+// Decode reads the v2 fetch response from a reader. The response has
+// explicit sections separated by delim-pkt:
+//
+//	acknowledgments\n
+//	ACK <oid>\n
+//	ready\n
+//	0001
+//	shallow-info\n
+//	shallow <oid>\n
+//	0001
+//	packfile\n
+//	<sideband packfile data>
+//	0000
+//
+// A response is one of two shapes (gitprotocol-v2):
+//
+//	output = acknowledgments flush-pkt |
+//	         [acknowledgments delim-pkt] [shallow-info delim-pkt]
+//	         [wanted-refs delim-pkt] [packfile-uris delim-pkt]
+//	         packfile flush-pkt
+//
+// When a metadata section ends with a flush-pkt (the first shape) the
+// response is a negotiation round that carries no packfile, and Decode
+// returns with Packfile set to false. When Decode reaches the "packfile"
+// section header it sets Packfile to true and returns with the reader
+// positioned at the first packfile pkt-line; Decode does not read the
+// packfile data, leaving the caller to stream it (demultiplexing the
+// sideband as needed).
+//
+// For HTTP, the transport layer consumes response-end (0002) after
+// Decode returns.
+func (r *FetchOutput) Decode(rd io.Reader) error {
+	for {
+		l, pkt, err := pktline.ReadLine(rd)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		// A flush-pkt at the top level ends a response with no packfile.
+		if l == pktline.Flush || l == pktline.ResponseEnd {
+			return nil
+		}
+
+		header := strings.TrimSpace(string(pkt))
+		switch header {
+		case "packfile":
+			// Leave the reader positioned at the packfile data and let
+			// the caller stream it. Decode never reads packfile bytes.
+			r.Packfile = true
+			return nil
+
+		case "acknowledgments":
+			r.Acknowledgments = &Acknowledgments{}
+			term, err := r.decodeAcknowledgments(rd)
+			if err != nil {
+				return err
+			}
+			if term != pktline.Delim {
+				return nil
+			}
+
+		case "shallow-info":
+			r.ShallowInfo = &ShallowInfo{}
+			term, err := r.decodeShallowInfo(rd)
+			if err != nil {
+				return err
+			}
+			if term != pktline.Delim {
+				return nil
+			}
+
+		case "wanted-refs":
+			r.WantedRefs = &WantedRefs{}
+			term, err := r.decodeWantedRefs(rd)
+			if err != nil {
+				return err
+			}
+			if term != pktline.Delim {
+				return nil
+			}
+
+		case "packfile-uris":
+			r.PackfileURIs = &PackfileURIs{}
+			term, err := r.decodePackfileURIs(rd)
+			if err != nil {
+				return err
+			}
+			if term != pktline.Delim {
+				return nil
+			}
+
+		default:
+			// Unknown section: skip its body to the next delimiter so the
+			// following pkt-lines aren't mis-read as top-level section headers.
+			term, err := skipSection(rd)
+			if err != nil {
+				return err
+			}
+			if term != pktline.Delim {
+				return nil
+			}
+		}
+	}
+}
+
+// skipSection consumes pkt-lines until a delim, flush, or response-end packet,
+// returning which terminator was seen. It lets Decode tolerate unknown sections
+// from a newer server without desynchronizing the stream.
+func skipSection(rd io.Reader) (int, error) {
+	for {
+		l, _, err := pktline.ReadLine(rd)
+		if err != nil {
+			return 0, err
+		}
+		if l == pktline.Delim || l == pktline.Flush || l == pktline.ResponseEnd {
+			return l, nil
+		}
+	}
+}
+
+// Encode writes the v2 fetch response to a writer.
+//
+// When Packfile is true, Encode writes the present metadata sections
+// (acknowledgments, shallow-info, wanted-refs, packfile-uris), each
+// terminated by a delim-pkt, followed by the "packfile" section header.
+// The caller then streams the packfile data and writes the final
+// flush-pkt.
+//
+// When Packfile is false, the response is a negotiation round: Encode
+// writes the acknowledgments section terminated by a flush-pkt and writes
+// nothing else. In that case the acknowledgments section must be present
+// and must not be ready, and no other metadata sections may be set.
+func (r *FetchOutput) Encode(w io.Writer) error {
+	if !r.Packfile {
+		if r.Acknowledgments == nil {
+			return fmt.Errorf("fetch response without a packfile must carry acknowledgments")
+		}
+		if r.Acknowledgments.Ready {
+			return fmt.Errorf("fetch response with ready must carry a packfile")
+		}
+		if r.ShallowInfo != nil || r.WantedRefs != nil || r.PackfileURIs != nil {
+			return fmt.Errorf("fetch response without a packfile cannot carry metadata sections")
+		}
+		if _, err := pktline.WriteString(w, "acknowledgments\n"); err != nil {
+			return err
+		}
+		if err := r.encodeAcknowledgments(w); err != nil {
+			return err
+		}
+		return pktline.WriteFlush(w)
+	}
+
+	if r.Acknowledgments != nil {
+		if _, err := pktline.WriteString(w, "acknowledgments\n"); err != nil {
+			return err
+		}
+		if err := r.encodeAcknowledgments(w); err != nil {
+			return err
+		}
+		if err := pktline.WriteDelim(w); err != nil {
+			return err
+		}
+	}
+
+	if r.ShallowInfo != nil {
+		if _, err := pktline.WriteString(w, "shallow-info\n"); err != nil {
+			return err
+		}
+		if err := r.encodeShallowInfo(w); err != nil {
+			return err
+		}
+		if err := pktline.WriteDelim(w); err != nil {
+			return err
+		}
+	}
+
+	if r.WantedRefs != nil {
+		if _, err := pktline.WriteString(w, "wanted-refs\n"); err != nil {
+			return err
+		}
+		if err := r.encodeWantedRefs(w); err != nil {
+			return err
+		}
+		if err := pktline.WriteDelim(w); err != nil {
+			return err
+		}
+	}
+
+	if r.PackfileURIs != nil {
+		if _, err := pktline.WriteString(w, "packfile-uris\n"); err != nil {
+			return err
+		}
+		if err := r.encodePackfileURIs(w); err != nil {
+			return err
+		}
+		if err := pktline.WriteDelim(w); err != nil {
+			return err
+		}
+	}
+
+	// Packfile section header. The caller writes the packfile data and the
+	// final flush-pkt after this.
+	if _, err := pktline.WriteString(w, "packfile\n"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *FetchOutput) decodeAcknowledgments(rd io.Reader) (int, error) {
+	for {
+		l, pkt, err := pktline.ReadLine(rd)
+		if err != nil {
+			return 0, err
+		}
+
+		if l == pktline.Delim || l == pktline.Flush || l == pktline.ResponseEnd {
+			return l, nil
+		}
+
+		line := strings.TrimSpace(string(pkt))
+
+		switch {
+		case strings.HasPrefix(line, "ACK "):
+			parts := strings.SplitN(line, " ", 2)
+			if len(parts) < 2 {
+				return 0, fmt.Errorf("malformed ACK line: %q", line)
+			}
+			h, ok := parseFullHash(strings.TrimSpace(parts[1]))
+			if !ok {
+				return 0, fmt.Errorf("malformed ACK hash: %q", parts[1])
+			}
+			r.Acknowledgments.ACKs = append(r.Acknowledgments.ACKs, h)
+
+		case line == "NAK":
+			// NAK: no common objects
+
+		case line == "ready":
+			r.Acknowledgments.Ready = true
+		}
+	}
+}
+
+func (r *FetchOutput) decodeShallowInfo(rd io.Reader) (int, error) {
+	for {
+		l, pkt, err := pktline.ReadLine(rd)
+		if err != nil {
+			return 0, err
+		}
+
+		if l == pktline.Delim || l == pktline.Flush || l == pktline.ResponseEnd {
+			return l, nil
+		}
+
+		line := strings.TrimSpace(string(pkt))
+
+		switch {
+		case strings.HasPrefix(line, "shallow "):
+			h, ok := parseFullHash(line[8:])
+			if !ok {
+				return 0, fmt.Errorf("malformed shallow hash: %q", line)
+			}
+			r.ShallowInfo.Shallows = append(r.ShallowInfo.Shallows, h)
+
+		case strings.HasPrefix(line, "unshallow "):
+			h, ok := parseFullHash(line[10:])
+			if !ok {
+				return 0, fmt.Errorf("malformed unshallow hash: %q", line)
+			}
+			r.ShallowInfo.Unshallows = append(r.ShallowInfo.Unshallows, h)
+		}
+	}
+}
+
+func (r *FetchOutput) decodeWantedRefs(rd io.Reader) (int, error) {
+	for {
+		l, pkt, err := pktline.ReadLine(rd)
+		if err != nil {
+			return 0, err
+		}
+
+		if l == pktline.Delim || l == pktline.Flush || l == pktline.ResponseEnd {
+			return l, nil
+		}
+
+		line := strings.TrimSpace(string(pkt))
+
+		parts := strings.SplitN(line, " ", 2)
+		if len(parts) < 2 {
+			return 0, fmt.Errorf("malformed wanted-refs line: %q", line)
+		}
+
+		h, ok := parseFullHash(parts[0])
+		if !ok {
+			return 0, fmt.Errorf("malformed wanted-refs hash: %q", parts[0])
+		}
+
+		r.WantedRefs.Refs = append(r.WantedRefs.Refs,
+			plumbing.NewHashReference(plumbing.ReferenceName(parts[1]), h),
+		)
+	}
+}
+
+func (r *FetchOutput) decodePackfileURIs(rd io.Reader) (int, error) {
+	for {
+		l, pkt, err := pktline.ReadLine(rd)
+		if err != nil {
+			return 0, err
+		}
+
+		if l == pktline.Delim || l == pktline.Flush || l == pktline.ResponseEnd {
+			return l, nil
+		}
+
+		line := strings.TrimSuffix(string(pkt), "\n")
+
+		r.PackfileURIs.URIs = append(r.PackfileURIs.URIs, line)
+	}
+}
+
+func (r *FetchOutput) encodeAcknowledgments(w io.Writer) error {
+	for _, h := range r.Acknowledgments.ACKs {
+		if _, err := pktline.Writef(w, "ACK %s\n", h); err != nil {
+			return err
+		}
+	}
+	if r.Acknowledgments.Ready {
+		if _, err := pktline.WriteString(w, "ready\n"); err != nil {
+			return err
+		}
+	}
+	if len(r.Acknowledgments.ACKs) == 0 {
+		if _, err := pktline.WriteString(w, "NAK\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *FetchOutput) encodeShallowInfo(w io.Writer) error {
+	for _, h := range r.ShallowInfo.Shallows {
+		if _, err := pktline.Writef(w, "shallow %s\n", h); err != nil {
+			return err
+		}
+	}
+	for _, h := range r.ShallowInfo.Unshallows {
+		if _, err := pktline.Writef(w, "unshallow %s\n", h); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *FetchOutput) encodeWantedRefs(w io.Writer) error {
+	for _, ref := range r.WantedRefs.Refs {
+		if _, err := pktline.Writef(w, "%s %s\n", ref.Hash(), ref.Name()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *FetchOutput) encodePackfileURIs(w io.Writer) error {
+	for _, uri := range r.PackfileURIs.URIs {
+		if _, err := pktline.WriteString(w, uri+"\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/plumbing/protocol/packp/fetch_test.go
+++ b/plumbing/protocol/packp/fetch_test.go
@@ -1,0 +1,521 @@
+package packp
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+func TestFetchArgsEncode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty wants", func(t *testing.T) {
+		t.Parallel()
+		req := &FetchArgs{}
+		var buf bytes.Buffer
+		require.Error(t, req.Encode(&buf))
+	})
+
+	t.Run("wants only", func(t *testing.T) {
+		t.Parallel()
+		req := &FetchArgs{
+			Wants: []plumbing.Hash{
+				plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+			},
+			Done: true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &FetchArgs{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Equal(t, req.Wants, got.Wants)
+		assert.True(t, got.Done)
+	})
+
+	t.Run("wants and haves", func(t *testing.T) {
+		t.Parallel()
+		req := &FetchArgs{
+			Wants: []plumbing.Hash{
+				plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+			},
+			Haves: []plumbing.Hash{
+				plumbing.NewHash("a6930aaee06755d1bdcfd943fbf614e4d92bb0c7"),
+			},
+			Done: true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &FetchArgs{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Equal(t, req.Wants, got.Wants)
+		assert.Equal(t, req.Haves, got.Haves)
+		assert.True(t, got.Done)
+	})
+
+	t.Run("all arguments", func(t *testing.T) {
+		t.Parallel()
+		req := &FetchArgs{
+			Wants: []plumbing.Hash{
+				plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+				plumbing.NewHash("a6930aaee06755d1bdcfd943fbf614e4d92bb0c7"),
+			},
+			Haves: []plumbing.Hash{
+				plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c"),
+			},
+			Done:        true,
+			ThinPack:    true,
+			NoProgress:  true,
+			IncludeTag:  true,
+			OFSDelta:    true,
+			Shallows:    []plumbing.Hash{plumbing.NewHash("1111111111111111111111111111111111111111")},
+			Deepen:      1,
+			DeepenSince: time.Unix(1700000000, 0).UTC(),
+			DeepenNot:   []string{"refs/heads/main"},
+			Filter:      FilterBlobNone(),
+			WaitForDone: true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &FetchArgs{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Equal(t, req.Wants, got.Wants)
+		assert.Equal(t, req.Haves, got.Haves)
+		assert.True(t, got.Done)
+		assert.True(t, got.ThinPack)
+		assert.True(t, got.NoProgress)
+		assert.True(t, got.IncludeTag)
+		assert.True(t, got.OFSDelta)
+		assert.Equal(t, req.Shallows, got.Shallows)
+		assert.Equal(t, 1, got.Deepen)
+		assert.True(t, got.DeepenSince.Equal(req.DeepenSince))
+		assert.Equal(t, req.DeepenNot, got.DeepenNot)
+		assert.Equal(t, req.Filter, got.Filter)
+		assert.True(t, got.WaitForDone)
+	})
+
+	t.Run("deepen-relative", func(t *testing.T) {
+		t.Parallel()
+		req := &FetchArgs{
+			Wants:          []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+			Done:           true,
+			Deepen:         3,
+			DeepenRelative: true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+		wire := buf.String()
+		assert.Contains(t, wire, "deepen-relative\n", "deepen-relative must be a flag, not carry a numeric argument")
+		assert.NotContains(t, wire, "deepen-relative 3")
+		pktline.WriteFlush(&buf)
+
+		got := &FetchArgs{}
+		require.NoError(t, got.Decode(&buf))
+		assert.True(t, got.DeepenRelative)
+		assert.Equal(t, 3, got.Deepen)
+	})
+}
+
+func TestFetchArgsDecodeFromWire(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wants and done", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.Writef(&buf, "want 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+		pktline.WriteString(&buf, "done\n")
+		pktline.WriteFlush(&buf)
+
+		got := &FetchArgs{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Equal(t, []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")}, got.Wants)
+		assert.True(t, got.Done)
+	})
+
+	t.Run("wants haves and flags", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.Writef(&buf, "want 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+		pktline.Writef(&buf, "have a6930aaee06755d1bdcfd943fbf614e4d92bb0c7\n")
+		pktline.WriteString(&buf, "done\n")
+		pktline.WriteString(&buf, "thin-pack\n")
+		pktline.WriteString(&buf, "ofs-delta\n")
+		pktline.Writef(&buf, "filter blob:none\n")
+		pktline.WriteFlush(&buf)
+
+		got := &FetchArgs{}
+		require.NoError(t, got.Decode(&buf))
+		require.Len(t, got.Wants, 1)
+		require.Len(t, got.Haves, 1)
+		assert.True(t, got.Done)
+		assert.True(t, got.ThinPack)
+		assert.True(t, got.OFSDelta)
+		assert.Equal(t, Filter("blob:none"), got.Filter)
+	})
+}
+
+func TestFetchOutputDecode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("acknowledgments only", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "acknowledgments\n")
+		pktline.Writef(&buf, "ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+		pktline.WriteString(&buf, "ready\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "packfile\n")
+		// Packfile data would follow; we write a flush to simulate end.
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.NotNil(t, got.Acknowledgments)
+		require.Len(t, got.Acknowledgments.ACKs, 1)
+		assert.Equal(t, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), got.Acknowledgments.ACKs[0])
+		assert.True(t, got.Acknowledgments.Ready)
+		assert.True(t, got.Packfile)
+	})
+
+	t.Run("negotiation round has no packfile", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "acknowledgments\n")
+		pktline.Writef(&buf, "ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.NotNil(t, got.Acknowledgments)
+		require.Len(t, got.Acknowledgments.ACKs, 1)
+		assert.False(t, got.Acknowledgments.Ready)
+		assert.False(t, got.Packfile)
+	})
+
+	t.Run("done response without acknowledgments", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "packfile\n")
+		pktline.WriteString(&buf, "PACK")
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Nil(t, got.Acknowledgments)
+		assert.True(t, got.Packfile)
+	})
+
+	t.Run("NAK only", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "acknowledgments\n")
+		pktline.WriteString(&buf, "NAK\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "packfile\n")
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.NotNil(t, got.Acknowledgments)
+		assert.Empty(t, got.Acknowledgments.ACKs)
+		assert.False(t, got.Acknowledgments.Ready)
+	})
+
+	t.Run("full response with shallow-info", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "acknowledgments\n")
+		pktline.Writef(&buf, "ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+		pktline.WriteString(&buf, "ready\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "shallow-info\n")
+		pktline.Writef(&buf, "shallow 1111111111111111111111111111111111111111\n")
+		pktline.Writef(&buf, "unshallow 2222222222222222222222222222222222222222\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "packfile\n")
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.NotNil(t, got.Acknowledgments)
+		require.Len(t, got.Acknowledgments.ACKs, 1)
+		assert.True(t, got.Acknowledgments.Ready)
+
+		require.NotNil(t, got.ShallowInfo)
+		require.Len(t, got.ShallowInfo.Shallows, 1)
+		assert.Equal(t, plumbing.NewHash("1111111111111111111111111111111111111111"), got.ShallowInfo.Shallows[0])
+		require.Len(t, got.ShallowInfo.Unshallows, 1)
+		assert.Equal(t, plumbing.NewHash("2222222222222222222222222222222222222222"), got.ShallowInfo.Unshallows[0])
+	})
+
+	t.Run("full response with wanted-refs", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "acknowledgments\n")
+		pktline.Writef(&buf, "ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+		pktline.WriteString(&buf, "ready\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "wanted-refs\n")
+		pktline.Writef(&buf, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/main\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "packfile\n")
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.NotNil(t, got.WantedRefs)
+		require.Len(t, got.WantedRefs.Refs, 1)
+		assert.Equal(t, "refs/heads/main", got.WantedRefs.Refs[0].Name().String())
+		assert.Equal(t, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), got.WantedRefs.Refs[0].Hash())
+	})
+
+	t.Run("packfile-uris section", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "acknowledgments\n")
+		pktline.WriteString(&buf, "NAK\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "packfile-uris\n")
+		pktline.WriteString(&buf, "https://example.com/pack-123.pack\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "packfile\n")
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.NotNil(t, got.PackfileURIs)
+		require.Len(t, got.PackfileURIs.URIs, 1)
+		assert.Equal(t, "https://example.com/pack-123.pack", got.PackfileURIs.URIs[0])
+	})
+
+	t.Run("empty response", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Nil(t, got.Acknowledgments)
+		assert.Nil(t, got.ShallowInfo)
+		assert.False(t, got.Packfile)
+	})
+
+	t.Run("packfile reader is live", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.WriteString(&buf, "acknowledgments\n")
+		pktline.WriteString(&buf, "NAK\n")
+		pktline.WriteDelim(&buf)
+		pktline.WriteString(&buf, "packfile\n")
+		// Write some packfile data
+		pktline.WriteString(&buf, "PACK")
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.True(t, got.Packfile)
+
+		// The same reader is positioned after the "packfile\n" header, so
+		// the caller streams the packfile data straight from it.
+		b := make([]byte, 4)
+		n, err := io.ReadFull(&buf, b)
+		require.NoError(t, err)
+		assert.Equal(t, 4, n)
+	})
+}
+
+func TestFetchOutputEncode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("acknowledgments with ready", func(t *testing.T) {
+		t.Parallel()
+		resp := &FetchOutput{
+			Acknowledgments: &Acknowledgments{
+				ACKs: []plumbing.Hash{
+					plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+				},
+				Ready: true,
+			},
+			Packfile: true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, resp.Encode(&buf))
+
+		// Encode stops at the packfile header; append the caller's final
+		// flush-pkt to form a complete response before decoding it back.
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.NotNil(t, got.Acknowledgments)
+		require.Len(t, got.Acknowledgments.ACKs, 1)
+		assert.True(t, got.Acknowledgments.Ready)
+		assert.True(t, got.Packfile)
+	})
+
+	t.Run("negotiation round is self-terminated", func(t *testing.T) {
+		t.Parallel()
+		resp := &FetchOutput{
+			Acknowledgments: &Acknowledgments{},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, resp.Encode(&buf))
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.NotNil(t, got.Acknowledgments)
+		assert.Empty(t, got.Acknowledgments.ACKs)
+		assert.False(t, got.Acknowledgments.Ready)
+		assert.False(t, got.Packfile)
+	})
+
+	t.Run("ready without packfile is rejected", func(t *testing.T) {
+		t.Parallel()
+		resp := &FetchOutput{
+			Acknowledgments: &Acknowledgments{Ready: true},
+		}
+		require.Error(t, resp.Encode(&bytes.Buffer{}))
+	})
+
+	t.Run("metadata without packfile is rejected", func(t *testing.T) {
+		t.Parallel()
+		resp := &FetchOutput{
+			Acknowledgments: &Acknowledgments{},
+			ShallowInfo:     &ShallowInfo{},
+		}
+		require.Error(t, resp.Encode(&bytes.Buffer{}))
+	})
+
+	t.Run("full response round trip", func(t *testing.T) {
+		t.Parallel()
+		resp := &FetchOutput{
+			Acknowledgments: &Acknowledgments{
+				ACKs: []plumbing.Hash{
+					plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+				},
+				Ready: true,
+			},
+			ShallowInfo: &ShallowInfo{
+				Shallows:   []plumbing.Hash{plumbing.NewHash("1111111111111111111111111111111111111111")},
+				Unshallows: []plumbing.Hash{plumbing.NewHash("2222222222222222222222222222222222222222")},
+			},
+			WantedRefs: &WantedRefs{
+				Refs: []*plumbing.Reference{
+					plumbing.NewHashReference("refs/heads/main", plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")),
+				},
+			},
+			PackfileURIs: &PackfileURIs{
+				URIs: []string{"https://example.com/pack-123.pack"},
+			},
+			Packfile: true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, resp.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &FetchOutput{}
+		require.NoError(t, got.Decode(&buf))
+
+		require.NotNil(t, got.Acknowledgments)
+		require.Len(t, got.Acknowledgments.ACKs, 1)
+		assert.True(t, got.Acknowledgments.Ready)
+
+		require.NotNil(t, got.ShallowInfo)
+		require.Len(t, got.ShallowInfo.Shallows, 1)
+		require.Len(t, got.ShallowInfo.Unshallows, 1)
+
+		require.NotNil(t, got.WantedRefs)
+		require.Len(t, got.WantedRefs.Refs, 1)
+
+		require.NotNil(t, got.PackfileURIs)
+		require.Len(t, got.PackfileURIs.URIs, 1)
+		assert.True(t, got.Packfile)
+	})
+}
+
+func TestFetchArgsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("minimal", func(t *testing.T) {
+		t.Parallel()
+		req := &FetchArgs{
+			Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")},
+			Done:  true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &FetchArgs{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Equal(t, req.Wants, got.Wants)
+		assert.True(t, got.Done)
+		assert.Empty(t, got.Haves)
+		assert.False(t, got.ThinPack)
+		assert.False(t, got.OFSDelta)
+		assert.Empty(t, got.Filter)
+	})
+
+	t.Run("complete", func(t *testing.T) {
+		t.Parallel()
+		ts := time.Unix(1700000000, 0).UTC()
+		req := &FetchArgs{
+			Wants: []plumbing.Hash{
+				plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+				plumbing.NewHash("a6930aaee06755d1bdcfd943fbf614e4d92bb0c7"),
+			},
+			Haves: []plumbing.Hash{
+				plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c"),
+			},
+			Done:        true,
+			ThinPack:    true,
+			NoProgress:  true,
+			IncludeTag:  true,
+			OFSDelta:    true,
+			Shallows:    []plumbing.Hash{plumbing.NewHash("3333333333333333333333333333333333333333")},
+			Deepen:      10,
+			DeepenSince: ts,
+			DeepenNot:   []string{"refs/heads/feature"},
+			Filter:      FilterBlobNone(),
+			WaitForDone: true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &FetchArgs{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Equal(t, req.Wants, got.Wants)
+		assert.Equal(t, req.Haves, got.Haves)
+		assert.Equal(t, req.Done, got.Done)
+		assert.Equal(t, req.ThinPack, got.ThinPack)
+		assert.Equal(t, req.NoProgress, got.NoProgress)
+		assert.Equal(t, req.IncludeTag, got.IncludeTag)
+		assert.Equal(t, req.OFSDelta, got.OFSDelta)
+		assert.Equal(t, req.Shallows, got.Shallows)
+		assert.Equal(t, req.Deepen, got.Deepen)
+		assert.True(t, got.DeepenSince.Equal(ts))
+		assert.Equal(t, req.DeepenNot, got.DeepenNot)
+		assert.Equal(t, req.Filter, got.Filter)
+		assert.Equal(t, req.WaitForDone, got.WaitForDone)
+	})
+}

--- a/plumbing/protocol/packp/fuzz_test.go
+++ b/plumbing/protocol/packp/fuzz_test.go
@@ -98,3 +98,27 @@ func FuzzPushOptionsDecode(f *testing.F) {
 		_ = po.Decode(bytes.NewReader(data))
 	})
 }
+
+func FuzzFetchArgsDecode(f *testing.F) {
+	f.Add([]byte("0032want 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0009done\n0000"))
+	f.Add([]byte("0000"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		fa := &FetchArgs{}
+		_ = fa.Decode(bytes.NewReader(data))
+	})
+}
+
+func FuzzFetchOutputDecode(f *testing.F) {
+	// Negotiation round (acknowledgments flush-pkt, no packfile).
+	f.Add([]byte("0012acknowledgments\n0008NAK\n0000"))
+	// Final round (acknowledgments delim-pkt ... packfile flush-pkt).
+	f.Add([]byte("0012acknowledgments\n000aready\n00010009packfile\n0000"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		fo := &FetchOutput{}
+		_ = fo.Decode(bytes.NewReader(data))
+	})
+}

--- a/plumbing/protocol/packp/list.go
+++ b/plumbing/protocol/packp/list.go
@@ -1,0 +1,68 @@
+package packp
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+)
+
+// EncodeListV2 writes capabilities in v2 format: one capability per pkt-line.
+// Each capability is written as "key\n" or "key=value\n" or "key=v1 v2\n". The
+// caller is responsible for writing the terminating packet (flush-pkt or
+// delim-pkt) after the last capability.
+func EncodeListV2(w io.Writer, l *capability.List) error {
+	for _, key := range l.All() {
+		values := l.Get(key)
+		if len(values) == 0 {
+			if _, err := pktline.Writef(w, "%s\n", key); err != nil {
+				return err
+			}
+		} else {
+			if _, err := pktline.Writef(w, "%s=%s\n", key, strings.Join(values, " ")); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DecodeListV2 reads capabilities in v2 format from a pkt-line stream. It
+// reads pkt-lines until flush-pkt, delim-pkt, or EOF, appending each parsed
+// capability to the list. It returns the terminating packet length
+// (pktline.Flush, pktline.Delim, or pktline.ResponseEnd) so the caller knows
+// what terminated the capability list.
+func DecodeListV2(r io.Reader, l *capability.List) (int, error) {
+	for {
+		length, line, err := pktline.ReadLine(r)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return pktline.Flush, nil
+			}
+			return 0, err
+		}
+
+		if length == pktline.Flush || length == pktline.Delim || length == pktline.ResponseEnd {
+			return length, nil
+		}
+
+		line = bytes.TrimSuffix(line, []byte("\n"))
+		if len(line) == 0 {
+			continue
+		}
+
+		key, value, hasValue := strings.Cut(string(line), "=")
+		if hasValue {
+			for v := range strings.SplitSeq(value, " ") {
+				if v != "" {
+					l.Add(key, v)
+				}
+			}
+		} else {
+			l.Add(key)
+		}
+	}
+}

--- a/plumbing/protocol/packp/lsrefs.go
+++ b/plumbing/protocol/packp/lsrefs.go
@@ -1,0 +1,248 @@
+package packp
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+// LsRefsArgs represents the arguments for the v2 ls-refs command.
+// It is encoded as the command-specific arguments and a flush-pkt in a v2
+// command request.
+type LsRefsArgs struct {
+	Peel        bool
+	Symrefs     bool
+	Unborn      bool
+	RefPrefixes []string
+}
+
+// Encode writes the ls-refs arguments to a writer. Each argument is
+// written as a separate pkt-line. The caller is responsible for writing
+// the delim-pkt before and the flush-pkt after these arguments.
+func (r *LsRefsArgs) Encode(w io.Writer) error {
+	if r.Peel {
+		if _, err := pktline.WriteString(w, "peel\n"); err != nil {
+			return err
+		}
+	}
+	if r.Symrefs {
+		if _, err := pktline.WriteString(w, "symrefs\n"); err != nil {
+			return err
+		}
+	}
+	if r.Unborn {
+		if _, err := pktline.WriteString(w, "unborn\n"); err != nil {
+			return err
+		}
+	}
+	for _, p := range r.RefPrefixes {
+		if _, err := pktline.Writef(w, "ref-prefix %s\n", p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Decode reads ls-refs arguments from a reader until a flush-pkt is encountered.
+func (r *LsRefsArgs) Decode(rd io.Reader) error {
+	for {
+		l, pkt, err := pktline.ReadLine(rd)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		if l == pktline.Flush {
+			return nil
+		}
+
+		line := strings.TrimSuffix(string(pkt), "\n")
+
+		if len(line) == 0 {
+			continue
+		}
+
+		switch {
+		case line == "peel":
+			r.Peel = true
+		case line == "symrefs":
+			r.Symrefs = true
+		case line == "unborn":
+			r.Unborn = true
+		case strings.HasPrefix(line, "ref-prefix "):
+			r.RefPrefixes = append(r.RefPrefixes, line[len("ref-prefix "):])
+		}
+	}
+}
+
+// LsRefsOutput represents the server response to an ls-refs command.
+//
+// Each ref line has the format:
+//
+//	<oid> SP <refname> [SP symref-target:<target>] [SP peeled:<oid>]
+//
+// or for unborn refs:
+//
+//	unborn SP <refname> SP symref-target:<target>
+//
+// The response ends with a flush-pkt. For HTTP, response-end (0002) is
+// consumed by the transport layer and not seen by Decode.
+type LsRefsOutput struct {
+	References []*plumbing.Reference
+}
+
+// Encode writes the ls-refs response lines as pkt-lines following the v2
+// grammar: "<oid> SP <refname> [SP symref-target:<target>] [SP peeled:<oid>]",
+// or "unborn SP <refname> SP symref-target:<target>" for an unborn HEAD. Peeled
+// "^{}" entries are folded into their base ref's line as a peeled attribute, and
+// a symbolic ref carries the resolved oid of its target when present. The caller
+// is responsible for writing the flush-pkt after these lines.
+func (r *LsRefsOutput) Encode(w io.Writer) error {
+	hashByName := make(map[string]plumbing.Hash, len(r.References))
+	for _, ref := range r.References {
+		if ref.Type() == plumbing.HashReference {
+			hashByName[ref.Name().String()] = ref.Hash()
+		}
+	}
+
+	for _, ref := range r.References {
+		name := ref.Name().String()
+
+		// Peeled entries are folded into their base ref's line below.
+		if ref.Name().IsPeeled() {
+			continue
+		}
+
+		if ref.Type() == plumbing.SymbolicReference {
+			oid := "unborn"
+			if h, ok := hashByName[ref.Target().String()]; ok && !h.IsZero() {
+				oid = h.String()
+			}
+			if _, err := pktline.Writef(w, "%s %s symref-target:%s\n", oid, name, ref.Target()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		line := fmt.Sprintf("%s %s", ref.Hash(), name)
+		if peeled, ok := hashByName[name+"^{}"]; ok {
+			line += " peeled:" + peeled.String()
+		}
+		if _, err := pktline.Writef(w, "%s\n", line); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Decode reads ref lines until a flush-pkt.
+func (r *LsRefsOutput) Decode(rd io.Reader) error {
+	for {
+		l, pkt, err := pktline.ReadLine(rd)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		if l == pktline.Flush {
+			return nil
+		}
+
+		line := strings.TrimSuffix(string(pkt), "\n")
+
+		if len(line) == 0 {
+			continue
+		}
+
+		refs, err := parseLsRefsLine(line)
+		if err != nil {
+			return err
+		}
+		r.References = append(r.References, refs...)
+	}
+}
+
+// parseLsRefsLine parses a single ref line from ls-refs output.
+// Format: <oid-or-unborn> SP <refname> [SP <attr>...] LF
+// Returns one or two references (base + peeled if the peeled attribute is present).
+func parseLsRefsLine(line string) ([]*plumbing.Reference, error) {
+	// Fields tolerates the SP-separated grammar without producing empty tokens
+	// on repeated spaces: [oid-or-unborn, refname, attr1, attr2, ...].
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("malformed ref line: %q", line)
+	}
+
+	oidStr := parts[0]
+	refName := plumbing.ReferenceName(parts[1])
+
+	var symrefTarget plumbing.ReferenceName
+	var peeledHash plumbing.Hash
+	hasPeeled := false
+
+	for _, attr := range parts[2:] {
+		if strings.HasPrefix(attr, "symref-target:") {
+			symrefTarget = plumbing.ReferenceName(attr[len("symref-target:"):])
+		} else if strings.HasPrefix(attr, "peeled:") {
+			h, ok := parseFullHash(attr[len("peeled:"):])
+			if !ok {
+				return nil, fmt.Errorf("malformed peeled hash: %q", attr)
+			}
+			peeledHash = h
+			hasPeeled = true
+		}
+	}
+
+	var refs []*plumbing.Reference
+
+	// Handle unborn refs
+	if oidStr == "unborn" {
+		if symrefTarget == "" {
+			return nil, fmt.Errorf("malformed unborn ref line, missing symref-target: %q", line)
+		}
+		refs = append(refs, plumbing.NewSymbolicReference(refName, symrefTarget))
+		return refs, nil
+	}
+
+	// Regular hash ref
+	hash, ok := parseFullHash(oidStr)
+	if !ok {
+		return nil, fmt.Errorf("malformed object id: %q", oidStr)
+	}
+
+	if symrefTarget != "" {
+		refs = append(refs, plumbing.NewSymbolicReference(refName, symrefTarget))
+	} else {
+		refs = append(refs, plumbing.NewHashReference(refName, hash))
+	}
+
+	// If "peeled:" attribute is present, add the peeled ref as a separate entry
+	if hasPeeled {
+		refs = append(refs, plumbing.NewHashReference(
+			plumbing.ReferenceName(refName.String()+"^{}"),
+			peeledHash,
+		))
+	}
+
+	return refs, nil
+}
+
+// parseFullHash strictly parses a full-length SHA-1 or SHA-256 object id in hex
+// form. Object ids on the wire are always full length, so unlike
+// plumbing.FromHex (which zero-pads shorter input as a partial SHA-1) it rejects
+// anything that is not exactly an object-id length, refusing malformed input.
+func parseFullHash(s string) (plumbing.Hash, bool) {
+	if !plumbing.IsHash(s) {
+		return plumbing.ZeroHash, false
+	}
+	return plumbing.FromHex(s)
+}

--- a/plumbing/protocol/packp/lsrefs_test.go
+++ b/plumbing/protocol/packp/lsrefs_test.go
@@ -1,0 +1,229 @@
+package packp
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+func TestLsRefsArgsEncode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all arguments", func(t *testing.T) {
+		t.Parallel()
+		req := &LsRefsArgs{
+			Peel:        true,
+			Symrefs:     true,
+			Unborn:      true,
+			RefPrefixes: []string{"refs/heads/", "refs/tags/"},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+
+		got := &LsRefsArgs{}
+		require.NoError(t, got.Decode(&buf))
+
+		assert.True(t, got.Peel)
+		assert.True(t, got.Symrefs)
+		assert.True(t, got.Unborn)
+		assert.Equal(t, []string{"refs/heads/", "refs/tags/"}, got.RefPrefixes)
+	})
+
+	t.Run("minimal request", func(t *testing.T) {
+		t.Parallel()
+		req := &LsRefsArgs{
+			Symrefs: true,
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+
+		got := &LsRefsArgs{}
+		require.NoError(t, got.Decode(&buf))
+
+		assert.False(t, got.Peel)
+		assert.True(t, got.Symrefs)
+		assert.False(t, got.Unborn)
+		assert.Nil(t, got.RefPrefixes)
+	})
+
+	t.Run("round trip", func(t *testing.T) {
+		t.Parallel()
+		req := &LsRefsArgs{
+			Peel:        true,
+			Symrefs:     true,
+			RefPrefixes: []string{"refs/heads/"},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, req.Encode(&buf))
+
+		got := &LsRefsArgs{}
+		require.NoError(t, got.Decode(&buf))
+		assert.Equal(t, req.Peel, got.Peel)
+		assert.Equal(t, req.Symrefs, got.Symrefs)
+		assert.Equal(t, req.Unborn, got.Unborn)
+		assert.Equal(t, req.RefPrefixes, got.RefPrefixes)
+	})
+}
+
+func TestLsRefsOutputDecode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("simple refs", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.Writef(&buf, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/main\n")
+		pktline.Writef(&buf, "a6930aaee06755d1bdcfd943fbf614e4d92bb0c7 refs/heads/develop\n")
+		pktline.Writef(&buf, "5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c refs/tags/v1.0\n")
+		pktline.WriteFlush(&buf)
+
+		resp := &LsRefsOutput{}
+		require.NoError(t, resp.Decode(&buf))
+		require.Len(t, resp.References, 3)
+
+		assert.Equal(t, "refs/heads/main", resp.References[0].Name().String())
+		assert.Equal(t, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), resp.References[0].Hash())
+		assert.Equal(t, "refs/heads/develop", resp.References[1].Name().String())
+		assert.Equal(t, "refs/tags/v1.0", resp.References[2].Name().String())
+	})
+
+	t.Run("symref-target HEAD decodes to a symbolic reference", func(t *testing.T) {
+		t.Parallel()
+		for _, headLine := range []string{
+			"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD symref-target:refs/heads/main",
+			"unborn HEAD symref-target:refs/heads/main",
+		} {
+			var buf bytes.Buffer
+			pktline.Writef(&buf, "%s\n", headLine)
+			pktline.Writef(&buf, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/main\n")
+			pktline.WriteFlush(&buf)
+
+			resp := &LsRefsOutput{}
+			require.NoError(t, resp.Decode(&buf))
+			require.Len(t, resp.References, 2)
+
+			assert.Equal(t, plumbing.SymbolicReference, resp.References[0].Type())
+			assert.Equal(t, "HEAD", resp.References[0].Name().String())
+			assert.Equal(t, "refs/heads/main", resp.References[0].Target().String())
+
+			assert.Equal(t, plumbing.HashReference, resp.References[1].Type())
+			assert.Equal(t, "refs/heads/main", resp.References[1].Name().String())
+		}
+	})
+
+	t.Run("refs with peeled attribute", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		pktline.Writef(&buf, "5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c refs/tags/v1.0 peeled:c39ae07f393806ccf406ef966e9a15afc43cc36a\n")
+		pktline.WriteFlush(&buf)
+
+		resp := &LsRefsOutput{}
+		require.NoError(t, resp.Decode(&buf))
+		require.Len(t, resp.References, 2)
+
+		assert.Equal(t, "refs/tags/v1.0", resp.References[0].Name().String())
+		assert.Equal(t, plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c"), resp.References[0].Hash())
+
+		assert.Equal(t, "refs/tags/v1.0^{}", resp.References[1].Name().String())
+		assert.Equal(t, plumbing.NewHash("c39ae07f393806ccf406ef966e9a15afc43cc36a"), resp.References[1].Hash())
+	})
+
+	t.Run("malformed lines are rejected", func(t *testing.T) {
+		t.Parallel()
+		for name, line := range map[string]string{
+			"invalid object id":        "nothex refs/heads/main",
+			"short even-length oid":    "abcd refs/heads/main",
+			"unborn without symref":    "unborn HEAD",
+			"missing refname":          "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+			"malformed peeled":         "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/tags/v1.0 peeled:nothex",
+			"short even-length peeled": "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/tags/v1.0 peeled:abcd",
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				var buf bytes.Buffer
+				pktline.Writef(&buf, "%s\n", line)
+				pktline.WriteFlush(&buf)
+
+				resp := &LsRefsOutput{}
+				require.Error(t, resp.Decode(&buf))
+			})
+		}
+	})
+}
+
+func TestLsRefsOutputEncode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("simple refs", func(t *testing.T) {
+		t.Parallel()
+		resp := &LsRefsOutput{
+			References: []*plumbing.Reference{
+				plumbing.NewHashReference("refs/heads/main", plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")),
+				plumbing.NewHashReference("refs/heads/develop", plumbing.NewHash("a6930aaee06755d1bdcfd943fbf614e4d92bb0c7")),
+			},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, resp.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &LsRefsOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.Len(t, got.References, 2)
+		assert.Equal(t, "refs/heads/main", got.References[0].Name().String())
+		assert.Equal(t, "refs/heads/develop", got.References[1].Name().String())
+	})
+
+	t.Run("symbolic reference", func(t *testing.T) {
+		t.Parallel()
+		resp := &LsRefsOutput{
+			References: []*plumbing.Reference{
+				plumbing.NewSymbolicReference("HEAD", "refs/heads/main"),
+				plumbing.NewHashReference("refs/heads/main", plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")),
+			},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, resp.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &LsRefsOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.Len(t, got.References, 2)
+
+		assert.Equal(t, plumbing.SymbolicReference, got.References[0].Type())
+		assert.Equal(t, "HEAD", got.References[0].Name().String())
+		assert.Equal(t, "refs/heads/main", got.References[0].Target().String())
+
+		assert.Equal(t, plumbing.HashReference, got.References[1].Type())
+		assert.Equal(t, "refs/heads/main", got.References[1].Name().String())
+	})
+
+	t.Run("round trip with peeled refs", func(t *testing.T) {
+		t.Parallel()
+		resp := &LsRefsOutput{
+			References: []*plumbing.Reference{
+				plumbing.NewHashReference("refs/tags/v1.0", plumbing.NewHash("5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c")),
+				plumbing.NewHashReference("refs/tags/v1.0^{}", plumbing.NewHash("c39ae07f393806ccf406ef966e9a15afc43cc36a")),
+			},
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, resp.Encode(&buf))
+		pktline.WriteFlush(&buf)
+
+		got := &LsRefsOutput{}
+		require.NoError(t, got.Decode(&buf))
+		require.Len(t, got.References, 2)
+		assert.Equal(t, "refs/tags/v1.0", got.References[0].Name().String())
+		assert.Equal(t, "refs/tags/v1.0^{}", got.References[1].Name().String())
+		assert.Equal(t, plumbing.NewHash("c39ae07f393806ccf406ef966e9a15afc43cc36a"), got.References[1].Hash())
+	})
+}

--- a/plumbing/transport/pack_session.go
+++ b/plumbing/transport/pack_session.go
@@ -5,8 +5,22 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/storage"
 )
+
+// Commander is an optional capability that Protocol v2-capable sessions
+// implement. It provides access to arbitrary v2 commands beyond the
+// built-in Fetch and Push operations.
+//
+// Sessions that negotiate Protocol v2 (version 2) implement this interface.
+// The Command method executes a named v2 command, encoding the request
+// via req.Encode and decoding the response via resp.Decode. The transport
+// layer handles the v2 envelope (command name, capabilities, delim-pkt,
+// flush-pkt, and for HTTP, response-end).
+type Commander interface {
+	Command(ctx context.Context, cmd string, req packp.Encoder, resp packp.Decoder) error
+}
 
 // Transport is implemented by transports that speak the Git pack
 // protocol. Each transport implements this directly — stream transports


### PR DESCRIPTION
## Part 4 of 11: Protocol v2 wire types

Fourth of the Protocol v2 series. Builds on Part 3 (#2226). Session wiring
follows in Parts 5-11.

This part adds the Protocol v2 wire encoding and decoding. It is types only:
nothing is wired into the transport sessions yet, so there is no behavior
change for existing callers.

### What changes

- `command.go`: the generic v2 command request envelope.
- `lsrefs.go`: the ls-refs command arguments and response (ref-prefix,
  symrefs, peel, unborn).
- `fetch.go`: the fetch command arguments and the fetch response.
- `capability_adv.go`: the v2 capability advertisement.
- `list.go`: v2 capability list encoding.
- A `Commander` session interface for running arbitrary v2 commands.

### Fetch response: caller-owned packfile streaming

`FetchOutput` decodes and encodes only the metadata sections
(`acknowledgments`, `shallow-info`, `wanted-refs`, `packfile-uris`). It does
not carry the packfile. A `Packfile bool` reports whether a packfile section
follows; when it does, the reader is left positioned at the first packfile
pkt-line so the caller streams it, and on encode the caller writes the packfile
data and the final flush-pkt. A negotiation round that ends with a flush-pkt
carries no packfile. This matches the two response shapes in gitprotocol-v2.

Fuzz targets are added for the fetch decoders.

### Reviewing just this part

https://github.com/go-git/go-git/compare/gitprotocol-v2-3-getremoterefs...gitprotocol-v2-4-v2types

### Notes

- Targets `main` (v6). Built and tested green, including a fuzz smoke of the
  fetch response decoder. Squashed.

Depends on Part 3 (#2226); merge that first.





---
_Recreated as a same-repo stacked PR (supersedes #2209)._

