### PR TITLE
plumbing: gitignore, Clarify pattern and matcher parameters

### DIFF
--- a/plumbing/format/gitignore/matcher.go
+++ b/plumbing/format/gitignore/matcher.go
@@ -1,16 +1,21 @@
 package gitignore
 
-// Matcher defines a global multi-pattern matcher for gitignore patterns
+// Matcher defines a global multi-pattern matcher for gitignore patterns.
 type Matcher interface {
-	// Match matches patterns in the order of priorities. As soon as an inclusion or
-	// exclusion is found, not further matching is performed.
+	// Match reports whether path is excluded by the highest-priority matching
+	// pattern. Path is an ordered sequence of logical path components. Patterns
+	// created with ParsePattern match only paths beginning with their domain.
+	// isDir reports whether the final path component is a directory. For a
+	// pattern ending in "/", isDir only restricts a match at the candidate
+	// endpoint; descendants of a matched directory may still match.
 	Match(path []string, isDir bool) bool
 }
 
-// NewMatcher constructs a new global matcher. Patterns must be given in the order of
-// increasing priority. That is most generic settings files first, then the content of
-// the repo .gitignore, then content of .gitignore down the path or the repo and then
-// the content command line arguments.
+// NewMatcher constructs a new global matcher from patterns in increasing
+// priority order. Match evaluates them from last to first and uses the first
+// Exclude or Include result. Generic settings files should come first, followed
+// by the repository .gitignore, .gitignore files in successively deeper
+// directories, and command-line arguments.
 func NewMatcher(ps []Pattern) Matcher {
 	return &matcher{ps}
 }

--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -24,7 +24,12 @@ const (
 
 // Pattern defines a single gitignore pattern.
 type Pattern interface {
-	// Match matches the given path to the pattern.
+	// Match reports how the pattern applies to path. Path is an ordered sequence
+	// of logical path components. Patterns created with ParsePattern match only
+	// paths beginning with their domain. isDir reports whether the final path
+	// component is a directory. For a pattern ending in "/", isDir only
+	// restricts a match at the candidate endpoint; descendants of a matched
+	// directory may still match.
 	Match(path []string, isDir bool) MatchResult
 }
 
@@ -36,7 +41,14 @@ type pattern struct {
 	isGlob    bool
 }
 
-// ParsePattern parses a gitignore pattern string into the Pattern structure.
+// ParsePattern parses a gitignore pattern string into a Pattern. The domain is
+// an ordered prefix of logical path components that scopes the pattern.
+// Matching applies to the components after that prefix. A nil or empty domain
+// applies the pattern without a prefix.
+//
+// ReadPatterns uses the path of the directory containing a .gitignore file as
+// its domain. When the filesystem is rooted at a repository, that path is
+// repository-relative.
 func ParsePattern(p string, domain []string) Pattern {
 	// storing domain, copy it to ensure it isn't changed externally
 	domain = append([]string(nil), domain...)


### PR DESCRIPTION
## Summary

Clarifies the exported comments for `Pattern.Match`, `ParsePattern`,
`Matcher.Match`, and `NewMatcher`.

## What changed

- Defines `domain` and `path` as ordered logical path components and explains how each domain scopes matching.
- Documents the endpoint meaning of `isDir`, descendant behavior for patterns ending in `/`, and matcher priority.

The two-file patch contains exported comment changes. It does not change runtime behavior or add dependencies.

## Why

The existing comments do not explain how callers should construct `domain` and
`path` or how `isDir` affects directory-only patterns. The new wording follows
the current implementation, `ReadPatterns` traversal, and focused matcher tests.

## Tests

- [x] `go test ./plumbing/format/gitignore`
- [x] `go doc github.com/go-git/go-git/v6/plumbing/format/gitignore`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run ./plumbing/format/gitignore`
- [x] `git diff --check`

Closes #494

## AI assistance

OpenAI GPT-5.6 Sol (xhigh) via Codex assisted with repository research and
drafting the documentation update. I reviewed each statement against the
current implementation and tests and ran the listed checks.
