### PR TITLE
git: submodule, skip .gitmodules entries missing from the index

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -247,6 +247,16 @@ func (s *Submodule) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions
 	return s.update(ctx, o, plumbing.ZeroHash)
 }
 
+// indexEntry returns the index entry recorded for the submodule path.
+func (s *Submodule) indexEntry() (*index.Entry, error) {
+	idx, err := s.w.r.Storer.Index()
+	if err != nil {
+		return nil, err
+	}
+
+	return idx.Entry(s.c.Path)
+}
+
 func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, forceHash plumbing.Hash) error {
 	if !s.initialized && !o.Init {
 		return ErrSubmoduleNotInitialized
@@ -258,16 +268,11 @@ func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, force
 		}
 	}
 
-	idx, err := s.w.r.Storer.Index()
-	if err != nil {
-		return err
-	}
-
 	hash := forceHash
 	if hash.IsZero() {
-		e, err := idx.Entry(s.c.Path)
+		e, err := s.indexEntry()
 		if err != nil {
-			return err
+			return fmt.Errorf("submodule %q: %w", s.c.Name, err)
 		}
 
 		hash = e.Hash
@@ -364,18 +369,33 @@ func (s Submodules) Init() error {
 	return nil
 }
 
-// Update updates all the submodules in this list.
+// Update updates all the submodules in this list. Submodules declared in
+// .gitmodules but missing from the index are skipped, matching the behaviour
+// of the git CLI.
 func (s Submodules) Update(o *SubmoduleUpdateOptions) error {
 	return s.UpdateContext(context.Background(), o)
 }
 
-// UpdateContext updates all the submodules in this list.
+// UpdateContext updates all the submodules in this list. Submodules declared
+// in .gitmodules but missing from the index are skipped, matching the
+// behaviour of the git CLI.
 //
 // The provided Context must be non-nil. If the context expires before the
 // operation is complete, an error is returned. The context only affects the
 // transport operations.
 func (s Submodules) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions) error {
 	for _, sub := range s {
+		// A .gitmodules entry whose path has no gitlink in the index is not
+		// a submodule from git's point of view: the git CLI silently ignores
+		// such stale entries on clone, update and status, so skip them here
+		// instead of failing the whole operation.
+		if _, err := sub.indexEntry(); err != nil {
+			if errors.Is(err, index.ErrEntryNotFound) {
+				continue
+			}
+			return err
+		}
+
 		if err := sub.UpdateContext(ctx, o); err != nil {
 			return err
 		}

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
@@ -11,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
 	"github.com/go-git/go-git/v6/storage/memory"
@@ -291,6 +294,119 @@ func TestSubmodulesUpdateContext(t *testing.T) {
 
 		err = sm.UpdateContext(ctx, &SubmoduleUpdateOptions{Init: true})
 		require.Error(t, err)
+	})
+}
+
+// newRepoWithStaleGitmodulesEntry creates a repository whose .gitmodules
+// declares a submodule with no corresponding entry in the index, as left
+// behind when a submodule is removed with `git rm` but its .gitmodules
+// section is not deleted.
+func newRepoWithStaleGitmodulesEntry(t *testing.T) (string, *Repository) {
+	t.Helper()
+
+	dir := t.TempDir()
+	r, err := PlainInit(dir, false)
+	require.NoError(t, err)
+
+	wt, err := r.Worktree()
+	require.NoError(t, err)
+
+	gitmodules := "[submodule \"ghost\"]\n\tpath = ghost\n\turl = https://example.com/ghost.git\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitmodules"), []byte(gitmodules), 0o644))
+
+	_, err = wt.Add(".gitmodules")
+	require.NoError(t, err)
+	_, err = wt.Commit("stale .gitmodules entry", &CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	return dir, r
+}
+
+func TestSubmodulesUpdateSkipsEntryMissingFromIndex(t *testing.T) {
+	t.Parallel()
+
+	_, r := newRepoWithStaleGitmodulesEntry(t)
+	defer func() { _ = r.Close() }()
+
+	wt, err := r.Worktree()
+	require.NoError(t, err)
+
+	sm, err := wt.Submodules()
+	require.NoError(t, err)
+	require.Len(t, sm, 1)
+
+	require.NoError(t, sm.Update(&SubmoduleUpdateOptions{Init: true}))
+
+	// The skipped entry must not have been initialized into .git/config.
+	cfg, err := r.Config()
+	require.NoError(t, err)
+	require.NotContains(t, cfg.Submodules, "ghost")
+}
+
+func TestSubmoduleUpdateEntryMissingFromIndex(t *testing.T) {
+	t.Parallel()
+
+	_, r := newRepoWithStaleGitmodulesEntry(t)
+	defer func() { _ = r.Close() }()
+
+	wt, err := r.Worktree()
+	require.NoError(t, err)
+
+	sm := namedSubmodule(t, wt, "ghost")
+
+	err = sm.Update(&SubmoduleUpdateOptions{Init: true})
+	require.ErrorIs(t, err, index.ErrEntryNotFound)
+	require.ErrorContains(t, err, `submodule "ghost"`)
+}
+
+func TestCloneRecurseSubmodulesSkipsEntryMissingFromIndex(t *testing.T) {
+	t.Parallel()
+
+	dir, r := newRepoWithStaleGitmodulesEntry(t)
+	defer func() { _ = r.Close() }()
+
+	clone, err := PlainClone(t.TempDir(), &CloneOptions{
+		URL:               dir,
+		RecurseSubmodules: DefaultSubmoduleRecursionDepth,
+	})
+	require.NoError(t, err)
+	defer func() { _ = clone.Close() }()
+}
+
+func TestSubmodulesUpdateWithStaleGitmodulesEntry(t *testing.T) {
+	t.Parallel()
+
+	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
+		t.Parallel()
+
+		if testing.Short() {
+			t.Skip("skipping test in short mode.")
+		}
+
+		r, wt := cloneFixture(t, f)
+		defer func() { _ = r.Close() }()
+
+		// Append a stale entry alongside the fixture's real submodules.
+		file, err := wt.Filesystem().OpenFile(".gitmodules", os.O_APPEND|os.O_WRONLY, 0o644)
+		require.NoError(t, err)
+		_, err = file.Write([]byte("[submodule \"ghost\"]\n\tpath = ghost\n\turl = https://example.com/ghost.git\n"))
+		require.NoError(t, err)
+		require.NoError(t, file.Close())
+
+		sm, err := wt.Submodules()
+		require.NoError(t, err)
+
+		require.NoError(t, sm.Update(&SubmoduleUpdateOptions{Init: true}))
+
+		// The real submodule must still have been updated.
+		realSub := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
+		subRepo, err := realSub.Repository()
+		require.NoError(t, err)
+		defer subRepo.Close()
+
+		ref, err := subRepo.Reference(plumbing.HEAD, true)
+		require.NoError(t, err)
+		require.Equal(t, submoduleHashFromIndex(t, r, primaryFixtureSubmoduleName(f)), ref.Hash())
 	})
 }
 


