### PR TITLE
plumbing: protocol/packp, compare zero object ids by value in Action

### DIFF
--- a/options.go
+++ b/options.go
@@ -464,7 +464,7 @@ type ResetOptions struct {
 
 // Validate validates the fields and sets the default values.
 func (o *ResetOptions) Validate(r *Repository) error {
-	if o.Commit == plumbing.ZeroHash {
+	if o.Commit.IsZero() {
 		ref, err := r.Head()
 		if err != nil {
 			return err

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -470,7 +470,7 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 	// from either cache or storage, else we would need to inflate
 	// it to then inflate the current object, which could go on
 	// indefinitely.
-	if p.storage != nil && parent.Hash != plumbing.ZeroHash {
+	if p.storage != nil && !parent.Hash.IsZero() {
 		obj, err := p.storage.EncodedObject(parent.Type, parent.Hash)
 		if err == nil {
 			// Ensure that external references have the correct type and size.

--- a/plumbing/protocol/packp/updreq.go
+++ b/plumbing/protocol/packp/updreq.go
@@ -57,15 +57,20 @@ type Command struct {
 
 // Action returns the action type of the command.
 func (c *Command) Action() Action {
-	if c.Old == plumbing.ZeroHash && c.New == plumbing.ZeroHash {
+	// Compare with IsZero rather than == plumbing.ZeroHash: the latter also
+	// matches on the object-format field, and a zero object id decoded from
+	// the wire carries the negotiated format (e.g. sha256 for a 64-hex id)
+	// while plumbing.ZeroHash is format-unset. IsZero looks only at the
+	// bytes, mirroring Git's is_null_oid.
+	if c.Old.IsZero() && c.New.IsZero() {
 		return Invalid
 	}
 
-	if c.Old == plumbing.ZeroHash {
+	if c.Old.IsZero() {
 		return Create
 	}
 
-	if c.New == plumbing.ZeroHash {
+	if c.New.IsZero() {
 		return Delete
 	}
 

--- a/plumbing/protocol/packp/updreq_test.go
+++ b/plumbing/protocol/packp/updreq_test.go
@@ -1,0 +1,49 @@
+package packp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// A zero object id decoded from the wire carries the negotiated object
+// format. On a sha256 repository (or from a client that sends a 64-hex
+// id) the deletion/creation marker is a 64-hex zero, which does not
+// compare equal to the format-unset plumbing.ZeroHash. Action must key
+// off the bytes so create/delete/invalid are classified correctly.
+func TestCommandActionZeroHashObjectFormat(t *testing.T) {
+	t.Parallel()
+
+	sha1Zero := plumbing.NewHash("0000000000000000000000000000000000000000")
+	sha256Zero := plumbing.NewHash("0000000000000000000000000000000000000000000000000000000000000000")
+	sha1Ref := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	sha256Ref := plumbing.NewHash("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
+
+	require.False(t, sha256Zero == plumbing.ZeroHash, "precondition: 64-hex zero is not == ZeroHash")
+	require.True(t, sha256Zero.IsZero(), "precondition: 64-hex zero IsZero")
+
+	for _, tc := range []struct {
+		name string
+		cmd  *Command
+		want Action
+	}{
+		{"sha1 create", &Command{Name: "refs/heads/x", Old: sha1Zero, New: sha1Ref}, Create},
+		{"sha1 delete", &Command{Name: "refs/heads/x", Old: sha1Ref, New: sha1Zero}, Delete},
+		{"sha1 invalid", &Command{Name: "refs/heads/x", Old: sha1Zero, New: sha1Zero}, Invalid},
+		{"sha256 create", &Command{Name: "refs/heads/x", Old: sha256Zero, New: sha256Ref}, Create},
+		{"sha256 delete", &Command{Name: "refs/heads/x", Old: sha256Ref, New: sha256Zero}, Delete},
+		{"sha256 invalid", &Command{Name: "refs/heads/x", Old: sha256Zero, New: sha256Zero}, Invalid},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, tc.cmd.Action())
+		})
+	}
+
+	// The both-zero command is malformed and validate must reject it even
+	// when the ids arrive 64-hex encoded.
+	require.Error(t, (&Command{Name: "refs/heads/x", Old: sha256Zero, New: sha256Zero}).validate())
+}

--- a/remote.go
+++ b/remote.go
@@ -1108,7 +1108,7 @@ func objectExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
 }
 
 func checkFastForwardUpdate(s storer.EncodedObjectStorer, remoteRefs storer.ReferenceStorer, cmd *packp.Command) error {
-	if cmd.Old == plumbing.ZeroHash {
+	if cmd.Old.IsZero() {
 		_, err := remoteRefs.Reference(cmd.Name)
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return nil
@@ -1410,7 +1410,7 @@ func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Refe
 func objectsToPush(commands []*packp.Command) []plumbing.Hash {
 	objects := make([]plumbing.Hash, 0, len(commands))
 	for _, cmd := range commands {
-		if cmd.New == plumbing.ZeroHash {
+		if cmd.New.IsZero() {
 			continue
 		}
 		objects = append(objects, cmd.New)

--- a/repository.go
+++ b/repository.go
@@ -1578,7 +1578,7 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 
 func (r *Repository) log(from plumbing.Hash, commitIterFunc func(*object.Commit) object.CommitIter) (object.CommitIter, error) {
 	h := from
-	if from == plumbing.ZeroHash {
+	if from.IsZero() {
 		head, err := r.Head()
 		if err != nil {
 			return nil, err

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -584,7 +584,7 @@ func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (size int64, err erro
 	// degrades gracefully — same shape as HasEncodedObject.
 	idxErr := s.requireIndex()
 	if idxErr == nil {
-		if pack, idx, offset := s.findObjectInPackfile(h); pack != plumbing.ZeroHash {
+		if pack, idx, offset := s.findObjectInPackfile(h); !pack.IsZero() {
 			if cached, ok := s.objectCache.Get(h); ok {
 				return cached.Size(), nil
 			}
@@ -637,7 +637,7 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 	idxErr := s.requireIndex()
 	routed := false
 	if idxErr == nil {
-		if pack, idx, offset := s.findObjectInPackfile(h); pack != plumbing.ZeroHash {
+		if pack, idx, offset := s.findObjectInPackfile(h); !pack.IsZero() {
 			routed = true
 			if cached, ok := s.objectCache.Get(h); ok {
 				if t == plumbing.AnyObject || cached.Type() == t {


### PR DESCRIPTION
**Zero id check in Command.Action is object-format sensitive**

`Command.Action` decides create/delete/update by comparing `Old`/`New` to `plumbing.ZeroHash` with `==`, and that comparison also covers the id's object-format field. A zero id parsed from a push request carries the negotiated format ("sha256" for a 64-hex id) while `plumbing.ZeroHash` is format-unset, so a 64-hex zero never matches: on the receive-pack side a real delete is read as an update and the ref gets rewritten to the all-zero id instead of removed, and a both-zero command that should be rejected as invalid passes `validate`. The client controls the id text, so this is reachable on sha1 repos too. Moved the three checks to `Hash.IsZero`, which looks only at the bytes like Git's `is_null_oid`, so the sentinel no longer depends on the id's format.
