### PR TITLE
plumbing/transport: receive_pack, add ReceivePackHooks with PreReceive/PostReceive

### DIFF
--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -23,10 +23,38 @@ type ReceivePackRequest struct {
 	GitProtocol   string
 	AdvertiseRefs bool
 	StatelessRPC  bool
+
+	// Hooks, if set, are invoked between packfile unpack and ref update
+	// (PreReceive) and after ref update (PostReceive). A non-nil PreReceive
+	// error rejects every ref in the push with that error as the
+	// report-status reason; refs are not updated and PostReceive is not run.
+	Hooks *ReceivePackHooks
+}
+
+// ReceivePackHooks holds server-side callbacks for ReceivePack.
+//
+// These are the in-process equivalent of git's pre-receive and post-receive
+// hooks. They run after the packfile has been unpacked into st but before
+// (PreReceive) and after (PostReceive) ref updates, so a server can enforce
+// branch protection, signed-commit checks, or other policy without
+// reimplementing receive-pack.
+type ReceivePackHooks struct {
+	// PreReceive runs after the packfile is unpacked into st but before any
+	// ref is updated. cmds are the proposed updates. progress writes to the
+	// sideband progress channel (band 2) when the client negotiated
+	// side-band/side-band-64k, or is discarded otherwise; write human-readable
+	// lines for the client's `remote:` output. Returning a non-nil error
+	// refuses every ref with err.Error() as the report-status reason.
+	PreReceive func(ctx context.Context, st storage.Storer, cmds []*packp.Command, progress io.Writer) error
+
+	// PostReceive runs after refs are updated. cmds are the same commands
+	// passed to PreReceive. The hook itself must handle any failure it cares
+	// about; nothing is surfaced to the client and the function does not
+	// return an error.
+	PostReceive func(ctx context.Context, st storage.Storer, cmds []*packp.Command)
 }
 
 // ReceivePack is a server command that serves the receive-pack service.
