### PR TITLE
git: fetch, refuse to clobber existing tags

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -788,6 +788,9 @@ func (r *Remote) addObject(rs config.RefSpec,
 		return nil
 	}
 	if !rs.IsForceUpdate() {
+		if err := checkTagUpdate(cmd); err != nil {
+			return err
+		}
 		if err := checkFastForwardUpdate(r.s, remoteRefs, cmd); err != nil {
 			return err
 		}
@@ -836,6 +839,9 @@ func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
 			return err
 		}
 	} else if !rs.IsForceUpdate() {
+		if err := checkTagUpdate(cmd); err != nil {
+			return err
+		}
 		if err := checkFastForwardUpdate(r.s, remoteRefs, cmd); err != nil {
 			return err
 		}
@@ -865,6 +871,14 @@ func (r *Remote) checkForceWithLease(localRef *plumbing.Reference, cmd *packp.Co
 		if cmd.Old != expectedOID {
 			return fmt.Errorf("non-fast-forward update: %s", cmd.Name.String())
 		}
+	}
+
+	return nil
+}
+
+func checkTagUpdate(cmd *packp.Command) error {
+	if cmd.Name.IsTag() && cmd.Old != plumbing.ZeroHash {
+		return fmt.Errorf("tag already exists: %s", cmd.Name.String())
 	}
 
 	return nil

--- a/remote.go
+++ b/remote.go
@@ -979,7 +979,7 @@ func getHaves(
 	return result, nil
 }
 
-const refspecAllTags = "+refs/tags/*:refs/tags/*"
+const refspecAllTags = "refs/tags/*:refs/tags/*"
 
 func calculateRefs(
 	spec []config.RefSpec,
@@ -1263,6 +1263,11 @@ func (r *Remote) updateLocalReferenceStorage(
 			old, _ := storer.ResolveReference(r.s, localName)
 			newRef := plumbing.NewHashReference(localName, ref.Hash())
 
+			if old != nil && localName.IsTag() && old.Hash() != newRef.Hash() && !force && !spec.IsForceUpdate() {
+				forceNeeded = true
+				continue
+			}
+
 			// If the ref exists locally as a non-tag and force is not
 			// specified, only update if the new ref is an ancestor of the old
 			if old != nil && !old.Name().IsTag() && !force && !spec.IsForceUpdate() {
@@ -1296,13 +1301,16 @@ func (r *Remote) updateLocalReferenceStorage(
 	if isWildcard {
 		tags = remoteRefs
 	}
-	tagUpdated, err := r.buildFetchedTags(tags)
+	tagUpdated, tagForceNeeded, err := r.buildFetchedTags(tags, tagMode == plumbing.AllTags, force)
 	if err != nil {
 		return updated, err
 	}
 
 	if tagUpdated {
 		updated = true
+	}
+	if tagForceNeeded {
+		forceNeeded = true
 	}
 
 	if forceNeeded {
@@ -1312,7 +1320,7 @@ func (r *Remote) updateLocalReferenceStorage(
 	return updated, err
 }
 
-func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, err error) {
+func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage, allTags, force bool) (updated, forceNeeded bool, err error) {
 	for _, ref := range refs {
 		if !ref.Name().IsTag() {
 			continue
@@ -1324,24 +1332,28 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 		}
 
 		if err != nil {
-			return false, err
+			return updated, forceNeeded, err
 		}
 
-		// An auto-followed tag only creates one that is missing locally; it
-		// never moves a tag that already points elsewhere. This mirrors git's
-		// "would clobber existing tag" refusal and keeps a remote from silently
-		// repointing a pinned local tag on fetch/pull.
 		old, err := r.s.Reference(ref.Name())
 		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
-			return updated, err
+			return updated, forceNeeded, err
 		}
 		if err == nil && old.Hash() != ref.Hash() {
-			continue
+			if !allTags {
+				// An auto-followed tag only creates one that is missing locally; it
+				// never moves a tag that already points elsewhere.
+				continue
+			}
+			if !force {
+				forceNeeded = true
+				continue
+			}
 		}
 
 		refUpdated, err := updateReferenceStorerIfNeeded(r.s, ref)
 		if err != nil {
-			return updated, err
+			return updated, forceNeeded, err
 		}
 
 		if refUpdated {
@@ -1349,7 +1361,7 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 		}
 	}
 
-	return updated, err
+	return updated, forceNeeded, err
 }
 
 // ListContext lists the references on the remote repository.

--- a/remote.go
+++ b/remote.go
@@ -1327,6 +1327,18 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 			return false, err
 		}
 
+		// An auto-followed tag only creates one that is missing locally; it
+		// never moves a tag that already points elsewhere. This mirrors git's
+		// "would clobber existing tag" refusal and keeps a remote from silently
+		// repointing a pinned local tag on fetch/pull.
+		old, err := r.s.Reference(ref.Name())
+		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return updated, err
+		}
+		if err == nil && old.Hash() != ref.Hash() {
+			continue
+		}
+
 		refUpdated, err := updateReferenceStorerIfNeeded(r.s, ref)
 		if err != nil {
 			return updated, err

--- a/remote_test.go
+++ b/remote_test.go
@@ -1113,6 +1113,104 @@ func (s *RemoteSuite) TestPushRejectNonFastForward() {
 	s.Equal(oldRef, newRef)
 }
 
+func (s *RemoteSuite) TestPushRejectExistingTagUpdate() {
+	server, local, remote, oldHash, newHash := s.newPushExistingTagUpdate()
+
+	err := local.Storer.SetReference(plumbing.NewHashReference("refs/tags/v1", newHash))
+	s.Require().NoError(err)
+
+	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+		"refs/tags/v1:refs/tags/v1",
+	}})
+	s.ErrorContains(err, "tag already exists: refs/tags/v1")
+
+	AssertReferences(s.T(), server, map[string]string{
+		"refs/tags/v1": oldHash.String(),
+	})
+}
+
+func (s *RemoteSuite) TestPushRejectExistingTagUpdateByOID() {
+	server, _, remote, oldHash, newHash := s.newPushExistingTagUpdate()
+
+	err := remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+		config.RefSpec(newHash.String() + ":refs/tags/v1"),
+	}})
+	s.ErrorContains(err, "tag already exists: refs/tags/v1")
+
+	AssertReferences(s.T(), server, map[string]string{
+		"refs/tags/v1": oldHash.String(),
+	})
+}
+
+func (s *RemoteSuite) TestPushRejectExistingTagUpdateToAnnotatedTag() {
+	server, local, remote, oldHash, newHash := s.newPushExistingTagUpdate()
+
+	_, err := local.CreateTag("v1-annotated", newHash, &CreateTagOptions{
+		Tagger:  defaultSignature(),
+		Message: "annotated tag",
+	})
+	s.Require().NoError(err)
+
+	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+		"refs/tags/v1-annotated:refs/tags/v1",
+	}})
+	s.ErrorContains(err, "tag already exists: refs/tags/v1")
+
+	AssertReferences(s.T(), server, map[string]string{
+		"refs/tags/v1": oldHash.String(),
+	})
+}
+
+func (s *RemoteSuite) TestPushForceUpdatesExistingTag() {
+	server, local, remote, _, newHash := s.newPushExistingTagUpdate()
+
+	err := local.Storer.SetReference(plumbing.NewHashReference("refs/tags/v1", newHash))
+	s.Require().NoError(err)
+
+	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+		"+refs/tags/v1:refs/tags/v1",
+	}})
+	s.NoError(err)
+
+	AssertReferences(s.T(), server, map[string]string{
+		"refs/tags/v1": newHash.String(),
+	})
+}
+
+func (s *RemoteSuite) newPushExistingTagUpdate() (*Repository, *Repository, *Remote, plumbing.Hash, plumbing.Hash) {
+	s.T().Helper()
+
+	dir := s.T().TempDir()
+	remoteURL := filepath.Join(dir, "remote")
+
+	server, err := PlainInit(remoteURL, true)
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { _ = server.Close() })
+
+	local, err := PlainInit(filepath.Join(dir, "local"), false)
+	s.Require().NoError(err)
+	s.T().Cleanup(func() { _ = local.Close() })
+
+	oldHash := CommitNewFile(s.T(), local, "old")
+	newHash := CommitNewFile(s.T(), local, "new")
+
+	_, err = local.CreateTag("v1", oldHash, nil)
+	s.Require().NoError(err)
+
+	remote, err := local.CreateRemote(&config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{remoteURL},
+	})
+	s.Require().NoError(err)
+
+	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+		"refs/tags/v1:refs/tags/v1",
+	}})
+	s.Require().NoError(err)
+
+	return server, local, remote, oldHash, newHash
+}
+
 func (s *RemoteSuite) TestPushForce() {
 	f := fixtures.Basic().One()
 	dotgit, dotgitErr := f.DotGit()

--- a/remote_test.go
+++ b/remote_test.go
@@ -307,6 +307,31 @@ func (s *RemoteSuite) TestFetchDoesNotClobberExistingTag() {
 	s.Equal(pinned.Hash(), got.Hash())
 }
 
+func (s *RemoteSuite) TestFetchForcedTagRefSpecClobbersExistingTag() {
+	sto := memory.NewStorage()
+
+	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
+	s.Require().NoError(sto.SetReference(pinned))
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		URLs: []string{s.GetBasicLocalRepositoryURL()},
+	})
+
+	// The clobber refusal only applies to auto-followed tags. An explicit
+	// forced tag refspec is the user asking for the update, so it must still
+	// move the existing tag.
+	err := r.Fetch(&FetchOptions{
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("+refs/tags/*:refs/tags/*"),
+		},
+	})
+	s.NoError(err)
+
+	got, err := sto.Reference("refs/tags/v1.0.0")
+	s.Require().NoError(err)
+	s.Equal(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), got.Hash())
+}
+
 func (s *RemoteSuite) TestFetchWithNoTags() {
 	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},

