### PR TITLE
plumbing: transport, ls-refs over Protocol v2 for GetRemoteRefs (6/11)

### DIFF
--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/go-git/go-git/v6/plumbing/protocol"
@@ -94,8 +95,14 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 func (s *StreamSession) Capabilities() *capability.List { return &s.caps }
 
 // GetRemoteRefs implements Session. For v0/v1 the server advertises every
-// reference during the handshake, so opts is ignored.
-func (s *StreamSession) GetRemoteRefs(_ context.Context, _ *GetRemoteRefsOptions) (*RemoteRefs, error) {
+// reference during the handshake, so opts is ignored. For v2 the references
+// are retrieved on demand via the ls-refs command, honoring the ref-prefix
+// filters in opts.
+func (s *StreamSession) GetRemoteRefs(ctx context.Context, opts *GetRemoteRefsOptions) (*RemoteRefs, error) {
+	if s.version == protocol.V2 {
+		return s.getRemoteRefsV2(ctx, opts)
+	}
+
 	if s.refs == nil {
 		return nil, ErrEmptyRemoteRepository
 	}
@@ -109,6 +116,39 @@ func (s *StreamSession) GetRemoteRefs(_ context.Context, _ *GetRemoteRefsOptions
 		return nil, err
 	}
 	return NewRemoteRefs(refs), nil
+}
+
+// getRemoteRefsV2 lists references using the v2 ls-refs command. It always
+// requests peeled tags and symref targets so HEAD resolves to its branch, and
+// requests unborn HEAD reporting when the server advertises support for it.
+func (s *StreamSession) getRemoteRefsV2(ctx context.Context, opts *GetRemoteRefsOptions) (*RemoteRefs, error) {
+	args := &packp.LsRefsArgs{
+		Peel:    true,
+		Symrefs: true,
+		Unborn:  s.lsRefsSupportsUnborn(),
+	}
+	if opts != nil {
+		args.RefPrefixes = opts.RefPrefixes
+	}
+
+	out := &packp.LsRefsOutput{}
+	if err := s.Command(ctx, "ls-refs", args, out); err != nil {
+		return nil, err
+	}
+
+	forPush := s.svc == ReceivePackService
+	if !forPush && len(out.References) == 0 {
+		return nil, ErrEmptyRemoteRepository
+	}
+
+	return NewRemoteRefs(out.References), nil
+}
+
+// lsRefsSupportsUnborn reports whether the server advertised the ls-refs
+// "unborn" feature (ls-refs=unborn), allowing the client to request an unborn
+// HEAD on an otherwise empty repository.
+func (s *StreamSession) lsRefsSupportsUnborn() bool {
+	return slices.Contains(s.caps.Get(capability.LsRefs), "unborn")
 }
 
 // Fetch implements PackSession.

--- a/plumbing/transport/v2_lsrefs_test.go
+++ b/plumbing/transport/v2_lsrefs_test.go
@@ -1,0 +1,143 @@
+package transport
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+func newV2Session(t testing.TB, serve func(serverConn net.Conn) error) *StreamSession {
+	t.Helper()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- serve(serverConn) }()
+	t.Cleanup(func() { require.NoError(t, <-serveErr) })
+
+	conn := &testConn{
+		r:     clientConn,
+		w:     clientConn,
+		close: func() error { return clientConn.Close() },
+	}
+
+	s, err := NewStreamSession(conn, UploadPackService)
+	require.NoError(t, err)
+	require.Equal(t, protocol.V2, s.version)
+	return s
+}
+
+func serveUploadPackV2Once(st storage.Storer) func(net.Conn) error {
+	return func(serverConn net.Conn) error {
+		defer func() { _ = serverConn.Close() }()
+		if err := AdvertiseRefs(context.TODO(), st, serverConn, UploadPackService, false, protocol.V2); err != nil {
+			return err
+		}
+		return serveUploadPackV2(
+			context.TODO(),
+			st,
+			bufio.NewReader(serverConn),
+			ioutil.WriteNopCloser(serverConn),
+			&UploadPackRequest{GitProtocol: "version=2", StatelessRPC: true},
+		)
+	}
+}
+
+func refNames(refs []*plumbing.Reference) map[string]*plumbing.Reference {
+	m := make(map[string]*plumbing.Reference, len(refs))
+	for _, ref := range refs {
+		m[ref.Name().String()] = ref
+	}
+	return m
+}
+
+func TestV2GetRemoteRefs(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	s := newV2Session(t, serveUploadPackV2Once(st))
+
+	rr, err := s.GetRemoteRefs(context.TODO(), nil)
+	require.NoError(t, err)
+
+	byName := refNames(rr.References)
+	require.Contains(t, byName, "refs/heads/master")
+	require.Contains(t, byName, "HEAD")
+	require.Equal(t, plumbing.SymbolicReference, byName["HEAD"].Type())
+	require.Equal(t, plumbing.ReferenceName("refs/heads/master"), byName["HEAD"].Target())
+	require.Empty(t, rr.Unborn)
+}
+
+func TestV2GetRemoteRefsRefPrefixes(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	s := newV2Session(t, serveUploadPackV2Once(st))
+
+	rr, err := s.GetRemoteRefs(context.TODO(), &GetRemoteRefsOptions{
+		RefPrefixes: []string{"refs/heads/"},
+	})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, rr.References)
+	for _, ref := range rr.References {
+		require.True(t, ref.Name().IsBranch(),
+			"expected only refs/heads/* with the heads prefix, got %s", ref.Name())
+	}
+}
+
+func TestV2GetRemoteRefsUnbornHead(t *testing.T) {
+	t.Parallel()
+
+	const unbornTarget = "refs/heads/main"
+
+	serve := func(serverConn net.Conn) (err error) {
+		defer func() { _ = serverConn.Close() }()
+
+		w := serverConn
+		for _, line := range []string{
+			"version 2\n",
+			"agent=test\n",
+			"ls-refs=unborn\n",
+			"object-format=sha1\n",
+		} {
+			if _, err := pktline.WriteString(w, line); err != nil {
+				return err
+			}
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return err
+		}
+
+		req := &packp.CommandRequest{Args: &packp.LsRefsArgs{}}
+		if err := req.Decode(bufio.NewReader(serverConn)); err != nil {
+			return err
+		}
+		args, ok := req.Args.(*packp.LsRefsArgs)
+		if !ok || !args.Unborn {
+			return errors.New("server did not receive unborn request")
+		}
+
+		if _, err := pktline.Writef(w, "unborn HEAD symref-target:%s\n", unbornTarget); err != nil {
+			return err
+		}
+		return pktline.WriteFlush(w)
+	}
+
+	s := newV2Session(t, serve)
+	require.True(t, s.lsRefsSupportsUnborn())
+
+	rr, err := s.GetRemoteRefs(context.TODO(), nil)
+	require.NoError(t, err)
+	require.Equal(t, plumbing.ReferenceName(unbornTarget), rr.Unborn)
+}


