### PR TITLE
plumbing: transport, Wire Protocol v2 across HTTP and share the client core (8/11)

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -1,0 +1,39 @@
+// Package transport holds transport internals shared across go-git's transport
+// implementations (the public facade lives in plumbing/transport, which aliases
+// the exported types here). It is not part of go-git's public API.
+package transport
+
+import (
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+)
+
+// FetchRequest describes a fetch. It is shared by the v0/v1 and v2 fetch paths;
+// plumbing/transport aliases it as transport.FetchRequest.
+type FetchRequest struct {
+	// Progress is the progress sideband.
+	Progress sideband.Progress
+
+	// Wants is the list of object hashes the client wants to fetch.
+	// The caller selects which remote refs to fetch (refspec matching)
+	// and extracts their hashes.
+	Wants []plumbing.Hash
+
+	// Haves is the list of object hashes the client already has.
+	// TODO: The transport should compute haves internally from the
+	// storer during pack negotiation, matching how canonical git's
+	// fetch-pack walks the local object graph to determine common
+	// ancestors. Once implemented, remove this field.
+	Haves []plumbing.Hash
+
+	// Depth is the depth of the fetch.
+	Depth int
+
+	// Filter holds the filters to be applied when deciding what
+	// objects will be added to the packfile.
+	Filter packp.Filter
+
+	// IncludeTags indicates whether tags should be fetched.
+	IncludeTags bool
+}

