### PR TITLE
storage: dotgit, align reference-name safety with refname_is_safe

### DIFF
--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -120,6 +120,50 @@ func (r ReferenceName) IsPeeled() bool {
 	return strings.HasSuffix(string(r), "^{}")
 }
 
+// IsSafe reports whether the reference name can be safely turned into a path
+// under the .git directory, mirroring Git's refname_is_safe (refs.c). A name
+// is safe when it is either:
+//
+//   - under "refs/", non-empty after the prefix, containing no backslash and
+//     no empty, "." or ".." path component (so it cannot escape the refs/
+//     sub-tree, or alias another name, once turned into a path); or
+//   - a one-level pseudo-ref whose spelling is restricted to [A-Z_]
+//     (e.g. HEAD, ORIG_HEAD, FETCH_HEAD).
+//
+// Everything else — a lowercase or mixed one-level name such as "config" or
+// "index", an absolute or drive-prefixed name, or a refs/ name that escapes —
+// is unsafe, because it could resolve onto unrelated repository metadata.
+// This is a storage-safety check, not full check_refname_format validation;
+// see Validate for the latter.
+func (r ReferenceName) IsSafe() bool {
+	s := string(r)
+	if s == "" {
+		return false
+	}
+
+	if rest, ok := strings.CutPrefix(s, refPrefix); ok {
+		// '\' is a path separator on Windows, so a refs/ name containing one
+		// could escape the sub-tree or alias another name once turned into a
+		// path; reject it outright (check_refname_format forbids '\' too).
+		if rest == "" || strings.Contains(rest, "\\") {
+			return false
+		}
+		for part := range strings.SplitSeq(rest, "/") {
+			if part == "" || part == "." || part == ".." {
+				return false
+			}
+		}
+		return true
+	}
+
+	for i := 0; i < len(s); i++ {
+		if (s[i] < 'A' || s[i] > 'Z') && s[i] != '_' {
+			return false
+		}
+	}
+	return true
+}
+
 func (r ReferenceName) String() string {
 	return string(r)
 }

--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -28,6 +28,55 @@ func (s *ReferenceSuite) TestReferenceNameShort() {
 	s.Equal("v4", ExampleReferenceName.Short())
 }
 
