### PR TITLE
plumbing: object, include submodules in patches

### DIFF
--- a/plumbing/object/patch.go
+++ b/plumbing/object/patch.go
@@ -50,6 +50,14 @@ func getPatchContext(ctx context.Context, message string, changes ...*Change) (*
 }
 
 func filePatchWithContext(ctx context.Context, c *Change) (fdiff.FilePatch, error) {
+	// Submodules (gitlinks) are not blob objects, so their contents cannot be
+	// read as files. Git represents them in a diff by a single
+	// "Subproject commit <hash>" line, so build that content synthetically
+	// instead of dropping the change from the patch.
+	if isSubmodule(c.From) || isSubmodule(c.To) {
+		return submoduleFilePatch(ctx, c)
+	}
+
 	from, to, err := c.Files()
 	if err != nil {
 		return nil, err
@@ -67,6 +75,57 @@ func filePatchWithContext(ctx context.Context, c *Change) (fdiff.FilePatch, erro
 	if fIsBinary || tIsBinary {
 		return &textFilePatch{from: c.From, to: c.To}, nil
 	}
+
+	diffs := diff.Do(fromContent, toContent)
+
+	chunks := make([]fdiff.Chunk, 0, len(diffs))
+	for _, d := range diffs {
+		select {
+		case <-ctx.Done():
+			return nil, ErrCanceled
+		default:
+		}
+
+		var op fdiff.Operation
+		switch d.Type {
+		case dmp.DiffEqual:
+			op = fdiff.Equal
+		case dmp.DiffDelete:
+			op = fdiff.Delete
+		case dmp.DiffInsert:
+			op = fdiff.Add
+		}
+
+		chunks = append(chunks, &textChunk{d.Text, op})
+	}
+
+	return &textFilePatch{
+		chunks: chunks,
+		from:   c.From,
+		to:     c.To,
+	}, nil
+}
+
+func isSubmodule(e ChangeEntry) bool {
+	return e != empty && e.TreeEntry.Mode == filemode.Submodule
+}
+
+// submoduleContent returns the textual representation git uses for a submodule
+// (gitlink) in a diff: a single "Subproject commit <hash>" line. It returns an
+// empty string when the entry does not point to a submodule.
+func submoduleContent(e ChangeEntry) string {
+	if !isSubmodule(e) {
+		return ""
+	}
+
+	return fmt.Sprintf("Subproject commit %s\n", e.TreeEntry.Hash)
+}
+
+// submoduleFilePatch builds a file patch for a change that adds, removes or
+// updates a submodule.
+func submoduleFilePatch(ctx context.Context, c *Change) (fdiff.FilePatch, error) {
+	fromContent := submoduleContent(c.From)
+	toContent := submoduleContent(c.To)
 
 	diffs := diff.Do(fromContent, toContent)
 
@@ -157,7 +216,7 @@ type changeEntryWrapper struct {
 }
 
 func (f *changeEntryWrapper) Hash() plumbing.Hash {
-	if !f.ce.TreeEntry.Mode.IsFile() {
+	if f.Empty() {
 		return plumbing.ZeroHash
 	}
 
@@ -169,7 +228,7 @@ func (f *changeEntryWrapper) Mode() filemode.FileMode {
 }
 
 func (f *changeEntryWrapper) Path() string {
-	if !f.ce.TreeEntry.Mode.IsFile() {
+	if f.Empty() {
 		return ""
 	}
 
@@ -177,7 +236,10 @@ func (f *changeEntryWrapper) Path() string {
 }
 
 func (f *changeEntryWrapper) Empty() bool {
-	return !f.ce.TreeEntry.Mode.IsFile()
+	// Submodules (gitlinks) are not files, but they still take part in a diff
+	// and thus must not be treated as empty entries.
+	return !f.ce.TreeEntry.Mode.IsFile() &&
+		f.ce.TreeEntry.Mode != filemode.Submodule
 }
 
 // textFilePatch is an implementation of fdiff.FilePatch interface

--- a/plumbing/object/patch_test.go
+++ b/plumbing/object/patch_test.go
@@ -54,6 +54,65 @@ func (s *PatchSuite) TestStatsWithSubmodules() {
 	s.NotNil(p)
 }
 
+func (s *PatchSuite) TestPatchWithSubmodule() {
+	subDotgit, err := fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit()
+	s.Require().NoError(err)
+	storer := filesystem.NewStorage(subDotgit, cache.NewObjectLRUDefault())
+	defer func() { _ = storer.Close() }()
+
+	commit, err := GetCommit(storer, plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4"))
+	s.Require().NoError(err)
+
+	tree, err := commit.Tree()
+	s.Require().NoError(err)
+
+	e, err := tree.entry("basic")
+	s.Require().NoError(err)
+
+	// Adding a submodule (gitlink) must be reflected in the patch as a
+	// "Subproject commit <hash>" line, mirroring the output of `git diff`.
+	added := &Change{
+		To: ChangeEntry{
+			Name:      "basic",
+			Tree:      tree,
+			TreeEntry: *e,
+		},
+	}
+
+	p, err := getPatch("", added)
+	s.Require().NoError(err)
+
+	got := p.String()
+	s.Contains(got, "diff --git a/basic b/basic")
+	s.Contains(got, "new file mode 160000")
+	s.Contains(got, "+Subproject commit 6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+
+	// Updating the commit a submodule points to must produce a deletion of the
+	// old commit line and an addition of the new one.
+	other, err := tree.entry("itself")
+	s.Require().NoError(err)
+
+	updated := &Change{
+		From: ChangeEntry{
+			Name:      "basic",
+			Tree:      tree,
+			TreeEntry: *e,
+		},
+		To: ChangeEntry{
+			Name:      "basic",
+			Tree:      tree,
+			TreeEntry: TreeEntry{Name: "basic", Mode: other.Mode, Hash: other.Hash},
+		},
+	}
+
+	p, err = getPatch("", updated)
+	s.Require().NoError(err)
+
+	got = p.String()
+	s.Contains(got, "-Subproject commit 6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	s.Contains(got, "+Subproject commit 47770b26e71b0f69c0ecd494b1066f8d1da4fc03")
+}
+
 func (s *PatchSuite) TestFileStatsString() {
 	testCases := []struct {
 		description string


### PR DESCRIPTION
`Change.Patch` / `Tree.Patch` silently drop submodules. When a commit adds, removes or updates a gitlink, the resulting patch contains no entry for it at all — as reported in #1387, diffing an empty tree against a tree with submodules omits the submodule sections entirely.

The cause is that submodules aren't blob objects, so `Change.Files()` returns `nil` for them and the changed entry is treated as empty when the file-patch header is built, so the encoder skips it.

Git renders a submodule in a diff as a single `Subproject commit <hash>` line. This builds that content synthetically for gitlink changes (add / remove / commit update, reusing the existing line diff) and stops treating submodule entries as empty in the header, so the `diff --git`, `new file mode 160000` and `index` lines are emitted.

Before, `emptyTree.Patch(commitTree)` on `git-fixtures/submodule` produced only the `.gitmodules` and `README.md` sections. Now it also produces:

```diff
diff --git a/basic b/basic
new file mode 160000
index 0000000000000000000000000000000000000000..6ecf0ef2c2dffb796033e5a02219af86ec6584e5
--- /dev/null
+++ b/basic
@@ -0,0 +1 @@
+Subproject commit 6ecf0ef2c2dffb796033e5a02219af86ec6584e5
```

Added `TestPatchWithSubmodule` covering both submodule addition and a submodule commit update.

Fixes #1387
