### PR TITLE
plumbing: protocol/packp, reject control bytes in daemon request

### DIFF
--- a/plumbing/protocol/packp/gitproto.go
+++ b/plumbing/protocol/packp/gitproto.go
@@ -33,6 +33,42 @@ func (g *GitProtoRequest) validate() error {
 		return fmt.Errorf("%w: empty request command", ErrInvalidGitProtoRequest)
 	}
 
+	// The request is a single pkt-line whose fields are separated by NUL
+	// bytes ("<command> <pathname>\x00host=<host>\x00\x00<params>..."). A
+	// control byte in any field breaks that framing or splices in extra
+	// NUL-delimited fields (a second host=, additional parameters) that the
+	// caller never set. A git:// URL with a percent-encoded NUL, for example
+	// "git://host/repo%00host=evil", decodes into exactly such a Pathname, so
+	// refuse control bytes in every field before encoding.
+	if err := validateGitProtoField("request command", g.RequestCommand); err != nil {
+		return err
+	}
+	if err := validateGitProtoField("pathname", g.Pathname); err != nil {
+		return err
+	}
+	if err := validateGitProtoField("host", g.Host); err != nil {
+		return err
+	}
+	for _, p := range g.ExtraParams {
+		if err := validateGitProtoField("extra parameter", p); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateGitProtoField rejects a request field containing an ASCII control
+// byte (0x00-0x1f or 0x7f). Such a byte would break the NUL-framed pkt-line or
+// inject additional fields; no valid command, path, host, or parameter
+// contains one. The rejected range matches the worktree path validator.
+func validateGitProtoField(name, value string) error {
+	for i := 0; i < len(value); i++ {
+		if value[i] < 0x20 || value[i] == 0x7f {
+			return fmt.Errorf("%w: %s contains control byte %#02x",
+				ErrInvalidGitProtoRequest, name, value[i])
+		}
+	}
 	return nil
 }
 

--- a/plumbing/protocol/packp/gitproto.go
+++ b/plumbing/protocol/packp/gitproto.go
@@ -39,7 +39,7 @@ func (g *GitProtoRequest) validate() error {
 	// NUL-delimited fields (a second host=, additional parameters) that the
 	// caller never set. A git:// URL with a percent-encoded NUL, for example
 	// "git://host/repo%00host=evil", decodes into exactly such a Pathname, so
-	// refuse control bytes in every field before encoding.
+	// refuse control bytes in every field.
 	if err := validateGitProtoField("request command", g.RequestCommand); err != nil {
 		return err
 	}
@@ -60,8 +60,11 @@ func (g *GitProtoRequest) validate() error {
 
 // validateGitProtoField rejects a request field containing an ASCII control
 // byte (0x00-0x1f or 0x7f). Such a byte would break the NUL-framed pkt-line or
-// inject additional fields; no valid command, path, host, or parameter
-// contains one. The rejected range matches the worktree path validator.
+// splice in additional fields. No valid command, path, host, or parameter
+// contains one. This matches upstream git, which forbids newlines in the host
+// and path of a git:// request (git.git a02ea577, CVE-2021-40330), and extends
+// it to the full control range including NUL, which a Go string can carry
+// through where a C string cannot.
 func validateGitProtoField(name, value string) error {
 	for i := 0; i < len(value); i++ {
 		if value[i] < 0x20 || value[i] == 0x7f {
@@ -150,5 +153,10 @@ func (g *GitProtoRequest) Decode(r io.Reader) error {
 		}
 	}
 
-	return nil
+	// A decoded request comes straight off the wire from an untrusted peer.
+	// NUL cannot survive here (it delimits the fields split above), but other
+	// control bytes such as newline or ESC can, and the server forwards these
+	// fields into URL construction and log lines. Reject them symmetrically
+	// with Encode.
+	return g.validate()
 }

--- a/plumbing/protocol/packp/gitproto_test.go
+++ b/plumbing/protocol/packp/gitproto_test.go
@@ -2,6 +2,7 @@ package packp
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -106,13 +107,14 @@ func TestValidateEmptyGitProtoRequest(t *testing.T) {
 func TestEncodeGitProtoRequestRejectsControlBytes(t *testing.T) {
 	t.Parallel()
 	// A git:// URL such as "git://host/repo%00host=evil%00%00version=2"
-	// decodes to this Pathname; encoding it verbatim would append a second
+	// decodes to this Pathname. Encoding it verbatim would append a second
 	// host= selector and extra parameters to the single daemon request.
 	cases := []GitProtoRequest{
 		{RequestCommand: "git-upload-pack", Pathname: "/repo\x00host=evil"},
 		{RequestCommand: "git-upload-pack", Pathname: "/repo", Host: "host\x00evil"},
 		{RequestCommand: "git-upload-pack", Pathname: "/repo\nhost=evil"},
 		{RequestCommand: "git-upload-pack", Pathname: "/repo", ExtraParams: []string{"version=2\x00inject"}},
+		{RequestCommand: "git-upload-pack\x7f", Pathname: "/repo"},
 	}
 	for _, p := range cases {
 		var buf bytes.Buffer
@@ -121,6 +123,26 @@ func TestEncodeGitProtoRequestRejectsControlBytes(t *testing.T) {
 		}
 		if buf.Len() != 0 {
 			t.Fatalf("expected no bytes written on rejection, got %q", buf.String())
+		}
+	}
+}
+
+func TestDecodeGitProtoRequestRejectsControlBytes(t *testing.T) {
+	t.Parallel()
+	// NUL is the field delimiter and cannot appear inside a field, but a peer
+	// can put a newline or other control byte in the pathname or host. The
+	// server forwards these into URL construction and log lines, so a decoded
+	// request carrying one must be rejected.
+	payloads := []string{
+		"git-upload-pack /repo\nhost=evil\x00",
+		"git-upload-pack /repo\x00host=ev\x1bil\x00",
+	}
+	for _, payload := range payloads {
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "%04x%s", len(payload)+4, payload)
+		var p GitProtoRequest
+		if err := p.Decode(&buf); err == nil {
+			t.Fatalf("expected error decoding %q", payload)
 		}
 	}
 }

--- a/plumbing/protocol/packp/gitproto_test.go
+++ b/plumbing/protocol/packp/gitproto_test.go
@@ -102,3 +102,25 @@ func TestValidateEmptyGitProtoRequest(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestEncodeGitProtoRequestRejectsControlBytes(t *testing.T) {
+	t.Parallel()
+	// A git:// URL such as "git://host/repo%00host=evil%00%00version=2"
+	// decodes to this Pathname; encoding it verbatim would append a second
+	// host= selector and extra parameters to the single daemon request.
+	cases := []GitProtoRequest{
+		{RequestCommand: "git-upload-pack", Pathname: "/repo\x00host=evil"},
+		{RequestCommand: "git-upload-pack", Pathname: "/repo", Host: "host\x00evil"},
+		{RequestCommand: "git-upload-pack", Pathname: "/repo\nhost=evil"},
+		{RequestCommand: "git-upload-pack", Pathname: "/repo", ExtraParams: []string{"version=2\x00inject"}},
+	}
+	for _, p := range cases {
+		var buf bytes.Buffer
+		if err := p.Encode(&buf); err == nil {
+			t.Fatalf("expected error for %+v, got encoded %q", p, buf.String())
+		}
+		if buf.Len() != 0 {
+			t.Fatalf("expected no bytes written on rejection, got %q", buf.String())
+		}
+	}
+}


### PR DESCRIPTION
An attacker-controlled `git://` URL like `git://host/repo%00host=evil%00%00version=2` reaches the daemon-request encoder with a `Pathname` that still holds the decoded NUL bytes (`net/url` unescapes `%00`, and the git transport passes `req.URL.Path` straight through). `Encode` wrote every field verbatim into the single NUL-framed pkt-line:

    git-upload-pack /repo\x00host=evil\x00\x00version=2\x00host=realhost:9418\x00

So the request the client sends carries an attacker-chosen `host=` selector and extra parameters in front of the ones the transport set from the connection, which is enough to steer a daemon's virtual-host routing on a path-only injection (a malicious `.gitmodules` submodule url is one way in). Canonical git never hits this because the path is a C string a NUL truncates.

`validate()`, which `Encode` always calls first, now refuses control bytes in the command, pathname, host, and extra params before anything is written. It is the same rejection `ls-refs` already applies to ref-prefixes. The other NUL-delimited pkt-line writers take storage-validated ref names or fixed capabilities, so the daemon request is the one field reachable directly from a URL, and I kept the change to it.