### PR DESCRIPTION
## Part 6: ls-refs over Protocol v2 for GetRemoteRefs

Builds on Part 5 (#2228). When the session negotiated v2, `GetRemoteRefs` lists references through the `ls-refs` command instead of relying on the handshake advertisement (which v2 does not send).

### What changed

- `GetRemoteRefs` on the stream session maps its `GetRemoteRefsOptions` to a `packp.LsRefsArgs`: it always requests peeled tags and symref targets so `HEAD` resolves to its branch, passes through any ref-prefix filters, and requests unborn `HEAD` reporting when the server advertises `ls-refs=unborn`.
- The decoded `LsRefsOutput` is converted to `RemoteRefs`. An unborn `HEAD` (a symbolic `HEAD` whose target has no corresponding hash reference) is surfaced via `RemoteRefs.Unborn`.
- The v0/v1 path is unchanged: the server advertises every reference at handshake time and the options are ignored.

### Tests

End-to-end `ls-refs` against the server v2 path, ref-prefix filtering, and an unborn-`HEAD` case driven by a crafted advertisement.

### Reviewing just this part

https://github.com/go-git/go-git/compare/gitprotocol-v2-5-v2-handshake...gitprotocol-v2-6-v2-lsrefs

### Notes

Targets `main` (v6). Depends on Part 5 (#2228); merge that first.



---
_Recreated as a same-repo stacked PR (supersedes #2211)._

