### PR TITLE
plumbing: transport, Protocol v2 session handshake and Command (5/11)

### DIFF
--- a/plumbing/transport/pack_session.go
+++ b/plumbing/transport/pack_session.go
@@ -14,12 +14,15 @@ import (
 // built-in Fetch and Push operations.
 //
 // Sessions that negotiate Protocol v2 (version 2) implement this interface.
-// The Command method executes a named v2 command, encoding the request
-// via req.Encode and decoding the response via resp.Decode. The transport
-// layer handles the v2 envelope (command name, capabilities, delim-pkt,
-// flush-pkt, and for HTTP, response-end).
+// The Command method executes a named v2 command: req carries the
+// command-specific arguments and is encoded into the request, while resp
+// decodes the response. For example, GetRemoteRefs runs
+// Command(ctx, "ls-refs", lsRefsArgs, lsRefsOutput). The session builds the v2
+// request envelope (command name, the capabilities collected during the
+// handshake, delim-pkt, the arguments, and flush-pkt) and, for HTTP, handles
+// the response-end packet.
 type Commander interface {
-	Command(ctx context.Context, cmd string, req packp.Encoder, resp packp.Decoder) error
+	Command(ctx context.Context, cmd string, req packp.CommandArgs, resp packp.Decoder) error
 }
 
 // Transport is implemented by transports that speak the Git pack

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -25,6 +25,9 @@ type StreamSession struct {
 	version protocol.Version
 	caps    capability.List
 	refs    *packp.AdvRefs
+	// v2 holds the Protocol v2 capability advertisement when the server
+	// negotiated version 2. It is nil for v0/v1.
+	v2 *packp.CapabilityAdv
 }
 
 // NewStreamSession creates a session from an open Conn.
@@ -52,11 +55,21 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 		return nil, err
 	}
 
-	switch ver {
-	case protocol.V1, protocol.V0, protocol.V2:
-		// V2 is accepted; full client v2 negotiation (ls-refs/fetch commands)
-		// not yet implemented for stream transports. Advertise/decode will
-		// proceed and may result in empty refs for pure v2 servers.
+	s.version = ver
+
+	if ver == protocol.V2 {
+		// Protocol v2: the server sends a capability advertisement
+		// (version line + capability lines) instead of the v0/v1 ref
+		// advertisement. References are retrieved lazily via the ls-refs
+		// command, so nothing is read here beyond the advertisement.
+		adv := &packp.CapabilityAdv{}
+		if err := adv.Decode(r); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+		s.v2 = adv
+		s.caps = adv.Capabilities
+		return s, nil
 	}
 
 	ar := &packp.AdvRefs{}
@@ -71,7 +84,6 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 		return nil, err
 	}
 
-	s.version = ver
 	s.caps = ar.Capabilities
 	s.refs = ar
 
@@ -119,6 +131,51 @@ func (s *StreamSession) Push(ctx context.Context, st storage.Storer, req *PushRe
 	return nil
 }
 
+// Command implements Commander. It builds a Protocol v2 request envelope for
+// the named command, encodes it, and decodes the response. The request
+// carries the capabilities collected during the handshake (the agent and the
+// server's object-format), so callers only provide the command arguments.
+//
+// Command is only valid on a session that negotiated Protocol v2.
+func (s *StreamSession) Command(_ context.Context, cmd string, req packp.CommandArgs, resp packp.Decoder) error {
+	if s.version != protocol.V2 {
+		return ErrUnsupportedVersion
+	}
+
+	cr := &packp.CommandRequest{
+		Command:      cmd,
+		Capabilities: s.commandCapabilities(),
+		Args:         req,
+	}
+
+	if err := cr.Encode(s.w); err != nil {
+		return s.wrapStderr(err)
+	}
+
+	if resp != nil {
+		if err := resp.Decode(s.r); err != nil {
+			return s.wrapStderr(err)
+		}
+	}
+
+	return nil
+}
+
+// commandCapabilities returns the capabilities the client sends with each v2
+// command. It always advertises the agent and echoes the object-format the
+// server advertised during the handshake so both sides agree on the hash
+// algorithm.
+func (s *StreamSession) commandCapabilities() capability.List {
+	var caps capability.List
+	caps.Set(capability.Agent, capability.DefaultAgent())
+	if s.v2 != nil {
+		if of := s.v2.Capabilities.Get(capability.ObjectFormat); len(of) > 0 {
+			caps.Set(capability.ObjectFormat, of[0])
+		}
+	}
+	return caps
+}
+
 // wrapStderr checks if the underlying connection has stderr output and
 // returns it as a RemoteError so that remote error messages surface at
 // the operation site rather than at Close time.
@@ -158,6 +215,7 @@ func (s *StreamSession) Archive(ctx context.Context, req *ArchiveRequest) (io.Re
 }
 
 var (
-	_ Session  = (*StreamSession)(nil)
-	_ Archiver = (*StreamSession)(nil)
+	_ Session   = (*StreamSession)(nil)
+	_ Archiver  = (*StreamSession)(nil)
+	_ Commander = (*StreamSession)(nil)
 )