--- a/remote_test.go
+++ b/remote_test.go
@@ -282,6 +282,31 @@ func (s *RemoteSuite) TestFetchWithAllTags() {
 	})
 }
 
+func (s *RemoteSuite) TestFetchDoesNotClobberExistingTag() {
+	sto := memory.NewStorage()
+
+	// A tag the user has already pinned to a specific object.
+	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
+	s.Require().NoError(sto.SetReference(pinned))
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		URLs: []string{s.GetBasicLocalRepositoryURL()},
+	})
+
+	// The remote advertises refs/tags/v1.0.0 at a different object. A default
+	// fetch auto-follows tags, but must not move a tag that already exists.
+	err := r.Fetch(&FetchOptions{
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		},
+	})
+	s.NoError(err)
+
+	got, err := sto.Reference("refs/tags/v1.0.0")
+	s.Require().NoError(err)
+	s.Equal(pinned.Hash(), got.Hash())
+}
+
 func (s *RemoteSuite) TestFetchWithNoTags() {
 	r := NewRemote(memory.NewStorage(), &config.RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},

--- a/remote_test.go
+++ b/remote_test.go
@@ -307,6 +307,28 @@ func (s *RemoteSuite) TestFetchDoesNotClobberExistingTag() {
 	s.Equal(pinned.Hash(), got.Hash())
 }
 
+func (s *RemoteSuite) TestFetchTagRefSpecDoesNotClobberExistingTag() {
+	sto := memory.NewStorage()
+
+	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
+	s.Require().NoError(sto.SetReference(pinned))
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		URLs: []string{s.GetBasicLocalRepositoryURL()},
+	})
+
+	err := r.Fetch(&FetchOptions{
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("refs/tags/*:refs/tags/*"),
+		},
+	})
+	s.ErrorIs(err, ErrForceNeeded)
+
+	got, err := sto.Reference("refs/tags/v1.0.0")
+	s.Require().NoError(err)
+	s.Equal(pinned.Hash(), got.Hash())
+}
+
 func (s *RemoteSuite) TestFetchForcedTagRefSpecClobbersExistingTag() {
 	sto := memory.NewStorage()
 
@@ -317,12 +339,58 @@ func (s *RemoteSuite) TestFetchForcedTagRefSpecClobbersExistingTag() {
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	// The clobber refusal only applies to auto-followed tags. An explicit
-	// forced tag refspec is the user asking for the update, so it must still
-	// move the existing tag.
+	// A forced tag refspec is the user asking for the update, so it must still
+	// move an existing tag.
 	err := r.Fetch(&FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/tags/*:refs/tags/*"),
+		},
+	})
+	s.NoError(err)
+
+	got, err := sto.Reference("refs/tags/v1.0.0")
+	s.Require().NoError(err)
+	s.Equal(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), got.Hash())
+}
+
+func (s *RemoteSuite) TestFetchAllTagsDoesNotClobberExistingTag() {
+	sto := memory.NewStorage()
+
+	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
+	s.Require().NoError(sto.SetReference(pinned))
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		URLs: []string{s.GetBasicLocalRepositoryURL()},
+	})
+
+	err := r.Fetch(&FetchOptions{
+		Tags: AllTags,
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
+		},
+	})
+	s.ErrorIs(err, ErrForceNeeded)
+
+	got, err := sto.Reference("refs/tags/v1.0.0")
+	s.Require().NoError(err)
+	s.Equal(pinned.Hash(), got.Hash())
+}
+
+func (s *RemoteSuite) TestFetchForcedAllTagsClobbersExistingTag() {
+	sto := memory.NewStorage()
+
+	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
+	s.Require().NoError(sto.SetReference(pinned))
+
+	r := NewRemote(sto, &config.RemoteConfig{
+		URLs: []string{s.GetBasicLocalRepositoryURL()},
+	})
+
+	err := r.Fetch(&FetchOptions{
+		Force: true,
+		Tags:  AllTags,
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 	})
 	s.NoError(err)


### PR DESCRIPTION
A remote can silently repoint an existing local tag on a normal fetch or pull:
- buildFetchedTags is the sole path that writes auto-followed tags (a default fetch runs under AllTags, pull under TagFollowing), and it wrote the server's value with old set to nil, so an existing tag was overwritten unconditionally
- a hostile or on-path remote can advertise refs/tags/<pinned> at an object it also serves in the pack, moving a tag out from under a user or CI that later builds or verifies it
- git refuses the same case with "would clobber existing tag"; the guard here creates a tag that is missing and leaves an existing one pointing where it was

Force updates and the AllTags refspec are unaffected, since tags reach storage only through this helper.
