### PR TITLE
plumbing/format/diff: use git's funcname heuristic for hunk context

### DIFF
--- a/plumbing/format/diff/unified_encoder.go
+++ b/plumbing/format/diff/unified_encoder.go
@@ -179,6 +179,7 @@ type hunksGenerator struct {
 	current                     *hunk
 	hunks                       []*hunk
 	beforeContext, afterContext []string
+	funcName                    string
 }
 
 func newHunksGenerator(chunks []Chunk, ctxLines int) *hunksGenerator {
@@ -228,15 +229,14 @@ func (g *hunksGenerator) processHunk(i int, op Operation) {
 		return
 	}
 
-	var ctxPrefix string
 	linesBefore := len(g.beforeContext)
 	if linesBefore > g.ctxLines {
-		ctxPrefix = g.beforeContext[linesBefore-g.ctxLines-1]
+		g.funcName = g.findFuncName(linesBefore-g.ctxLines-1, g.funcName)
 		g.beforeContext = g.beforeContext[linesBefore-g.ctxLines:]
 		linesBefore = g.ctxLines
 	}
 
-	g.current = &hunk{ctxPrefix: strings.TrimSuffix(ctxPrefix, "\n")}
+	g.current = &hunk{ctxPrefix: strings.TrimSuffix(g.funcName, "\n")}
 	g.current.AddOp(Equal, g.beforeContext...)
 
 	switch op {
@@ -247,6 +247,28 @@ func (g *hunksGenerator) processHunk(i int, op Operation) {
 	}
 
 	g.beforeContext = nil
+}
+
+// findFuncName searches g.beforeContext backwards from idx for a line that
+// looks like a function or section header, matching git's default heuristic
+// (a line starting with a letter, '_' or '$'). If none is found, prev is kept,
+// so a hunk keeps the enclosing header found before an earlier hunk.
+func (g *hunksGenerator) findFuncName(idx int, prev string) string {
+	for i := idx; i >= 0; i-- {
+		if line := g.beforeContext[i]; isFuncLine(line) {
+			return line
+		}
+	}
+	return prev
+}
+
+func isFuncLine(line string) bool {
+	if line == "" {
+		return false
+	}
+	c := line[0]
+	return c == '_' || c == '$' ||
+		('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
 }
 
 // addLineNumbers obtains the line numbers in a new chunk.

--- a/plumbing/format/diff/unified_encoder_test.go
+++ b/plumbing/format/diff/unified_encoder_test.go
@@ -186,6 +186,50 @@ var oneChunkPatchInverted Patch = testPatch{
 	}},
 }
 
+// funcContextPatch deletes two lines from the body of a C function whose
+// opening brace sits on its own line. Every other fixture here uses one-letter
+// context lines, which all satisfy the funcname heuristic, so they cannot tell
+// "the line just above the context window" apart from "the nearest enclosing
+// header": the first hunk's preceding line is "{" and the second hunk is
+// preceded only by indented statements. Cross-checked against
+// `git diff -U2`, which labels both hunks "int main(void)".
+var funcContextPatch Patch = testPatch{
+	message: "",
+	filePatches: []testFilePatch{{
+		from: &testFile{
+			mode: filemode.Regular,
+			path: "main.c",
+			seed: "int main(void)\n{\n\tint a = 1;\n\tint b = 2;\n\tint old1 = 3;\n" +
+				"\tint c = 4;\n\tint d = 5;\n\tint e = 6;\n\tint f = 7;\n\tint g = 8;\n" +
+				"\tint old2 = 9;\n\tint h = 10;\n\tint i = 11;\n}\n",
+		},
+		to: &testFile{
+			mode: filemode.Regular,
+			path: "main.c",
+			seed: "int main(void)\n{\n\tint a = 1;\n\tint b = 2;\n" +
+				"\tint c = 4;\n\tint d = 5;\n\tint e = 6;\n\tint f = 7;\n\tint g = 8;\n" +
+				"\tint h = 10;\n\tint i = 11;\n}\n",
+		},
+
+		chunks: []testChunk{{
+			content: "int main(void)\n{\n\tint a = 1;\n\tint b = 2;\n",
+			op:      Equal,
+		}, {
+			content: "\tint old1 = 3;\n",
+			op:      Delete,
+		}, {
+			content: "\tint c = 4;\n\tint d = 5;\n\tint e = 6;\n\tint f = 7;\n\tint g = 8;\n",
+			op:      Equal,
+		}, {
+			content: "\tint old2 = 9;\n",
+			op:      Delete,
+		}, {
+			content: "\tint h = 10;\n\tint i = 11;\n}\n",
+			op:      Equal,
+		}},
+	}},
+}
+
 var fixtures = []*fixture{{
 	patch: testPatch{
 		message: "",
@@ -1000,6 +1044,27 @@ index 0adddcde4fd38042c354518351820eb06c417c82..d39ae38aad7ba9447b5e7998b2e4714f
 		" T\n" +
 		color.Red + "-U" + color.Reset + "\n" +
 		" V\n",
+}, {
+	patch:   funcContextPatch,
+	desc:    "hunk header names the enclosing function, not the line above the context",
+	context: 2,
+	diff: `diff --git a/main.c b/main.c
+index 9f03bde1c31d472737d36825dc9f653033738e2b..33770a8ab26e425bad0f91f78fd7498c9a84f38b 100644
+--- a/main.c
++++ b/main.c
+@@ -3,5 +3,4 @@ int main(void)
+ 	int a = 1;
+ 	int b = 2;
+-	int old1 = 3;
+ 	int c = 4;
+ 	int d = 5;
+@@ -9,5 +8,4 @@ int main(void)
+ 	int f = 7;
+ 	int g = 8;
+-	int old2 = 9;
+ 	int h = 10;
+ 	int i = 11;
+`,
 }}
 
 type testPatch struct {


### PR DESCRIPTION
Fixes #2193.

go-git's unified diff used the line immediately before a change as the hunk header context (`@@ ... @@ {`), whereas git shows the enclosing function or section line (`@@ ... @@ int main(int argc, char *argv[])`).

This searches backward for a line matching git's default funcname heuristic (first character a letter, `_`, or `$`) and carries the last match across hunks, matching git's output.

Affected package tests pass locally.

## AI Assistance Disclosure

Per go-git's [AI Contribution Policy](https://github.com/go-git/go-git/blob/master/AI_POLICY.md): this patch was developed with AI assistance. I reviewed and tested the change before submission (affected package tests pass locally, and the output was verified against reference `git` behaviour), and I take responsibility for it. The commit carries an `Assisted-by:` trailer.