--- a/plumbing/transport/v2_handshake_test.go
+++ b/plumbing/transport/v2_handshake_test.go
@@ -1,0 +1,135 @@
+package transport
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+func TestStreamSessionV2Handshake(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+
+	var adv bytes.Buffer
+	require.NoError(t, AdvertiseRefs(context.TODO(), st, &adv, UploadPackService, false, protocol.V2))
+
+	conn := &testConn{
+		r:     &adv,
+		w:     ioutil.WriteNopCloser(io.Discard),
+		close: func() error { return nil },
+	}
+
+	s, err := NewStreamSession(conn, UploadPackService)
+	require.NoError(t, err)
+
+	require.Equal(t, protocol.V2, s.version)
+	require.NotNil(t, s.v2)
+	require.Nil(t, s.refs)
+
+	caps := s.Capabilities()
+	require.True(t, caps.Supports(capability.LsRefs))
+	require.True(t, caps.Supports(capability.FetchCmd))
+	require.NotEmpty(t, caps.Get(capability.ObjectFormat))
+}
+
+func TestStreamSessionCommandEnvelope(t *testing.T) {
+	t.Parallel()
+
+	serverCaps := capability.List{}
+	serverCaps.Set(capability.ObjectFormat, "sha1")
+
+	var out bytes.Buffer
+	s := &StreamSession{
+		version: protocol.V2,
+		w:       ioutil.WriteNopCloser(&out),
+		v2:      &packp.CapabilityAdv{Version: protocol.V2, Capabilities: serverCaps},
+	}
+
+	req := &packp.LsRefsArgs{
+		Symrefs:     true,
+		RefPrefixes: []string{"refs/heads/"},
+	}
+	require.NoError(t, s.Command(context.TODO(), "ls-refs", req, nil))
+
+	got := &packp.CommandRequest{Args: &packp.LsRefsArgs{}}
+	require.NoError(t, got.Decode(&out))
+
+	require.Equal(t, "ls-refs", got.Command)
+	require.Equal(t, []string{capability.DefaultAgent()}, got.Capabilities.Get(capability.Agent))
+	require.Equal(t, []string{"sha1"}, got.Capabilities.Get(capability.ObjectFormat))
+
+	gotArgs, ok := got.Args.(*packp.LsRefsArgs)
+	require.True(t, ok)
+	require.True(t, gotArgs.Symrefs)
+	require.Equal(t, []string{"refs/heads/"}, gotArgs.RefPrefixes)
+}
+
+func TestStreamSessionCommandRejectsNonV2(t *testing.T) {
+	t.Parallel()
+
+	s := &StreamSession{
+		version: protocol.V1,
+		w:       ioutil.WriteNopCloser(io.Discard),
+	}
+
+	err := s.Command(context.TODO(), "ls-refs", nil, nil)
+	require.ErrorIs(t, err, ErrUnsupportedVersion)
+}
+
+func TestStreamSessionCommandLsRefsEndToEnd(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	serveErr := make(chan error, 1)
+	go func() {
+		if err := AdvertiseRefs(context.TODO(), st, serverConn, UploadPackService, false, protocol.V2); err != nil {
+			serveErr <- err
+			return
+		}
+		serveErr <- serveUploadPackV2(
+			context.TODO(),
+			st,
+			bufio.NewReader(serverConn),
+			ioutil.WriteNopCloser(serverConn),
+			&UploadPackRequest{GitProtocol: "version=2", StatelessRPC: true},
+		)
+		_ = serverConn.Close()
+	}()
+
+	conn := &testConn{
+		r:     clientConn,
+		w:     clientConn,
+		close: func() error { return clientConn.Close() },
+	}
+
+	s, err := NewStreamSession(conn, UploadPackService)
+	require.NoError(t, err)
+	require.Equal(t, protocol.V2, s.version)
+
+	req := &packp.LsRefsArgs{Symrefs: true, RefPrefixes: []string{"refs/heads/"}}
+	out := &packp.LsRefsOutput{}
+	require.NoError(t, s.Command(context.TODO(), "ls-refs", req, out))
+	require.NoError(t, <-serveErr)
+
+	require.NotEmpty(t, out.References)
+	var foundMaster bool
+	for _, ref := range out.References {
+		if ref.Name().String() == "refs/heads/master" {
+			foundMaster = true
+		}
+	}
+	require.True(t, foundMaster, "expected refs/heads/master in ls-refs output")
+}


### PR DESCRIPTION
## Part 5: Protocol v2 session handshake and Command

First piece of the Protocol v2 client wiring, built on the v2 wire types from Part 4 (#2227). This part is implemented (no longer a scaffold).

### What changed

- Stream sessions (SSH, git://, file) now detect `protocol.V2` during the handshake and decode the v2 capability advertisement (`packp.CapabilityAdv`) instead of the v0/v1 `AdvRefs`. For v2, references are not read at handshake time; they come later via `ls-refs` (Part 6).
- The negotiated version and the server's v2 capabilities are stored on the session.
- `StreamSession` implements the `Commander` interface. `Command` takes the command-specific arguments (a `packp.CommandArgs` such as `LsRefsArgs` or `FetchArgs`) plus a response decoder, builds the v2 request envelope through `packp.CommandRequest` (command line, the capabilities collected during the handshake, delim-pkt, the arguments, flush-pkt), and decodes the response.
- The capabilities sent with each command are the agent and the server's `object-format` echoed back, so both sides agree on the hash algorithm.

### Tests

Real coverage replaces the earlier skipped scaffold: a v2 handshake decode, the `Command` envelope encoding, a non-v2 rejection, and an end-to-end `ls-refs` round over an in-memory pipe against the server's v2 path.

### Reviewing just this part

https://github.com/go-git/go-git/compare/gitprotocol-v2-4-v2types...gitprotocol-v2-5-v2-handshake

### Notes

Targets `main` (v6). Depends on Part 4 (#2227); merge that first.



---
_Recreated as a same-repo stacked PR (supersedes #2210)._

