### PR TITLE
storage: dotgit, reject path traversal in reference names

### DIFF
--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -110,6 +110,48 @@ func (r ReferenceName) IsTag() bool {
 	return strings.HasPrefix(string(r), refTagPrefix)
 }
 
+// IsSafe reports whether the reference name can be safely turned into a path
+// under the .git directory, mirroring Git's refname_is_safe (refs.c). A name
+// is safe when it is either:
+//
+//   - under "refs/", non-empty after the prefix, containing no backslash and
+//     no empty, "." or ".." path component (so it cannot escape the refs/
+//     sub-tree, or alias another name, once turned into a path); or
+//   - a one-level pseudo-ref whose spelling is restricted to [A-Z_]
+//     (e.g. HEAD, ORIG_HEAD, FETCH_HEAD).
+//
+// Everything else — a lowercase or mixed one-level name such as "config" or
+// "index", an absolute or drive-prefixed name, or a refs/ name that escapes —
+// is unsafe, because it could resolve onto unrelated repository metadata.
+func (r ReferenceName) IsSafe() bool {
+	s := string(r)
+	if s == "" {
+		return false
+	}
+
+	if rest, ok := strings.CutPrefix(s, refPrefix); ok {
+		// '\' is a path separator on Windows, so a refs/ name containing one
+		// could escape the sub-tree or alias another name once turned into a
+		// path; reject it outright (check_refname_format forbids '\' too).
+		if rest == "" || strings.Contains(rest, "\\") {
+			return false
+		}
+		for part := range strings.SplitSeq(rest, "/") {
+			if part == "" || part == "." || part == ".." {
+				return false
+			}
+		}
+		return true
+	}
+
+	for i := 0; i < len(s); i++ {
+		if (s[i] < 'A' || s[i] > 'Z') && s[i] != '_' {
+			return false
+		}
+	}
+	return true
+}
+
 func (r ReferenceName) String() string {
 	return string(r)
 }

--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -18,6 +18,55 @@ func (s *ReferenceSuite) TestReferenceTypeString(c *C) {
 	c.Assert(SymbolicReference.String(), Equals, "symbolic-reference")
 }
 
+func (s *ReferenceSuite) TestReferenceNameIsSafe(c *C) {
+	for _, tc := range []struct {
+		name ReferenceName
+		safe bool
+	}{
+		// One-level pseudo-refs ([A-Z_] only).
+		{"HEAD", true},
+		{"ORIG_HEAD", true},
+		{"FETCH_HEAD", true},
+		{"MERGE_HEAD", true},
+		{"CHERRY_PICK_HEAD", true},
+		// Well-formed refs/ names.
+		{"refs/heads/main", true},
+		{"refs/heads/release-1.2", true},
+		{"refs/tags/v1.0.0", true},
+		{"refs/remotes/origin/HEAD", true},
+		{"refs/stash", true},
+		// Empty, and one-level names that are not pseudo-refs (would land on
+		// top-level .git metadata).
+		{"", false},
+		{"config", false},
+		{"index", false},
+		{"packed-refs", false},
+		{"config.worktree", false},
+		{"bar", false},
+		{"head", false},
+		{"HEAD2", false},
+		// refs/ names that escape or have empty components.
+		{"refs/", false},
+		{"refs/heads/.", false},
+		{"refs/heads/..", false},
+		{"refs/heads/../../config", false},
+		{"refs/heads//main", false},
+		{"refs/heads/", false},
+		// Absolute and drive-prefixed forms.
+		{"/config", false},
+		{"/refs/heads/main", false},
+		{"\\config", false},
+		{"C:config", false},
+		// Backslash inside a refs/ name: a Windows path separator that could
+		// escape the sub-tree or alias another name once turned into a path.
+		{"refs/heads/foo\\bar", false},
+		{"refs/heads\\..\\config", false},
+		{"refs/heads\\foo", false},
+	} {
+		c.Assert(tc.name.IsSafe(), Equals, tc.safe, Commentf("IsSafe(%q)", tc.name))
+	}
+}
+
 func (s *ReferenceSuite) TestReferenceNameShort(c *C) {
 	c.Assert(ExampleReferenceName.Short(), Equals, "v4")
 }

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-git/v5/internal/pathutil"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/hash"
 	"github.com/go-git/go-git/v5/storage"
