### PR TITLE
plumbing: transport/http, redact credentials in error messages

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -24,9 +24,9 @@ func (e *Err) StatusCode() int { return e.Status }
 func (e *Err) Error() string {
 	format := "unexpected requesting %q status code: %d"
 	if e.Reason != "" {
-		return fmt.Sprintf(format+": %s", e.URL, e.Status, e.Reason)
+		return fmt.Sprintf(format+": %s", redactedURL(e.URL), e.Status, e.Reason)
 	}
-	return fmt.Sprintf(format, e.URL, e.Status)
+	return fmt.Sprintf(format, redactedURL(e.URL), e.Status)
 }
 
 // checkError maps HTTP response status codes to typed transport errors.

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -92,6 +92,23 @@ func TestCheckError_WithReason(t *testing.T) {
 	assert.Contains(t, err.Error(), "server error details")
 }
 
+func TestErr_ErrorRedactsCredentials(t *testing.T) {
+	t.Parallel()
+	req, _ := http.NewRequest("GET", "https://user:s3cr3t@example.com/repo.git/info/refs?service=git-upload-pack", nil)
+	resp := &http.Response{
+		Request:    req,
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader("boom")),
+	}
+	err := checkError(resp)
+	require.Error(t, err)
+	msg := err.Error()
+	assert.NotContains(t, msg, "s3cr3t")
+	assert.Contains(t, msg, "REDACTED")
+	// the rest of the URL is still reported so the error stays useful
+	assert.Contains(t, msg, "example.com/repo.git")
+}
+
 func TestApplyRedirect(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -488,7 +488,7 @@ func (r *httpRequester) doPost() error {
 	}
 	if r.resp.StatusCode != http.StatusOK {
 		_ = r.resp.Body.Close()
-		return fmt.Errorf("http transport: POST %s unexpected status %d", serviceURL, r.resp.StatusCode)
+		return fmt.Errorf("http transport: POST %s unexpected status %d", redactedURL(r.resp.Request.URL), r.resp.StatusCode)
 	}
 	return nil
 }


### PR DESCRIPTION
On any non-2xx response the error carries the full request URL, and that URL keeps whatever userinfo came from the clone URL:

    unexpected requesting "https://user:s3cr3t@example.com/repo.git/info/refs?service=git-upload-pack" status code: 500

`Err.Error` formats `resp.Request.URL` with `%q` and `httpRequester.doPost` formats the joined service URL with `%s`. Both errors surface to `Clone`/`Fetch` callers that commonly log them, so a password passed as `https://user:token@host/repo` lands in logs in cleartext.

The package already has `redactedURL`, used for the trace output and the redirect errors, so I routed these two paths through it too. Only the password becomes `REDACTED`; the rest of the URL stays so the message is still useful. Added a regression test on the `checkError` path.