### PR TITLE
git: worktree, stat checked-out files via the open fd.

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -993,11 +993,12 @@ func (w *Worktree) checkoutChangeRegularFile(cfg *config.Config,
 			return err
 		}
 
-		if err := w.checkoutFile(cfg, fs, f); err != nil {
+		fi, err := w.checkoutFile(cfg, fs, f)
+		if err != nil {
 			return err
 		}
 
-		return w.addIndexFromFile(fs, name, e.Hash, idx)
+		return w.addIndexFromFile(name, e.Hash, fi, idx)
 	}
 
 	return nil
@@ -1044,18 +1045,18 @@ func (w *Worktree) clearBlockingSymlinks(fs *worktreeFilesystem, name string) er
 	return nil
 }
 
-func (w *Worktree) checkoutFile(cfg *config.Config, fs *worktreeFilesystem, f *object.File) (err error) {
+func (w *Worktree) checkoutFile(cfg *config.Config, fs *worktreeFilesystem, f *object.File) (fi os.FileInfo, err error) {
 	// checkoutFile is the materialisation boundary for tracked entries.
 	// Remove any blocking symlink first so the subsequent OpenFile or
 	// Symlink call writes the entry itself instead of following a planted
 	// final-component link in the underlying filesystem.
 	if err := w.clearBlockingSymlinks(fs, f.Name); err != nil {
-		return err
+		return nil, err
 	}
 
 	mode, err := f.Mode.ToOSFileMode()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if mode&os.ModeSymlink != 0 {
@@ -1064,11 +1065,16 @@ func (w *Worktree) checkoutFile(cfg *config.Config, fs *worktreeFilesystem, f *o
 
 	dstFile, err := fs.OpenFile(f.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer ioutil.CheckClose(dstFile, &err)
 
-	return w.copyObjectToWorktree(cfg, f, dstFile)
+	if err := w.copyObjectToWorktree(cfg, f, dstFile); err != nil {
+		return nil, err
+	}
+
+	fi, err = dstFile.Stat()
+	return fi, err
 }
 
 func (w *Worktree) copyObjectToWorktree(cfg *config.Config, object *object.File, file billy.File) (err error) {
@@ -1105,7 +1111,7 @@ func (w *Worktree) copyObjectToWorktree(cfg *config.Config, object *object.File,
 	return err
 }
 
-func (w *Worktree) checkoutFileSymlink(fs *worktreeFilesystem, f *object.File) (err error) {
+func (w *Worktree) checkoutFileSymlink(fs *worktreeFilesystem, f *object.File) (fi os.FileInfo, err error) {
 	// .gitmodules symlink rejection (and its NTFS / HFS variants) is
 	// enforced by the worktreeFilesystem wrapper's Symlink method via
 	// validSymlinkName. See https://github.com/git/git/commit/10ecfa7
@@ -1113,14 +1119,14 @@ func (w *Worktree) checkoutFileSymlink(fs *worktreeFilesystem, f *object.File) (
 
 	from, err := f.Reader()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	defer ioutil.CheckClose(from, &err)
 
 	bytes, err := io.ReadAll(from)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = fs.Symlink(string(bytes), f.Name)
@@ -1132,15 +1138,19 @@ func (w *Worktree) checkoutFileSymlink(fs *worktreeFilesystem, f *object.File) (
 
 		to, err := fs.OpenFile(f.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		defer ioutil.CheckClose(to, &err)
 
-		_, err = to.Write(bytes)
-		return err
+		if _, err = to.Write(bytes); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
 	}
-	return err
+
+	return fs.Lstat(f.Name)
 }
 
 func (w *Worktree) addIndexFromTreeEntry(name string, f *object.TreeEntry, idx *indexBuilder) error {
@@ -1153,12 +1163,8 @@ func (w *Worktree) addIndexFromTreeEntry(name string, f *object.TreeEntry, idx *
 	return nil
 }
 
-func (w *Worktree) addIndexFromFile(fs *worktreeFilesystem, name string, h plumbing.Hash, idx *indexBuilder) error {
+func (w *Worktree) addIndexFromFile(name string, h plumbing.Hash, fi os.FileInfo, idx *indexBuilder) error {
 	idx.Remove(name)
-	fi, err := fs.Lstat(name)
-	if err != nil {
-		return err
-	}
 
 	mode, err := filemode.NewFromOSFileMode(fi.Mode())
 	if err != nil {

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -181,7 +181,7 @@ func (w *Worktree) CherryPick(commitOpts *CommitOptions, ortStrategyOption OrtMe
 				// worktree write needs the full path so it lands at the
 				// right location and is validated by the wrapper.
 				to.Name = change.To.Name
-				if err := w.checkoutFile(cfg, fs, to); err != nil {
+				if _, err := w.checkoutFile(cfg, fs, to); err != nil {
 					return err
 				}
 				if _, err := w.Add(to.Name); err != nil {

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -576,7 +576,7 @@ func (s *WorktreeSuite) TestCheckoutReplacesBlockingFinalSymlink() {
 		blob, err := object.DecodeBlob(blobObj)
 		require.NoError(t, err)
 
-		err = w.checkoutFile(&config.Config{}, w.filesystem, object.NewFile("tracked.txt", filemode.Regular, blob))
+		_, err = w.checkoutFile(&config.Config{}, w.filesystem, object.NewFile("tracked.txt", filemode.Regular, blob))
 		require.NoError(t, err)
 
 		got, err := fs.Open("tracked.txt")


### PR DESCRIPTION
checkoutFile returns the file FileInfo obtained from fstat on the open descriptor before it is closed, and addIndexFromFile consumes it directly instead of issuing a separate lstat per checked-out file. This removes a path lookup from the checkout hot path and, for BoundOS, an extra os.Root open/close per file. Symlinks still lstat since there is no fd to fstat.

```
Benchmark results (darwin/arm64, Apple M4 Pro, benchstat):
  BenchmarkCloneLargeRepo                       537.6ms -> 380.1ms  -29.30% (p=0.001, n=7)
  BenchmarkCloneDeepRepo                       1283.4ms -> 969.8ms  -24.43% (p=0.001, n=7)
  BenchmarkResetHardIgnoredDir/BaselineNoIgnoredFiles
                                               11.74ms -> 11.80ms        ~ (p=0.683, n=15)
```

The reset benchmark resets to HEAD, so no checkout occurs and it is unaffected by this change, as expected.