@@ -79,7 +80,49 @@ var (
 	// resolve outside the modules/ subtree, mirroring canonical Git's
 	// "ignoring suspicious submodule name" defence.
 	ErrModuleNameEscape = errors.New("submodule name escapes modules/ directory")
+	// ErrReferenceNameEscape is returned when a reference name would
+	// resolve outside its reference sub-tree once turned into a path
+	// under the .git directory (e.g. a name with a ".." component).
+	ErrReferenceNameEscape = errors.New("reference name escapes the reference storage")
 )
+
+// validReferenceName rejects reference names that cannot be safely turned
+// into a path under the .git directory. A loose reference is stored verbatim
+// at ".git/<name>", so a name carrying a "." or ".." path component, a volume
+// prefix, or a control character would let a crafted name — for instance one
+// advertised by a malicious remote — climb out of its reference sub-tree and
+// read, overwrite, or delete unrelated metadata such as .git/config. This is a
+// defence-in-depth check at the storage choke point, mirroring the containment
+// applied to submodule names in validSubmoduleName and canonical Git's
+// check_refname_format.
+//
+// The per-component check is delegated to pathutil.IsHFSDot and
+// pathutil.IsNTFSDot with "." as the needle, exactly as validSubmoduleName
+// does: besides the bare "." and ".." cases, these reject components that
+// still resolve to ".." after HFS+ Unicode normalisation (ignored code
+// points, e.g. ".<U+200C>.") or NTFS trailing-space/period/ADS
+// canonicalisation (e.g. ".. ", "..::$INDEX_ALLOCATION"). Because a name
+// can be authored on one OS and reach this layer on another, both checks
+// run unconditionally regardless of host OS.
+func validReferenceName(name plumbing.ReferenceName) error {
+	s := string(name)
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
+		}
+	}
+	if filepath.VolumeName(s) != "" {
+		return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
+	}
+	for _, part := range strings.FieldsFunc(s, func(r rune) bool { return r == '/' || r == '\\' }) {
+		// IsNTFSDot/IsHFSDot with a "." needle match ".." and its disguises
+		// but not a bare ".", so reject that component explicitly too.
+		if part == "." || pathutil.IsHFSDot(part, ".") || pathutil.IsNTFSDot(part, ".", "") {
+			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
+		}
+	}
+	return nil
+}
 
 // Options holds configuration for the storage.
 type Options struct {
@@ -706,6 +749,10 @@ func (d *DotGit) checkReferenceAndTruncate(f billy.File, old *plumbing.Reference
 }
 
 func (d *DotGit) SetRef(r, old *plumbing.Reference) error {
+	if err := validReferenceName(r.Name()); err != nil {
+		return err
+	}
+
 	var content string
 	switch r.Type() {
 	case plumbing.SymbolicReference:
@@ -741,6 +788,10 @@ func (d *DotGit) Refs() ([]*plumbing.Reference, error) {
 
 // Ref returns the reference for a given reference name.
 func (d *DotGit) Ref(name plumbing.ReferenceName) (*plumbing.Reference, error) {
+	if err := validReferenceName(name); err != nil {
+		return nil, err
+	}
+
 	ref, err := d.readReferenceFile(".", name.String())
 	if err == nil {
 		return ref, nil
@@ -804,6 +855,10 @@ func (d *DotGit) packedRef(name plumbing.ReferenceName) (*plumbing.Reference, er
 
 // RemoveRef removes a reference by name.
 func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
+	if err := validReferenceName(name); err != nil {
+		return err
+	}
+
 	path := d.fs.Join(".", name.String())
 	_, err := d.fs.Stat(path)
 	if err == nil {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -86,35 +86,37 @@ var (
 	ErrReferenceNameEscape = errors.New("reference name escapes the reference storage")
 )
 
-// validReferenceName rejects reference names that cannot be safely turned
-// into a path under the .git directory. A loose reference is stored verbatim
-// at ".git/<name>", so a name carrying a "." or ".." path component, a volume
-// prefix, or a control character would let a crafted name — for instance one
-// advertised by a malicious remote — climb out of its reference sub-tree and
-// read, overwrite, or delete unrelated metadata such as .git/config. This is a
-// defence-in-depth check at the storage choke point, mirroring the containment
-// applied to submodule names in validSubmoduleName and canonical Git's
-// check_refname_format.
+// isPathSep reports whether r is a path separator in reference names.
+// It treats both '/' and '\\' as separators to harden against cross-OS paths.
+func isPathSep(r rune) bool { return r == '/' || r == '\\' }
+
+// validReferenceName rejects reference names that cannot be safely turned into
+// a path under the .git directory. A loose reference is stored verbatim at
+// ".git/<name>", so a crafted name — for instance one advertised by a malicious
+// remote — could climb out of its reference sub-tree and read, overwrite, or
+// delete unrelated metadata such as .git/config.
 //
-// The per-component check is delegated to pathutil.IsHFSDot and
-// pathutil.IsNTFSDot with "." as the needle, exactly as validSubmoduleName
-// does: besides the bare "." and ".." cases, these reject components that
-// still resolve to ".." after HFS+ Unicode normalisation (ignored code
-// points, e.g. ".<U+200C>.") or NTFS trailing-space/period/ADS
-// canonicalisation (e.g. ".. ", "..::$INDEX_ALLOCATION"). Because a name
-// can be authored on one OS and reach this layer on another, both checks
-// run unconditionally regardless of host OS.
+// The storage-safety gate is plumbing.ReferenceName.IsSafe, mirroring Git's
+// refname_is_safe: a name must be under refs/ without escaping it, or be a
+// [A-Z_] pseudo-ref. This alone rejects absolute, drive-prefixed, escaping and
+// single-level metadata names. On top of it, this adds filesystem-specific
+// hardening that IsSafe's literal check does not cover: control characters, and
+// components a case-insensitive/NTFS/HFS+ filesystem would fold back to "." or
+// ".." (trailing dots/spaces, Alternate Data Streams, ignorable Unicode code
+// points), delegated to pathutil.IsHFSDot and pathutil.IsNTFSDot with "." as
+// the needle — as validSubmoduleName does — and run regardless of host OS.
 func validReferenceName(name plumbing.ReferenceName) error {
+	if !name.IsSafe() {
+		return fmt.Errorf("%w: %q is not under refs/ nor a valid pseudo-ref", ErrReferenceNameEscape, string(name))
+	}
+
 	s := string(name)
 	for i := 0; i < len(s); i++ {
 		if s[i] < 0x20 || s[i] == 0x7f {
 			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
 		}
 	}
-	if filepath.VolumeName(s) != "" {
-		return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
-	}
-	for _, part := range strings.FieldsFunc(s, func(r rune) bool { return r == '/' || r == '\\' }) {
+	for _, part := range strings.FieldsFunc(s, isPathSep) {
 		// IsNTFSDot/IsHFSDot with a "." needle match ".." and its disguises
 		// but not a bare ".", so reject that component explicitly too.
 		if part == "." || pathutil.IsHFSDot(part, ".") || pathutil.IsNTFSDot(part, ".", "") {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -148,11 +148,60 @@ func (s *SuiteDotGit) TestReferenceNameRejectsHFSDisguisedTraversal(c *C) {
 	c.Assert(err, NotNil, Commentf("traversal must not create .git/config"))
 }
 
+func (s *SuiteDotGit) TestReferenceNameRejectsAbsoluteAndDriveNames(c *C) {
+	d := New(memfs.New())
+	c.Assert(d.Initialize(), IsNil)
+
+	// A leading or trailing separator, or a drive-letter prefix, lets the
+	// name collapse onto a top-level .git file (e.g. "/config" -> .git/config)
+	// once joined. filepath.VolumeName alone would not catch "C:config" off
+	// Windows, so these are rejected host-independently as validSubmoduleName
+	// does.
+	bad := []plumbing.ReferenceName{
+		"/config",
+		"\\config",
+		"C:config",
+		"refs/heads/foo/",
+		"",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		c.Assert(errors.Is(d.SetRef(ref, nil), ErrReferenceNameEscape), Equals, true, Commentf("SetRef %q", n))
+
+		_, err := d.Ref(n)
+		c.Assert(errors.Is(err, ErrReferenceNameEscape), Equals, true, Commentf("Ref %q", n))
+		c.Assert(errors.Is(d.RemoveRef(n), ErrReferenceNameEscape), Equals, true, Commentf("RemoveRef %q", n))
+	}
+
+	_, err := d.fs.Stat(configPath)
+	c.Assert(err, NotNil, Commentf("must not create .git/config"))
+}
+
+func (s *SuiteDotGit) TestReferenceNameRejectsTopLevelMetadata(c *C) {
+	d := New(memfs.New())
+	c.Assert(d.Initialize(), IsNil)
+
+	// A single-level name that is neither under refs/ nor a [A-Z_] pseudo-ref
+	// would land on top-level .git metadata once joined; the IsSafe gate
+	// rejects it, matching upstream refname_is_safe.
+	bad := []plumbing.ReferenceName{
+		"config", "config.worktree", "index", "packed-refs",
+		"shallow", "hooks", "objects", "bar", "HEAD2", "head",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		c.Assert(errors.Is(d.SetRef(ref, nil), ErrReferenceNameEscape), Equals, true, Commentf("SetRef %q", n))
+	}
+
+	_, err := d.fs.Stat(configPath)
+	c.Assert(err, NotNil, Commentf("must not create .git/config"))
+}
+
 func (s *SuiteDotGit) TestReferenceNameAcceptsBenignNames(c *C) {
 	d := New(memfs.New())
 	c.Assert(d.Initialize(), IsNil)
 	for _, n := range []plumbing.ReferenceName{
-		"HEAD", "ORIG_HEAD", "FETCH_HEAD",
+		"HEAD", "ORIG_HEAD", "FETCH_HEAD", "MERGE_HEAD", "CHERRY_PICK_HEAD",
 		"refs/heads/main", "refs/heads/release-1.2",
 		"refs/tags/v1.0.0", "refs/remotes/origin/HEAD", "refs/stash",
 	} {
@@ -223,11 +272,14 @@ func testSetRefs(c *C, dir *DotGit) {
 
 	c.Assert(err, IsNil)
 
+	// A single-level, non-pseudo-ref name is refused: it is not under refs/
+	// and its spelling is not the [A-Z_] pseudo-ref form (upstream
+	// refname_is_safe rejects it likewise).
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"bar",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	c.Assert(err, IsNil)
+	c.Assert(errors.Is(err, ErrReferenceNameEscape), Equals, true)
 
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"refs/heads/feature/baz",
@@ -266,10 +318,9 @@ func testSetRefs(c *C, dir *DotGit) {
 	c.Assert(ref, NotNil)
 	c.Assert(ref.Target().String(), Equals, "refs/heads/foo")
 
-	ref, err = dir.Ref("bar")
-	c.Assert(err, IsNil)
-	c.Assert(ref, NotNil)
-	c.Assert(ref.Hash().String(), Equals, "e8d3ffab552895c19b9fcf7aa264d277cde33881")
+	// "bar" was refused at write time and is refused at read time too.
+	_, err = dir.Ref("bar")
+	c.Assert(errors.Is(err, ErrReferenceNameEscape), Equals, true)
 
 	// Check that SetRef with a non-nil `old` works.
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -73,6 +73,94 @@ func (s *SuiteDotGit) TestModuleAcceptsBenignNames(c *C) {
 	}
 }
 
+func (s *SuiteDotGit) TestReferenceNameRejectsEscapingNames(c *C) {
+	d := New(memfs.New())
+	c.Assert(d.Initialize(), IsNil)
+
+	// A ".." component (or a control character) lets a reference name climb
+	// out of its sub-tree into unrelated .git metadata such as config; a
+	// malicious remote can advertise such a name and, after refspec mapping,
+	// have it reach the storage layer.
+	bad := []plumbing.ReferenceName{
+		"refs/heads/../../config",
+		"refs/remotes/origin/../../../config",
+		"refs/heads/..",
+		"refs/heads/foo\x00bar",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		c.Assert(errors.Is(d.SetRef(ref, nil), ErrReferenceNameEscape), Equals, true, Commentf("SetRef %q", n))
+
+		_, err := d.Ref(n)
+		c.Assert(errors.Is(err, ErrReferenceNameEscape), Equals, true, Commentf("Ref %q", n))
+
+		c.Assert(errors.Is(d.RemoveRef(n), ErrReferenceNameEscape), Equals, true, Commentf("RemoveRef %q", n))
+	}
+
+	// The rejected traversals must not have written .git/config.
+	_, err := d.fs.Stat(configPath)
+	c.Assert(err, NotNil, Commentf("traversal must not create .git/config"))
+}
+
+func (s *SuiteDotGit) TestReferenceNameRejectsWindowsDisguisedTraversal(c *C) {
+	d := New(memfs.New())
+	c.Assert(d.Initialize(), IsNil)
+
+	// On NTFS, ".." followed by trailing periods/spaces or an Alternate Data
+	// Stream / $INDEX_ALLOCATION suffix is canonicalised back to "..", so a
+	// literal `== ".."` check would miss these while the filesystem still
+	// performs the parent-directory hop. These are pure-string checks, so the
+	// containment must hold on every host, not only Windows.
+	bad := []plumbing.ReferenceName{
+		"refs/heads/..::$INDEX_ALLOCATION",
+		"refs/heads/..:$DATA",
+		"refs/heads/.. /config",
+		"refs/heads/.../config",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		c.Assert(errors.Is(d.SetRef(ref, nil), ErrReferenceNameEscape), Equals, true, Commentf("SetRef %q", n))
+
+		_, err := d.Ref(n)
+		c.Assert(errors.Is(err, ErrReferenceNameEscape), Equals, true, Commentf("Ref %q", n))
+	}
+
+	_, err := d.fs.Stat(configPath)
+	c.Assert(err, NotNil, Commentf("traversal must not create .git/config"))
+}
+
+func (s *SuiteDotGit) TestReferenceNameRejectsHFSDisguisedTraversal(c *C) {
+	d := New(memfs.New())
+	c.Assert(d.Initialize(), IsNil)
+
+	// HFS+ strips a set of ignorable Unicode code points during
+	// normalisation, so ".<U+200C>." (zero-width non-joiner) collapses to
+	// ".." on disk. As above, this is a string-level check that must hold
+	// regardless of host OS.
+	n := plumbing.ReferenceName("refs/heads/." + "\u200c" + "./config")
+	ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+	c.Assert(errors.Is(d.SetRef(ref, nil), ErrReferenceNameEscape), Equals, true, Commentf("SetRef %q", n))
+
+	_, err := d.Ref(n)
+	c.Assert(errors.Is(err, ErrReferenceNameEscape), Equals, true, Commentf("Ref %q", n))
+
+	_, err = d.fs.Stat(configPath)
+	c.Assert(err, NotNil, Commentf("traversal must not create .git/config"))
+}
+
+func (s *SuiteDotGit) TestReferenceNameAcceptsBenignNames(c *C) {
+	d := New(memfs.New())
+	c.Assert(d.Initialize(), IsNil)
+	for _, n := range []plumbing.ReferenceName{
+		"HEAD", "ORIG_HEAD", "FETCH_HEAD",
+		"refs/heads/main", "refs/heads/release-1.2",
+		"refs/tags/v1.0.0", "refs/remotes/origin/HEAD", "refs/stash",
+	} {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		c.Assert(d.SetRef(ref, nil), IsNil, Commentf("SetRef %q", n))
+	}
+}
+
 func (s *SuiteDotGit) TestInitialize(c *C) {
 	fs := s.TemporalFilesystem(c)
 

--- a/storage/test/storage_suite.go
+++ b/storage/test/storage_suite.go
@@ -261,100 +261,100 @@ func (s *BaseStorageSuite) TestObjectStorerTxSetObjectAndRollback(c *C) {
 
 func (s *BaseStorageSuite) TestSetReferenceAndGetReference(c *C) {
 	err := s.Storer.SetReference(
-		plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+		plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 	)
 	c.Assert(err, IsNil)
 
 	err = s.Storer.SetReference(
-		plumbing.NewReferenceFromStrings("bar", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+		plumbing.NewReferenceFromStrings("refs/bar", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 	)
 	c.Assert(err, IsNil)
 
-	e, err := s.Storer.Reference(plumbing.ReferenceName("foo"))
+	e, err := s.Storer.Reference(plumbing.ReferenceName("refs/foo"))
 	c.Assert(err, IsNil)
 	c.Assert(e.Hash().String(), Equals, "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 }
 
 func (s *BaseStorageSuite) TestCheckAndSetReference(c *C) {
 	err := s.Storer.SetReference(
-		plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+		plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 	)
 	c.Assert(err, IsNil)
 
 	err = s.Storer.CheckAndSetReference(
-		plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
-		plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+		plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+		plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 	)
 	c.Assert(err, IsNil)
 
-	e, err := s.Storer.Reference(plumbing.ReferenceName("foo"))
+	e, err := s.Storer.Reference(plumbing.ReferenceName("refs/foo"))
 	c.Assert(err, IsNil)
 	c.Assert(e.Hash().String(), Equals, "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 }
 
 func (s *BaseStorageSuite) TestCheckAndSetReferenceNil(c *C) {
 	err := s.Storer.SetReference(
-		plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+		plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 	)
 	c.Assert(err, IsNil)
 
 	err = s.Storer.CheckAndSetReference(
-		plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+		plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		nil,
 	)
 	c.Assert(err, IsNil)
 
-	e, err := s.Storer.Reference(plumbing.ReferenceName("foo"))
+	e, err := s.Storer.Reference(plumbing.ReferenceName("refs/foo"))
 	c.Assert(err, IsNil)
 	c.Assert(e.Hash().String(), Equals, "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 }
 
 func (s *BaseStorageSuite) TestCheckAndSetReferenceError(c *C) {
 	err := s.Storer.SetReference(
-		plumbing.NewReferenceFromStrings("foo", "c3f4688a08fd86f1bf8e055724c84b7a40a09733"),
+		plumbing.NewReferenceFromStrings("refs/foo", "c3f4688a08fd86f1bf8e055724c84b7a40a09733"),
 	)
 	c.Assert(err, IsNil)
 
 	err = s.Storer.CheckAndSetReference(
-		plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
-		plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+		plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+		plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 	)
 	c.Assert(err, Equals, storage.ErrReferenceHasChanged)
 
-	e, err := s.Storer.Reference(plumbing.ReferenceName("foo"))
+	e, err := s.Storer.Reference(plumbing.ReferenceName("refs/foo"))
 	c.Assert(err, IsNil)
 	c.Assert(e.Hash().String(), Equals, "c3f4688a08fd86f1bf8e055724c84b7a40a09733")
 }
 
 func (s *BaseStorageSuite) TestRemoveReference(c *C) {
 	err := s.Storer.SetReference(
-		plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+		plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 	)
 	c.Assert(err, IsNil)
 
-	err = s.Storer.RemoveReference(plumbing.ReferenceName("foo"))
+	err = s.Storer.RemoveReference(plumbing.ReferenceName("refs/foo"))
 	c.Assert(err, IsNil)
 
-	_, err = s.Storer.Reference(plumbing.ReferenceName("foo"))
+	_, err = s.Storer.Reference(plumbing.ReferenceName("refs/foo"))
 	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
 }
 
 func (s *BaseStorageSuite) TestRemoveReferenceNonExistent(c *C) {
 	err := s.Storer.SetReference(
-		plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+		plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 	)
 	c.Assert(err, IsNil)
 
-	err = s.Storer.RemoveReference(plumbing.ReferenceName("nonexistent"))
+	err = s.Storer.RemoveReference(plumbing.ReferenceName("refs/nonexistent"))
 	c.Assert(err, IsNil)
 
-	e, err := s.Storer.Reference(plumbing.ReferenceName("foo"))
+	e, err := s.Storer.Reference(plumbing.ReferenceName("refs/foo"))
 	c.Assert(err, IsNil)
 	c.Assert(e.Hash().String(), Equals, "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 }
 
 func (s *BaseStorageSuite) TestGetReferenceNotFound(c *C) {
-	r, err := s.Storer.Reference(plumbing.ReferenceName("bar"))
+	r, err := s.Storer.Reference(plumbing.ReferenceName("refs/bar"))
 	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
 	c.Assert(r, IsNil)
 }


### PR DESCRIPTION
Backport of the v6 reference-name containment (#2247 and #2257) to v5.

A loose reference is stored verbatim at `.git/<name>`, so a name with a `.` or `..` path component, a volume prefix, or a control character — for instance one advertised by a malicious remote and mapped through a refspec — could climb out of its reference sub-tree and read, overwrite, or delete unrelated metadata such as .git/config. validReferenceName guards SetRef, Ref and RemoveRef at the storage choke point.

The per-component check is delegated to `pathutil.IsHFSDot` and `pathutil.IsNTFSDot` with `.` as the needle, exactly as `validSubmoduleName` does, so besides bare `.` and `..` it also rejects components that resolve to `..` after `HFS+` Unicode normalisation or NTFS trailing-space/period/ADS canonicalisation (e.g. `..::$INDEX_ALLOCATION`, `.<U+200C>.`). Both checks run unconditionally since a name can be authored on one OS and reach this layer on another.