+func (s *ReferenceSuite) TestReferenceNameIsSafe() {
+	for _, tc := range []struct {
+		name ReferenceName
+		safe bool
+	}{
+		// One-level pseudo-refs ([A-Z_] only).
+		{"HEAD", true},
+		{"ORIG_HEAD", true},
+		{"FETCH_HEAD", true},
+		{"MERGE_HEAD", true},
+		{"CHERRY_PICK_HEAD", true},
+		// Well-formed refs/ names.
+		{"refs/heads/main", true},
+		{"refs/heads/release-1.2", true},
+		{"refs/tags/v1.0.0", true},
+		{"refs/remotes/origin/HEAD", true},
+		{"refs/stash", true},
+		// Empty, and one-level names that are not pseudo-refs (would land on
+		// top-level .git metadata).
+		{"", false},
+		{"config", false},
+		{"index", false},
+		{"packed-refs", false},
+		{"config.worktree", false},
+		{"bar", false},
+		{"head", false},
+		{"HEAD2", false},
+		// refs/ names that escape or have empty components.
+		{"refs/", false},
+		{"refs/heads/.", false},
+		{"refs/heads/..", false},
+		{"refs/heads/../../config", false},
+		{"refs/heads//main", false},
+		{"refs/heads/", false},
+		// Absolute and drive-prefixed forms.
+		{"/config", false},
+		{"/refs/heads/main", false},
+		{"\\config", false},
+		{"C:config", false},
+		// Backslash inside a refs/ name: a Windows path separator that could
+		// escape the sub-tree or alias another name once turned into a path.
+		{"refs/heads/foo\\bar", false},
+		{"refs/heads\\..\\config", false},
+		{"refs/heads\\foo", false},
+	} {
+		s.Equal(tc.safe, tc.name.IsSafe(), "IsSafe(%q)", tc.name)
+	}
+}
+
 func (s *ReferenceSuite) TestReferenceNameWithSlash() {
 	r := ReferenceName("refs/remotes/origin/feature/AllowSlashes")
 	s.Equal("origin/feature/AllowSlashes", r.Short())

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -95,35 +95,37 @@ var (
 	ErrReferenceNameEscape = errors.New("reference name escapes the reference storage")
 )
 
-// validReferenceName rejects reference names that cannot be safely turned
-// into a path under the .git directory. A loose reference (and its reflog)
-// is stored verbatim at ".git/<name>", so a name carrying a "." or ".."
-// path component, a volume prefix, or a control character would let a
-// crafted name — for instance one advertised by a malicious remote — climb
-// out of its reference sub-tree and read, overwrite, or delete unrelated
-// metadata such as .git/config. This is a defence-in-depth check at the
-// storage choke point, mirroring the containment applied to submodule names
-// in validSubmoduleName and canonical Git's check_refname_format.
+func isPathSep(r rune) bool { return r == '/' || r == '\\' }
+
+// validReferenceName rejects reference names that cannot be safely turned into
+// a path under the .git directory. A loose reference (and its reflog) is stored
+// verbatim at ".git/<name>", so a crafted name — for instance one advertised by
+// a malicious remote — could climb out of its reference sub-tree and read,
+// overwrite, or delete unrelated metadata such as .git/config.
 //
-// The per-component check is delegated to pathutil.IsHFSDot and
+// The storage-safety gate is plumbing.ReferenceName.IsSafe, mirroring Git's
+// refname_is_safe: a name must be under refs/ without escaping it, or be a
+// [A-Z_] pseudo-ref. This alone rejects absolute, drive-prefixed, escaping and
+// single-level metadata names. On top of it, this adds filesystem-specific
+// hardening that IsSafe's literal check does not cover: control characters, and
+// components a case-insensitive/NTFS/HFS+ filesystem would fold back to "." or
+// ".." (trailing dots/spaces, Alternate Data Streams, ignorable Unicode code
+// points). The per-component check is delegated to pathutil.IsHFSDot and
 // pathutil.IsNTFSDot with "." as the needle, exactly as validSubmoduleName
-// does: besides the bare "." and ".." cases, these reject components that
-// still resolve to ".." after HFS+ Unicode normalisation (ignored code
-// points, e.g. ".<U+200C>.") or NTFS trailing-space/period/ADS
-// canonicalisation (e.g. ".. ", "..::$INDEX_ALLOCATION"). Because a name
-// can be authored on one OS and reach this layer on another, both checks
-// run unconditionally regardless of host OS.
+// does, and runs regardless of host OS because a name can be authored on one OS
+// and reach this layer on another.
 func validReferenceName(name plumbing.ReferenceName) error {
+	if !name.IsSafe() {
+		return fmt.Errorf("%w: %q is not under refs/ nor a valid pseudo-ref", ErrReferenceNameEscape, string(name))
+	}
+
 	s := string(name)
 	for i := 0; i < len(s); i++ {
 		if s[i] < 0x20 || s[i] == 0x7f {
 			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
 		}
 	}
-	if filepath.VolumeName(s) != "" {
-		return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
-	}
-	for _, part := range strings.FieldsFunc(s, func(r rune) bool { return r == '/' || r == '\\' }) {
+	for _, part := range strings.FieldsFunc(s, isPathSep) {
 		// IsNTFSDot/IsHFSDot with a "." needle match ".." and its disguises
 		// but not a bare ".", so reject that component explicitly too.
 		if part == "." || pathutil.IsHFSDot(part, ".") || pathutil.IsNTFSDot(part, ".", "") {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -147,11 +147,56 @@ func (s *SuiteDotGit) TestReferenceNameRejectsHFSDisguisedTraversal() {
 	s.Error(err, "traversal must not create .git/config")
 }
 
+func (s *SuiteDotGit) TestReferenceNameRejectsAbsoluteAndDriveNames() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	// A leading or trailing separator, or a drive-letter prefix, lets the
+	// name collapse onto a top-level .git file (e.g. "/config" -> .git/config)
+	// once joined. filepath.VolumeName alone would not catch "C:config" off
+	// Windows, so these are rejected host-independently as validSubmoduleName
+	// does.
+	bad := []plumbing.ReferenceName{
+		"/config",
+		"\\config",
+		"C:config",
+		"refs/heads/foo/",
+		"",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		s.ErrorIs(d.SetRef(ref, nil), ErrReferenceNameEscape, "SetRef %q", n)
+	}
+
+	_, err := d.fs.Stat(configPath)
+	s.Error(err, "must not create .git/config")
+}
+
+func (s *SuiteDotGit) TestReferenceNameRejectsTopLevelMetadata() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	// A single-level name that is neither under refs/ nor a [A-Z_] pseudo-ref
+	// would land on top-level .git metadata once joined; the IsSafe gate
+	// rejects it, matching upstream refname_is_safe.
+	bad := []plumbing.ReferenceName{
+		"config", "config.worktree", "index", "packed-refs",
+		"shallow", "hooks", "objects", "bar", "HEAD2", "head",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		s.ErrorIs(d.SetRef(ref, nil), ErrReferenceNameEscape, "SetRef %q", n)
+	}
+
+	_, err := d.fs.Stat(configPath)
+	s.Error(err, "must not create .git/config")
+}
+
 func (s *SuiteDotGit) TestReferenceNameAcceptsBenignNames() {
 	d := New(s.EmptyFS())
 	s.Require().NoError(d.Initialize())
 	for _, n := range []plumbing.ReferenceName{
-		"HEAD", "ORIG_HEAD", "FETCH_HEAD",
+		"HEAD", "ORIG_HEAD", "FETCH_HEAD", "MERGE_HEAD", "CHERRY_PICK_HEAD",
 		"refs/heads/main", "refs/heads/release-1.2",
 		"refs/tags/v1.0.0", "refs/remotes/origin/HEAD", "refs/stash",
 	} {
@@ -223,11 +268,14 @@ func testSetRefs(s *SuiteDotGit, dir *DotGit) {
 
 	s.Require().NoError(err)
 
+	// A single-level, non-pseudo-ref name is refused: it is not under refs/
+	// and its spelling is not the [A-Z_] pseudo-ref form (upstream
+	// refname_is_safe rejects it likewise).
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"bar",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
-	s.Require().NoError(err)
+	s.ErrorIs(err, ErrReferenceNameEscape)
 
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(
 		"refs/heads/feature/baz",
@@ -266,10 +314,9 @@ func testSetRefs(s *SuiteDotGit, dir *DotGit) {
 	s.NotNil(ref)
 	s.Equal("refs/heads/foo", ref.Target().String())
 
-	ref, err = dir.Ref("bar")
-	s.Require().NoError(err)
-	s.NotNil(ref)
-	s.Equal("e8d3ffab552895c19b9fcf7aa264d277cde33881", ref.Hash().String())
+	// "bar" was refused at write time and is refused at read time too.
+	_, err = dir.Ref("bar")
+	s.ErrorIs(err, ErrReferenceNameEscape)
 
 	// Check that SetRef with a non-nil `old` works.
 	err = dir.SetRef(plumbing.NewReferenceFromStrings(

--- a/storage/tests/storage_test.go
+++ b/storage/tests/storage_test.go
@@ -366,16 +366,16 @@ func TestSetReferenceAndGetReference(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		err := sto.SetReference(
-			plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		)
 		require.NoError(t, err)
 
 		err = sto.SetReference(
-			plumbing.NewReferenceFromStrings("bar", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+			plumbing.NewReferenceFromStrings("refs/bar", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		require.NoError(t, err)
 
-		e, err := sto.Reference(plumbing.ReferenceName("foo"))
+		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	})
@@ -386,17 +386,17 @@ func TestCheckAndSetReference(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		err := sto.SetReference(
-			plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+			plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		require.NoError(t, err)
 
 		err = sto.CheckAndSetReference(
-			plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
-			plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+			plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		require.NoError(t, err)
 
-		e, err := sto.Reference(plumbing.ReferenceName("foo"))
+		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	})
@@ -407,17 +407,17 @@ func TestCheckAndSetReferenceNil(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		err := sto.SetReference(
-			plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+			plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		require.NoError(t, err)
 
 		err = sto.CheckAndSetReference(
-			plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 			nil,
 		)
 		require.NoError(t, err)
 
-		e, err := sto.Reference(plumbing.ReferenceName("foo"))
+		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	})
@@ -428,17 +428,17 @@ func TestCheckAndSetReferenceError(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		err := sto.SetReference(
-			plumbing.NewReferenceFromStrings("foo", "c3f4688a08fd86f1bf8e055724c84b7a40a09733"),
+			plumbing.NewReferenceFromStrings("refs/foo", "c3f4688a08fd86f1bf8e055724c84b7a40a09733"),
 		)
 		require.NoError(t, err)
 
 		err = sto.CheckAndSetReference(
-			plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
-			plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
+			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+			plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		assert.ErrorIs(t, err, storage.ErrReferenceHasChanged)
 
-		e, err := sto.Reference(plumbing.ReferenceName("foo"))
+		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "c3f4688a08fd86f1bf8e055724c84b7a40a09733")
 	})
@@ -449,14 +449,14 @@ func TestRemoveReference(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		err := sto.SetReference(
-			plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		)
 		require.NoError(t, err)
 
-		err = sto.RemoveReference(plumbing.ReferenceName("foo"))
+		err = sto.RemoveReference(plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 
-		_, err = sto.Reference(plumbing.ReferenceName("foo"))
+		_, err = sto.Reference(plumbing.ReferenceName("refs/foo"))
 		assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
 	})
 }
@@ -466,14 +466,14 @@ func TestRemoveReferenceNonExistent(t *testing.T) {
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		err := sto.SetReference(
-			plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
+			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		)
 		require.NoError(t, err)
 
-		err = sto.RemoveReference(plumbing.ReferenceName("nonexistent"))
+		err = sto.RemoveReference(plumbing.ReferenceName("refs/nonexistent"))
 		require.NoError(t, err)
 
-		e, err := sto.Reference(plumbing.ReferenceName("foo"))
+		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, "bc9968d75e48de59f0870ffb71f5e160bbbdcf52", e.Hash().String())
 	})
@@ -483,7 +483,7 @@ func TestGetReferenceNotFound(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		r, err := sto.Reference(plumbing.ReferenceName("bar"))
+		r, err := sto.Reference(plumbing.ReferenceName("refs/bar"))
 		assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
 		assert.Nil(t, r)
 	})


### PR DESCRIPTION
Add `plumbing.ReferenceName.IsSafe`, mirroring Git's `refname_is_safe` (refs.c): a name is safe only when it lives under refs/ without escaping the sub-tree, or is a one-level `[A-Z_]` pseudo-ref (`HEAD`, `ORIG_HEAD`, ...).

`validReferenceName` now gates on IsSafe before its filesystem-specific hardening (control characters, NTFS/HFS ".." disguises). This closes the remaining gap where a single-level name such as "config" or "index" would resolve onto top-level .git metadata, while still accepting the pseudo-refs and refs/ names real callers use.

The check stays at the filesystem storage boundary, matching upstream (refname_is_safe runs when writing the on-disk ref store); the in-memory backend is intentionally left permissive, as go-git reuses it as a scratch buffer during fetch (e.g. exact-SHA1 refspecs) where transient bare-hash entries are never persisted.

The storage conformance suite used bare single-level names (foo, bar) that are invalid on a filesystem ref store; these now use refs/ names.

Follow-up from #2247.