### PR DESCRIPTION
Fixes #2255.

A `.gitmodules` section whose `path` has no gitlink entry in the index — typically left behind when a submodule is removed with `git rm` but its `.gitmodules` section is not deleted — caused `Submodules.Update` to abort the whole operation with a bare `entry not found`. Since clone and pull recursion go through this path, any repository carrying such a stale entry could not be cloned with `RecurseSubmodules` at all, while the git CLI handles it fine (it enumerates gitlink entries in the index and looks up their metadata in `.gitmodules`, so `.gitmodules`-only entries are invisible to clone, update and status alike).

Changes:

* `Submodules.UpdateContext` now skips entries missing from the index, matching the git CLI. The check runs before `Init`, so a skipped entry is not recorded into `.git/config` either (git does not initialize such entries).
* A direct `Update` on a single stale `Submodule` still fails, but the error is now wrapped with the submodule name (`submodule "ghost": entry not found`) instead of surfacing as a bare index lookup failure — the unwrapped message is what made this so hard to diagnose downstream (fluxcd/flux2#4564).
* New `Submodule.indexEntry` helper shared by both paths.

Tests: three self-contained offline tests (list update skips + no config pollution, single update error wrapping, end-to-end `PlainClone` with `RecurseSubmodules`) and one fixture-based test verifying that real submodules alongside a stale entry still update correctly. All three offline tests fail with `entry not found` before the fix.

Happy to follow up with a backport to `releases/v5.x` — that is where the downstream impact currently lives.