--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -1,0 +1,247 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+// Negotiation pacing, mirroring git's fetch-pack.c (INITIAL_FLUSH, LARGE_FLUSH,
+// MAX_IN_VAIN). v2 is stateless per command, so the stateless schedule applies.
+const (
+	initialFlush = 16
+	largeFlush   = 16384
+	maxInVain    = 256
+)
+
+func nextFlush(count int) int {
+	if count < largeFlush {
+		return count << 1
+	}
+	return count * 11 / 10
+}
+
+// CommandFunc runs a single Protocol v2 command: it encodes req into the
+// request and decodes the response via resp. A session's Command method
+// satisfies this signature, so the shared v2 helpers stay decoupled from the
+// public transport.Commander interface (and the import cycle it would create).
+type CommandFunc func(ctx context.Context, cmd string, req packp.CommandArgs, resp packp.Decoder) error
+
+// ClientCapabilities returns the capabilities a v2 client sends with each
+// command: the agent and the server's object-format echoed back so both sides
+// agree on the hash algorithm. server is the capability advertisement the
+// server sent during the handshake.
+func ClientCapabilities(server capability.List) capability.List {
+	var caps capability.List
+	caps.Set(capability.Agent, capability.DefaultAgent())
+	if of := server.Get(capability.ObjectFormat); len(of) > 0 {
+		caps.Set(capability.ObjectFormat, of[0])
+	}
+	return caps
+}
+
+// FetchSupports reports whether the server advertised the given fetch feature
+// in its v2 capability advertisement (fetch=<feature>...).
+func FetchSupports(server capability.List, feature string) bool {
+	for _, v := range server.Get(capability.FetchCmd) {
+		if slices.Contains(strings.Fields(v), feature) {
+			return true
+		}
+	}
+	return false
+}
+
+// lsRefsSupportsUnborn reports whether the server advertised the ls-refs
+// "unborn" feature (ls-refs=unborn).
+func lsRefsSupportsUnborn(server capability.List) bool {
+	return slices.Contains(server.Get(capability.LsRefs), "unborn")
+}
+
+// LsRefs lists references using the v2 ls-refs command run through cmd. It
+// always requests peeled tags and symref targets so HEAD resolves to its
+// branch, and requests unborn HEAD reporting when the server advertises it. The
+// returned references include a symbolic HEAD (and an unborn HEAD as a symref
+// whose target has no hash reference) so callers can detect an unborn branch.
+func LsRefs(ctx context.Context, cmd CommandFunc, server capability.List, refPrefixes []string) ([]*plumbing.Reference, error) {
+	args := &packp.LsRefsArgs{
+		Peel:        true,
+		Symrefs:     true,
+		Unborn:      lsRefsSupportsUnborn(server),
+		RefPrefixes: refPrefixes,
+	}
+
+	out := &packp.LsRefsOutput{}
+	if err := cmd(ctx, "ls-refs", args, out); err != nil {
+		return nil, err
+	}
+
+	return out.References, nil
+}
+
+// FetchRound runs a single fetch command round. When the returned output has
+// Packfile set, packReader is positioned at the first packfile pkt-line so the
+// caller can stream it. If packReader implements io.Closer, Fetch closes it
+// once the round is done (each HTTP round owns a response body; a stream
+// transport returns its persistent reader, which is not a Closer).
+type FetchRound func(args *packp.FetchArgs) (out *packp.FetchOutput, packReader io.Reader, err error)
+
+// FetchV2 drives the v2 fetch negotiation and streams the resulting packfile into
+// st. It mirrors git's do_fetch_pack_v2: each round sends the wants, the common
+// commits acked so far, and a growing batch of haves, until the server reports
+// "ready" (the packfile follows in the same response) or the client runs out of
+// haves and sends "done". The packfile (always sideband-64k muxed in v2) is
+// streamed here, and any shallow-info from the response is applied to st.
+//
+// The caller is responsible for validating optional features against the server
+// advertisement (see FetchSupports) before requesting Filter or Depth.
+func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round FetchRound) error {
+	baseArgs := &packp.FetchArgs{
+		Wants:      req.Wants,
+		OFSDelta:   true,
+		NoProgress: req.Progress == nil,
+		IncludeTag: req.IncludeTags,
+	}
+	if req.Filter != "" {
+		baseArgs.Filter = req.Filter
+	}
+	if req.Depth > 0 {
+		baseArgs.Deepen = req.Depth
+		shallows, err := st.Shallow()
+		if err != nil {
+			return err
+		}
+		baseArgs.Shallows = shallows
+	}
+
+	// Pop haves from a private copy so the caller's slice is left untouched.
+	remaining := append([]plumbing.Hash(nil), req.Haves...)
+	var common []plumbing.Hash
+	seen := make(map[plumbing.Hash]struct{})
+	havesToSend := initialFlush
+	inVain := 0
+	seenAck := false
+
+	var shallowInfo *packp.ShallowUpdate
+	for {
+		args := *baseArgs
+		// v2 fetch is stateless per command: re-send every common commit acked
+		// so far, then a fresh batch of haves.
+		roundHaves := append([]plumbing.Hash(nil), common...)
+		batch := 0
+		for batch < havesToSend && len(remaining) > 0 {
+			roundHaves = append(roundHaves, remaining[len(remaining)-1])
+			remaining = remaining[:len(remaining)-1]
+			batch++
+			inVain++
+		}
+		havesToSend = nextFlush(havesToSend)
+		args.Haves = roundHaves
+		args.Done = batch == 0 || (seenAck && inVain >= maxInVain)
+
+		out, packReader, err := round(&args)
+		if err != nil {
+			return err
+		}
+
+		if out.ShallowInfo != nil {
+			shallowInfo = &packp.ShallowUpdate{
+				Shallows:   out.ShallowInfo.Shallows,
+				Unshallows: out.ShallowInfo.Unshallows,
+			}
+		}
+
+		if out.Acknowledgments != nil {
+			for _, ack := range out.Acknowledgments.ACKs {
+				if _, ok := seen[ack]; !ok {
+					seen[ack] = struct{}{}
+					common = append(common, ack)
+				}
+				seenAck = true
+				inVain = 0
+			}
+		}
+
+		if out.Packfile {
+			streamErr := streamPackfile(ctx, st, packReader, req.Progress)
+			closeReader(packReader)
+			if streamErr != nil {
+				return streamErr
+			}
+			break
+		}
+
+		closeReader(packReader)
+		if args.Done {
+			return fmt.Errorf("transport: server sent no packfile after done")
+		}
+	}
+
+	if shallowInfo != nil {
+		if err := updateShallow(st, shallowInfo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// streamPackfile demultiplexes the sideband-64k packfile stream into st.
+func streamPackfile(ctx context.Context, st storage.Storer, packReader io.Reader, progress sideband.Progress) error {
+	reader := ioutil.NewContextReader(ctx, packReader)
+	demuxer := sideband.NewDemuxer(sideband.Sideband64k, reader)
+	if progress != nil {
+		demuxer.Progress = progress
+	}
+	return packfile.UpdateObjectStorage(st, demuxer)
+}
+
+// closeReader drains and closes r when it owns a closable resource (such as an
+// HTTP response body). Draining any unread bytes (e.g. the v2 response-end
+// pkt-line) before Close lets net/http reuse the connection across negotiation
+// rounds. Persistent stream readers do not implement io.Closer and are left
+// open for the next round.
+func closeReader(r io.Reader) {
+	if c, ok := r.(io.Closer); ok {
+		_, _ = io.Copy(io.Discard, r)
+		_ = c.Close()
+	}
+}
+
+// updateShallow merges a shallow-info update into st's shallow boundary.
+func updateShallow(st storage.Storer, info *packp.ShallowUpdate) error {
+	shallows, err := st.Shallow()
+	if err != nil {
+		return err
+	}
+
+outer:
+	for _, s := range info.Shallows {
+		for _, old := range shallows {
+			if s == old {
+				continue outer
+			}
+		}
+		shallows = append(shallows, s)
+	}
+
+	for _, s := range info.Unshallows {
+		for i, old := range shallows {
+			if s == old {
+				shallows = append(shallows[:i], shallows[i+1:]...)
+				break
+			}
+		}
+	}
+
+	return st.SetShallow(shallows)
+}

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net"
 
-	"github.com/go-git/go-git/v6/plumbing"
+	internal "github.com/go-git/go-git/v6/internal/transport"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 )
@@ -44,32 +44,10 @@ func NewRemoteError(reason string) error {
 // FetchRequest contains the parameters for a fetch-pack request.
 // This is used during the pack negotiation phase of the fetch operation.
 // See https://git-scm.com/docs/pack-protocol#_packfile_negotiation
-type FetchRequest struct {
-	// Progress is the progress sideband.
-	Progress sideband.Progress
-
-	// Wants is the list of object hashes the client wants to fetch.
-	// The caller selects which remote refs to fetch (refspec matching)
-	// and extracts their hashes.
-	Wants []plumbing.Hash
-
-	// Haves is the list of object hashes the client already has.
-	// TODO: The transport should compute haves internally from the
-	// storer during pack negotiation, matching how canonical git's
-	// fetch-pack walks the local object graph to determine common
-	// ancestors. Once implemented, remove this field.
-	Haves []plumbing.Hash
-
-	// Depth is the depth of the fetch.
-	Depth int
-
-	// Filter holds the filters to be applied when deciding what
-	// objects will be added to the packfile.
-	Filter packp.Filter
-
-	// IncludeTags indicates whether tags should be fetched.
-	IncludeTags bool
-}
+// FetchRequest is the request sent to the remote to fetch objects. It is an
+// alias of the shared internal type so the v0/v1 and v2 fetch paths use the
+// exact same request.
+type FetchRequest = internal.FetchRequest
 
 // PushRequest contains the parameters for a push request.
 type PushRequest struct {

--- a/plumbing/transport/http/backend_test.go
+++ b/plumbing/transport/http/backend_test.go
@@ -122,8 +122,9 @@ func setupGoGitBackendServer(t testing.TB) (baseURL, repoName string) {
 // git CLI operations explicitly force GIT_PROTOCOL=version=2 (via runV2) so that
 // this test actually exercises the v2 wire protocol on the server and would catch
 // bugs like the previous "packfile after ready" negotiation issues.
-// go-git HTTP transport is exercised via low-level Session for the transport requirement
-// (these use classic format; v2 client send is not yet implemented).
+// The go-git HTTP transport is exercised here via the low-level Session using the
+// classic (v0/v1) format; the go-git v2 client path has its own end-to-end
+// coverage in TestBackend_HTTP_V2_GoGitClient.
 func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
+	internal "github.com/go-git/go-git/v6/internal/transport"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
@@ -129,12 +130,23 @@ func handshakeSmart(resp *http.Response, req *transport.Request, client *http.Cl
 	if err != nil {
 		return nil, err
 	}
-	// V2 client support is partial (server v2 is fully supported for HTTP e2e with git CLI).
-	// If ver==V2 the subsequent AdvRefs decode will typically yield empty refs for
-	// a real v2 advertisement (refs come via ls-refs); GetRemoteRefs will surface
-	// an appropriate error. Explicit V2 requests from go-git remain best-effort.
-	switch ver {
-	case protocol.V1, protocol.V0, protocol.V2:
+
+	if ver == protocol.V2 {
+		// Protocol v2: the server sends a capability advertisement instead of
+		// the v0/v1 ref advertisement. References are retrieved lazily via the
+		// ls-refs command, so refs stays nil here.
+		adv := &packp.CapabilityAdv{}
+		if err := adv.Decode(rd); err != nil {
+			return nil, err
+		}
+		return &smartPackSession{
+			client:     client,
+			baseURL:    req.URL,
+			service:    req.Command,
+			authorizer: authorizer,
+			version:    ver,
+			caps:       adv.Capabilities,
+		}, nil
 	}
 
 	ar := &packp.AdvRefs{}
@@ -181,7 +193,10 @@ func handshakeDumb(resp *http.Response, req *transport.Request, client *http.Cli
 
 // --- smart HTTP pack session ---
 
-var _ transport.Session = (*smartPackSession)(nil)
+var (
+	_ transport.Session   = (*smartPackSession)(nil)
+	_ transport.Commander = (*smartPackSession)(nil)
+)
 
 type smartPackSession struct {
 	client     *http.Client
@@ -195,11 +210,26 @@ type smartPackSession struct {
 
 func (s *smartPackSession) Capabilities() *capability.List { return &s.caps }
 
-func (s *smartPackSession) GetRemoteRefs(_ context.Context, _ *transport.GetRemoteRefsOptions) (*transport.RemoteRefs, error) {
+func (s *smartPackSession) GetRemoteRefs(ctx context.Context, opts *transport.GetRemoteRefsOptions) (*transport.RemoteRefs, error) {
+	forPush := s.service == transport.ReceivePackService
+	if s.version == protocol.V2 {
+		var prefixes []string
+		if opts != nil {
+			prefixes = opts.RefPrefixes
+		}
+		refs, err := internal.LsRefs(ctx, s.Command, s.caps, prefixes)
+		if err != nil {
+			return nil, err
+		}
+		if !forPush && len(refs) == 0 {
+			return nil, transport.ErrEmptyRemoteRepository
+		}
+		return transport.NewRemoteRefs(refs), nil
+	}
+
 	if s.refs == nil {
 		return nil, transport.ErrEmptyRemoteRepository
 	}
-	forPush := s.service == transport.ReceivePackService
 	if !forPush && s.refs.IsEmpty() {
 		return nil, transport.ErrEmptyRemoteRepository
 	}
@@ -210,7 +240,42 @@ func (s *smartPackSession) GetRemoteRefs(_ context.Context, _ *transport.GetRemo
 	return transport.NewRemoteRefs(refs), nil
 }
 
+// Command implements transport.Commander. It runs a Protocol v2 command as a
+// single stateless HTTP POST: the request envelope is buffered and sent, and
+// the response is decoded from the response body. Fetch uses its own round
+// instead so it can stream the packfile from the body; Command is for
+// non-streaming commands such as ls-refs.
+func (s *smartPackSession) Command(ctx context.Context, cmd string, req packp.CommandArgs, resp packp.Decoder) error {
+	if s.version != protocol.V2 {
+		return transport.ErrUnsupportedVersion
+	}
+
+	r := &httpRequester{session: s, ctx: ctx}
+	cr := &packp.CommandRequest{
+		Command:      cmd,
+		Capabilities: internal.ClientCapabilities(s.caps),
+		Args:         req,
+	}
+	if err := cr.Encode(r); err != nil {
+		return err
+	}
+	if resp != nil {
+		if err := resp.Decode(r); err != nil {
+			return err
+		}
+	}
+	if r.resp != nil {
+		_, _ = io.Copy(io.Discard, r.resp.Body)
+		_ = r.resp.Body.Close()
+	}
+	return nil
+}
+
 func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *transport.FetchRequest) error {
+	if s.version == protocol.V2 {
+		return s.fetchV2(ctx, st, req)
+	}
+
 	neg := &httpNegotiator{session: s, ctx: ctx}
 
 	shallows, err := transport.NegotiatePack(ctx, st, s.caps, true, neg, neg, req)
@@ -239,6 +304,42 @@ func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *tr
 		neg.closeResponse()
 	}
 	return err
+}
+
+// fetchV2 fetches over Protocol v2. Each negotiation round is a fresh stateless
+// POST; internal.FetchV2 decodes the metadata via FetchOutput and, once the
+// server commits to a packfile, streams it from that round's response body.
+func (s *smartPackSession) fetchV2(ctx context.Context, st storage.Storer, req *transport.FetchRequest) error {
+	if req.Filter != "" && !internal.FetchSupports(s.caps, "filter") {
+		return transport.ErrFilterNotSupported
+	}
+	if req.Depth > 0 && !internal.FetchSupports(s.caps, "shallow") {
+		return transport.ErrShallowNotSupported
+	}
+
+	round := func(args *packp.FetchArgs) (*packp.FetchOutput, io.Reader, error) {
+		r := &httpRequester{session: s, ctx: ctx}
+		cr := &packp.CommandRequest{
+			Command:      "fetch",
+			Capabilities: internal.ClientCapabilities(s.caps),
+			Args:         args,
+		}
+		if err := cr.Encode(r); err != nil {
+			return nil, nil, err
+		}
+		out := &packp.FetchOutput{}
+		if err := out.Decode(r); err != nil {
+			return nil, nil, err
+		}
+		if r.resp == nil {
+			return nil, nil, fmt.Errorf("http transport: fetch command produced no response")
+		}
+		// The response body is positioned at the packfile (when out.Packfile);
+		// internal.FetchV2 streams it and closes the body via io.Closer.
+		return out, r.resp.Body, nil
+	}
+
+	return internal.FetchV2(ctx, st, req, round)
 }
 
 func (s *smartPackSession) Push(ctx context.Context, st storage.Storer, req *transport.PushRequest) error {
@@ -293,6 +394,9 @@ func (r *httpRequester) doPost() error {
 	httpReq.Header.Set("Content-Type", fmt.Sprintf("application/x-%s-request", r.session.service))
 	httpReq.Header.Set("Accept", fmt.Sprintf("application/x-%s-result", r.session.service))
 	httpReq.Header.Set("User-Agent", capability.DefaultAgent())
+	if gp := transport.GitProtocolEnv(r.session.version); gp != "" {
+		httpReq.Header.Set("Git-Protocol", gp)
+	}
 	if r.session.baseURL.User != nil {
 		password, _ := r.session.baseURL.User.Password()
 		httpReq.SetBasicAuth(r.session.baseURL.User.Username(), password)

--- a/plumbing/transport/http/v2_client_test.go
+++ b/plumbing/transport/http/v2_client_test.go
@@ -1,0 +1,75 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// TestBackend_HTTP_V2_GoGitClient exercises the go-git HTTP transport speaking
+// Protocol v2 (handshake, ls-refs, and fetch) against go-git's own v2 server.
+func TestBackend_HTTP_V2_GoGitClient(t *testing.T) {
+	t.Parallel()
+	requireGitV2(t)
+
+	base, name := setupGoGitBackendServer(t)
+	pu, err := url.Parse(fmt.Sprintf("http://u:p@%s/%s", strings.TrimPrefix(base, "http://"), name))
+	require.NoError(t, err)
+
+	tr := NewTransport(Options{})
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:      pu,
+		Command:  transport.UploadPackService,
+		Protocol: protocol.V2,
+	})
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	sps, ok := sess.(*smartPackSession)
+	require.True(t, ok)
+	require.Equal(t, protocol.V2, sps.version)
+
+	refs, err := sess.GetRemoteRefs(context.Background(), nil)
+	require.NoError(t, err)
+
+	var want plumbing.Hash
+	var sawHead bool
+	for _, r := range refs.References {
+		if r.Name() == "refs/heads/main" {
+			want = r.Hash()
+		}
+		if r.Name() == plumbing.HEAD {
+			sawHead = true
+			require.Equal(t, plumbing.ReferenceName("refs/heads/main"), r.Target())
+		}
+	}
+	require.False(t, want.IsZero(), "expected refs/heads/main from v2 ls-refs")
+	require.True(t, sawHead, "expected symref HEAD from v2 ls-refs")
+
+	st := memory.NewStorage()
+	require.NoError(t, sess.Fetch(context.Background(), st, &transport.FetchRequest{
+		Wants: []plumbing.Hash{want},
+	}))
+	cobj, err := st.EncodedObject(plumbing.CommitObject, want)
+	require.NoError(t, err)
+	require.Equal(t, want, cobj.Hash())
+
+	refsHeads, err := sess.GetRemoteRefs(context.Background(), &transport.GetRemoteRefsOptions{
+		RefPrefixes: []string{"refs/heads/"},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, refsHeads.References)
+	for _, r := range refsHeads.References {
+		require.True(t, strings.HasPrefix(r.Name().String(), "refs/heads/"),
+			"ref-prefix filter should drop %s", r.Name())
+	}
+}

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -4,16 +4,13 @@ import (
 	"bufio"
 	"context"
 	"errors"
-	"fmt"
 	"io"
-	"slices"
 	"strings"
 
-	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+	internal "github.com/go-git/go-git/v6/internal/transport"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
-	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
@@ -29,9 +26,6 @@ type StreamSession struct {
 	version protocol.Version
 	caps    capability.List
 	refs    *packp.AdvRefs
-	// v2 holds the Protocol v2 capability advertisement when the server
-	// negotiated version 2. It is nil for v0/v1.
-	v2 *packp.CapabilityAdv
 }
 
 // NewStreamSession creates a session from an open Conn.
@@ -71,7 +65,6 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 			_ = conn.Close()
 			return nil, err
 		}
-		s.v2 = adv
 		s.caps = adv.Capabilities
 		return s, nil
 	}
@@ -102,14 +95,25 @@ func (s *StreamSession) Capabilities() *capability.List { return &s.caps }
 // are retrieved on demand via the ls-refs command, honoring the ref-prefix
 // filters in opts.
 func (s *StreamSession) GetRemoteRefs(ctx context.Context, opts *GetRemoteRefsOptions) (*RemoteRefs, error) {
+	forPush := s.svc == ReceivePackService
 	if s.version == protocol.V2 {
-		return s.getRemoteRefsV2(ctx, opts)
+		var prefixes []string
+		if opts != nil {
+			prefixes = opts.RefPrefixes
+		}
+		refs, err := internal.LsRefs(ctx, s.Command, s.caps, prefixes)
+		if err != nil {
+			return nil, err
+		}
+		if !forPush && len(refs) == 0 {
+			return nil, ErrEmptyRemoteRepository
+		}
+		return NewRemoteRefs(refs), nil
 	}
 
 	if s.refs == nil {
 		return nil, ErrEmptyRemoteRepository
 	}
-	forPush := s.svc == ReceivePackService
 	if !forPush && s.refs.IsEmpty() {
 		return nil, ErrEmptyRemoteRepository
 	}
@@ -121,43 +125,28 @@ func (s *StreamSession) GetRemoteRefs(ctx context.Context, opts *GetRemoteRefsOp
 	return NewRemoteRefs(refs), nil
 }
 
-// getRemoteRefsV2 lists references using the v2 ls-refs command. It always
-// requests peeled tags and symref targets so HEAD resolves to its branch, and
-// requests unborn HEAD reporting when the server advertises support for it.
-func (s *StreamSession) getRemoteRefsV2(ctx context.Context, opts *GetRemoteRefsOptions) (*RemoteRefs, error) {
-	args := &packp.LsRefsArgs{
-		Peel:    true,
-		Symrefs: true,
-		Unborn:  s.lsRefsSupportsUnborn(),
-	}
-	if opts != nil {
-		args.RefPrefixes = opts.RefPrefixes
-	}
-
-	out := &packp.LsRefsOutput{}
-	if err := s.Command(ctx, "ls-refs", args, out); err != nil {
-		return nil, err
-	}
-
-	forPush := s.svc == ReceivePackService
-	if !forPush && len(out.References) == 0 {
-		return nil, ErrEmptyRemoteRepository
-	}
-
-	return NewRemoteRefs(out.References), nil
-}
-
-// lsRefsSupportsUnborn reports whether the server advertised the ls-refs
-// "unborn" feature (ls-refs=unborn), allowing the client to request an unborn
-// HEAD on an otherwise empty repository.
-func (s *StreamSession) lsRefsSupportsUnborn() bool {
-	return slices.Contains(s.caps.Get(capability.LsRefs), "unborn")
-}
-
 // Fetch implements PackSession.
 func (s *StreamSession) Fetch(ctx context.Context, st storage.Storer, req *FetchRequest) error {
 	if s.version == protocol.V2 {
-		return s.fetchV2(ctx, st, req)
+		if req.Filter != "" && !internal.FetchSupports(s.caps, "filter") {
+			return ErrFilterNotSupported
+		}
+		if req.Depth > 0 && !internal.FetchSupports(s.caps, "shallow") {
+			return ErrShallowNotSupported
+		}
+		// Each negotiation round reuses the persistent stream: Command writes
+		// the request and decodes the metadata, leaving s.r at the packfile.
+		round := func(args *packp.FetchArgs) (*packp.FetchOutput, io.Reader, error) {
+			out := &packp.FetchOutput{}
+			if err := s.Command(ctx, "fetch", args, out); err != nil {
+				return nil, nil, err
+			}
+			return out, s.r, nil
+		}
+		if err := internal.FetchV2(ctx, st, req, round); err != nil {
+			return s.wrapStderr(err)
+		}
+		return nil
 	}
 
 	shallows, err := NegotiatePack(ctx, st, s.caps, false, s.r, s.w, req)
@@ -168,113 +157,6 @@ func (s *StreamSession) Fetch(ctx context.Context, st storage.Storer, req *Fetch
 		return s.wrapStderr(err)
 	}
 	return nil
-}
-
-// fetchV2 fetches a packfile using the Protocol v2 fetch command. It runs the
-// fetch command, advancing negotiation rounds until the server commits to a
-// packfile, then streams that packfile (always sideband-64k muxed in v2) into
-// storage. Packfile streaming is owned here, not by the FetchOutput type.
-func (s *StreamSession) fetchV2(ctx context.Context, st storage.Storer, req *FetchRequest) error {
-	args, err := s.buildFetchArgs(st, req)
-	if err != nil {
-		return err
-	}
-
-	var shallowInfo *packp.ShallowUpdate
-	for {
-		out := &packp.FetchOutput{}
-		if err := s.Command(ctx, "fetch", args, out); err != nil {
-			return s.wrapStderr(err)
-		}
-
-		if out.ShallowInfo != nil {
-			shallowInfo = &packp.ShallowUpdate{
-				Shallows:   out.ShallowInfo.Shallows,
-				Unshallows: out.ShallowInfo.Unshallows,
-			}
-		}
-
-		if out.Packfile {
-			break
-		}
-
-		// The acknowledgments section ended with a flush-pkt: no packfile this
-		// round. We send every known have up front, so there is nothing more to
-		// offer; declare done to force the server to send a packfile next round.
-		if args.Done {
-			return fmt.Errorf("transport: server sent no packfile after done")
-		}
-		args.Done = true
-	}
-
-	if err := s.streamPackfileV2(ctx, st, req); err != nil {
-		return s.wrapStderr(err)
-	}
-
-	if shallowInfo != nil {
-		if err := updateShallow(st, shallowInfo); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// streamPackfileV2 reads the v2 fetch packfile section, which the reader is
-// positioned at after FetchOutput decoding. The packfile is always
-// demultiplexed from the sideband-64k channel.
-func (s *StreamSession) streamPackfileV2(ctx context.Context, st storage.Storer, req *FetchRequest) error {
-	reader := ioutil.NewContextReader(ctx, s.r)
-	demuxer := sideband.NewDemuxer(sideband.Sideband64k, reader)
-	if req.Progress != nil {
-		demuxer.Progress = req.Progress
-	}
-	return packfile.UpdateObjectStorage(st, demuxer)
-}
-
-// buildFetchArgs maps a FetchRequest to the v2 fetch command arguments,
-// validating that optional features (filters, shallow) are advertised by the
-// server before requesting them.
-func (s *StreamSession) buildFetchArgs(st storage.Storer, req *FetchRequest) (*packp.FetchArgs, error) {
-	args := &packp.FetchArgs{
-		Wants:      req.Wants,
-		Haves:      req.Haves,
-		OFSDelta:   true,
-		NoProgress: req.Progress == nil,
-		IncludeTag: req.IncludeTags,
-	}
-
-	if req.Filter != "" {
-		if !s.fetchSupports("filter") {
-			return nil, ErrFilterNotSupported
-		}
-		args.Filter = req.Filter
-	}
-
-	if req.Depth > 0 {
-		if !s.fetchSupports("shallow") {
-			return nil, ErrShallowNotSupported
-		}
-		args.Deepen = req.Depth
-		shallows, err := st.Shallow()
-		if err != nil {
-			return nil, err
-		}
-		args.Shallows = shallows
-	}
-
-	return args, nil
-}
-
-// fetchSupports reports whether the server advertised the given fetch feature
-// in its v2 capability advertisement (fetch=<feature>...).
-func (s *StreamSession) fetchSupports(feature string) bool {
-	for _, v := range s.caps.Get(capability.FetchCmd) {
-		if slices.Contains(strings.Fields(v), feature) {
-			return true
-		}
-	}
-	return false
 }
 
 // Push implements PackSession.
@@ -320,14 +202,7 @@ func (s *StreamSession) Command(_ context.Context, cmd string, req packp.Command
 // server advertised during the handshake so both sides agree on the hash
 // algorithm.
 func (s *StreamSession) commandCapabilities() capability.List {
-	var caps capability.List
-	caps.Set(capability.Agent, capability.DefaultAgent())
-	if s.v2 != nil {
-		if of := s.v2.Capabilities.Get(capability.ObjectFormat); len(of) > 0 {
-			caps.Set(capability.ObjectFormat, of[0])
-		}
-	}
-	return caps
+	return internal.ClientCapabilities(s.caps)
 }
 
 // wrapStderr checks if the underlying connection has stderr output and

--- a/plumbing/transport/v2_fetch_test.go
+++ b/plumbing/transport/v2_fetch_test.go
@@ -37,6 +37,69 @@ func TestV2FetchClone(t *testing.T) {
 	require.Equal(t, want, obj.Hash())
 }
 
+func TestV2FetchManyRounds(t *testing.T) {
+	t.Parallel()
+	serverSt := basicV2Storage(t)
+	want := plumbing.NewHash(basicMasterHash)
+
+	// More haves than the initial batch (16) so negotiation needs several
+	// rounds: round 1 sends 16, round 2 the remainder, round 3 sends "done".
+	haves := make([]plumbing.Hash, 20)
+	for i := range haves {
+		haves[i] = plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")
+	}
+
+	var rounds int
+	serve := func(serverConn net.Conn) (err error) {
+		defer func() { _ = serverConn.Close() }()
+
+		w := serverConn
+		for _, line := range []string{"version 2\n", "agent=test\n", "fetch=shallow\n", "object-format=sha1\n"} {
+			if _, err := pktline.WriteString(w, line); err != nil {
+				return err
+			}
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return err
+		}
+
+		rd := bufio.NewReader(serverConn)
+		for {
+			req := &packp.CommandRequest{Args: &packp.FetchArgs{}}
+			if err := req.Decode(rd); err != nil {
+				return err
+			}
+			rounds++
+			args := req.Args.(*packp.FetchArgs)
+			if args.Done {
+				return writeV2PackfileSection(w, serverSt, args.Wants, args.Haves)
+			}
+			if _, err := pktline.WriteString(w, "acknowledgments\n"); err != nil {
+				return err
+			}
+			if _, err := pktline.WriteString(w, "NAK\n"); err != nil {
+				return err
+			}
+			if err := pktline.WriteFlush(w); err != nil {
+				return err
+			}
+		}
+	}
+
+	clientSt := memory.NewStorage()
+	s := newV2Session(t, serve)
+
+	err := s.Fetch(context.TODO(), clientSt, &FetchRequest{
+		Wants: []plumbing.Hash{want},
+		Haves: haves,
+	})
+	require.NoError(t, err)
+	require.Greater(t, rounds, 2, "incremental have batching should take more than two rounds")
+
+	_, err = clientSt.EncodedObject(plumbing.CommitObject, want)
+	require.NoError(t, err)
+}
+
 func TestV2FetchNegotiationRounds(t *testing.T) {
 	t.Parallel()
 	serverSt := basicV2Storage(t)
@@ -102,18 +165,19 @@ func TestV2FetchNegotiationRounds(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestV2BuildFetchArgsUnsupportedFeatures(t *testing.T) {
+func TestV2FetchUnsupportedFeatures(t *testing.T) {
 	t.Parallel()
 
+	// A v2 session whose server advertised no fetch features.
 	s := &StreamSession{version: protocol.V2}
 
-	_, err := s.buildFetchArgs(memory.NewStorage(), &FetchRequest{
+	err := s.Fetch(context.TODO(), memory.NewStorage(), &FetchRequest{
 		Wants:  []plumbing.Hash{plumbing.NewHash(basicMasterHash)},
 		Filter: "blob:none",
 	})
 	require.ErrorIs(t, err, ErrFilterNotSupported)
 
-	_, err = s.buildFetchArgs(memory.NewStorage(), &FetchRequest{
+	err = s.Fetch(context.TODO(), memory.NewStorage(), &FetchRequest{
 		Wants: []plumbing.Hash{plumbing.NewHash(basicMasterHash)},
 		Depth: 1,
 	})

--- a/plumbing/transport/v2_handshake_test.go
+++ b/plumbing/transport/v2_handshake_test.go
@@ -33,7 +33,6 @@ func TestStreamSessionV2Handshake(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, protocol.V2, s.version)
-	require.NotNil(t, s.v2)
 	require.Nil(t, s.refs)
 
 	caps := s.Capabilities()
@@ -52,7 +51,7 @@ func TestStreamSessionCommandEnvelope(t *testing.T) {
 	s := &StreamSession{
 		version: protocol.V2,
 		w:       ioutil.WriteNopCloser(&out),
-		v2:      &packp.CapabilityAdv{Version: protocol.V2, Capabilities: serverCaps},
+		caps:    serverCaps,
 	}
 
 	req := &packp.LsRefsArgs{

--- a/plumbing/transport/v2_lsrefs_test.go
+++ b/plumbing/transport/v2_lsrefs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
@@ -135,7 +136,7 @@ func TestV2GetRemoteRefsUnbornHead(t *testing.T) {
 	}
 
 	s := newV2Session(t, serve)
-	require.True(t, s.lsRefsSupportsUnborn())
+	require.Contains(t, s.caps.Get(capability.LsRefs), "unborn")
 
 	rr, err := s.GetRemoteRefs(context.TODO(), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
## Part 8: wire Protocol v2 across HTTP and share the client core

Builds on Part 7 (#2230). Parts 5 to 7 implemented v2 for the stream sessions (SSH, git://, file) inline. This part extracts that orchestration into one shared place and wires the HTTP transport to it, so the client speaks v2 over HTTP too.

### What changed

- New `internal/transport` package holds the v2 client orchestration: `ls-refs`, the `do_fetch_pack_v2`-style fetch negotiation with incremental have batching, `FetchSupports`, the capability echo, and caller-owned packfile streaming. It is internal, so no new public v2 API is added.
- `FetchRequest` moves into `internal/transport` and `plumbing/transport` aliases it, so the v0/v1 and v2 fetch paths use the exact same request type. The public `transport.Commander` interface is unchanged; the shared helpers take a plain `CommandFunc` to avoid an import cycle.
- Stream transports delegate their v2 `GetRemoteRefs` and `Fetch` to the shared helpers, passing their `FetchRequest` straight through.
- The smart HTTP session decodes the v2 capability advertisement, implements `Commander` over a single stateless POST (with the `Git-Protocol` header), and runs `GetRemoteRefs` and `Fetch` through the same helpers. Each fetch round owns its response body, which the helper closes between rounds.

### Tests

An end-to-end test drives the go-git HTTP client over v2 (handshake, ls-refs with HEAD symref and ref-prefix filtering, and fetch) against go-git's own v2 server. The existing stream tests run through the shared core unchanged.

### Reviewing just this part

https://github.com/go-git/go-git/compare/gitprotocol-v2-7-v2-fetch...gitprotocol-v2-9-http-shared

### Notes

Targets `main` (v6). Depends on Part 7 (#2230); merge that first. Server-side v2 cleanup and HTTP archive support follow in later parts.




---
_Recreated as a same-repo stacked PR (supersedes #2216)._