-// TODO: support hooks
 func ReceivePack(
 	ctx context.Context,
 	st storage.Storer,
@@ -128,13 +156,18 @@ func ReceivePack(
 	var (
 		useSideband bool
 		writer      io.Writer = w
+		progress              = io.Writer(io.Discard)
 	)
 	if !caps.Supports(capability.NoProgress) {
+		var mux *sideband.Muxer
 		if caps.Supports(capability.Sideband64k) {
-			writer = sideband.NewMuxer(sideband.Sideband64k, w)
-			useSideband = true
+			mux = sideband.NewMuxer(sideband.Sideband64k, w)
 		} else if caps.Supports(capability.Sideband) {
-			writer = sideband.NewMuxer(sideband.Sideband, w)
+			mux = sideband.NewMuxer(sideband.Sideband, w)
+		}
+		if mux != nil {
+			writer = mux
+			progress = sidebandProgress{mux}
 			useSideband = true
 		}
 	}
@@ -146,9 +179,36 @@ func ReceivePack(
 		return res
 	}
 
+	if opts.Hooks != nil && opts.Hooks.PreReceive != nil {
+		if hookErr := opts.Hooks.PreReceive(ctx, st, updreq.Commands, progress); hookErr != nil {
+			rejected := make(map[plumbing.ReferenceName]error, len(updreq.Commands))
+			for _, cmd := range updreq.Commands {
+				rejected[cmd.Name] = hookErr
+			}
+			if err := sendReportStatus(writeCloser, nil, rejected); err != nil {
+				_ = closeWriter(w)
+				return err
+			}
+			if useSideband {
+				if err := pktline.WriteFlush(w); err != nil {
+					_ = closeWriter(w)
+					return fmt.Errorf("flushing sideband: %w", err)
+				}
+			}
+			if err := closeWriter(w); err != nil {
+				return err
+			}
+			return hookErr
+		}
+	}
+
 	var firstErr error
 	cmdStatus := make(map[plumbing.ReferenceName]error)
 	updateReferences(st, updreq, cmdStatus, &firstErr)
+
+	if opts.Hooks != nil && opts.Hooks.PostReceive != nil {
+		opts.Hooks.PostReceive(ctx, st, updreq.Commands)
+	}
 
 	if err := sendReportStatus(writeCloser, firstErr, cmdStatus); err != nil {
 		return err
@@ -163,6 +223,12 @@ func ReceivePack(
 		return firstErr
 	}
 	return closeWriter(w)
+}
+
+type sidebandProgress struct{ mux *sideband.Muxer }
+
+func (p sidebandProgress) Write(b []byte) (int, error) {
+	return p.mux.WriteChannel(sideband.ProgressMessage, b)
 }
 
 func closeWriter(w io.WriteCloser) error {

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -24,34 +24,57 @@ type ReceivePackRequest struct {
 	AdvertiseRefs bool
 	StatelessRPC  bool
 
-	// Hooks, if set, are invoked between packfile unpack and ref update
-	// (PreReceive) and after ref update (PostReceive). A non-nil PreReceive
-	// error rejects every ref in the push with that error as the
-	// report-status reason; refs are not updated and PostReceive is not run.
-	Hooks *ReceivePackHooks
+	// Hooks are optional server-side callbacks. The zero value installs none.
+	Hooks ReceivePackHooks
 }
 
 // ReceivePackHooks holds server-side callbacks for ReceivePack.
 //
 // These are the in-process equivalent of git's pre-receive and post-receive
-// hooks. They run after the packfile has been unpacked into st but before
-// (PreReceive) and after (PostReceive) ref updates, so a server can enforce
-// branch protection, signed-commit checks, or other policy without
+// hooks. They run after the packfile has been unpacked into the storer but
+// before (PreReceive) and after (PostReceive) ref updates, so a server can
+// enforce branch protection, signed-commit checks, or other policy without
 // reimplementing receive-pack.
 type ReceivePackHooks struct {
-	// PreReceive runs after the packfile is unpacked into st but before any
-	// ref is updated. cmds are the proposed updates. progress writes to the
-	// sideband progress channel (band 2) when the client negotiated
-	// side-band/side-band-64k, or is discarded otherwise; write human-readable
-	// lines for the client's `remote:` output. Returning a non-nil error
-	// refuses every ref with err.Error() as the report-status reason.
-	PreReceive func(ctx context.Context, st storage.Storer, cmds []*packp.Command, progress io.Writer) error
+	// PreReceive runs after the packfile is unpacked but before any ref is
+	// updated. Returning a non-nil error refuses every ref with err.Error()
+	// as the report-status reason; refs are not updated and PostReceive is
+	// not run.
+	PreReceive func(context.Context, *PreReceiveInfo) error
 
-	// PostReceive runs after refs are updated. cmds are the same commands
-	// passed to PreReceive. The hook itself must handle any failure it cares
-	// about; nothing is surfaced to the client and the function does not
-	// return an error.
-	PostReceive func(ctx context.Context, st storage.Storer, cmds []*packp.Command)
+	// PostReceive runs after refs are updated. Any returned error is ignored
+	// for transport purposes: the refs have already moved and the
+	// report-status sent to the client reflects the ref-update outcome, not
+	// this error. The hook itself must handle or log failures it cares about.
+	PostReceive func(context.Context, *PostReceiveInfo) error
+}
+
+// PreReceiveInfo carries the inputs to a PreReceive hook.
+type PreReceiveInfo struct {
+	// Storer reads the proposed new state: the objects from this push are
+	// already present alongside the existing repository.
+	Storer storage.Storer
+	// Commands are the proposed ref updates. Treat as read-only.
+	Commands []*packp.Command
+	// PushOptions are the client's push options (empty if none).
+	PushOptions []string
+	// Progress writes to the client's sideband progress channel (band 2) when
+	// negotiated, or is io.Discard otherwise. Valid only during the call.
+	Progress io.Writer
+}
+
+// PostReceiveInfo carries the inputs to a PostReceive hook.
+type PostReceiveInfo struct {
+	// Storer reads the committed repository state.
+	Storer storage.Storer
+	// Commands are the ref updates that were applied successfully. Refs whose
+	// update failed are omitted. Treat as read-only.
+	Commands []*packp.Command
+	// PushOptions are the client's push options (empty if none).
+	PushOptions []string
+	// Progress writes to the client's sideband progress channel (band 2) when
+	// negotiated, or is io.Discard otherwise. Valid only during the call.
+	Progress io.Writer
 }
 
 // ReceivePack is a server command that serves the receive-pack service.
@@ -121,7 +144,6 @@ func ReceivePack(
 		pushOpts     packp.PushOptions
 	)
 
-	// TODO: Pass the options to the server-side hooks.
 	if updreq.Capabilities.Supports(capability.PushOptions) {
 		if err := pushOpts.Decode(rd); err != nil {
 			return fmt.Errorf("decoding push-options: %w", err)
@@ -179,8 +201,14 @@ func ReceivePack(
 		return res
 	}
 
-	if opts.Hooks != nil && opts.Hooks.PreReceive != nil {
-		if hookErr := opts.Hooks.PreReceive(ctx, st, updreq.Commands, progress); hookErr != nil {
+	if opts.Hooks.PreReceive != nil {
+		info := &PreReceiveInfo{
+			Storer:      st,
+			Commands:    updreq.Commands,
+			PushOptions: pushOpts.Options,
+			Progress:    progress,
+		}
+		if hookErr := opts.Hooks.PreReceive(ctx, info); hookErr != nil {
 			rejected := make(map[plumbing.ReferenceName]error, len(updreq.Commands))
 			for _, cmd := range updreq.Commands {
 				rejected[cmd.Name] = hookErr
@@ -206,8 +234,20 @@ func ReceivePack(
 	cmdStatus := make(map[plumbing.ReferenceName]error)
 	updateReferences(st, updreq, cmdStatus, &firstErr)
 
-	if opts.Hooks != nil && opts.Hooks.PostReceive != nil {
-		opts.Hooks.PostReceive(ctx, st, updreq.Commands)
+	if opts.Hooks.PostReceive != nil {
+		applied := make([]*packp.Command, 0, len(updreq.Commands))
+		for _, cmd := range updreq.Commands {
+			if cmdStatus[cmd.Name] == nil {
+				applied = append(applied, cmd)
+			}
+		}
+		info := &PostReceiveInfo{
+			Storer:      st,
+			Commands:    applied,
+			PushOptions: pushOpts.Options,
+			Progress:    progress,
+		}
+		_ = opts.Hooks.PostReceive(ctx, info)
 	}
 
 	if err := sendReportStatus(writeCloser, firstErr, cmdStatus); err != nil {

--- a/plumbing/transport/receive_pack_test.go
+++ b/plumbing/transport/receive_pack_test.go
@@ -21,11 +21,11 @@ import (
 
 const receivePackTestHash = "0123456789012345678901234567890123456789"
 
-// receivePackRequest builds a wire-format receive-pack body for a Delete of
-// the named ref at hash, with ReportStatus advertised plus any extra caps.
-// Delete-only requests skip the packfile, which keeps tests focused on the
-// hook plumbing rather than pack handling.
-func receivePackRequest(t *testing.T, ref plumbing.ReferenceName, hash plumbing.Hash, extra ...capability.Capability) io.ReadCloser {
+// receivePackRequest builds a wire-format receive-pack body for the given
+// commands, with ReportStatus advertised plus any extra caps. Tests use
+// Delete-only commands so no packfile follows, which keeps focus on hook
+// plumbing rather than pack handling.
+func receivePackRequest(t *testing.T, cmds []*packp.Command, extra ...capability.Capability) io.ReadCloser {
 	t.Helper()
 
 	caps := capability.List{}
@@ -36,16 +36,16 @@ func receivePackRequest(t *testing.T, ref plumbing.ReferenceName, hash plumbing.
 
 	req := &packp.UpdateRequests{
 		Capabilities: caps,
-		Commands: []*packp.Command{{
-			Name: ref,
-			Old:  hash,
-			New:  plumbing.ZeroHash,
-		}},
+		Commands:     cmds,
 	}
 
 	var buf bytes.Buffer
 	require.NoError(t, req.Encode(&buf))
 	return io.NopCloser(&buf)
+}
+
+func deleteCmd(ref plumbing.ReferenceName, hash plumbing.Hash) *packp.Command {
+	return &packp.Command{Name: ref, Old: hash, New: plumbing.ZeroHash}
 }
 
 func seedRef(t *testing.T, ref plumbing.ReferenceName, hash plumbing.Hash) storage.Storer {
@@ -66,7 +66,7 @@ func TestReceivePackNilHooksDeleteRef(t *testing.T) {
 	err := ReceivePack(
 		context.Background(),
 		st,
-		receivePackRequest(t, ref, hash),
+		receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)}),
 		ioutil.WriteNopCloser(&out),
 		&ReceivePackRequest{StatelessRPC: true},
 	)
@@ -87,21 +87,19 @@ func TestReceivePackPreReceiveAllowsUpdate(t *testing.T) {
 	st := seedRef(t, ref, hash)
 
 	var (
-		out      bytes.Buffer
-		seen     []*packp.Command
-		gotStore storage.Storer
+		out  bytes.Buffer
+		info *PreReceiveInfo
 	)
 	err := ReceivePack(
 		context.Background(),
 		st,
-		receivePackRequest(t, ref, hash),
+		receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)}),
 		ioutil.WriteNopCloser(&out),
 		&ReceivePackRequest{
 			StatelessRPC: true,
-			Hooks: &ReceivePackHooks{
-				PreReceive: func(_ context.Context, s storage.Storer, cmds []*packp.Command, _ io.Writer) error {
-					gotStore = s
-					seen = cmds
+			Hooks: ReceivePackHooks{
+				PreReceive: func(_ context.Context, i *PreReceiveInfo) error {
+					info = i
 					return nil
 				},
 			},
@@ -109,10 +107,13 @@ func TestReceivePackPreReceiveAllowsUpdate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	assert.Same(t, st, gotStore)
-	require.Len(t, seen, 1)
-	assert.Equal(t, ref, seen[0].Name)
-	assert.Equal(t, packp.Delete, seen[0].Action())
+	require.NotNil(t, info)
+	assert.Same(t, st, info.Storer)
+	assert.NotNil(t, info.Progress)
+	assert.Empty(t, info.PushOptions)
+	require.Len(t, info.Commands, 1)
+	assert.Equal(t, ref, info.Commands[0].Name)
+	assert.Equal(t, packp.Delete, info.Commands[0].Action())
 	assert.Contains(t, out.String(), "ok refs/heads/main")
 }
 
@@ -128,16 +129,17 @@ func TestReceivePackPreReceiveRejectsRef(t *testing.T) {
 	err := ReceivePack(
 		context.Background(),
 		st,
-		receivePackRequest(t, ref, hash),
+		receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)}),
 		ioutil.WriteNopCloser(&out),
 		&ReceivePackRequest{
 			StatelessRPC: true,
-			Hooks: &ReceivePackHooks{
-				PreReceive: func(context.Context, storage.Storer, []*packp.Command, io.Writer) error {
+			Hooks: ReceivePackHooks{
+				PreReceive: func(context.Context, *PreReceiveInfo) error {
 					return errors.New("policy blocks main")
 				},
-				PostReceive: func(context.Context, storage.Storer, []*packp.Command) {
+				PostReceive: func(context.Context, *PostReceiveInfo) error {
 					postReceiveCalled = true
+					return nil
 				},
 			},
 		},
@@ -163,30 +165,74 @@ func TestReceivePackPostReceiveRunsAfterUpdate(t *testing.T) {
 
 	var (
 		out        bytes.Buffer
-		postCmds   []*packp.Command
+		info       *PostReceiveInfo
 		refMissing bool
 	)
 	err := ReceivePack(
 		context.Background(),
 		st,
-		receivePackRequest(t, ref, hash),
+		receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)}),
 		ioutil.WriteNopCloser(&out),
 		&ReceivePackRequest{
 			StatelessRPC: true,
-			Hooks: &ReceivePackHooks{
-				PostReceive: func(_ context.Context, s storage.Storer, cmds []*packp.Command) {
-					postCmds = cmds
-					_, refErr := s.Reference(ref)
+			Hooks: ReceivePackHooks{
+				PostReceive: func(_ context.Context, i *PostReceiveInfo) error {
+					info = i
+					_, refErr := i.Storer.Reference(ref)
 					refMissing = errors.Is(refErr, plumbing.ErrReferenceNotFound)
+					return nil
 				},
 			},
 		},
 	)
 	require.NoError(t, err)
 
-	require.Len(t, postCmds, 1)
-	assert.Equal(t, ref, postCmds[0].Name)
+	require.NotNil(t, info)
+	require.Len(t, info.Commands, 1)
+	assert.Equal(t, ref, info.Commands[0].Name)
+	assert.NotNil(t, info.Progress)
 	assert.True(t, refMissing, "ref must be gone by the time PostReceive runs")
+}
+
+func TestReceivePackPostReceivePartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	good := plumbing.ReferenceName("refs/heads/good")
+	bad := plumbing.ReferenceName("refs/heads/bad")
+	hash := plumbing.NewHash(receivePackTestHash)
+	// Only seed `good`; deleting `bad` will fail with ErrUpdateReference.
+	st := seedRef(t, good, hash)
+
+	var (
+		out  bytes.Buffer
+		info *PostReceiveInfo
+	)
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			deleteCmd(good, hash),
+			deleteCmd(bad, hash),
+		}),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{
+			StatelessRPC: true,
+			Hooks: ReceivePackHooks{
+				PostReceive: func(_ context.Context, i *PostReceiveInfo) error {
+					info = i
+					return nil
+				},
+			},
+		},
+	)
+	require.ErrorIs(t, err, ErrUpdateReference)
+
+	require.NotNil(t, info)
+	require.Len(t, info.Commands, 1, "PostReceive must only see refs that applied")
+	assert.Equal(t, good, info.Commands[0].Name)
+
+	assert.Contains(t, out.String(), "ok refs/heads/good")
+	assert.Contains(t, out.String(), "ng refs/heads/bad")
 }
 
 func TestReceivePackPreReceiveWritesProgressOnSideband(t *testing.T) {
@@ -200,13 +246,13 @@ func TestReceivePackPreReceiveWritesProgressOnSideband(t *testing.T) {
 	err := ReceivePack(
 		context.Background(),
 		st,
-		receivePackRequest(t, ref, hash, capability.Sideband64k),
+		receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)}, capability.Sideband64k),
 		ioutil.WriteNopCloser(&out),
 		&ReceivePackRequest{
 			StatelessRPC: true,
-			Hooks: &ReceivePackHooks{
-				PreReceive: func(_ context.Context, _ storage.Storer, _ []*packp.Command, progress io.Writer) error {
-					_, _ = io.WriteString(progress, "policy check passed\n")
+			Hooks: ReceivePackHooks{
+				PreReceive: func(_ context.Context, info *PreReceiveInfo) error {
+					_, _ = io.WriteString(info.Progress, "policy check passed\n")
 					return nil
 				},
 			},
@@ -229,8 +275,7 @@ func readSideband(t *testing.T, r io.Reader) sidebandPayload {
 	var p sidebandPayload
 	demux := sideband.NewDemuxer(sideband.Sideband64k, r)
 	demux.Progress = &p.progress
-	if _, err := io.Copy(&p.data, demux); err != nil && !errors.Is(err, io.EOF) {
-		require.NoError(t, err)
-	}
+	_, err := io.Copy(&p.data, demux)
+	require.NoError(t, err)
 	return p
 }

--- a/plumbing/transport/receive_pack_test.go
+++ b/plumbing/transport/receive_pack_test.go
@@ -1,0 +1,236 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/memory"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+const receivePackTestHash = "0123456789012345678901234567890123456789"
+
+// receivePackRequest builds a wire-format receive-pack body for a Delete of
+// the named ref at hash, with ReportStatus advertised plus any extra caps.
+// Delete-only requests skip the packfile, which keeps tests focused on the
+// hook plumbing rather than pack handling.
+func receivePackRequest(t *testing.T, ref plumbing.ReferenceName, hash plumbing.Hash, extra ...capability.Capability) io.ReadCloser {
+	t.Helper()
+
+	caps := capability.List{}
+	caps.Add(capability.ReportStatus)
+	for _, c := range extra {
+		caps.Add(c)
+	}
+
+	req := &packp.UpdateRequests{
+		Capabilities: caps,
+		Commands: []*packp.Command{{
+			Name: ref,
+			Old:  hash,
+			New:  plumbing.ZeroHash,
+		}},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, req.Encode(&buf))
+	return io.NopCloser(&buf)
+}
+
+func seedRef(t *testing.T, ref plumbing.ReferenceName, hash plumbing.Hash) storage.Storer {
+	t.Helper()
+	st := memory.NewStorage()
+	require.NoError(t, st.SetReference(plumbing.NewHashReference(ref, hash)))
+	return st
+}
+
+func TestReceivePackNilHooksDeleteRef(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := seedRef(t, ref, hash)
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, ref, hash),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, out.String(), "unpack ok")
+	assert.Contains(t, out.String(), "ok refs/heads/main")
+
+	_, err = st.Reference(ref)
+	assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+}
+
+func TestReceivePackPreReceiveAllowsUpdate(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := seedRef(t, ref, hash)
+
+	var (
+		out      bytes.Buffer
+		seen     []*packp.Command
+		gotStore storage.Storer
+	)
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, ref, hash),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{
+			StatelessRPC: true,
+			Hooks: &ReceivePackHooks{
+				PreReceive: func(_ context.Context, s storage.Storer, cmds []*packp.Command, _ io.Writer) error {
+					gotStore = s
+					seen = cmds
+					return nil
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Same(t, st, gotStore)
+	require.Len(t, seen, 1)
+	assert.Equal(t, ref, seen[0].Name)
+	assert.Equal(t, packp.Delete, seen[0].Action())
+	assert.Contains(t, out.String(), "ok refs/heads/main")
+}
+
+func TestReceivePackPreReceiveRejectsRef(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := seedRef(t, ref, hash)
+
+	postReceiveCalled := false
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, ref, hash),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{
+			StatelessRPC: true,
+			Hooks: &ReceivePackHooks{
+				PreReceive: func(context.Context, storage.Storer, []*packp.Command, io.Writer) error {
+					return errors.New("policy blocks main")
+				},
+				PostReceive: func(context.Context, storage.Storer, []*packp.Command) {
+					postReceiveCalled = true
+				},
+			},
+		},
+	)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "policy blocks main")
+
+	assert.Contains(t, out.String(), "unpack ok")
+	assert.Contains(t, out.String(), "ng refs/heads/main policy blocks main")
+	assert.False(t, postReceiveCalled, "PostReceive must not run when PreReceive rejects")
+
+	got, err := st.Reference(ref)
+	require.NoError(t, err)
+	assert.Equal(t, hash, got.Hash(), "ref must not move when PreReceive rejects")
+}
+
+func TestReceivePackPostReceiveRunsAfterUpdate(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := seedRef(t, ref, hash)
+
+	var (
+		out        bytes.Buffer
+		postCmds   []*packp.Command
+		refMissing bool
+	)
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, ref, hash),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{
+			StatelessRPC: true,
+			Hooks: &ReceivePackHooks{
+				PostReceive: func(_ context.Context, s storage.Storer, cmds []*packp.Command) {
+					postCmds = cmds
+					_, refErr := s.Reference(ref)
+					refMissing = errors.Is(refErr, plumbing.ErrReferenceNotFound)
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, postCmds, 1)
+	assert.Equal(t, ref, postCmds[0].Name)
+	assert.True(t, refMissing, "ref must be gone by the time PostReceive runs")
+}
+
+func TestReceivePackPreReceiveWritesProgressOnSideband(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := seedRef(t, ref, hash)
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, ref, hash, capability.Sideband64k),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{
+			StatelessRPC: true,
+			Hooks: &ReceivePackHooks{
+				PreReceive: func(_ context.Context, _ storage.Storer, _ []*packp.Command, progress io.Writer) error {
+					_, _ = io.WriteString(progress, "policy check passed\n")
+					return nil
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	demuxed := readSideband(t, &out)
+	assert.Contains(t, demuxed.progress.String(), "policy check passed")
+	assert.Contains(t, demuxed.data.String(), "ok refs/heads/main")
+}
+
+type sidebandPayload struct {
+	data     bytes.Buffer
+	progress bytes.Buffer
+}
+
+func readSideband(t *testing.T, r io.Reader) sidebandPayload {
+	t.Helper()
+	var p sidebandPayload
+	demux := sideband.NewDemuxer(sideband.Sideband64k, r)
+	demux.Progress = &p.progress
+	if _, err := io.Copy(&p.data, demux); err != nil && !errors.Is(err, io.EOF) {
+		require.NoError(t, err)
+	}
+	return p
+}


### PR DESCRIPTION
Refs #2185.

Adds an optional `Hooks` field to `ReceivePackRequest` so a server using `transport.ReceivePack` can run policy checks between unpack and ref update without reimplementing receive-pack on top of `packp.UpdateRequests` + `packfile.UpdateObjectStorage` + ref writes.

```go
type ReceivePackHooks struct {
    PreReceive  func(ctx context.Context, st storage.Storer, cmds []*packp.Command, progress io.Writer) error
    PostReceive func(ctx context.Context, st storage.Storer, cmds []*packp.Command)
}
```

`PreReceive` runs after the packfile is unpacked into the storer but before any ref is updated. Returning a non-nil error rejects every ref in the push with `err.Error()` as the report-status reason, mirroring git's pre-receive hook semantics. `PostReceive` runs after refs are updated.

`PreReceive` is given a progress writer. When the client negotiated `side-band` or `side-band-64k`, writes go to sideband band 2 so a hook can produce `remote:` lines for the client (rule names, principal lists, links to a policy page). Without sideband it is `io.Discard`.

This replaces the `// TODO: support hooks` marker. The per-ref `update` hook from #2185 is not included; the same shape can carry it later.

Motivation: this is what silo (a small forge that runs gittuf verification on the receive path) needs to drop its private receive-pack adapter. Branch protection, signed-commit checks, and any other policy that must inspect proposed updates after objects are available but before refs move now sits on `transport.ReceivePack` directly.

Tests cover nil hooks, allow path, reject path with `ng <ref> <reason>` in the report-status, that `PostReceive` does not run when `PreReceive` rejects, and that `PreReceive` progress writes are demultiplexable on sideband band 2.

AI disclosure: drafting and the test suite were assisted by Claude Opus 4.7. Every line is owned by me and was reviewed against the existing `transport.ReceivePack` flow before submission.