### PR TITLE
storage: dotgit, reject path traversal in reference names

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-git/go-billy/v6"
 
 	"github.com/go-git/go-git/v6/internal/packhandle"
+	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/plumbing"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
@@ -102,7 +103,16 @@ var (
 // out of its reference sub-tree and read, overwrite, or delete unrelated
 // metadata such as .git/config. This is a defence-in-depth check at the
 // storage choke point, mirroring the containment applied to submodule names
-// in Module and canonical Git's check_refname_format.
+// in validSubmoduleName and canonical Git's check_refname_format.
+//
+// The per-component check is delegated to pathutil.IsHFSDot and
+// pathutil.IsNTFSDot with "." as the needle, exactly as validSubmoduleName
+// does: besides the bare "." and ".." cases, these reject components that
+// still resolve to ".." after HFS+ Unicode normalisation (ignored code
+// points, e.g. ".<U+200C>.") or NTFS trailing-space/period/ADS
+// canonicalisation (e.g. ".. ", "..::$INDEX_ALLOCATION"). Because a name
+// can be authored on one OS and reach this layer on another, both checks
+// run unconditionally regardless of host OS.
 func validReferenceName(name plumbing.ReferenceName) error {
 	s := string(name)
 	for i := 0; i < len(s); i++ {
@@ -114,7 +124,9 @@ func validReferenceName(name plumbing.ReferenceName) error {
 		return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
 	}
 	for _, part := range strings.FieldsFunc(s, func(r rune) bool { return r == '/' || r == '\\' }) {
-		if part == "." || part == ".." {
+		// IsNTFSDot/IsHFSDot with a "." needle match ".." and its disguises
+		// but not a bare ".", so reject that component explicitly too.
+		if part == "." || pathutil.IsHFSDot(part, ".") || pathutil.IsNTFSDot(part, ".", "") {
 			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
 		}
 	}

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -88,7 +88,38 @@ var (
 	// resolve outside the modules/ subtree, mirroring canonical Git's
 	// "ignoring suspicious submodule name" defence.
 	ErrModuleNameEscape = errors.New("submodule name escapes modules/ directory")
+	// ErrReferenceNameEscape is returned when a reference name would
+	// resolve outside its reference sub-tree once turned into a path
+	// under the .git directory (e.g. a name with a ".." component).
+	ErrReferenceNameEscape = errors.New("reference name escapes the reference storage")
 )
+
+// validReferenceName rejects reference names that cannot be safely turned
+// into a path under the .git directory. A loose reference (and its reflog)
+// is stored verbatim at ".git/<name>", so a name carrying a "." or ".."
+// path component, a volume prefix, or a control character would let a
+// crafted name — for instance one advertised by a malicious remote — climb
+// out of its reference sub-tree and read, overwrite, or delete unrelated
+// metadata such as .git/config. This is a defence-in-depth check at the
+// storage choke point, mirroring the containment applied to submodule names
+// in Module and canonical Git's check_refname_format.
+func validReferenceName(name plumbing.ReferenceName) error {
+	s := string(name)
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
+		}
+	}
+	if filepath.VolumeName(s) != "" {
+		return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
+	}
+	for _, part := range strings.FieldsFunc(s, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if part == "." || part == ".." {
+			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
+		}
+	}
+	return nil
+}
 
 // Options holds configuration for the storage.
 type Options struct {
@@ -268,6 +299,9 @@ func (d *DotGit) Shallow() (billy.File, error) {
 // ReflogReader returns a file pointer for reading the reflog for the given reference.
 // Returns nil, nil if the reflog file does not exist.
 func (d *DotGit) ReflogReader(name plumbing.ReferenceName) (billy.File, error) {
+	if err := validReferenceName(name); err != nil {
+		return nil, err
+	}
 	p := d.fs.Join(logsPath, string(name))
 	f, err := d.fs.Open(p)
 	if err != nil {
@@ -282,6 +316,9 @@ func (d *DotGit) ReflogReader(name plumbing.ReferenceName) (billy.File, error) {
 // ReflogWriter returns a file pointer for appending to the reflog for the given reference.
 // It creates the file and any necessary parent directories if they don't exist.
 func (d *DotGit) ReflogWriter(name plumbing.ReferenceName) (billy.File, error) {
+	if err := validReferenceName(name); err != nil {
+		return nil, err
+	}
 	p := d.fs.Join(logsPath, string(name))
 	if err := d.fs.MkdirAll(filepath.Dir(p), os.ModePerm); err != nil {
 		return nil, err
@@ -291,6 +328,9 @@ func (d *DotGit) ReflogWriter(name plumbing.ReferenceName) (billy.File, error) {
 
 // DeleteReflog removes the reflog file for the given reference.
 func (d *DotGit) DeleteReflog(name plumbing.ReferenceName) error {
+	if err := validReferenceName(name); err != nil {
+		return err
+	}
 	p := d.fs.Join(logsPath, string(name))
 	err := d.fs.Remove(p)
 	if os.IsNotExist(err) {
@@ -1045,6 +1085,10 @@ func (d *DotGit) checkReferenceAndTruncate(f billy.File, old *plumbing.Reference
 
 // SetRef stores a reference, optionally checking that old matches the current value.
 func (d *DotGit) SetRef(r, old *plumbing.Reference) error {
+	if err := validReferenceName(r.Name()); err != nil {
+		return err
+	}
+
 	var content string
 	switch r.Type() {
 	case plumbing.SymbolicReference:
@@ -1080,6 +1124,10 @@ func (d *DotGit) Refs() ([]*plumbing.Reference, error) {
 
 // Ref returns the reference for a given reference name.
 func (d *DotGit) Ref(name plumbing.ReferenceName) (*plumbing.Reference, error) {
+	if err := validReferenceName(name); err != nil {
+		return nil, err
+	}
+
 	ref, err := d.readReferenceFile(".", name.String())
 	if err == nil {
 		return ref, nil
@@ -1143,6 +1191,10 @@ func (d *DotGit) packedRef(name plumbing.ReferenceName) (*plumbing.Reference, er
 
 // RemoveRef removes a reference by name.
 func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
+	if err := validReferenceName(name); err != nil {
+		return err
+	}
+
 	path := d.fs.Join(".", name.String())
 	_, err := d.fs.Stat(path)
 	if err == nil {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -101,8 +101,55 @@ func (s *SuiteDotGit) TestReferenceNameRejectsEscapingNames() {
 	s.Error(err, "traversal must not create .git/config")
 }
 
+func (s *SuiteDotGit) TestReferenceNameRejectsWindowsDisguisedTraversal() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	// On NTFS, ".." followed by trailing periods/spaces or an Alternate Data
+	// Stream / $INDEX_ALLOCATION suffix is canonicalised back to "..", so a
+	// literal `== ".."` check would miss these while the filesystem still
+	// performs the parent-directory hop. These are pure-string checks, so the
+	// containment must hold on every host, not only Windows.
+	bad := []plumbing.ReferenceName{
+		"refs/heads/..::$INDEX_ALLOCATION",
+		"refs/heads/..:$DATA",
+		"refs/heads/.. /config",
+		"refs/heads/.../config",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		s.ErrorIs(d.SetRef(ref, nil), ErrReferenceNameEscape, "SetRef %q", n)
+
+		_, err := d.Ref(n)
+		s.ErrorIs(err, ErrReferenceNameEscape, "Ref %q", n)
+	}
+
+	_, err := d.fs.Stat(configPath)
+	s.Error(err, "traversal must not create .git/config")
+}
+
+func (s *SuiteDotGit) TestReferenceNameRejectsHFSDisguisedTraversal() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	// HFS+ strips a set of ignorable Unicode code points during
+	// normalisation, so ".<U+200C>." (zero-width non-joiner) collapses to
+	// ".." on disk. As above, this is a string-level check that must hold
+	// regardless of host OS.
+	n := plumbing.ReferenceName("refs/heads/." + "\u200c" + "./config")
+	ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+	s.ErrorIs(d.SetRef(ref, nil), ErrReferenceNameEscape, "SetRef %q", n)
+
+	_, err := d.Ref(n)
+	s.ErrorIs(err, ErrReferenceNameEscape, "Ref %q", n)
+
+	_, err = d.fs.Stat(configPath)
+	s.Error(err, "traversal must not create .git/config")
+}
+
 func (s *SuiteDotGit) TestReferenceNameAcceptsBenignNames() {
 	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
 	for _, n := range []plumbing.ReferenceName{
 		"HEAD", "ORIG_HEAD", "FETCH_HEAD",
 		"refs/heads/main", "refs/heads/release-1.2",

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -69,6 +69,50 @@ func (s *SuiteDotGit) TestModuleAcceptsBenignNames() {
 	}
 }
 
+func (s *SuiteDotGit) TestReferenceNameRejectsEscapingNames() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	// A ".." component (or a control character) lets a reference name climb
+	// out of its sub-tree into unrelated .git metadata such as config; a
+	// malicious remote can advertise such a name and, after refspec mapping,
+	// have it reach the storage layer.
+	bad := []plumbing.ReferenceName{
+		"refs/heads/../../config",
+		"refs/remotes/origin/../../../config",
+		"refs/heads/..",
+		"refs/heads/foo\x00bar",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		s.ErrorIs(d.SetRef(ref, nil), ErrReferenceNameEscape, "SetRef %q", n)
+
+		_, err := d.Ref(n)
+		s.ErrorIs(err, ErrReferenceNameEscape, "Ref %q", n)
+
+		s.ErrorIs(d.RemoveRef(n), ErrReferenceNameEscape, "RemoveRef %q", n)
+
+		_, err = d.ReflogWriter(n)
+		s.ErrorIs(err, ErrReferenceNameEscape, "ReflogWriter %q", n)
+	}
+
+	// The rejected traversals must not have written .git/config.
+	_, err := d.fs.Stat(configPath)
+	s.Error(err, "traversal must not create .git/config")
+}
+
+func (s *SuiteDotGit) TestReferenceNameAcceptsBenignNames() {
+	d := New(s.EmptyFS())
+	for _, n := range []plumbing.ReferenceName{
+		"HEAD", "ORIG_HEAD", "FETCH_HEAD",
+		"refs/heads/main", "refs/heads/release-1.2",
+		"refs/tags/v1.0.0", "refs/remotes/origin/HEAD", "refs/stash",
+	} {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		s.Require().NoError(d.SetRef(ref, nil), "SetRef %q", n)
+	}
+}
+
 func (s *SuiteDotGit) TestInitialize() {
 	fs := s.EmptyFS()
 


### PR DESCRIPTION
**Reference names weren't contained to the ref storage**

A loose reference is written to `.git/<name>` with the name used verbatim as a path, so a name such as `refs/heads/../../config` (which a malicious remote can advertise, and which survives refspec mapping to `refs/remotes/origin/../../config`) resolves to unrelated metadata like `.git/config` or `.git/HEAD`. The check lives at the dotgit storage entry points, the same choke point as the existing submodule-name containment in `Module`, so every path that stores, reads, or removes a ref is covered and benign names such as `HEAD` and `refs/heads/*` are unaffected.