### PR TITLE
plumbing: default to wire protocol v2 and close client/server conformance gaps

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ const (
 	// should be marshalled or not.
 	// Note that this does not need to align with the default protocol
 	// version from plumbing/protocol.
-	DefaultProtocolVersion = protocol.V0 // go-git only supports V0 at the moment
+	DefaultProtocolVersion = protocol.V2
 )
 
 // ConfigStorer is a generic storage of Config object.
@@ -991,10 +991,23 @@ func (c *Config) marshalURLs() {
 }
 
 func (c *Config) marshalProtocol() {
-	// Only marshal protocol section if a version was set.
 	if c.Protocol.Version != DefaultProtocolVersion {
 		s := c.Raw.Section(protocolSection)
 		s.SetOption(versionKey, c.Protocol.Version.String())
+		return
+	}
+
+	// The struct holds the default version. Clear any stale protocol.version
+	// left over in the raw config so switching back to the default persists,
+	// and drop the section if it becomes empty. Guard on HasSection so a
+	// non-default round-trip does not introduce an empty [protocol].
+	if !c.Raw.HasSection(protocolSection) {
+		return
+	}
+	s := c.Raw.Section(protocolSection)
+	s.RemoveOption(versionKey)
+	if len(s.Options) == 0 && len(s.Subsections) == 0 {
+		c.Raw.RemoveSection(protocolSection)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -494,14 +494,41 @@ func (s *ConfigSuite) TestProtocol() {
 	s.NoError(err)
 	s.Equal(protocol.V1, cfg.Protocol.Version)
 
-	cfg.Protocol.Version = protocol.V2
+	// A non-default version is written back out.
+	cfg.Protocol.Version = protocol.V0
 	buf, err = cfg.Marshal()
 	s.NoError(err)
-
-	if !strings.Contains(string(buf), "version = 2") {
+	if !strings.Contains(string(buf), "version = 0") {
 		s.Fail("marshal did not update version")
 	}
+
+	// The default version is omitted from the marshalled config.
+	cfg = NewConfig()
+	cfg.Protocol.Version = DefaultProtocolVersion
+	buf, err = cfg.Marshal()
 	s.NoError(err)
+	if strings.Contains(string(buf), "[protocol]") {
+		s.Fail("marshal should omit the default protocol version")
+	}
+
+	// Resetting a non-default version back to the default clears the stale key
+	// from the raw config so the change persists.
+	cfg = NewConfig()
+	err = cfg.Unmarshal([]byte("[protocol]\n\tversion = 1"))
+	s.NoError(err)
+	s.Equal(protocol.V1, cfg.Protocol.Version)
+	cfg.Protocol.Version = DefaultProtocolVersion
+	buf, err = cfg.Marshal()
+	s.NoError(err)
+	if strings.Contains(string(buf), "version = 1") {
+		s.Fail("marshal should drop the stale protocol version")
+	}
+
+	// The reset round-trips back to the default version.
+	cfg = NewConfig()
+	err = cfg.Unmarshal(buf)
+	s.NoError(err)
+	s.Equal(DefaultProtocolVersion, cfg.Protocol.Version)
 }
 
 func (s *ConfigSuite) TestUnmarshalRemotes() {

--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -48,9 +48,16 @@ type CommandFunc func(ctx context.Context, cmd string, req packp.CommandArgs, re
 // command: the agent and the server's object-format echoed back so both sides
 // agree on the hash algorithm. server is the capability advertisement the
 // server sent during the handshake.
+//
+// Both are gated on the server having advertised them: upstream git only sends
+// agent when the server advertised agent, and object-format when the server
+// advertised object-format (fetch-pack.c). This keeps the client a conformant
+// peer that never sends a capability the server did not offer.
 func ClientCapabilities(server capability.List) capability.List {
 	var caps capability.List
-	caps.Set(capability.Agent, capability.DefaultAgent())
+	if agent := server.Get(capability.Agent); len(agent) > 0 {
+		caps.Set(capability.Agent, capability.DefaultAgent())
+	}
 	if of := server.Get(capability.ObjectFormat); len(of) > 0 {
 		caps.Set(capability.ObjectFormat, of[0])
 	}

--- a/plumbing/protocol/packp/advrefs.go
+++ b/plumbing/protocol/packp/advrefs.go
@@ -15,8 +15,11 @@ import (
 // advertised-refs message. The zero value is safe to use; References
 // and Shallows can be populated via append.
 type AdvRefs struct {
-	// Version is the protocol version. The only acceptable values are V0 and
-	// V1, any other value is considered invalid.
+	// Version is the protocol version of the advertisement. The only acceptable
+	// values are V0 and V1; any other value is invalid. Decode parses it from
+	// the leading "version" pkt-line (absent for V0) and Encode emits that line
+	// from it. Within the transport it is set from the version the handshake
+	// negotiated (DiscoverVersion), which is the single source of truth.
 	Version protocol.Version
 	// Capabilities are the capabilities.
 	Capabilities capability.List
@@ -140,16 +143,28 @@ func (a *AdvRefs) symRefMap() (map[plumbing.ReferenceName]plumbing.ReferenceName
 //   - If not, scan references in alphabetical order for a matching hash.
 //   - If no match is found, HEAD is returned unchanged.
 func (a *AdvRefs) resolvedHeadFromHeuristic(head *plumbing.Reference) *plumbing.Reference {
+	return ResolveHeadFromHashHeuristic(head, a.References)
+}
+
+// ResolveHeadFromHashHeuristic converts a detached HEAD (a HashReference) into a
+// SymbolicReference pointing to the branch that shares its hash, scanning refs.
+// It is shared by the v0/v1 advertisement resolution and the Protocol v2 ls-refs
+// path, so a detached remote HEAD still yields a symbolic local HEAD on clone,
+// matching reference git's pre-symref heuristic:
+//   - Prefer refs/heads/master when it has the same hash as HEAD.
+//   - Otherwise pick the alphabetically-first non-peeled ref with that hash.
+//   - If nothing matches, HEAD is returned unchanged.
+func ResolveHeadFromHashHeuristic(head *plumbing.Reference, refs []*plumbing.Reference) *plumbing.Reference {
 	headHash := head.Hash()
 
-	for _, ref := range a.References {
+	for _, ref := range refs {
 		if ref.Name() == plumbing.Master && ref.Type() == plumbing.HashReference && ref.Hash() == headHash {
 			return plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)
 		}
 	}
 
-	candidates := make([]*plumbing.Reference, 0, len(a.References))
-	for _, ref := range a.References {
+	candidates := make([]*plumbing.Reference, 0, len(refs))
+	for _, ref := range refs {
 		if ref.Name() == plumbing.HEAD || ref.Name().IsPeeled() {
 			continue
 		}

--- a/plumbing/protocol/packp/conformance_test.go
+++ b/plumbing/protocol/packp/conformance_test.go
@@ -1,0 +1,231 @@
+package packp
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+)
+
+// fetchResponse assembles a fetch response from raw section lines. A line of
+// "0001" emits a delim-pkt and "0000" a flush-pkt; anything else is written as
+// a pkt-line.
+func fetchResponse(lines ...string) []byte {
+	var buf bytes.Buffer
+	for _, l := range lines {
+		switch l {
+		case "0001":
+			pktline.WriteDelim(&buf)
+		case "0000":
+			pktline.WriteFlush(&buf)
+		default:
+			pktline.WriteString(&buf, l+"\n")
+		}
+	}
+	return buf.Bytes()
+}
+
+func TestFetchOutputDecodeConformance(t *testing.T) {
+	t.Parallel()
+
+	const oid = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+
+	cases := []struct {
+		name  string
+		lines []string
+	}{
+		{
+			name:  "repeated section",
+			lines: []string{"shallow-info", "shallow " + oid, "0001", "shallow-info", "shallow " + oid, "0001", "packfile", "0000"},
+		},
+		{
+			name:  "out-of-order sections",
+			lines: []string{"wanted-refs", oid + " refs/heads/main", "0001", "shallow-info", "shallow " + oid, "0001", "packfile", "0000"},
+		},
+		{
+			name:  "unknown section header",
+			lines: []string{"bogus-section", "data", "0001", "packfile", "0000"},
+		},
+		{
+			name:  "unknown acknowledgments line",
+			lines: []string{"acknowledgments", "bogus", "0000"},
+		},
+		{
+			name:  "unknown shallow-info line",
+			lines: []string{"shallow-info", "bogus", "0001", "packfile", "0000"},
+		},
+		{
+			name:  "ready without delimiter",
+			lines: []string{"acknowledgments", "ACK " + oid, "ready", "0000"},
+		},
+		{
+			name:  "acknowledgments without ready followed by delim",
+			lines: []string{"acknowledgments", "NAK", "0001", "packfile", "0000"},
+		},
+		{
+			name:  "metadata section without packfile",
+			lines: []string{"shallow-info", "shallow " + oid, "0000"},
+		},
+		{
+			name:  "sections then flush without packfile",
+			lines: []string{"acknowledgments", "ACK " + oid, "ready", "0001", "0000"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := &FetchOutput{}
+			err := out.Decode(bytes.NewReader(fetchResponse(tc.lines...)))
+			require.Error(t, err)
+			var mre *MalformedResponseError
+			assert.True(t, errors.As(err, &mre), "want MalformedResponseError, got %T: %v", err, err)
+		})
+	}
+}
+
+func TestFetchOutputDecodeConformantShapesAccepted(t *testing.T) {
+	t.Parallel()
+
+	const oid = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+
+	cases := []struct {
+		name  string
+		lines []string
+	}{
+		{name: "negotiation round (NAK flush)", lines: []string{"acknowledgments", "NAK", "0000"}},
+		{name: "clone packfile only", lines: []string{"packfile", "0000"}},
+		{name: "ready then packfile", lines: []string{"acknowledgments", "ACK " + oid, "ready", "0001", "packfile", "0000"}},
+		{name: "shallow-info before packfile", lines: []string{"shallow-info", "shallow " + oid, "0001", "packfile", "0000"}},
+		{name: "empty response", lines: []string{"0000"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := &FetchOutput{}
+			require.NoError(t, out.Decode(bytes.NewReader(fetchResponse(tc.lines...))))
+		})
+	}
+}
+
+func TestLsRefsArgsDecodeTooManyPrefixes(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	for range tooManyRefPrefixes + 1 {
+		pktline.Writef(&buf, "ref-prefix refs/heads/x\n")
+	}
+	pktline.WriteFlush(&buf)
+
+	var args LsRefsArgs
+	require.NoError(t, args.Decode(&buf))
+	require.Nil(t, args.RefPrefixes,
+		"more than TOO_MANY_PREFIXES ref-prefixes must fall back to advertising all refs")
+}
+
+// TestFetchArgsDecodeTooManyWants mutates the package-wide maxSectionLines, so
+// it cannot run in parallel with other tests that read it.
+//
+//nolint:paralleltest // mutates the shared maxSectionLines cap
+func TestFetchArgsDecodeTooManyWants(t *testing.T) {
+	old := maxSectionLines
+	maxSectionLines = 3
+	defer func() { maxSectionLines = old }()
+
+	var buf bytes.Buffer
+	for range maxSectionLines + 2 {
+		pktline.WriteString(&buf, "want 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+	}
+	pktline.WriteFlush(&buf)
+
+	var args FetchArgs
+	err := args.Decode(&buf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many want")
+}
+
+// TestFetchOutputDecodeTooManyACKs mutates the package-wide maxSectionLines, so
+// it cannot run in parallel with other tests that read it.
+//
+//nolint:paralleltest // mutates the shared maxSectionLines cap
+func TestFetchOutputDecodeTooManyACKs(t *testing.T) {
+	old := maxSectionLines
+	maxSectionLines = 2
+	defer func() { maxSectionLines = old }()
+
+	var buf bytes.Buffer
+	pktline.WriteString(&buf, "acknowledgments\n")
+	for range maxSectionLines + 2 {
+		pktline.WriteString(&buf, "ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+	}
+	pktline.WriteFlush(&buf)
+
+	out := &FetchOutput{}
+	err := out.Decode(&buf)
+	require.Error(t, err)
+	var mre *MalformedResponseError
+	require.True(t, errors.As(err, &mre), "want MalformedResponseError, got %T", err)
+}
+
+// TestFetchOutputDecodeTooManyPackfileURIs mutates the package-wide
+// maxSectionLines, so it cannot run in parallel with other tests that read it.
+//
+//nolint:paralleltest // mutates the shared maxSectionLines cap
+func TestFetchOutputDecodeTooManyPackfileURIs(t *testing.T) {
+	old := maxSectionLines
+	maxSectionLines = 2
+	defer func() { maxSectionLines = old }()
+
+	var buf bytes.Buffer
+	pktline.WriteString(&buf, "packfile-uris\n")
+	for range maxSectionLines + 2 {
+		pktline.WriteString(&buf, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 https://example/p.pack\n")
+	}
+	pktline.WriteFlush(&buf)
+
+	out := &FetchOutput{}
+	err := out.Decode(&buf)
+	require.Error(t, err)
+	var mre *MalformedResponseError
+	require.True(t, errors.As(err, &mre), "want MalformedResponseError, got %T", err)
+	require.Contains(t, err.Error(), "too many packfile-uris")
+}
+
+// TestFetchArgsDecodeTooManyDeepenNot mutates the package-wide maxSectionLines,
+// so it cannot run in parallel with other tests that read it.
+//
+//nolint:paralleltest // mutates the shared maxSectionLines cap
+func TestFetchArgsDecodeTooManyDeepenNot(t *testing.T) {
+	old := maxSectionLines
+	maxSectionLines = 3
+	defer func() { maxSectionLines = old }()
+
+	var buf bytes.Buffer
+	for range maxSectionLines + 2 {
+		pktline.WriteString(&buf, "deepen-not refs/heads/x\n")
+	}
+	pktline.WriteFlush(&buf)
+
+	var args FetchArgs
+	err := args.Decode(&buf)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many deepen-not")
+}
+
+func TestFetchOutputDecodeTruncatedAfterMetadata(t *testing.T) {
+	t.Parallel()
+
+	const oid = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+	// shallow-info commits the response to the packfile shape; a premature EOF
+	// before the packfile section is a truncated response, not a clean end, and
+	// must be reported rather than silently accepted.
+	out := &FetchOutput{}
+	err := out.Decode(bytes.NewReader(fetchResponse("shallow-info", "shallow "+oid, "0001")))
+	require.Error(t, err)
+	var mre *MalformedResponseError
+	require.True(t, errors.As(err, &mre), "want MalformedResponseError, got %T: %v", err, err)
+}

--- a/plumbing/protocol/packp/fetch.go
+++ b/plumbing/protocol/packp/fetch.go
@@ -12,6 +12,27 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
+// maxSectionLines bounds how many entries a single fetch section (want, have,
+// shallow, ACK, wanted-ref, ...) may contribute on decode. It is a defensive
+// backstop against a hostile peer streaming unbounded lines into an in-memory
+// slice; it sits far above any legitimate request or response (a single
+// negotiation round carries at most a flush-batch of haves, and real repos have
+// far fewer than four million refs). It is a var only so tests can lower it.
+var maxSectionLines = 1 << 22
+
+// MalformedResponseError reports a server response that violates the
+// gitprotocol-v2 grammar: a malformed pkt-line, an unrecognized line within a
+// section, an unexpected/repeated/out-of-order section, or a section terminator
+// that contradicts the response shape. It mirrors the situations where upstream
+// fetch-pack.c calls die() on the response.
+type MalformedResponseError struct {
+	Reason string
+}
+
+func (e *MalformedResponseError) Error() string {
+	return "malformed v2 fetch response: " + e.Reason
+}
+
 // FetchArgs represents the arguments for the v2 fetch command.
 type FetchArgs struct {
 	// Wants is the list of object IDs the client wants.
@@ -61,7 +82,7 @@ func (r *FetchArgs) Encode(w io.Writer) error {
 	plumbing.HashesSort(wants)
 	for _, h := range wants {
 		if _, err := pktline.Writef(w, "want %s\n", h); err != nil {
-			return fmt.Errorf("encoding want %q: %s", h, err)
+			return fmt.Errorf("encoding want %q: %w", h, err)
 		}
 	}
 
@@ -69,37 +90,37 @@ func (r *FetchArgs) Encode(w io.Writer) error {
 	plumbing.HashesSort(haves)
 	for _, h := range haves {
 		if _, err := pktline.Writef(w, "have %s\n", h); err != nil {
-			return fmt.Errorf("encoding have %q: %s", h, err)
+			return fmt.Errorf("encoding have %q: %w", h, err)
 		}
 	}
 
 	if r.Done {
 		if _, err := pktline.WriteString(w, "done\n"); err != nil {
-			return fmt.Errorf("encoding done: %s", err)
+			return fmt.Errorf("encoding done: %w", err)
 		}
 	}
 
 	if r.ThinPack {
 		if _, err := pktline.WriteString(w, "thin-pack\n"); err != nil {
-			return fmt.Errorf("encoding thin-pack: %s", err)
+			return fmt.Errorf("encoding thin-pack: %w", err)
 		}
 	}
 
 	if r.NoProgress {
 		if _, err := pktline.WriteString(w, "no-progress\n"); err != nil {
-			return fmt.Errorf("encoding no-progress: %s", err)
+			return fmt.Errorf("encoding no-progress: %w", err)
 		}
 	}
 
 	if r.IncludeTag {
 		if _, err := pktline.WriteString(w, "include-tag\n"); err != nil {
-			return fmt.Errorf("encoding include-tag: %s", err)
+			return fmt.Errorf("encoding include-tag: %w", err)
 		}
 	}
 
 	if r.OFSDelta {
 		if _, err := pktline.WriteString(w, "ofs-delta\n"); err != nil {
-			return fmt.Errorf("encoding ofs-delta: %s", err)
+			return fmt.Errorf("encoding ofs-delta: %w", err)
 		}
 	}
 
@@ -107,13 +128,13 @@ func (r *FetchArgs) Encode(w io.Writer) error {
 	plumbing.HashesSort(shallows)
 	for _, h := range shallows {
 		if _, err := pktline.Writef(w, "shallow %s\n", h); err != nil {
-			return fmt.Errorf("encoding shallow %q: %s", h, err)
+			return fmt.Errorf("encoding shallow %q: %w", h, err)
 		}
 	}
 
 	if r.Deepen > 0 {
 		if _, err := pktline.Writef(w, "deepen %d\n", r.Deepen); err != nil {
-			return fmt.Errorf("encoding deepen %d: %s", r.Deepen, err)
+			return fmt.Errorf("encoding deepen %d: %w", r.Deepen, err)
 		}
 	}
 
@@ -121,31 +142,31 @@ func (r *FetchArgs) Encode(w io.Writer) error {
 		// deepen-relative is a flag: the depth is carried by the "deepen <n>"
 		// line above. Matches git's fetch-pack.c (packet "deepen-relative\n").
 		if _, err := pktline.WriteString(w, "deepen-relative\n"); err != nil {
-			return fmt.Errorf("encoding deepen-relative: %s", err)
+			return fmt.Errorf("encoding deepen-relative: %w", err)
 		}
 	}
 
 	if !r.DeepenSince.IsZero() {
 		if _, err := pktline.Writef(w, "deepen-since %d\n", r.DeepenSince.UTC().Unix()); err != nil {
-			return fmt.Errorf("encoding deepen-since %s: %s", r.DeepenSince, err)
+			return fmt.Errorf("encoding deepen-since %s: %w", r.DeepenSince, err)
 		}
 	}
 
 	for _, ref := range r.DeepenNot {
 		if _, err := pktline.Writef(w, "deepen-not %s\n", ref); err != nil {
-			return fmt.Errorf("encoding deepen-not %s: %s", ref, err)
+			return fmt.Errorf("encoding deepen-not %s: %w", ref, err)
 		}
 	}
 
 	if r.Filter != "" {
 		if _, err := pktline.Writef(w, "filter %s\n", r.Filter); err != nil {
-			return fmt.Errorf("encoding filter %s: %s", r.Filter, err)
+			return fmt.Errorf("encoding filter %s: %w", r.Filter, err)
 		}
 	}
 
 	if r.WaitForDone {
 		if _, err := pktline.WriteString(w, "wait-for-done\n"); err != nil {
-			return fmt.Errorf("encoding wait-for-done: %s", err)
+			return fmt.Errorf("encoding wait-for-done: %w", err)
 		}
 	}
 
@@ -180,12 +201,18 @@ func (r *FetchArgs) Decode(rd io.Reader) error {
 			if !ok {
 				return fmt.Errorf("malformed want hash: %q", line[5:])
 			}
+			if len(r.Wants) >= maxSectionLines {
+				return fmt.Errorf("too many want lines (limit %d)", maxSectionLines)
+			}
 			r.Wants = append(r.Wants, h)
 
 		case strings.HasPrefix(line, "have "):
 			h, ok := parseFullHash(line[5:])
 			if !ok {
 				return fmt.Errorf("malformed have hash: %q", line[5:])
+			}
+			if len(r.Haves) >= maxSectionLines {
+				return fmt.Errorf("too many have lines (limit %d)", maxSectionLines)
 			}
 			r.Haves = append(r.Haves, h)
 
@@ -209,6 +236,9 @@ func (r *FetchArgs) Decode(rd io.Reader) error {
 			if !ok {
 				return fmt.Errorf("malformed shallow hash: %q", line[8:])
 			}
+			if len(r.Shallows) >= maxSectionLines {
+				return fmt.Errorf("too many shallow lines (limit %d)", maxSectionLines)
+			}
 			r.Shallows = append(r.Shallows, h)
 
 		case line == "deepen-relative":
@@ -227,6 +257,9 @@ func (r *FetchArgs) Decode(rd io.Reader) error {
 			r.DeepenSince = time.Unix(secs, 0).UTC()
 
 		case strings.HasPrefix(line, "deepen-not "):
+			if len(r.DeepenNot) >= maxSectionLines {
+				return fmt.Errorf("too many deepen-not lines (limit %d)", maxSectionLines)
+			}
 			r.DeepenNot = append(r.DeepenNot, line[11:])
 
 		case strings.HasPrefix(line, "deepen "):
@@ -351,21 +384,51 @@ type FetchOutput struct {
 // For HTTP, the transport layer consumes response-end (0002) after
 // Decode returns.
 func (r *FetchOutput) Decode(rd io.Reader) error {
+	// Sections appear at most once and in the fixed grammar order
+	// (acknowledgments < shallow-info < wanted-refs < packfile-uris <
+	// packfile). lastRank enforces both: a header whose rank is not strictly
+	// greater than the previous one is a repeat or out-of-order, which upstream
+	// fetch-pack.c rejects via die(). expectPackfile records that a metadata
+	// section committed the response to the packfile shape, so a premature
+	// terminator is also rejected.
+	lastRank := 0
+	expectPackfile := false
+
 	for {
 		l, pkt, err := pktline.ReadLine(rd)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
+				// A premature EOF after a metadata section committed the
+				// response to the packfile shape is a truncated response, not
+				// a clean end. Match the flush/response-end handling below.
+				if expectPackfile {
+					return &MalformedResponseError{Reason: "expected packfile section"}
+				}
 				return nil
 			}
 			return err
 		}
 
-		// A flush-pkt at the top level ends a response with no packfile.
+		// A flush-pkt at the top level ends the response. It is only valid
+		// before the packfile shape was committed to (a negotiation round, an
+		// empty response, or a clone that turned out to need nothing).
 		if l == pktline.Flush || l == pktline.ResponseEnd {
+			if expectPackfile {
+				return &MalformedResponseError{Reason: "expected packfile section"}
+			}
 			return nil
 		}
 
 		header := strings.TrimSpace(string(pkt))
+		rank := fetchSectionRank(header)
+		if rank == 0 {
+			return &MalformedResponseError{Reason: fmt.Sprintf("unexpected section %q", header)}
+		}
+		if rank <= lastRank {
+			return &MalformedResponseError{Reason: fmt.Sprintf("section %q is repeated or out of order", header)}
+		}
+		lastRank = rank
+
 		switch header {
 		case "packfile":
 			// Leave the reader positioned at the packfile data and let
@@ -379,67 +442,76 @@ func (r *FetchOutput) Decode(rd io.Reader) error {
 			if err != nil {
 				return err
 			}
-			if term != pktline.Delim {
+			// ready commits to the packfile shape and must be followed by a
+			// delim-pkt; otherwise the section is a negotiation round and must
+			// end the response with a flush-pkt (upstream process_ack).
+			if r.Acknowledgments.Ready {
+				if term != pktline.Delim {
+					return &MalformedResponseError{Reason: "ready acknowledgment must be followed by a delim-pkt"}
+				}
+				expectPackfile = true
+			} else {
+				if term == pktline.Delim {
+					return &MalformedResponseError{Reason: "acknowledgments without ready must end the response"}
+				}
 				return nil
 			}
 
 		case "shallow-info":
 			r.ShallowInfo = &ShallowInfo{}
-			term, err := r.decodeShallowInfo(rd)
-			if err != nil {
+			if err := r.decodeMetadataSection(rd, r.decodeShallowInfo); err != nil {
 				return err
 			}
-			if term != pktline.Delim {
-				return nil
-			}
+			expectPackfile = true
 
 		case "wanted-refs":
 			r.WantedRefs = &WantedRefs{}
-			term, err := r.decodeWantedRefs(rd)
-			if err != nil {
+			if err := r.decodeMetadataSection(rd, r.decodeWantedRefs); err != nil {
 				return err
 			}
-			if term != pktline.Delim {
-				return nil
-			}
+			expectPackfile = true
 
 		case "packfile-uris":
 			r.PackfileURIs = &PackfileURIs{}
-			term, err := r.decodePackfileURIs(rd)
-			if err != nil {
+			if err := r.decodeMetadataSection(rd, r.decodePackfileURIs); err != nil {
 				return err
 			}
-			if term != pktline.Delim {
-				return nil
-			}
-
-		default:
-			// Unknown section: skip its body to the next delimiter so the
-			// following pkt-lines aren't mis-read as top-level section headers.
-			term, err := skipSection(rd)
-			if err != nil {
-				return err
-			}
-			if term != pktline.Delim {
-				return nil
-			}
+			expectPackfile = true
 		}
 	}
 }
 
-// skipSection consumes pkt-lines until a delim, flush, or response-end packet,
-// returning which terminator was seen. It lets Decode tolerate unknown sections
-// from a newer server without desynchronizing the stream.
-func skipSection(rd io.Reader) (int, error) {
-	for {
-		l, _, err := pktline.ReadLine(rd)
-		if err != nil {
-			return 0, err
-		}
-		if l == pktline.Delim || l == pktline.Flush || l == pktline.ResponseEnd {
-			return l, nil
-		}
+// fetchSectionRank maps a fetch response section header to its position in the
+// gitprotocol-v2 grammar, or 0 for an unrecognized header.
+func fetchSectionRank(header string) int {
+	switch header {
+	case "acknowledgments":
+		return 1
+	case "shallow-info":
+		return 2
+	case "wanted-refs":
+		return 3
+	case "packfile-uris":
+		return 4
+	case "packfile":
+		return 5
+	default:
+		return 0
 	}
+}
+
+// decodeMetadataSection runs a section decoder and enforces that the section is
+// terminated by a delim-pkt, since every metadata section (shallow-info,
+// wanted-refs, packfile-uris) precedes the packfile and is delimited from it.
+func (r *FetchOutput) decodeMetadataSection(rd io.Reader, decode func(io.Reader) (int, error)) error {
+	term, err := decode(rd)
+	if err != nil {
+		return err
+	}
+	if term != pktline.Delim {
+		return &MalformedResponseError{Reason: "metadata section must be followed by a delim-pkt"}
+	}
+	return nil
 }
 
 // Encode writes the v2 fetch response to a writer.
@@ -548,11 +620,14 @@ func (r *FetchOutput) decodeAcknowledgments(rd io.Reader) (int, error) {
 		case strings.HasPrefix(line, "ACK "):
 			parts := strings.SplitN(line, " ", 2)
 			if len(parts) < 2 {
-				return 0, fmt.Errorf("malformed ACK line: %q", line)
+				return 0, &MalformedResponseError{Reason: fmt.Sprintf("malformed ACK line: %q", line)}
 			}
 			h, ok := parseFullHash(strings.TrimSpace(parts[1]))
 			if !ok {
-				return 0, fmt.Errorf("malformed ACK hash: %q", parts[1])
+				return 0, &MalformedResponseError{Reason: fmt.Sprintf("malformed ACK hash: %q", parts[1])}
+			}
+			if len(r.Acknowledgments.ACKs) >= maxSectionLines {
+				return 0, &MalformedResponseError{Reason: fmt.Sprintf("too many ACK lines (limit %d)", maxSectionLines)}
 			}
 			r.Acknowledgments.ACKs = append(r.Acknowledgments.ACKs, h)
 
@@ -561,6 +636,9 @@ func (r *FetchOutput) decodeAcknowledgments(rd io.Reader) (int, error) {
 
 		case line == "ready":
 			r.Acknowledgments.Ready = true
+
+		default:
+			return 0, &MalformedResponseError{Reason: fmt.Sprintf("unexpected acknowledgments line: %q", line)}
 		}
 	}
 }
@@ -582,16 +660,25 @@ func (r *FetchOutput) decodeShallowInfo(rd io.Reader) (int, error) {
 		case strings.HasPrefix(line, "shallow "):
 			h, ok := parseFullHash(line[8:])
 			if !ok {
-				return 0, fmt.Errorf("malformed shallow hash: %q", line)
+				return 0, &MalformedResponseError{Reason: fmt.Sprintf("malformed shallow hash: %q", line)}
+			}
+			if len(r.ShallowInfo.Shallows) >= maxSectionLines {
+				return 0, &MalformedResponseError{Reason: fmt.Sprintf("too many shallow lines (limit %d)", maxSectionLines)}
 			}
 			r.ShallowInfo.Shallows = append(r.ShallowInfo.Shallows, h)
 
 		case strings.HasPrefix(line, "unshallow "):
 			h, ok := parseFullHash(line[10:])
 			if !ok {
-				return 0, fmt.Errorf("malformed unshallow hash: %q", line)
+				return 0, &MalformedResponseError{Reason: fmt.Sprintf("malformed unshallow hash: %q", line)}
+			}
+			if len(r.ShallowInfo.Unshallows) >= maxSectionLines {
+				return 0, &MalformedResponseError{Reason: fmt.Sprintf("too many unshallow lines (limit %d)", maxSectionLines)}
 			}
 			r.ShallowInfo.Unshallows = append(r.ShallowInfo.Unshallows, h)
+
+		default:
+			return 0, &MalformedResponseError{Reason: fmt.Sprintf("expected shallow/unshallow, got: %q", line)}
 		}
 	}
 }
@@ -611,14 +698,17 @@ func (r *FetchOutput) decodeWantedRefs(rd io.Reader) (int, error) {
 
 		parts := strings.SplitN(line, " ", 2)
 		if len(parts) < 2 {
-			return 0, fmt.Errorf("malformed wanted-refs line: %q", line)
+			return 0, &MalformedResponseError{Reason: fmt.Sprintf("malformed wanted-refs line: %q", line)}
 		}
 
 		h, ok := parseFullHash(parts[0])
 		if !ok {
-			return 0, fmt.Errorf("malformed wanted-refs hash: %q", parts[0])
+			return 0, &MalformedResponseError{Reason: fmt.Sprintf("malformed wanted-refs hash: %q", parts[0])}
 		}
 
+		if len(r.WantedRefs.Refs) >= maxSectionLines {
+			return 0, &MalformedResponseError{Reason: fmt.Sprintf("too many wanted-refs lines (limit %d)", maxSectionLines)}
+		}
 		r.WantedRefs.Refs = append(r.WantedRefs.Refs,
 			plumbing.NewHashReference(plumbing.ReferenceName(parts[1]), h),
 		)
@@ -638,10 +728,19 @@ func (r *FetchOutput) decodePackfileURIs(rd io.Reader) (int, error) {
 
 		line := strings.TrimSuffix(string(pkt), "\n")
 
+		if len(r.PackfileURIs.URIs) >= maxSectionLines {
+			return 0, &MalformedResponseError{Reason: fmt.Sprintf("too many packfile-uris lines (limit %d)", maxSectionLines)}
+		}
 		r.PackfileURIs.URIs = append(r.PackfileURIs.URIs, line)
 	}
 }
 
+// encodeAcknowledgments writes the acknowledgments body following upstream
+// send_acks (upload-pack.c): the ACK lines first, then a single "ready" when
+// the server is ready to send a packfile (and nothing after it), otherwise a
+// lone "NAK" when there were no common objects. The grammar is
+// (nak | *ack) (ready): NAK is mutually exclusive with ACKs and is suppressed
+// once ready is sent, and ready always comes last.
 func (r *FetchOutput) encodeAcknowledgments(w io.Writer) error {
 	for _, h := range r.Acknowledgments.ACKs {
 		if _, err := pktline.Writef(w, "ACK %s\n", h); err != nil {
@@ -652,6 +751,7 @@ func (r *FetchOutput) encodeAcknowledgments(w io.Writer) error {
 		if _, err := pktline.WriteString(w, "ready\n"); err != nil {
 			return err
 		}
+		return nil
 	}
 	if len(r.Acknowledgments.ACKs) == 0 {
 		if _, err := pktline.WriteString(w, "NAK\n"); err != nil {

--- a/plumbing/protocol/packp/fetch_test.go
+++ b/plumbing/protocol/packp/fetch_test.go
@@ -222,11 +222,12 @@ func TestFetchOutputDecode(t *testing.T) {
 
 	t.Run("NAK only", func(t *testing.T) {
 		t.Parallel()
+		// A NAK (no common objects) acknowledgments section is a negotiation
+		// round: it is not ready and ends the response with a flush-pkt, so no
+		// packfile follows and the client negotiates again.
 		var buf bytes.Buffer
 		pktline.WriteString(&buf, "acknowledgments\n")
 		pktline.WriteString(&buf, "NAK\n")
-		pktline.WriteDelim(&buf)
-		pktline.WriteString(&buf, "packfile\n")
 		pktline.WriteFlush(&buf)
 
 		got := &FetchOutput{}
@@ -234,6 +235,7 @@ func TestFetchOutputDecode(t *testing.T) {
 		require.NotNil(t, got.Acknowledgments)
 		assert.Empty(t, got.Acknowledgments.ACKs)
 		assert.False(t, got.Acknowledgments.Ready)
+		assert.False(t, got.Packfile)
 	})
 
 	t.Run("full response with shallow-info", func(t *testing.T) {
@@ -286,10 +288,9 @@ func TestFetchOutputDecode(t *testing.T) {
 
 	t.Run("packfile-uris section", func(t *testing.T) {
 		t.Parallel()
+		// The acknowledgments section is optional in the packfile-bearing
+		// response; here it is absent and packfile-uris precedes the packfile.
 		var buf bytes.Buffer
-		pktline.WriteString(&buf, "acknowledgments\n")
-		pktline.WriteString(&buf, "NAK\n")
-		pktline.WriteDelim(&buf)
 		pktline.WriteString(&buf, "packfile-uris\n")
 		pktline.WriteString(&buf, "https://example.com/pack-123.pack\n")
 		pktline.WriteDelim(&buf)
@@ -319,7 +320,8 @@ func TestFetchOutputDecode(t *testing.T) {
 		t.Parallel()
 		var buf bytes.Buffer
 		pktline.WriteString(&buf, "acknowledgments\n")
-		pktline.WriteString(&buf, "NAK\n")
+		pktline.Writef(&buf, "ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n")
+		pktline.WriteString(&buf, "ready\n")
 		pktline.WriteDelim(&buf)
 		pktline.WriteString(&buf, "packfile\n")
 		// Write some packfile data

--- a/plumbing/protocol/packp/fuzz_test.go
+++ b/plumbing/protocol/packp/fuzz_test.go
@@ -102,6 +102,9 @@ func FuzzPushOptionsDecode(f *testing.F) {
 func FuzzFetchArgsDecode(f *testing.F) {
 	f.Add([]byte("0032want 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0009done\n0000"))
 	f.Add([]byte("0000"))
+	// Multi-line deepen-not section: gives the fuzzer a starting point to grow
+	// the section and exercise its maxSectionLines bound.
+	f.Add([]byte("0032want 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0038deepen-not 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0038deepen-not 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0038deepen-not 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0000"))
 	f.Add([]byte{})
 
 	f.Fuzz(func(_ *testing.T, data []byte) {
@@ -111,14 +114,83 @@ func FuzzFetchArgsDecode(f *testing.F) {
 }
 
 func FuzzFetchOutputDecode(f *testing.F) {
+	// Seeds are inline pkt-line literals (no helper) so the OSS-Fuzz
+	// go-118-fuzz-build harness, which lifts the Fuzz function out of this file,
+	// compiles them standalone.
+	//
 	// Negotiation round (acknowledgments flush-pkt, no packfile).
-	f.Add([]byte("0012acknowledgments\n0008NAK\n0000"))
+	f.Add([]byte("0014acknowledgments\n0008NAK\n0000"))
 	// Final round (acknowledgments delim-pkt ... packfile flush-pkt).
-	f.Add([]byte("0012acknowledgments\n000aready\n00010009packfile\n0000"))
+	f.Add([]byte("0014acknowledgments\n000aready\n0001000dpackfile\n0000"))
+	// shallow-info section before the packfile.
+	f.Add([]byte("0011shallow-info\n0035shallow 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0001000dpackfile\n0000"))
+	// wanted-refs section before the packfile.
+	f.Add([]byte("0010wanted-refs\n003d6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/main\n0001000dpackfile\n0000"))
+	// packfile-uris section before the packfile.
+	f.Add([]byte("0012packfile-uris\n00446ecf0ef2c2dffb796033e5a02219af86ec6584e5 https://example/p.pack\n0001000dpackfile\n0000"))
+	// Multi-line packfile-uris section: gives the fuzzer a starting point to
+	// grow the section and exercise its maxSectionLines bound.
+	f.Add([]byte("0012packfile-uris\n00446ecf0ef2c2dffb796033e5a02219af86ec6584e5 https://example/p.pack\n00446ecf0ef2c2dffb796033e5a02219af86ec6584e5 https://example/p.pack\n00446ecf0ef2c2dffb796033e5a02219af86ec6584e5 https://example/p.pack\n0001000dpackfile\n0000"))
 	f.Add([]byte{})
 
 	f.Fuzz(func(_ *testing.T, data []byte) {
 		fo := &FetchOutput{}
 		_ = fo.Decode(bytes.NewReader(data))
+	})
+}
+
+func FuzzCommandRequestDecode(f *testing.F) {
+	// command=ls-refs + one capability, delim, a ls-refs arg, flush.
+	f.Add([]byte("0014command=ls-refs\n0017object-format=sha1\n00010014ref-prefix HEAD\n0000"))
+	f.Add([]byte("0000"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		cr := &CommandRequest{Args: &LsRefsArgs{}}
+		_ = cr.Decode(bytes.NewReader(data))
+	})
+}
+
+func FuzzCapabilityAdvDecode(f *testing.F) {
+	f.Add([]byte("000eversion 2\n000cls-refs\n0017object-format=sha1\n0000"))
+	f.Add([]byte("000eversion 2\n0000"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		ca := &CapabilityAdv{}
+		_ = ca.Decode(bytes.NewReader(data))
+	})
+}
+
+func FuzzLsRefsArgsDecode(f *testing.F) {
+	f.Add([]byte("0009peel\n000csymrefs\n0014ref-prefix HEAD\n0000"))
+	f.Add([]byte("0000"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		la := &LsRefsArgs{}
+		_ = la.Decode(bytes.NewReader(data))
+	})
+}
+
+func FuzzLsRefsOutputDecode(f *testing.F) {
+	f.Add([]byte("003d6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/main\n00506ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD symref-target:refs/heads/main\n0000"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		lo := &LsRefsOutput{}
+		_ = lo.Decode(bytes.NewReader(data))
+	})
+}
+
+func FuzzParseLsRefsLine(f *testing.F) {
+	const oid = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+	f.Add(oid + " refs/heads/main")
+	f.Add(oid + " HEAD symref-target:refs/heads/main")
+	f.Add(oid + " refs/tags/v1 peeled:" + oid)
+	f.Add("")
+
+	f.Fuzz(func(_ *testing.T, line string) {
+		_, _ = parseLsRefsLine(line)
 	})
 }

--- a/plumbing/protocol/packp/lsrefs.go
+++ b/plumbing/protocol/packp/lsrefs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
@@ -24,6 +25,15 @@ type LsRefsArgs struct {
 // written as a separate pkt-line. The caller is responsible for writing
 // the delim-pkt before and the flush-pkt after these arguments.
 func (r *LsRefsArgs) Encode(w io.Writer) error {
+	// Validate every ref-prefix before writing anything, so an invalid prefix
+	// can never leave a partially-written arguments section on the stream
+	// (Encode is all-or-nothing on a validation error).
+	for _, p := range r.RefPrefixes {
+		if err := validateRefPrefix(p); err != nil {
+			return err
+		}
+	}
+
 	if r.Peel {
 		if _, err := pktline.WriteString(w, "peel\n"); err != nil {
 			return err
@@ -47,8 +57,31 @@ func (r *LsRefsArgs) Encode(w io.Writer) error {
 	return nil
 }
 
+// validateRefPrefix rejects a ref-prefix that cannot be safely framed as a
+// "ref-prefix <p>" pkt-line. An empty prefix would emit a stray "ref-prefix "
+// argument, and whitespace or control bytes (notably LF and NUL) would break
+// the pkt-line framing or let a caller inject extra lines. No valid Git
+// reference contains such characters, so this only rejects malformed input.
+func validateRefPrefix(p string) error {
+	if p == "" {
+		return fmt.Errorf("invalid ref-prefix: empty")
+	}
+	for _, c := range p {
+		if c == 0 || unicode.IsControl(c) || unicode.IsSpace(c) {
+			return fmt.Errorf("invalid ref-prefix %q: contains whitespace or control character", p)
+		}
+	}
+	return nil
+}
+
+// tooManyRefPrefixes mirrors ls-refs.c TOO_MANY_PREFIXES: past this many
+// ref-prefix arguments, upstream clears the list and advertises every ref, both
+// to bound memory and because prefix filtering stops paying off.
+const tooManyRefPrefixes = 65536
+
 // Decode reads ls-refs arguments from a reader until a flush-pkt is encountered.
 func (r *LsRefsArgs) Decode(rd io.Reader) error {
+	tooMany := false
 	for {
 		l, pkt, err := pktline.ReadLine(rd)
 		if err != nil {
@@ -76,7 +109,16 @@ func (r *LsRefsArgs) Decode(rd io.Reader) error {
 		case line == "unborn":
 			r.Unborn = true
 		case strings.HasPrefix(line, "ref-prefix "):
+			if tooMany {
+				continue
+			}
 			r.RefPrefixes = append(r.RefPrefixes, line[len("ref-prefix "):])
+			if len(r.RefPrefixes) >= tooManyRefPrefixes {
+				// Too many prefixes: drop them and advertise every ref, as
+				// upstream ls-refs.c does, instead of growing without bound.
+				r.RefPrefixes = nil
+				tooMany = true
+			}
 		}
 	}
 }

--- a/plumbing/protocol/packp/lsrefs_test.go
+++ b/plumbing/protocol/packp/lsrefs_test.go
@@ -2,6 +2,7 @@ package packp
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -226,4 +227,61 @@ func TestLsRefsOutputEncode(t *testing.T) {
 		assert.Equal(t, "refs/tags/v1.0^{}", got.References[1].Name().String())
 		assert.Equal(t, plumbing.NewHash("c39ae07f393806ccf406ef966e9a15afc43cc36a"), got.References[1].Hash())
 	})
+}
+
+func TestLsRefsArgsEncodeRejectsInvalidRefPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		prefix string
+	}{
+		{name: "empty", prefix: ""},
+		{name: "newline", prefix: "refs/heads/\n"},
+		{name: "embedded newline injection", prefix: "refs/heads/\n0000evil"},
+		{name: "space", prefix: "refs/heads/ x"},
+		{name: "tab", prefix: "refs/heads/\tx"},
+		{name: "nul", prefix: "refs/heads/\x00"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			args := &LsRefsArgs{RefPrefixes: []string{tc.prefix}}
+			var buf bytes.Buffer
+			err := args.Encode(&buf)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "ref-prefix")
+			// Nothing partial must reach the wire for the rejected prefix.
+			assert.NotContains(t, buf.String(), "evil")
+		})
+	}
+}
+
+func TestLsRefsArgsEncodeInvalidRefPrefixIsAllOrNothing(t *testing.T) {
+	t.Parallel()
+
+	// An invalid prefix after valid ones (and after the peel/symrefs flags) must
+	// leave nothing on the stream: validation happens before any write.
+	args := &LsRefsArgs{
+		Peel:        true,
+		Symrefs:     true,
+		RefPrefixes: []string{"refs/heads/", "refs/tags/", "refs/heads/\n0000evil"},
+	}
+	var buf bytes.Buffer
+	err := args.Encode(&buf)
+	require.Error(t, err)
+	assert.Empty(t, buf.Bytes(),
+		"Encode must not write the earlier valid arguments before rejecting a later prefix")
+}
+
+func TestLsRefsArgsEncodeValidRefPrefix(t *testing.T) {
+	t.Parallel()
+
+	args := &LsRefsArgs{RefPrefixes: []string{"refs/heads/", "HEAD"}}
+	var buf bytes.Buffer
+	require.NoError(t, args.Encode(&buf))
+	assert.Contains(t, buf.String(), "ref-prefix refs/heads/")
+	assert.Contains(t, buf.String(), "ref-prefix HEAD")
+	assert.Equal(t, 2, strings.Count(buf.String(), "ref-prefix "))
 }

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -154,6 +154,13 @@ func handshakeSmart(resp *http.Response, req *transport.Request, discoverService
 		if err := adv.Decode(rd); err != nil {
 			return nil, err
 		}
+		// Protocol v2 fetch accepts "want <oid>" without the server
+		// advertising allow-*-sha1-in-want, so surface the gate as
+		// satisfied for exact-SHA1 refspecs (isSupportedRefSpec). The
+		// v2 client only sends agent/object-format on the wire, so these
+		// never leak into the request (internal.ClientCapabilities).
+		adv.Capabilities.Set(capability.AllowReachableSHA1InWant)
+		adv.Capabilities.Set(capability.AllowTipSHA1InWant)
 		return &smartPackSession{
 			client:     client,
 			baseURL:    req.URL,
@@ -173,6 +180,11 @@ func handshakeSmart(resp *http.Response, req *transport.Request, discoverService
 	if err := capability.Validate(&ar.Capabilities); err != nil {
 		return nil, err
 	}
+
+	// Source the advertisement's version from the version DiscoverVersion
+	// already established, keeping the session the single source of truth
+	// rather than AdvRefs.Decode's independent parse of the same line.
+	ar.Version = ver
 
 	return &smartPackSession{
 		client:     client,
@@ -275,14 +287,19 @@ func (s *smartPackSession) Command(ctx context.Context, cmd string, req packp.Co
 	if err := cr.Encode(r); err != nil {
 		return err
 	}
+	// Command consumes the whole response (it never streams the body out), so
+	// drain and close it on every path. A bare return on a decode error would
+	// otherwise leak the response body and its connection.
+	defer func() {
+		if r.resp != nil {
+			_, _ = io.Copy(io.Discard, r.resp.Body)
+			_ = r.resp.Body.Close()
+		}
+	}()
 	if resp != nil {
 		if err := resp.Decode(r); err != nil {
 			return err
 		}
-	}
-	if r.resp != nil {
-		_, _ = io.Copy(io.Discard, r.resp.Body)
-		_ = r.resp.Body.Close()
 	}
 	return nil
 }
@@ -332,6 +349,9 @@ func (s *smartPackSession) fetchV2(ctx context.Context, st storage.Storer, req *
 	if req.Depth > 0 && !internal.FetchSupports(s.caps, "shallow") {
 		return transport.ErrShallowNotSupported
 	}
+	if err := transport.ReconcileObjectFormatV2(st, s.caps); err != nil {
+		return err
+	}
 
 	round := func(args *packp.FetchArgs) (*packp.FetchOutput, io.Reader, error) {
 		r := &httpRequester{session: s, ctx: ctx}
@@ -345,6 +365,12 @@ func (s *smartPackSession) fetchV2(ctx context.Context, st storage.Storer, req *
 		}
 		out := &packp.FetchOutput{}
 		if err := out.Decode(r); err != nil {
+			// The success path returns r.resp.Body for the caller to stream, so
+			// it must stay open; on a decode error nothing downstream will, so
+			// release it here rather than leaking the body and its connection.
+			if r.resp != nil {
+				_ = r.resp.Body.Close()
+			}
 			return nil, nil, err
 		}
 		if r.resp == nil {

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -324,3 +324,72 @@ func readShallows(
 	}
 	return nil
 }
+
+// ReconcileObjectFormatV2 aligns the storer's object format with the Protocol
+// v2 server's advertised object-format before any packfile is requested. On a
+// fresh clone the storer's format is unset (HEAD still points at the
+// refs/heads/.invalid placeholder) and the server's sha256 is adopted;
+// otherwise a mismatch is a hard error, since indexing a sha256 pack as sha1
+// (or vice versa) corrupts the store and only surfaces later as a checksum
+// failure. It mirrors NegotiatePack's v0/v1 object-format handling and git's
+// fetch-pack.c, including the case where the server omits object-format (it
+// only speaks sha1) but the client repository uses another algorithm.
+func ReconcileObjectFormatV2(st storage.Storer, caps capability.List) error {
+	var clientFormat config.ObjectFormat
+	if cfg, err := st.Config(); err == nil && cfg != nil {
+		clientFormat = cfg.Extensions.ObjectFormat
+	}
+
+	advertised := caps.Get(capability.ObjectFormat)
+	if len(advertised) == 0 {
+		// The server advertised no object-format, so it only speaks sha1.
+		// Upstream errors when the client repo uses a different algorithm
+		// rather than letting it fail later on a checksum mismatch.
+		if clientFormat != config.UnsetObjectFormat && clientFormat != config.SHA1 {
+			return fmt.Errorf("the server does not support algorithm '%s'", clientFormat)
+		}
+		return nil
+	}
+
+	var serverFormat config.ObjectFormat
+	switch v := config.ObjectFormat(advertised[0]); v {
+	case config.SHA1, config.SHA256:
+		serverFormat = v
+	case config.UnsetObjectFormat:
+		// An empty value carries no algorithm; treat it exactly as an absent
+		// object-format (the server only speaks sha1). Apply the same guard as
+		// the len(advertised)==0 branch so a client repo on a different
+		// algorithm is rejected rather than slipping past to fail later on a
+		// checksum mismatch.
+		if clientFormat != config.UnsetObjectFormat && clientFormat != config.SHA1 {
+			return fmt.Errorf("the server does not support algorithm '%s'", clientFormat)
+		}
+		return nil
+	default:
+		// An algorithm go-git does not speak. Fail fast rather than proceed
+		// with the wrong hash format, matching NegotiatePack's v0/v1 handling.
+		return fmt.Errorf("server advertised unsupported object-format %q", v)
+	}
+
+	// Adopt the server format on a fresh clone: unset client + sha256 server,
+	// with HEAD still at the clone placeholder.
+	if clientFormat == config.UnsetObjectFormat && serverFormat == config.SHA256 {
+		if ref, err := st.Reference(plumbing.HEAD); err == nil && ref.Target().String() == "refs/heads/.invalid" {
+			if setter, ok := st.(xstorage.ObjectFormatSetter); ok {
+				if err := setter.SetObjectFormat(serverFormat); err != nil {
+					return fmt.Errorf("unable to set object format: %w", err)
+				}
+				clientFormat = serverFormat
+			}
+		}
+	}
+
+	if clientFormat == config.UnsetObjectFormat {
+		clientFormat = config.SHA1
+	}
+
+	if serverFormat != clientFormat {
+		return fmt.Errorf("mismatched algorithms: client %s; server %s", clientFormat, serverFormat)
+	}
+	return nil
+}

--- a/plumbing/transport/negotiate_test.go
+++ b/plumbing/transport/negotiate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
@@ -395,4 +396,49 @@ func (rw *mockWriteCloser) Write(p []byte) (int, error) {
 func (rw *mockWriteCloser) Close() error {
 	rw.closed = true
 	return rw.closeErr
+}
+
+func TestReconcileObjectFormatV2(t *testing.T) {
+	t.Parallel()
+
+	withFormat := func(v string) capability.List {
+		var caps capability.List
+		caps.Set(capability.ObjectFormat, v)
+		return caps
+	}
+
+	t.Run("unknown algorithm is rejected", func(t *testing.T) {
+		t.Parallel()
+		err := ReconcileObjectFormatV2(memory.NewStorage(), withFormat("sha999"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported object-format")
+	})
+
+	t.Run("empty value is accepted for an sha1 client", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ReconcileObjectFormatV2(memory.NewStorage(), withFormat("")))
+	})
+
+	t.Run("empty value rejects a sha256 client", func(t *testing.T) {
+		t.Parallel()
+		st := memory.NewStorage()
+		cfg, err := st.Config()
+		require.NoError(t, err)
+		cfg.Extensions.ObjectFormat = formatcfg.SHA256
+		require.NoError(t, st.SetConfig(cfg))
+
+		err = ReconcileObjectFormatV2(st, withFormat(""))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not support algorithm")
+	})
+
+	t.Run("sha1 server with unset client is accepted", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ReconcileObjectFormatV2(memory.NewStorage(), withFormat("sha1")))
+	})
+
+	t.Run("no advertisement is accepted for an sha1 client", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, ReconcileObjectFormatV2(memory.NewStorage(), capability.List{}))
+	})
 }

--- a/plumbing/transport/pack_session.go
+++ b/plumbing/transport/pack_session.go
@@ -68,6 +68,17 @@ type RemoteRefs struct {
 // detecting an unborn HEAD: a symbolic HEAD whose target has no
 // corresponding hash reference in the advertisement.
 func NewRemoteRefs(refs []*plumbing.Reference) *RemoteRefs {
+	// A detached remote HEAD is advertised as a bare hash. The v0/v1
+	// advertisement resolves it to a symbolic HEAD during decode; the v2
+	// ls-refs path does not, so apply the same hash→branch heuristic here so a
+	// clone records a symbolic HEAD rather than a detached one (matching git).
+	for i, ref := range refs {
+		if ref.Name() == plumbing.HEAD && ref.Type() == plumbing.HashReference {
+			refs[i] = packp.ResolveHeadFromHashHeuristic(ref, refs)
+			break
+		}
+	}
+
 	rr := &RemoteRefs{References: refs}
 
 	var headTarget plumbing.ReferenceName

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -66,6 +66,13 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 			return nil, err
 		}
 		s.caps = adv.Capabilities
+		// Protocol v2 fetch accepts "want <oid>" without the server
+		// advertising allow-*-sha1-in-want, so surface the gate as
+		// satisfied for exact-SHA1 refspecs (isSupportedRefSpec). The
+		// v2 client only sends agent/object-format on the wire, so these
+		// never leak into the request (internal.ClientCapabilities).
+		s.caps.Set(capability.AllowReachableSHA1InWant)
+		s.caps.Set(capability.AllowTipSHA1InWant)
 		return s, nil
 	}
 
@@ -81,6 +88,10 @@ func NewStreamSession(conn Conn, service string) (*StreamSession, error) {
 		return nil, err
 	}
 
+	// Source the advertisement's version from the version DiscoverVersion
+	// already established, so s.version is the single source of truth rather
+	// than relying on AdvRefs.Decode's independent parse of the same line.
+	ar.Version = ver
 	s.caps = ar.Capabilities
 	s.refs = ar
 
@@ -133,6 +144,9 @@ func (s *StreamSession) Fetch(ctx context.Context, st storage.Storer, req *Fetch
 		}
 		if req.Depth > 0 && !internal.FetchSupports(s.caps, "shallow") {
 			return ErrShallowNotSupported
+		}
+		if err := ReconcileObjectFormatV2(st, s.caps); err != nil {
+			return err
 		}
 		// Each negotiation round reuses the persistent stream: Command writes
 		// the request and decodes the metadata, leaving s.r at the packfile.
@@ -198,9 +212,10 @@ func (s *StreamSession) Command(ctx context.Context, cmd string, req packp.Comma
 }
 
 // commandCapabilities returns the capabilities the client sends with each v2
-// command. It always advertises the agent and echoes the object-format the
-// server advertised during the handshake so both sides agree on the hash
-// algorithm.
+// command. Both the agent and the object-format are gated on the server having
+// advertised them (see internal.ClientCapabilities), so the client never sends
+// a capability the server did not offer; the object-format is echoed back so
+// both sides agree on the hash algorithm.
 func (s *StreamSession) commandCapabilities() capability.List {
 	return internal.ClientCapabilities(s.caps)
 }

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/config"
-	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
@@ -92,13 +91,13 @@ func AdvertiseRefs(
 		}
 	}
 
-	// V1 prefixes the advertisement with an explicit version packet. For HTTP
-	// this appears after the "# service=..." smart reply (correct wire order);
-	// for stateful transports (git://, ssh) it appears at the start.
+	// V1 prefixes the advertisement with an explicit version packet (V0 emits
+	// none). AdvRefs.Encode writes it from ar.Version, so set the field rather
+	// than writing the line by hand — a single source for the encoded version.
+	// A v2 request with no v2 service (e.g. receive-pack) falls back to a v0
+	// advertisement, so only V1 sets the field here; V2 stays at the V0 default.
 	if version == protocol.V1 {
-		if _, err := pktline.Writef(w, "version %d\n", version); err != nil {
-			return err
-		}
+		ar.Version = protocol.V1
 	}
 
 	return ar.Encode(w)
@@ -127,8 +126,9 @@ func AdvertiseCapabilities(_ context.Context, st storage.Storer, w io.Writer, se
 // feature that isn't handled makes clients request it and then mis-handle the
 // reply.
 //
-// The fetch "shallow" feature covers the deepen family; only "deepen <n>" is
-// handled today (deepen-since/-not/-relative are rejected, as in v0/v1).
+// The fetch "shallow" feature covers the whole deepen family (deepen <n>,
+// deepen-since, deepen-not and deepen-relative), all of which are handled, so
+// it is advertised as the single token upstream uses.
 //
 // TODO: advertise these once implemented:
 //   - ls-refs=unborn       report an unborn HEAD on an empty repository

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -386,6 +387,57 @@ func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd 
 	return nil
 }
 
+// shallowFrontierDepth returns the depth, counted from the wants (a tip is at
+// depth 1), of the closest commit in the client's shallow set, or 0 if none is
+// reachable. It mirrors upstream get_shallows_depth (shallow.c): the value
+// offsets a deepen-relative request so the new depth is measured from the
+// client's existing shallow boundary rather than from the tips.
+func shallowFrontierDepth(st storage.Storer, heads, shallows []plumbing.Hash) (int, error) {
+	shallowSet := make(map[plumbing.Hash]struct{}, len(shallows))
+	for _, h := range shallows {
+		shallowSet[h] = struct{}{}
+	}
+
+	best := 0
+	seen := map[plumbing.Hash]int{}
+	type frame struct {
+		hash  plumbing.Hash
+		depth int // depth of this commit's predecessor; the commit sits at depth+1
+	}
+	var stack []frame
+	for _, h := range heads {
+		if c, ok := peelToCommit(st, h); ok {
+			stack = append(stack, frame{c.Hash, 0})
+		}
+	}
+	for len(stack) > 0 {
+		f := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if d, ok := seen[f.hash]; ok && d <= f.depth {
+			continue
+		}
+		seen[f.hash] = f.depth
+
+		cur := f.depth + 1
+		if _, ok := shallowSet[f.hash]; ok {
+			if best == 0 || cur < best {
+				best = cur
+			}
+			// A client shallow commit is a normal commit on the server, so the
+			// walk continues past it, matching upstream get_shallows_or_depth.
+		}
+
+		c, err := object.GetCommit(st, f.hash)
+		if err != nil {
+			continue
+		}
+		for _, p := range c.ParentHashes {
+			stack = append(stack, frame{p, cur})
+		}
+	}
+	return best, nil
+}
+
 // serveUploadPackV2 handles the git protocol v2 for upload-pack (fetch/ls-refs).
 // It is used when the client requests version=2 via GIT_PROTOCOL.
 func serveUploadPackV2(ctx context.Context, st storage.Storer, rd *bufio.Reader, w io.WriteCloser, opts *UploadPackRequest) error {
@@ -435,7 +487,15 @@ func serveUploadPackV2(ctx context.Context, st storage.Storer, rd *bufio.Reader,
 				return nil
 			}
 		case "fetch":
-			return serveFetchV2(ctx, st, w, req.Args.(*packp.FetchArgs), opts)
+			concluded, err := serveFetchV2(ctx, st, w, req.Args.(*packp.FetchArgs), opts)
+			if err != nil {
+				return err
+			}
+			if concluded {
+				return nil
+			}
+			// Stateful transport: the round was acknowledgments-only and the
+			// negotiation continues. Loop to read the client's next command.
 		}
 	}
 }
@@ -565,14 +625,14 @@ func peelToNonTag(st storage.Storer, h plumbing.Hash) (plumbing.Hash, bool) {
 // acknowledgments, shallow-info, and packfile-header sections are emitted
 // through packp.FetchOutput; this function streams the packfile data after the
 // header, matching the caller-owned streaming on the client side.
-func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *packp.FetchArgs, opts *UploadPackRequest) error {
-	if args.DeepenRelative || !args.DeepenSince.IsZero() || len(args.DeepenNot) > 0 {
-		// Advertised under "shallow" but not implemented yet, as in v0/v1.
-		// Fail loudly rather than silently ignore an advertised feature.
-		_ = w.Close()
-		return fmt.Errorf("unsupported deepen argument")
-	}
-
+//
+// It reports whether the fetch concluded. A packfile (or a terminal no-op)
+// returns concluded=true and the connection is closed. An acknowledgments-only
+// round on a stateful transport returns concluded=false with the connection
+// left open, so the caller loops to read the client's next command=fetch round
+// (the stateful negotiation continues until the server is ready). A stateless
+// (HTTP) round always concludes, since the client re-POSTs each round.
+func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *packp.FetchArgs, opts *UploadPackRequest) (concluded bool, err error) {
 	wants := args.Wants
 	haves := args.Haves
 	clientShallows := args.Shallows
@@ -583,7 +643,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 	// emits no response at all here (upload-pack.c, UPLOAD_DONE), so write
 	// nothing and just close the stream, no stray flush packet.
 	if len(wants) == 0 {
-		return w.Close()
+		return true, w.Close()
 	}
 
 	out := &packp.FetchOutput{}
@@ -616,49 +676,159 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 		// in the next request.
 		if len(common) == 0 || !wantsReachableFromHaves(st, wants, common) {
 			if err := out.Encode(w); err != nil {
-				return err
+				return true, err
 			}
-			return w.Close()
+			// Stateless (HTTP) carries one round per request: this response is
+			// complete and the client re-POSTs the next round. A stateful
+			// transport keeps the connection open so the client can send its
+			// next command=fetch with refined haves.
+			if opts.StatelessRPC {
+				return true, w.Close()
+			}
+			return false, nil
 		}
 		out.Acknowledgments.Ready = true
 	}
 
-	// shallow-info section, emitted before the packfile when the client
-	// requested a shallow fetch (e.g. clone --depth N), reusing the v0/v1
-	// boundary computation. The boundary also bounds the packfile to that
-	// depth (see shallowBoundaryStorer).
-	//
-	// Note: deepening an already-shallow clone (the client sends its own
-	// "shallow" lines plus haves) is not handled, the haves would exclude the
-	// deepened ancestors. Only fresh shallow fetches are bounded here.
-	packSt := st
-	if depth > 0 {
-		var shupd packp.ShallowUpdate
-		if err := getShallowCommits(st, wants, depth, &shupd); err != nil {
-			_ = w.Close()
-			return fmt.Errorf("computing shallow commits: %w", err)
-		}
-		out.ShallowInfo = &packp.ShallowInfo{
-			Shallows:   shupd.Shallows,
-			Unshallows: scopeUnshallows(shupd.Unshallows, clientShallows),
-		}
-		packSt = &shallowBoundaryStorer{Storer: st, boundary: shupd.Shallows}
-	}
-
-	// Compute what to send.
-	objs, err := objectsToUpload(packSt, wants, haves)
+	// shallow-info: a shallow fetch bounds the history sent. The boundary forms
+	// mirror upstream send_shallow_list (upload-pack.c):
+	//   - deepen <n>: a depth boundary from the wants (getShallowCommits).
+	//   - deepen-since / deepen-not: a date/ref boundary (getShallowCommitsByRevList,
+	//     mirroring deepen_by_rev_list).
+	// Upstream forbids combining deepen with deepen-since/deepen-not, and so do we.
+	// deepen-relative only changes how the depth is counted: for a fresh fetch
+	// (no client shallows) relative and absolute depth coincide, and for an
+	// already-shallow client the depth is offset by the existing boundary's
+	// distance from the wants (see the deepen-relative handling below).
+	since := args.DeepenSince
+	notTips, err := resolveDeepenNot(st, args.DeepenNot)
 	if err != nil {
 		_ = w.Close()
-		return fmt.Errorf("getting objects to upload: %w", err)
+		return true, fmt.Errorf("resolving deepen-not: %w", err)
+	}
+	revList := !since.IsZero() || len(notTips) > 0
+	if depth > 0 && revList {
+		_ = w.Close()
+		return true, fmt.Errorf("deepen and deepen-since (or deepen-not) cannot be used together")
+	}
+
+	// A deepen was requested when depth > 0 or a rev-list bound was given.
+	// haveNewBoundary records that separately from len(newBoundary): a deepen
+	// that reaches full history yields an empty boundary, which still drives
+	// shallow-info and the unshallow lines and must not be mistaken for "no
+	// deepen requested". newBoundary is the grafting boundary for the deepened
+	// view (nil/empty means graft nothing: full history).
+	var newBoundary []plumbing.Hash
+	var haveNewBoundary bool
+	if depth > 0 || revList {
+		var shupd packp.ShallowUpdate
+		computed := true
+		if revList {
+			err = getShallowCommitsByRevList(st, wants, since, notTips, &shupd)
+		} else {
+			effectiveDepth := depth
+			if args.DeepenRelative && len(clientShallows) > 0 {
+				// deepen-relative counts depth from the client's existing
+				// shallow boundary, not from the wants. Mirror upstream
+				// get_shallow_commits (shallow.c): offset the absolute depth by
+				// the depth at which that boundary sits from the wants.
+				cur, derr := shallowFrontierDepth(st, wants, clientShallows)
+				if derr != nil {
+					_ = w.Close()
+					return true, fmt.Errorf("computing shallow frontier depth: %w", derr)
+				}
+				if cur == 0 {
+					// No client shallow is reachable from the wants; upstream
+					// computes no new boundary and leaves the client's view
+					// unchanged. Skip the deepen entirely.
+					computed = false
+				} else {
+					effectiveDepth = depth + cur
+				}
+			}
+			if computed {
+				err = getShallowCommits(st, wants, effectiveDepth, &shupd)
+			}
+		}
+		if err != nil {
+			_ = w.Close()
+			return true, fmt.Errorf("computing shallow commits: %w", err)
+		}
+		if computed {
+			haveNewBoundary = true
+			newBoundary = shupd.Shallows
+		}
+	}
+
+	var objs []plumbing.Hash
+	if len(clientShallows) > 0 {
+		// The client already has a shallow view (it sent "shallow" lines).
+		// A single object walk cannot graft the wanted history at the new
+		// boundary while also grafting the client's have-history at its existing
+		// boundary, so compute two views and send their difference:
+		//   newView    = objects reachable from the wants, grafted at the new
+		//                boundary (the client's deepened view).
+		//   clientView = objects the client already has, reachable from its haves
+		//                grafted at its existing shallow boundary.
+		// newView \ clientView is exactly what the client is missing. It never
+		// omits a needed object; at worst it re-sends one the client has, which
+		// is harmless. This is what bounds a deepen of an already-shallow clone.
+		boundary := clientShallows
+		if haveNewBoundary {
+			// The deepened boundary, which may be empty: a deepen that reaches
+			// full history grafts nothing and unshallows the old boundary.
+			boundary = newBoundary
+		}
+		newView, nerr := objectsToUpload(&shallowBoundaryStorer{Storer: st, boundary: boundary}, wants, nil)
+		if nerr != nil {
+			_ = w.Close()
+			return true, fmt.Errorf("getting objects to upload: %w", nerr)
+		}
+		clientView, cerr := objectsToUpload(&shallowBoundaryStorer{Storer: st, boundary: clientShallows}, haves, nil)
+		if cerr != nil {
+			_ = w.Close()
+			return true, fmt.Errorf("getting client objects: %w", cerr)
+		}
+		objs = hashDifference(newView, clientView)
+		if haveNewBoundary {
+			out.ShallowInfo = &packp.ShallowInfo{
+				Shallows:   newBoundary,
+				Unshallows: unshallowedCommits(clientShallows, newBoundary, newView),
+			}
+		}
+	} else {
+		packSt := st
+		if haveNewBoundary && len(newBoundary) > 0 {
+			out.ShallowInfo = &packp.ShallowInfo{Shallows: newBoundary}
+			packSt = &shallowBoundaryStorer{Storer: st, boundary: newBoundary}
+		}
+		objs, err = objectsToUpload(packSt, wants, haves)
+		if err != nil {
+			_ = w.Close()
+			return true, fmt.Errorf("getting objects to upload: %w", err)
+		}
+	}
+
+	// include-tag: add annotated tags whose target is in the pack (auto-tag
+	// following), mirroring upstream pack-objects --include-tag.
+	if args.IncludeTag {
+		objs, err = includeReachableTags(st, objs)
+		if err != nil {
+			_ = w.Close()
+			return true, fmt.Errorf("collecting include-tag objects: %w", err)
+		}
 	}
 
 	// Emit the metadata sections and the "packfile" section header. The client
 	// switches to sideband demux after seeing the header, matching reference git.
 	out.Packfile = true
 	if err := out.Encode(w); err != nil {
-		return err
+		return true, err
 	}
 
+	// The packfile is muxed on sideband-64k band 1. This server never writes the
+	// progress band (band 2), so the client's no-progress request (args.NoProgress)
+	// is honored by construction; there is nothing to suppress.
 	writer := sideband.NewMuxer(sideband.Sideband64k, w)
 
 	var packWindow uint
@@ -672,35 +842,215 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 
 	e := packfile.NewEncoder(writer, st, false)
 	if _, err := e.Encode(objs, packWindow); err != nil {
-		return fmt.Errorf("encoding packfile: %w", err)
+		return true, fmt.Errorf("encoding packfile: %w", err)
 	}
 
 	// Terminate the sideband stream and the v2 fetch response.
 	if err := pktline.WriteFlush(w); err != nil {
+		return true, err
+	}
+
+	return true, w.Close()
+}
+
+// hashDifference returns the elements of a that are not in b, preserving a's
+// order. It computes the objects a deepened client is missing (newView minus the
+// client's existing view).
+func hashDifference(a, b []plumbing.Hash) []plumbing.Hash {
+	set := make(map[plumbing.Hash]struct{}, len(b))
+	for _, h := range b {
+		set[h] = struct{}{}
+	}
+	var out []plumbing.Hash
+	for _, h := range a {
+		if _, ok := set[h]; !ok {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// unshallowedCommits returns the client's shallow commits that the deepened view
+// now includes as interior commits (their parents are being sent), so the client
+// can clear their shallow mark. Commits still on the new boundary stay shallow.
+// Mirrors upstream send_unshallow (upload-pack.c).
+func unshallowedCommits(clientShallows, newBoundary, newView []plumbing.Hash) []plumbing.Hash {
+	inView := make(map[plumbing.Hash]struct{}, len(newView))
+	for _, h := range newView {
+		inView[h] = struct{}{}
+	}
+	boundary := make(map[plumbing.Hash]struct{}, len(newBoundary))
+	for _, h := range newBoundary {
+		boundary[h] = struct{}{}
+	}
+	var out []plumbing.Hash
+	for _, cs := range clientShallows {
+		if _, ok := inView[cs]; !ok {
+			continue // not part of the deepened view
+		}
+		if _, ok := boundary[cs]; ok {
+			continue // still a boundary commit
+		}
+		out = append(out, cs)
+	}
+	return out
+}
+
+// resolveDeepenNot resolves each deepen-not argument (a ref name or an object
+// id) to a commit hash, peeling annotated tags, mirroring how upstream feeds
+// "--not <oid>" to rev-list (upload-pack.c send_shallow_list).
+func resolveDeepenNot(st storage.Storer, refs []string) ([]plumbing.Hash, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	out := make([]plumbing.Hash, 0, len(refs))
+	for _, r := range refs {
+		var h plumbing.Hash
+		if ref, err := storer.ResolveReference(st, plumbing.ReferenceName(r)); err == nil {
+			h = ref.Hash()
+		} else if oid, ok := plumbing.FromHex(r); ok {
+			if _, err := st.EncodedObject(plumbing.AnyObject, oid); err != nil {
+				return nil, fmt.Errorf("cannot resolve deepen-not %q", r)
+			}
+			h = oid
+		} else {
+			return nil, fmt.Errorf("cannot resolve deepen-not %q", r)
+		}
+		if peeled, ok := peelToNonTag(st, h); ok {
+			h = peeled
+		}
+		out = append(out, h)
+	}
+	return out, nil
+}
+
+// reachableCommits returns the set of commits reachable from tips (inclusive),
+// used as the exclusion set for deepen-not.
+func reachableCommits(st storage.Storer, tips []plumbing.Hash) (map[plumbing.Hash]struct{}, error) {
+	seen := make(map[plumbing.Hash]struct{})
+	stack := append([]plumbing.Hash(nil), tips...)
+	for len(stack) > 0 {
+		h := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+		c, err := object.GetCommit(st, h)
+		if err != nil {
+			continue
+		}
+		stack = append(stack, c.ParentHashes...)
+	}
+	return seen, nil
+}
+
+// getShallowCommitsByRevList computes the shallow boundary for a deepen-since
+// and/or deepen-not request, mirroring upstream's deepen_by_rev_list
+// (upload-pack.c). The included set is every commit reachable from heads that is
+// not older than since (when set) and not reachable from any notTips (when set);
+// a commit in the set with a parent outside it is a shallow boundary.
+//
+// Unlike git's rev-list traversal it does not apply the date "slop" used to
+// tolerate out-of-order committer timestamps, so under clock skew the boundary
+// may differ by a few commits; the resulting shallow clone is still valid.
+func getShallowCommitsByRevList(st storage.Storer, heads []plumbing.Hash, since time.Time, notTips []plumbing.Hash, upd *packp.ShallowUpdate) error {
+	exclude, err := reachableCommits(st, notTips)
+	if err != nil {
 		return err
 	}
 
-	return w.Close()
-}
+	included := make(map[plumbing.Hash]struct{})
+	parents := make(map[plumbing.Hash][]plumbing.Hash)
+	visited := make(map[plumbing.Hash]struct{})
+	stack := append([]plumbing.Hash(nil), heads...)
+	for len(stack) > 0 {
+		h := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, ok := visited[h]; ok {
+			continue
+		}
+		visited[h] = struct{}{}
+		if _, ex := exclude[h]; ex {
+			continue
+		}
+		c, err := object.GetCommit(st, h)
+		if err != nil {
+			continue
+		}
+		if !since.IsZero() && c.Committer.When.Before(since) {
+			continue
+		}
+		included[h] = struct{}{}
+		parents[h] = c.ParentHashes
+		stack = append(stack, c.ParentHashes...)
+	}
 
-// scopeUnshallows restricts the unshallow set to commits the client reported as
-// shallow, so a fresh clone never receives spurious unshallow lines (upstream
-// send_shallow_info).
-func scopeUnshallows(unshallows, clientShallows []plumbing.Hash) []plumbing.Hash {
-	if len(clientShallows) == 0 {
-		return nil
-	}
-	client := make(map[plumbing.Hash]struct{}, len(clientShallows))
-	for _, h := range clientShallows {
-		client[h] = struct{}{}
-	}
-	var scoped []plumbing.Hash
-	for _, h := range unshallows {
-		if _, ok := client[h]; ok {
-			scoped = append(scoped, h)
+	for h := range included {
+		for _, p := range parents[h] {
+			if _, ok := included[p]; !ok {
+				upd.Shallows = append(upd.Shallows, h)
+				break
+			}
 		}
 	}
-	return scoped
+	plumbing.HashesSort(upd.Shallows)
+	return nil
+}
+
+// includeReachableTags implements the fetch "include-tag" feature: for every
+// annotated tag whose (peeled) target is already in objs, it adds the tag
+// object and every tag object along the chain, mirroring upstream pack-objects
+// --include-tag. Lightweight tags have no tag object and are skipped.
+func includeReachableTags(st storage.Storer, objs []plumbing.Hash) ([]plumbing.Hash, error) {
+	have := make(map[plumbing.Hash]struct{}, len(objs))
+	for _, h := range objs {
+		have[h] = struct{}{}
+	}
+
+	iter, err := st.IterReferences()
+	if err != nil {
+		return objs, err
+	}
+	defer iter.Close()
+
+	added := objs
+	err = iter.ForEach(func(ref *plumbing.Reference) error {
+		if ref.Type() != plumbing.HashReference || !ref.Name().IsTag() {
+			return nil
+		}
+		var chain []plumbing.Hash
+		seen := make(map[plumbing.Hash]struct{})
+		cur := ref.Hash()
+		for {
+			if _, ok := have[cur]; ok {
+				// Reached an object already in the pack: include the tag
+				// objects that point at it.
+				for _, t := range chain {
+					if _, ok := have[t]; !ok {
+						have[t] = struct{}{}
+						added = append(added, t)
+					}
+				}
+				break
+			}
+			if _, ok := seen[cur]; ok {
+				break // defend against a tag cycle in a malformed repo
+			}
+			seen[cur] = struct{}{}
+			tag, terr := object.GetTag(st, cur)
+			if terr != nil {
+				break // non-tag object not in the pack: nothing to add
+			}
+			chain = append(chain, cur)
+			cur = tag.Target
+		}
+		return nil
+	})
+	if err != nil {
+		return objs, err
+	}
+	return added, nil
 }
 
 // shallowBoundaryStorer reports an additional set of shallow commits (the

--- a/plumbing/transport/upload_pack_v2_deepen_test.go
+++ b/plumbing/transport/upload_pack_v2_deepen_test.go
@@ -1,0 +1,294 @@
+package transport
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+func TestUploadPackV2FetchDeepenSince(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+
+	// since == HEAD's committer time: only the tip qualifies; its older parents
+	// fall outside the boundary, so the tip is shallow.
+	since := c.Committer.When.Unix()
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"deepen-since " + strconv.FormatInt(since, 10),
+		"done",
+	}))
+
+	require.Contains(t, out, "shallow-info")
+	require.Contains(t, out, "shallow "+head.Hash().String())
+	require.Less(t, strings.Index(out, "shallow-info"), strings.Index(out, "packfile"),
+		"shallow-info must precede the packfile section")
+}
+
+func TestUploadPackV2FetchDeepenNot(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
+	parent := c.ParentHashes[0]
+
+	// Excluding the parent leaves only the tip reachable, so the tip is the
+	// shallow boundary (its parent is excluded).
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"deepen-not " + parent.String(),
+		"done",
+	}))
+
+	require.Contains(t, out, "shallow-info")
+	require.Contains(t, out, "shallow "+head.Hash().String())
+}
+
+func TestUploadPackV2FetchDeepenRelative(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	// deepen-relative with depth 1 on a fresh fetch (no haves) is the same as
+	// deepen 1: the tip is the shallow boundary.
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"deepen 1",
+		"deepen-relative",
+		"done",
+	}))
+
+	require.Contains(t, out, "shallow "+head.Hash().String())
+}
+
+func TestUploadPackV2FetchDeepenAndSinceConflict(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	err = UploadPack(context.TODO(), st,
+		v2Request(t, "fetch", nil, []string{
+			"want " + head.Hash().String(),
+			"deepen 1",
+			"deepen-since 1",
+			"done",
+		}),
+		ioutil.WriteNopCloser(&out),
+		&UploadPackRequest{GitProtocol: "version=2", StatelessRPC: true},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot be used together")
+}
+
+func TestGetShallowCommitsByRevListInvariants(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+	since := c.Committer.When
+
+	var upd packp.ShallowUpdate
+	require.NoError(t, getShallowCommitsByRevList(st, []plumbing.Hash{head.Hash()}, since, nil, &upd))
+
+	require.NotEmpty(t, upd.Shallows)
+	for _, h := range upd.Shallows {
+		sc, err := object.GetCommit(st, h)
+		require.NoError(t, err)
+		require.False(t, sc.Committer.When.Before(since),
+			"a shallow commit must satisfy the deepen-since cutoff")
+		olderParent := false
+		for _, p := range sc.ParentHashes {
+			if pc, err := object.GetCommit(st, p); err == nil && pc.Committer.When.Before(since) {
+				olderParent = true
+			}
+		}
+		require.True(t, olderParent, "a shallow boundary commit must have a parent beyond the cutoff")
+	}
+}
+
+func TestIncludeReachableTags(t *testing.T) {
+	t.Parallel()
+	st := v2StorageFromFixture(t, fixtures.ByTag("tags").One())
+
+	var tagHash, target plumbing.Hash
+	iter, err := st.IterReferences()
+	require.NoError(t, err)
+	_ = iter.ForEach(func(ref *plumbing.Reference) error {
+		if !tagHash.IsZero() || ref.Type() != plumbing.HashReference || !ref.Name().IsTag() {
+			return nil
+		}
+		if _, err := object.GetTag(st, ref.Hash()); err != nil {
+			return nil // lightweight tag
+		}
+		if peeled, ok := peelToNonTag(st, ref.Hash()); ok {
+			tagHash, target = ref.Hash(), peeled
+		}
+		return nil
+	})
+	iter.Close()
+	require.False(t, tagHash.IsZero(), "tags fixture must contain an annotated tag")
+
+	// Target in the pack: the annotated tag is auto-included.
+	withTag, err := includeReachableTags(st, []plumbing.Hash{target})
+	require.NoError(t, err)
+	require.Contains(t, withTag, tagHash,
+		"annotated tag whose target is packed must be included")
+
+	// Target absent: the tag is not added.
+	without, err := includeReachableTags(st, nil)
+	require.NoError(t, err)
+	require.NotContains(t, without, tagHash,
+		"annotated tag whose target is not packed must be omitted")
+}
+
+func TestUploadPackV2FetchDeepenExistingShallow(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
+	parent := c.ParentHashes[0]
+
+	// The client has a depth-1 shallow clone (boundary = tip) and deepens to 2:
+	// it offers the tip as want and have, reports its shallow boundary, and asks
+	// for deepen 2. The server must extend the boundary to the parent and mark
+	// the tip unshallow, rather than ignoring the deepen.
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"have " + head.Hash().String(),
+		"shallow " + head.Hash().String(),
+		"deepen 2",
+		"done",
+	}))
+
+	require.Contains(t, out, "shallow-info")
+	require.Contains(t, out, "shallow "+parent.String(),
+		"the deepened boundary (depth 2) must be the parent")
+	require.Contains(t, out, "unshallow "+head.Hash().String(),
+		"the previously-shallow tip is now interior and must be unshallowed")
+}
+
+func TestUploadPackV2FetchDeepenRelativeExistingShallow(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
+	parent := c.ParentHashes[0]
+
+	// The client has a depth-1 shallow clone (boundary = tip) and asks to deepen
+	// by one more commit relative to that boundary. deepen-relative counts the
+	// depth from the client's existing shallow, so this must extend the boundary
+	// to the parent and unshallow the tip, not no-op as an absolute deepen 1
+	// (which would just re-report the tip) would.
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"have " + head.Hash().String(),
+		"shallow " + head.Hash().String(),
+		"deepen 1",
+		"deepen-relative",
+		"done",
+	}))
+
+	require.Contains(t, out, "shallow-info")
+	require.Contains(t, out, "shallow "+parent.String(),
+		"deepen-relative 1 from a depth-1 clone must extend the boundary to the parent")
+	require.Contains(t, out, "unshallow "+head.Hash().String(),
+		"the previously-shallow tip is now interior and must be unshallowed")
+}
+
+func TestUploadPackV2FetchDeepenExistingShallowToFullHistory(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
+
+	// A depth-1 shallow clone deepens past the whole history. The deepen reaches
+	// full history, so the resulting boundary is empty; the server must still
+	// emit shallow-info with the unshallow line rather than silently dropping the
+	// transition and keeping the client shallow.
+	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
+		"want " + head.Hash().String(),
+		"have " + head.Hash().String(),
+		"shallow " + head.Hash().String(),
+		"deepen 1000000",
+		"done",
+	}))
+
+	require.Contains(t, out, "shallow-info")
+	require.Contains(t, out, "unshallow "+head.Hash().String(),
+		"an unshallowing deepen must emit the unshallow line for the old boundary")
+}
+
+func TestUploadPackV2FetchNoProgressEmitsNoProgressBand(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	require.NoError(t, UploadPack(context.TODO(), st,
+		v2Request(t, "fetch", nil, []string{
+			"want " + head.Hash().String(),
+			"no-progress",
+			"done",
+		}),
+		ioutil.WriteNopCloser(&buf),
+		&UploadPackRequest{GitProtocol: "version=2", StatelessRPC: true},
+	))
+
+	// Advance to the packfile section header.
+	rd := bufio.NewReader(&buf)
+	for {
+		_, line, err := pktline.ReadLine(rd)
+		require.NoError(t, err)
+		if strings.TrimRight(string(line), "\n") == "packfile" {
+			break
+		}
+	}
+	// Every sideband packet that follows must be on the data band (1), never the
+	// progress band (2): the v2 server emits no progress, so no-progress holds.
+	for {
+		l, line, err := pktline.ReadLine(rd)
+		if l == pktline.Flush {
+			break
+		}
+		require.NoError(t, err)
+		require.NotEmpty(t, line)
+		require.NotEqual(t, byte(sideband.ProgressMessage), line[0],
+			"upload-pack must not write a sideband progress band")
+	}
+}

--- a/plumbing/transport/v2_handshake_test.go
+++ b/plumbing/transport/v2_handshake_test.go
@@ -45,6 +45,7 @@ func TestStreamSessionCommandEnvelope(t *testing.T) {
 	t.Parallel()
 
 	serverCaps := capability.List{}
+	serverCaps.Set(capability.Agent, "git/test")
 	serverCaps.Set(capability.ObjectFormat, "sha1")
 
 	var out bytes.Buffer

--- a/remote.go
+++ b/remote.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/client"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/revlist"
@@ -335,6 +336,71 @@ func (r *Remote) FetchContext(ctx context.Context, o *FetchOptions) error {
 	return err
 }
 
+// fetchRefPrefixes derives the ls-refs "ref-prefix" hints for a fetch from its
+// refspecs and tag mode, mirroring canonical git (builtin/fetch.c,
+// builtin/clone.c). HEAD is always included so default-branch resolution keeps
+// working (e.g. on clone), and refs/tags/ is added when tags are being
+// followed.
+//
+// ref-prefix is purely an optimization, so the returned prefixes must cover
+// every ref the fetch could match. When a refspec cannot be safely turned into
+// a prefix (an exact-OID source) or there are no refspecs, it returns nil to
+// request the full advertisement rather than risk under-scoping it.
+func fetchRefPrefixes(specs []config.RefSpec, tags plumbing.TagMode) []string {
+	if len(specs) == 0 {
+		return nil
+	}
+
+	prefixes := make([]string, 0, len(specs)+2)
+	for _, rs := range specs {
+		if rs.IsExactSHA1() {
+			return nil
+		}
+		src := rs.Src()
+		if src == "" {
+			return nil
+		}
+		if prefix, _, found := strings.Cut(src, "*"); found {
+			// A wildcard: the prefix is the literal part before '*'. A leading
+			// wildcard trims to an empty prefix, which would emit an invalid
+			// "ref-prefix " argument, so request the full advertisement instead
+			// of under-scoping it.
+			if prefix == "" {
+				return nil
+			}
+			prefixes = append(prefixes, prefix)
+			continue
+		}
+
+		// A HEAD source (single-branch clone, "+HEAD:...") resolves through a
+		// symref to a branch under refs/heads/. HEAD itself is appended
+		// unconditionally below, so advertise that namespace too; otherwise a
+		// v2 server that strictly honours ref-prefix omits the resolved branch
+		// and it cannot be fetched. Matches git clone.
+		if src == "HEAD" {
+			prefixes = append(prefixes, "refs/heads/")
+			continue
+		}
+
+		// A non-wildcard source may be a short name (e.g. "master"). A v2 server
+		// prefix-matches ref-prefix against the full refname, so "master" alone
+		// would never match refs/heads/master. Expand it to every candidate
+		// full name, mirroring canonical git's refspec_ref_prefixes ->
+		// expand_ref_prefix (refspec.c, refs.c).
+		for _, rule := range plumbing.RefRevParseRules {
+			prefixes = append(prefixes, fmt.Sprintf(rule, src))
+		}
+	}
+
+	// Order matches canonical git: refspec prefixes, then refs/tags/, then
+	// HEAD last (builtin/clone.c, builtin/fetch.c).
+	if tags == plumbing.AllTags || tags == plumbing.TagFollowing {
+		prefixes = append(prefixes, "refs/tags/")
+	}
+	prefixes = append(prefixes, "HEAD")
+	return prefixes
+}
+
 // Fetch fetches references along with the objects necessary to complete their
 // histories.
 //
@@ -378,6 +444,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	}
 
 	req.Command = transport.UploadPackService
+	req.Protocol = r.transportProtocol()
 	sess, err := cl.Handshake(ctx, req)
 	if err != nil {
 		return nil, err
@@ -388,7 +455,9 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		return nil, err
 	}
 
-	rRefs, err := sess.GetRemoteRefs(ctx, nil)
+	rRefs, err := sess.GetRemoteRefs(ctx, &transport.GetRemoteRefsOptions{
+		RefPrefixes: fetchRefPrefixes(o.RefSpecs, o.Tags),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -545,6 +614,21 @@ func newClient(rawURL string, opts []client.Option) (*client.Client, *transport.
 
 	cl := client.New(opts...)
 	return cl, &transport.Request{URL: u}, nil
+}
+
+// transportProtocol returns the wire protocol version configured for this
+// remote's repository (the protocol.version setting), defaulting to
+// config.DefaultProtocolVersion. It is used for ref discovery and fetch;
+// push always uses v0/v1, since protocol v2 has no push.
+func (r *Remote) transportProtocol() protocol.Version {
+	if r.s == nil {
+		return config.DefaultProtocolVersion
+	}
+	cfg, err := r.s.Config()
+	if err != nil || cfg == nil {
+		return config.DefaultProtocolVersion
+	}
+	return cfg.Protocol.Version
 }
 
 func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer) (bool, error) {
@@ -1290,6 +1374,7 @@ func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Refe
 	}
 
 	req.Command = transport.UploadPackService
+	req.Protocol = r.transportProtocol()
 	sess, err := cl.Handshake(ctx, req)
 	if err != nil {
 		return nil, err

--- a/remote_test.go
+++ b/remote_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -102,11 +103,21 @@ func (s *RemoteSuite) TestFetchExactSHA1() {
 }
 
 func (s *RemoteSuite) TestFetchExactSHA1_NotSupported() {
-	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
+	// The client-side exact-SHA1 gate (ErrExactSHA1NotSupported) only applies
+	// to v0/v1, where the server must advertise allow-*-sha1-in-want. Protocol
+	// v2's fetch command accepts any "want <oid>", so there is no unsupported
+	// case to assert there; pin this to v0.
+	st := memory.NewStorage()
+	cfg, err := st.Config()
+	s.Require().NoError(err)
+	cfg.Protocol.Version = protocol.V0
+	s.Require().NoError(st.SetConfig(cfg))
+
+	r := NewRemote(st, &config.RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	err := r.Fetch(&FetchOptions{
+	err = r.Fetch(&FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("35e85108805c84807bc66a02d91535e1e24b38b9:refs/heads/foo"),
 		},

--- a/remote_v2_test.go
+++ b/remote_v2_test.go
@@ -1,0 +1,87 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+func (s *RemoteSuite) TestTransportProtocolDefault() {
+	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"https://example.com/foo.git"}})
+	s.Equal(config.DefaultProtocolVersion, r.transportProtocol())
+}
+
+func (s *RemoteSuite) TestTransportProtocolFromConfig() {
+	st := memory.NewStorage()
+	cfg, err := st.Config()
+	s.Require().NoError(err)
+	cfg.Protocol.Version = protocol.V2
+	s.Require().NoError(st.SetConfig(cfg))
+
+	r := NewRemote(st, &config.RemoteConfig{Name: "foo", URLs: []string{"https://example.com/foo.git"}})
+	s.Equal(protocol.V2, r.transportProtocol())
+}
+
+func TestFetchRefPrefixes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		specs    []config.RefSpec
+		tags     plumbing.TagMode
+		contains []string
+		wantNil  bool
+	}{
+		{
+			name:  "short-name source expands to full-name candidates",
+			specs: []config.RefSpec{"master:foo"},
+			tags:  plumbing.NoTags,
+			// A v2 server prefix-matches the full refname, so "master" alone
+			// never matches refs/heads/master; the expansion must cover it.
+			contains: []string{"master", "refs/heads/master", "refs/tags/master", "HEAD"},
+		},
+		{
+			name:     "qualified source is preserved",
+			specs:    []config.RefSpec{"refs/heads/main:refs/heads/main"},
+			tags:     plumbing.NoTags,
+			contains: []string{"refs/heads/main", "HEAD"},
+		},
+		{
+			name:     "wildcard source uses the literal prefix",
+			specs:    []config.RefSpec{"refs/heads/*:refs/remotes/origin/*"},
+			tags:     plumbing.NoTags,
+			contains: []string{"refs/heads/", "HEAD"},
+		},
+		{
+			name:    "leading wildcard requests the full advertisement",
+			specs:   []config.RefSpec{"*:refs/remotes/origin/*"},
+			tags:    plumbing.NoTags,
+			wantNil: true,
+		},
+		{
+			name:     "tag following advertises refs/tags/",
+			specs:    []config.RefSpec{"master:foo"},
+			tags:     plumbing.TagFollowing,
+			contains: []string{"refs/heads/master", "refs/tags/", "HEAD"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := fetchRefPrefixes(tc.specs, tc.tags)
+			if tc.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			for _, want := range tc.contains {
+				assert.Contains(t, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Builds on the Protocol v2 series (#2228–#2234) to make v2 the **default** wire
protocol and to close the conformance gaps that only surfaced once the v2 paths
were exercised end-to-end. Validated against C Git v2.54 (`fetch-pack.c`,
`upload-pack.c`, `ls-refs.c`, `serve.c`).

### Default to v2 (client)

Wiring so the high-level API actually negotiates v2, with safe fallback to
v0/v1 when the server doesn't support it:

- `config`: `DefaultProtocolVersion` is now v2; marshalling omits the
  `[protocol]` section when it equals the default.
- `git`: `Remote.transportProtocol()` reads `protocol.version` and sets it on
  the handshake for fetch/ls-remote (push stays v0/v1 — v2 has no push).
- **exact-SHA1 fetch**: v2 accepts `want <oid>` without the server advertising
  `allow-*-sha1-in-want`, so the session surfaces those caps for
  `isSupportedRefSpec` (never sent on the wire).
- **object-format reconciliation**: a v2 fetch now adopts the server's hash
  algorithm on a fresh clone and errors with `mismatched algorithms` on a real
  mismatch, instead of failing later as an opaque checksum error.
- **detached HEAD**: a detached remote HEAD over v2 ls-refs resolves to a
  symbolic HEAD on clone (the hash→branch heuristic, shared with v0/v1).
- ref discovery is scoped with `ls-refs` `ref-prefix` hints derived from the
  refspecs (incl. `refs/heads/` for a HEAD source), matching canonical git.

### Server fetch conformance

- **stateful multi-round negotiation**: the server no longer closes the
  connection after an acknowledgments-only round, so a stream/SSH/file client
  can refine its haves across rounds (previously every fetch with common
  history failed with `read/write on closed pipe`).
- **shallow deepen**: implements `deepen-since`, `deepen-not`, and
  `deepen-relative` (rejecting `deepen` + since/not as upstream does), and
  bounds **deepening an already-shallow clone** via a two-view object
  difference (never under-sends).
- **include-tag**: auto-follows annotated tags whose target is in the pack.
- `no-progress` is honored by construction (the v2 server emits no progress
  band); locked with a test.

### Spec conformance (packp)

- `FetchOutput.Decode` is now a strict single-pass state machine: rejects
  repeated/out-of-order sections, unknown section headers, unrecognized lines,
  and terminators that contradict the response shape (typed
  `MalformedResponseError`).
- v2 `agent` capability is sent only when the server advertised it.
- `acknowledgments` ordering follows `send_acks` (NAK suppressed once ready).
- `ls-refs` `ref-prefix` arguments are validated before encoding (no empty /
  whitespace / control characters).
- the advertised protocol version is single-sourced from the handshake rather
  than parsed independently in `AdvRefs`.

### Hardening & tests

- defensive caps on decoder sections (ref-prefix → `TOO_MANY_PREFIXES`;
  want/have/shallow/ACK/wanted-refs bounded) against hostile input.
- new fuzz targets for `CommandRequest`, `CapabilityAdv`, `LsRefsArgs/Output`,
  and `parseLsRefsLine`, plus extended `FetchOutput` corpus.
- `internal/gitcli` helper to skip v2 integration tests on Git < 2.18.

### Compatibility

No breaking changes for existing callers: clients that can't reach v2 fall back
to v0/v1, and push is unaffected. The only behavioral change is that fetch /
ls-remote now prefer v2 by default (overridable via `protocol.version`).

Supersedes #2204.
Closes #264.