### PR TITLE
storage: filesystem, Refresh pack index after external repack

### DIFF
--- a/repository_test.go
+++ b/repository_test.go
@@ -3279,6 +3279,48 @@ func (s *RepositorySuite) TestRepackObjectsWithNoDelete(c *C) {
 	s.testRepackObjects(c, time.Unix(0, 1), 3)
 }
 
+func (s *RepositorySuite) TestObjectLookupRefreshesPackIndexAfterExternalRepack(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
+	path := c.MkDir()
+	runGitOnPathC(c, path, "init", "-q")
+	runGitOnPathC(c, path, "config", "user.name", "go-git tests")
+	runGitOnPathC(c, path, "config", "user.email", "go-git@example.com")
+
+	c.Assert(os.WriteFile(filepath.Join(path, "f"), []byte("one\n"), 0o644), IsNil)
+	runGitOnPathC(c, path, "add", "f")
+	runGitOnPathC(c, path, "-c", "maintenance.auto=false", "commit", "-qm", "A")
+	runGitOnPathC(c, path, "repack", "-adq")
+
+	c.Assert(os.WriteFile(filepath.Join(path, "f"), []byte("two\n"), 0o644), IsNil)
+	runGitOnPathC(c, path, "add", "f")
+	runGitOnPathC(c, path, "-c", "maintenance.auto=false", "commit", "-qm", "B")
+
+	repo, err := PlainOpen(path)
+	c.Assert(err, IsNil)
+
+	head, err := repo.Head()
+	c.Assert(err, IsNil)
+	commitB, err := repo.CommitObject(head.Hash())
+	c.Assert(err, IsNil)
+	_, err = commitB.Parent(0)
+	c.Assert(err, IsNil)
+
+	runGitOnPathC(c, path, "repack", "-adq")
+
+	tree, err := commitB.Tree()
+	c.Assert(err, IsNil)
+	c.Assert(tree.Type(), Equals, plumbing.TreeObject)
+}
+
+func runGitOnPathC(c *C, path string, args ...string) {
+	cmd := exec.Command("git", append([]string{"-C", path}, args...)...)
+	out, err := cmd.CombinedOutput()
+	c.Assert(err, IsNil, Commentf("git %v: %s", args, out))
+}
+
 func ExecuteOnPath(c *C, path string, cmds ...string) error {
 	for _, cmd := range cmds {
 		err := executeOnPath(path, cmd)

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -70,6 +70,38 @@ func (s *ObjectStorage) requireIndex() error {
 	return nil
 }
 
+func (s *ObjectStorage) refreshIndexIfPackInventoryChanged() error {
+	changed, err := s.packInventoryChanged()
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+	s.Reindex()
+	return s.requireIndex()
+}
+
+func (s *ObjectStorage) packInventoryChanged() (bool, error) {
+	if s.index == nil {
+		return false, nil
+	}
+
+	packs, err := s.dir.ObjectPacks()
+	if err != nil {
+		return false, err
+	}
+	if len(packs) != len(s.index) {
+		return true, nil
+	}
+	for _, h := range packs {
+		if _, ok := s.index[h]; !ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Reindex indexes again all packfiles. Useful if git changed packfiles externally
 func (s *ObjectStorage) Reindex() {
 	s.index = nil
@@ -187,7 +219,13 @@ func (s *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
 	}
 	_, _, offset := s.findObjectInPackfile(h)
 	if offset == -1 {
-		return plumbing.ErrObjectNotFound
+		if err := s.refreshIndexIfPackInventoryChanged(); err != nil {
+			return err
+		}
+		_, _, offset = s.findObjectInPackfile(h)
+		if offset == -1 {
+			return plumbing.ErrObjectNotFound
+		}
 	}
 	return nil
 }
@@ -290,7 +328,13 @@ func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (
 
 	pack, _, offset := s.findObjectInPackfile(h)
 	if offset == -1 {
-		return 0, plumbing.ErrObjectNotFound
+		if err := s.refreshIndexIfPackInventoryChanged(); err != nil {
+			return 0, err
+		}
+		pack, _, offset = s.findObjectInPackfile(h)
+		if offset == -1 {
+			return 0, plumbing.ErrObjectNotFound
+		}
 	}
 
 	idx := s.index[pack]
@@ -470,7 +514,13 @@ func (s *ObjectStorage) getFromPackfile(h plumbing.Hash, canBeDelta bool) (
 
 	pack, hash, offset := s.findObjectInPackfile(h)
 	if offset == -1 {
-		return nil, plumbing.ErrObjectNotFound
+		if err := s.refreshIndexIfPackInventoryChanged(); err != nil {
+			return nil, err
+		}
+		pack, hash, offset = s.findObjectInPackfile(h)
+		if offset == -1 {
+			return nil, plumbing.ErrObjectNotFound
+		}
 	}
 
 	idx := s.index[pack]

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -331,7 +331,7 @@ func copyFile(c *C, dstDir, dstFilename string, srcFile billy.File) {
 }
 
 // TestPackfileReindex tests that externally-added packfiles are considered by go-git
-// after calling the Reindex method
+// after the pack inventory changes.
 func (s *FsSuite) TestPackfileReindex(c *C) {
 	// obtain a standalone packfile that is not part of any other repository
 	// in the fixtures:
@@ -355,13 +355,13 @@ func (s *FsSuite) TestPackfileReindex(c *C) {
 		copyFile(c, filepath.Join(storer.Filesystem().Root(), "objects", "pack"),
 			fmt.Sprintf("pack-%s.idx", packFilename), idxFile)
 
-		// check that we cannot still retrieve the test object
+		// The changed pack inventory should be detected on the miss and reindexed.
 		_, err = storer.EncodedObject(plumbing.CommitObject, testObjectHash)
-		c.Assert(err, Equals, plumbing.ErrObjectNotFound)
+		c.Assert(err, IsNil)
 
-		storer.Reindex() // actually reindex
+		storer.Reindex()
 
-		// Now check that the test object can be retrieved
+		// Explicit reindexing should still leave the object retrievable.
 		_, err = storer.EncodedObject(plumbing.CommitObject, testObjectHash)
 		c.Assert(err, IsNil)
 	})


### PR DESCRIPTION
## Summary

- refresh the v5 filesystem pack index once when a packed object miss sees a changed pack inventory
- add a regression for reading from an open repository after an external `git repack -adq`

## Why

Fixes #2242. The issue reproduces on v5.19.1: after go-git caches the pack list, an external Git repack can move loose objects into a new pack and leave the open v5 storage with stale pack inventory. Current `main` already passes this regression, so this targets `releases/v5.x`.

This follows Git's reprepare-and-retry shape when the object database may have changed: https://github.com/git/git/blob/94f057755b7941b321fd11fec1b2e3ca5313a4e0/odb.c#L622-L636

## Validation

- `go test -v . -check.f TestObjectLookupRefreshesPackIndexAfterExternalRepack -count=1`
- `go test ./storage/... -count=1`
- `go test -p 1 ./...` - one unrelated failure in `WorktreeSuite.TestCheckoutIndexOS`; the container runs as UID 0 and the test expects a nonzero UID. The listed package tests, including `storage/filesystem`, passed.
- `git diff --check`

AI assistance: Codex.