### PR TITLE
git: Worktree: Add stores index entires with backslashes on Windows

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -398,6 +398,7 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 		}
 		path = relPath
 	}
+	path = filepath.ToSlash(path)
 
 	if err != nil || !fi.IsDir() {
 		added, h, err = w.doAddFile(cfg, idx, s, path, ignorePattern)

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -176,3 +176,31 @@ func BenchmarkWorktreeStatus(b *testing.B) {
 		wt.Status()
 	}
 }
+
+// TestAddSubdirectoryForwardSlash verifies that Add("dir/foo") stores the
+// index entry with a forward-slash path. On Windows filepath.Clean converts
+// "dir/foo" to "dir\foo"; without filepath.ToSlash the cleaned path would be
+// stored in the index rather than the git-canonical forward-slash form.
+func TestAddSubdirectoryForwardSlash(t *testing.T) {
+	t.Parallel()
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	require.NoError(t, wt.Filesystem().MkdirAll("dir", 0o755))
+	require.NoError(t, util.WriteFile(wt.Filesystem(), "dir/foo", []byte("content"), 0o644))
+
+	_, err = wt.Add("dir/foo")
+	require.NoError(t, err)
+
+	idx, err := repo.Storer.Index()
+	require.NoError(t, err)
+	e, err := idx.Entry("dir/foo")
+	require.NoError(t, err)
+	assert.Equal(t, "dir/foo", e.Name)
+}


### PR DESCRIPTION
Assisted-by: Claude Sonnet 4.6

On Windows, Worktree.Add("dir/foo") stores the index entry as dir\foo instead of the git-canonical dir/foo. This causes subsequent Status() calls to report the file as untracked, and Checkout to misidentify it as missing.

See also https://github.com/go-git/go-git/commit/e428c3b913ebc483f14e711063626d2e3ca13e69 for the v5 bugfix backport. 