### PR TITLE
[WIP] Add `ctx` argument to `Storer` interface

### DIFF
--- a/_examples/blame/main.go
+++ b/_examples/blame/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -10,27 +11,29 @@ import (
 
 // Basic example of how to blame a repository.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<path>", "<file_to_blame>")
 	url := os.Args[1]
 	path := os.Args[2]
 
 	// Clone the given repository.
 	Info("git open %s", url)
-	r, err := git.PlainOpen(url)
+	r, err := git.PlainOpen(ctx, url)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
 	// Retrieve the branch's HEAD, to then get the HEAD commit.
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 
-	c, err := r.CommitObject(ref.Hash())
+	c, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	Info("git blame %s", path)
 
 	// Blame the given file/path.
-	br, err := git.Blame(c, path)
+	br, err := git.Blame(ctx, c, path)
 	CheckIfError(err)
 
 	fmt.Printf("%s", br.String())

--- a/_examples/branch/main.go
+++ b/_examples/branch/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/go-git/go-git/v6"
@@ -10,12 +11,14 @@ import (
 
 // An example of how to create and remove branches or any other kind of reference.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>")
 	url, directory := os.Args[1], os.Args[2]
 
 	// Clone the given repository to the given directory
 	Info("git clone %s %s", url, directory)
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL: url,
 	})
 	CheckIfError(err)
@@ -24,7 +27,7 @@ func main() {
 	// Create a new branch to the current HEAD
 	Info("git branch my-branch")
 
-	headRef, err := r.Head()
+	headRef, err := r.Head(ctx)
 	CheckIfError(err)
 
 	// Create a new plumbing.HashReference object with the name of the branch
@@ -36,11 +39,11 @@ func main() {
 	ref := plumbing.NewHashReference("refs/heads/my-branch", headRef.Hash())
 
 	// The created reference is saved in the storage.
-	err = r.Storer.SetReference(ref)
+	err = r.Storer.SetReference(ctx, ref)
 	CheckIfError(err)
 
 	// Or deleted from it.
 	Info("git branch -D my-branch")
-	err = r.Storer.RemoveReference(ref.Name())
+	err = r.Storer.RemoveReference(ctx, ref.Name())
 	CheckIfError(err)
 }

--- a/_examples/checkout-branch/main.go
+++ b/_examples/checkout-branch/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -13,12 +14,14 @@ import (
 
 // Checkout a branch
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>", "<branch>")
 	url, directory, branch := os.Args[1], os.Args[2], os.Args[3]
 
 	// Clone the given repository to the given directory
 	Info("git clone %s %s", url, directory)
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL: url,
 	})
 	CheckIfError(err)
@@ -26,12 +29,12 @@ func main() {
 
 	// ... retrieving the commit being pointed by HEAD
 	Info("git show-ref --head HEAD")
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 
 	fmt.Println(ref.Hash())
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	CheckIfError(err)
 
 	// ... checking out branch
@@ -42,15 +45,15 @@ func main() {
 		Branch: plumbing.ReferenceName(branchRefName),
 		Force:  true,
 	}
-	if err := w.Checkout(&branchCoOpts); err != nil {
+	if err := w.Checkout(ctx, &branchCoOpts); err != nil {
 		Warning("local checkout of branch '%s' failed, will attempt to fetch remote branch of same name.", branch)
 		Warning("like `git checkout <branch>` defaulting to `git checkout -b <branch> --track <remote>/<branch>`")
 
 		mirrorRemoteBranchRefSpec := fmt.Sprintf("refs/heads/%s:refs/heads/%s", branch, branch)
-		err = fetchOrigin(r, mirrorRemoteBranchRefSpec)
+		err = fetchOrigin(ctx, r, mirrorRemoteBranchRefSpec)
 		CheckIfError(err)
 
-		err = w.Checkout(&branchCoOpts)
+		err = w.Checkout(ctx, &branchCoOpts)
 		CheckIfError(err)
 	}
 	CheckIfError(err)
@@ -59,13 +62,13 @@ func main() {
 
 	// ... retrieving the commit being pointed by HEAD (branch now)
 	Info("git show-ref --head HEAD")
-	ref, err = r.Head()
+	ref, err = r.Head(ctx)
 	CheckIfError(err)
 	fmt.Println(ref.Hash())
 }
 
-func fetchOrigin(repo *git.Repository, refSpecStr string) error {
-	remote, err := repo.Remote("origin")
+func fetchOrigin(ctx context.Context, repo *git.Repository, refSpecStr string) error {
+	remote, err := repo.Remote(ctx, "origin")
 	CheckIfError(err)
 
 	var refSpecs []config.RefSpec
@@ -73,7 +76,7 @@ func fetchOrigin(repo *git.Repository, refSpecStr string) error {
 		refSpecs = []config.RefSpec{config.RefSpec(refSpecStr)}
 	}
 
-	if err = remote.Fetch(&git.FetchOptions{
+	if err = remote.Fetch(ctx, &git.FetchOptions{
 		RefSpecs: refSpecs,
 	}); err != nil {
 		if errors.Is(err, git.NoErrAlreadyUpToDate) {

--- a/_examples/checkout/main.go
+++ b/_examples/checkout/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,12 +12,14 @@ import (
 
 // Basic example of how to checkout a specific commit.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>", "<commit>")
 	url, directory, commit := os.Args[1], os.Args[2], os.Args[3]
 
 	// Clone the given repository to the given directory
 	Info("git clone %s %s", url, directory)
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL: url,
 	})
 
@@ -25,16 +28,16 @@ func main() {
 
 	// ... retrieving the commit being pointed by HEAD
 	Info("git show-ref --head HEAD")
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 	fmt.Println(ref.Hash())
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	CheckIfError(err)
 
 	// ... checking out to commit
 	Info("git checkout %s", commit)
-	err = w.Checkout(&git.CheckoutOptions{
+	err = w.Checkout(ctx, &git.CheckoutOptions{
 		Hash: plumbing.NewHash(commit),
 	})
 	CheckIfError(err)
@@ -42,7 +45,7 @@ func main() {
 	// ... retrieving the commit being pointed by HEAD, it shows that the
 	// repository is pointing to the giving commit in detached mode
 	Info("git show-ref --head HEAD")
-	ref, err = r.Head()
+	ref, err = r.Head(ctx)
 	CheckIfError(err)
 	fmt.Println(ref.Hash())
 }

--- a/_examples/clone/auth/basic/access_token/main.go
+++ b/_examples/clone/auth/basic/access_token/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,12 +12,14 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>", "<github_access_token>")
 	url, directory, token := os.Args[1], os.Args[2], os.Args[3]
 
 	Info("git clone %s %s", url, directory)
 
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:      url,
 		Progress: os.Stdout,
 		ClientOptions: []client.Option{
@@ -29,9 +32,9 @@ func main() {
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/clone/auth/basic/username_password/main.go
+++ b/_examples/clone/auth/basic/username_password/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,12 +12,14 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>", "<username>", "<password>")
 	url, directory, username, password := os.Args[1], os.Args[2], os.Args[3], os.Args[4]
 
 	Info("git clone %s %s", url, directory)
 
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:      url,
 		Progress: os.Stdout,
 		ClientOptions: []client.Option{
@@ -29,9 +32,9 @@ func main() {
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/clone/auth/ssh/private_key/main.go
+++ b/_examples/clone/auth/ssh/private_key/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,6 +12,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>", "<private_key_file>")
 	url, directory, privateKeyFile := os.Args[1], os.Args[2], os.Args[3]
 	var password string
@@ -31,7 +34,7 @@ func main() {
 		return
 	}
 
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:      url,
 		Progress: os.Stdout,
 		ClientOptions: []client.Option{
@@ -41,9 +44,9 @@ func main() {
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/clone/auth/ssh/ssh_agent/main.go
+++ b/_examples/clone/auth/ssh/ssh_agent/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,6 +12,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>")
 	url, directory := os.Args[1], os.Args[2]
 
@@ -19,7 +22,7 @@ func main() {
 
 	Info("git clone %s ", url)
 
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:      url,
 		Progress: os.Stdout,
 		ClientOptions: []client.Option{
@@ -29,9 +32,9 @@ func main() {
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/clone/main.go
+++ b/_examples/clone/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -10,6 +11,8 @@ import (
 
 // Basic example of how to clone a repository using clone options.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>")
 	url := os.Args[1]
 	directory := os.Args[2]
@@ -17,7 +20,7 @@ func main() {
 	// Clone the given repository to the given directory
 	Info("git clone %s %s --recursive", url, directory)
 
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:               url,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})
@@ -26,10 +29,10 @@ func main() {
 	defer func() { _ = r.Close() }()
 
 	// ... retrieving the branch being pointed by HEAD
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 	// ... retrieving the commit object
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/commit/main.go
+++ b/_examples/commit/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,15 +15,17 @@ import (
 // Basic example of how to commit changes to the current branch to an existing
 // repository.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<directory>")
 	directory := os.Args[1]
 
 	// Opens an already existing repository.
-	r, err := git.PlainOpen(directory)
+	r, err := git.PlainOpen(ctx, directory)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	CheckIfError(err)
 
 	// ... we need a file to commit so let's create a new file inside of the
@@ -34,12 +37,12 @@ func main() {
 
 	// Adds the new file to the staging area.
 	Info("git add example-git-file")
-	_, err = w.Add("example-git-file")
+	_, err = w.Add(ctx, "example-git-file")
 	CheckIfError(err)
 
 	// We can verify the current status of the worktree using the method Status.
 	Info("git status --porcelain")
-	status, err := w.Status()
+	status, err := w.Status(ctx)
 	CheckIfError(err)
 
 	fmt.Println(status)
@@ -49,7 +52,7 @@ func main() {
 	// commit Since version 5.0.1, we can omit the Author signature, being read
 	// from the git config files.
 	Info("git commit -m \"example go-git commit\"")
-	commit, err := w.Commit("example go-git commit", &git.CommitOptions{
+	commit, err := w.Commit(ctx, "example go-git commit", &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "John Doe",
 			Email: "john@doe.org",
@@ -61,7 +64,7 @@ func main() {
 
 	// Prints the current HEAD to verify that all worked well.
 	Info("git show -s")
-	obj, err := r.CommitObject(commit)
+	obj, err := r.CommitObject(ctx, commit)
 	CheckIfError(err)
 
 	fmt.Println(obj)

--- a/_examples/config/main.go
+++ b/_examples/config/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/go-git/go-git/v6"
@@ -13,17 +14,19 @@ import (
 // - Set basic local config params
 
 func main() {
+	ctx := context.Background()
+
 	tmp, err := os.MkdirTemp("", "go-git-example")
 	CheckIfError(err)
 	defer os.RemoveAll(tmp)
 
 	Info("git init")
-	r, err := git.PlainInit(tmp, false)
+	r, err := git.PlainInit(ctx, tmp, false)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
 	// Load the configuration
-	cfg, err := r.Config()
+	cfg, err := r.Config(ctx)
 	CheckIfError(err)
 
 	Info("worktree is %s", cfg.Core.Worktree)
@@ -42,5 +45,5 @@ func main() {
 
 	// In order to save the config file, you need to call SetConfig
 	// After calling this go to .git/config and see the custom.name added and the changes to the remote
-	r.Storer.SetConfig(cfg)
+	r.Storer.SetConfig(ctx, cfg)
 }

--- a/_examples/context/main.go
+++ b/_examples/context/main.go
@@ -34,9 +34,9 @@ func main() {
 
 	Warning("To gracefully stop the clone operation, push Crtl-C.")
 
-	// Using PlainCloneContext we can provide to a context, if the context
-	// is cancelled, the clone operation stops gracefully.
-	r, err := git.PlainCloneContext(ctx, directory, &git.CloneOptions{
+	// PlainClone takes a context; if the context is cancelled, the clone
+	// operation stops gracefully.
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:      url,
 		Progress: os.Stdout,
 	})

--- a/_examples/custom_http/main.go
+++ b/_examples/custom_http/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -14,6 +15,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>")
 	url := os.Args[1]
 
@@ -29,7 +32,7 @@ func main() {
 
 	Info("git clone %s", url)
 
-	r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+	r, err := git.Clone(ctx, memory.NewStorage(), nil, &git.CloneOptions{
 		URL: url,
 		ClientOptions: []client.Option{
 			client.WithHTTPClient(customClient),
@@ -40,7 +43,7 @@ func main() {
 
 	Info("git rev-parse HEAD")
 
-	head, err := r.Head()
+	head, err := r.Head(ctx)
 	CheckIfError(err)
 	fmt.Println(head.Hash())
 }

--- a/_examples/find-if-any-tag-point-head/main.go
+++ b/_examples/find-if-any-tag-point-head/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,25 +12,27 @@ import (
 
 // Basic example of how to find if HEAD is tagged.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<path>")
 	path := os.Args[1]
 
 	// We instantiate a new repository targeting the given path (the .git folder)
-	r, err := git.PlainOpen(path)
+	r, err := git.PlainOpen(ctx, path)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
 	// Get HEAD reference to use for comparison later on.
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 
-	tags, err := r.Tags()
+	tags, err := r.Tags(ctx)
 	CheckIfError(err)
 
 	// List all tags, both lightweight tags and annotated tags and see if some tag points to HEAD reference.
-	err = tags.ForEach(func(t *plumbing.Reference) error {
+	err = tags.ForEach(ctx, func(t *plumbing.Reference) error {
 		// This technique should work for both lightweight and annotated tags.
-		revHash, err := r.ResolveRevision(plumbing.Revision(t.Name()))
+		revHash, err := r.ResolveRevision(ctx, plumbing.Revision(t.Name()))
 		CheckIfError(err)
 		if *revHash == ref.Hash() {
 			fmt.Printf("Found tag %s with hash %s pointing to HEAD %s\n", t.Name().Short(), revHash, ref.Hash())

--- a/_examples/http-server/main.go
+++ b/_examples/http-server/main.go
@@ -16,7 +16,7 @@
 // For pushes (receive-pack), the backend performs a basic auth check.
 // Use a URL with credentials or run with -allow-anonymous-receive.
 //
-//	 git clone http://user:pass@localhost:8080/myrepo.git
+//	git clone http://user:pass@localhost:8080/myrepo.git
 //
 // The server supports the Git-Protocol header (version=2) automatically.
 package main
@@ -50,7 +50,6 @@ func main() {
 	if len(flag.Args()) > 0 {
 		*root = flag.Arg(0)
 	}
-
 
 	loader := transport.NewFilesystemLoader(osfs.New(*root), false)
 	b := backend.New(loader)

--- a/_examples/log/main.go
+++ b/_examples/log/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -16,10 +17,12 @@ import (
 // - Using the HEAD reference, obtain the commit this reference is pointing to
 // - Using the commit, obtain its history and print it
 func main() {
+	ctx := context.Background()
+
 	// Clones the given repository, creating the remote, the local branches
 	// and fetching the objects, everything in memory:
 	Info("git clone https://github.com/src-d/go-siva")
-	r, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+	r, err := git.Clone(ctx, memory.NewStorage(), nil, &git.CloneOptions{
 		URL: "https://github.com/src-d/go-siva",
 	})
 	CheckIfError(err)
@@ -29,17 +32,17 @@ func main() {
 	Info("git log")
 
 	// ... retrieves the branch pointed by HEAD
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 
 	// ... retrieves the commit history
 	since := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
 	until := time.Date(2019, 7, 30, 0, 0, 0, 0, time.UTC)
-	cIter, err := r.Log(&git.LogOptions{From: ref.Hash(), Since: &since, Until: &until})
+	cIter, err := r.Log(ctx, &git.LogOptions{From: ref.Hash(), Since: &since, Until: &until})
 	CheckIfError(err)
 
 	// ... just iterates over the commits, printing it
-	err = cIter.ForEach(func(c *object.Commit) error {
+	err = cIter.ForEach(ctx, func(c *object.Commit) error {
 		fmt.Println(c)
 
 		return nil

--- a/_examples/ls-remote/main.go
+++ b/_examples/ls-remote/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -12,6 +13,8 @@ import (
 
 // Retrieve remote tags without cloning repository
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>")
 	url := os.Args[1]
 
@@ -26,7 +29,7 @@ func main() {
 	log.Print("Fetching tags...")
 
 	// We can then use every Remote functions to retrieve wanted information
-	refs, err := rem.List(&git.ListOptions{
+	refs, err := rem.List(ctx, &git.ListOptions{
 		// Returns all references, including peeled references.
 		PeelingOption: git.AppendPeeled,
 	})

--- a/_examples/ls/main.go
+++ b/_examples/ls/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +25,8 @@ import (
 
 // Example how to resolve a revision into its commit counterpart
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<path>", "<revision>", "<tree path>")
 
 	path := os.Args[1]
@@ -38,7 +41,7 @@ func main() {
 	}
 
 	s := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-	r, err := git.Open(s, fs)
+	r, err := git.Open(ctx, s, fs)
 	CheckIfError(err)
 	defer s.Close()
 
@@ -46,16 +49,16 @@ func main() {
 	// look at the doc to get more details
 	Info("git rev-parse %s", revision)
 
-	h, err := r.ResolveRevision(plumbing.Revision(revision))
+	h, err := r.ResolveRevision(ctx, plumbing.Revision(revision))
 	CheckIfError(err)
 
-	commit, err := r.CommitObject(*h)
+	commit, err := r.CommitObject(ctx, *h)
 	CheckIfError(err)
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(ctx)
 	CheckIfError(err)
 	if treePath != "" {
-		tree, err = tree.Tree(treePath)
+		tree, err = tree.Tree(ctx, treePath)
 		CheckIfError(err)
 	}
 
@@ -69,10 +72,10 @@ func main() {
 		defer file.Close()
 	}
 
-	commitNode, err := commitNodeIndex.Get(*h)
+	commitNode, err := commitNodeIndex.Get(ctx, *h)
 	CheckIfError(err)
 
-	revs, err := getLastCommitForPaths(commitNode, treePath, paths)
+	revs, err := getLastCommitForPaths(ctx, commitNode, treePath, paths)
 	CheckIfError(err)
 	for path, rev := range revs {
 		// Print one line per file (name hash message)
@@ -103,15 +106,15 @@ type commitAndPaths struct {
 	hashes map[string]plumbing.Hash
 }
 
-func getCommitTree(c commitgraph.CommitNode, treePath string) (*object.Tree, error) {
-	tree, err := c.Tree()
+func getCommitTree(ctx context.Context, c commitgraph.CommitNode, treePath string) (*object.Tree, error) {
+	tree, err := c.Tree(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// Optimize deep traversals by focusing only on the specific tree
 	if treePath != "" {
-		tree, err = tree.Tree(treePath)
+		tree, err = tree.Tree(ctx, treePath)
 		if err != nil {
 			return nil, err
 		}
@@ -130,8 +133,8 @@ func getFullPath(treePath, path string) string {
 	return path
 }
 
-func getFileHashes(c commitgraph.CommitNode, treePath string, paths []string) (map[string]plumbing.Hash, error) {
-	tree, err := getCommitTree(c, treePath)
+func getFileHashes(ctx context.Context, c commitgraph.CommitNode, treePath string, paths []string) (map[string]plumbing.Hash, error) {
+	tree, err := getCommitTree(ctx, c, treePath)
 	if errors.Is(err, object.ErrDirectoryNotFound) {
 		// The whole tree didn't exist, so return empty map
 		return make(map[string]plumbing.Hash), nil
@@ -143,7 +146,7 @@ func getFileHashes(c commitgraph.CommitNode, treePath string, paths []string) (m
 	hashes := make(map[string]plumbing.Hash)
 	for _, path := range paths {
 		if path != "" {
-			entry, err := tree.FindEntry(path)
+			entry, err := tree.FindEntry(ctx, path)
 			if err == nil {
 				hashes[path] = entry.Hash
 			}
@@ -155,7 +158,7 @@ func getFileHashes(c commitgraph.CommitNode, treePath string, paths []string) (m
 	return hashes, nil
 }
 
-func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []string) (map[string]*object.Commit, error) {
+func getLastCommitForPaths(ctx context.Context, c commitgraph.CommitNode, treePath string, paths []string) (map[string]*object.Commit, error) {
 	// We do a tree traversal with nodes sorted by commit time
 	heap := binaryheap.NewWith(func(a, b any) int {
 		if a.(*commitAndPaths).commit.CommitTime().Before(b.(*commitAndPaths).commit.CommitTime()) {
@@ -165,7 +168,7 @@ func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []st
 	})
 
 	resultNodes := make(map[string]commitgraph.CommitNode)
-	initialHashes, err := getFileHashes(c, treePath, paths)
+	initialHashes, err := getFileHashes(ctx, c, treePath, paths)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +187,7 @@ func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []st
 		numParents := current.commit.NumParents()
 		var parents []commitgraph.CommitNode
 		for i := range numParents {
-			parent, err := current.commit.ParentNode(i)
+			parent, err := current.commit.ParentNode(ctx, i)
 			if err != nil {
 				break
 			}
@@ -195,7 +198,7 @@ func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []st
 		pathUnchanged := make([]bool, len(current.paths))
 		parentHashes := make([]map[string]plumbing.Hash, len(parents))
 		for j, parent := range parents {
-			parentHashes[j], err = getFileHashes(parent, treePath, current.paths)
+			parentHashes[j], err = getFileHashes(ctx, parent, treePath, current.paths)
 			if err != nil {
 				break
 			}
@@ -263,7 +266,7 @@ func getLastCommitForPaths(c commitgraph.CommitNode, treePath string, paths []st
 	result := make(map[string]*object.Commit)
 	for path, commitNode := range resultNodes {
 		var err error
-		result[path], err = commitNode.Commit()
+		result[path], err = commitNode.Commit(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/_examples/memory/main.go
+++ b/_examples/memory/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -13,6 +14,8 @@ import (
 
 // Basic example of how to clone a repository using clone options.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>")
 	url := os.Args[1]
 
@@ -21,7 +24,7 @@ func main() {
 
 	wt := memfs.New()
 	storer := memory.NewStorage()
-	r, err := git.Clone(storer, wt, &git.CloneOptions{
+	r, err := git.Clone(ctx, storer, wt, &git.CloneOptions{
 		URL: url,
 	})
 
@@ -29,10 +32,10 @@ func main() {
 	defer func() { _ = r.Close() }()
 
 	// ... retrieving the branch being pointed by HEAD
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 	// ... retrieving the commit object
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/merge_base/main.go
+++ b/_examples/merge_base/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/go-git/go-git/v6"
@@ -42,6 +43,8 @@ options:
 // Command that mimics `git merge-base --is-ancestor <baseRev> <headRev>`
 // Command that mimics `git merge-base --independent <commitRev>...`
 func main() {
+	ctx := context.Background()
+
 	if len(os.Args) == 1 {
 		helpAndExit("Returns the merge-base between two commits:", helpShortMsg, exitCodeSuccess)
 	}
@@ -78,14 +81,14 @@ func main() {
 	}
 
 	// Open a git repository from current directory
-	repo, err := git.PlainOpen(path)
+	repo, err := git.PlainOpen(ctx, path)
 	checkIfError(err, exitCodeCouldNotOpenRepository, "not in a git repository")
 	defer func() { _ = repo.Close() }()
 
 	// Get the hashes of the passed revisions
 	var hashes []*plumbing.Hash
 	for _, rev := range commitRevs {
-		hash, err := repo.ResolveRevision(plumbing.Revision(rev))
+		hash, err := repo.ResolveRevision(ctx, plumbing.Revision(rev))
 		checkIfError(err, exitCodeCouldNotParseRevision, "could not parse revision '%s'", rev)
 		hashes = append(hashes, hash)
 	}
@@ -93,13 +96,13 @@ func main() {
 	// Get the commits identified by the passed hashes
 	var commits []*object.Commit
 	for _, hash := range hashes {
-		commit, err := repo.CommitObject(*hash)
+		commit, err := repo.CommitObject(ctx, *hash)
 		checkIfError(err, exitCodeUnexpected, "could not find commit '%s'", hash.String())
 		commits = append(commits, commit)
 	}
 
 	if modeAncestor {
-		isAncestor, err := commits[0].IsAncestor(commits[1])
+		isAncestor, err := commits[0].IsAncestor(ctx, commits[1])
 		checkIfError(err, exitCodeUnexpected, "could not traverse the repository history")
 
 		if !isAncestor {
@@ -110,10 +113,10 @@ func main() {
 	}
 
 	if modeIndependent {
-		res, err = object.Independents(commits)
+		res, err = object.Independents(ctx, commits)
 		checkIfError(err, exitCodeUnexpected, "could not traverse the repository history")
 	} else {
-		res, err = commits[0].MergeBase(commits[1])
+		res, err = commits[0].MergeBase(ctx, commits[1])
 		checkIfError(err, exitCodeUnexpected, "could not traverse the repository history")
 
 		if len(res) == 0 {

--- a/_examples/open/main.go
+++ b/_examples/open/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,11 +12,13 @@ import (
 
 // Open an existing repository in a specific folder.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<path>")
 	path := os.Args[1]
 
 	// We instantiate a new repository targeting the given path (the .git folder)
-	r, err := git.PlainOpen(path)
+	r, err := git.PlainOpen(ctx, path)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
@@ -23,16 +26,16 @@ func main() {
 	Info("git rev-list HEAD --count")
 
 	// ... retrieving the HEAD reference
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 
 	// ... retrieves the commit history
-	cIter, err := r.Log(&git.LogOptions{From: ref.Hash()})
+	cIter, err := r.Log(ctx, &git.LogOptions{From: ref.Hash()})
 	CheckIfError(err)
 
 	// ... just iterates over the commits
 	var cCount int
-	err = cIter.ForEach(func(c *object.Commit) error {
+	err = cIter.ForEach(ctx, func(c *object.Commit) error {
 		cCount++
 
 		return nil

--- a/_examples/performance/clone/main.go
+++ b/_examples/performance/clone/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto"
 	"crypto/sha1"
 	"fmt"
@@ -17,6 +18,8 @@ import (
 
 // Expands the Basic example focusing in performance.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>")
 	url := os.Args[1]
 	directory := os.Args[2]
@@ -48,7 +51,7 @@ func main() {
 		HighMemoryMode: true,
 	})
 
-	r, err := git.Clone(storer, fs, &git.CloneOptions{
+	r, err := git.Clone(ctx, storer, fs, &git.CloneOptions{
 		URL: url,
 		// Differently than the git CLI, by default go-git downloads
 		// all tags and its related objects. To avoid unnecessary
@@ -66,9 +69,9 @@ func main() {
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/progress/main.go
+++ b/_examples/progress/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/go-git/go-git/v6"
@@ -9,6 +10,8 @@ import (
 
 // Example of how to show the progress when you do a basic clone operation.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>")
 	url := os.Args[1]
 	directory := os.Args[2]
@@ -16,7 +19,7 @@ func main() {
 	// Clone the given repository to the given directory
 	Info("git clone %s %s", url, directory)
 
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:   url,
 		Depth: 1,
 

--- a/_examples/pull/main.go
+++ b/_examples/pull/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -10,27 +11,29 @@ import (
 
 // Pull changes from a remote repository
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<path>")
 	path := os.Args[1]
 
 	// We instantiate a new repository targeting the given path (the .git folder)
-	r, err := git.PlainOpen(path)
+	r, err := git.PlainOpen(ctx, path)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
 	// Get the working directory for the repository
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	CheckIfError(err)
 
 	// Pull the latest changes from the origin remote and merge into the current branch
 	Info("git pull origin")
-	err = w.Pull(&git.PullOptions{RemoteName: "origin"})
+	err = w.Pull(ctx, &git.PullOptions{RemoteName: "origin"})
 	CheckIfError(err)
 
 	// Print the latest commit that was just pulled
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/push/main.go
+++ b/_examples/push/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/go-git/go-git/v6"
@@ -10,15 +11,17 @@ import (
 // Example of how to open a repository in a specific path, and push to
 // its default remote (origin).
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<repository-path>")
 	path := os.Args[1]
 
-	r, err := git.PlainOpen(path)
+	r, err := git.PlainOpen(ctx, path)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
 	Info("git push")
 	// push using default options
-	err = r.Push(&git.PushOptions{})
+	err = r.Push(ctx, &git.PushOptions{})
 	CheckIfError(err)
 }

--- a/_examples/remotes/main.go
+++ b/_examples/remotes/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-git/go-git/v6"
@@ -18,15 +19,17 @@ import (
 // - Iterate the references again, but only showing hash references, not symbolic ones
 // - Remove remote "example"
 func main() {
+	ctx := context.Background()
+
 	// Create a new repository
 	Info("git init")
-	r, err := git.Init(memory.NewStorage())
+	r, err := git.Init(ctx, memory.NewStorage())
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
 	// Add a new remote, with the default fetch refspec
 	Info("git remote add example https://github.com/git-fixtures/basic.git")
-	_, err = r.CreateRemote(&config.RemoteConfig{
+	_, err = r.CreateRemote(ctx, &config.RemoteConfig{
 		Name: "example",
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})
@@ -36,7 +39,7 @@ func main() {
 	// List remotes from a repository
 	Info("git remote -v")
 
-	list, err := r.Remotes()
+	list, err := r.Remotes(ctx)
 	CheckIfError(err)
 
 	for _, r := range list {
@@ -45,7 +48,7 @@ func main() {
 
 	// Fetch using the new remote
 	Info("git fetch example")
-	err = r.Fetch(&git.FetchOptions{
+	err = r.Fetch(ctx, &git.FetchOptions{
 		RemoteName: "example",
 	})
 
@@ -55,10 +58,10 @@ func main() {
 	// > git show-ref
 	Info("git show-ref")
 
-	refs, err := r.References()
+	refs, err := r.References(ctx)
 	CheckIfError(err)
 
-	err = refs.ForEach(func(ref *plumbing.Reference) error {
+	err = refs.ForEach(ctx, func(ref *plumbing.Reference) error {
 		// The HEAD is omitted in a `git show-ref` so we ignore the symbolic
 		// references, the HEAD
 		if ref.Type() == plumbing.SymbolicReference {
@@ -74,6 +77,6 @@ func main() {
 	// Delete the example remote
 	Info("git remote rm example")
 
-	err = r.DeleteRemote("example")
+	err = r.DeleteRemote(ctx, "example")
 	CheckIfError(err)
 }

--- a/_examples/restore/main.go
+++ b/_examples/restore/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,24 +12,24 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
-func prepareRepo(w *git.Worktree, directory string) {
+func prepareRepo(ctx context.Context, w *git.Worktree, directory string) {
 	// We need a known state of files inside the worktree for testing revert a modify and delete
 	Info("echo \"hello world! Modify\" > for-modify")
 	err := os.WriteFile(filepath.Join(directory, "for-modify"), []byte("hello world! Modify"), 0o644)
 	CheckIfError(err)
 	Info("git add for-modify")
-	_, err = w.Add("for-modify")
+	_, err = w.Add(ctx, "for-modify")
 	CheckIfError(err)
 
 	Info("echo \"hello world! Delete\" > for-delete")
 	err = os.WriteFile(filepath.Join(directory, "for-delete"), []byte("hello world! Delete"), 0o644)
 	CheckIfError(err)
 	Info("git add for-delete")
-	_, err = w.Add("for-delete")
+	_, err = w.Add(ctx, "for-delete")
 	CheckIfError(err)
 
 	Info("git commit -m \"example go-git commit\"")
-	_, err = w.Commit("example go-git commit", &git.CommitOptions{
+	_, err = w.Commit(ctx, "example go-git commit", &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "John Doe",
 			Email: "john@doe.org",
@@ -40,64 +41,66 @@ func prepareRepo(w *git.Worktree, directory string) {
 
 // An example of how to restore AKA unstage files
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<directory>")
 	directory := os.Args[1]
 
 	// Opens an already existing repository.
-	r, err := git.PlainOpen(directory)
+	r, err := git.PlainOpen(ctx, directory)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	CheckIfError(err)
 
-	prepareRepo(w, directory)
+	prepareRepo(ctx, w, directory)
 
 	// Perform the operation and stage them
 	Info("echo \"hello world! Modify 2\" > for-modify")
 	err = os.WriteFile(filepath.Join(directory, "for-modify"), []byte("hello world! Modify 2"), 0o644)
 	CheckIfError(err)
 	Info("git add for-modify")
-	_, err = w.Add("for-modify")
+	_, err = w.Add(ctx, "for-modify")
 	CheckIfError(err)
 
 	Info("echo \"hello world! Add\" > for-add")
 	err = os.WriteFile(filepath.Join(directory, "for-add"), []byte("hello world! Add"), 0o644)
 	CheckIfError(err)
 	Info("git add for-add")
-	_, err = w.Add("for-add")
+	_, err = w.Add(ctx, "for-add")
 	CheckIfError(err)
 
 	Info("rm for-delete")
 	err = os.Remove(filepath.Join(directory, "for-delete"))
 	CheckIfError(err)
 	Info("git add for-delete")
-	_, err = w.Add("for-delete")
+	_, err = w.Add(ctx, "for-delete")
 	CheckIfError(err)
 
 	// We can verify the current status of the worktree using the method Status.
 	Info("git status --porcelain")
-	status, err := w.Status()
+	status, err := w.Status(ctx)
 	CheckIfError(err)
 	fmt.Println(status)
 
 	// Unstage a single file and see the status
 	Info("git restore --staged for-modify")
-	err = w.Restore(&git.RestoreOptions{Staged: true, Files: []string{"for-modify"}})
+	err = w.Restore(ctx, &git.RestoreOptions{Staged: true, Files: []string{"for-modify"}})
 	CheckIfError(err)
 
 	Info("git status --porcelain")
-	status, err = w.Status()
+	status, err = w.Status(ctx)
 	CheckIfError(err)
 	fmt.Println(status)
 
 	// Unstage the other 2 files and see the status
 	Info("git restore --staged for-add for-delete")
-	err = w.Restore(&git.RestoreOptions{Staged: true, Files: []string{"for-add", "for-delete"}})
+	err = w.Restore(ctx, &git.RestoreOptions{Staged: true, Files: []string{"for-add", "for-delete"}})
 	CheckIfError(err)
 
 	Info("git status --porcelain")
-	status, err = w.Status()
+	status, err = w.Status(ctx)
 	CheckIfError(err)
 	fmt.Println(status)
 }

--- a/_examples/revision/main.go
+++ b/_examples/revision/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,13 +12,15 @@ import (
 
 // Example how to resolve a revision into its commit counterpart
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<path>", "<revision>")
 
 	path := os.Args[1]
 	revision := os.Args[2]
 
 	// We instantiate a new repository targeting the given path (the .git folder)
-	r, err := git.PlainOpen(path)
+	r, err := git.PlainOpen(ctx, path)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
@@ -25,7 +28,7 @@ func main() {
 	// look at the doc to get more details
 	Info("git rev-parse %s", revision)
 
-	h, err := r.ResolveRevision(plumbing.Revision(revision))
+	h, err := r.ResolveRevision(ctx, plumbing.Revision(revision))
 
 	CheckIfError(err)
 

--- a/_examples/sha256/main.go
+++ b/_examples/sha256/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,17 +18,19 @@ import (
 
 // Basic example of how to initialise a repository using sha256 as the hashing algorithm.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<directory>")
 	directory := os.Args[1]
 
 	os.RemoveAll(directory)
 
 	// Init a new repository using the ObjectFormat SHA256.
-	r, err := git.PlainInit(directory, false, git.WithObjectFormat(config.SHA256))
+	r, err := git.PlainInit(ctx, directory, false, git.WithObjectFormat(config.SHA256))
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	CheckIfError(err)
 
 	// ... we need a file to commit so let's create a new file inside of the
@@ -39,7 +42,7 @@ func main() {
 
 	// Adds the new file to the staging area.
 	Info("git add example-git-file")
-	_, err = w.Add("example-git-file")
+	_, err = w.Add(ctx, "example-git-file")
 	CheckIfError(err)
 
 	// Commits the current staging area to the repository, with the new file
@@ -47,7 +50,7 @@ func main() {
 	// commit Since version 5.0.1, we can omit the Author signature, being read
 	// from the git config files.
 	Info("git commit -m \"example go-git commit\"")
-	commit, err := w.Commit("example go-git commit", &git.CommitOptions{
+	commit, err := w.Commit(ctx, "example go-git commit", &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "John Doe",
 			Email: "john@doe.org",
@@ -59,7 +62,7 @@ func main() {
 
 	// Prints the current HEAD to verify that all worked well.
 	Info("git show -s")
-	obj, err := r.CommitObject(commit)
+	obj, err := r.CommitObject(ctx, commit)
 	CheckIfError(err)
 
 	fmt.Println(obj)

--- a/_examples/showcase/main.go
+++ b/_examples/showcase/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -19,6 +20,8 @@ import (
 // - Print all the commit history with commit messages, short hash and the
 // first line of the commit message
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url> <path>")
 	url := os.Args[1]
 	path := os.Args[2]
@@ -27,7 +30,7 @@ func main() {
 	// and fetching the objects, exactly as:
 	Info("git clone %s %s", url, path)
 
-	r, err := git.PlainClone(path, &git.CloneOptions{URL: url})
+	r, err := git.PlainClone(ctx, path, &git.CloneOptions{URL: url})
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
@@ -35,11 +38,11 @@ func main() {
 	Info("git log -1")
 
 	// ... retrieving the branch being pointed by HEAD
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 
 	// ... retrieving the commit object
-	commit, err := r.CommitObject(ref.Hash())
+	commit, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 	fmt.Println(commit)
 
@@ -47,11 +50,11 @@ func main() {
 	Info("git ls-tree -r HEAD")
 
 	// ... retrieve the tree from the commit
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(ctx)
 	CheckIfError(err)
 
 	// ... get the files iterator and print the file
-	tree.Files().ForEach(func(f *object.File) error {
+	tree.Files().ForEach(ctx, func(f *object.File) error {
 		fmt.Printf("100644 blob %s    %s\n", f.Hash, f.Name)
 		return nil
 	})
@@ -59,10 +62,10 @@ func main() {
 	// List the history of the repository
 	Info("git log --oneline")
 
-	commitIter, err := r.Log(&git.LogOptions{From: commit.Hash})
+	commitIter, err := r.Log(ctx, &git.LogOptions{From: commit.Hash})
 	CheckIfError(err)
 
-	err = commitIter.ForEach(func(c *object.Commit) error {
+	err = commitIter.ForEach(ctx, func(c *object.Commit) error {
 		hash := c.Hash.String()
 		line := strings.Split(c.Message, "\n")
 		fmt.Println(hash[:7], line[0])

--- a/_examples/sparse-checkout/main.go
+++ b/_examples/sparse-checkout/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/go-git/go-git/v6"
@@ -8,6 +9,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<sparse_path>", "<directory>")
 	url := os.Args[1]
 	path := os.Args[2]
@@ -15,17 +18,17 @@ func main() {
 
 	Info("git clone %s %s", url, directory)
 
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:        url,
 		NoCheckout: true,
 	})
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	CheckIfError(err)
 
-	err = w.Checkout(&git.CheckoutOptions{
+	err = w.Checkout(ctx, &git.CheckoutOptions{
 		SparseCheckoutDirectories: []string{path},
 	})
 	CheckIfError(err)

--- a/_examples/submodule/main.go
+++ b/_examples/submodule/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/go-git/go-git/v6"
@@ -10,6 +11,8 @@ import (
 // Basic example of how to clone a repository including a submodule and
 // updating submodule ref
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<url>", "<directory>", "<submodule>")
 	url := os.Args[1]
 	directory := os.Args[2]
@@ -18,7 +21,7 @@ func main() {
 	// Clone the given repository to the given directory
 	Info("git clone %s %s --recursive", url, directory)
 
-	r, err := git.PlainClone(directory, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, directory, &git.CloneOptions{
 		URL:               url,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})
@@ -26,28 +29,28 @@ func main() {
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	if err != nil {
 		CheckIfError(err)
 	}
 
-	sub, err := w.Submodule(submodule)
+	sub, err := w.Submodule(ctx, submodule)
 	if err != nil {
 		CheckIfError(err)
 	}
 
-	sr, err := sub.Repository()
+	sr, err := sub.Repository(ctx)
 	if err != nil {
 		CheckIfError(err)
 	}
 
-	sw, err := sr.Worktree()
+	sw, err := sr.Worktree(ctx)
 	if err != nil {
 		CheckIfError(err)
 	}
 
 	Info("git submodule update --remote")
-	err = sw.Pull(&git.PullOptions{
+	err = sw.Pull(ctx, &git.PullOptions{
 		RemoteName: "origin",
 	})
 	if err != nil {

--- a/_examples/tag-create-push/main.go
+++ b/_examples/tag-create-push/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"log"
 	"os"
@@ -15,27 +16,29 @@ import (
 
 // Example of how create a tag and push it to a remote.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<ssh-url>", "<directory>", "<tag>", "<name>", "<email>", "<public-key>")
 	url := os.Args[1]
 	directory := os.Args[2]
 	tag := os.Args[3]
 	key := os.Args[6]
 
-	r, err := cloneRepo(url, directory, key)
+	r, err := cloneRepo(ctx, url, directory, key)
 	if err != nil {
 		log.Printf("clone repo error: %s", err)
 		return
 	}
 	defer func() { _ = r.Close() }()
 
-	created, err := setTag(r, tag)
+	created, err := setTag(ctx, r, tag)
 	if err != nil {
 		log.Printf("create tag error: %s", err)
 		return
 	}
 
 	if created {
-		err = pushTags(r, key)
+		err = pushTags(ctx, r, key)
 		if err != nil {
 			log.Printf("push tag error: %s", err)
 			return
@@ -43,7 +46,7 @@ func main() {
 	}
 }
 
-func cloneRepo(url, dir, publicKeyPath string) (*git.Repository, error) {
+func cloneRepo(ctx context.Context, url, dir, publicKeyPath string) (*git.Repository, error) {
 	log.Printf("cloning %s into %s", url, dir)
 	auth, keyErr := publicKey(publicKeyPath)
 	if keyErr != nil {
@@ -51,7 +54,7 @@ func cloneRepo(url, dir, publicKeyPath string) (*git.Repository, error) {
 	}
 
 	Info("git clone %s", url)
-	r, err := git.PlainClone(dir, &git.CloneOptions{
+	r, err := git.PlainClone(ctx, dir, &git.CloneOptions{
 		Progress:      os.Stdout,
 		URL:           url,
 		ClientOptions: []client.Option{client.WithSSHAuth(auth)},
@@ -74,16 +77,16 @@ func publicKey(filePath string) (*ssh.PublicKeys, error) {
 	return publicKey, err
 }
 
-func tagExists(tag string, r *git.Repository) bool {
+func tagExists(ctx context.Context, tag string, r *git.Repository) bool {
 	tagFoundErr := "tag was found"
 	Info("git show-ref --tag")
-	tags, err := r.TagObjects()
+	tags, err := r.TagObjects(ctx)
 	if err != nil {
 		log.Printf("get tags error: %s", err)
 		return false
 	}
 	res := false
-	err = tags.ForEach(func(t *object.Tag) error {
+	err = tags.ForEach(ctx, func(t *object.Tag) error {
 		if t.Name == tag {
 			res = true
 			return errors.New(tagFoundErr)
@@ -97,19 +100,19 @@ func tagExists(tag string, r *git.Repository) bool {
 	return res
 }
 
-func setTag(r *git.Repository, tag string) (bool, error) {
-	if tagExists(tag, r) {
+func setTag(ctx context.Context, r *git.Repository, tag string) (bool, error) {
+	if tagExists(ctx, tag, r) {
 		log.Printf("tag %s already exists", tag)
 		return false, nil
 	}
 	log.Printf("Set tag %s", tag)
-	h, err := r.Head()
+	h, err := r.Head(ctx)
 	if err != nil {
 		log.Printf("get HEAD error: %s", err)
 		return false, err
 	}
 	Info("git tag -a %s %s -m \"%s\"", tag, h.Hash(), tag)
-	_, err = r.CreateTag(tag, h.Hash(), &git.CreateTagOptions{
+	_, err = r.CreateTag(ctx, tag, h.Hash(), &git.CreateTagOptions{
 		Message: tag,
 	})
 	if err != nil {
@@ -120,7 +123,7 @@ func setTag(r *git.Repository, tag string) (bool, error) {
 	return true, nil
 }
 
-func pushTags(r *git.Repository, publicKeyPath string) error {
+func pushTags(ctx context.Context, r *git.Repository, publicKeyPath string) error {
 	auth, _ := publicKey(publicKeyPath)
 
 	po := &git.PushOptions{
@@ -130,7 +133,7 @@ func pushTags(r *git.Repository, publicKeyPath string) error {
 		ClientOptions: []client.Option{client.WithSSHAuth(auth)},
 	}
 	Info("git push --tags")
-	err := r.Push(po)
+	err := r.Push(ctx, po)
 	if err != nil {
 		if errors.Is(err, git.NoErrAlreadyUpToDate) {
 			log.Print("origin remote was up to date, no push done")

--- a/_examples/tag/main.go
+++ b/_examples/tag/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -12,20 +13,22 @@ import (
 
 // Basic example of how to list tags.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<path>")
 	path := os.Args[1]
 
 	// We instantiate a new repository targeting the given path (the .git folder)
-	r, err := git.PlainOpen(path)
+	r, err := git.PlainOpen(ctx, path)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
 	// List all tag references, both lightweight tags and annotated tags
 	Info("git show-ref --tag")
 
-	tagrefs, err := r.Tags()
+	tagrefs, err := r.Tags(ctx)
 	CheckIfError(err)
-	err = tagrefs.ForEach(func(t *plumbing.Reference) error {
+	err = tagrefs.ForEach(ctx, func(t *plumbing.Reference) error {
 		fmt.Println(t)
 		return nil
 	})
@@ -34,9 +37,9 @@ func main() {
 	// Print each annotated tag object (lightweight tags are not included)
 	Info("for t in $(git show-ref --tag); do if [ \"$(git cat-file -t $t)\" = \"tag\" ]; then git cat-file -p $t ; fi; done")
 
-	tags, err := r.TagObjects()
+	tags, err := r.TagObjects(ctx)
 	CheckIfError(err)
-	err = tags.ForEach(func(t *object.Tag) error {
+	err = tags.ForEach(ctx, func(t *object.Tag) error {
 		fmt.Println(t)
 		return nil
 	})

--- a/_examples/update-server-info/main.go
+++ b/_examples/update-server-info/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/go-git/go-git/v6"
@@ -15,16 +16,18 @@ import (
 // https://git-scm.com/docs/git-update-server-info
 // https://git-scm.com/book/id/v2/Git-Internals-Transfer-Protocols#_the_dumb_protocol
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<path>")
 	path := os.Args[1]
 
 	// We instantiate a new repository targeting the given path (the .git folder)
-	r, err := git.PlainOpen(path)
+	r, err := git.PlainOpen(ctx, path)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
 	// Update the server info files & save them to the file-system.
 	fs := r.Storer.(*filesystem.Storage).Filesystem()
-	err = transport.UpdateServerInfo(r.Storer, fs)
+	err = transport.UpdateServerInfo(ctx, r.Storer, fs)
 	CheckIfError(err)
 }

--- a/_examples/worktrees/main.go
+++ b/_examples/worktrees/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,8 @@ import (
 
 // Create a linked worktree from a commit.
 func main() {
+	ctx := context.Background()
+
 	CheckArgs("<dotgit> <worktree>")
 	path := os.Args[1]
 	wtPath := os.Args[2]
@@ -31,18 +34,18 @@ func main() {
 
 	// No options are specified here, so Add will use the repository's HEAD commit by default.
 	// To use a specific commit instead, pass xworktree.WithCommit(<hash>) as an additional option.
-	err = w.Add(worktreeFs, name)
+	err = w.Add(ctx, worktreeFs, name)
 	CheckIfError(err)
 
 	Info("opening linked worktree at %q", wtPath)
-	r, err := w.Open(worktreeFs)
+	r, err := w.Open(ctx, worktreeFs)
 	CheckIfError(err)
 	defer func() { _ = r.Close() }()
 
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	CheckIfError(err)
 
-	c, err := r.CommitObject(ref.Hash())
+	c, err := r.CommitObject(ctx, ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(c)

--- a/archive.go
+++ b/archive.go
@@ -11,13 +11,8 @@ import (
 // ArchiveRemote creates an archive from a remote repository.
 // It returns an io.ReadCloser that yields the archive data.
 // The caller must close the returned ReadCloser.
-func ArchiveRemote(url string, o *ArchiveOptions) (io.ReadCloser, error) {
-	return ArchiveRemoteContext(context.Background(), url, o)
-}
-
-// ArchiveRemoteContext creates an archive from a remote repository.
 // The provided Context can be used to cancel the operation.
-func ArchiveRemoteContext(ctx context.Context, url string, o *ArchiveOptions) (io.ReadCloser, error) {
+func ArchiveRemote(ctx context.Context, url string, o *ArchiveOptions) (io.ReadCloser, error) {
 	if o == nil {
 		o = &ArchiveOptions{}
 	}

--- a/archive_test.go
+++ b/archive_test.go
@@ -132,7 +132,7 @@ func TestArchiveRemote(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := ArchiveRemote(tt.url, tt.opts)
+			_, err := ArchiveRemote(t.Context(), tt.url, tt.opts)
 			if tt.wantErr == "" {
 				if err != nil {
 					assert.NotContains(t, err.Error(), "unsupported format")
@@ -209,7 +209,7 @@ func TestArchiveRemoteIntegration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			rc, err := ArchiveRemote(repoURL, tt.opts)
+			rc, err := ArchiveRemote(t.Context(), repoURL, tt.opts)
 			require.NoError(t, err)
 			t.Cleanup(func() { rc.Close() })
 

--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -121,7 +121,7 @@ func (l *tagLoader) Load(_ *url.URL) (storage.Storer, error) {
 	// do not add close here otherwise you will either double close, or hide a missing close
 
 	if l.objectFormat != "" {
-		cfg, err := st.Config(l.TB.Context())
+		cfg, err := st.Config(l.Context())
 		require.NoError(l.TB, err)
 
 		want := config.ObjectFormat(l.objectFormat)

--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -121,7 +121,7 @@ func (l *tagLoader) Load(_ *url.URL) (storage.Storer, error) {
 	// do not add close here otherwise you will either double close, or hide a missing close
 
 	if l.objectFormat != "" {
-		cfg, err := st.Config()
+		cfg, err := st.Config(l.TB.Context())
 		require.NoError(l.TB, err)
 
 		want := config.ObjectFormat(l.objectFormat)

--- a/blame.go
+++ b/blame.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"container/heap"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -29,7 +30,7 @@ type BlameResult struct {
 
 // Blame returns a BlameResult with the information about the last author of
 // each line from file `path` at commit `c`.
-func Blame(c *object.Commit, path string) (*BlameResult, error) {
+func Blame(ctx context.Context, c *object.Commit, path string) (*BlameResult, error) {
 	// The file to blame is identified by the input arguments:
 	// commit and path. commit is a Commit object obtained from a Repository. Path
 	// represents a path to a specific file contained in the repository.
@@ -51,7 +52,7 @@ func Blame(c *object.Commit, path string) (*BlameResult, error) {
 	b.path = path
 	b.q = new(priorityQueue)
 
-	file, err := b.fRev.File(path)
+	file, err := b.fRev.File(ctx, path)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +95,7 @@ func Blame(c *object.Commit, path string) (*BlameResult, error) {
 				break
 			}
 		}
-		finished, err := b.addBlames(items)
+		finished, err := b.addBlames(ctx, items)
 		if err != nil {
 			return nil, err
 		}
@@ -172,7 +173,7 @@ type lineMap struct {
 	FromParentNo int
 }
 
-func (b *blame) addBlames(curItems []*queueItem) (bool, error) {
+func (b *blame) addBlames(ctx context.Context, curItems []*queueItem) (bool, error) {
 	curItem := curItems[0]
 
 	// Simple optimisation to merge paths, there is potential to go a bit further here and check for any duplicates
@@ -243,18 +244,18 @@ func (b *blame) addBlames(curItems []*queueItem) (bool, error) {
 		curItem.Child = nil
 	}
 
-	parents, err := parentsContainingPath(curItem.path, curItem.Commit)
+	parents, err := parentsContainingPath(ctx, curItem.path, curItem.Commit)
 	if err != nil {
 		return false, err
 	}
 
 	anyPushed := false
 	for parnetNo, prev := range parents {
-		currentHash, err := blobHash(curItem.path, curItem.Commit)
+		currentHash, err := blobHash(ctx, curItem.path, curItem.Commit)
 		if err != nil {
 			return false, err
 		}
-		prevHash, err := blobHash(prev.Path, prev.Commit)
+		prevHash, err := blobHash(ctx, prev.Path, prev.Commit)
 		if err != nil {
 			return false, err
 		}
@@ -287,7 +288,7 @@ func (b *blame) addBlames(curItems []*queueItem) (bool, error) {
 		}
 
 		// get the contents of the file
-		file, err := prev.Commit.File(prev.Path)
+		file, err := prev.Commit.File(ctx, prev.Path)
 		if err != nil {
 			return false, err
 		}
@@ -533,24 +534,24 @@ type parentCommit struct {
 	Path   string
 }
 
-func parentsContainingPath(path string, c *object.Commit) ([]parentCommit, error) {
+func parentsContainingPath(ctx context.Context, path string, c *object.Commit) ([]parentCommit, error) {
 	// TODO: benchmark this method making git.object.Commit.parent public instead of using
 	// an iterator
 	var result []parentCommit
 	iter := c.Parents()
 	for {
-		parent, err := iter.Next()
+		parent, err := iter.Next(ctx)
 		if err == io.EOF {
 			return result, nil
 		}
 		if err != nil {
 			return nil, err
 		}
-		if _, err := parent.File(path); err == nil {
+		if _, err := parent.File(ctx, path); err == nil {
 			result = append(result, parentCommit{parent, path})
 		} else {
 			// look for renames
-			patch, err := parent.Patch(c)
+			patch, err := parent.Patch(ctx, c)
 			if err != nil {
 				return nil, err
 			} else if patch != nil {
@@ -566,8 +567,8 @@ func parentsContainingPath(path string, c *object.Commit) ([]parentCommit, error
 	}
 }
 
-func blobHash(path string, commit *object.Commit) (plumbing.Hash, error) {
-	file, err := commit.File(path)
+func blobHash(ctx context.Context, path string, commit *object.Commit) (plumbing.Hash, error) {
+	file, err := commit.File(ctx, path)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}

--- a/blame_test.go
+++ b/blame_test.go
@@ -56,10 +56,10 @@ func (s *BlameSuite) TestBlame() {
 		r := s.NewRepositoryFromPackfile(fixtures.ByURL(t.repo).One())
 
 		exp := s.mockBlame(t, r)
-		commit, err := r.CommitObject(plumbing.NewHash(t.rev))
+		commit, err := r.CommitObject(s.T().Context(), plumbing.NewHash(t.rev))
 		s.Require().NoError(err)
 
-		obt, err := Blame(commit, t.path)
+		obt, err := Blame(s.T().Context(), commit, t.path)
 		s.Require().NoError(err)
 		s.Equal(exp, obt)
 
@@ -70,10 +70,10 @@ func (s *BlameSuite) TestBlame() {
 }
 
 func (s *BlameSuite) mockBlame(t blameTest, r *Repository) (blame *BlameResult) {
-	commit, err := r.CommitObject(plumbing.NewHash(t.rev))
+	commit, err := r.CommitObject(s.T().Context(), plumbing.NewHash(t.rev))
 	s.Require().NoError(err, fmt.Sprintf("%v: repo=%s, rev=%s", err, t.repo, t.rev))
 
-	f, err := commit.File(t.path)
+	f, err := commit.File(s.T().Context(), t.path)
 	s.Require().NoError(err)
 	lines, err := f.Lines()
 	s.Require().NoError(err)
@@ -82,7 +82,7 @@ func (s *BlameSuite) mockBlame(t blameTest, r *Repository) (blame *BlameResult) 
 
 	blamedLines := make([]*Line, 0, len(t.blames))
 	for i := range t.blames {
-		commit, err := r.CommitObject(plumbing.NewHash(t.blames[i]))
+		commit, err := r.CommitObject(s.T().Context(), plumbing.NewHash(t.blames[i]))
 		s.Require().NoError(err)
 		l := &Line{
 			Author:     commit.Author.Email,

--- a/common_test.go
+++ b/common_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -76,7 +77,7 @@ func (s *BaseSuite) NewRepository(f *fixtures.Fixture) *Repository {
 
 	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
-	r, err := Open(st, worktree)
+	r, err := Open(s.T().Context(), st, worktree)
 	s.Require().NoError(err)
 
 	return r
@@ -85,7 +86,7 @@ func (s *BaseSuite) NewRepository(f *fixtures.Fixture) *Repository {
 // NewRepositoryWithEmptyWorktree returns a new repository using the .git folder
 // from the fixture but without a empty memfs worktree, the index and the
 // modules are deleted from the .git folder.
-func NewRepositoryWithEmptyWorktree(f *fixtures.Fixture) *Repository {
+func NewRepositoryWithEmptyWorktree(ctx context.Context, f *fixtures.Fixture) *Repository {
 	dotgit, err := f.DotGit()
 	if err != nil {
 		panic(err)
@@ -104,7 +105,7 @@ func NewRepositoryWithEmptyWorktree(f *fixtures.Fixture) *Repository {
 
 	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
-	r, err := Open(st, worktree)
+	r, err := Open(ctx, st, worktree)
 	if err != nil {
 		panic(err)
 	}
@@ -123,10 +124,10 @@ func (s *BaseSuite) NewRepositoryFromPackfile(f *fixtures.Fixture) *Repository {
 	s.Require().NoError(err)
 	defer func() { _ = p.Close() }()
 
-	s.Require().NoError(packfile.UpdateObjectStorage(storer, p))
-	s.Require().NoError(storer.SetReference(plumbing.NewHashReference(plumbing.HEAD, plumbing.NewHash(f.Head))))
+	s.Require().NoError(packfile.UpdateObjectStorage(s.T().Context(), storer, p))
+	s.Require().NoError(storer.SetReference(s.T().Context(), plumbing.NewHashReference(plumbing.HEAD, plumbing.NewHash(f.Head))))
 
-	r, err := Open(storer, memfs.New())
+	r, err := Open(s.T().Context(), storer, memfs.New())
 	s.Require().NoError(err)
 
 	s.cache[h] = r
@@ -206,7 +207,7 @@ func AssertReferences(t *testing.T, r *Repository, expected map[string]string) {
 	for name, target := range expected {
 		expected := plumbing.NewReferenceFromStrings(name, target)
 
-		obtained, err := r.Reference(expected.Name(), true)
+		obtained, err := r.Reference(t.Context(), expected.Name(), true)
 		assert.NoError(t, err)
 
 		assert.Equal(t, expected, obtained)
@@ -215,14 +216,14 @@ func AssertReferences(t *testing.T, r *Repository, expected map[string]string) {
 
 func AssertReferencesMissing(t *testing.T, r *Repository, expected []string) {
 	for _, name := range expected {
-		_, err := r.Reference(plumbing.ReferenceName(name), false)
+		_, err := r.Reference(t.Context(), plumbing.ReferenceName(name), false)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
 	}
 }
 
 func CommitNewFile(t *testing.T, repo *Repository, fileName string) plumbing.Hash {
-	wt, err := repo.Worktree()
+	wt, err := repo.Worktree(t.Context())
 	assert.NoError(t, err)
 
 	fd, err := wt.filesystem.Create(fileName)
@@ -234,10 +235,10 @@ func CommitNewFile(t *testing.T, repo *Repository, fileName string) plumbing.Has
 	err = fd.Close()
 	assert.NoError(t, err)
 
-	_, err = wt.Add(fileName)
+	_, err = wt.Add(t.Context(), fileName)
 	assert.NoError(t, err)
 
-	sha, err := wt.Commit("test commit", &CommitOptions{
+	sha, err := wt.Commit(t.Context(), "test commit", &CommitOptions{
 		Author: &object.Signature{
 			Name:  "test",
 			Email: "test@example.com",

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -36,8 +37,8 @@ const (
 
 // ConfigStorer is a generic storage of Config object.
 type ConfigStorer interface { //nolint:revive // stutters but is a well-established name
-	Config() (*Config, error)
-	SetConfig(*Config) error
+	Config(ctx context.Context) (*Config, error)
+	SetConfig(ctx context.Context, c *Config) error
 }
 
 var (

--- a/context_cancel_test.go
+++ b/context_cancel_test.go
@@ -18,6 +18,8 @@ import (
 // commit iterator both observe cancellation instead of silently swapping in
 // a background context.
 func TestContextCancellationPropagates(t *testing.T) {
+	t.Parallel()
+
 	f := fixtures.Basic().One()
 	dotgit, err := f.DotGit()
 	require.NoError(t, err)

--- a/context_cancel_test.go
+++ b/context_cancel_test.go
@@ -1,0 +1,44 @@
+package git
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/memfs"
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+)
+
+// TestContextCancellationPropagates asserts that a canceled context reaches
+// the storer through the full read path: Repository.Log resolution and the
+// commit iterator both observe cancellation instead of silently swapping in
+// a background context.
+func TestContextCancellationPropagates(t *testing.T) {
+	f := fixtures.Basic().One()
+	dotgit, err := f.DotGit()
+	require.NoError(t, err)
+	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+	r, err := Open(t.Context(), st, memfs.New())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
+
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// Entry-point resolution observes cancellation.
+	_, err = r.Log(canceled, &LogOptions{})
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Iteration observes cancellation: obtain a live iterator with a good
+	// ctx, then cancel mid-iteration.
+	iter, err := r.Log(t.Context(), &LogOptions{})
+	require.NoError(t, err)
+	defer iter.Close()
+
+	err = iter.ForEach(canceled, func(*object.Commit) error { return nil })
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -25,7 +26,7 @@ func ExampleClone() {
 
 	// Clones the repository into the worktree (fs) and stores all the .git
 	// content into the storer
-	r, err := git.Clone(storer, fs, &git.CloneOptions{
+	r, err := git.Clone(context.Background(), storer, fs, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 	})
 	if err != nil {
@@ -54,7 +55,7 @@ func ExamplePlainClone() {
 	defer os.RemoveAll(dir) // clean up
 
 	// Clones the repository into the given dir, just as a normal git clone does
-	r, err := git.PlainClone(dir, &git.CloneOptions{
+	r, err := git.PlainClone(context.Background(), dir, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 	})
 	if err != nil {
@@ -84,7 +85,7 @@ func ExamplePlainClone_usernamePassword() {
 	defer os.RemoveAll(dir) // clean up
 
 	// Clones the repository into the given dir, just as a normal git clone does
-	r, err := git.PlainClone(dir, &git.CloneOptions{
+	r, err := git.PlainClone(context.Background(), dir, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 		ClientOptions: []client.Option{
 			client.WithHTTPAuth(&http.BasicAuth{
@@ -110,7 +111,7 @@ func ExamplePlainClone_accessToken() {
 	defer os.RemoveAll(dir) // clean up
 
 	// Clones the repository into the given dir, just as a normal git clone does
-	r, err := git.PlainClone(dir, &git.CloneOptions{
+	r, err := git.PlainClone(context.Background(), dir, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 		ClientOptions: []client.Option{
 			client.WithHTTPAuth(&http.BasicAuth{
@@ -127,14 +128,15 @@ func ExamplePlainClone_accessToken() {
 }
 
 func ExampleRepository_References() {
-	r, _ := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+	ctx := context.Background()
+	r, _ := git.Clone(ctx, memory.NewStorage(), nil, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 	})
 	defer func() { _ = r.Close() }()
 
 	// simulating a git show-ref
-	refs, _ := r.References()
-	refs.ForEach(func(ref *plumbing.Reference) error {
+	refs, _ := r.References(ctx)
+	refs.ForEach(ctx, func(ref *plumbing.Reference) error {
 		if ref.Type() == plumbing.HashReference {
 			fmt.Println(ref)
 		}
@@ -149,13 +151,14 @@ func ExampleRepository_References() {
 }
 
 func ExampleRepository_Branches() {
-	r, _ := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+	ctx := context.Background()
+	r, _ := git.Clone(ctx, memory.NewStorage(), nil, &git.CloneOptions{
 		URL: "https://github.com/git-fixtures/basic.git",
 	})
 	defer func() { _ = r.Close() }()
 
-	branches, _ := r.Branches()
-	branches.ForEach(func(branch *plumbing.Reference) error {
+	branches, _ := r.Branches(ctx)
+	branches.ForEach(ctx, func(branch *plumbing.Reference) error {
 		fmt.Println(branch.Hash().String(), branch.Name())
 		return nil
 	})
@@ -165,11 +168,12 @@ func ExampleRepository_Branches() {
 }
 
 func ExampleRepository_CreateRemote() {
-	r, _ := git.Init(memory.NewStorage(), nil)
+	ctx := context.Background()
+	r, _ := git.Init(ctx, memory.NewStorage())
 	defer func() { _ = r.Close() }()
 
 	// Add a new remote, with the default fetch refspec
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(ctx, &config.RemoteConfig{
 		Name: "example",
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})
@@ -178,7 +182,7 @@ func ExampleRepository_CreateRemote() {
 		return
 	}
 
-	list, err := r.Remotes()
+	list, err := r.Remotes(ctx)
 	if err != nil {
 		log.Print(err)
 		return

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -6,6 +6,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -97,7 +98,7 @@ func ApplyUmaskDir(mode int64) int64 {
 // allowUnreachable is true. See https://git-scm.com/docs/git-upload-archive
 //
 // Returns the tree, commit hash (if applicable), commit time, and any error.
-func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*object.Tree, *plumbing.Hash, time.Time, error) {
+func ResolveTreeish(ctx context.Context, st storage.Storer, treeish string, allowUnreachable bool) (*object.Tree, *plumbing.Hash, time.Time, error) {
 	var subPath string
 	if idx := strings.IndexByte(treeish, ':'); idx >= 0 {
 		subPath = treeish[idx+1:]
@@ -113,12 +114,12 @@ func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 		}
 	}
 
-	h, err := ResolveRef(st, treeish, allowUnreachable)
+	h, err := ResolveRef(ctx, st, treeish, allowUnreachable)
 	if err != nil {
 		return nil, nil, time.Time{}, err
 	}
 
-	obj, err := object.GetObject(st, h)
+	obj, err := object.GetObject(ctx, st, h)
 	if err != nil {
 		return nil, nil, time.Time{}, fmt.Errorf("%w: %s", ErrObjectNotFound, treeish)
 	}
@@ -129,7 +130,7 @@ func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 			break
 		}
 
-		obj, err = object.GetObject(st, tag.Target)
+		obj, err = object.GetObject(ctx, st, tag.Target)
 		if err != nil {
 			return nil, nil, time.Time{}, fmt.Errorf("resolve annotated tag: %w", err)
 		}
@@ -143,7 +144,7 @@ func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 	case *object.Commit:
 		commitHash = &o.Hash
 		commitTime = o.Committer.When
-		tree, err = o.Tree()
+		tree, err = o.Tree(ctx)
 		if err != nil {
 			return nil, nil, time.Time{}, err
 		}
@@ -163,14 +164,14 @@ func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 	}
 
 	if subPath != "" {
-		entry, err := tree.FindEntry(subPath)
+		entry, err := tree.FindEntry(ctx, subPath)
 		if err != nil {
 			return nil, nil, time.Time{}, fmt.Errorf("path not found in tree: %s", subPath)
 		}
 		if entry.Mode != filemode.Dir {
 			return nil, nil, time.Time{}, fmt.Errorf("path is not a directory: %s", subPath)
 		}
-		tree, err = object.GetTree(st, entry.Hash)
+		tree, err = object.GetTree(ctx, st, entry.Hash)
 		if err != nil {
 			return nil, nil, time.Time{}, err
 		}
@@ -180,7 +181,7 @@ func ResolveTreeish(st storage.Storer, treeish string, allowUnreachable bool) (*
 }
 
 // ResolveRef resolves a ref name to a hash.
-func ResolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, error) {
+func ResolveRef(ctx context.Context, st storage.Storer, name string, allowHash bool) (plumbing.Hash, error) {
 	if allowHash && plumbing.IsHash(name) {
 		return plumbing.NewHash(name), nil
 	}
@@ -190,7 +191,7 @@ func ResolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, 
 		plumbing.ReferenceName("refs/heads/" + name),
 		plumbing.ReferenceName("refs/tags/" + name),
 	} {
-		ref, err := storer.ResolveReference(st, candidate)
+		ref, err := storer.ResolveReference(ctx, st, candidate)
 		if err == nil {
 			return ref.Hash(), nil
 		}
@@ -200,7 +201,7 @@ func ResolveRef(st storage.Storer, name string, allowHash bool) (plumbing.Hash, 
 }
 
 // WriteTarArchive writes a tar archive from a tree.
-func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
+func WriteTarArchive(ctx context.Context, st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
 	tw := tar.NewWriter(w)
 
 	// Write PAX global extended header with commit ID if available.
@@ -235,7 +236,7 @@ func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 
 	var matchedAny bool
 	for {
-		name, entry, err := walker.Next()
+		name, entry, err := walker.Next(ctx)
 		if err == io.EOF {
 			break
 		}
@@ -265,7 +266,7 @@ func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 			continue
 		}
 
-		blob, err := object.GetBlob(st, entry.Hash)
+		blob, err := object.GetBlob(ctx, st, entry.Hash)
 		if err != nil {
 			return err
 		}
@@ -333,7 +334,7 @@ func WriteTarArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 }
 
 // WriteZipArchive writes a zip archive from a tree.
-func WriteZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
+func WriteZipArchive(ctx context.Context, st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, prefix string, pathFilter []string, modTime time.Time) error {
 	zw := zip.NewWriter(w)
 
 	walker := object.NewTreeWalker(tree, true, nil)
@@ -341,7 +342,7 @@ func WriteZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 
 	var matchedAny bool
 	for {
-		name, entry, err := walker.Next()
+		name, entry, err := walker.Next(ctx)
 		if err == io.EOF {
 			break
 		}
@@ -359,7 +360,7 @@ func WriteZipArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHa
 		}
 
 		fullName := prefix + name
-		blob, err := object.GetBlob(st, entry.Hash)
+		blob, err := object.GetBlob(ctx, st, entry.Hash)
 		if err != nil {
 			return err
 		}
@@ -470,22 +471,22 @@ func GetTarCommitID(r io.Reader) (*plumbing.Hash, error) {
 // Supported formats: tar, zip, tar.gz, tgz.
 // The prefix is prepended to all file paths in the archive.
 // The paths slice can be used to filter which files are included.
-func WriteArchive(st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, commitTime time.Time, format, prefix string, paths []string) error {
+func WriteArchive(ctx context.Context, st storage.Storer, w io.Writer, tree *object.Tree, commitHash *plumbing.Hash, commitTime time.Time, format, prefix string, paths []string) error {
 	if HasInvalidPrefix(prefix) {
 		return fmt.Errorf("%w: %s", ErrInvalidPrefix, prefix)
 	}
 
 	switch format {
 	case "tar":
-		return WriteTarArchive(st, w, tree, commitHash, prefix, paths, commitTime)
+		return WriteTarArchive(ctx, st, w, tree, commitHash, prefix, paths, commitTime)
 	case "tar.gz", "tgz":
 		gw := gzip.NewWriter(w)
-		if err := WriteTarArchive(st, gw, tree, commitHash, prefix, paths, commitTime); err != nil {
+		if err := WriteTarArchive(ctx, st, gw, tree, commitHash, prefix, paths, commitTime); err != nil {
 			return err
 		}
 		return gw.Close()
 	case "zip":
-		return WriteZipArchive(st, w, tree, commitHash, prefix, paths, commitTime)
+		return WriteZipArchive(ctx, st, w, tree, commitHash, prefix, paths, commitTime)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnsupportedFormat, format)
 	}

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -197,6 +197,12 @@ func ResolveRef(ctx context.Context, st storage.Storer, name string, allowHash b
 		}
 	}
 
+	// A canceled context makes every candidate lookup fail; report the
+	// cancellation rather than a misleading resolution failure.
+	if err := ctx.Err(); err != nil {
+		return plumbing.ZeroHash, err
+	}
+
 	return plumbing.ZeroHash, fmt.Errorf("cannot resolve %q", name)
 }
 

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -122,11 +122,11 @@ func TestResolveRef(t *testing.T) {
 	defer func() { _ = storer.Close() }()
 
 	// Get expected hashes from the fixture
-	masterRef, err := storer.Reference(plumbing.ReferenceName("refs/heads/master"))
+	masterRef, err := storer.Reference(t.Context(), plumbing.ReferenceName("refs/heads/master"))
 	require.NoError(t, err)
 	masterHash := masterRef.Hash()
 
-	tagRef, err := storer.Reference(plumbing.ReferenceName("refs/tags/v1.0.0"))
+	tagRef, err := storer.Reference(t.Context(), plumbing.ReferenceName("refs/tags/v1.0.0"))
 	require.NoError(t, err)
 	tagHash := tagRef.Hash()
 
@@ -186,7 +186,7 @@ func TestResolveRef(t *testing.T) {
 
 	for _, tt := range tests { //nolint:paralleltest // avoid parallel test because of shared fixture state
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ResolveRef(storer, tt.ref, tt.allowHash)
+			got, err := ResolveRef(t.Context(), storer, tt.ref, tt.allowHash)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errContain != "" {
@@ -241,7 +241,7 @@ func TestResolveTreeish_Errors(t *testing.T) {
 
 	for _, tt := range tests { //nolint:paralleltest // avoid parallel test because of shared fixture state
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, _, err := ResolveTreeish(storer, tt.treeish, tt.allowUnreachable)
+			_, _, _, err := ResolveTreeish(t.Context(), storer, tt.treeish, tt.allowUnreachable)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errIs != nil {
@@ -268,7 +268,7 @@ func TestResolveTreeish_AllowUnreachable(t *testing.T) {
 	defer func() { _ = storer.Close() }()
 
 	// Get the master commit hash for testing
-	masterRef, err := storer.Reference(plumbing.ReferenceName("refs/heads/master"))
+	masterRef, err := storer.Reference(t.Context(), plumbing.ReferenceName("refs/heads/master"))
 	require.NoError(t, err)
 	masterHash := masterRef.Hash().String()
 
@@ -373,7 +373,7 @@ func TestResolveTreeish_AllowUnreachable(t *testing.T) {
 
 	for _, tt := range tests { //nolint:paralleltest // avoid parallel test because of shared fixture state
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, _, err := ResolveTreeish(storer, tt.treeish, tt.allowUnreachable)
+			_, _, _, err := ResolveTreeish(t.Context(), storer, tt.treeish, tt.allowUnreachable)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errIs != nil {
@@ -406,13 +406,13 @@ func TestResolveTreeish_AnnotatedTags(t *testing.T) {
 			name:    "commit target",
 			treeish: "commit-tag",
 			assert: func(t *testing.T, tag *object.Tag) {
-				commit, err := object.GetCommit(storer, tag.Target)
+				commit, err := object.GetCommit(t.Context(), storer, tag.Target)
 				require.NoError(t, err)
 
-				expectedTree, err := commit.Tree()
+				expectedTree, err := commit.Tree(t.Context())
 				require.NoError(t, err)
 
-				tree, commitHash, commitTime, err := ResolveTreeish(storer, "commit-tag", false)
+				tree, commitHash, commitTime, err := ResolveTreeish(t.Context(), storer, "commit-tag", false)
 				require.NoError(t, err)
 				require.NotNil(t, commitHash)
 				assert.Equal(t, expectedTree.Hash, tree.Hash)
@@ -424,10 +424,10 @@ func TestResolveTreeish_AnnotatedTags(t *testing.T) {
 			name:    "tree target",
 			treeish: "tree-tag",
 			assert: func(t *testing.T, tag *object.Tag) {
-				expectedTree, err := object.GetTree(storer, tag.Target)
+				expectedTree, err := object.GetTree(t.Context(), storer, tag.Target)
 				require.NoError(t, err)
 
-				tree, commitHash, commitTime, err := ResolveTreeish(storer, "tree-tag", false)
+				tree, commitHash, commitTime, err := ResolveTreeish(t.Context(), storer, "tree-tag", false)
 				require.NoError(t, err)
 				assert.Equal(t, expectedTree.Hash, tree.Hash)
 				assert.Nil(t, commitHash)
@@ -438,7 +438,7 @@ func TestResolveTreeish_AnnotatedTags(t *testing.T) {
 			name:    "unsupported target",
 			treeish: "blob-tag",
 			assert: func(t *testing.T, _ *object.Tag) {
-				_, _, _, err := ResolveTreeish(storer, "blob-tag", false)
+				_, _, _, err := ResolveTreeish(t.Context(), storer, "blob-tag", false)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unsupported object type for archive")
 			},
@@ -447,10 +447,10 @@ func TestResolveTreeish_AnnotatedTags(t *testing.T) {
 
 	for _, tt := range tests { //nolint:paralleltest // object / storer are not thread safe
 		t.Run(tt.name, func(t *testing.T) {
-			tagRef, err := storer.Reference(plumbing.ReferenceName("refs/tags/" + tt.treeish))
+			tagRef, err := storer.Reference(t.Context(), plumbing.ReferenceName("refs/tags/"+tt.treeish))
 			require.NoError(t, err)
 
-			tag, err := object.GetTag(storer, tagRef.Hash())
+			tag, err := object.GetTag(t.Context(), storer, tagRef.Hash())
 			require.NoError(t, err)
 
 			tt.assert(t, tag)
@@ -467,7 +467,7 @@ func TestWriteTarArchive_RejectsOversizedSymlinkTarget(t *testing.T) {
 	blobObj.SetType(plumbing.BlobObject)
 	_, err := blobObj.Write([]byte(strings.Repeat("a", maxTarSymlinkTargetSize+1)))
 	require.NoError(t, err)
-	blobHash, err := st.SetEncodedObject(blobObj)
+	blobHash, err := st.SetEncodedObject(t.Context(), blobObj)
 	require.NoError(t, err)
 
 	treeObj := &object.Tree{
@@ -483,14 +483,14 @@ func TestWriteTarArchive_RejectsOversizedSymlinkTarget(t *testing.T) {
 	encodedTree := &plumbing.MemoryObject{}
 	encodedTree.SetType(plumbing.TreeObject)
 	require.NoError(t, treeObj.Encode(encodedTree))
-	treeHash, err := st.SetEncodedObject(encodedTree)
+	treeHash, err := st.SetEncodedObject(t.Context(), encodedTree)
 	require.NoError(t, err)
 
-	tree, err := object.GetTree(st, treeHash)
+	tree, err := object.GetTree(t.Context(), st, treeHash)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = WriteTarArchive(st, &buf, tree, nil, "", nil, time.Now())
+	err = WriteTarArchive(t.Context(), st, &buf, tree, nil, "", nil, time.Now())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrSymlinkTargetTooLarge)
 	assert.Contains(t, err.Error(), "link")

--- a/internal/reference/refs.go
+++ b/internal/reference/refs.go
@@ -2,6 +2,7 @@
 package reference
 
 import (
+	"context"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -9,16 +10,16 @@ import (
 )
 
 // References returns all references from the storage.
-func References(st storage.Storer) ([]*plumbing.Reference, error) {
+func References(ctx context.Context, st storage.Storer) ([]*plumbing.Reference, error) {
 	var localRefs []*plumbing.Reference
 
-	iter, err := st.IterReferences()
+	iter, err := st.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	for {
-		ref, err := iter.Next()
+		ref, err := iter.Next(ctx)
 		if err == io.EOF {
 			break
 		}

--- a/internal/repository/refs.go
+++ b/internal/repository/refs.go
@@ -2,6 +2,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -13,12 +14,12 @@ import (
 )
 
 // ExpandRef resolves a reference name using git ref parsing rules.
-func ExpandRef(s storer.ReferenceStorer, ref plumbing.ReferenceName) (*plumbing.Reference, error) {
+func ExpandRef(ctx context.Context, s storer.ReferenceStorer, ref plumbing.ReferenceName) (*plumbing.Reference, error) {
 	// For improving troubleshooting, this preserves the error for the provided `ref`,
 	// and returns the error for that specific ref in case all parse rules fails.
 	var ret error
 	for _, rule := range plumbing.RefRevParseRules {
-		resolvedRef, err := storer.ResolveReference(s, plumbing.ReferenceName(fmt.Sprintf(rule, ref)))
+		resolvedRef, err := storer.ResolveReference(ctx, s, plumbing.ReferenceName(fmt.Sprintf(rule, ref)))
 
 		if err == nil {
 			return resolvedRef, nil
@@ -34,14 +35,14 @@ func ExpandRef(s storer.ReferenceStorer, ref plumbing.ReferenceName) (*plumbing.
 // It generates a list of available refs for the repository.
 // Used by git http transport (dumb), for more information refer to:
 // https://git-scm.com/book/id/v2/Git-Internals-Transfer-Protocols#_the_dumb_protocol
-func WriteInfoRefs(w io.Writer, s storage.Storer) error {
-	refsIter, err := s.IterReferences()
+func WriteInfoRefs(ctx context.Context, w io.Writer, s storage.Storer) error {
+	refsIter, err := s.IterReferences(ctx)
 	if err != nil {
 		return err
 	}
 
 	var refs []*plumbing.Reference
-	if err := refsIter.ForEach(func(ref *plumbing.Reference) error {
+	if err := refsIter.ForEach(ctx, func(ref *plumbing.Reference) error {
 		refs = append(refs, ref)
 		return nil
 	}); err != nil {
@@ -57,7 +58,7 @@ func WriteInfoRefs(w io.Writer, s storage.Storer) error {
 			if name == plumbing.HEAD {
 				continue
 			}
-			ref, err := s.Reference(ref.Target())
+			ref, err := s.Reference(ctx, ref.Target())
 			if err != nil {
 				return err
 			}
@@ -69,7 +70,7 @@ func WriteInfoRefs(w io.Writer, s storage.Storer) error {
 				return fmt.Errorf("writing info reference: %w", err)
 			}
 			if name.IsTag() {
-				tag, err := object.GetTag(s, hash)
+				tag, err := object.GetTag(ctx, s, hash)
 				if err == nil {
 					if _, err := fmt.Fprintf(w, "%s\t%s^{}\n", tag.Target, name); err != nil {
 						return fmt.Errorf("writing info tag reference: %w", err)
@@ -86,8 +87,8 @@ func WriteInfoRefs(w io.Writer, s storage.Storer) error {
 // It generates a list of available packs for the repository.
 // Used by git http transport (dumb), for more information refer to:
 // https://git-scm.com/book/id/v2/Git-Internals-Transfer-Protocols#_the_dumb_protocol
-func WriteObjectsInfoPacks(w io.Writer, s storer.PackedObjectStorer) error {
-	packs, err := s.ObjectPacks()
+func WriteObjectsInfoPacks(ctx context.Context, w io.Writer, s storer.PackedObjectStorer) error {
+	packs, err := s.ObjectPacks(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -50,11 +50,11 @@ func (s *ReceivePackSuite) packClient() transport.Transport {
 // TestAdvertisedReferencesEmpty tests advertised references on an empty repo.
 func (s *ReceivePackSuite) TestAdvertisedReferencesEmpty() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.EmptyEndpoint, Command: transport.ReceivePackService})
+	conn, err := pc.Handshake(s.T().Context(), &transport.Request{URL: s.EmptyEndpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	refs, err := conn.GetRemoteRefs(context.TODO(), nil)
+	refs, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().Len(refs.References, 0)
 }
@@ -62,22 +62,22 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesEmpty() {
 // TestAdvertisedReferencesNotExists tests advertised references on a non-existent repo.
 func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists() {
 	pc := s.packClient()
-	_, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.NonExistentEndpoint, Command: transport.ReceivePackService})
+	_, err := pc.Handshake(s.T().Context(), &transport.Request{URL: s.NonExistentEndpoint, Command: transport.ReceivePackService})
 	s.Require().Error(err)
 }
 
 // TestCallAdvertisedReferenceTwice tests that calling advertised references twice returns the same result.
 func (s *ReceivePackSuite) TestCallAdvertisedReferenceTwice() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
+	conn, err := pc.Handshake(s.T().Context(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	refs1, err := conn.GetRemoteRefs(context.TODO(), nil)
+	refs1, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(refs1)
 
-	refs2, err := conn.GetRemoteRefs(context.TODO(), nil)
+	refs2, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().Equal(refs1, refs2)
 }
@@ -85,11 +85,11 @@ func (s *ReceivePackSuite) TestCallAdvertisedReferenceTwice() {
 // TestDefaultBranch tests that the default branch is correctly advertised.
 func (s *ReceivePackSuite) TestDefaultBranch() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
+	conn, err := pc.Handshake(s.T().Context(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	refs, err := conn.GetRemoteRefs(context.TODO(), nil)
+	refs, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	ok := false
 	var ref *plumbing.Reference
@@ -107,7 +107,7 @@ func (s *ReceivePackSuite) TestDefaultBranch() {
 // TestCapabilities tests that capabilities are correctly reported.
 func (s *ReceivePackSuite) TestCapabilities() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
+	conn, err := pc.Handshake(s.T().Context(), &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 	s.Require().Len(conn.Capabilities().Get("agent"), 1)
@@ -137,11 +137,11 @@ func (s *ReceivePackSuite) TestSendPackWithContext() {
 	}
 
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), &transport.Request{URL: s.EmptyEndpoint, Command: transport.ReceivePackService})
+	conn, err := pc.Handshake(s.T().Context(), &transport.Request{URL: s.EmptyEndpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(s.T().Context())
 	cancel()
 
 	err = conn.Push(ctx, s.EmptyStorer, req)
@@ -232,7 +232,7 @@ func (s *ReceivePackSuite) receivePackNoCheck(ep *url.URL,
 	callAdvertisedReferences bool,
 ) error {
 	s.T().Helper()
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	fixtureURL := ""
 	if fixture != nil {
 		fixtureURL = fixture.URL
@@ -311,7 +311,7 @@ func (s *ReceivePackSuite) checkRemoteReference(ep *url.URL,
 	refName plumbing.ReferenceName, head plumbing.Hash,
 ) {
 	s.T().Helper()
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	pc := s.packClient()
 	conn, err := pc.Handshake(ctx, &transport.Request{URL: ep, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
@@ -343,7 +343,7 @@ func (s *ReceivePackSuite) TestSendPackAddDeleteReference() {
 
 func (s *ReceivePackSuite) testSendPackAddReference() {
 	s.T().Helper()
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	pc := s.packClient()
 	conn, err := pc.Handshake(ctx, &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)
@@ -365,7 +365,7 @@ func (s *ReceivePackSuite) testSendPackAddReference() {
 
 func (s *ReceivePackSuite) testSendPackDeleteReference() {
 	s.T().Helper()
-	ctx := context.TODO()
+	ctx := s.T().Context()
 	pc := s.packClient()
 	conn, err := pc.Handshake(ctx, &transport.Request{URL: s.Endpoint, Command: transport.ReceivePackService})
 	s.Require().NoError(err)

--- a/internal/transport/test/receive_pack.go
+++ b/internal/transport/test/receive_pack.go
@@ -401,8 +401,9 @@ func (s *ReceivePackSuite) mustPackfile(fixture *fixtures.Fixture) io.ReadCloser
 func (s *ReceivePackSuite) emptyPackfile() io.ReadCloser {
 	s.T().Helper()
 	var buf bytes.Buffer
-	e := packfile.NewEncoder(&buf, memory.NewStorage(), false)
-	_, err := e.Encode(nil, 10)
+	ctx := s.T().Context()
+	e := packfile.NewEncoder(ctx, &buf, memory.NewStorage(), false)
+	_, err := e.Encode(ctx, nil, 10)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -53,11 +53,11 @@ func (s *UploadPackSuite) request(url *url.URL, command string) *transport.Reque
 // TestAdvertisedReferencesEmpty tests advertised references on an empty repo.
 func (s *UploadPackSuite) TestAdvertisedReferencesEmpty() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.EmptyEndpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.EmptyEndpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	ar, err := conn.GetRemoteRefs(context.TODO(), nil)
+	ar, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().ErrorIs(err, transport.ErrEmptyRemoteRepository)
 	s.Require().Nil(ar)
 }
@@ -65,21 +65,21 @@ func (s *UploadPackSuite) TestAdvertisedReferencesEmpty() {
 // TestAdvertisedReferencesNotExists tests advertised references on a non-existent repo.
 func (s *UploadPackSuite) TestAdvertisedReferencesNotExists() {
 	pc := s.packClient()
-	_, err := pc.Handshake(context.TODO(), s.request(s.NonExistentEndpoint, transport.UploadPackService))
+	_, err := pc.Handshake(s.T().Context(), s.request(s.NonExistentEndpoint, transport.UploadPackService))
 	s.Require().Error(err)
 }
 
 // TestCallAdvertisedReferenceTwice tests that calling advertised references twice returns the same result.
 func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	ar1, err := conn.GetRemoteRefs(context.TODO(), nil)
+	ar1, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(ar1)
-	ar2, err := conn.GetRemoteRefs(context.TODO(), nil)
+	ar2, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().Equal(ar1, ar2)
 }
@@ -87,11 +87,11 @@ func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice() {
 // TestDefaultBranch tests that the default branch is correctly advertised.
 func (s *UploadPackSuite) TestDefaultBranch() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO(), nil)
+	info, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 
@@ -118,11 +118,11 @@ func (s *UploadPackSuite) TestDefaultBranch() {
 // TestAdvertisedReferencesFilterUnsupported tests filtering unsupported capabilities.
 func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO(), nil)
+	info, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 	if s.Protocol == protocol.V2 {
@@ -139,11 +139,11 @@ func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported() {
 // TestCapabilities tests that capabilities are correctly reported.
 func (s *UploadPackSuite) TestCapabilities() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO(), nil)
+	info, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 	s.Require().Len(conn.Capabilities().Get(capability.Agent), 1)
@@ -152,7 +152,7 @@ func (s *UploadPackSuite) TestCapabilities() {
 // TestUploadPack tests a basic upload-pack fetch.
 func (s *UploadPackSuite) TestUploadPack() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -173,11 +173,11 @@ func (s *UploadPackSuite) TestUploadPackWithContext() {
 	defer cancel()
 
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO(), nil)
+	info, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 
@@ -194,11 +194,11 @@ func (s *UploadPackSuite) TestUploadPackWithContextOnRead() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO(), nil)
+	info, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 
@@ -213,11 +213,11 @@ func (s *UploadPackSuite) TestUploadPackWithContextOnRead() {
 // TestUploadPackFull tests a full upload-pack fetch with advertised references.
 func (s *UploadPackSuite) TestUploadPackFull() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
-	info, err := conn.GetRemoteRefs(context.TODO(), nil)
+	info, err := conn.GetRemoteRefs(s.T().Context(), nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(info)
 
@@ -235,7 +235,7 @@ func (s *UploadPackSuite) TestUploadPackFull() {
 // TestUploadPackInvalidReq tests upload-pack with an invalid request.
 func (s *UploadPackSuite) TestUploadPackInvalidReq() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -249,7 +249,7 @@ func (s *UploadPackSuite) TestUploadPackInvalidReq() {
 // TestUploadPackNoChanges tests upload-pack when there are no changes.
 func (s *UploadPackSuite) TestUploadPackNoChanges() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -279,7 +279,7 @@ func (s *UploadPackSuite) TestUploadPackPartial() {
 
 func (s *UploadPackSuite) testUploadPackFetch(req *transport.FetchRequest, expectedObjects int) {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 
@@ -296,7 +296,7 @@ func (s *UploadPackSuite) testUploadPackFetch(req *transport.FetchRequest, expec
 // TestFetchError tests that fetching a non-existent object returns an error.
 func (s *UploadPackSuite) TestFetchError() {
 	pc := s.packClient()
-	conn, err := pc.Handshake(context.TODO(), s.request(s.Endpoint, transport.UploadPackService))
+	conn, err := pc.Handshake(s.T().Context(), s.request(s.Endpoint, transport.UploadPackService))
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(conn.Close()) }()
 

--- a/internal/transport/test/upload_pack.go
+++ b/internal/transport/test/upload_pack.go
@@ -308,11 +308,12 @@ func (s *UploadPackSuite) TestFetchError() {
 }
 
 func (s *UploadPackSuite) countObjects(st storage.Storer) int {
-	iter, err := st.IterEncodedObjects(plumbing.AnyObject)
+	ctx := s.T().Context()
+	iter, err := st.IterEncodedObjects(ctx, plumbing.AnyObject)
 	s.Require().NoError(err)
 	defer iter.Close()
 	var count int
-	err = iter.ForEach(func(plumbing.EncodedObject) error {
+	err = iter.ForEach(ctx, func(plumbing.EncodedObject) error {
 		count++
 		return nil
 	})

--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -167,7 +167,7 @@ func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round Fe
 	}
 	if req.Depth > 0 {
 		baseArgs.Deepen = req.Depth
-		shallows, err := st.Shallow()
+		shallows, err := st.Shallow(ctx)
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round Fe
 	}
 
 	if shallowInfo != nil {
-		if err := updateShallow(st, shallowInfo); err != nil {
+		if err := updateShallow(ctx, st, shallowInfo); err != nil {
 			return err
 		}
 	}
@@ -253,7 +253,7 @@ func streamPackfile(ctx context.Context, st storage.Storer, packReader io.Reader
 	if progress != nil {
 		demuxer.Progress = progress
 	}
-	return packfile.UpdateObjectStorage(st, demuxer)
+	return packfile.UpdateObjectStorage(ctx, st, demuxer)
 }
 
 // closeReader drains and closes r when it owns a closable resource (such as an
@@ -269,8 +269,8 @@ func closeReader(r io.Reader) {
 }
 
 // updateShallow merges a shallow-info update into st's shallow boundary.
-func updateShallow(st storage.Storer, info *packp.ShallowUpdate) error {
-	shallows, err := st.Shallow()
+func updateShallow(ctx context.Context, st storage.Storer, info *packp.ShallowUpdate) error {
+	shallows, err := st.Shallow(ctx)
 	if err != nil {
 		return err
 	}
@@ -294,5 +294,5 @@ outer:
 		}
 	}
 
-	return st.SetShallow(shallows)
+	return st.SetShallow(ctx, shallows)
 }

--- a/object_walker.go
+++ b/object_walker.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -22,19 +23,19 @@ func newObjectWalker(s storage.Storer) *objectWalker {
 }
 
 // walkAllRefs walks all (hash) references from the repo.
-func (p *objectWalker) walkAllRefs() error {
+func (p *objectWalker) walkAllRefs(ctx context.Context) error {
 	// Walk over all the references in the repo.
-	it, err := p.Storer.IterReferences()
+	it, err := p.Storer.IterReferences(ctx)
 	if err != nil {
 		return err
 	}
 	defer it.Close()
-	err = it.ForEach(func(ref *plumbing.Reference) error {
+	err = it.ForEach(ctx, func(ref *plumbing.Reference) error {
 		// Exit this iteration early for non-hash references.
 		if ref.Type() != plumbing.HashReference {
 			return nil
 		}
-		return p.walkObjectTree(ref.Hash())
+		return p.walkObjectTree(ctx, ref.Hash())
 	})
 	return err
 }
@@ -51,26 +52,26 @@ func (p *objectWalker) add(hash plumbing.Hash) {
 // walkObjectTree walks over all objects and remembers references
 // to them in the objectWalker. This is used instead of the revlist
 // walks because memory usage is tight with huge repos.
-func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
+func (p *objectWalker) walkObjectTree(ctx context.Context, hash plumbing.Hash) error {
 	// Check if we have already seen, and mark this object
 	if p.isSeen(hash) {
 		return nil
 	}
 	p.add(hash)
 	// Fetch the object.
-	obj, err := object.GetObject(p.Storer, hash)
+	obj, err := object.GetObject(ctx, p.Storer, hash)
 	if err != nil {
 		return fmt.Errorf("getting object %s failed: %v", hash, err)
 	}
 	// Walk all children depending on object type.
 	switch obj := obj.(type) {
 	case *object.Commit:
-		err = p.walkObjectTree(obj.TreeHash)
+		err = p.walkObjectTree(ctx, obj.TreeHash)
 		if err != nil {
 			return err
 		}
 		for _, h := range obj.ParentHashes {
-			err = p.walkObjectTree(h)
+			err = p.walkObjectTree(ctx, h)
 			if err != nil {
 				return err
 			}
@@ -89,13 +90,13 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 				continue
 			}
 			// Normal walk for sub-trees (and symlinks etc).
-			err = p.walkObjectTree(obj.Entries[i].Hash)
+			err = p.walkObjectTree(ctx, obj.Entries[i].Hash)
 			if err != nil {
 				return err
 			}
 		}
 	case *object.Tag:
-		return p.walkObjectTree(obj.Target)
+		return p.walkObjectTree(ctx, obj.Target)
 	default:
 		// Error out on unhandled object types.
 		return fmt.Errorf("unknown object %X %s %T", obj.ID(), obj.Type(), obj)

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -463,16 +464,16 @@ type ResetOptions struct {
 }
 
 // Validate validates the fields and sets the default values.
-func (o *ResetOptions) Validate(r *Repository) error {
+func (o *ResetOptions) Validate(ctx context.Context, r *Repository) error {
 	if o.Commit == plumbing.ZeroHash {
-		ref, err := r.Head()
+		ref, err := r.Head(ctx)
 		if err != nil {
 			return err
 		}
 
 		o.Commit = ref.Hash()
 	} else {
-		_, err := r.CommitObject(o.Commit)
+		_, err := r.CommitObject(ctx, o.Commit)
 		if err != nil {
 			return fmt.Errorf("invalid reset option: %w", err)
 		}
@@ -595,7 +596,7 @@ type CommitOptions struct {
 }
 
 // Validate validates the fields and sets the default values.
-func (o *CommitOptions) Validate(r *Repository) error {
+func (o *CommitOptions) Validate(ctx context.Context, r *Repository) error {
 	if o.All && o.Amend {
 		return errors.New("all and amend cannot be used together")
 	}
@@ -605,7 +606,7 @@ func (o *CommitOptions) Validate(r *Repository) error {
 	}
 
 	if o.Author == nil {
-		if err := o.loadConfigAuthorAndCommitter(r); err != nil {
+		if err := o.loadConfigAuthorAndCommitter(ctx, r); err != nil {
 			return err
 		}
 	}
@@ -615,7 +616,7 @@ func (o *CommitOptions) Validate(r *Repository) error {
 	}
 
 	if len(o.Parents) == 0 {
-		head, err := r.Head()
+		head, err := r.Head(ctx)
 		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return err
 		}
@@ -628,8 +629,8 @@ func (o *CommitOptions) Validate(r *Repository) error {
 	return nil
 }
 
-func (o *CommitOptions) loadConfigAuthorAndCommitter(r *Repository) error {
-	cfg, err := r.ConfigScoped(config.SystemScope)
+func (o *CommitOptions) loadConfigAuthorAndCommitter(ctx context.Context, r *Repository) error {
+	cfg, err := r.ConfigScoped(ctx, config.SystemScope)
 	if err != nil {
 		return err
 	}
@@ -687,9 +688,9 @@ type CreateTagOptions struct {
 }
 
 // Validate validates the fields and sets the default values.
-func (o *CreateTagOptions) Validate(r *Repository, _ plumbing.Hash) error {
+func (o *CreateTagOptions) Validate(ctx context.Context, r *Repository, _ plumbing.Hash) error {
 	if o.Tagger == nil {
-		if err := o.loadConfigTagger(r); err != nil {
+		if err := o.loadConfigTagger(ctx, r); err != nil {
 			return err
 		}
 	}
@@ -704,8 +705,8 @@ func (o *CreateTagOptions) Validate(r *Repository, _ plumbing.Hash) error {
 	return nil
 }
 
-func (o *CreateTagOptions) loadConfigTagger(r *Repository) error {
-	cfg, err := r.ConfigScoped(config.SystemScope)
+func (o *CreateTagOptions) loadConfigTagger(ctx context.Context, r *Repository) error {
+	cfg, err := r.ConfigScoped(ctx, config.SystemScope)
 	if err != nil {
 		return err
 	}
@@ -785,11 +786,11 @@ var ErrHashOrReference = errors.New("ambiguous options, only one of CommitHash o
 // Validate validates the fields and sets the default values.
 //
 // TODO: deprecate in favor of Validate(r *Repository) in v6.
-func (o *GrepOptions) Validate(w *Worktree) error {
-	return o.validate(w.r)
+func (o *GrepOptions) Validate(ctx context.Context, w *Worktree) error {
+	return o.validate(ctx, w.r)
 }
 
-func (o *GrepOptions) validate(r *Repository) error {
+func (o *GrepOptions) validate(ctx context.Context, r *Repository) error {
 	if !o.CommitHash.IsZero() && o.ReferenceName != "" {
 		return ErrHashOrReference
 	}
@@ -797,7 +798,7 @@ func (o *GrepOptions) validate(r *Repository) error {
 	// If none of CommitHash and ReferenceName are provided, set commit hash of
 	// the repository's head.
 	if o.CommitHash.IsZero() && o.ReferenceName == "" {
-		ref, err := r.Head()
+		ref, err := r.Head(ctx)
 		if err != nil {
 			return err
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -23,14 +23,14 @@ func TestOptionsSuite(t *testing.T) {
 
 func (s *OptionsSuite) TestCommitOptionsParentsFromHEAD() {
 	o := CommitOptions{Author: &object.Signature{}}
-	err := o.Validate(s.Repository)
+	err := o.Validate(s.T().Context(), s.Repository)
 	s.NoError(err)
 	s.Len(o.Parents, 1)
 }
 
 func (s *OptionsSuite) TestResetOptionsCommitNotFound() {
 	o := ResetOptions{Commit: plumbing.NewHash("ab1b15c6f6487b4db16f10d8ec69bb8bf91dcabd")}
-	err := o.Validate(s.Repository)
+	err := o.Validate(s.T().Context(), s.Repository)
 	s.NotNil(err)
 }
 
@@ -38,7 +38,7 @@ func (s *OptionsSuite) TestCommitOptionsCommitter() {
 	sig := &object.Signature{}
 
 	o := CommitOptions{Author: sig}
-	err := o.Validate(s.Repository)
+	err := o.Validate(s.T().Context(), s.Repository)
 	s.NoError(err)
 
 	s.Equal(o.Author, o.Committer)
@@ -53,7 +53,7 @@ func (s *OptionsSuite) TestCommitOptionsLoadGlobalConfigUser() {
 	defer clean()
 
 	o := CommitOptions{}
-	err := o.Validate(s.Repository)
+	err := o.Validate(s.T().Context(), s.Repository)
 	s.NoError(err)
 
 	s.Equal("foo", o.Author.Name)
@@ -73,7 +73,7 @@ func (s *OptionsSuite) TestCommitOptionsLoadGlobalCommitter() {
 	defer clean()
 
 	o := CommitOptions{}
-	err := o.Validate(s.Repository)
+	err := o.Validate(s.T().Context(), s.Repository)
 	s.NoError(err)
 
 	s.Equal("foo", o.Author.Name)
@@ -94,7 +94,7 @@ func (s *OptionsSuite) TestCreateTagOptionsLoadGlobal() {
 		Message: "foo",
 	}
 
-	err := o.Validate(s.Repository, plumbing.ZeroHash)
+	err := o.Validate(s.T().Context(), s.Repository, plumbing.ZeroHash)
 	s.NoError(err)
 
 	s.Equal("foo", o.Tagger.Name)

--- a/plumbing/format/commitgraph/commitgraph_test.go
+++ b/plumbing/format/commitgraph/commitgraph_test.go
@@ -102,7 +102,7 @@ func (s *CommitgraphSuite) TestDecodeMultiChain() {
 		s.Require().NoError(err)
 		defer p.Close()
 
-		err = packfile.UpdateObjectStorage(storer, p)
+		err = packfile.UpdateObjectStorage(s.T().Context(), storer, p)
 		s.Require().NoError(err)
 
 		for idx, hash := range index.Hashes() {
@@ -115,7 +115,7 @@ func (s *CommitgraphSuite) TestDecodeMultiChain() {
 
 			commitData, err := index.GetCommitDataByIndex(uint32(idx))
 			s.Require().NoError(err)
-			commit, err := object.GetCommit(storer, hash)
+			commit, err := object.GetCommit(s.T().Context(), storer, hash)
 			s.Require().NoError(err)
 
 			for i, parent := range commit.ParentHashes {

--- a/plumbing/format/idxfile/writer_test.go
+++ b/plumbing/format/idxfile/writer_test.go
@@ -34,7 +34,7 @@ func (s *WriterSuite) TestWriter() {
 	obs := new(idxfile.Writer)
 	parser := packfile.NewParser(scanner, packfile.WithScannerObservers(obs))
 
-	_, err = parser.Parse()
+	_, err = parser.Parse(s.T().Context())
 	s.NoError(err)
 
 	idx, err := obs.Index()

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
@@ -27,7 +28,7 @@ const (
 
 // UpdateObjectStorage updates the storer with the objects in the given
 // packfile.
-func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
+func UpdateObjectStorage(ctx context.Context, s storer.Storer, packfile io.Reader) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -36,29 +37,30 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
 	}
 
 	if pw, ok := s.(storer.PackfileWriter); ok {
-		return WritePackfileToObjectStorage(pw, packfile)
+		return WritePackfileToObjectStorage(ctx, pw, packfile)
 	}
 
 	of := formatcfg.DefaultObjectFormat
 	if c, ok := s.(config.ConfigStorer); ok {
-		cfg, err := c.Config()
+		cfg, err := c.Config(ctx)
 		if err == nil {
 			of = cfg.Extensions.ObjectFormat
 		}
 	}
 
 	p := NewParser(packfile, WithStorage(s), WithObjectFormat(of))
-	_, err := p.Parse()
+	_, err := p.Parse(ctx)
 	return err
 }
 
 // WritePackfileToObjectStorage writes all the packfile objects into the given
 // object storage.
 func WritePackfileToObjectStorage(
+	ctx context.Context,
 	sw storer.PackfileWriter,
 	packfile io.Reader,
 ) (err error) {
-	w, err := sw.PackfileWriter()
+	w, err := sw.PackfileWriter(ctx)
 	if err != nil {
 		return err
 	}

--- a/plumbing/format/packfile/common_test.go
+++ b/plumbing/format/packfile/common_test.go
@@ -15,7 +15,7 @@ func TestEmptyUpdateObjectStorage(t *testing.T) {
 	var buf bytes.Buffer
 	sto := memory.NewStorage()
 
-	err := UpdateObjectStorage(sto, &buf)
+	err := UpdateObjectStorage(t.Context(), sto, &buf)
 	assert.ErrorIs(t, err, ErrEmptyPackfile)
 }
 

--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"context"
 	"sort"
 	"sync"
 
@@ -45,10 +46,11 @@ func NewDeltaSelector(s storer.EncodedObjectStorer) *DeltaSelector {
 // window used to compare objects for delta compression; 0 turns off
 // delta compression entirely.
 func (dw *DeltaSelector) ObjectsToPack(
+	ctx context.Context,
 	hashes []plumbing.Hash,
 	packWindow uint,
 ) ([]*ObjectToPack, error) {
-	otp, err := dw.objectsToPack(hashes, packWindow)
+	otp, err := dw.objectsToPack(ctx, hashes, packWindow)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +78,7 @@ func (dw *DeltaSelector) ObjectsToPack(
 	var once sync.Once
 	for _, objs := range objectGroups {
 		wg.Go(func() {
-			if walkErr := dw.walk(objs, packWindow); walkErr != nil {
+			if walkErr := dw.walk(ctx, objs, packWindow); walkErr != nil {
 				once.Do(func() {
 					err = walkErr
 				})
@@ -93,6 +95,7 @@ func (dw *DeltaSelector) ObjectsToPack(
 }
 
 func (dw *DeltaSelector) objectsToPack(
+	ctx context.Context,
 	hashes []plumbing.Hash,
 	packWindow uint,
 ) ([]*ObjectToPack, error) {
@@ -101,9 +104,9 @@ func (dw *DeltaSelector) objectsToPack(
 		var o plumbing.EncodedObject
 		var err error
 		if packWindow == 0 {
-			o, err = dw.encodedObject(h)
+			o, err = dw.encodedObject(ctx, h)
 		} else {
-			o, err = dw.encodedDeltaObject(h)
+			o, err = dw.encodedDeltaObject(ctx, h)
 		}
 		if err != nil {
 			return nil, err
@@ -121,34 +124,34 @@ func (dw *DeltaSelector) objectsToPack(
 		return objectsToPack, nil
 	}
 
-	if err := dw.fixAndBreakChains(objectsToPack); err != nil {
+	if err := dw.fixAndBreakChains(ctx, objectsToPack); err != nil {
 		return nil, err
 	}
 
 	return objectsToPack, nil
 }
 
-func (dw *DeltaSelector) encodedDeltaObject(h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (dw *DeltaSelector) encodedDeltaObject(ctx context.Context, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	edos, ok := dw.storer.(storer.DeltaObjectStorer)
 	if !ok {
-		return dw.encodedObject(h)
+		return dw.encodedObject(ctx, h)
 	}
 
-	return edos.DeltaObject(plumbing.AnyObject, h)
+	return edos.DeltaObject(ctx, plumbing.AnyObject, h)
 }
 
-func (dw *DeltaSelector) encodedObject(h plumbing.Hash) (plumbing.EncodedObject, error) {
-	return dw.storer.EncodedObject(plumbing.AnyObject, h)
+func (dw *DeltaSelector) encodedObject(ctx context.Context, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	return dw.storer.EncodedObject(ctx, plumbing.AnyObject, h)
 }
 
-func (dw *DeltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error {
+func (dw *DeltaSelector) fixAndBreakChains(ctx context.Context, objectsToPack []*ObjectToPack) error {
 	m := make(map[plumbing.Hash]*ObjectToPack, len(objectsToPack))
 	for _, otp := range objectsToPack {
 		m[otp.Hash()] = otp
 	}
 
 	for _, otp := range objectsToPack {
-		if err := dw.fixAndBreakChainsOne(m, otp); err != nil {
+		if err := dw.fixAndBreakChainsOne(ctx, m, otp); err != nil {
 			return err
 		}
 	}
@@ -156,7 +159,7 @@ func (dw *DeltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error 
 	return nil
 }
 
-func (dw *DeltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*ObjectToPack, otp *ObjectToPack) error {
+func (dw *DeltaSelector) fixAndBreakChainsOne(ctx context.Context, objectsToPack map[plumbing.Hash]*ObjectToPack, otp *ObjectToPack) error {
 	if !otp.Object.Type().IsDelta() {
 		return nil
 	}
@@ -172,17 +175,17 @@ func (dw *DeltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*O
 	if !ok {
 		// if this is not a DeltaObject, then we cannot retrieve its base,
 		// so we have to break the delta chain here.
-		return dw.undeltify(otp)
+		return dw.undeltify(ctx, otp)
 	}
 
 	base, ok := objectsToPack[do.BaseHash()]
 	if !ok {
 		// The base of the delta is not in our list of objects to pack, so
 		// we break the chain.
-		return dw.undeltify(otp)
+		return dw.undeltify(ctx, otp)
 	}
 
-	if err := dw.fixAndBreakChainsOne(objectsToPack, base); err != nil {
+	if err := dw.fixAndBreakChainsOne(ctx, objectsToPack, base); err != nil {
 		return err
 	}
 
@@ -190,7 +193,7 @@ func (dw *DeltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*O
 	return nil
 }
 
-func (dw *DeltaSelector) restoreOriginal(otp *ObjectToPack) error {
+func (dw *DeltaSelector) restoreOriginal(ctx context.Context, otp *ObjectToPack) error {
 	if otp.Original != nil {
 		return nil
 	}
@@ -199,7 +202,7 @@ func (dw *DeltaSelector) restoreOriginal(otp *ObjectToPack) error {
 		return nil
 	}
 
-	obj, err := dw.encodedObject(otp.Hash())
+	obj, err := dw.encodedObject(ctx, otp.Hash())
 	if err != nil {
 		return err
 	}
@@ -211,8 +214,8 @@ func (dw *DeltaSelector) restoreOriginal(otp *ObjectToPack) error {
 
 // undeltify undeltifies an *ObjectToPack by retrieving the original object from
 // the storer and resetting it.
-func (dw *DeltaSelector) undeltify(otp *ObjectToPack) error {
-	if err := dw.restoreOriginal(otp); err != nil {
+func (dw *DeltaSelector) undeltify(ctx context.Context, otp *ObjectToPack) error {
+	if err := dw.restoreOriginal(ctx, otp); err != nil {
 		return err
 	}
 
@@ -226,6 +229,7 @@ func (dw *DeltaSelector) sort(objectsToPack []*ObjectToPack) {
 }
 
 func (dw *DeltaSelector) walk(
+	ctx context.Context,
 	objectsToPack []*ObjectToPack,
 	packWindow uint,
 ) error {
@@ -267,7 +271,7 @@ func (dw *DeltaSelector) walk(
 				break
 			}
 
-			if err := dw.tryToDeltify(indexMap, base, target); err != nil {
+			if err := dw.tryToDeltify(ctx, indexMap, base, target); err != nil {
 				return err
 			}
 		}
@@ -276,14 +280,14 @@ func (dw *DeltaSelector) walk(
 	return nil
 }
 
-func (dw *DeltaSelector) tryToDeltify(indexMap map[plumbing.Hash]*deltaIndex, base, target *ObjectToPack) error {
+func (dw *DeltaSelector) tryToDeltify(ctx context.Context, indexMap map[plumbing.Hash]*deltaIndex, base, target *ObjectToPack) error {
 	// Original object might not be present if we're reusing a delta, so we
 	// ensure it is restored.
-	if err := dw.restoreOriginal(target); err != nil {
+	if err := dw.restoreOriginal(ctx, target); err != nil {
 		return err
 	}
 
-	if err := dw.restoreOriginal(base); err != nil {
+	if err := dw.restoreOriginal(ctx, base); err != nil {
 		return err
 	}
 

--- a/plumbing/format/packfile/delta_selector_test.go
+++ b/plumbing/format/packfile/delta_selector_test.go
@@ -141,7 +141,7 @@ var testObjects = []*testObject{{
 func (s *DeltaSelectorSuite) createTestObjects() {
 	s.hashes = make(map[string]plumbing.Hash)
 	for _, o := range testObjects {
-		h, err := s.store.SetEncodedObject(o.object)
+		h, err := s.store.SetEncodedObject(s.T().Context(), o.object)
 		if err != nil {
 			panic(err)
 		}
@@ -150,10 +150,11 @@ func (s *DeltaSelectorSuite) createTestObjects() {
 }
 
 func (s *DeltaSelectorSuite) TestObjectsToPack() {
+	ctx := s.T().Context()
 	// Different type
 	hashes := []plumbing.Hash{s.hashes["base"], s.hashes["treeType"]}
 	deltaWindowSize := uint(10)
-	otp, err := s.ds.ObjectsToPack(hashes, deltaWindowSize)
+	otp, err := s.ds.ObjectsToPack(ctx, hashes, deltaWindowSize)
 	s.NoError(err)
 	s.Len(otp, 2)
 	s.Equal(s.store.Objects[s.hashes["base"]], otp[0].Object)
@@ -161,7 +162,7 @@ func (s *DeltaSelectorSuite) TestObjectsToPack() {
 
 	// Size radically different
 	hashes = []plumbing.Hash{s.hashes["bigBase"], s.hashes["target"]}
-	otp, err = s.ds.ObjectsToPack(hashes, deltaWindowSize)
+	otp, err = s.ds.ObjectsToPack(ctx, hashes, deltaWindowSize)
 	s.NoError(err)
 	s.Len(otp, 2)
 	s.Equal(s.store.Objects[s.hashes["bigBase"]], otp[0].Object)
@@ -169,7 +170,7 @@ func (s *DeltaSelectorSuite) TestObjectsToPack() {
 
 	// Delta Size Limit with no best delta yet
 	hashes = []plumbing.Hash{s.hashes["smallBase"], s.hashes["smallTarget"]}
-	otp, err = s.ds.ObjectsToPack(hashes, deltaWindowSize)
+	otp, err = s.ds.ObjectsToPack(ctx, hashes, deltaWindowSize)
 	s.NoError(err)
 	s.Len(otp, 2)
 	s.Equal(s.store.Objects[s.hashes["smallBase"]], otp[0].Object)
@@ -177,7 +178,7 @@ func (s *DeltaSelectorSuite) TestObjectsToPack() {
 
 	// It will create the delta
 	hashes = []plumbing.Hash{s.hashes["base"], s.hashes["target"]}
-	otp, err = s.ds.ObjectsToPack(hashes, deltaWindowSize)
+	otp, err = s.ds.ObjectsToPack(ctx, hashes, deltaWindowSize)
 	s.NoError(err)
 	s.Len(otp, 2)
 	s.Equal(s.store.Objects[s.hashes["target"]], otp[0].Object)
@@ -192,7 +193,7 @@ func (s *DeltaSelectorSuite) TestObjectsToPack() {
 		s.hashes["o2"],
 		s.hashes["o3"],
 	}
-	otp, err = s.ds.ObjectsToPack(hashes, deltaWindowSize)
+	otp, err = s.ds.ObjectsToPack(ctx, hashes, deltaWindowSize)
 	s.NoError(err)
 	s.Len(otp, 3)
 	s.Equal(s.store.Objects[s.hashes["o1"]], otp[0].Object)
@@ -215,9 +216,9 @@ func (s *DeltaSelectorSuite) TestObjectsToPack() {
 
 	// Don't sort so we can easily check the sliding window without
 	// creating a bunch of new objects.
-	otp, err = s.ds.objectsToPack(hashes, deltaWindowSize)
+	otp, err = s.ds.objectsToPack(ctx, hashes, deltaWindowSize)
 	s.NoError(err)
-	err = s.ds.walk(otp, deltaWindowSize)
+	err = s.ds.walk(ctx, otp, deltaWindowSize)
 	s.NoError(err)
 	s.Len(otp, int(deltaWindowSize)+2)
 	targetIdx := len(otp) - 1
@@ -226,7 +227,7 @@ func (s *DeltaSelectorSuite) TestObjectsToPack() {
 	// Check that no deltas are created, and the objects are unsorted,
 	// if compression is off.
 	hashes = []plumbing.Hash{s.hashes["base"], s.hashes["target"]}
-	otp, err = s.ds.ObjectsToPack(hashes, 0)
+	otp, err = s.ds.ObjectsToPack(ctx, hashes, 0)
 	s.NoError(err)
 	s.Len(otp, 2)
 	s.Equal(s.store.Objects[s.hashes["base"]], otp[0].Object)

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"context"
 	"crypto"
 	"errors"
 	"fmt"
@@ -20,7 +21,7 @@ import (
 // order, including any delta relationships. The default selector is
 // *DeltaSelector.
 type ObjectSelector interface {
-	ObjectsToPack(hashes []plumbing.Hash, packWindow uint) ([]*ObjectToPack, error)
+	ObjectsToPack(ctx context.Context, hashes []plumbing.Hash, packWindow uint) ([]*ObjectToPack, error)
 }
 
 // Encoder gets the data from the storage and write it into the writer in PACK
@@ -73,10 +74,10 @@ func WithObjectSelector(s ObjectSelector) EncoderOption {
 // Optional EncoderOptions configure encoder behavior; see
 // WithObjectSelector for the main use case (precomputed selection for
 // streaming output).
-func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool, opts ...EncoderOption) *Encoder {
+func NewEncoder(ctx context.Context, w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool, opts ...EncoderOption) *Encoder {
 	var of cfgformat.ObjectFormat
 	if c, ok := s.(config.ConfigStorer); ok {
-		cfg, err := c.Config()
+		cfg, err := c.Config(ctx)
 		if err == nil {
 			of = cfg.Extensions.ObjectFormat
 		}
@@ -117,24 +118,25 @@ func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool, op
 // used for recovery operations during the write phase regardless of
 // the configured selector.
 func (e *Encoder) Encode(
+	ctx context.Context,
 	hashes []plumbing.Hash,
 	packWindow uint,
 ) (plumbing.Hash, error) {
-	objects, err := e.objectSelector.ObjectsToPack(hashes, packWindow)
+	objects, err := e.objectSelector.ObjectsToPack(ctx, hashes, packWindow)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	return e.encode(objects)
+	return e.encode(ctx, objects)
 }
 
-func (e *Encoder) encode(objects []*ObjectToPack) (plumbing.Hash, error) {
+func (e *Encoder) encode(ctx context.Context, objects []*ObjectToPack) (plumbing.Hash, error) {
 	if err := e.head(len(objects)); err != nil {
 		return plumbing.ZeroHash, err
 	}
 
 	for _, o := range objects {
-		if err := e.entry(o); err != nil {
+		if err := e.entry(ctx, o); err != nil {
 			return plumbing.ZeroHash, err
 		}
 	}
@@ -151,14 +153,14 @@ func (e *Encoder) head(numEntries int) error {
 	)
 }
 
-func (e *Encoder) entry(o *ObjectToPack) (err error) {
+func (e *Encoder) entry(ctx context.Context, o *ObjectToPack) (err error) {
 	if o.WantWrite() {
 		// A cycle exists in this delta chain. This should only occur if a
 		// selected object representation disappeared during writing
 		// (for example due to a concurrent repack) and a different base
 		// was chosen, forcing a cycle. Select something other than a
 		// delta, and write this object.
-		if err := e.deltaSelector.restoreOriginal(o); err != nil {
+		if err := e.deltaSelector.restoreOriginal(ctx, o); err != nil {
 			return err
 		}
 		o.BackToOriginal()
@@ -170,7 +172,7 @@ func (e *Encoder) entry(o *ObjectToPack) (err error) {
 
 	o.MarkWantWrite()
 
-	if err := e.writeBaseIfDelta(o); err != nil {
+	if err := e.writeBaseIfDelta(ctx, o); err != nil {
 		return err
 	}
 
@@ -206,10 +208,10 @@ func (e *Encoder) entry(o *ObjectToPack) (err error) {
 	return err
 }
 
-func (e *Encoder) writeBaseIfDelta(o *ObjectToPack) error {
+func (e *Encoder) writeBaseIfDelta(ctx context.Context, o *ObjectToPack) error {
 	if o.IsDelta() && !o.Base.IsWritten() {
 		// We must write base first
-		return e.entry(o.Base)
+		return e.entry(ctx, o.Base)
 	}
 
 	return nil

--- a/plumbing/format/packfile/encoder_advanced_test.go
+++ b/plumbing/format/packfile/encoder_advanced_test.go
@@ -2,6 +2,7 @@ package packfile_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"math/rand"
 	"testing"
@@ -43,7 +44,7 @@ func (s *EncoderAdvancedSuite) TestEncodeDecode() {
 		s.Require().NoError(err)
 		storage := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 		defer func() { _ = storage.Close() }()
-		s.testEncodeDecode(storage, 10)
+		s.testEncodeDecode(s.T().Context(), storage, 10)
 	}
 }
 
@@ -61,31 +62,32 @@ func (s *EncoderAdvancedSuite) TestEncodeDecodeNoDeltaCompression() {
 		s.Require().NoError(err)
 		storage := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 		defer func() { _ = storage.Close() }()
-		s.testEncodeDecode(storage, 0)
+		s.testEncodeDecode(s.T().Context(), storage, 0)
 	}
 }
 
 func (s *EncoderAdvancedSuite) testEncodeDecode(
+	ctx context.Context,
 	storage storer.Storer,
 	packWindow uint,
 ) {
 	objectFormat := formatcfg.DefaultObjectFormat
 	if cs, ok := storage.(interface {
-		Config() (*config.Config, error)
+		Config(ctx context.Context) (*config.Config, error)
 	}); ok {
-		cfg, err := cs.Config()
+		cfg, err := cs.Config(ctx)
 		s.Require().NoError(err)
 		if cfg.Extensions.ObjectFormat != formatcfg.UnsetObjectFormat {
 			objectFormat = cfg.Extensions.ObjectFormat
 		}
 	}
 
-	objIter, err := storage.IterEncodedObjects(plumbing.AnyObject)
+	objIter, err := storage.IterEncodedObjects(ctx, plumbing.AnyObject)
 	s.NoError(err)
 
 	expectedObjects := map[plumbing.Hash]bool{}
 	var hashes []plumbing.Hash
-	err = objIter.ForEach(func(o plumbing.EncodedObject) error {
+	err = objIter.ForEach(ctx, func(o plumbing.EncodedObject) error {
 		expectedObjects[o.Hash()] = true
 		hashes = append(hashes, o.Hash())
 		return err
@@ -101,8 +103,8 @@ func (s *EncoderAdvancedSuite) testEncodeDecode(
 	hashes = auxHashes
 
 	buf := bytes.NewBuffer(nil)
-	enc := NewEncoder(buf, storage, false)
-	encodeHash, err := enc.Encode(hashes, packWindow)
+	enc := NewEncoder(ctx, buf, storage, false)
+	encodeHash, err := enc.Encode(ctx, hashes, packWindow)
 	s.NoError(err)
 
 	fs := memfs.New()
@@ -118,7 +120,7 @@ func (s *EncoderAdvancedSuite) testEncodeDecode(
 	w := new(idxfile.Writer)
 	parser := NewParser(NewScanner(f), WithScannerObservers(w), WithObjectFormat(objectFormat))
 
-	_, err = parser.Parse()
+	_, err = parser.Parse(ctx)
 	s.NoError(err)
 	index, err := w.Index()
 	s.NoError(err)
@@ -135,7 +137,7 @@ func (s *EncoderAdvancedSuite) testEncodeDecode(
 	objIter, err = p.GetAll()
 	s.NoError(err)
 	obtainedObjects := map[plumbing.Hash]bool{}
-	err = objIter.ForEach(func(o plumbing.EncodedObject) error {
+	err = objIter.ForEach(ctx, func(o plumbing.EncodedObject) error {
 		obtainedObjects[o.Hash()] = true
 		return nil
 	})

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -2,6 +2,7 @@ package packfile
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 
@@ -28,11 +29,11 @@ func TestEncoderSuite(t *testing.T) {
 func (s *EncoderSuite) SetupTest() {
 	s.buf = bytes.NewBuffer(nil)
 	s.store = memory.NewStorage()
-	s.enc = NewEncoder(s.buf, s.store, false)
+	s.enc = NewEncoder(s.T().Context(), s.buf, s.store, false)
 }
 
 func (s *EncoderSuite) TestCorrectPackHeader() {
-	h, err := s.enc.Encode([]plumbing.Hash{}, 10)
+	h, err := s.enc.Encode(s.T().Context(), []plumbing.Hash{}, 10)
 	s.NoError(err)
 
 	hb := h.Bytes()
@@ -51,10 +52,10 @@ func (s *EncoderSuite) TestCorrectPackWithOneEmptyObject() {
 	o := &plumbing.MemoryObject{}
 	o.SetType(plumbing.CommitObject)
 	o.SetSize(0)
-	_, err := s.store.SetEncodedObject(o)
+	_, err := s.store.SetEncodedObject(s.T().Context(), o)
 	s.NoError(err)
 
-	h, err := s.enc.Encode([]plumbing.Hash{o.Hash()}, 10)
+	h, err := s.enc.Encode(s.T().Context(), []plumbing.Hash{o.Hash()}, 10)
 	s.NoError(err)
 
 	// + HASH
@@ -81,47 +82,47 @@ func (s *EncoderSuite) TestMaxObjectSize() {
 	o := s.store.NewEncodedObject()
 	o.SetSize(9223372036854775807)
 	o.SetType(plumbing.CommitObject)
-	_, err := s.store.SetEncodedObject(o)
+	_, err := s.store.SetEncodedObject(s.T().Context(), o)
 	s.NoError(err)
-	hash, err := s.enc.Encode([]plumbing.Hash{o.Hash()}, 10)
+	hash, err := s.enc.Encode(s.T().Context(), []plumbing.Hash{o.Hash()}, 10)
 	s.NoError(err)
 	s.NotEqual(true, hash.IsZero())
 }
 
 func (s *EncoderSuite) TestHashNotFound() {
-	h, err := s.enc.Encode([]plumbing.Hash{plumbing.NewHash("BAD")}, 10)
+	h, err := s.enc.Encode(s.T().Context(), []plumbing.Hash{plumbing.NewHash("BAD")}, 10)
 	s.Equal(plumbing.ZeroHash, h)
 	s.NotNil(err)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 }
 
 func (s *EncoderSuite) TestDecodeEncodeWithDeltaDecodeREF() {
-	s.enc = NewEncoder(s.buf, s.store, true)
+	s.enc = NewEncoder(s.T().Context(), s.buf, s.store, true)
 	s.simpleDeltaTest()
 }
 
 func (s *EncoderSuite) TestDecodeEncodeWithDeltaDecodeOFS() {
-	s.enc = NewEncoder(s.buf, s.store, false)
+	s.enc = NewEncoder(s.T().Context(), s.buf, s.store, false)
 	s.simpleDeltaTest()
 }
 
 func (s *EncoderSuite) TestDecodeEncodeWithDeltasDecodeREF() {
-	s.enc = NewEncoder(s.buf, s.store, true)
+	s.enc = NewEncoder(s.T().Context(), s.buf, s.store, true)
 	s.deltaOverDeltaTest()
 }
 
 func (s *EncoderSuite) TestDecodeEncodeWithDeltasDecodeOFS() {
-	s.enc = NewEncoder(s.buf, s.store, false)
+	s.enc = NewEncoder(s.T().Context(), s.buf, s.store, false)
 	s.deltaOverDeltaTest()
 }
 
 func (s *EncoderSuite) TestDecodeEncodeWithCycleREF() {
-	s.enc = NewEncoder(s.buf, s.store, true)
+	s.enc = NewEncoder(s.T().Context(), s.buf, s.store, true)
 	s.deltaOverDeltaCyclicTest()
 }
 
 func (s *EncoderSuite) TestDecodeEncodeWithCycleOFS() {
-	s.enc = NewEncoder(s.buf, s.store, false)
+	s.enc = NewEncoder(s.T().Context(), s.buf, s.store, false)
 	s.deltaOverDeltaCyclicTest()
 }
 
@@ -132,7 +133,7 @@ func (s *EncoderSuite) TestDecodeEncodeWithCycleOFS() {
 // back via WithObjectSelector.
 type fixedSelector struct{ objects []*ObjectToPack }
 
-func (f fixedSelector) ObjectsToPack(_ []plumbing.Hash, _ uint) ([]*ObjectToPack, error) {
+func (f fixedSelector) ObjectsToPack(_ context.Context, _ []plumbing.Hash, _ uint) ([]*ObjectToPack, error) {
 	return f.objects, nil
 }
 
@@ -147,27 +148,27 @@ func (s *EncoderSuite) TestWithObjectSelectorMatchesDefault() {
 	o2 := newObject(plumbing.BlobObject, []byte("hello world"))
 	o3 := newObject(plumbing.BlobObject, []byte("goodbye"))
 	for _, o := range []plumbing.EncodedObject{o1, o2, o3} {
-		_, err := s.store.SetEncodedObject(o)
+		_, err := s.store.SetEncodedObject(s.T().Context(), o)
 		s.NoError(err)
 	}
 	hashes := []plumbing.Hash{o1.Hash(), o2.Hash(), o3.Hash()}
 
 	// Default path: encoder runs selection internally.
 	defaultBuf := bytes.NewBuffer(nil)
-	defaultEnc := NewEncoder(defaultBuf, s.store, false)
-	defaultHash, err := defaultEnc.Encode(hashes, 10)
+	defaultEnc := NewEncoder(s.T().Context(), defaultBuf, s.store, false)
+	defaultHash, err := defaultEnc.Encode(s.T().Context(), hashes, 10)
 	s.NoError(err)
 
 	// Precomputed path: caller runs selection ahead of time, then
 	// feeds the result back via a passthrough ObjectSelector.
 	sel := NewDeltaSelector(s.store)
-	objects, err := sel.ObjectsToPack(hashes, 10)
+	objects, err := sel.ObjectsToPack(s.T().Context(), hashes, 10)
 	s.NoError(err)
 
 	precomputedBuf := bytes.NewBuffer(nil)
-	precomputedEnc := NewEncoder(precomputedBuf, s.store, false,
+	precomputedEnc := NewEncoder(s.T().Context(), precomputedBuf, s.store, false,
 		WithObjectSelector(fixedSelector{objects: objects}))
-	precomputedHash, err := precomputedEnc.Encode(hashes, 10)
+	precomputedHash, err := precomputedEnc.Encode(s.T().Context(), hashes, 10)
 	s.NoError(err)
 
 	s.Equal(defaultHash, precomputedHash)
@@ -180,11 +181,11 @@ func (s *EncoderSuite) TestWithObjectSelectorMatchesDefault() {
 // conditionally.
 func (s *EncoderSuite) TestWithObjectSelectorNilPreservesDefault() {
 	o := newObject(plumbing.BlobObject, []byte("x"))
-	_, err := s.store.SetEncodedObject(o)
+	_, err := s.store.SetEncodedObject(s.T().Context(), o)
 	s.NoError(err)
 
-	enc := NewEncoder(bytes.NewBuffer(nil), s.store, false, WithObjectSelector(nil))
-	_, err = enc.Encode([]plumbing.Hash{o.Hash()}, 10)
+	enc := NewEncoder(s.T().Context(), bytes.NewBuffer(nil), s.store, false, WithObjectSelector(nil))
+	_, err = enc.Encode(s.T().Context(), []plumbing.Hash{o.Hash()}, 10)
 	s.NoError(err)
 }
 
@@ -196,7 +197,7 @@ func (s *EncoderSuite) simpleDeltaTest() {
 	s.NoError(err)
 
 	srcToPack := newObjectToPack(srcObject)
-	encHash, err := s.enc.encode([]*ObjectToPack{
+	encHash, err := s.enc.encode(s.T().Context(), []*ObjectToPack{
 		srcToPack,
 		newDeltaObjectToPack(srcToPack, targetObject, deltaObject),
 	})
@@ -233,7 +234,7 @@ func (s *EncoderSuite) deltaOverDeltaTest() {
 
 	srcToPack := newObjectToPack(srcObject)
 	targetToPack := newObjectToPack(targetObject)
-	encHash, err := s.enc.encode([]*ObjectToPack{
+	encHash, err := s.enc.encode(s.T().Context(), []*ObjectToPack{
 		targetToPack,
 		srcToPack,
 		newDeltaObjectToPack(srcToPack, targetObject, deltaObject),
@@ -267,13 +268,13 @@ func (s *EncoderSuite) deltaOverDeltaCyclicTest() {
 	o3 := newObject(plumbing.BlobObject, []byte("011111"))
 	o4 := newObject(plumbing.BlobObject, []byte("01111100000"))
 
-	_, err := s.store.SetEncodedObject(o1)
+	_, err := s.store.SetEncodedObject(s.T().Context(), o1)
 	s.NoError(err)
-	_, err = s.store.SetEncodedObject(o2)
+	_, err = s.store.SetEncodedObject(s.T().Context(), o2)
 	s.NoError(err)
-	_, err = s.store.SetEncodedObject(o3)
+	_, err = s.store.SetEncodedObject(s.T().Context(), o3)
 	s.NoError(err)
-	_, err = s.store.SetEncodedObject(o4)
+	_, err = s.store.SetEncodedObject(s.T().Context(), o4)
 	s.NoError(err)
 
 	d2, err := GetDelta(o1, o2)
@@ -305,7 +306,7 @@ func (s *EncoderSuite) deltaOverDeltaCyclicTest() {
 
 	pd4.SetOriginal(pd4.Original)
 
-	encHash, err := s.enc.encode([]*ObjectToPack{
+	encHash, err := s.enc.encode(s.T().Context(), []*ObjectToPack{
 		po1,
 		pd2,
 		pd3,
@@ -379,7 +380,7 @@ func packfileFromReader(s *EncoderSuite, buf *bytes.Buffer) (*Packfile, func()) 
 	w := new(idxfile.Writer)
 	p := NewParser(scanner, WithScannerObservers(w))
 
-	_, err = p.Parse()
+	_, err = p.Parse(s.T().Context())
 	s.NoError(err)
 
 	index, err := w.Index()

--- a/plumbing/format/packfile/internal_test.go
+++ b/plumbing/format/packfile/internal_test.go
@@ -46,7 +46,7 @@ func TestParserRejectsDeepDeltaChain(t *testing.T) {
 	pack, _ := buildTestPack(t, objects...)
 	parser := NewParser(bytes.NewReader(pack))
 
-	_, err := parser.Parse()
+	_, err := parser.Parse(t.Context())
 	require.ErrorIs(t, err, ErrMalformedPackfile)
 	require.ErrorContains(t, err, "delta chain depth")
 }
@@ -94,7 +94,7 @@ func TestObjectIterReturnsObjectNotFoundForMissingDeltaBase(t *testing.T) {
 			require.NoError(t, err)
 			defer iter.Close()
 
-			obj, err := iter.Next()
+			obj, err := iter.Next(t.Context())
 			require.Nil(t, obj)
 			require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 		})

--- a/plumbing/format/packfile/packfile_iter.go
+++ b/plumbing/format/packfile/packfile_iter.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"context"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -13,7 +14,11 @@ type objectIter struct {
 	iter idxfile.EntryIter
 }
 
-func (i *objectIter) Next() (plumbing.EncodedObject, error) {
+// Next returns the next object. The Packfile read paths below this
+// boundary do not take a context yet.
+//
+// TODO(ctx): propagate ctx into Packfile reads.
+func (i *objectIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
 	if err := i.p.init(); err != nil {
 		return nil, err
 	}
@@ -62,7 +67,7 @@ func (i *objectIter) next() (plumbing.EncodedObject, error) {
 	}
 }
 
-func (i *objectIter) ForEach(f func(plumbing.EncodedObject) error) error {
+func (i *objectIter) ForEach(ctx context.Context, f func(plumbing.EncodedObject) error) error {
 	if err := i.p.init(); err != nil {
 		return err
 	}
@@ -71,6 +76,10 @@ func (i *objectIter) ForEach(f func(plumbing.EncodedObject) error) error {
 	defer i.p.m.Unlock()
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		o, err := i.next()
 		if err != nil {
 			if err == io.EOF {

--- a/plumbing/format/packfile/packfile_iter.go
+++ b/plumbing/format/packfile/packfile_iter.go
@@ -18,7 +18,7 @@ type objectIter struct {
 // boundary do not take a context yet.
 //
 // TODO(ctx): propagate ctx into Packfile reads.
-func (i *objectIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
+func (i *objectIter) Next(_ context.Context) (plumbing.EncodedObject, error) {
 	if err := i.p.init(); err != nil {
 		return nil, err
 	}

--- a/plumbing/format/packfile/packfile_test.go
+++ b/plumbing/format/packfile/packfile_test.go
@@ -89,7 +89,7 @@ func TestGetAll(t *testing.T) {
 
 		var objects int
 		for {
-			o, err := iter.Next()
+			o, err := iter.Next(t.Context())
 			if err == io.EOF {
 				break
 			}
@@ -154,7 +154,7 @@ func TestDecodeByTypeRefDelta(t *testing.T) {
 			iter, err := p.GetByType(typ)
 			require.NoError(t, err)
 
-			err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+			err = iter.ForEach(t.Context(), func(obj plumbing.EncodedObject) error {
 				assert.Equal(t, typ, obj.Type())
 				total++
 				return nil
@@ -189,7 +189,7 @@ func TestDecodeByType(t *testing.T) {
 			iter, err := p.GetByType(typ)
 			require.NoError(t, err)
 
-			err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+			err = iter.ForEach(t.Context(), func(obj plumbing.EncodedObject) error {
 				assert.Equal(t, typ, obj.Type())
 				return nil
 			})

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"context"
 	"bytes"
 	"errors"
 	"fmt"
@@ -127,11 +128,11 @@ func NewParser(data io.Reader, opts ...ParserOption) *Parser {
 	return p
 }
 
-func (p *Parser) storeOrCache(oh *ObjectHeader) error {
+func (p *Parser) storeOrCache(ctx context.Context, oh *ObjectHeader) error {
 	// Only need to store deltas, as the scanner already stored non-delta
 	// objects.
 	if p.storage != nil && oh.diskType.IsDelta() {
-		w, err := p.storage.RawObjectWriter(oh.Type, oh.Size)
+		w, err := p.storage.RawObjectWriter(ctx, oh.Type, oh.Size)
 		if err != nil {
 			return err
 		}
@@ -172,7 +173,7 @@ func (p *Parser) resetCache(qty int) {
 }
 
 // Parse start decoding phase of the packfile.
-func (p *Parser) Parse() (plumbing.Hash, error) {
+func (p *Parser) Parse(ctx context.Context) (plumbing.Hash, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
 
@@ -180,6 +181,7 @@ func (p *Parser) Parse() (plumbing.Hash, error) {
 		return plumbing.ZeroHash, ErrParserConsumed
 	}
 	p.parsed = true
+	p.scanner.ctx = ctx
 
 	var pendingDeltas []*ObjectHeader
 	var pendingDeltaREFs []*ObjectHeader
@@ -211,7 +213,7 @@ func (p *Parser) Parse() (plumbing.Hash, error) {
 				oh.content = nil
 			}
 
-			_ = p.storeOrCache(&oh)
+			_ = p.storeOrCache(ctx, &oh)
 
 		case FooterSection:
 			p.checksum = data.Value().(plumbing.Hash)
@@ -226,7 +228,7 @@ func (p *Parser) Parse() (plumbing.Hash, error) {
 		return plumbing.ZeroHash, err
 	}
 
-	if err := p.resolveDeltas(pendingDeltas, pendingDeltaREFs); err != nil {
+	if err := p.resolveDeltas(ctx, pendingDeltas, pendingDeltaREFs); err != nil {
 		return plumbing.ZeroHash, err
 	}
 
@@ -243,7 +245,7 @@ func (p *Parser) Parse() (plumbing.Hash, error) {
 	return p.checksum, p.onFooter(p.checksum)
 }
 
-func (p *Parser) ensureContent(oh *ObjectHeader) error {
+func (p *Parser) ensureContent(ctx context.Context, oh *ObjectHeader) error {
 	// Skip if this object already has the correct content.
 	if oh.content != nil && oh.content.Len() == int(oh.Size) && !oh.Hash.IsZero() {
 		return nil
@@ -261,7 +263,7 @@ func (p *Parser) ensureContent(oh *ObjectHeader) error {
 
 		defer sync.PutBytesBuffer(source)
 
-		err = p.applyPatchBaseHeader(oh, source, oh.content, nil)
+		err = p.applyPatchBaseHeader(ctx, oh, source, oh.content, nil)
 	case p.scanner.seeker != nil:
 		deltaData := sync.GetBytesBuffer()
 		defer sync.PutBytesBuffer(deltaData)
@@ -271,7 +273,7 @@ func (p *Parser) ensureContent(oh *ObjectHeader) error {
 			return fmt.Errorf("inflating content at offset %v: %w", oh.ContentOffset, err)
 		}
 
-		err = p.applyPatchBaseHeader(oh, deltaData, oh.content, nil)
+		err = p.applyPatchBaseHeader(ctx, oh, deltaData, oh.content, nil)
 	default:
 		return fmt.Errorf("can't ensure content: %w", plumbing.ErrObjectNotFound)
 	}
@@ -301,7 +303,7 @@ func (p *Parser) ensureContent(oh *ObjectHeader) error {
 // not match any in-pack object header is rejected as malformed input.
 //
 // [1]: https://github.com/git/git/blob/v2.54.0/builtin/index-pack.c#L1103
-func (p *Parser) resolveDeltas(ofsDeltas, refDeltas []*ObjectHeader) error {
+func (p *Parser) resolveDeltas(ctx context.Context, ofsDeltas, refDeltas []*ObjectHeader) error {
 	// Map sizes correspond to the count of distinct parent offsets /
 	// hashes, not the count of delta entries. Real packs cluster many
 	// children under one parent (chains and wide trees), so a hint
@@ -325,7 +327,7 @@ func (p *Parser) resolveDeltas(ofsDeltas, refDeltas []*ObjectHeader) error {
 			if c.parent != nil {
 				continue
 			}
-			if err := p.processDelta(c); err != nil {
+			if err := p.processDelta(ctx, c); err != nil {
 				return fmt.Errorf("processing ref-delta at offset %v: %w", c.Offset, err)
 			}
 			if err := visit(c); err != nil {
@@ -336,7 +338,7 @@ func (p *Parser) resolveDeltas(ofsDeltas, refDeltas []*ObjectHeader) error {
 			if c.parent != nil {
 				continue
 			}
-			if err := p.processDelta(c); err != nil {
+			if err := p.processDelta(ctx, c); err != nil {
 				return fmt.Errorf("processing ofs-delta at offset %v: %w", c.Offset, err)
 			}
 			if err := visit(c); err != nil {
@@ -366,7 +368,7 @@ func (p *Parser) resolveDeltas(ofsDeltas, refDeltas []*ObjectHeader) error {
 		if d.parent != nil {
 			continue
 		}
-		if err := p.processDelta(d); err != nil {
+		if err := p.processDelta(ctx, d); err != nil {
 			return fmt.Errorf("processing ref-delta at offset %v: %w", d.Offset, err)
 		}
 	}
@@ -381,7 +383,7 @@ func (p *Parser) resolveDeltas(ofsDeltas, refDeltas []*ObjectHeader) error {
 	return nil
 }
 
-func (p *Parser) processDelta(oh *ObjectHeader) error {
+func (p *Parser) processDelta(ctx context.Context, oh *ObjectHeader) error {
 	switch oh.Type {
 	case plumbing.OFSDeltaObject:
 		pa, ok := p.cache.oiByOffset[oh.OffsetReference]
@@ -417,11 +419,11 @@ func (p *Parser) processDelta(oh *ObjectHeader) error {
 		return err
 	}
 
-	if err := p.ensureContent(oh); err != nil {
+	if err := p.ensureContent(ctx, oh); err != nil {
 		return err
 	}
 
-	return p.storeOrCache(oh)
+	return p.storeOrCache(ctx, oh)
 }
 
 // checkDeltaChainDepth verifies that the delta chain rooted at oh
@@ -461,7 +463,7 @@ func (oh *ObjectHeader) isDeltaOnDisk() bool {
 
 // parentReader returns a [io.ReaderAt] for the decompressed contents
 // of the parent.
-func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
+func (p *Parser) parentReader(ctx context.Context, parent *ObjectHeader) (io.ReaderAt, error) {
 	if parent.content != nil && parent.content.Len() > 0 {
 		return bytes.NewReader(parent.content.Bytes()), nil
 	}
@@ -471,7 +473,7 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 	// it to then inflate the current object, which could go on
 	// indefinitely.
 	if p.storage != nil && parent.Hash != plumbing.ZeroHash {
-		obj, err := p.storage.EncodedObject(parent.Type, parent.Hash)
+		obj, err := p.storage.EncodedObject(ctx, parent.Type, parent.Hash)
 		if err == nil {
 			// Ensure that external references have the correct type and size.
 			parent.Type = obj.Type()
@@ -517,12 +519,12 @@ func (p *Parser) parentReader(parent *ObjectHeader) (io.ReaderAt, error) {
 	return bytes.NewReader(parent.content.Bytes()), nil
 }
 
-func (p *Parser) applyPatchBaseHeader(ota *ObjectHeader, delta io.Reader, target io.Writer, wh objectHeaderWriter) error {
+func (p *Parser) applyPatchBaseHeader(ctx context.Context, ota *ObjectHeader, delta io.Reader, target io.Writer, wh objectHeaderWriter) error {
 	if target == nil {
 		return fmt.Errorf("cannot apply patch against nil target")
 	}
 
-	parentContents, err := p.parentReader(ota.parent)
+	parentContents, err := p.parentReader(ctx, ota.parent)
 	if err != nil {
 		return err
 	}

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -1,8 +1,8 @@
 package packfile
 
 import (
-	"context"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"

--- a/plumbing/format/packfile/parser_fuzz_test.go
+++ b/plumbing/format/packfile/parser_fuzz_test.go
@@ -3,6 +3,7 @@ package packfile
 import (
 	"bytes"
 	"compress/zlib"
+	"context"
 	"crypto/sha1"
 	"encoding/binary"
 	"io"
@@ -89,8 +90,10 @@ func FuzzParser(f *testing.F) {
 		f.Add(pack.Bytes())
 	}
 
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		p := NewParser(bytes.NewReader(data))
-		_, _ = p.Parse(t.Context())
+		// context.Background instead of t.Context: OSS-Fuzz builds fuzz
+		// targets with a shim testing.T that has no Context method.
+		_, _ = p.Parse(context.Background())
 	})
 }

--- a/plumbing/format/packfile/parser_fuzz_test.go
+++ b/plumbing/format/packfile/parser_fuzz_test.go
@@ -89,8 +89,8 @@ func FuzzParser(f *testing.F) {
 		f.Add(pack.Bytes())
 	}
 
-	f.Fuzz(func(_ *testing.T, data []byte) {
+	f.Fuzz(func(t *testing.T, data []byte) {
 		p := NewParser(bytes.NewReader(data))
-		_, _ = p.Parse()
+		_, _ = p.Parse(t.Context())
 	})
 }

--- a/plumbing/format/packfile/parser_test.go
+++ b/plumbing/format/packfile/parser_test.go
@@ -108,7 +108,7 @@ func TestParserStorageModes(t *testing.T) {
 				field := reflect.ValueOf(parser).Elem().FieldByName("lowMemoryMode")
 				assert.Equal(t, tc.wantLowMemoryMode, field.Bool())
 
-				_, err := parser.Parse()
+				_, err := parser.Parse(t.Context())
 				require.NoError(t, err)
 
 				assert.Equal(t, f.PackfileHash, obs.checksum)
@@ -139,7 +139,7 @@ func assertParserOutput(t *testing.T, f *fixtures.Fixture, entries map[plumbing.
 
 	parser := packfile.NewParser(pf, opts...)
 
-	_, err := parser.Parse()
+	_, err := parser.Parse(t.Context())
 	require.NoError(t, err)
 
 	assert.Equal(t, f.PackfileHash, obs.checksum)
@@ -160,14 +160,14 @@ func TestParserMalformedPack(t *testing.T) {
 	require.NoError(t, pfErr)
 	parser := packfile.NewParser(io.LimitReader(pf, 300))
 
-	_, err := parser.Parse()
+	_, err := parser.Parse(t.Context())
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }
 
 func TestThinPack(t *testing.T) {
 	t.Parallel()
 	// Initialize an empty repository
-	r, err := git.PlainInit(t.TempDir(), true)
+	r, err := git.PlainInit(t.Context(), t.TempDir(), true)
 	assert.NoError(t, err)
 
 	// Try to parse a thin pack without having the required objects in the repo to
@@ -177,18 +177,18 @@ func TestThinPack(t *testing.T) {
 	require.NoError(t, thinPfErr)
 	parser := packfile.NewParser(thinPf, packfile.WithStorage(r.Storer)) // ParserWithStorage writes to the storer all parsed objects!
 
-	_, err = parser.Parse()
+	_, err = parser.Parse(t.Context())
 	assert.ErrorIs(t, err, packfile.ErrReferenceDeltaNotFound)
 
 	// start over with a clean repo
 	_ = r.Close()
-	r, err = git.PlainInit(t.TempDir(), true)
+	r, err = git.PlainInit(t.Context(), t.TempDir(), true)
 	assert.NoError(t, err)
 	defer func() { _ = r.Close() }()
 
 	// Now unpack a base packfile into our empty repo:
 	f := fixtures.ByURL("https://github.com/spinnaker/spinnaker.git").One()
-	w, err := r.Storer.(storer.PackfileWriter).PackfileWriter()
+	w, err := r.Storer.(storer.PackfileWriter).PackfileWriter(t.Context())
 	assert.NoError(t, err)
 	fPf, fPfErr := f.Packfile()
 	require.NoError(t, fPfErr)
@@ -197,7 +197,7 @@ func TestThinPack(t *testing.T) {
 	assert.NoError(t, w.Close())
 
 	// Check that the test object that will come with our thin pack is *not* in the repo
-	_, err = r.Storer.EncodedObject(plumbing.CommitObject, plumbing.NewHash(thinpack.Head))
+	_, err = r.Storer.EncodedObject(t.Context(), plumbing.CommitObject, plumbing.NewHash(thinpack.Head))
 	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 
 	// Now unpack the thin pack:
@@ -205,12 +205,12 @@ func TestThinPack(t *testing.T) {
 	require.NoError(t, thinPf2Err)
 	parser = packfile.NewParser(thinPf2, packfile.WithStorage(r.Storer)) // ParserWithStorage writes to the storer all parsed objects!
 
-	h, err := parser.Parse()
+	h, err := parser.Parse(t.Context())
 	assert.NoError(t, err)
 	assert.Equal(t, plumbing.NewHash("1288734cbe0b95892e663221d94b95de1f5d7be8"), h)
 
 	// Check that our test object is now accessible
-	_, err = r.Storer.EncodedObject(plumbing.CommitObject, plumbing.NewHash(thinpack.Head))
+	_, err = r.Storer.EncodedObject(t.Context(), plumbing.CommitObject, plumbing.NewHash(thinpack.Head))
 	assert.NoError(t, err)
 }
 
@@ -221,7 +221,7 @@ func TestResolveExternalRefsInThinPack(t *testing.T) {
 
 	parser := packfile.NewParser(extRefsThinPack)
 
-	checksum, err := parser.Parse()
+	checksum, err := parser.Parse(t.Context())
 	assert.NoError(t, err)
 	assert.NotEqual(t, checksum, plumbing.ZeroHash)
 }
@@ -233,7 +233,7 @@ func TestResolveExternalRefs(t *testing.T) {
 
 	parser := packfile.NewParser(extRefsThinPack)
 
-	checksum, err := parser.Parse()
+	checksum, err := parser.Parse(t.Context())
 	assert.NoError(t, err)
 	assert.NotEqual(t, plumbing.ZeroHash, checksum)
 }
@@ -245,7 +245,7 @@ func TestMemoryResolveExternalRefs(t *testing.T) {
 
 	parser := packfile.NewParser(extRefsThinPack, packfile.WithStorage(memory.NewStorage()))
 
-	checksum, err := parser.Parse()
+	checksum, err := parser.Parse(t.Context())
 	assert.NoError(t, err)
 	assert.NotEqual(t, plumbing.ZeroHash, checksum)
 }
@@ -304,7 +304,7 @@ func benchmarkParseBasic(b *testing.B,
 		}
 		parser := packfile.NewParser(scanner, opts...)
 
-		checksum, err := parser.Parse()
+		checksum, err := parser.Parse(b.Context())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -344,7 +344,7 @@ func BenchmarkParseAlternatingDeltaChain(b *testing.B) {
 			b.SetBytes(int64(len(pack)))
 			for i := 0; i < b.N; i++ {
 				parser := packfile.NewParser(bytes.NewReader(pack))
-				if _, err := parser.Parse(); err != nil {
+				if _, err := parser.Parse(b.Context()); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -498,7 +498,7 @@ func TestChecksumMismatch(t *testing.T) {
 	scanner := packfile.NewScanner(f)
 	parser := packfile.NewParser(scanner)
 
-	_, err = parser.Parse()
+	_, err = parser.Parse(t.Context())
 	require.ErrorContains(t, err, "checksum mismatch")
 }
 
@@ -520,7 +520,7 @@ func TestMalformedPack(t *testing.T) {
 	scanner := packfile.NewScanner(f)
 	parser := packfile.NewParser(scanner)
 
-	_, err = parser.Parse()
+	_, err = parser.Parse(t.Context())
 	require.ErrorContains(t, err, "malformed pack")
 }
 
@@ -544,7 +544,7 @@ func TestParserRejectsOverflowingObjectHeader(t *testing.T) {
 
 	parser := packfile.NewParser(bytes.NewReader(body.Bytes()))
 
-	_, err := parser.Parse()
+	_, err := parser.Parse(t.Context())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "malformed pack")
 }
@@ -647,7 +647,7 @@ func TestParserResolvesRefDeltaOfOfsDelta(t *testing.T) {
 
 			parser := packfile.NewParser(bytes.NewReader(pack), opts...)
 
-			_, err := parser.Parse()
+			_, err := parser.Parse(t.Context())
 			require.NoError(t, err, "parser must resolve REF-delta whose base is an in-pack OFS-delta")
 
 			seen := make(map[plumbing.Hash]bool, len(obs.objects))
@@ -727,9 +727,9 @@ func TestParserParseRejectsSecondCall(t *testing.T) {
 	_, _ = buf.Write(h.Sum(nil))
 
 	p := packfile.NewParser(bytes.NewReader(buf.Bytes()))
-	_, err := p.Parse()
+	_, err := p.Parse(t.Context())
 	require.NoError(t, err, "first Parse on the empty-object pack should succeed")
 
-	_, err = p.Parse()
+	_, err = p.Parse(t.Context())
 	assert.ErrorIs(t, err, packfile.ErrParserConsumed, "second Parse must return ErrParserConsumed")
 }

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"context"
 	"bufio"
 	"bytes"
 	"crypto"
@@ -182,6 +183,11 @@ type Scanner struct {
 	// storage is optional, and when set is used to store full objects found.
 	// Note that delta objects are not stored.
 	storage storer.EncodedObjectStorer
+	// ctx is the context of the in-progress scan operation. Scan is a
+	// state machine driven step-by-step by callers (io.Closer-style, no
+	// per-call context parameter), so the operation context is carried
+	// here; Parser.Parse sets it for the duration of the parse.
+	ctx context.Context
 
 	*scannerReader
 	rbuf *bufio.Reader
@@ -195,6 +201,7 @@ func NewScanner(rs io.Reader, opts ...ScannerOption) *Scanner {
 	packhash := gogithash.New(crypto.SHA1)
 
 	r := &Scanner{
+		ctx:      context.Background(),
 		objIndex: -1,
 		hasher:   plumbing.NewHasher(format.SHA1, plumbing.AnyObject, 0),
 		crc:      crc,
@@ -507,7 +514,7 @@ func objectEntry(r *Scanner) (stateFn, error) {
 		r.hasher.Reset(oh.Type, oh.Size)
 		mw = r.hasher
 		if r.storage != nil {
-			w, err := r.storage.RawObjectWriter(oh.Type, oh.Size)
+			w, err := r.storage.RawObjectWriter(r.ctx, oh.Type, oh.Size)
 			if err != nil {
 				return nil, err
 			}

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -1,9 +1,9 @@
 package packfile
 
 import (
-	"context"
 	"bufio"
 	"bytes"
+	"context"
 	"crypto"
 	"encoding/hex"
 	"errors"

--- a/plumbing/object/blob.go
+++ b/plumbing/object/blob.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -19,8 +20,8 @@ type Blob struct {
 }
 
 // GetBlob gets a blob from an object storer and decodes it.
-func GetBlob(s storer.EncodedObjectStorer, h plumbing.Hash) (*Blob, error) {
-	o, err := s.EncodedObject(plumbing.BlobObject, h)
+func GetBlob(ctx context.Context, s storer.EncodedObjectStorer, h plumbing.Hash) (*Blob, error) {
+	o, err := s.EncodedObject(ctx, plumbing.BlobObject, h)
 	if err != nil {
 		return nil, err
 	}
@@ -110,9 +111,9 @@ func NewBlobIter(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter) *B
 
 // Next moves the iterator to the next blob and returns a pointer to it. If
 // there are no more blobs, it returns io.EOF.
-func (iter *BlobIter) Next() (*Blob, error) {
+func (iter *BlobIter) Next(ctx context.Context) (*Blob, error) {
 	for {
-		obj, err := iter.EncodedObjectIter.Next()
+		obj, err := iter.EncodedObjectIter.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -128,8 +129,8 @@ func (iter *BlobIter) Next() (*Blob, error) {
 // ForEach call the cb function for each blob contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *BlobIter) ForEach(cb func(*Blob) error) error {
-	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
+func (iter *BlobIter) ForEach(ctx context.Context, cb func(*Blob) error) error {
+	return iter.EncodedObjectIter.ForEach(ctx, func(obj plumbing.EncodedObject) error {
 		if obj.Type() != plumbing.BlobObject {
 			return nil
 		}

--- a/plumbing/object/blob_test.go
+++ b/plumbing/object/blob_test.go
@@ -72,12 +72,12 @@ func (s *BlobsSuite) TestBlobDecodeEncodeIdempotent() {
 }
 
 func (s *BlobsSuite) TestBlobIter() {
-	encIter, err := s.Storer.IterEncodedObjects(plumbing.BlobObject)
+	encIter, err := s.Storer.IterEncodedObjects(s.T().Context(), plumbing.BlobObject)
 	s.NoError(err)
 	iter := NewBlobIter(s.Storer, encIter)
 
 	blobs := []*Blob{}
-	iter.ForEach(func(b *Blob) error {
+	iter.ForEach(s.T().Context(), func(b *Blob) error {
 		blobs = append(blobs, b)
 		return nil
 	})
@@ -85,13 +85,13 @@ func (s *BlobsSuite) TestBlobIter() {
 	s.True(len(blobs) > 0)
 	iter.Close()
 
-	encIter, err = s.Storer.IterEncodedObjects(plumbing.BlobObject)
+	encIter, err = s.Storer.IterEncodedObjects(s.T().Context(), plumbing.BlobObject)
 	s.NoError(err)
 	iter = NewBlobIter(s.Storer, encIter)
 
 	i := 0
 	for {
-		b, err := iter.Next()
+		b, err := iter.Next(s.T().Context())
 		if err == io.EOF {
 			break
 		}

--- a/plumbing/object/change.go
+++ b/plumbing/object/change.go
@@ -41,14 +41,14 @@ func (c *Change) Action() (merkletrie.Action, error) {
 
 // Files returns the files before and after a change.
 // For insertions from will be nil. For deletions to will be nil.
-func (c *Change) Files() (from, to *File, err error) {
+func (c *Change) Files(ctx context.Context) (from, to *File, err error) {
 	action, err := c.Action()
 	if err != nil {
 		return from, to, err
 	}
 
 	if action == merkletrie.Insert || action == merkletrie.Modify {
-		to, err = c.To.Tree.TreeEntryFile(&c.To.TreeEntry)
+		to, err = c.To.Tree.TreeEntryFile(ctx, &c.To.TreeEntry)
 		if !c.To.TreeEntry.Mode.IsFile() {
 			return nil, nil, nil
 		}
@@ -59,7 +59,7 @@ func (c *Change) Files() (from, to *File, err error) {
 	}
 
 	if action == merkletrie.Delete || action == merkletrie.Modify {
-		from, err = c.From.Tree.TreeEntryFile(&c.From.TreeEntry)
+		from, err = c.From.Tree.TreeEntryFile(ctx, &c.From.TreeEntry)
 		if !c.From.TreeEntry.Mode.IsFile() {
 			return nil, nil, nil
 		}
@@ -83,16 +83,10 @@ func (c *Change) String() string {
 
 // Patch returns a Patch with all the file changes in chunks. This
 // representation can be used to create several diff outputs.
-func (c *Change) Patch() (*Patch, error) {
-	return c.PatchContext(context.Background())
-}
-
-// PatchContext returns a Patch with all the file changes in chunks. This
-// representation can be used to create several diff outputs.
 // If context expires, an non-nil error will be returned.
 // Provided context must be non-nil.
-func (c *Change) PatchContext(ctx context.Context) (*Patch, error) {
-	return getPatchContext(ctx, "", c)
+func (c *Change) Patch(ctx context.Context) (*Patch, error) {
+	return getPatch(ctx, "", c)
 }
 
 func (c *Change) name() string {
@@ -146,14 +140,8 @@ func (c Changes) String() string {
 
 // Patch returns a Patch with all the changes in chunks. This
 // representation can be used to create several diff outputs.
-func (c Changes) Patch() (*Patch, error) {
-	return c.PatchContext(context.Background())
-}
-
-// PatchContext returns a Patch with all the changes in chunks. This
-// representation can be used to create several diff outputs.
 // If context expires, an non-nil error will be returned.
 // Provided context must be non-nil.
-func (c Changes) PatchContext(ctx context.Context) (*Patch, error) {
-	return getPatchContext(ctx, "", c...)
+func (c Changes) Patch(ctx context.Context) (*Patch, error) {
+	return getPatch(ctx, "", c...)
 }

--- a/plumbing/object/change_adaptor_test.go
+++ b/plumbing/object/change_adaptor_test.go
@@ -32,7 +32,7 @@ func (s *ChangeAdaptorSuite) SetupSuite() {
 }
 
 func (s *ChangeAdaptorSuite) tree(h plumbing.Hash) *Tree {
-	t, err := GetTree(s.Storer, h)
+	t, err := GetTree(s.T().Context(), s.Storer, h)
 	s.NoError(err)
 	return t
 }
@@ -173,7 +173,7 @@ func (s *ChangeAdaptorSuite) TestEmptyChangeFails() {
 	_, err := change.Action()
 	s.ErrorContains(err, "malformed change")
 
-	_, _, err = change.Files()
+	_, _, err = change.Files(s.T().Context())
 	s.ErrorContains(err, "malformed change")
 
 	str := change.String()
@@ -226,7 +226,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesInsert() {
 	change.To.TreeEntry.Mode = filemode.Regular
 	change.To.TreeEntry.Hash = plumbing.NewHash("49c6bb89b17060d7b4deacb7b338fcc6ea2352a9")
 
-	from, to, err := change.Files()
+	from, to, err := change.Files(s.T().Context())
 	s.NoError(err)
 	s.Nil(from)
 	s.Equal(change.To.TreeEntry.Hash, to.ID())
@@ -243,7 +243,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesInsertNotFound() {
 	// there is no object for this hash
 	change.To.TreeEntry.Hash = plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
-	_, _, err := change.Files()
+	_, _, err := change.Files(s.T().Context())
 	s.Error(err)
 }
 
@@ -257,7 +257,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesDelete() {
 	change.From.TreeEntry.Mode = filemode.Regular
 	change.From.TreeEntry.Hash = plumbing.NewHash("49c6bb89b17060d7b4deacb7b338fcc6ea2352a9")
 
-	from, to, err := change.Files()
+	from, to, err := change.Files(s.T().Context())
 	s.NoError(err)
 	s.Nil(to)
 	s.Equal(change.From.TreeEntry.Hash, from.ID())
@@ -274,7 +274,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesDeleteNotFound() {
 	// there is no object for this hash
 	change.From.TreeEntry.Hash = plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
-	_, _, err := change.Files()
+	_, _, err := change.Files(s.T().Context())
 	s.Error(err)
 }
 
@@ -293,7 +293,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesModify() {
 	change.From.TreeEntry.Mode = filemode.Regular
 	change.From.TreeEntry.Hash = plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492")
 
-	from, to, err := change.Files()
+	from, to, err := change.Files(s.T().Context())
 	s.NoError(err)
 	s.Equal(change.To.TreeEntry.Hash, to.ID())
 	s.Equal(change.From.TreeEntry.Hash, from.ID())

--- a/plumbing/object/change_test.go
+++ b/plumbing/object/change_test.go
@@ -34,7 +34,7 @@ func (s *ChangeSuite) SetupSuite() {
 }
 
 func (s *ChangeSuite) tree(h plumbing.Hash) *Tree {
-	t, err := GetTree(s.Storer, h)
+	t, err := GetTree(s.T().Context(), s.Storer, h)
 	s.NoError(err)
 	return t
 }
@@ -77,19 +77,19 @@ func (s *ChangeSuite) TestInsert() {
 	s.NoError(err)
 	s.Equal(merkletrie.Insert, action)
 
-	from, to, err := change.Files()
+	from, to, err := change.Files(s.T().Context())
 	s.NoError(err)
 	s.Nil(from)
 	s.Equal(name, to.Name)
 	s.Equal(blob, to.Hash)
 
-	p, err := change.Patch()
+	p, err := change.Patch(s.T().Context())
 	s.NoError(err)
 	s.Equal(1, len(p.FilePatches()))
 	s.Equal(1, len(p.FilePatches()[0].Chunks()))
 	s.Equal(diff.Add, p.FilePatches()[0].Chunks()[0].Type())
 
-	p, err = change.PatchContext(context.Background())
+	p, err = change.Patch(s.T().Context())
 	s.NoError(err)
 	s.Equal(1, len(p.FilePatches()))
 	s.Equal(1, len(p.FilePatches()[0].Chunks()))
@@ -135,19 +135,19 @@ func (s *ChangeSuite) TestDelete() {
 	s.NoError(err)
 	s.Equal(merkletrie.Delete, action)
 
-	from, to, err := change.Files()
+	from, to, err := change.Files(s.T().Context())
 	s.NoError(err)
 	s.Nil(to)
 	s.Equal(name, from.Name)
 	s.Equal(blob, from.Hash)
 
-	p, err := change.Patch()
+	p, err := change.Patch(s.T().Context())
 	s.NoError(err)
 	s.Equal(1, len(p.FilePatches()))
 	s.Equal(1, len(p.FilePatches()[0].Chunks()))
 	s.Equal(diff.Delete, p.FilePatches()[0].Chunks()[0].Type())
 
-	p, err = change.PatchContext(context.Background())
+	p, err = change.Patch(s.T().Context())
 	s.NoError(err)
 	s.Equal(1, len(p.FilePatches()))
 	s.Equal(1, len(p.FilePatches()[0].Chunks()))
@@ -205,7 +205,7 @@ func (s *ChangeSuite) TestModify() {
 	s.NoError(err)
 	s.Equal(merkletrie.Modify, action)
 
-	from, to, err := change.Files()
+	from, to, err := change.Files(s.T().Context())
 	s.NoError(err)
 
 	s.Equal(name, from.Name)
@@ -213,7 +213,7 @@ func (s *ChangeSuite) TestModify() {
 	s.Equal(name, to.Name)
 	s.Equal(toBlob, to.Hash)
 
-	p, err := change.Patch()
+	p, err := change.Patch(s.T().Context())
 	s.NoError(err)
 	s.Equal(1, len(p.FilePatches()))
 	s.Equal(7, len(p.FilePatches()[0].Chunks()))
@@ -225,7 +225,7 @@ func (s *ChangeSuite) TestModify() {
 	s.Equal(diff.Add, p.FilePatches()[0].Chunks()[5].Type())
 	s.Equal(diff.Equal, p.FilePatches()[0].Chunks()[6].Type())
 
-	p, err = change.PatchContext(context.Background())
+	p, err = change.Patch(s.T().Context())
 	s.NoError(err)
 	s.Equal(1, len(p.FilePatches()))
 	s.Equal(7, len(p.FilePatches()[0].Chunks()))
@@ -247,7 +247,7 @@ func (s *ChangeSuite) TestEmptyChangeFails() {
 	_, err := change.Action()
 	s.ErrorContains(err, "malformed")
 
-	_, _, err = change.Files()
+	_, _, err = change.Files(s.T().Context())
 	s.ErrorContains(err, "malformed")
 
 	str := change.String()
@@ -263,12 +263,12 @@ func (s *ChangeSuite) TestNoFileFilemodes() {
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	iter, err := sto.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := sto.IterEncodedObjects(s.T().Context(), plumbing.AnyObject)
 	s.NoError(err)
 	var commits []*Commit
-	iter.ForEach(func(o plumbing.EncodedObject) error {
+	iter.ForEach(s.T().Context(), func(o plumbing.EncodedObject) error {
 		if o.Type() == plumbing.CommitObject {
-			commit, err := GetCommit(sto, o.Hash())
+			commit, err := GetCommit(s.T().Context(), sto, o.Hash())
 			s.NoError(err)
 			commits = append(commits, commit)
 		}
@@ -284,14 +284,14 @@ func (s *ChangeSuite) TestNoFileFilemodes() {
 			prev = commit
 			continue
 		}
-		tree, err := commit.Tree()
+		tree, err := commit.Tree(s.T().Context())
 		s.NoError(err)
-		prevTree, err := prev.Tree()
+		prevTree, err := prev.Tree(s.T().Context())
 		s.NoError(err)
-		changes, err := DiffTree(tree, prevTree)
+		changes, err := DiffTree(s.T().Context(), tree, prevTree)
 		s.NoError(err)
 		for _, change := range changes {
-			_, _, err := change.Files()
+			_, _, err := change.Files(s.T().Context())
 			s.NoError(err)
 		}
 
@@ -335,7 +335,7 @@ func (s *ChangeSuite) TestErrorsFindingChildsAreDetected() {
 		To: ChangeEntry{},
 	}
 
-	_, _, err := change.Files()
+	_, _, err := change.Files(s.T().Context())
 	s.ErrorContains(err, "object not found")
 
 	change = &Change{
@@ -351,7 +351,7 @@ func (s *ChangeSuite) TestErrorsFindingChildsAreDetected() {
 		},
 	}
 
-	_, _, err = change.Files()
+	_, _, err = change.Files(s.T().Context())
 	s.ErrorContains(err, "object not found")
 }
 
@@ -428,9 +428,9 @@ func (s *ChangeSuite) TestCancel() {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(s.T().Context())
 	cancel()
-	p, err := change.PatchContext(ctx)
+	p, err := change.Patch(ctx)
 	s.Nil(p)
 	s.ErrorContains(err, "operation canceled")
 }

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -116,8 +116,8 @@ func parseExtraHeader(line []byte) (ExtraHeader, bool) {
 }
 
 // GetCommit gets a commit from an object storer and decodes it.
-func GetCommit(s storer.EncodedObjectStorer, h plumbing.Hash) (*Commit, error) {
-	o, err := s.EncodedObject(plumbing.CommitObject, h)
+func GetCommit(ctx context.Context, s storer.EncodedObjectStorer, h plumbing.Hash) (*Commit, error) {
+	o, err := s.EncodedObject(ctx, plumbing.CommitObject, h)
 	if err != nil {
 		return nil, err
 	}
@@ -137,38 +137,30 @@ func DecodeCommit(s storer.EncodedObjectStorer, o plumbing.EncodedObject) (*Comm
 }
 
 // Tree returns the Tree from the commit.
-func (c *Commit) Tree() (*Tree, error) {
-	return GetTree(c.s, c.TreeHash)
+func (c *Commit) Tree(ctx context.Context) (*Tree, error) {
+	return GetTree(ctx, c.s, c.TreeHash)
 }
 
-// PatchContext returns the Patch between the actual commit and the provided one.
+// Patch returns the Patch between the actual commit and the provided one.
 // Error will be return if context expires. Provided context must be non-nil.
 //
 // NOTE: Since version 5.1.0 the renames are correctly handled, the settings
 // used are the recommended options DefaultDiffTreeOptions.
-func (c *Commit) PatchContext(ctx context.Context, to *Commit) (*Patch, error) {
-	fromTree, err := c.Tree()
+func (c *Commit) Patch(ctx context.Context, to *Commit) (*Patch, error) {
+	fromTree, err := c.Tree(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var toTree *Tree
 	if to != nil {
-		toTree, err = to.Tree()
+		toTree, err = to.Tree(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return fromTree.PatchContext(ctx, toTree)
-}
-
-// Patch returns the Patch between the actual commit and the provided one.
-//
-// NOTE: Since version 5.1.0 the renames are correctly handled, the settings
-// used are the recommended options DefaultDiffTreeOptions.
-func (c *Commit) Patch(to *Commit) (*Patch, error) {
-	return c.PatchContext(context.Background(), to)
+	return fromTree.Patch(ctx, toTree)
 }
 
 // Parents return a CommitIter to the parent Commits.
@@ -192,29 +184,29 @@ var ErrParentNotFound = errors.New("commit parent not found")
 var ErrMalformedCommit = errors.New("malformed commit")
 
 // Parent returns the ith parent of a commit.
-func (c *Commit) Parent(i int) (*Commit, error) {
+func (c *Commit) Parent(ctx context.Context, i int) (*Commit, error) {
 	if len(c.ParentHashes) == 0 || i > len(c.ParentHashes)-1 {
 		return nil, ErrParentNotFound
 	}
 
-	return GetCommit(c.s, c.ParentHashes[i])
+	return GetCommit(ctx, c.s, c.ParentHashes[i])
 }
 
 // File returns the file with the specified "path" in the commit and a
 // nil error if the file exists. If the file does not exist, it returns
 // a nil file and the ErrFileNotFound error.
-func (c *Commit) File(path string) (*File, error) {
-	tree, err := c.Tree()
+func (c *Commit) File(ctx context.Context, path string) (*File, error) {
+	tree, err := c.Tree(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return tree.File(path)
+	return tree.File(ctx, path)
 }
 
 // Files returns a FileIter allowing to iterate over the Tree
-func (c *Commit) Files() (*FileIter, error) {
-	tree, err := c.Tree()
+func (c *Commit) Files(ctx context.Context) (*FileIter, error) {
+	tree, err := c.Tree(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -435,33 +427,28 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	return err
 }
 
-// Stats returns the stats of a commit.
-func (c *Commit) Stats() (FileStats, error) {
-	return c.StatsContext(context.Background())
-}
-
-// StatsContext returns the stats of a commit. Error will be return if context
+// Stats returns the stats of a commit. Error will be return if context
 // expires. Provided context must be non-nil.
-func (c *Commit) StatsContext(ctx context.Context) (FileStats, error) {
-	fromTree, err := c.Tree()
+func (c *Commit) Stats(ctx context.Context) (FileStats, error) {
+	fromTree, err := c.Tree(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	toTree := &Tree{}
 	if c.NumParents() != 0 {
-		firstParent, err := c.Parents().Next()
+		firstParent, err := c.Parents().Next(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		toTree, err = firstParent.Tree()
+		toTree, err = firstParent.Tree(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	patch, err := toTree.PatchContext(ctx, fromTree)
+	patch, err := toTree.Patch(ctx, fromTree)
 	if err != nil {
 		return nil, err
 	}
@@ -540,8 +527,8 @@ func indent(t string) string {
 
 // CommitIter is a generic closable interface for iterating over commits.
 type CommitIter interface {
-	Next() (*Commit, error)
-	ForEach(func(*Commit) error) error
+	Next(ctx context.Context) (*Commit, error)
+	ForEach(ctx context.Context, cb func(*Commit) error) error
 	Close()
 }
 
@@ -562,8 +549,8 @@ func NewCommitIter(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter) 
 
 // Next moves the iterator to the next commit and returns a pointer to it. If
 // there are no more commits, it returns io.EOF.
-func (iter *storerCommitIter) Next() (*Commit, error) {
-	obj, err := iter.EncodedObjectIter.Next()
+func (iter *storerCommitIter) Next(ctx context.Context) (*Commit, error) {
+	obj, err := iter.EncodedObjectIter.Next(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -574,8 +561,8 @@ func (iter *storerCommitIter) Next() (*Commit, error) {
 // ForEach call the cb function for each commit contained on this iter until
 // an error appends or the end of the iter is reached. If ErrStop is sent
 // the iteration is stopped but no error is returned. The iterator is closed.
-func (iter *storerCommitIter) ForEach(cb func(*Commit) error) error {
-	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
+func (iter *storerCommitIter) ForEach(ctx context.Context, cb func(*Commit) error) error {
+	return iter.EncodedObjectIter.ForEach(ctx, func(obj plumbing.EncodedObject) error {
 		c, err := DecodeCommit(iter.s, obj)
 		if err != nil {
 			return err

--- a/plumbing/object/commit_stats_test.go
+++ b/plumbing/object/commit_stats_test.go
@@ -25,13 +25,13 @@ func TestCommitStatsSuite(t *testing.T) {
 }
 
 func (s *CommitStatsSuite) TestStats() {
-	r, hash := s.writeHistory([]byte("foo\n"), []byte("foo\nbar\n"))
+	r, hash := s.writeHistory(s.T().Context(), []byte("foo\n"), []byte("foo\nbar\n"))
 	defer func() { _ = r.Close() }()
 
-	aCommit, err := r.CommitObject(hash)
+	aCommit, err := r.CommitObject(s.T().Context(), hash)
 	s.NoError(err)
 
-	fileStats, err := aCommit.StatsContext(context.Background())
+	fileStats, err := aCommit.Stats(s.T().Context())
 	s.NoError(err)
 
 	s.Equal("foo", fileStats[0].Name)
@@ -41,13 +41,13 @@ func (s *CommitStatsSuite) TestStats() {
 }
 
 func (s *CommitStatsSuite) TestStats_RootCommit() {
-	r, hash := s.writeHistory([]byte("foo\n"))
+	r, hash := s.writeHistory(s.T().Context(), []byte("foo\n"))
 	defer func() { _ = r.Close() }()
 
-	aCommit, err := r.CommitObject(hash)
+	aCommit, err := r.CommitObject(s.T().Context(), hash)
 	s.NoError(err)
 
-	fileStats, err := aCommit.Stats()
+	fileStats, err := aCommit.Stats(s.T().Context())
 	s.NoError(err)
 
 	s.Len(fileStats, 1)
@@ -58,13 +58,13 @@ func (s *CommitStatsSuite) TestStats_RootCommit() {
 }
 
 func (s *CommitStatsSuite) TestStats_WithoutNewLine() {
-	r, hash := s.writeHistory([]byte("foo\nbar"), []byte("foo\nbar\n"))
+	r, hash := s.writeHistory(s.T().Context(), []byte("foo\nbar"), []byte("foo\nbar\n"))
 	defer func() { _ = r.Close() }()
 
-	aCommit, err := r.CommitObject(hash)
+	aCommit, err := r.CommitObject(s.T().Context(), hash)
 	s.NoError(err)
 
-	fileStats, err := aCommit.Stats()
+	fileStats, err := aCommit.Stats(s.T().Context())
 	s.NoError(err)
 
 	s.Equal("foo", fileStats[0].Name)
@@ -73,26 +73,26 @@ func (s *CommitStatsSuite) TestStats_WithoutNewLine() {
 	s.Equal(" foo | 2 +-\n", fileStats[0].String())
 }
 
-func (s *CommitStatsSuite) writeHistory(files ...[]byte) (*git.Repository, plumbing.Hash) {
+func (s *CommitStatsSuite) writeHistory(ctx context.Context, files ...[]byte) (*git.Repository, plumbing.Hash) {
 	cm := &git.CommitOptions{
 		Author: &object.Signature{Name: "Foo", Email: "foo@example.local", When: time.Now()},
 	}
 
 	fs := memfs.New()
-	r, err := git.Init(memory.NewStorage(), git.WithWorkTree(fs))
+	r, err := git.Init(ctx, memory.NewStorage(), git.WithWorkTree(fs))
 	s.NoError(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	s.NoError(err)
 
 	var hash plumbing.Hash
 	for _, content := range files {
 		util.WriteFile(fs, "foo", content, 0o644)
 
-		_, err = w.Add("foo")
+		_, err = w.Add(ctx, "foo")
 		s.NoError(err)
 
-		hash, err = w.Commit("foo\n", cm)
+		hash, err = w.Commit(ctx, "foo\n", cm)
 		s.NoError(err)
 	}
 

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -38,7 +38,7 @@ func (s *SuiteCommit) SetupSuite() {
 
 func (s *SuiteCommit) TestDecodeNonCommit() {
 	hash := plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492")
-	blob, err := s.Storer.EncodedObject(plumbing.AnyObject, hash)
+	blob, err := s.Storer.EncodedObject(s.T().Context(), plumbing.AnyObject, hash)
 	s.NoError(err)
 
 	commit := &Commit{}
@@ -94,7 +94,7 @@ func (s *SuiteCommit) TestType() {
 }
 
 func (s *SuiteCommit) TestTree() {
-	tree, err := s.Commit.Tree()
+	tree, err := s.Commit.Tree(s.T().Context())
 	s.NoError(err)
 	s.Equal("eba74343e2f15d62adedfd8c883ee0262b5c8021", tree.ID().String())
 }
@@ -107,7 +107,7 @@ func (s *SuiteCommit) TestParents() {
 
 	var output []string
 	i := s.Commit.Parents()
-	err := i.ForEach(func(commit *Commit) error {
+	err := i.ForEach(s.T().Context(), func(commit *Commit) error {
 		output = append(output, commit.ID().String())
 		return nil
 	})
@@ -119,13 +119,13 @@ func (s *SuiteCommit) TestParents() {
 }
 
 func (s *SuiteCommit) TestParent() {
-	commit, err := s.Commit.Parent(1)
+	commit, err := s.Commit.Parent(s.T().Context(), 1)
 	s.NoError(err)
 	s.Equal("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69", commit.Hash.String())
 }
 
 func (s *SuiteCommit) TestParentNotFound() {
-	commit, err := s.Commit.Parent(42)
+	commit, err := s.Commit.Parent(s.T().Context(), 42)
 	s.ErrorIs(err, ErrParentNotFound)
 	s.Nil(commit)
 }
@@ -134,7 +134,7 @@ func (s *SuiteCommit) TestPatch() {
 	from := s.commit(plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
 	to := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	patch, err := from.Patch(to)
+	patch, err := from.Patch(s.T().Context(), to)
 	s.NoError(err)
 
 	buf := bytes.NewBuffer(nil)
@@ -161,7 +161,7 @@ index 0000000000000000000000000000000000000000..9dea2395f5403188298c1dabe8bdafe5
 	from = s.commit(plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"))
 	to = s.commit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
 
-	patch, err = from.Patch(to)
+	patch, err = from.Patch(s.T().Context(), to)
 	s.NoError(err)
 
 	buf.Reset()
@@ -189,7 +189,7 @@ func (s *SuiteCommit) TestPatchContext() {
 	from := s.commit(plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
 	to := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	patch, err := from.PatchContext(context.Background(), to)
+	patch, err := from.Patch(s.T().Context(), to)
 	s.NoError(err)
 
 	buf := bytes.NewBuffer(nil)
@@ -216,7 +216,7 @@ index 0000000000000000000000000000000000000000..9dea2395f5403188298c1dabe8bdafe5
 	from = s.commit(plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"))
 	to = s.commit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
 
-	patch, err = from.PatchContext(context.Background(), to)
+	patch, err = from.Patch(s.T().Context(), to)
 	s.NoError(err)
 
 	buf.Reset()
@@ -243,7 +243,7 @@ Binary files /dev/null and b/binary.jpg differ
 func (s *SuiteCommit) TestPatchContext_ToNil() {
 	from := s.commit(plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
 
-	patch, err := from.PatchContext(context.Background(), nil)
+	patch, err := from.Patch(s.T().Context(), nil)
 	s.NoError(err)
 
 	s.Equal(242679, len(patch.String()))
@@ -340,7 +340,7 @@ change
 }
 
 func (s *SuiteCommit) TestFile() {
-	file, err := s.Commit.File("CHANGELOG")
+	file, err := s.Commit.File(s.T().Context(), "CHANGELOG")
 	s.NoError(err)
 	s.Equal("CHANGELOG", file.Name)
 }
@@ -370,7 +370,7 @@ func (s *SuiteCommit) TestStringMultiLine() {
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	o, err := sto.EncodedObject(plumbing.CommitObject, hash)
+	o, err := sto.EncodedObject(s.T().Context(), plumbing.CommitObject, hash)
 	s.NoError(err)
 	commit, err := DecodeCommit(sto, o)
 	s.NoError(err)
@@ -392,15 +392,15 @@ func (s *SuiteCommit) TestStringMultiLine() {
 func (s *SuiteCommit) TestCommitIterNext() {
 	i := s.Commit.Parents()
 
-	commit, err := i.Next()
+	commit, err := i.Next(s.T().Context())
 	s.NoError(err)
 	s.Equal("35e85108805c84807bc66a02d91535e1e24b38b9", commit.ID().String())
 
-	commit, err = i.Next()
+	commit, err = i.Next(s.T().Context())
 	s.NoError(err)
 	s.Equal("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69", commit.ID().String())
 
-	commit, err = i.Next()
+	commit, err = i.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 	s.Nil(commit)
 }
@@ -512,7 +512,7 @@ func readAll(t *testing.T, o *plumbing.MemoryObject) string {
 
 func (s *SuiteCommit) TestStat() {
 	aCommit := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-	fileStats, err := aCommit.Stats()
+	fileStats, err := aCommit.Stats(s.T().Context())
 	s.NoError(err)
 
 	s.Equal("vendor/foo.go", fileStats[0].Name)
@@ -522,7 +522,7 @@ func (s *SuiteCommit) TestStat() {
 
 	// Stats for another commit.
 	aCommit = s.commit(plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
-	fileStats, err = aCommit.Stats()
+	fileStats, err = aCommit.Stats(s.T().Context())
 	s.NoError(err)
 
 	s.Equal("go/example.go", fileStats[0].Name)
@@ -585,11 +585,13 @@ func (s *SuiteCommit) TestPatchCancel() {
 	from := s.commit(plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
 	to := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(s.T().Context())
 	cancel()
-	patch, err := from.PatchContext(ctx, to)
+	patch, err := from.Patch(ctx, to)
 	s.Nil(patch)
-	s.ErrorContains(err, "operation canceled")
+	// The already-canceled ctx is observed by the storer at the first
+	// storage read, before the merkletrie walk begins.
+	s.ErrorIs(err, context.Canceled)
 }
 
 func (s *SuiteCommit) TestDecodeRequiresTreeFirst() {

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -185,62 +185,7 @@ Binary files /dev/null and b/binary.jpg differ
 	s.Equal(patch.String(), buf.String())
 }
 
-func (s *SuiteCommit) TestPatchContext() {
-	from := s.commit(plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
-	to := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-
-	patch, err := from.Patch(s.T().Context(), to)
-	s.NoError(err)
-
-	buf := bytes.NewBuffer(nil)
-	err = patch.Encode(buf)
-	s.NoError(err)
-
-	s.Equal(`diff --git a/vendor/foo.go b/vendor/foo.go
-new file mode 100644
-index 0000000000000000000000000000000000000000..9dea2395f5403188298c1dabe8bdafe562c491e3
---- /dev/null
-+++ b/vendor/foo.go
-@@ -0,0 +1,7 @@
-+package main
-+
-+import "fmt"
-+
-+func main() {
-+	fmt.Println("Hello, playground")
-+}
-`,
-		buf.String())
-	s.Equal(patch.String(), buf.String())
-
-	from = s.commit(plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"))
-	to = s.commit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
-
-	patch, err = from.Patch(s.T().Context(), to)
-	s.NoError(err)
-
-	buf.Reset()
-	err = patch.Encode(buf)
-	s.NoError(err)
-
-	s.Equal(`diff --git a/CHANGELOG b/CHANGELOG
-deleted file mode 100644
-index d3ff53e0564a9f87d8e84b6e28e5060e517008aa..0000000000000000000000000000000000000000
---- a/CHANGELOG
-+++ /dev/null
-@@ -1 +0,0 @@
--Initial changelog
-diff --git a/binary.jpg b/binary.jpg
-new file mode 100644
-index 0000000000000000000000000000000000000000..d5c0f4ab811897cadf03aec358ae60d21f91c50d
-Binary files /dev/null and b/binary.jpg differ
-`,
-		buf.String())
-
-	s.Equal(patch.String(), buf.String())
-}
-
-func (s *SuiteCommit) TestPatchContext_ToNil() {
+func (s *SuiteCommit) TestPatchToNil() {
 	from := s.commit(plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
 
 	patch, err := from.Patch(s.T().Context(), nil)

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"container/list"
+	"context"
 	"errors"
 	"io"
 
@@ -17,9 +18,9 @@ type commitPreIterator struct {
 	start        *Commit
 }
 
-func forEachCommit(next func() (*Commit, error), cb func(*Commit) error) error {
+func forEachCommit(ctx context.Context, next func(context.Context) (*Commit, error), cb func(*Commit) error) error {
 	for {
-		c, err := next()
+		c, err := next(ctx)
 		if errors.Is(err, io.EOF) {
 			break
 		}
@@ -63,7 +64,7 @@ func NewCommitPreorderIter(
 	}
 }
 
-func (w *commitPreIterator) Next() (*Commit, error) {
+func (w *commitPreIterator) Next(ctx context.Context) (*Commit, error) {
 	var c *Commit
 	for {
 		if w.start != nil {
@@ -76,7 +77,7 @@ func (w *commitPreIterator) Next() (*Commit, error) {
 			}
 
 			var err error
-			c, err = w.stack[current].Next()
+			c, err = w.stack[current].Next(ctx)
 			if err == io.EOF {
 				w.stack = w.stack[:current]
 				continue
@@ -114,8 +115,8 @@ func filteredParentIter(c *Commit, seen map[plumbing.Hash]bool) CommitIter {
 	)
 }
 
-func (w *commitPreIterator) ForEach(cb func(*Commit) error) error {
-	return forEachCommit(w.Next, cb)
+func (w *commitPreIterator) ForEach(ctx context.Context, cb func(*Commit) error) error {
+	return forEachCommit(ctx, w.Next, cb)
 }
 
 func (w *commitPreIterator) Close() {}
@@ -142,7 +143,7 @@ func NewCommitPostorderIter(c *Commit, ignore []plumbing.Hash) CommitIter {
 	}
 }
 
-func (w *commitPostIterator) Next() (*Commit, error) {
+func (w *commitPostIterator) Next(ctx context.Context) (*Commit, error) {
 	for {
 		if len(w.stack) == 0 {
 			return nil, io.EOF
@@ -157,15 +158,15 @@ func (w *commitPostIterator) Next() (*Commit, error) {
 
 		w.seen[c.Hash] = true
 
-		return c, c.Parents().ForEach(func(p *Commit) error {
+		return c, c.Parents().ForEach(ctx, func(p *Commit) error {
 			w.stack = append(w.stack, p)
 			return nil
 		})
 	}
 }
 
-func (w *commitPostIterator) ForEach(cb func(*Commit) error) error {
-	return forEachCommit(w.Next, cb)
+func (w *commitPostIterator) ForEach(ctx context.Context, cb func(*Commit) error) error {
+	return forEachCommit(ctx, w.Next, cb)
 }
 
 func (w *commitPostIterator) Close() {}
@@ -193,7 +194,7 @@ func NewCommitPostorderIterFirstParent(c *Commit, ignore []plumbing.Hash) Commit
 	}
 }
 
-func (w *commitPostIteratorFirstParent) Next() (*Commit, error) {
+func (w *commitPostIteratorFirstParent) Next(ctx context.Context) (*Commit, error) {
 	for {
 		if len(w.stack) == 0 {
 			return nil, io.EOF
@@ -208,7 +209,7 @@ func (w *commitPostIteratorFirstParent) Next() (*Commit, error) {
 
 		w.seen[c.Hash] = true
 
-		return c, c.Parents().ForEach(func(p *Commit) error {
+		return c, c.Parents().ForEach(ctx, func(p *Commit) error {
 			if len(c.ParentHashes) > 0 && p.Hash == c.ParentHashes[0] {
 				w.stack = append(w.stack, p)
 			}
@@ -217,8 +218,8 @@ func (w *commitPostIteratorFirstParent) Next() (*Commit, error) {
 	}
 }
 
-func (w *commitPostIteratorFirstParent) ForEach(cb func(*Commit) error) error {
-	return forEachCommit(w.Next, cb)
+func (w *commitPostIteratorFirstParent) ForEach(ctx context.Context, cb func(*Commit) error) error {
+	return forEachCommit(ctx, w.Next, cb)
 }
 
 func (w *commitPostIteratorFirstParent) Close() {}
@@ -232,12 +233,12 @@ type commitAllIterator struct {
 // NewCommitAllIter returns a new commit iterator for all refs.
 // repoStorer is a repo Storer used to get commits and references.
 // commitIterFunc is a commit iterator function, used to iterate through ref commits in chosen order
-func NewCommitAllIter(repoStorer storage.Storer, commitIterFunc func(*Commit) CommitIter) (CommitIter, error) {
+func NewCommitAllIter(ctx context.Context, repoStorer storage.Storer, commitIterFunc func(*Commit) CommitIter) (CommitIter, error) {
 	commitsPath := list.New()
 	commitsLookup := make(map[plumbing.Hash]*list.Element)
-	head, err := storer.ResolveReference(repoStorer, plumbing.HEAD)
+	head, err := storer.ResolveReference(ctx, repoStorer, plumbing.HEAD)
 	if err == nil {
-		err = addReference(repoStorer, commitIterFunc, head, commitsPath, commitsLookup)
+		err = addReference(ctx, repoStorer, commitIterFunc, head, commitsPath, commitsLookup)
 	}
 
 	if err != nil && err != plumbing.ErrReferenceNotFound {
@@ -245,14 +246,14 @@ func NewCommitAllIter(repoStorer storage.Storer, commitIterFunc func(*Commit) Co
 	}
 
 	// add all references along with the HEAD
-	refIter, err := repoStorer.IterReferences()
+	refIter, err := repoStorer.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer refIter.Close()
 
 	for {
-		ref, err := refIter.Next()
+		ref, err := refIter.Next(ctx)
 		if err == io.EOF {
 			break
 		}
@@ -265,7 +266,7 @@ func NewCommitAllIter(repoStorer storage.Storer, commitIterFunc func(*Commit) Co
 			return nil, err
 		}
 
-		if err = addReference(repoStorer, commitIterFunc, ref, commitsPath, commitsLookup); err != nil {
+		if err = addReference(ctx, repoStorer, commitIterFunc, ref, commitsPath, commitsLookup); err != nil {
 			return nil, err
 		}
 	}
@@ -274,6 +275,7 @@ func NewCommitAllIter(repoStorer storage.Storer, commitIterFunc func(*Commit) Co
 }
 
 func addReference(
+	ctx context.Context,
 	repoStorer storage.Storer,
 	commitIterFunc func(*Commit) CommitIter,
 	ref *plumbing.Reference,
@@ -286,7 +288,7 @@ func addReference(
 		return nil
 	}
 
-	refCommit, _ := GetCommit(repoStorer, ref.Hash())
+	refCommit, _ := GetCommit(ctx, repoStorer, ref.Hash())
 	if refCommit == nil {
 		// if it's not a commit - skip it.
 		return nil
@@ -298,13 +300,13 @@ func addReference(
 	)
 	// collect all ref commits to add
 	commitIter := commitIterFunc(refCommit)
-	for c, e := commitIter.Next(); e == nil; {
+	for c, e := commitIter.Next(ctx); e == nil; {
 		parent, exists = commitsLookup[c.Hash]
 		if exists {
 			break
 		}
 		refCommits = append(refCommits, c)
-		c, e = commitIter.Next()
+		c, e = commitIter.Next(ctx)
 	}
 	commitIter.Close()
 
@@ -328,7 +330,7 @@ func addReference(
 	return nil
 }
 
-func (it *commitAllIterator) Next() (*Commit, error) {
+func (it *commitAllIterator) Next(_ context.Context) (*Commit, error) {
 	if it.currCommit == nil {
 		return nil, io.EOF
 	}
@@ -339,8 +341,8 @@ func (it *commitAllIterator) Next() (*Commit, error) {
 	return c, nil
 }
 
-func (it *commitAllIterator) ForEach(cb func(*Commit) error) error {
-	return forEachCommit(it.Next, cb)
+func (it *commitAllIterator) ForEach(ctx context.Context, cb func(*Commit) error) error {
+	return forEachCommit(ctx, it.Next, cb)
 }
 
 func (it *commitAllIterator) Close() {

--- a/plumbing/object/commit_walker_bfs.go
+++ b/plumbing/object/commit_walker_bfs.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -38,11 +39,11 @@ func NewCommitIterBSF(
 	}
 }
 
-func (w *bfsCommitIterator) appendHash(store storer.EncodedObjectStorer, h plumbing.Hash) error {
+func (w *bfsCommitIterator) appendHash(ctx context.Context, store storer.EncodedObjectStorer, h plumbing.Hash) error {
 	if w.seen[h] || w.seenExternal[h] {
 		return nil
 	}
-	c, err := GetCommit(store, h)
+	c, err := GetCommit(ctx, store, h)
 	if err != nil {
 		return err
 	}
@@ -50,7 +51,7 @@ func (w *bfsCommitIterator) appendHash(store storer.EncodedObjectStorer, h plumb
 	return nil
 }
 
-func (w *bfsCommitIterator) Next() (*Commit, error) {
+func (w *bfsCommitIterator) Next(ctx context.Context) (*Commit, error) {
 	var c *Commit
 	for {
 		if len(w.queue) == 0 {
@@ -66,7 +67,7 @@ func (w *bfsCommitIterator) Next() (*Commit, error) {
 		w.seen[c.Hash] = true
 
 		for _, h := range c.ParentHashes {
-			err := w.appendHash(c.s, h)
+			err := w.appendHash(ctx, c.s, h)
 			if err != nil {
 				return nil, err
 			}
@@ -76,9 +77,9 @@ func (w *bfsCommitIterator) Next() (*Commit, error) {
 	}
 }
 
-func (w *bfsCommitIterator) ForEach(cb func(*Commit) error) error {
+func (w *bfsCommitIterator) ForEach(ctx context.Context, cb func(*Commit) error) error {
 	for {
-		c, err := w.Next()
+		c, err := w.Next(ctx)
 		if err == io.EOF {
 			break
 		}

--- a/plumbing/object/commit_walker_bfs_filtered.go
+++ b/plumbing/object/commit_walker_bfs_filtered.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -63,7 +64,7 @@ type filterCommitIter struct {
 // Next returns the next commit of the CommitIter.
 // It will return io.EOF if there are no more commits to visit,
 // or an error if the history could not be traversed.
-func (w *filterCommitIter) Next() (*Commit, error) {
+func (w *filterCommitIter) Next(ctx context.Context) (*Commit, error) {
 	var commit *Commit
 	var err error
 	for {
@@ -75,7 +76,7 @@ func (w *filterCommitIter) Next() (*Commit, error) {
 		w.visited[commit.Hash] = struct{}{}
 
 		if !w.isLimit(commit) {
-			err = w.addToQueue(commit.s, commit.ParentHashes...)
+			err = w.addToQueue(ctx, commit.s, commit.ParentHashes...)
 			if err != nil {
 				return nil, w.close(err)
 			}
@@ -89,9 +90,9 @@ func (w *filterCommitIter) Next() (*Commit, error) {
 
 // ForEach runs the passed callback over each Commit returned by the CommitIter
 // until the callback returns an error or there is no more commits to traverse.
-func (w *filterCommitIter) ForEach(cb func(*Commit) error) error {
+func (w *filterCommitIter) ForEach(ctx context.Context, cb func(*Commit) error) error {
 	for {
-		commit, err := w.Next()
+		commit, err := w.Next(ctx)
 		if err == io.EOF {
 			break
 		}
@@ -156,6 +157,7 @@ func (w *filterCommitIter) popNewFromQueue() (*Commit, error) {
 // addToQueue adds the passed commits to the internal fifo queue if they weren't seen
 // or returns an error if the passed hashes could not be used to get valid commits
 func (w *filterCommitIter) addToQueue(
+	ctx context.Context,
 	store storer.EncodedObjectStorer,
 	hashes ...plumbing.Hash,
 ) error {
@@ -164,7 +166,7 @@ func (w *filterCommitIter) addToQueue(
 			continue
 		}
 
-		commit, err := GetCommit(store, hash)
+		commit, err := GetCommit(ctx, store, hash)
 		if err != nil {
 			return err
 		}

--- a/plumbing/object/commit_walker_bfs_filtered_test.go
+++ b/plumbing/object/commit_walker_bfs_filtered_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -23,9 +24,9 @@ type filterCommitIterSuite struct {
 	BaseObjectsSuite
 }
 
-func commitsFromIter(iter CommitIter) ([]*Commit, error) {
+func commitsFromIter(ctx context.Context, iter CommitIter) ([]*Commit, error) {
 	var commits []*Commit
-	err := iter.ForEach(func(c *Commit) error {
+	err := iter.ForEach(ctx, func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -91,7 +92,7 @@ func not(filter CommitFilter) CommitFilter {
 func (s *filterCommitIterSuite) TestFilterCommitIter() {
 	from := s.commit(plumbing.NewHash(s.Fixture.Head))
 
-	commits, err := commitsFromIter(NewFilterCommitIter(from, nil, nil))
+	commits, err := commitsFromIter(s.T().Context(), NewFilterCommitIter(from, nil, nil))
 	s.NoError(err)
 
 	expected := []string{
@@ -115,7 +116,7 @@ func (s *filterCommitIterSuite) TestFilterCommitIterWithValid() {
 	from := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	validIf := validIfCommit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
-	commits, err := commitsFromIter(NewFilterCommitIter(from, &validIf, nil))
+	commits, err := commitsFromIter(s.T().Context(), NewFilterCommitIter(from, &validIf, nil))
 	s.NoError(err)
 
 	expected := []string{
@@ -132,7 +133,7 @@ func (s *filterCommitIterSuite) TestFilterCommitIterWithInvalid() {
 
 	validIf := validIfCommit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
 	validIfNot := not(validIf)
-	commits, err := commitsFromIter(NewFilterCommitIter(from, &validIfNot, nil))
+	commits, err := commitsFromIter(s.T().Context(), NewFilterCommitIter(from, &validIfNot, nil))
 	s.NoError(err)
 
 	expected := []string{
@@ -154,7 +155,7 @@ func (s *filterCommitIterSuite) TestFilterCommitIterWithNoValidCommits() {
 	from := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	validIf := validIfCommit(plumbing.NewHash("THIS_COMMIT_DOES_NOT_EXIST"))
-	commits, err := commitsFromIter(NewFilterCommitIter(from, &validIf, nil))
+	commits, err := commitsFromIter(s.T().Context(), NewFilterCommitIter(from, &validIf, nil))
 	s.NoError(err)
 	s.Len(commits, 0)
 }
@@ -165,7 +166,7 @@ func (s *filterCommitIterSuite) TestFilterCommitIterWithStopAt() {
 	from := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	stopAtRule := validIfCommit(plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"))
-	commits, err := commitsFromIter(NewFilterCommitIter(from, nil, &stopAtRule))
+	commits, err := commitsFromIter(s.T().Context(), NewFilterCommitIter(from, nil, &stopAtRule))
 	s.NoError(err)
 
 	expected := []string{
@@ -189,7 +190,7 @@ func (s *filterCommitIterSuite) TestFilterCommitIterWithInvalidAndStopAt() {
 	stopAtRule := validIfCommit(plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"))
 	validIf := validIfCommit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
 	validIfNot := not(validIf)
-	commits, err := commitsFromIter(NewFilterCommitIter(from, &validIfNot, &stopAtRule))
+	commits, err := commitsFromIter(s.T().Context(), NewFilterCommitIter(from, &validIfNot, &stopAtRule))
 	s.NoError(err)
 
 	expected := []string{
@@ -233,14 +234,14 @@ func (s *filterCommitIterSuite) TestIteratorForEachCallbackReturn() {
 	from := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	iter := NewFilterCommitIter(from, nil, nil)
-	err := iter.ForEach(cb)
+	err := iter.ForEach(s.T().Context(), cb)
 	s.NoError(err)
 	expected := []string{
 		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
 	}
 	assertHashes(s, visited, expected)
 
-	err = iter.ForEach(cb)
+	err = iter.ForEach(s.T().Context(), cb)
 	s.ErrorIs(err, errUnexpected)
 	expected = []string{
 		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
@@ -248,7 +249,7 @@ func (s *filterCommitIterSuite) TestIteratorForEachCallbackReturn() {
 	}
 	assertHashes(s, visited, expected)
 
-	err = iter.ForEach(cb)
+	err = iter.ForEach(s.T().Context(), cb)
 	s.NoError(err)
 	expected = []string{
 		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",

--- a/plumbing/object/commit_walker_ctime.go
+++ b/plumbing/object/commit_walker_ctime.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -49,7 +50,7 @@ func NewCommitIterCTime(
 	}
 }
 
-func (w *commitIteratorByCTime) Next() (*Commit, error) {
+func (w *commitIteratorByCTime) Next(ctx context.Context) (*Commit, error) {
 	var c *Commit
 	for {
 		cIn, ok := w.heap.Pop()
@@ -68,7 +69,7 @@ func (w *commitIteratorByCTime) Next() (*Commit, error) {
 			if w.seen[h] || w.seenExternal[h] {
 				continue
 			}
-			pc, err := GetCommit(c.s, h)
+			pc, err := GetCommit(ctx, c.s, h)
 			if err != nil {
 				return nil, err
 			}
@@ -79,9 +80,9 @@ func (w *commitIteratorByCTime) Next() (*Commit, error) {
 	}
 }
 
-func (w *commitIteratorByCTime) ForEach(cb func(*Commit) error) error {
+func (w *commitIteratorByCTime) ForEach(ctx context.Context, cb func(*Commit) error) error {
 	for {
-		c, err := w.Next()
+		c, err := w.Next(ctx)
 		if err == io.EOF {
 			break
 		}

--- a/plumbing/object/commit_walker_limit.go
+++ b/plumbing/object/commit_walker_limit.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"io"
 	"time"
@@ -29,9 +30,9 @@ func NewCommitLimitIterFromIter(commitIter CommitIter, limitOptions LogLimitOpti
 	return iterator
 }
 
-func (c *commitLimitIter) Next() (*Commit, error) {
+func (c *commitLimitIter) Next(ctx context.Context) (*Commit, error) {
 	for {
-		commit, err := c.sourceIter.Next()
+		commit, err := c.sourceIter.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -49,9 +50,9 @@ func (c *commitLimitIter) Next() (*Commit, error) {
 	}
 }
 
-func (c *commitLimitIter) ForEach(cb func(*Commit) error) error {
+func (c *commitLimitIter) ForEach(ctx context.Context, cb func(*Commit) error) error {
 	for {
-		commit, nextErr := c.Next()
+		commit, nextErr := c.Next(ctx)
 		if nextErr == io.EOF {
 			break
 		}

--- a/plumbing/object/commit_walker_path.go
+++ b/plumbing/object/commit_walker_path.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"io"
 	"slices"
@@ -41,15 +42,15 @@ func NewCommitFileIterFromIter(fileName string, commitIter CommitIter, checkPare
 	)
 }
 
-func (c *commitPathIter) Next() (*Commit, error) {
+func (c *commitPathIter) Next(ctx context.Context) (*Commit, error) {
 	if c.currentCommit == nil {
 		var err error
-		c.currentCommit, err = c.sourceIter.Next()
+		c.currentCommit, err = c.sourceIter.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
-	commit, commitErr := c.getNextFileCommit()
+	commit, commitErr := c.getNextFileCommit(ctx)
 
 	// Setting current-commit to nil to prevent unwanted states when errors are raised
 	if commitErr != nil {
@@ -58,12 +59,12 @@ func (c *commitPathIter) Next() (*Commit, error) {
 	return commit, commitErr
 }
 
-func (c *commitPathIter) getNextFileCommit() (*Commit, error) {
+func (c *commitPathIter) getNextFileCommit(ctx context.Context) (*Commit, error) {
 	var parentTree, currentTree *Tree
 
 	for {
 		// Parent-commit can be nil if the current-commit is the initial commit
-		parentCommit, parentCommitErr := c.sourceIter.Next()
+		parentCommit, parentCommitErr := c.sourceIter.Next(ctx)
 		if parentCommitErr != nil {
 			// If the parent-commit is beyond the initial commit, keep it nil
 			if parentCommitErr != io.EOF {
@@ -74,7 +75,7 @@ func (c *commitPathIter) getNextFileCommit() (*Commit, error) {
 
 		if parentTree == nil {
 			var currTreeErr error
-			currentTree, currTreeErr = c.currentCommit.Tree()
+			currentTree, currTreeErr = c.currentCommit.Tree(ctx)
 			if currTreeErr != nil {
 				return nil, currTreeErr
 			}
@@ -85,14 +86,14 @@ func (c *commitPathIter) getNextFileCommit() (*Commit, error) {
 
 		if parentCommit != nil {
 			var parentTreeErr error
-			parentTree, parentTreeErr = parentCommit.Tree()
+			parentTree, parentTreeErr = parentCommit.Tree(ctx)
 			if parentTreeErr != nil {
 				return nil, parentTreeErr
 			}
 		}
 
 		// Find diff between current and parent trees
-		changes, diffErr := DiffTree(currentTree, parentTree)
+		changes, diffErr := DiffTree(ctx, currentTree, parentTree)
 		if diffErr != nil {
 			return nil, diffErr
 		}
@@ -140,9 +141,9 @@ func isParentHash(hash plumbing.Hash, commit *Commit) bool {
 	return slices.Contains(commit.ParentHashes, hash)
 }
 
-func (c *commitPathIter) ForEach(cb func(*Commit) error) error {
+func (c *commitPathIter) ForEach(ctx context.Context, cb func(*Commit) error) error {
 	for {
-		commit, nextErr := c.Next()
+		commit, nextErr := c.Next(ctx)
 		if nextErr == io.EOF {
 			break
 		}

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -27,7 +27,7 @@ func (s *CommitWalkerSuite) TestCommitPreIterator() {
 	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
-	NewCommitPreorderIter(commit, nil, nil).ForEach(func(c *Commit) error {
+	NewCommitPreorderIter(commit, nil, nil).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -55,7 +55,7 @@ func (s *CommitWalkerSuite) TestCommitPreIteratorWithIgnore() {
 	var commits []*Commit
 	NewCommitPreorderIter(commit, nil, []plumbing.Hash{
 		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
-	}).ForEach(func(c *Commit) error {
+	}).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -86,7 +86,7 @@ func (s *CommitWalkerSuite) TestCommitLimitIterByTrailingHash() {
 	}
 	NewCommitLimitIterFromIter(commitIter, LogLimitOptions{
 		TailHash: plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"),
-	}).ForEach(func(c *Commit) error {
+	}).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -111,7 +111,7 @@ func (s *CommitWalkerSuite) TestCommitLimitIterByTime() {
 	NewCommitLimitIterFromIter(commitIter, LogLimitOptions{
 		Since:    &since,
 		TailHash: plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"),
-	}).ForEach(func(c *Commit) error {
+	}).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -129,7 +129,7 @@ func (s *CommitWalkerSuite) TestCommitPreIteratorWithSeenExternal() {
 		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"): true,
 	}
 	NewCommitPreorderIter(commit, seenExternal, nil).
-		ForEach(func(c *Commit) error {
+		ForEach(s.T().Context(), func(c *Commit) error {
 			commits = append(commits, c)
 			return nil
 		})
@@ -149,7 +149,7 @@ func (s *CommitWalkerSuite) TestCommitPostIterator() {
 	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
-	NewCommitPostorderIter(commit, nil).ForEach(func(c *Commit) error {
+	NewCommitPostorderIter(commit, nil).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -178,7 +178,7 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnore() {
 	var commits []*Commit
 	NewCommitPostorderIter(commit, []plumbing.Hash{
 		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
-	}).ForEach(func(c *Commit) error {
+	}).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -198,7 +198,7 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorFirstParent() {
 	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
-	NewCommitPostorderIterFirstParent(commit, nil).ForEach(func(c *Commit) error {
+	NewCommitPostorderIterFirstParent(commit, nil).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -225,7 +225,7 @@ func (s *CommitWalkerSuite) TestCommitPostIteratorWithIgnoreFirstParent() {
 	var commits []*Commit
 	NewCommitPostorderIterFirstParent(commit, []plumbing.Hash{
 		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
-	}).ForEach(func(c *Commit) error {
+	}).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -245,7 +245,7 @@ func (s *CommitWalkerSuite) TestCommitCTimeIterator() {
 	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
-	NewCommitIterCTime(commit, nil, nil).ForEach(func(c *Commit) error {
+	NewCommitIterCTime(commit, nil, nil).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -273,7 +273,7 @@ func (s *CommitWalkerSuite) TestCommitCTimeIteratorWithIgnore() {
 	var commits []*Commit
 	NewCommitIterCTime(commit, nil, []plumbing.Hash{
 		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
-	}).ForEach(func(c *Commit) error {
+	}).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -293,7 +293,7 @@ func (s *CommitWalkerSuite) TestCommitBSFIterator() {
 	commit := s.commit(plumbing.NewHash(s.Fixture.Head))
 
 	var commits []*Commit
-	NewCommitIterBSF(commit, nil, nil).ForEach(func(c *Commit) error {
+	NewCommitIterBSF(commit, nil, nil).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -321,7 +321,7 @@ func (s *CommitWalkerSuite) TestCommitBSFIteratorWithIgnore() {
 	var commits []*Commit
 	NewCommitIterBSF(commit, nil, []plumbing.Hash{
 		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
-	}).ForEach(func(c *Commit) error {
+	}).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -347,7 +347,7 @@ func (s *CommitWalkerSuite) TestCommitPathIteratorInitialCommit() {
 		func(path string) bool { return path == fileName },
 		NewCommitIterCTime(commit, nil, nil),
 		true,
-	).ForEach(func(c *Commit) error {
+	).ForEach(s.T().Context(), func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})

--- a/plumbing/object/commitgraph/commitnode.go
+++ b/plumbing/object/commitgraph/commitnode.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"context"
 	"errors"
 	"io"
 	"time"
@@ -16,7 +17,7 @@ type CommitNode interface {
 	// ID returns the Commit object id referenced by the commit graph node.
 	ID() plumbing.Hash
 	// Tree returns the Tree referenced by the commit graph node.
-	Tree() (*object.Tree, error)
+	Tree(ctx context.Context) (*object.Tree, error)
 	// CommitTime returns the Committer.When time of the Commit referenced by the commit graph node.
 	CommitTime() time.Time
 	// NumParents returns the number of parents in a commit.
@@ -24,7 +25,7 @@ type CommitNode interface {
 	// ParentNodes return a CommitNodeIter for parents of specified node.
 	ParentNodes() CommitNodeIter
 	// ParentNode returns the ith parent of a commit.
-	ParentNode(i int) (CommitNode, error)
+	ParentNode(ctx context.Context, i int) (CommitNode, error)
 	// ParentHashes returns hashes of the parent commits for a specified node
 	ParentHashes() []plumbing.Hash
 	// Generation returns the generation of the commit for reachability analysis.
@@ -35,19 +36,19 @@ type CommitNode interface {
 	// with the commit time portion of the CDAT section.
 	GenerationV2() uint64
 	// Commit returns the full commit object from the node
-	Commit() (*object.Commit, error)
+	Commit(ctx context.Context) (*object.Commit, error)
 }
 
 // CommitNodeIndex is generic interface encapsulating an index of CommitNode objects
 type CommitNodeIndex interface {
 	// Get returns a commit node from a commit hash
-	Get(hash plumbing.Hash) (CommitNode, error)
+	Get(ctx context.Context, hash plumbing.Hash) (CommitNode, error)
 }
 
 // CommitNodeIter is a generic closable interface for iterating over commit nodes.
 type CommitNodeIter interface {
-	Next() (CommitNode, error)
-	ForEach(func(CommitNode) error) error
+	Next(ctx context.Context) (CommitNode, error)
+	ForEach(ctx context.Context, cb func(CommitNode) error) error
 	Close()
 }
 
@@ -63,8 +64,8 @@ func newParentgraphCommitNodeIter(node CommitNode) CommitNodeIter {
 
 // Next moves the iterator to the next commit and returns a pointer to it. If
 // there are no more commits, it returns io.EOF.
-func (iter *parentCommitNodeIter) Next() (CommitNode, error) {
-	obj, err := iter.node.ParentNode(iter.i)
+func (iter *parentCommitNodeIter) Next(ctx context.Context) (CommitNode, error) {
+	obj, err := iter.node.ParentNode(ctx, iter.i)
 	if errors.Is(err, object.ErrParentNotFound) {
 		return nil, io.EOF
 	}
@@ -78,9 +79,9 @@ func (iter *parentCommitNodeIter) Next() (CommitNode, error) {
 // ForEach call the cb function for each commit contained on this iter until
 // an error appends or the end of the iter is reached. If ErrStop is sent
 // the iteration is stopped but no error is returned. The iterator is closed.
-func (iter *parentCommitNodeIter) ForEach(cb func(CommitNode) error) error {
+func (iter *parentCommitNodeIter) ForEach(ctx context.Context, cb func(CommitNode) error) error {
 	for {
-		obj, err := iter.Next()
+		obj, err := iter.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
 				return nil

--- a/plumbing/object/commitgraph/commitnode_graph.go
+++ b/plumbing/object/commitgraph/commitnode_graph.go
@@ -92,7 +92,7 @@ func (c *graphCommitNode) ParentNodes() CommitNodeIter {
 	return newParentgraphCommitNodeIter(c)
 }
 
-func (c *graphCommitNode) ParentNode(ctx context.Context, i int) (CommitNode, error) {
+func (c *graphCommitNode) ParentNode(_ context.Context, i int) (CommitNode, error) {
 	if i < 0 || i >= len(c.commitData.ParentIndexes) {
 		return nil, object.ErrParentNotFound
 	}

--- a/plumbing/object/commitgraph/commitnode_graph.go
+++ b/plumbing/object/commitgraph/commitnode_graph.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -40,7 +41,7 @@ func NewGraphCommitNodeIndex(commitGraph commitgraph.Index, s storer.EncodedObje
 	return &graphCommitNodeIndex{commitGraph, s}
 }
 
-func (gci *graphCommitNodeIndex) Get(hash plumbing.Hash) (CommitNode, error) {
+func (gci *graphCommitNodeIndex) Get(ctx context.Context, hash plumbing.Hash) (CommitNode, error) {
 	if gci.commitGraph != nil {
 		// Check the commit graph first
 		parentIndex, err := gci.commitGraph.GetIndexByHash(hash)
@@ -60,7 +61,7 @@ func (gci *graphCommitNodeIndex) Get(hash plumbing.Hash) (CommitNode, error) {
 	}
 
 	// Fallback to loading full commit object
-	commit, err := object.GetCommit(gci.s, hash)
+	commit, err := object.GetCommit(ctx, gci.s, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +76,8 @@ func (c *graphCommitNode) ID() plumbing.Hash {
 	return c.hash
 }
 
-func (c *graphCommitNode) Tree() (*object.Tree, error) {
-	return object.GetTree(c.gci.s, c.commitData.TreeHash)
+func (c *graphCommitNode) Tree(ctx context.Context) (*object.Tree, error) {
+	return object.GetTree(ctx, c.gci.s, c.commitData.TreeHash)
 }
 
 func (c *graphCommitNode) CommitTime() time.Time {
@@ -91,7 +92,7 @@ func (c *graphCommitNode) ParentNodes() CommitNodeIter {
 	return newParentgraphCommitNodeIter(c)
 }
 
-func (c *graphCommitNode) ParentNode(i int) (CommitNode, error) {
+func (c *graphCommitNode) ParentNode(ctx context.Context, i int) (CommitNode, error) {
 	if i < 0 || i >= len(c.commitData.ParentIndexes) {
 		return nil, object.ErrParentNotFound
 	}
@@ -127,8 +128,8 @@ func (c *graphCommitNode) GenerationV2() uint64 {
 	return c.commitData.GenerationV2
 }
 
-func (c *graphCommitNode) Commit() (*object.Commit, error) {
-	return object.GetCommit(c.gci.s, c.hash)
+func (c *graphCommitNode) Commit(ctx context.Context) (*object.Commit, error) {
+	return object.GetCommit(ctx, c.gci.s, c.hash)
 }
 
 func (c *graphCommitNode) String() string {

--- a/plumbing/object/commitgraph/commitnode_object.go
+++ b/plumbing/object/commitgraph/commitnode_object.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -23,8 +24,8 @@ func NewObjectCommitNodeIndex(s storer.EncodedObjectStorer) CommitNodeIndex {
 	return &objectCommitNodeIndex{s}
 }
 
-func (oci *objectCommitNodeIndex) Get(hash plumbing.Hash) (CommitNode, error) {
-	commit, err := object.GetCommit(oci.s, hash)
+func (oci *objectCommitNodeIndex) Get(ctx context.Context, hash plumbing.Hash) (CommitNode, error) {
+	commit, err := object.GetCommit(ctx, oci.s, hash)
 	if err != nil {
 		return nil, err
 	}
@@ -51,8 +52,8 @@ func (c *objectCommitNode) ID() plumbing.Hash {
 	return c.commit.ID()
 }
 
-func (c *objectCommitNode) Tree() (*object.Tree, error) {
-	return c.commit.Tree()
+func (c *objectCommitNode) Tree(ctx context.Context) (*object.Tree, error) {
+	return c.commit.Tree(ctx)
 }
 
 func (c *objectCommitNode) NumParents() int {
@@ -63,7 +64,7 @@ func (c *objectCommitNode) ParentNodes() CommitNodeIter {
 	return newParentgraphCommitNodeIter(c)
 }
 
-func (c *objectCommitNode) ParentNode(i int) (CommitNode, error) {
+func (c *objectCommitNode) ParentNode(ctx context.Context, i int) (CommitNode, error) {
 	if i < 0 || i >= len(c.commit.ParentHashes) {
 		return nil, object.ErrParentNotFound
 	}
@@ -71,7 +72,7 @@ func (c *objectCommitNode) ParentNode(i int) (CommitNode, error) {
 	// Note: It's necessary to go through CommitNodeIndex here to ensure
 	// that if the commit-graph file covers only part of the history we
 	// start using it when that part is reached.
-	return c.nodeIndex.Get(c.commit.ParentHashes[i])
+	return c.nodeIndex.Get(ctx, c.commit.ParentHashes[i])
 }
 
 func (c *objectCommitNode) ParentHashes() []plumbing.Hash {
@@ -92,6 +93,6 @@ func (c *objectCommitNode) GenerationV2() uint64 {
 	return math.MaxUint64
 }
 
-func (c *objectCommitNode) Commit() (*object.Commit, error) {
+func (c *objectCommitNode) Commit(ctx context.Context) (*object.Commit, error) {
 	return c.commit, nil
 }

--- a/plumbing/object/commitgraph/commitnode_object.go
+++ b/plumbing/object/commitgraph/commitnode_object.go
@@ -93,6 +93,6 @@ func (c *objectCommitNode) GenerationV2() uint64 {
 	return math.MaxUint64
 }
 
-func (c *objectCommitNode) Commit(ctx context.Context) (*object.Commit, error) {
+func (c *objectCommitNode) Commit(_ context.Context) (*object.Commit, error) {
 	return c.commit, nil
 }

--- a/plumbing/object/commitgraph/commitnode_test.go
+++ b/plumbing/object/commitgraph/commitnode_test.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"context"
 	"path"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestCommitNodeSuite(t *testing.T) {
 	suite.Run(t, new(CommitNodeSuite))
 }
 
-func unpackRepository(f *fixtures.Fixture) *filesystem.Storage {
+func unpackRepository(ctx context.Context, f *fixtures.Fixture) *filesystem.Storage {
 	dotgit, err := f.DotGit()
 	if err != nil {
 		panic(err)
@@ -34,12 +35,12 @@ func unpackRepository(f *fixtures.Fixture) *filesystem.Storage {
 		panic(err)
 	}
 	defer p.Close()
-	packfile.UpdateObjectStorage(storer, p)
+	packfile.UpdateObjectStorage(ctx, storer, p)
 	return storer
 }
 
 func testWalker(s *CommitNodeSuite, nodeIndex CommitNodeIndex) {
-	head, err := nodeIndex.Get(plumbing.NewHash("b9d69064b190e7aedccf84731ca1d917871f8a1c"))
+	head, err := nodeIndex.Get(s.T().Context(), plumbing.NewHash("b9d69064b190e7aedccf84731ca1d917871f8a1c"))
 	s.NoError(err)
 
 	iter := NewCommitNodeIterCTime(
@@ -49,7 +50,7 @@ func testWalker(s *CommitNodeSuite, nodeIndex CommitNodeIndex) {
 	)
 
 	var commits []CommitNode
-	iter.ForEach(func(c CommitNode) error {
+	iter.ForEach(s.T().Context(), func(c CommitNode) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -73,11 +74,11 @@ func testWalker(s *CommitNodeSuite, nodeIndex CommitNodeIndex) {
 }
 
 func testParents(s *CommitNodeSuite, nodeIndex CommitNodeIndex) {
-	merge3, err := nodeIndex.Get(plumbing.NewHash("6f6c5d2be7852c782be1dd13e36496dd7ad39560"))
+	merge3, err := nodeIndex.Get(s.T().Context(), plumbing.NewHash("6f6c5d2be7852c782be1dd13e36496dd7ad39560"))
 	s.NoError(err)
 
 	var parents []CommitNode
-	merge3.ParentNodes().ForEach(func(c CommitNode) error {
+	merge3.ParentNodes().ForEach(s.T().Context(), func(c CommitNode) error {
 		parents = append(parents, c)
 		return nil
 	})
@@ -95,19 +96,19 @@ func testParents(s *CommitNodeSuite, nodeIndex CommitNodeIndex) {
 }
 
 func testCommitAndTree(s *CommitNodeSuite, nodeIndex CommitNodeIndex) {
-	merge3node, err := nodeIndex.Get(plumbing.NewHash("6f6c5d2be7852c782be1dd13e36496dd7ad39560"))
+	merge3node, err := nodeIndex.Get(s.T().Context(), plumbing.NewHash("6f6c5d2be7852c782be1dd13e36496dd7ad39560"))
 	s.NoError(err)
-	merge3commit, err := merge3node.Commit()
+	merge3commit, err := merge3node.Commit(s.T().Context())
 	s.NoError(err)
 	s.Equal(merge3commit.ID().String(), merge3node.ID().String())
-	tree, err := merge3node.Tree()
+	tree, err := merge3node.Tree(s.T().Context())
 	s.NoError(err)
 	s.Equal(merge3commit.TreeHash.String(), tree.ID().String())
 }
 
 func (s *CommitNodeSuite) TestObjectGraph() {
 	f := fixtures.ByTag("commit-graph").One()
-	storer := unpackRepository(f)
+	storer := unpackRepository(s.T().Context(), f)
 	defer func() { _ = storer.Close() }()
 
 	nodeIndex := NewObjectCommitNodeIndex(storer)
@@ -118,7 +119,7 @@ func (s *CommitNodeSuite) TestObjectGraph() {
 
 func (s *CommitNodeSuite) TestCommitGraph() {
 	f := fixtures.ByTag("commit-graph").One()
-	storer := unpackRepository(f)
+	storer := unpackRepository(s.T().Context(), f)
 	defer func() { _ = storer.Close() }()
 	reader, err := storer.Filesystem().Open(path.Join("objects", "info", "commit-graph"))
 	s.NoError(err)
@@ -135,7 +136,7 @@ func (s *CommitNodeSuite) TestCommitGraph() {
 
 func (s *CommitNodeSuite) TestMixedGraph() {
 	f := fixtures.ByTag("commit-graph").One()
-	storer := unpackRepository(f)
+	storer := unpackRepository(s.T().Context(), f)
 	defer func() { _ = storer.Close() }()
 
 	// Take the commit-graph file and copy it to memory index without the last commit

--- a/plumbing/object/commitgraph/commitnode_walker_author_order.go
+++ b/plumbing/object/commitgraph/commitnode_walker_author_order.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"context"
 	"github.com/emirpasic/gods/trees/binaryheap"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -14,7 +15,7 @@ import (
 //
 // This ordering requires that commit objects need to be loaded into memory - thus this
 // ordering is likely to be slower than other orderings.
-func NewCommitNodeIterAuthorDateOrder(c CommitNode,
+func NewCommitNodeIterAuthorDateOrder(ctx context.Context, c CommitNode,
 	seenExternal map[plumbing.Hash]bool,
 	ignore []plumbing.Hash,
 ) CommitNodeIter {
@@ -33,11 +34,11 @@ func NewCommitNodeIterAuthorDateOrder(c CommitNode,
 	exploreHeap.Push(c)
 
 	visitHeap := &commitNodeHeap{binaryheap.NewWith(func(left, right any) int {
-		leftCommit, err := left.(CommitNode).Commit()
+		leftCommit, err := left.(CommitNode).Commit(ctx)
 		if err != nil {
 			return -1
 		}
-		rightCommit, err := right.(CommitNode).Commit()
+		rightCommit, err := right.(CommitNode).Commit(ctx)
 		if err != nil {
 			return -1
 		}

--- a/plumbing/object/commitgraph/commitnode_walker_author_order.go
+++ b/plumbing/object/commitgraph/commitnode_walker_author_order.go
@@ -2,6 +2,7 @@ package commitgraph
 
 import (
 	"context"
+
 	"github.com/emirpasic/gods/trees/binaryheap"
 
 	"github.com/go-git/go-git/v6/plumbing"

--- a/plumbing/object/commitgraph/commitnode_walker_ctime.go
+++ b/plumbing/object/commitgraph/commitnode_walker_ctime.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -51,7 +52,7 @@ func NewCommitNodeIterCTime(
 	}
 }
 
-func (w *commitNodeIteratorByCTime) Next() (CommitNode, error) {
+func (w *commitNodeIteratorByCTime) Next(ctx context.Context) (CommitNode, error) {
 	var c CommitNode
 	for {
 		cIn, ok := w.heap.Pop()
@@ -71,7 +72,7 @@ func (w *commitNodeIteratorByCTime) Next() (CommitNode, error) {
 			if w.seen[h] || w.seenExternal[h] {
 				continue
 			}
-			pc, err := c.ParentNode(i)
+			pc, err := c.ParentNode(ctx, i)
 			if err != nil {
 				return nil, err
 			}
@@ -82,9 +83,9 @@ func (w *commitNodeIteratorByCTime) Next() (CommitNode, error) {
 	}
 }
 
-func (w *commitNodeIteratorByCTime) ForEach(cb func(CommitNode) error) error {
+func (w *commitNodeIteratorByCTime) ForEach(ctx context.Context, cb func(CommitNode) error) error {
 	for {
-		c, err := w.Next()
+		c, err := w.Next(ctx)
 		if err == io.EOF {
 			break
 		}

--- a/plumbing/object/commitgraph/commitnode_walker_test.go
+++ b/plumbing/object/commitgraph/commitnode_walker_test.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestCommitNodeIter(t *testing.T) {
 
 	f := fixtures.ByTag("commit-graph-chain-2").One()
 
-	storer := newUnpackRepository(f)
+	storer := newUnpackRepository(t.Context(), f)
 	defer func() { _ = storer.Close() }()
 
 	index, err := commitgraph.OpenChainOrFileIndex(storer.Filesystem())
@@ -27,7 +28,7 @@ func TestCommitNodeIter(t *testing.T) {
 
 	nodeIndex := NewGraphCommitNodeIndex(index, storer)
 
-	head, err := nodeIndex.Get(plumbing.NewHash("ec6f456c0e8c7058a29611429965aa05c190b54b"))
+	head, err := nodeIndex.Get(t.Context(), plumbing.NewHash("ec6f456c0e8c7058a29611429965aa05c190b54b"))
 	assert.NoError(t, err)
 
 	testTopoOrder(t, head)
@@ -35,7 +36,7 @@ func TestCommitNodeIter(t *testing.T) {
 	testAuthorDateOrder(t, head)
 }
 
-func newUnpackRepository(f *fixtures.Fixture) *filesystem.Storage {
+func newUnpackRepository(ctx context.Context, f *fixtures.Fixture) *filesystem.Storage {
 	dotgit, err := f.DotGit()
 	if err != nil {
 		panic(err)
@@ -46,7 +47,7 @@ func newUnpackRepository(f *fixtures.Fixture) *filesystem.Storage {
 		panic(err)
 	}
 	defer p.Close()
-	packfile.UpdateObjectStorage(storer, p)
+	packfile.UpdateObjectStorage(ctx, storer, p)
 	return storer
 }
 
@@ -58,7 +59,7 @@ func testTopoOrder(t *testing.T, head CommitNode) {
 	)
 
 	var commits []string
-	iter.ForEach(func(c CommitNode) error {
+	iter.ForEach(t.Context(), func(c CommitNode) error {
 		commits = append(commits, c.ID().String())
 		return nil
 	})
@@ -111,7 +112,7 @@ func testDateOrder(t *testing.T, head CommitNode) {
 	)
 
 	var commits []string
-	iter.ForEach(func(c CommitNode) error {
+	iter.ForEach(t.Context(), func(c CommitNode) error {
 		commits = append(commits, c.ID().String())
 		return nil
 	})
@@ -158,13 +159,14 @@ c088fd6a7e1a38e9d5a9815265cb575bb08d08ff
 
 func testAuthorDateOrder(t *testing.T, head CommitNode) {
 	iter := NewCommitNodeIterAuthorDateOrder(
+		t.Context(),
 		head,
 		nil,
 		nil,
 	)
 
 	var commits []string
-	iter.ForEach(func(c CommitNode) error {
+	iter.ForEach(t.Context(), func(c CommitNode) error {
 		commits = append(commits, c.ID().String())
 		return nil
 	})

--- a/plumbing/object/commitgraph/commitnode_walker_topo_order.go
+++ b/plumbing/object/commitgraph/commitnode_walker_topo_order.go
@@ -1,6 +1,7 @@
 package commitgraph
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -44,7 +45,7 @@ func NewCommitNodeIterTopoOrder(c CommitNode,
 	}
 }
 
-func (iter *commitNodeIteratorTopological) Next() (CommitNode, error) {
+func (iter *commitNodeIteratorTopological) Next(ctx context.Context) (CommitNode, error) {
 	var next CommitNode
 	for {
 		var ok bool
@@ -65,7 +66,7 @@ func (iter *commitNodeIteratorTopological) Next() (CommitNode, error) {
 
 	parents := make([]CommitNode, 0, len(next.ParentHashes()))
 	for i := range next.ParentHashes() {
-		pc, err := next.ParentNode(i)
+		pc, err := next.ParentNode(ctx, i)
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +113,7 @@ func (iter *commitNodeIteratorTopological) Next() (CommitNode, error) {
 			iter.inCounts[h]++
 
 			if iter.inCounts[h] == 1 {
-				pc, err := toExplore.ParentNode(i)
+				pc, err := toExplore.ParentNode(ctx, i)
 				if err != nil {
 					return nil, err
 				}
@@ -137,9 +138,9 @@ func (iter *commitNodeIteratorTopological) Next() (CommitNode, error) {
 	return next, nil
 }
 
-func (iter *commitNodeIteratorTopological) ForEach(cb func(CommitNode) error) error {
+func (iter *commitNodeIteratorTopological) ForEach(ctx context.Context, cb func(CommitNode) error) error {
 	for {
-		obj, err := iter.Next()
+		obj, err := iter.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
 				return nil

--- a/plumbing/object/difftree.go
+++ b/plumbing/object/difftree.go
@@ -10,17 +10,11 @@ import (
 )
 
 // DiffTree compares the content and mode of the blobs found via two
-// tree objects.
-// DiffTree does not perform rename detection, use DiffTreeWithOptions
-// instead to detect renames.
-func DiffTree(a, b *Tree) (Changes, error) {
-	return DiffTreeContext(context.Background(), a, b)
-}
-
-// DiffTreeContext compares the content and mode of the blobs found via two
 // tree objects. Provided context must be non-nil.
 // An error will be returned if context expires.
-func DiffTreeContext(ctx context.Context, a, b *Tree) (Changes, error) {
+// DiffTree does not perform rename detection, use DiffTreeWithOptions
+// instead to detect renames.
+func DiffTree(ctx context.Context, a, b *Tree) (Changes, error) {
 	return DiffTreeWithOptions(ctx, a, b, nil)
 }
 
@@ -92,7 +86,7 @@ func DiffTreeWithOptions(
 	}
 
 	if opts.DetectRenames {
-		return DetectRenames(changes, opts)
+		return DetectRenames(ctx, changes, opts)
 	}
 
 	return changes, nil

--- a/plumbing/object/difftree_test.go
+++ b/plumbing/object/difftree_test.go
@@ -42,7 +42,7 @@ func (s *DiffTreeSuite) SetupSuite() {
 func (s *DiffTreeSuite) commitFromStorer(sto storer.EncodedObjectStorer,
 	h plumbing.Hash,
 ) *Commit {
-	commit, err := GetCommit(sto, h)
+	commit, err := GetCommit(s.T().Context(), sto, h)
 	s.NoError(err)
 	return commit
 }
@@ -61,7 +61,7 @@ func (s *DiffTreeSuite) storageFromPackfile(f *fixtures.Fixture) storer.EncodedO
 	}
 	defer pf.Close()
 
-	if err := packfile.UpdateObjectStorage(storer, pf); err != nil {
+	if err := packfile.UpdateObjectStorage(s.T().Context(), storer, pf); err != nil {
 		panic(err)
 	}
 
@@ -334,22 +334,22 @@ func (s *DiffTreeSuite) TestDiffTree() {
 		var err error
 		if t.commit1 != "" {
 			tree1, err = s.commitFromStorer(sto,
-				plumbing.NewHash(t.commit1)).Tree()
+				plumbing.NewHash(t.commit1)).Tree(s.T().Context())
 			s.NoError(err,
 				fmt.Sprintf("subtest %d: unable to retrieve tree from commit %s and repo %s: %s", i, t.commit1, t.repository, err))
 		}
 
 		if t.commit2 != "" {
 			tree2, err = s.commitFromStorer(sto,
-				plumbing.NewHash(t.commit2)).Tree()
+				plumbing.NewHash(t.commit2)).Tree(s.T().Context())
 			s.NoError(err,
 				fmt.Sprintf("subtest %d: unable to retrieve tree from commit %s and repo %s", i, t.commit2, t.repository))
 		}
 
-		obtained, err := DiffTree(tree1, tree2)
+		obtained, err := DiffTree(s.T().Context(), tree1, tree2)
 		s.NoError(err,
 			fmt.Sprintf("subtest %d: unable to calculate difftree: %s", i, err))
-		obtainedFromMethod, err := tree1.Diff(tree2)
+		obtainedFromMethod, err := tree1.Diff(s.T().Context(), tree2)
 		s.NoError(err,
 			fmt.Sprintf("subtest %d: unable to calculate difftree: %s. Result calling Diff method from Tree object returns an error", i, err))
 
@@ -407,16 +407,16 @@ func TestDiffTreeAllowsControlCharInPath(t *testing.T) {
 		{Name: ctrlName, Mode: filemode.Regular, Hash: blob},
 	})
 
-	from, err := GetTree(st, empty)
+	from, err := GetTree(t.Context(), st, empty)
 	if err != nil {
 		t.Fatalf("GetTree(empty) = %v", err)
 	}
-	to, err := GetTree(st, withFile)
+	to, err := GetTree(t.Context(), st, withFile)
 	if err != nil {
 		t.Fatalf("GetTree(withFile) = %v", err)
 	}
 
-	changes, err := DiffTree(from, to)
+	changes, err := DiffTree(t.Context(), from, to)
 	if err != nil {
 		t.Fatalf("DiffTree on a tree with a control-char path = %v; want nil", err)
 	}
@@ -439,14 +439,14 @@ func TestTreeWalkerValidatesControlCharByDefault(t *testing.T) {
 	withFile := storeTestTree(t, st, []TreeEntry{
 		{Name: "foo\n.exs", Mode: filemode.Regular, Hash: blob},
 	})
-	tree, err := GetTree(st, withFile)
+	tree, err := GetTree(t.Context(), st, withFile)
 	if err != nil {
 		t.Fatalf("GetTree = %v", err)
 	}
 
 	w := NewTreeWalker(tree, true, nil)
 	defer w.Close()
-	_, _, err = w.Next()
+	_, _, err = w.Next(t.Context())
 	if !errors.Is(err, pathutil.ErrInvalidPath) {
 		t.Fatalf("TreeWalker.Next error = %v, want pathutil.ErrInvalidPath", err)
 	}
@@ -466,7 +466,7 @@ func storeTestObject(t *testing.T, st storer.EncodedObjectStorer, typ plumbing.O
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
-	h, err := st.SetEncodedObject(o)
+	h, err := st.SetEncodedObject(t.Context(), o)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -498,7 +498,7 @@ func storeTestTree(t *testing.T, st storer.EncodedObjectStorer, entries []TreeEn
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
-	h, err := st.SetEncodedObject(o)
+	h, err := st.SetEncodedObject(t.Context(), o)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plumbing/object/file.go
+++ b/plumbing/object/file.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"strings"
@@ -87,9 +88,9 @@ func NewFileIter(s storer.EncodedObjectStorer, t *Tree) *FileIter {
 
 // Next moves the iterator to the next file and returns a pointer to it. If
 // there are no more files, it returns io.EOF.
-func (iter *FileIter) Next() (*File, error) {
+func (iter *FileIter) Next(ctx context.Context) (*File, error) {
 	for {
-		name, entry, err := iter.w.Next()
+		name, entry, err := iter.w.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -98,7 +99,7 @@ func (iter *FileIter) Next() (*File, error) {
 			continue
 		}
 
-		blob, err := GetBlob(iter.s, entry.Hash)
+		blob, err := GetBlob(ctx, iter.s, entry.Hash)
 		if err != nil {
 			return nil, err
 		}
@@ -110,11 +111,11 @@ func (iter *FileIter) Next() (*File, error) {
 // ForEach call the cb function for each file contained in this iter until
 // an error happens or the end of the iter is reached. If plumbing.ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *FileIter) ForEach(cb func(*File) error) error {
+func (iter *FileIter) ForEach(ctx context.Context, cb func(*File) error) error {
 	defer iter.Close()
 
 	for {
-		f, err := iter.Next()
+		f, err := iter.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
 				return nil

--- a/plumbing/object/file_test.go
+++ b/plumbing/object/file_test.go
@@ -61,16 +61,16 @@ func (s *FileSuite) TestIter() {
 		defer func() { _ = sto.Close() }()
 
 		h := plumbing.NewHash(t.commit)
-		commit, err := GetCommit(sto, h)
+		commit, err := GetCommit(s.T().Context(), sto, h)
 		s.NoError(err, fmt.Sprintf("subtest %d: %v (%s)", i, err, t.commit))
 
-		tree, err := commit.Tree()
+		tree, err := commit.Tree(s.T().Context())
 		s.NoError(err)
 
 		iter := NewFileIter(sto, tree)
 		for k := 0; k < len(t.files); k++ {
 			exp := t.files[k]
-			file, err := iter.Next()
+			file, err := iter.Next(s.T().Context())
 			s.NoError(err, fmt.Sprintf("subtest %d, iter %d, err=%v", i, k, err))
 			s.Equal(filemode.Regular, file.Mode)
 			s.False(file.Hash.IsZero())
@@ -78,7 +78,7 @@ func (s *FileSuite) TestIter() {
 			s.Equal(exp.Name, file.Name, fmt.Sprintf("subtest %d, iter %d, name=%s, expected=%s", i, k, file.Name, exp.Hash))
 			s.Equal(exp.Hash, file.Hash.String(), fmt.Sprintf("subtest %d, iter %d, hash=%v, expected=%s", i, k, file.Hash.String(), exp.Hash))
 		}
-		_, err = iter.Next()
+		_, err = iter.Next(s.T().Context())
 		s.ErrorIs(err, io.EOF)
 	}
 }
@@ -125,10 +125,10 @@ func (s *FileSuite) TestContents() {
 		defer func() { _ = sto.Close() }()
 
 		h := plumbing.NewHash(t.commit)
-		commit, err := GetCommit(sto, h)
+		commit, err := GetCommit(s.T().Context(), sto, h)
 		s.NoError(err, fmt.Sprintf("subtest %d: %v (%s)", i, err, t.commit))
 
-		file, err := commit.File(t.path)
+		file, err := commit.File(s.T().Context(), t.path)
 		s.NoError(err)
 		content, err := file.Contents()
 		s.NoError(err)
@@ -181,10 +181,10 @@ func (s *FileSuite) TestLines() {
 		defer func() { _ = sto.Close() }()
 
 		h := plumbing.NewHash(t.commit)
-		commit, err := GetCommit(sto, h)
+		commit, err := GetCommit(s.T().Context(), sto, h)
 		s.NoError(err, fmt.Sprintf("subtest %d: %v (%s)", i, err, t.commit))
 
-		file, err := commit.File(t.path)
+		file, err := commit.File(s.T().Context(), t.path)
 		s.NoError(err)
 		lines, err := file.Lines()
 		s.NoError(err)
@@ -218,15 +218,15 @@ func (s *FileSuite) TestIgnoreEmptyDirEntries() {
 		defer func() { _ = sto.Close() }()
 
 		h := plumbing.NewHash(t.commit)
-		commit, err := GetCommit(sto, h)
+		commit, err := GetCommit(s.T().Context(), sto, h)
 		s.NoError(err, fmt.Sprintf("subtest %d: %v (%s)", i, err, t.commit))
 
-		tree, err := commit.Tree()
+		tree, err := commit.Tree(s.T().Context())
 		s.NoError(err)
 
 		iter := tree.Files()
 		defer iter.Close()
-		for file, err := iter.Next(); err == nil; file, err = iter.Next() {
+		for file, err := iter.Next(s.T().Context()); err == nil; file, err = iter.Next(s.T().Context()) {
 			_, _ = file.Contents()
 			// this would probably panic if we are not ignoring empty dirs
 		}
@@ -235,10 +235,10 @@ func (s *FileSuite) TestIgnoreEmptyDirEntries() {
 
 func (s *FileSuite) TestFileIter() {
 	hash := plumbing.NewHash("1669dce138d9b841a518c64b10914d88f5e488ea")
-	commit, err := GetCommit(s.Storer, hash)
+	commit, err := GetCommit(s.T().Context(), s.Storer, hash)
 	s.NoError(err)
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
 	expected := []string{
@@ -250,7 +250,7 @@ func (s *FileSuite) TestFileIter() {
 
 	var count int
 	i := tree.Files()
-	i.ForEach(func(f *File) error {
+	i.ForEach(s.T().Context(), func(f *File) error {
 		s.Equal(expected[count], f.Name)
 		count++
 		return nil
@@ -260,7 +260,7 @@ func (s *FileSuite) TestFileIter() {
 
 	count = 0
 	i = tree.Files()
-	i.ForEach(func(_ *File) error {
+	i.ForEach(s.T().Context(), func(_ *File) error {
 		count++
 		return storer.ErrStop
 	})
@@ -275,10 +275,10 @@ func (s *FileSuite) TestFileIterSubmodule() {
 	defer func() { _ = st.Close() }()
 
 	hash := plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4")
-	commit, err := GetCommit(st, hash)
+	commit, err := GetCommit(s.T().Context(), st, hash)
 	s.NoError(err)
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
 	expected := []string{
@@ -288,7 +288,7 @@ func (s *FileSuite) TestFileIterSubmodule() {
 
 	var count int
 	i := tree.Files()
-	i.ForEach(func(f *File) error {
+	i.ForEach(s.T().Context(), func(f *File) error {
 		s.Equal(expected[count], f.Name)
 		count++
 		return nil

--- a/plumbing/object/file_test.go
+++ b/plumbing/object/file_test.go
@@ -116,6 +116,7 @@ hs_err_pid*
 	},
 }
 
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *FileSuite) TestContents() {
 	for i, t := range contentsTests {
 		f := fixtures.ByURL(t.repo).One()
@@ -172,6 +173,7 @@ var linesTests = []struct {
 	},
 }
 
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *FileSuite) TestLines() {
 	for i, t := range linesTests {
 		f := fixtures.ByURL(t.repo).One()

--- a/plumbing/object/merge_base.go
+++ b/plumbing/object/merge_base.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -15,13 +16,13 @@ var errIsReachable = fmt.Errorf("first is reachable from second")
 // MergeBase mimics the behavior of `git merge-base actual other`, returning the
 // best common ancestor between the actual and the passed one.
 // The best common ancestors can not be reached from other common ancestors.
-func (c *Commit) MergeBase(other *Commit) ([]*Commit, error) {
+func (c *Commit) MergeBase(ctx context.Context, other *Commit) ([]*Commit, error) {
 	// use sortedByCommitDateDesc strategy
 	sorted := sortByCommitDateDesc(c, other)
 	newer := sorted[0]
 	older := sorted[1]
 
-	newerHistory, err := ancestorsIndex(older, newer)
+	newerHistory, err := ancestorsIndex(ctx, older, newer)
 	if errors.Is(err, errIsReachable) {
 		return []*Commit{older}, nil
 	}
@@ -33,21 +34,21 @@ func (c *Commit) MergeBase(other *Commit) ([]*Commit, error) {
 	var res []*Commit
 	inNewerHistory := isInIndexCommitFilter(newerHistory)
 	resIter := NewFilterCommitIter(older, &inNewerHistory, &inNewerHistory)
-	_ = resIter.ForEach(func(commit *Commit) error {
+	_ = resIter.ForEach(ctx, func(commit *Commit) error {
 		res = append(res, commit)
 		return nil
 	})
 
-	return Independents(res)
+	return Independents(ctx, res)
 }
 
 // IsAncestor returns true if the actual commit is ancestor of the passed one.
 // It returns an error if the history is not transversable
 // It mimics the behavior of `git merge --is-ancestor actual other`
-func (c *Commit) IsAncestor(other *Commit) (bool, error) {
+func (c *Commit) IsAncestor(ctx context.Context, other *Commit) (bool, error) {
 	found := false
 	iter := NewCommitPreorderIter(other, nil, nil)
-	err := iter.ForEach(func(comm *Commit) error {
+	err := iter.ForEach(ctx, func(comm *Commit) error {
 		if comm.Hash != c.Hash {
 			return nil
 		}
@@ -62,14 +63,14 @@ func (c *Commit) IsAncestor(other *Commit) (bool, error) {
 // ancestorsIndex returns a map with the ancestors of the starting commit if the
 // excluded one is not one of them. It returns errIsReachable if the excluded commit
 // is ancestor of the starting, or another error if the history is not traversable.
-func ancestorsIndex(excluded, starting *Commit) (map[plumbing.Hash]struct{}, error) {
+func ancestorsIndex(ctx context.Context, excluded, starting *Commit) (map[plumbing.Hash]struct{}, error) {
 	if excluded.Hash.String() == starting.Hash.String() {
 		return nil, errIsReachable
 	}
 
 	startingHistory := map[plumbing.Hash]struct{}{}
 	startingIter := NewCommitIterBSF(starting, nil, nil)
-	err := startingIter.ForEach(func(commit *Commit) error {
+	err := startingIter.ForEach(ctx, func(commit *Commit) error {
 		if commit.Hash == excluded.Hash {
 			return errIsReachable
 		}
@@ -86,7 +87,7 @@ func ancestorsIndex(excluded, starting *Commit) (map[plumbing.Hash]struct{}, err
 
 // Independents returns a subset of the passed commits, that are not reachable the others
 // It mimics the behavior of `git merge-base --independent commit...`.
-func Independents(commits []*Commit) ([]*Commit, error) {
+func Independents(ctx context.Context, commits []*Commit) ([]*Commit, error) {
 	// use sortedByCommitDateDesc strategy
 	candidates := sortByCommitDateDesc(commits...)
 	candidates = removeDuplicated(candidates)
@@ -106,7 +107,7 @@ func Independents(commits []*Commit) ([]*Commit, error) {
 		from := candidates[pos]
 		others := remove(candidates, from)
 		fromHistoryIter := NewFilterCommitIter(from, nil, &isLimit)
-		err := fromHistoryIter.ForEach(func(fromAncestor *Commit) error {
+		err := fromHistoryIter.ForEach(ctx, func(fromAncestor *Commit) error {
 			for _, other := range others {
 				if fromAncestor.Hash == other.Hash {
 					candidates = remove(candidates, other)

--- a/plumbing/object/merge_base_test.go
+++ b/plumbing/object/merge_base_test.go
@@ -80,6 +80,7 @@ func (s *mergeBaseSuite) SetupSuite() {
 		_ = sto.Close()
 	})
 	s.Storer = sto
+	s.t = s.T()
 }
 
 var revisionIndex = map[string]plumbing.Hash{
@@ -129,7 +130,7 @@ func (s *mergeBaseSuite) AssertMergeBase(revs, expectedRevs []string) {
 	commits, err := s.commitsFromRevs(revs)
 	s.NoError(err)
 
-	results, err := commits[0].MergeBase(commits[1])
+	results, err := commits[0].MergeBase(s.T().Context(), commits[1])
 	s.NoError(err)
 
 	expected, err := s.commitsFromRevs(expectedRevs)
@@ -149,7 +150,7 @@ func (s *mergeBaseSuite) AssertIndependents(revs, expectedRevs []string) {
 	commits, err := s.commitsFromRevs(revs)
 	s.NoError(err)
 
-	results, err := Independents(commits)
+	results, err := Independents(s.T().Context(), commits)
 	s.NoError(err)
 
 	expected, err := s.commitsFromRevs(expectedRevs)
@@ -171,7 +172,7 @@ func (s *mergeBaseSuite) AssertAncestor(revs []string, shouldBeAncestor bool) {
 	commits, err := s.commitsFromRevs(revs)
 	s.NoError(err)
 
-	isAncestor, err := commits[0].IsAncestor(commits[1])
+	isAncestor, err := commits[0].IsAncestor(s.T().Context(), commits[1])
 	s.NoError(err)
 	s.Equal(shouldBeAncestor, isAncestor)
 }

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -4,6 +4,7 @@ package object
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -48,18 +49,18 @@ type Object interface {
 }
 
 // GetObject gets an object from an object storer and decodes it.
-func GetObject(s storer.EncodedObjectStorer, h plumbing.Hash) (Object, error) {
-	o, err := s.EncodedObject(plumbing.AnyObject, h)
+func GetObject(ctx context.Context, s storer.EncodedObjectStorer, h plumbing.Hash) (Object, error) {
+	o, err := s.EncodedObject(ctx, plumbing.AnyObject, h)
 	if err != nil {
 		return nil, err
 	}
 
-	return DecodeObject(s, o)
+	return DecodeObject(ctx, s, o)
 }
 
 // DecodeObject decodes an encoded object into an Object and associates it to
 // the given object storer.
-func DecodeObject(s storer.EncodedObjectStorer, o plumbing.EncodedObject) (Object, error) {
+func DecodeObject(_ context.Context, s storer.EncodedObjectStorer, o plumbing.EncodedObject) (Object, error) {
 	switch o.Type() {
 	case plumbing.CommitObject:
 		return DecodeCommit(s, o)
@@ -178,9 +179,9 @@ func NewObjectIter(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter) 
 
 // Next moves the iterator to the next object and returns a pointer to it. If
 // there are no more objects, it returns io.EOF.
-func (iter *ObjectIter) Next() (Object, error) {
+func (iter *ObjectIter) Next(ctx context.Context) (Object, error) {
 	for {
-		obj, err := iter.EncodedObjectIter.Next()
+		obj, err := iter.EncodedObjectIter.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -201,8 +202,8 @@ func (iter *ObjectIter) Next() (Object, error) {
 // ForEach call the cb function for each object contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *ObjectIter) ForEach(cb func(Object) error) error {
-	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
+func (iter *ObjectIter) ForEach(ctx context.Context, cb func(Object) error) error {
+	return iter.EncodedObjectIter.ForEach(ctx, func(obj plumbing.EncodedObject) error {
 		o, err := iter.toObject(obj)
 		if errors.Is(err, plumbing.ErrInvalidType) {
 			return nil

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -38,19 +38,19 @@ func (s *BaseObjectsSuite) SetupSuite(t *testing.T) {
 }
 
 func (s *BaseObjectsSuite) tag(h plumbing.Hash) *Tag {
-	t, err := GetTag(s.Storer, h)
+	t, err := GetTag(s.t.Context(), s.Storer, h)
 	assert.NoError(s.t, err)
 	return t
 }
 
 func (s *BaseObjectsSuite) tree(h plumbing.Hash) *Tree {
-	t, err := GetTree(s.Storer, h)
+	t, err := GetTree(s.t.Context(), s.Storer, h)
 	assert.NoError(s.t, err)
 	return t
 }
 
 func (s *BaseObjectsSuite) commit(h plumbing.Hash) *Commit {
-	commit, err := GetCommit(s.Storer, h)
+	commit, err := GetCommit(s.t.Context(), s.Storer, h)
 	assert.NoError(s.t, err)
 	return commit
 }
@@ -76,16 +76,16 @@ func (s *ObjectsSuite) TestNewCommit() {
 	s.Equal(commit.ID(), commit.Hash)
 	s.Equal("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69", commit.Hash.String())
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.t.Context())
 	s.NoError(err)
 	s.Equal("c2d30fa8ef288618f65f6eed6e168e0d514886f4", tree.Hash.String())
 
 	parents := commit.Parents()
-	parentCommit, err := parents.Next()
+	parentCommit, err := parents.Next(s.t.Context())
 	s.NoError(err)
 	s.Equal("b029517f6300c2da0f4b651b8642506cd6aaf45d", parentCommit.Hash.String())
 
-	parentCommit, err = parents.Next()
+	parentCommit, err = parents.Next(s.t.Context())
 	s.NoError(err)
 	s.Equal("b8e471f58bcbca63b07bda20e428190409c2db47", parentCommit.Hash.String())
 
@@ -98,7 +98,7 @@ func (s *ObjectsSuite) TestNewCommit() {
 
 func (s *ObjectsSuite) TestParseTree() {
 	hash := plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")
-	tree, err := GetTree(s.Storer, hash)
+	tree, err := GetTree(s.t.Context(), s.Storer, hash)
 	s.NoError(err)
 
 	s.Len(tree.Entries, 8)
@@ -112,7 +112,7 @@ func (s *ObjectsSuite) TestParseTree() {
 	count := 0
 	iter := tree.Files()
 	defer iter.Close()
-	for f, err := iter.Next(); err == nil; f, err = iter.Next() {
+	for f, err := iter.Next(s.t.Context()); err == nil; f, err = iter.Next(s.t.Context()) {
 		count++
 		if f.Name == "go/example.go" {
 			reader, err := f.Reader()
@@ -186,12 +186,12 @@ func (s *ObjectsSuite) TestParseSignature() {
 }
 
 func (s *ObjectsSuite) TestObjectIter() {
-	encIter, err := s.Storer.IterEncodedObjects(plumbing.AnyObject)
+	encIter, err := s.Storer.IterEncodedObjects(s.t.Context(), plumbing.AnyObject)
 	s.NoError(err)
 	iter := NewObjectIter(s.Storer, encIter)
 
 	objects := []Object{}
-	iter.ForEach(func(o Object) error {
+	iter.ForEach(s.t.Context(), func(o Object) error {
 		objects = append(objects, o)
 		return nil
 	})
@@ -199,13 +199,13 @@ func (s *ObjectsSuite) TestObjectIter() {
 	s.True(len(objects) > 0)
 	iter.Close()
 
-	encIter, err = s.Storer.IterEncodedObjects(plumbing.AnyObject)
+	encIter, err = s.Storer.IterEncodedObjects(s.t.Context(), plumbing.AnyObject)
 	s.NoError(err)
 	iter = NewObjectIter(s.Storer, encIter)
 
 	i := 0
 	for {
-		o, err := iter.Next()
+		o, err := iter.Next(s.t.Context())
 		if err == io.EOF {
 			break
 		}

--- a/plumbing/object/patch.go
+++ b/plumbing/object/patch.go
@@ -20,12 +20,7 @@ import (
 // ErrCanceled is returned when the operation is canceled.
 var ErrCanceled = errors.New("operation canceled")
 
-func getPatch(message string, changes ...*Change) (*Patch, error) {
-	ctx := context.Background()
-	return getPatchContext(ctx, message, changes...)
-}
-
-func getPatchContext(ctx context.Context, message string, changes ...*Change) (*Patch, error) {
+func getPatch(ctx context.Context, message string, changes ...*Change) (*Patch, error) {
 	if len(changes) == 0 {
 		return &Patch{message: message}, nil
 	}
@@ -38,7 +33,7 @@ func getPatchContext(ctx context.Context, message string, changes ...*Change) (*
 		default:
 		}
 
-		fp, err := filePatchWithContext(ctx, c)
+		fp, err := filePatch(ctx, c)
 		if err != nil {
 			return nil, err
 		}
@@ -49,7 +44,7 @@ func getPatchContext(ctx context.Context, message string, changes ...*Change) (*
 	return &Patch{message, filePatches}, nil
 }
 
-func filePatchWithContext(ctx context.Context, c *Change) (fdiff.FilePatch, error) {
+func filePatch(ctx context.Context, c *Change) (fdiff.FilePatch, error) {
 	// Submodules (gitlinks) are not blob objects, so their contents cannot be
 	// read as files. Git represents them in a diff by a single
 	// "Subproject commit <hash>" line, so build that content synthetically
@@ -58,7 +53,7 @@ func filePatchWithContext(ctx context.Context, c *Change) (fdiff.FilePatch, erro
 		return submoduleFilePatch(ctx, c)
 	}
 
-	from, to, err := c.Files()
+	from, to, err := c.Files(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/plumbing/object/patch_stats_test.go
+++ b/plumbing/object/patch_stats_test.go
@@ -27,32 +27,33 @@ func (s *PatchStatsSuite) TestStatsWithRename() {
 		Author: &object.Signature{Name: "Foo", Email: "foo@example.local", When: time.Now()},
 	}
 
+	ctx := s.T().Context()
 	fs := memfs.New()
-	r, err := git.Init(memory.NewStorage(), git.WithWorkTree(fs))
+	r, err := git.Init(ctx, memory.NewStorage(), git.WithWorkTree(fs))
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	s.NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo\nbar\n"), 0o644)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(ctx, "foo")
 	s.NoError(err)
 
-	_, err = w.Commit("foo\n", cm)
+	_, err = w.Commit(ctx, "foo\n", cm)
 	s.NoError(err)
 
-	_, err = w.Move("foo", "bar")
+	_, err = w.Move(ctx, "foo", "bar")
 	s.NoError(err)
 
-	hash, err := w.Commit("rename foo to bar", cm)
+	hash, err := w.Commit(ctx, "rename foo to bar", cm)
 	s.NoError(err)
 
-	commit, err := r.CommitObject(hash)
+	commit, err := r.CommitObject(ctx, hash)
 	s.NoError(err)
 
-	fileStats, err := commit.Stats()
+	fileStats, err := commit.Stats(ctx)
 	s.NoError(err)
 	s.Equal("foo => bar", fileStats[0].Name)
 }

--- a/plumbing/object/patch_test.go
+++ b/plumbing/object/patch_test.go
@@ -27,10 +27,10 @@ func (s *PatchSuite) TestStatsWithSubmodules() {
 	storer := filesystem.NewStorage(subDotgit, cache.NewObjectLRUDefault())
 	defer func() { _ = storer.Close() }()
 
-	commit, err := GetCommit(storer, plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4"))
+	commit, err := GetCommit(s.T().Context(), storer, plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4"))
 	s.NoError(err)
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
 	e, err := tree.entry("basic")
@@ -49,7 +49,7 @@ func (s *PatchSuite) TestStatsWithSubmodules() {
 		},
 	}
 
-	p, err := getPatch("", ch)
+	p, err := getPatch(s.T().Context(), "", ch)
 	s.NoError(err)
 	s.NotNil(p)
 }
@@ -60,10 +60,10 @@ func (s *PatchSuite) TestPatchWithSubmodule() {
 	storer := filesystem.NewStorage(subDotgit, cache.NewObjectLRUDefault())
 	defer func() { _ = storer.Close() }()
 
-	commit, err := GetCommit(storer, plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4"))
+	commit, err := GetCommit(s.T().Context(), storer, plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4"))
 	s.Require().NoError(err)
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.Require().NoError(err)
 
 	e, err := tree.entry("basic")
@@ -79,7 +79,7 @@ func (s *PatchSuite) TestPatchWithSubmodule() {
 		},
 	}
 
-	p, err := getPatch("", added)
+	p, err := getPatch(s.T().Context(), "", added)
 	s.Require().NoError(err)
 
 	got := p.String()
@@ -105,7 +105,7 @@ func (s *PatchSuite) TestPatchWithSubmodule() {
 		},
 	}
 
-	p, err = getPatch("", updated)
+	p, err = getPatch(s.T().Context(), "", updated)
 	s.Require().NoError(err)
 
 	got = p.String()

--- a/plumbing/object/rename.go
+++ b/plumbing/object/rename.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"io"
 	"sort"
@@ -17,6 +18,7 @@ import (
 // deletions into modifications when possible.
 // If options is nil, the default diff tree options will be used.
 func DetectRenames(
+	ctx context.Context,
 	changes Changes,
 	opts *DiffTreeOptions,
 ) (Changes, error) {
@@ -46,7 +48,7 @@ func DetectRenames(
 		}
 	}
 
-	return detector.detect()
+	return detector.detect(ctx)
 }
 
 // renameDetector will detect and resolve renames in a set of changes.
@@ -207,14 +209,14 @@ func (d *renameDetector) detectExactRenames() {
 // in the files by building a matrix of pairs between sources and destinations
 // and matching by the highest score.
 // see: https://github.com/eclipse/jgit/blob/master/org.eclipse.jgit/src/org/eclipse/jgit/diff/SimilarityRenameDetector.java
-func (d *renameDetector) detectContentRenames() error {
+func (d *renameDetector) detectContentRenames(ctx context.Context) error {
 	cnt := max(len(d.added), len(d.deleted))
 	if d.renameLimit > 0 && cnt > d.renameLimit {
 		return nil
 	}
 
 	srcs, dsts := d.deleted, d.added
-	matrix, err := buildSimilarityMatrix(srcs, dsts, d.renameScore)
+	matrix, err := buildSimilarityMatrix(ctx, srcs, dsts, d.renameScore)
 	if err != nil {
 		return err
 	}
@@ -246,12 +248,12 @@ func (d *renameDetector) detectContentRenames() error {
 	return nil
 }
 
-func (d *renameDetector) detect() (Changes, error) {
+func (d *renameDetector) detect(ctx context.Context) (Changes, error) {
 	if len(d.added) > 0 && len(d.deleted) > 0 {
 		d.detectExactRenames()
 
 		if !d.onlyExact {
-			if err := d.detectContentRenames(); err != nil {
+			if err := d.detectContentRenames(ctx); err != nil {
 				return nil, err
 			}
 		}
@@ -393,7 +395,7 @@ type similarityPair struct {
 
 const maxMatrixSize = 10000
 
-func buildSimilarityMatrix(srcs, dsts []*Change, renameScore int) (similarityMatrix, error) {
+func buildSimilarityMatrix(ctx context.Context, srcs, dsts []*Change, renameScore int) (similarityMatrix, error) {
 	// Allocate for the worst-case scenario where every pair has a score
 	// that we need to consider. We might not need that many.
 	matrixSize := min(len(srcs)*len(dsts), maxMatrixSize)
@@ -431,7 +433,7 @@ outerLoop:
 			var to *File
 			srcSize := srcSizes[srcIdx]
 			if srcSize == 0 {
-				from, _, err = src.Files()
+				from, _, err = src.Files(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -441,7 +443,7 @@ outerLoop:
 
 			dstSize := dstSizes[dstIdx]
 			if dstSize == 0 {
-				_, to, err = dst.Files()
+				_, to, err = dst.Files(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -470,7 +472,7 @@ outerLoop:
 			}
 
 			if to == nil {
-				_, to, err = dst.Files()
+				_, to, err = dst.Files(ctx)
 				if err != nil {
 					return nil, err
 				}

--- a/plumbing/object/rename_test.go
+++ b/plumbing/object/rename_test.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -304,7 +305,7 @@ func (s *RenameSuite) TestRenameExactManyAddsManyDeletesNoGaps() {
 }
 
 func detectRenames(s *RenameSuite, changes Changes, opts *DiffTreeOptions, expectedResults int) Changes {
-	result, err := DetectRenames(changes, opts)
+	result, err := DetectRenames(s.T().Context(), changes, opts)
 	s.NoError(err)
 	s.Len(result, expectedResults)
 	return result
@@ -330,22 +331,22 @@ func (s *SimilarityIndexSuite) SetupSuite() {
 
 func (s *SimilarityIndexSuite) TestScoreFiles() {
 	tree := s.tree(plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c"))
-	binary, err := tree.File("binary.jpg")
+	binary, err := tree.File(s.T().Context(), "binary.jpg")
 	s.NoError(err)
 	binIndex, err := fileSimilarityIndex(binary)
 	s.NoError(err)
 
-	long, err := tree.File("json/long.json")
+	long, err := tree.File(s.T().Context(), "json/long.json")
 	s.NoError(err)
 	longIndex, err := fileSimilarityIndex(long)
 	s.NoError(err)
 
-	short, err := tree.File("json/short.json")
+	short, err := tree.File(s.T().Context(), "json/short.json")
 	s.NoError(err)
 	shortIndex, err := fileSimilarityIndex(short)
 	s.NoError(err)
 
-	php, err := tree.File("php/crappy.php")
+	php, err := tree.File(s.T().Context(), "php/crappy.php")
 	s.NoError(err)
 	phpIndex, err := fileSimilarityIndex(php)
 	s.NoError(err)
@@ -491,7 +492,7 @@ func makeFile(s *RenameSuite, name string, mode filemode.FileMode, content strin
 
 func makeChangeEntry(f *File) ChangeEntry {
 	sto := memory.NewStorage()
-	sto.SetEncodedObject(f.obj)
+	sto.SetEncodedObject(context.Background(), f.obj)
 	tree := &Tree{s: sto}
 
 	return ChangeEntry{

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -53,8 +54,8 @@ type Tag struct {
 }
 
 // GetTag gets a tag from an object storer and decodes it.
-func GetTag(s storer.EncodedObjectStorer, h plumbing.Hash) (*Tag, error) {
-	o, err := s.EncodedObject(plumbing.TagObject, h)
+func GetTag(ctx context.Context, s storer.EncodedObjectStorer, h plumbing.Hash) (*Tag, error) {
+	o, err := s.EncodedObject(ctx, plumbing.TagObject, h)
 	if err != nil {
 		return nil, err
 	}
@@ -258,12 +259,12 @@ func isZeroSignature(s Signature) bool {
 
 // Commit returns the commit pointed to by the tag. If the tag points to a
 // different type of object ErrUnsupportedObject will be returned.
-func (t *Tag) Commit() (*Commit, error) {
+func (t *Tag) Commit(ctx context.Context) (*Commit, error) {
 	if t.TargetType != plumbing.CommitObject {
 		return nil, ErrUnsupportedObject
 	}
 
-	o, err := t.s.EncodedObject(plumbing.CommitObject, t.Target)
+	o, err := t.s.EncodedObject(ctx, plumbing.CommitObject, t.Target)
 	if err != nil {
 		return nil, err
 	}
@@ -274,17 +275,17 @@ func (t *Tag) Commit() (*Commit, error) {
 // Tree returns the tree pointed to by the tag. If the tag points to a commit
 // object the tree of that commit will be returned. If the tag does not point
 // to a commit or tree object ErrUnsupportedObject will be returned.
-func (t *Tag) Tree() (*Tree, error) {
+func (t *Tag) Tree(ctx context.Context) (*Tree, error) {
 	switch t.TargetType {
 	case plumbing.CommitObject:
-		c, err := t.Commit()
+		c, err := t.Commit(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		return c.Tree()
+		return c.Tree(ctx)
 	case plumbing.TreeObject:
-		return GetTree(t.s, t.Target)
+		return GetTree(ctx, t.s, t.Target)
 	default:
 		return nil, ErrUnsupportedObject
 	}
@@ -292,28 +293,30 @@ func (t *Tag) Tree() (*Tree, error) {
 
 // Blob returns the blob pointed to by the tag. If the tag points to a
 // different type of object ErrUnsupportedObject will be returned.
-func (t *Tag) Blob() (*Blob, error) {
+func (t *Tag) Blob(ctx context.Context) (*Blob, error) {
 	if t.TargetType != plumbing.BlobObject {
 		return nil, ErrUnsupportedObject
 	}
 
-	return GetBlob(t.s, t.Target)
+	return GetBlob(ctx, t.s, t.Target)
 }
 
 // Object returns the object pointed to by the tag.
-func (t *Tag) Object() (Object, error) {
-	o, err := t.s.EncodedObject(t.TargetType, t.Target)
+func (t *Tag) Object(ctx context.Context) (Object, error) {
+	o, err := t.s.EncodedObject(ctx, t.TargetType, t.Target)
 	if err != nil {
 		return nil, err
 	}
 
-	return DecodeObject(t.s, o)
+	return DecodeObject(ctx, t.s, o)
 }
 
 // String returns the meta information contained in the tag as a formatted
 // string.
 func (t *Tag) String() string {
-	obj, _ := t.Object()
+	// TODO(ctx): String implements fmt.Stringer and cannot accept a
+	// context; the target object lookup falls back to context.Background().
+	obj, _ := t.Object(context.Background())
 
 	return fmt.Sprintf(
 		"%s %s\nTagger: %s\nDate:   %s\n\n%s\n%s",
@@ -365,8 +368,8 @@ func NewTagIter(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter) *Ta
 
 // Next moves the iterator to the next tag and returns a pointer to it. If
 // there are no more tags, it returns io.EOF.
-func (iter *TagIter) Next() (*Tag, error) {
-	obj, err := iter.EncodedObjectIter.Next()
+func (iter *TagIter) Next(ctx context.Context) (*Tag, error) {
+	obj, err := iter.EncodedObjectIter.Next(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -377,8 +380,8 @@ func (iter *TagIter) Next() (*Tag, error) {
 // ForEach call the cb function for each tag contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *TagIter) ForEach(cb func(*Tag) error) error {
-	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
+func (iter *TagIter) ForEach(ctx context.Context, cb func(*Tag) error) error {
+	return iter.EncodedObjectIter.ForEach(ctx, func(obj plumbing.EncodedObject) error {
 		t, err := DecodeTag(iter.s, obj)
 		if err != nil {
 			return err

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -54,7 +54,7 @@ func (s *TagSuite) TestAnnotated() {
 	tag := s.tag(plumbing.NewHash("b742a2a9fa0afcfa9a6fad080980fbc26b007c69"))
 	s.Equal("example annotated tag\n", tag.Message)
 
-	commit, err := tag.Commit()
+	commit, err := tag.Commit(s.T().Context())
 	s.NoError(err)
 	s.Equal(plumbing.CommitObject, commit.Type())
 	s.Equal("f7b877701fbf855b44c0a9e86f3fdce2c298b07f", commit.ID().String())
@@ -63,7 +63,7 @@ func (s *TagSuite) TestAnnotated() {
 func (s *TagSuite) TestCommitError() {
 	tag := s.tag(plumbing.NewHash("fe6cb94756faa81e5ed9240f9191b833db5f40ae"))
 
-	commit, err := tag.Commit()
+	commit, err := tag.Commit(s.T().Context())
 	s.Nil(commit)
 	s.NotNil(err)
 	s.ErrorIs(err, ErrUnsupportedObject)
@@ -73,7 +73,7 @@ func (s *TagSuite) TestCommit() {
 	tag := s.tag(plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"))
 	s.Equal("a tagged commit\n", tag.Message)
 
-	commit, err := tag.Commit()
+	commit, err := tag.Commit(s.T().Context())
 	s.NoError(err)
 	s.Equal(plumbing.CommitObject, commit.Type())
 	s.Equal("f7b877701fbf855b44c0a9e86f3fdce2c298b07f", commit.ID().String())
@@ -82,7 +82,7 @@ func (s *TagSuite) TestCommit() {
 func (s *TagSuite) TestBlobError() {
 	tag := s.tag(plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"))
 
-	commit, err := tag.Blob()
+	commit, err := tag.Blob(s.T().Context())
 	s.Nil(commit)
 	s.NotNil(err)
 	s.ErrorIs(err, ErrUnsupportedObject)
@@ -92,7 +92,7 @@ func (s *TagSuite) TestBlob() {
 	tag := s.tag(plumbing.NewHash("fe6cb94756faa81e5ed9240f9191b833db5f40ae"))
 	s.Equal("a tagged blob\n", tag.Message)
 
-	blob, err := tag.Blob()
+	blob, err := tag.Blob(s.T().Context())
 	s.NoError(err)
 	s.Equal(plumbing.BlobObject, blob.Type())
 	s.Equal("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", blob.ID().String())
@@ -101,7 +101,7 @@ func (s *TagSuite) TestBlob() {
 func (s *TagSuite) TestTreeError() {
 	tag := s.tag(plumbing.NewHash("fe6cb94756faa81e5ed9240f9191b833db5f40ae"))
 
-	tree, err := tag.Tree()
+	tree, err := tag.Tree(s.T().Context())
 	s.Nil(tree)
 	s.NotNil(err)
 	s.ErrorIs(err, ErrUnsupportedObject)
@@ -111,7 +111,7 @@ func (s *TagSuite) TestTree() {
 	tag := s.tag(plumbing.NewHash("152175bf7e5580299fa1f0ba41ef6474cc043b70"))
 	s.Equal("a tagged tree\n", tag.Message)
 
-	tree, err := tag.Tree()
+	tree, err := tag.Tree(s.T().Context())
 	s.NoError(err)
 	s.Equal(plumbing.TreeObject, tree.Type())
 	s.Equal("70846e9a10ef7b41064b40f07713d5b8b9a8fc73", tree.ID().String())
@@ -121,7 +121,7 @@ func (s *TagSuite) TestTreeFromCommit() {
 	tag := s.tag(plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"))
 	s.Equal("a tagged commit\n", tag.Message)
 
-	tree, err := tag.Tree()
+	tree, err := tag.Tree(s.T().Context())
 	s.NoError(err)
 	s.Equal(plumbing.TreeObject, tree.Type())
 	s.Equal("70846e9a10ef7b41064b40f07713d5b8b9a8fc73", tree.ID().String())
@@ -130,24 +130,24 @@ func (s *TagSuite) TestTreeFromCommit() {
 func (s *TagSuite) TestObject() {
 	tag := s.tag(plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"))
 
-	obj, err := tag.Object()
+	obj, err := tag.Object(s.T().Context())
 	s.NoError(err)
 	s.Equal(plumbing.CommitObject, obj.Type())
 	s.Equal("f7b877701fbf855b44c0a9e86f3fdce2c298b07f", obj.ID().String())
 }
 
 func (s *TagSuite) TestTagItter() {
-	iter, err := s.Storer.IterEncodedObjects(plumbing.TagObject)
+	iter, err := s.Storer.IterEncodedObjects(s.T().Context(), plumbing.TagObject)
 	s.NoError(err)
 
 	var count int
 	i := NewTagIter(s.Storer, iter)
-	tag, err := i.Next()
+	tag, err := i.Next(s.T().Context())
 	s.NoError(err)
 	s.NotNil(tag)
 	s.Equal(plumbing.TagObject, tag.Type())
 
-	err = i.ForEach(func(t *Tag) error {
+	err = i.ForEach(s.T().Context(), func(t *Tag) error {
 		s.NotNil(t)
 		s.Equal(plumbing.TagObject, t.Type())
 		count++
@@ -158,18 +158,18 @@ func (s *TagSuite) TestTagItter() {
 	s.NoError(err)
 	s.Equal(3, count)
 
-	tag, err = i.Next()
+	tag, err = i.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 	s.Nil(tag)
 }
 
 func (s *TagSuite) TestTagIterError() {
-	iter, err := s.Storer.IterEncodedObjects(plumbing.TagObject)
+	iter, err := s.Storer.IterEncodedObjects(s.T().Context(), plumbing.TagObject)
 	s.NoError(err)
 
 	randomErr := fmt.Errorf("a random error")
 	i := NewTagIter(s.Storer, iter)
-	err = i.ForEach(func(_ *Tag) error {
+	err = i.ForEach(s.T().Context(), func(_ *Tag) error {
 		return randomErr
 	})
 
@@ -674,7 +674,7 @@ func (s *TagSuite) TestStringNonCommit() {
 
 	targetObj := &plumbing.MemoryObject{}
 	target.Encode(targetObj)
-	store.SetEncodedObject(targetObj)
+	store.SetEncodedObject(s.T().Context(), targetObj)
 
 	tag := &Tag{
 		Target:     targetObj.Hash(),
@@ -686,9 +686,9 @@ func (s *TagSuite) TestStringNonCommit() {
 
 	tagObj := &plumbing.MemoryObject{}
 	tag.Encode(tagObj)
-	store.SetEncodedObject(tagObj)
+	store.SetEncodedObject(s.T().Context(), tagObj)
 
-	tag, err := GetTag(store, tagObj.Hash())
+	tag, err := GetTag(s.T().Context(), store, tagObj.Hash())
 	s.NoError(err)
 
 	s.Equal(

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -57,8 +57,8 @@ type Tree struct {
 }
 
 // GetTree gets a tree from an object storer and decodes it.
-func GetTree(s storer.EncodedObjectStorer, h plumbing.Hash) (*Tree, error) {
-	o, err := s.EncodedObject(plumbing.TreeObject, h)
+func GetTree(ctx context.Context, s storer.EncodedObjectStorer, h plumbing.Hash) (*Tree, error) {
+	o, err := s.EncodedObject(ctx, plumbing.TreeObject, h)
 	if err != nil {
 		return nil, err
 	}
@@ -86,13 +86,13 @@ type TreeEntry struct {
 
 // File returns the hash of the file identified by the `path` argument.
 // The path is interpreted as relative to the tree receiver.
-func (t *Tree) File(path string) (*File, error) {
-	e, err := t.FindEntry(path)
+func (t *Tree) File(ctx context.Context, path string) (*File, error) {
+	e, err := t.FindEntry(ctx, path)
 	if err != nil {
 		return nil, ErrFileNotFound
 	}
 
-	blob, err := GetBlob(t.s, e.Hash)
+	blob, err := GetBlob(ctx, t.s, e.Hash)
 	if err != nil {
 		if errors.Is(err, plumbing.ErrObjectNotFound) {
 			return nil, ErrFileNotFound
@@ -105,24 +105,24 @@ func (t *Tree) File(path string) (*File, error) {
 
 // Size returns the plaintext size of an object, without reading it
 // into memory.
-func (t *Tree) Size(path string) (int64, error) {
-	e, err := t.FindEntry(path)
+func (t *Tree) Size(ctx context.Context, path string) (int64, error) {
+	e, err := t.FindEntry(ctx, path)
 	if err != nil {
 		return 0, ErrEntryNotFound
 	}
 
-	return t.s.EncodedObjectSize(e.Hash)
+	return t.s.EncodedObjectSize(ctx, e.Hash)
 }
 
 // Tree returns the tree identified by the `path` argument.
 // The path is interpreted as relative to the tree receiver.
-func (t *Tree) Tree(path string) (*Tree, error) {
-	e, err := t.FindEntry(path)
+func (t *Tree) Tree(ctx context.Context, path string) (*Tree, error) {
+	e, err := t.FindEntry(ctx, path)
 	if err != nil {
 		return nil, ErrDirectoryNotFound
 	}
 
-	tree, err := GetTree(t.s, e.Hash)
+	tree, err := GetTree(ctx, t.s, e.Hash)
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		return nil, ErrDirectoryNotFound
 	}
@@ -136,12 +136,12 @@ func (t *Tree) Tree(path string) (*Tree, error) {
 // the same reason FindEntry validates: TreeEntryFile is a boundary
 // where attacker-controlled tree data leaves the trusted store as a
 // *File whose Name a caller can hand to filesystem ops.
-func (t *Tree) TreeEntryFile(e *TreeEntry) (*File, error) {
+func (t *Tree) TreeEntryFile(ctx context.Context, e *TreeEntry) (*File, error) {
 	if err := pathutil.ValidTreePath(e.Name); err != nil {
 		return nil, err
 	}
 
-	blob, err := GetBlob(t.s, e.Hash)
+	blob, err := GetBlob(ctx, t.s, e.Hash)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (t *Tree) TreeEntryFile(e *TreeEntry) (*File, error) {
 // boundary as `.git`-shaped or path-traversal-shaped names. Callers
 // that legitimately need to look up unsafe paths should walk the
 // tree manually.
-func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
+func (t *Tree) FindEntry(ctx context.Context, path string) (*TreeEntry, error) {
 	if err := pathutil.ValidTreePath(path); err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
 	var tree *Tree
 	var err error
 	for tree = startingTree; len(pathParts) > 1; pathParts = pathParts[1:] {
-		if tree, err = tree.dir(pathParts[0]); err != nil {
+		if tree, err = tree.dir(ctx, pathParts[0]); err != nil {
 			return nil, err
 		}
 
@@ -196,13 +196,13 @@ func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
 	return tree.entry(pathParts[0])
 }
 
-func (t *Tree) dir(baseName string) (*Tree, error) {
+func (t *Tree) dir(ctx context.Context, baseName string) (*Tree, error) {
 	entry, err := t.entry(baseName)
 	if err != nil {
 		return nil, ErrDirectoryNotFound
 	}
 
-	obj, err := t.s.EncodedObject(plumbing.TreeObject, entry.Hash)
+	obj, err := t.s.EncodedObject(ctx, plumbing.TreeObject, entry.Hash)
 	if err != nil {
 		return nil, err
 	}
@@ -556,39 +556,28 @@ func isValidTreeMode(mode filemode.FileMode) bool {
 }
 
 // Diff returns a list of changes between this tree and the provided one
-func (t *Tree) Diff(to *Tree) (Changes, error) {
-	return t.DiffContext(context.Background(), to)
-}
-
-// DiffContext returns a list of changes between this tree and the provided one
 // Error will be returned if context expires. Provided context must be non nil.
 //
 // NOTE: Since version 5.1.0 the renames are correctly handled, the settings
 // used are the recommended options DefaultDiffTreeOptions.
-func (t *Tree) DiffContext(ctx context.Context, to *Tree) (Changes, error) {
+func (t *Tree) Diff(ctx context.Context, to *Tree) (Changes, error) {
 	return DiffTreeWithOptions(ctx, t, to, DefaultDiffTreeOptions)
 }
 
-// Patch returns a slice of Patch objects with all the changes between trees
-// in chunks. This representation can be used to create several diff outputs.
-func (t *Tree) Patch(to *Tree) (*Patch, error) {
-	return t.PatchContext(context.Background(), to)
-}
-
-// PatchContext returns a slice of Patch objects with all the changes between
+// Patch returns a slice of Patch objects with all the changes between
 // trees in chunks. This representation can be used to create several diff
 // outputs. If context expires, an error will be returned. Provided context must
 // be non-nil.
 //
 // NOTE: Since version 5.1.0 the renames are correctly handled, the settings
 // used are the recommended options DefaultDiffTreeOptions.
-func (t *Tree) PatchContext(ctx context.Context, to *Tree) (*Patch, error) {
-	changes, err := t.DiffContext(ctx, to)
+func (t *Tree) Patch(ctx context.Context, to *Tree) (*Patch, error) {
+	changes, err := t.Diff(ctx, to)
 	if err != nil {
 		return nil, err
 	}
 
-	return changes.PatchContext(ctx)
+	return changes.Patch(ctx)
 }
 
 // treeEntryIter facilitates iterating through the TreeEntry objects in a Tree.
@@ -597,7 +586,7 @@ type treeEntryIter struct {
 	pos int
 }
 
-func (iter *treeEntryIter) Next() (TreeEntry, error) {
+func (iter *treeEntryIter) Next(_ context.Context) (TreeEntry, error) {
 	if iter.pos >= len(iter.t.Entries) {
 		return TreeEntry{}, io.EOF
 	}
@@ -656,7 +645,7 @@ func NewTreeWalker(t *Tree, recursive bool, seen map[plumbing.Hash]bool) *TreeWa
 // In the current implementation any objects which cannot be found in the
 // underlying repository will be skipped automatically. It is possible that this
 // may change in future versions.
-func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
+func (w *TreeWalker) Next(ctx context.Context) (name string, entry TreeEntry, err error) {
 	var obj *Tree
 	for {
 		current := len(w.stack) - 1
@@ -672,7 +661,7 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 			return name, entry, err
 		}
 
-		entry, err = w.stack[current].Next()
+		entry, err = w.stack[current].Next(ctx)
 		if err == io.EOF {
 			// Finished with the current tree, move back up to the parent
 			w.stack = w.stack[:current]
@@ -696,7 +685,7 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 		}
 
 		if entry.Mode == filemode.Dir {
-			obj, err = GetTree(w.s, entry.Hash)
+			obj, err = GetTree(ctx, w.s, entry.Hash)
 		}
 
 		name = simpleJoin(w.base, entry.Name)
@@ -757,9 +746,9 @@ func NewTreeIter(s storer.EncodedObjectStorer, iter storer.EncodedObjectIter) *T
 
 // Next moves the iterator to the next tree and returns a pointer to it. If
 // there are no more trees, it returns io.EOF.
-func (iter *TreeIter) Next() (*Tree, error) {
+func (iter *TreeIter) Next(ctx context.Context) (*Tree, error) {
 	for {
-		obj, err := iter.EncodedObjectIter.Next()
+		obj, err := iter.EncodedObjectIter.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -775,8 +764,8 @@ func (iter *TreeIter) Next() (*Tree, error) {
 // ForEach call the cb function for each tree contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *TreeIter) ForEach(cb func(*Tree) error) error {
-	return iter.EncodedObjectIter.ForEach(func(obj plumbing.EncodedObject) error {
+func (iter *TreeIter) ForEach(ctx context.Context, cb func(*Tree) error) error {
+	return iter.EncodedObjectIter.ForEach(ctx, func(obj plumbing.EncodedObject) error {
 		if obj.Type() != plumbing.TreeObject {
 			return nil
 		}

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -165,6 +165,8 @@ func (cs *countingStorer) EncodedObject(ctx context.Context, t plumbing.ObjectTy
 // paths with only one directory level (e.g., "vendor/foo.go").
 // This test ensures that repeated lookups in the same directory reuse
 // the cached subtree instead of fetching it from the storer each time.
+//
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *TreeSuite) TestFindEntryCacheDepth1() {
 	cs := newCountingStorer(s.Storer)
 
@@ -197,6 +199,8 @@ func (s *TreeSuite) TestFindEntryCacheDepth1() {
 // and "json/long.json") .
 // This complements TestFindEntryCacheDepth1 by testing multiple access with
 // different path in the same directory.
+//
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *TreeSuite) TestFindEntryCacheDepth2() {
 	cs := newCountingStorer(s.Storer)
 
@@ -497,7 +501,7 @@ func (s *TreeSuite) TestTreeWalkerNextNonRecursive() {
 	s.Equal(8, count)
 }
 
-func (s *TreeSuite) TestPatchContext_ToNil() {
+func (s *TreeSuite) TestPatchToNil() {
 	commit := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -53,7 +53,7 @@ func (s *TreeSuite) TestDecode() {
 
 func (s *TreeSuite) TestDecodeNonTree() {
 	hash := plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492")
-	blob, err := s.Storer.EncodedObject(plumbing.BlobObject, hash)
+	blob, err := s.Storer.EncodedObject(s.T().Context(), plumbing.BlobObject, hash)
 	s.NoError(err)
 
 	tree := &Tree{}
@@ -70,56 +70,56 @@ func (s *TreeSuite) TestTree() {
 	s.NoError(err)
 	expected := expectedEntry.Hash
 
-	obtainedTree, err := s.Tree.Tree("vendor")
+	obtainedTree, err := s.Tree.Tree(s.T().Context(), "vendor")
 	s.NoError(err)
 	s.Equal(expected, obtainedTree.Hash)
 }
 
 func (s *TreeSuite) TestTreeNotFound() {
-	d, err := s.Tree.Tree("not-found")
+	d, err := s.Tree.Tree(s.T().Context(), "not-found")
 	s.Nil(d)
 	s.ErrorIs(err, ErrDirectoryNotFound)
 }
 
 func (s *TreeSuite) TestTreeFailsWithExistingFiles() {
-	_, err := s.Tree.File("LICENSE")
+	_, err := s.Tree.File(s.T().Context(), "LICENSE")
 	s.NoError(err)
 
-	d, err := s.Tree.Tree("LICENSE")
+	d, err := s.Tree.Tree(s.T().Context(), "LICENSE")
 	s.Nil(d)
 	s.ErrorIs(err, ErrDirectoryNotFound)
 }
 
 func (s *TreeSuite) TestFile() {
-	f, err := s.Tree.File("LICENSE")
+	f, err := s.Tree.File(s.T().Context(), "LICENSE")
 	s.NoError(err)
 	s.Equal("LICENSE", f.Name)
 }
 
 func (s *TreeSuite) TestFileNotFound() {
-	f, err := s.Tree.File("not-found")
+	f, err := s.Tree.File(s.T().Context(), "not-found")
 	s.Nil(f)
 	s.ErrorIs(err, ErrFileNotFound)
 }
 
 func (s *TreeSuite) TestFileFailsWithExistingTrees() {
-	_, err := s.Tree.Tree("vendor")
+	_, err := s.Tree.Tree(s.T().Context(), "vendor")
 	s.NoError(err)
 
-	f, err := s.Tree.File("vendor")
+	f, err := s.Tree.File(s.T().Context(), "vendor")
 	s.Nil(f)
 	s.ErrorIs(err, ErrFileNotFound)
 }
 
 func (s *TreeSuite) TestSize() {
-	size, err := s.Tree.Size("LICENSE")
+	size, err := s.Tree.Size(s.T().Context(), "LICENSE")
 	s.NoError(err)
 	s.Equal(int64(1072), size)
 }
 
 func (s *TreeSuite) TestFiles() {
 	var count int
-	err := s.Tree.Files().ForEach(func(_ *File) error {
+	err := s.Tree.Files().ForEach(s.T().Context(), func(_ *File) error {
 		count++
 		return nil
 	})
@@ -129,16 +129,16 @@ func (s *TreeSuite) TestFiles() {
 }
 
 func (s *TreeSuite) TestFindEntry() {
-	e, err := s.Tree.FindEntry("vendor/foo.go")
+	e, err := s.Tree.FindEntry(s.T().Context(), "vendor/foo.go")
 	s.NoError(err)
 	s.Equal("foo.go", e.Name)
 }
 
 func (s *TreeSuite) TestFindEntryNotFound() {
-	e, err := s.Tree.FindEntry("not-found")
+	e, err := s.Tree.FindEntry(s.T().Context(), "not-found")
 	s.Nil(e)
 	s.ErrorIs(err, ErrEntryNotFound)
-	e, err = s.Tree.FindEntry("not-found/not-found/not-found")
+	e, err = s.Tree.FindEntry(s.T().Context(), "not-found/not-found/not-found")
 	s.Nil(e)
 	s.ErrorIs(err, ErrDirectoryNotFound)
 }
@@ -156,9 +156,9 @@ func newCountingStorer(s storer.EncodedObjectStorer) *countingStorer {
 	}
 }
 
-func (cs *countingStorer) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (cs *countingStorer) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	cs.calls[h]++
-	return cs.EncodedObjectStorer.EncodedObject(t, h)
+	return cs.EncodedObjectStorer.EncodedObject(ctx, t, h)
 }
 
 // TestFindEntryCacheDepth1 verifies that the tree path cache works for
@@ -169,7 +169,7 @@ func (s *TreeSuite) TestFindEntryCacheDepth1() {
 	cs := newCountingStorer(s.Storer)
 
 	hash := plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")
-	tree, err := GetTree(cs, hash)
+	tree, err := GetTree(s.T().Context(), cs, hash)
 	s.Require().NoError(err)
 
 	vendorEntry, err := tree.entry("vendor")
@@ -179,13 +179,13 @@ func (s *TreeSuite) TestFindEntryCacheDepth1() {
 	// Previous calls to GetTree and entry may pollute the "calls" state, reset it to start afresh.
 	cs.calls = make(map[plumbing.Hash]int)
 
-	e1, err := tree.FindEntry("vendor/foo.go")
+	e1, err := tree.FindEntry(s.T().Context(), "vendor/foo.go")
 	s.Require().NoError(err)
 	s.Equal("foo.go", e1.Name)
 
 	s.Equal(1, cs.calls[vendorHash], "first FindEntry should fetch vendor tree once")
 
-	e2, err := tree.FindEntry("vendor/foo.go")
+	e2, err := tree.FindEntry(s.T().Context(), "vendor/foo.go")
 	s.Require().NoError(err)
 	s.Equal("foo.go", e2.Name)
 
@@ -201,7 +201,7 @@ func (s *TreeSuite) TestFindEntryCacheDepth2() {
 	cs := newCountingStorer(s.Storer)
 
 	hash := plumbing.NewHash("a8d315b2b1c615d43042c3a62402b8a54288cf5c")
-	tree, err := GetTree(cs, hash)
+	tree, err := GetTree(s.T().Context(), cs, hash)
 	s.Require().NoError(err)
 
 	jsonEntry, err := tree.entry("json")
@@ -210,13 +210,13 @@ func (s *TreeSuite) TestFindEntryCacheDepth2() {
 
 	cs.calls = make(map[plumbing.Hash]int)
 
-	e1, err := tree.FindEntry("json/short.json")
+	e1, err := tree.FindEntry(s.T().Context(), "json/short.json")
 	s.Require().NoError(err)
 	s.Equal("short.json", e1.Name)
 
 	s.Equal(1, cs.calls[jsonHash], "first FindEntry should fetch json tree once")
 
-	e2, err := tree.FindEntry("json/long.json")
+	e2, err := tree.FindEntry(s.T().Context(), "json/long.json")
 	s.Require().NoError(err)
 	s.Equal("long.json", e2.Name)
 
@@ -231,11 +231,11 @@ type fakeStorer struct {
 	fake fakeEncodedObject
 }
 
-func (fs fakeStorer) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (fs fakeStorer) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	if fs.hash == h {
 		return fs.fake, nil
 	}
-	return fs.EncodedObjectStorer.EncodedObject(t, h)
+	return fs.EncodedObjectStorer.EncodedObject(ctx, t, h)
 }
 
 // Overrides reader of plumbing.EncodedObject to simulate read error
@@ -246,16 +246,16 @@ func (fe fakeEncodedObject) Reader() (io.ReadCloser, error) {
 }
 
 func (s *TreeSuite) TestDir() {
-	vendor, err := s.Tree.dir("vendor")
+	vendor, err := s.Tree.dir(s.T().Context(), "vendor")
 	s.NoError(err)
 
-	t, err := GetTree(s.Tree.s, s.Tree.ID())
+	t, err := GetTree(s.T().Context(), s.Tree.s, s.Tree.ID())
 	s.NoError(err)
-	o, err := t.s.EncodedObject(plumbing.AnyObject, vendor.ID())
+	o, err := t.s.EncodedObject(s.T().Context(), plumbing.AnyObject, vendor.ID())
 	s.NoError(err)
 
 	t.s = fakeStorer{t.s, vendor.ID(), fakeEncodedObject{o}}
-	_, err = t.dir("vendor")
+	_, err = t.dir(s.T().Context(), "vendor")
 	s.NotNil(err)
 }
 
@@ -364,37 +364,37 @@ func (s *TreeSuite) TestTreeDiff() {
 	s.Require().NoError(err)
 	storer := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 	defer func() { _ = storer.Close() }()
-	commit, err := GetCommit(storer, plumbing.NewHash("89f8bda31d29767a6d6ba8f9d0dfb941d598e843"))
+	commit, err := GetCommit(s.T().Context(), storer, plumbing.NewHash("89f8bda31d29767a6d6ba8f9d0dfb941d598e843"))
 	s.NoError(err)
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
-	parentCommit, err := commit.Parent(0)
+	parentCommit, err := commit.Parent(s.T().Context(), 0)
 	s.NoError(err)
 
-	parentTree, err := parentCommit.Tree()
+	parentTree, err := parentCommit.Tree(s.T().Context())
 	s.NoError(err)
 
-	ch, err := parentTree.Diff(tree)
+	ch, err := parentTree.Diff(s.T().Context(), tree)
 	s.NoError(err)
 
 	s.Len(ch, 3)
 	s.Equal("examples/object_storage/main.go", ch[0].From.Name)
 	s.Equal("examples/storage/main.go", ch[0].To.Name)
 
-	ch, err = parentTree.DiffContext(context.Background(), tree)
+	ch, err = parentTree.Diff(s.T().Context(), tree)
 	s.NoError(err)
 	s.Len(ch, 3)
 }
 
 func (s *TreeSuite) TestTreeIter() {
-	encIter, err := s.Storer.IterEncodedObjects(plumbing.TreeObject)
+	encIter, err := s.Storer.IterEncodedObjects(s.T().Context(), plumbing.TreeObject)
 	s.NoError(err)
 	iter := NewTreeIter(s.Storer, encIter)
 
 	trees := []*Tree{}
-	iter.ForEach(func(t *Tree) error {
+	iter.ForEach(s.T().Context(), func(t *Tree) error {
 		t.s = nil
 		trees = append(trees, t)
 		return nil
@@ -403,13 +403,13 @@ func (s *TreeSuite) TestTreeIter() {
 	s.True(len(trees) > 0)
 	iter.Close()
 
-	encIter, err = s.Storer.IterEncodedObjects(plumbing.TreeObject)
+	encIter, err = s.Storer.IterEncodedObjects(s.T().Context(), plumbing.TreeObject)
 	s.NoError(err)
 	iter = NewTreeIter(s.Storer, encIter)
 
 	i := 0
 	for {
-		t, err := iter.Next()
+		t, err := iter.Next(s.T().Context())
 		if err == io.EOF {
 			break
 		}
@@ -424,14 +424,14 @@ func (s *TreeSuite) TestTreeIter() {
 }
 
 func (s *TreeSuite) TestTreeWalkerNext() {
-	commit, err := GetCommit(s.Storer, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+	commit, err := GetCommit(s.T().Context(), s.Storer, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 	s.NoError(err)
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
 	walker := NewTreeWalker(tree, true, nil)
 	for _, e := range treeWalkerExpects {
-		name, entry, err := walker.Next()
+		name, entry, err := walker.Next(s.T().Context())
 		if err == io.EOF {
 			break
 		}
@@ -447,9 +447,9 @@ func (s *TreeSuite) TestTreeWalkerNext() {
 }
 
 func (s *TreeSuite) TestTreeWalkerNextSkipSeen() {
-	commit, err := GetCommit(s.Storer, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+	commit, err := GetCommit(s.T().Context(), s.Storer, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 	s.NoError(err)
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
 	seen := map[plumbing.Hash]bool{
@@ -457,7 +457,7 @@ func (s *TreeSuite) TestTreeWalkerNextSkipSeen() {
 	}
 	walker := NewTreeWalker(tree, true, seen)
 	for _, e := range treeWalkerExpects[1:] {
-		name, entry, err := walker.Next()
+		name, entry, err := walker.Next(s.T().Context())
 		if err == io.EOF {
 			break
 		}
@@ -474,13 +474,13 @@ func (s *TreeSuite) TestTreeWalkerNextSkipSeen() {
 
 func (s *TreeSuite) TestTreeWalkerNextNonRecursive() {
 	commit := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
 	var count int
 	walker := NewTreeWalker(tree, false, nil)
 	for {
-		name, entry, err := walker.Next()
+		name, entry, err := walker.Next(s.T().Context())
 		if err == io.EOF {
 			break
 		}
@@ -499,10 +499,10 @@ func (s *TreeSuite) TestTreeWalkerNextNonRecursive() {
 
 func (s *TreeSuite) TestPatchContext_ToNil() {
 	commit := s.commit(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
-	patch, err := tree.PatchContext(context.Background(), nil)
+	patch, err := tree.Patch(s.T().Context(), nil)
 	s.NoError(err)
 
 	s.Equal(242971, len(patch.String()))
@@ -515,10 +515,10 @@ func (s *TreeSuite) TestTreeWalkerNextSubmodule() {
 	defer func() { _ = st.Close() }()
 
 	hash := plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4")
-	commit, err := GetCommit(st, hash)
+	commit, err := GetCommit(s.T().Context(), st, hash)
 	s.NoError(err)
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 
 	expected := []string{
@@ -533,7 +533,7 @@ func (s *TreeSuite) TestTreeWalkerNextSubmodule() {
 	defer walker.Close()
 
 	for {
-		name, entry, err := walker.Next()
+		name, entry, err := walker.Next(s.T().Context())
 		if err == io.EOF {
 			break
 		}
@@ -1890,13 +1890,13 @@ func TestTreeDecodeClearsPathCache(t *testing.T) {
 	oldSubtree := newRawTreeObject(t, encodeRawTreeEntries(
 		rawTreeEntry{"100644", "old", oldFileHash},
 	))
-	oldSubtreeHash, err := store.SetEncodedObject(oldSubtree)
+	oldSubtreeHash, err := store.SetEncodedObject(t.Context(), oldSubtree)
 	require.NoError(t, err)
 
 	oldDir := newRawTreeObject(t, encodeRawTreeEntries(
 		rawTreeEntry{"40000", "sub", oldSubtreeHash.Bytes()},
 	))
-	oldDirHash, err := store.SetEncodedObject(oldDir)
+	oldDirHash, err := store.SetEncodedObject(t.Context(), oldDir)
 	require.NoError(t, err)
 
 	oldRoot := newRawTreeObject(t, encodeRawTreeEntries(
@@ -1906,13 +1906,13 @@ func TestTreeDecodeClearsPathCache(t *testing.T) {
 	newSubtree := newRawTreeObject(t, encodeRawTreeEntries(
 		rawTreeEntry{"100644", "new", newFileHash},
 	))
-	newSubtreeHash, err := store.SetEncodedObject(newSubtree)
+	newSubtreeHash, err := store.SetEncodedObject(t.Context(), newSubtree)
 	require.NoError(t, err)
 
 	newDir := newRawTreeObject(t, encodeRawTreeEntries(
 		rawTreeEntry{"40000", "sub", newSubtreeHash.Bytes()},
 	))
-	newDirHash, err := store.SetEncodedObject(newDir)
+	newDirHash, err := store.SetEncodedObject(t.Context(), newDir)
 	require.NoError(t, err)
 
 	newRoot := newRawTreeObject(t, encodeRawTreeEntries(
@@ -1921,12 +1921,12 @@ func TestTreeDecodeClearsPathCache(t *testing.T) {
 
 	tree := &Tree{s: store}
 	require.NoError(t, tree.Decode(oldRoot))
-	got, err := tree.FindEntry("dir/sub/old")
+	got, err := tree.FindEntry(t.Context(), "dir/sub/old")
 	require.NoError(t, err)
 	assert.Equal(t, 0, got.Hash.Compare(oldFileHash))
 
 	require.NoError(t, tree.Decode(newRoot))
-	got, err = tree.FindEntry("dir/sub/new")
+	got, err = tree.FindEntry(t.Context(), "dir/sub/new")
 	require.NoError(t, err)
 	assert.Equal(t, 0, got.Hash.Compare(newFileHash))
 }
@@ -2022,7 +2022,7 @@ func TestTreeFindEntryDuplicates(t *testing.T) {
 			require.Len(t, tree.Entries, tc.wantCount,
 				"all duplicate entries must be preserved in storage order")
 
-			got, err := tree.FindEntry(tc.lookup)
+			got, err := tree.FindEntry(t.Context(), tc.lookup)
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantMode, got.Mode)
 			assert.Equal(t, 0, bytes.Compare(tc.wantHash, got.Hash.Bytes()),
@@ -2053,7 +2053,7 @@ func TestTreeFindEntryStopsAtUnsortedEntryPastName(t *testing.T) {
 	var tree Tree
 	require.NoError(t, tree.Decode(obj))
 
-	got, err := tree.FindEntry("foo")
+	got, err := tree.FindEntry(t.Context(), "foo")
 	require.ErrorIs(t, err, ErrEntryNotFound)
 	assert.Nil(t, got)
 }
@@ -2079,7 +2079,7 @@ func TestTreeFindEntryFindsDirectoryAfterLexicallyEarlierFile(t *testing.T) {
 	var tree Tree
 	require.NoError(t, tree.Decode(obj))
 
-	got, err := tree.FindEntry("foo")
+	got, err := tree.FindEntry(t.Context(), "foo")
 	require.NoError(t, err)
 	assert.Equal(t, filemode.Dir, got.Mode)
 	assert.Equal(t, 0, bytes.Compare(hashB, got.Hash.Bytes()))
@@ -2186,7 +2186,7 @@ func TestTreeEntryFileRejectsDangerousNames(t *testing.T) {
 	_, err = bw.Write([]byte("payload"))
 	require.NoError(t, err)
 	require.NoError(t, bw.Close())
-	blobHash, err := store.SetEncodedObject(blob)
+	blobHash, err := store.SetEncodedObject(t.Context(), blob)
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -2212,7 +2212,7 @@ func TestTreeEntryFileRejectsDangerousNames(t *testing.T) {
 			t.Parallel()
 
 			tree := &Tree{s: store}
-			f, err := tree.TreeEntryFile(&TreeEntry{
+			f, err := tree.TreeEntryFile(t.Context(), &TreeEntry{
 				Name: tc.entryName,
 				Mode: filemode.Regular,
 				Hash: blobHash,
@@ -2261,7 +2261,7 @@ func TestTreeWalkerNextRejectsDangerousNames(t *testing.T) {
 			walker := NewTreeWalker(tree, true, nil)
 			defer walker.Close()
 
-			_, _, err := walker.Next()
+			_, _, err := walker.Next(t.Context())
 			assert.ErrorIs(t, err, pathutil.ErrInvalidPath)
 		})
 	}

--- a/plumbing/object/treenoder.go
+++ b/plumbing/object/treenoder.go
@@ -1,6 +1,7 @@
 package object
 
 import (
+	"context"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -77,25 +78,31 @@ func (t *treeNoder) Children() ([]noder.Noder, error) {
 		return t.children, nil
 	}
 
+	// TODO(ctx): the merkletrie noder.Noder interface does not carry a
+	// context, so tree loading performed while expanding children cannot
+	// receive the caller's context without changing merkletrie. This is an
+	// accepted boundary drop; context.Background() is used instead.
+	ctx := context.Background()
+
 	// the parent of the returned children will be ourself as a tree if
 	// we are a not the root treenoder.  The root is special as it
 	// is is own parent.
 	parent := t.parent
 	if !t.isRoot() {
 		var err error
-		if parent, err = t.parent.Tree(t.name); err != nil {
+		if parent, err = t.parent.Tree(ctx, t.name); err != nil {
 			return nil, err
 		}
 	}
 
 	var err error
-	t.children, err = transformChildren(parent)
+	t.children, err = transformChildren(ctx, parent)
 	return t.children, err
 }
 
 // Returns the children of a tree as treenoders.
 // Efficiency is key here.
-func transformChildren(t *Tree) ([]noder.Noder, error) {
+func transformChildren(ctx context.Context, t *Tree) ([]noder.Noder, error) {
 	var err error
 	var e TreeEntry
 
@@ -114,7 +121,7 @@ func transformChildren(t *Tree) ([]noder.Noder, error) {
 	walker.skipPathValidation = true
 	// don't defer walker.Close() for efficiency reasons.
 	for {
-		_, e, err = walker.Next()
+		_, e, err = walker.Next(ctx)
 		if err == io.EOF {
 			break
 		}

--- a/plumbing/revlist/object_walk.go
+++ b/plumbing/revlist/object_walk.go
@@ -1,6 +1,7 @@
 package revlist
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -23,8 +24,8 @@ type objectWalk struct {
 	result     []plumbing.Hash
 }
 
-func newObjectWalk(s storer.EncodedObjectStorer) (*objectWalk, error) {
-	shallows, err := shallowSet(s)
+func newObjectWalk(ctx context.Context, s storer.EncodedObjectStorer) (*objectWalk, error) {
+	shallows, err := shallowSet(ctx, s)
 	if err != nil {
 		return nil, err
 	}
@@ -38,13 +39,13 @@ func newObjectWalk(s storer.EncodedObjectStorer) (*objectWalk, error) {
 	}, nil
 }
 
-func shallowSet(s storer.EncodedObjectStorer) (map[plumbing.Hash]struct{}, error) {
+func shallowSet(ctx context.Context, s storer.EncodedObjectStorer) (map[plumbing.Hash]struct{}, error) {
 	ss, ok := s.(storer.ShallowStorer)
 	if !ok {
 		return map[plumbing.Hash]struct{}{}, nil
 	}
 
-	hashes, err := ss.Shallow()
+	hashes, err := ss.Shallow(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +60,7 @@ func shallowSet(s storer.EncodedObjectStorer) (map[plumbing.Hash]struct{}, error
 
 // seedWants resolves each want hash and enqueues commits for walking.
 // Non-commit objects (blobs, trees, tags) are added directly to the result.
-func (w *objectWalk) seedWants(wants []plumbing.Hash) error {
+func (w *objectWalk) seedWants(ctx context.Context, wants []plumbing.Hash) error {
 	for i := 0; i < len(wants); i++ {
 		h := wants[i]
 		if _, ok := w.wantsSeen[h]; ok {
@@ -69,21 +70,21 @@ func (w *objectWalk) seedWants(wants []plumbing.Hash) error {
 			continue
 		}
 
-		o, err := w.s.EncodedObject(plumbing.AnyObject, h)
+		o, err := w.s.EncodedObject(ctx, plumbing.AnyObject, h)
 		if err != nil {
 			return fmt.Errorf("getting wanted object %s: %w", h, err)
 		}
 
 		switch o.Type() {
 		case plumbing.CommitObject:
-			c, err := object.DecodeCommit(w.s, o)
+			c, err := object.DecodeCommit(ctx, w.s, o)
 			if err != nil {
 				return fmt.Errorf("decoding commit %s: %w", h, err)
 			}
 			w.wantsSeen[h] = struct{}{}
 			insertSorted(&w.wantsQueue, c)
 		case plumbing.TagObject:
-			tag, err := object.DecodeTag(w.s, o)
+			tag, err := object.DecodeTag(ctx, w.s, o)
 			if err != nil {
 				return fmt.Errorf("decoding tag %s: %w", h, err)
 			}
@@ -91,11 +92,11 @@ func (w *objectWalk) seedWants(wants []plumbing.Hash) error {
 			w.result = append(w.result, tag.Hash)
 			wants = append(wants, tag.Target)
 		case plumbing.TreeObject:
-			t, err := object.GetTree(w.s, h)
+			t, err := object.GetTree(ctx, w.s, h)
 			if err != nil {
 				return fmt.Errorf("getting tree %s: %w", h, err)
 			}
-			if err := collectAllTreeObjects(w.s, t, w.seen, &w.result); err != nil {
+			if err := collectAllTreeObjects(ctx, w.s, t, w.seen, &w.result); err != nil {
 				return err
 			}
 		case plumbing.BlobObject:
@@ -113,7 +114,7 @@ func (w *objectWalk) seedWants(wants []plumbing.Hash) error {
 // (tags, trees, blobs) are marked as seen so the diff walk skips them.
 // Missing objects (ErrObjectNotFound) are tolerated since the remote
 // may advertise refs we don't have locally.
-func (w *objectWalk) seedHaves(haves []plumbing.Hash) error {
+func (w *objectWalk) seedHaves(ctx context.Context, haves []plumbing.Hash) error {
 	for i := 0; i < len(haves); i++ {
 		h := haves[i]
 		if _, ok := w.havesSeen[h]; ok {
@@ -123,7 +124,7 @@ func (w *objectWalk) seedHaves(haves []plumbing.Hash) error {
 			continue
 		}
 
-		o, err := w.s.EncodedObject(plumbing.AnyObject, h)
+		o, err := w.s.EncodedObject(ctx, plumbing.AnyObject, h)
 		if err != nil {
 			if errors.Is(err, plumbing.ErrObjectNotFound) {
 				continue
@@ -133,25 +134,25 @@ func (w *objectWalk) seedHaves(haves []plumbing.Hash) error {
 
 		switch o.Type() {
 		case plumbing.CommitObject:
-			c, err := object.DecodeCommit(w.s, o)
+			c, err := object.DecodeCommit(ctx, w.s, o)
 			if err != nil {
 				return fmt.Errorf("decoding haves commit %s: %w", h, err)
 			}
 			w.havesSeen[h] = struct{}{}
 			insertSorted(&w.havesQueue, c)
-			if t, err := c.Tree(); err == nil {
-				markTreeSeen(w.s, t, w.seen)
+			if t, err := c.Tree(ctx); err == nil {
+				markTreeSeen(ctx, w.s, t, w.seen)
 			}
 		case plumbing.TagObject:
-			tag, err := object.DecodeTag(w.s, o)
+			tag, err := object.DecodeTag(ctx, w.s, o)
 			if err != nil {
 				return fmt.Errorf("decoding haves tag %s: %w", h, err)
 			}
 			w.seen[tag.Hash] = struct{}{}
 			haves = append(haves, tag.Target)
 		case plumbing.TreeObject:
-			if t, err := object.GetTree(w.s, h); err == nil {
-				markTreeSeen(w.s, t, w.seen)
+			if t, err := object.GetTree(ctx, w.s, h); err == nil {
+				markTreeSeen(ctx, w.s, t, w.seen)
 			}
 		case plumbing.BlobObject:
 			w.seen[h] = struct{}{}
@@ -169,10 +170,10 @@ const (
 )
 
 // walk identifies new commits and collects their tree objects.
-func (w *objectWalk) walk() error {
+func (w *objectWalk) walk(ctx context.Context) error {
 	// Fast path: no haves means we need all reachable objects.
 	if len(w.havesQueue) == 0 {
-		return w.walkFull()
+		return w.walkFull(ctx)
 	}
 
 	// Phase 1: merge wants and haves into a single priority queue
@@ -210,7 +211,7 @@ func (w *objectWalk) walk() error {
 
 		// Propagate this commit's flags to parents.
 		if _, shallow := w.shallows[lc.Hash]; !shallow {
-			if err := w.propagate(&queue, flags, &missing, lc, f); err != nil {
+			if err := w.propagate(ctx, &queue, flags, &missing, lc, f); err != nil {
 				return err
 			}
 		}
@@ -241,7 +242,7 @@ func (w *objectWalk) walk() error {
 		if flags[lc.Hash]&havePaint != 0 {
 			continue
 		}
-		if err := w.processCommitTrees(lc); err != nil {
+		if err := w.processCommitTrees(ctx, lc); err != nil {
 			return err
 		}
 	}
@@ -264,7 +265,7 @@ type missingParent struct {
 // walk, where we can tell whether the child was eventually painted by
 // haves (in which case the missing parent is behind the haves boundary
 // and tolerable, matching Git's behavior).
-func (w *objectWalk) propagate(queue *[]*object.Commit, flags map[plumbing.Hash]uint8, missing *[]missingParent, lc *object.Commit, f uint8) error {
+func (w *objectWalk) propagate(ctx context.Context, queue *[]*object.Commit, flags map[plumbing.Hash]uint8, missing *[]missingParent, lc *object.Commit, f uint8) error {
 	for _, ph := range lc.ParentHashes {
 		pf := flags[ph]
 		if pf|f == pf {
@@ -272,7 +273,7 @@ func (w *objectWalk) propagate(queue *[]*object.Commit, flags map[plumbing.Hash]
 		}
 		flags[ph] = pf | f
 
-		pc, err := object.GetCommit(w.s, ph)
+		pc, err := object.GetCommit(ctx, w.s, ph)
 		if err != nil {
 			if errors.Is(err, plumbing.ErrObjectNotFound) {
 				*missing = append(*missing, missingParent{hash: ph, child: lc.Hash})
@@ -300,7 +301,7 @@ func allStale(queue []*object.Commit, flags map[plumbing.Hash]uint8) bool {
 // walkFull is the fast path when there are no haves. It walks all
 // commits and collects every reachable tree/blob via a simple seen-set
 // traversal — no per-commit tree diffs needed.
-func (w *objectWalk) walkFull() error {
+func (w *objectWalk) walkFull(ctx context.Context) error {
 	for len(w.wantsQueue) > 0 {
 		lc := w.wantsQueue[0]
 		w.wantsQueue = w.wantsQueue[1:]
@@ -311,12 +312,12 @@ func (w *objectWalk) walkFull() error {
 		w.seen[lc.Hash] = struct{}{}
 		w.result = append(w.result, lc.Hash)
 
-		tree, err := lc.Tree()
+		tree, err := lc.Tree(ctx)
 		if err != nil {
 			return fmt.Errorf("getting tree for %s: %w", lc.Hash, err)
 		}
 
-		if err := collectAllTreeObjects(w.s, tree, w.seen, &w.result); err != nil {
+		if err := collectAllTreeObjects(ctx, w.s, tree, w.seen, &w.result); err != nil {
 			return fmt.Errorf("collecting tree objects for %s: %w", lc.Hash, err)
 		}
 
@@ -329,7 +330,7 @@ func (w *objectWalk) walkFull() error {
 				continue
 			}
 			w.wantsSeen[ph] = struct{}{}
-			pc, err := object.GetCommit(w.s, ph)
+			pc, err := object.GetCommit(ctx, w.s, ph)
 			if err != nil {
 				return fmt.Errorf("getting parent commit %s: %w", ph, err)
 			}
@@ -341,13 +342,13 @@ func (w *objectWalk) walkFull() error {
 
 // processCommitTrees collects new tree/blob objects for a commit by
 // diffing its tree against its parents' trees.
-func (w *objectWalk) processCommitTrees(lc *object.Commit) error {
+func (w *objectWalk) processCommitTrees(ctx context.Context, lc *object.Commit) error {
 	if _, ok := w.seen[lc.Hash]; !ok {
 		w.seen[lc.Hash] = struct{}{}
 		w.result = append(w.result, lc.Hash)
 	}
 
-	newTree, err := lc.Tree()
+	newTree, err := lc.Tree(ctx)
 	if err != nil {
 		return fmt.Errorf("getting tree for %s: %w", lc.Hash, err)
 	}
@@ -361,14 +362,14 @@ func (w *objectWalk) processCommitTrees(lc *object.Commit) error {
 			}
 			return fmt.Errorf("getting parent commit %s: %w", lc.ParentHashes[i], err)
 		}
-		pt, err := parent.Tree()
+		pt, err := parent.Tree(ctx)
 		if err != nil {
 			return fmt.Errorf("getting parent tree for %s: %w", parent.Hash, err)
 		}
 		oldTrees = append(oldTrees, pt)
 	}
 
-	if err := collectChangedTreeObjects(w.s, newTree, oldTrees, w.seen, &w.result); err != nil {
+	if err := collectChangedTreeObjects(ctx, w.s, newTree, oldTrees, w.seen, &w.result); err != nil {
 		return fmt.Errorf("diffing trees for %s: %w", lc.Hash, err)
 	}
 
@@ -391,6 +392,7 @@ func insertSorted(q *[]*object.Commit, c *object.Commit) {
 // same name with the same hash. Only new or modified tree and blob hashes are
 // added to result.
 func collectChangedTreeObjects(
+	ctx context.Context,
 	s storer.EncodedObjectStorer,
 	newTree *object.Tree,
 	oldTrees []*object.Tree,
@@ -447,19 +449,19 @@ func collectChangedTreeObjects(
 		if e.Mode == filemode.Dir {
 			// Recurse into changed subtree. Collect the old versions of
 			// this subtree from all parents that have it.
-			newSub, err := object.GetTree(s, e.Hash)
+			newSub, err := object.GetTree(ctx, s, e.Hash)
 			if err != nil {
 				return fmt.Errorf("getting subtree %s: %w", e.Hash, err)
 			}
 			var oldSubs []*object.Tree
 			for _, m := range oldEntryMaps {
 				if oh, ok := m[e.Name]; ok {
-					if ot, err := object.GetTree(s, oh); err == nil {
+					if ot, err := object.GetTree(ctx, s, oh); err == nil {
 						oldSubs = append(oldSubs, ot)
 					}
 				}
 			}
-			if err := collectChangedTreeObjects(s, newSub, oldSubs, seen, result); err != nil {
+			if err := collectChangedTreeObjects(ctx, s, newSub, oldSubs, seen, result); err != nil {
 				return err
 			}
 		} else {
@@ -475,6 +477,7 @@ func collectChangedTreeObjects(
 // tree and blob hashes to result. This is faster than collectChangedTreeObjects
 // when we need all objects (no haves to diff against).
 func collectAllTreeObjects(
+	ctx context.Context,
 	s storer.EncodedObjectStorer,
 	t *object.Tree,
 	seen map[plumbing.Hash]struct{},
@@ -494,11 +497,11 @@ func collectAllTreeObjects(
 			continue
 		}
 		if e.Mode == filemode.Dir {
-			sub, err := object.GetTree(s, e.Hash)
+			sub, err := object.GetTree(ctx, s, e.Hash)
 			if err != nil {
 				return fmt.Errorf("getting subtree %s: %w", e.Hash, err)
 			}
-			if err := collectAllTreeObjects(s, sub, seen, result); err != nil {
+			if err := collectAllTreeObjects(ctx, s, sub, seen, result); err != nil {
 				return err
 			}
 		} else {
@@ -512,7 +515,7 @@ func collectAllTreeObjects(
 // markTreeSeen recursively adds all tree and blob hashes in t to seen.
 // Objects added to seen are not added to result — this is used to mark
 // haves-reachable objects so they are skipped during diff walks.
-func markTreeSeen(s storer.EncodedObjectStorer, t *object.Tree, seen map[plumbing.Hash]struct{}) {
+func markTreeSeen(ctx context.Context, s storer.EncodedObjectStorer, t *object.Tree, seen map[plumbing.Hash]struct{}) {
 	if _, ok := seen[t.Hash]; ok {
 		return
 	}
@@ -525,8 +528,8 @@ func markTreeSeen(s storer.EncodedObjectStorer, t *object.Tree, seen map[plumbin
 			continue
 		}
 		if e.Mode == filemode.Dir {
-			if sub, err := object.GetTree(s, e.Hash); err == nil {
-				markTreeSeen(s, sub, seen)
+			if sub, err := object.GetTree(ctx, s, e.Hash); err == nil {
+				markTreeSeen(ctx, s, sub, seen)
 			}
 		} else {
 			seen[e.Hash] = struct{}{}

--- a/plumbing/revlist/object_walk.go
+++ b/plumbing/revlist/object_walk.go
@@ -77,14 +77,14 @@ func (w *objectWalk) seedWants(ctx context.Context, wants []plumbing.Hash) error
 
 		switch o.Type() {
 		case plumbing.CommitObject:
-			c, err := object.DecodeCommit(ctx, w.s, o)
+			c, err := object.DecodeCommit(w.s, o)
 			if err != nil {
 				return fmt.Errorf("decoding commit %s: %w", h, err)
 			}
 			w.wantsSeen[h] = struct{}{}
 			insertSorted(&w.wantsQueue, c)
 		case plumbing.TagObject:
-			tag, err := object.DecodeTag(ctx, w.s, o)
+			tag, err := object.DecodeTag(w.s, o)
 			if err != nil {
 				return fmt.Errorf("decoding tag %s: %w", h, err)
 			}
@@ -134,7 +134,7 @@ func (w *objectWalk) seedHaves(ctx context.Context, haves []plumbing.Hash) error
 
 		switch o.Type() {
 		case plumbing.CommitObject:
-			c, err := object.DecodeCommit(ctx, w.s, o)
+			c, err := object.DecodeCommit(w.s, o)
 			if err != nil {
 				return fmt.Errorf("decoding haves commit %s: %w", h, err)
 			}
@@ -144,7 +144,7 @@ func (w *objectWalk) seedHaves(ctx context.Context, haves []plumbing.Hash) error
 				markTreeSeen(ctx, w.s, t, w.seen)
 			}
 		case plumbing.TagObject:
-			tag, err := object.DecodeTag(ctx, w.s, o)
+			tag, err := object.DecodeTag(w.s, o)
 			if err != nil {
 				return fmt.Errorf("decoding haves tag %s: %w", h, err)
 			}
@@ -355,7 +355,7 @@ func (w *objectWalk) processCommitTrees(ctx context.Context, lc *object.Commit) 
 
 	var oldTrees []*object.Tree
 	for i := 0; i < lc.NumParents(); i++ {
-		parent, err := lc.Parent(i)
+		parent, err := lc.Parent(ctx, i)
 		if err != nil {
 			if errors.Is(err, plumbing.ErrObjectNotFound) {
 				continue // parent may be beyond haves boundary

--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -3,6 +3,8 @@
 package revlist
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 )
@@ -10,7 +12,7 @@ import (
 // objectWalker can be implemented by storers that provide a specialized
 // revlist object walk for a wants/haves query.
 type objectWalker interface {
-	RevListObjects(wants, haves []plumbing.Hash) ([]plumbing.Hash, error)
+	RevListObjects(ctx context.Context, wants, haves []plumbing.Hash) ([]plumbing.Hash, error)
 }
 
 // Objects computes object hashes reachable from wants while excluding
@@ -20,25 +22,26 @@ type objectWalker interface {
 // Otherwise, Objects expands haves first to establish commit boundaries,
 // then walks wants in the same object store.
 func Objects(
+	ctx context.Context,
 	s storer.EncodedObjectStorer,
 	wants,
 	haves []plumbing.Hash,
 ) ([]plumbing.Hash, error) {
 	if walker, ok := s.(objectWalker); ok {
-		return walker.RevListObjects(wants, haves)
+		return walker.RevListObjects(ctx, wants, haves)
 	}
 
-	w, err := newObjectWalk(s)
+	w, err := newObjectWalk(ctx, s)
 	if err != nil {
 		return nil, err
 	}
-	if err := w.seedHaves(haves); err != nil {
+	if err := w.seedHaves(ctx, haves); err != nil {
 		return nil, err
 	}
-	if err := w.seedWants(wants); err != nil {
+	if err := w.seedWants(ctx, wants); err != nil {
 		return nil, err
 	}
-	if err := w.walk(); err != nil {
+	if err := w.walk(ctx); err != nil {
 		return nil, err
 	}
 	return w.result, nil
@@ -47,13 +50,14 @@ func Objects(
 // ObjectsWithRef returns a map from each reachable object hash to the
 // list of want hashes that can reach it.
 func ObjectsWithRef(
+	ctx context.Context,
 	s storer.EncodedObjectStorer,
 	wants,
 	haves []plumbing.Hash,
 ) (map[plumbing.Hash][]plumbing.Hash, error) {
 	all := map[plumbing.Hash][]plumbing.Hash{}
 	for _, want := range wants {
-		hashes, err := Objects(s, []plumbing.Hash{want}, haves)
+		hashes, err := Objects(ctx, s, []plumbing.Hash{want}, haves)
 		if err != nil {
 			return nil, err
 		}

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -1,13 +1,12 @@
 package revlist
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
-
-	"context"
 
 	"github.com/go-git/go-billy/v6"
 	fixtures "github.com/go-git/go-git-fixtures/v6"

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/go-git/go-billy/v6"
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/require"
@@ -37,7 +39,7 @@ type delegatedObjectStorer struct {
 	result []plumbing.Hash
 }
 
-func (s *delegatedObjectStorer) RevListObjects(wants, haves []plumbing.Hash) ([]plumbing.Hash, error) {
+func (s *delegatedObjectStorer) RevListObjects(_ context.Context, wants, haves []plumbing.Hash) ([]plumbing.Hash, error) {
 	s.called = true
 	s.wants = append([]plumbing.Hash(nil), wants...)
 	s.haves = append([]plumbing.Hash(nil), haves...)
@@ -97,10 +99,10 @@ func (s *RevListSuite) TestRevListObjects_Submodules() {
 	sto := filesystem.NewStorage(subDotgit, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	ref, err := storer.ResolveReference(sto, plumbing.HEAD)
+	ref, err := storer.ResolveReference(s.T().Context(), sto, plumbing.HEAD)
 	s.NoError(err)
 
-	revList, err := Objects(sto, []plumbing.Hash{ref.Hash()}, nil)
+	revList, err := Objects(s.T().Context(), sto, []plumbing.Hash{ref.Hash()}, nil)
 	s.NoError(err)
 	for _, h := range revList {
 		s.False(submodules[h.String()])
@@ -117,7 +119,7 @@ func (s *RevListSuite) TestRevListObjects_DelegatesToObjectWalker() {
 		result:              expected,
 	}
 
-	got, err := Objects(sto, []plumbing.Hash{want}, []plumbing.Hash{have})
+	got, err := Objects(s.T().Context(), sto, []plumbing.Hash{want}, []plumbing.Hash{have})
 	s.Require().NoError(err)
 
 	s.True(sto.called)
@@ -140,11 +142,11 @@ func (s *RevListSuite) TestRevListObjects() {
 		"d3ff53e0564a9f87d8e84b6e28e5060e517008aa": true, // CHANGELOG
 	}
 
-	localHist, err := Objects(s.Storer,
+	localHist, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(initialCommit)}, nil)
 	s.NoError(err)
 
-	remoteHist, err := Objects(s.Storer,
+	remoteHist, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(secondCommit)}, localHist)
 	s.NoError(err)
 
@@ -171,7 +173,7 @@ func (s *RevListSuite) TestRevListObjectsTagObject() {
 		"f7b877701fbf855b44c0a9e86f3fdce2c298b07f": true,
 	}
 
-	hist, err := Objects(sto, []plumbing.Hash{plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc")}, nil)
+	hist, err := Objects(s.T().Context(), sto, []plumbing.Hash{plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc")}, nil)
 	s.NoError(err)
 
 	for _, h := range hist {
@@ -182,11 +184,11 @@ func (s *RevListSuite) TestRevListObjectsTagObject() {
 }
 
 func (s *RevListSuite) TestRevListObjectsReverse() {
-	localHist, err := Objects(s.Storer,
+	localHist, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(secondCommit)}, nil)
 	s.NoError(err)
 
-	remoteHist, err := Objects(s.Storer,
+	remoteHist, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(initialCommit)}, localHist)
 	s.NoError(err)
 
@@ -194,11 +196,11 @@ func (s *RevListSuite) TestRevListObjectsReverse() {
 }
 
 func (s *RevListSuite) TestRevListObjectsSameCommit() {
-	localHist, err := Objects(s.Storer,
+	localHist, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(secondCommit)}, nil)
 	s.NoError(err)
 
-	remoteHist, err := Objects(s.Storer,
+	remoteHist, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(secondCommit)}, localHist)
 	s.NoError(err)
 
@@ -211,12 +213,12 @@ func (s *RevListSuite) TestRevListObjectsSameCommit() {
 // * 918c48b some code
 // -----
 func (s *RevListSuite) TestRevListObjectsNewBranch() {
-	localHist, err := Objects(s.Storer,
+	localHist, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(someCommit)}, nil)
 	s.NoError(err)
 
 	remoteHist, err := Objects(
-		s.Storer, []plumbing.Hash{
+		s.T().Context(), s.Storer, []plumbing.Hash{
 			plumbing.NewHash(someCommitBranch),
 			plumbing.NewHash(someCommitOtherBranch),
 		}, localHist)
@@ -253,7 +255,7 @@ func (s *RevListSuite) TestRevListObjectsNewBranch() {
 // |/
 // * b029517 Initial commit
 func (s *RevListSuite) TestReachableObjectsNoRevisit() {
-	got, err := Objects(s.Storer,
+	got, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")},
 		[]plumbing.Hash{plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")})
 	s.NoError(err)
@@ -262,7 +264,7 @@ func (s *RevListSuite) TestReachableObjectsNoRevisit() {
 	// b8e471f) are included despite 35e8510 being in haves.
 	gotSet := make(map[plumbing.Hash]bool)
 	for _, h := range got {
-		if _, err := object.GetCommit(s.Storer, h); err == nil {
+		if _, err := object.GetCommit(s.T().Context(), s.Storer, h); err == nil {
 			gotSet[h] = true
 		}
 	}
@@ -287,7 +289,7 @@ func (s *RevListSuite) TestRevListObjectsNoIgnore() {
 		"c192bd6a24ea1ab01d78686e417c8bdc7c3d197f": true, // .gitignore
 	}
 
-	got, err := Objects(s.Storer,
+	got, err := Objects(s.T().Context(), s.Storer,
 		[]plumbing.Hash{plumbing.NewHash(initialCommit)}, nil)
 	s.NoError(err)
 
@@ -300,7 +302,7 @@ func (s *RevListSuite) TestRevListObjectsNoIgnore() {
 func (s *RevListSuite) TestRevListObjectsBlobWant() {
 	// Pushing a bare blob by OID should return just that blob.
 	blobHash := plumbing.NewHash("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88") // LICENSE
-	got, err := Objects(s.Storer, []plumbing.Hash{blobHash}, nil)
+	got, err := Objects(s.T().Context(), s.Storer, []plumbing.Hash{blobHash}, nil)
 	s.NoError(err)
 	s.Equal([]plumbing.Hash{blobHash}, got)
 }
@@ -308,7 +310,7 @@ func (s *RevListSuite) TestRevListObjectsBlobWant() {
 func (s *RevListSuite) TestRevListObjectsTreeWant() {
 	// Pushing a bare tree by OID should return the tree and all its contents.
 	treeHash := plumbing.NewHash("aa9b383c260e1d05fbbf6b30a02914555e20c725") // root tree of initial commit
-	got, err := Objects(s.Storer, []plumbing.Hash{treeHash}, nil)
+	got, err := Objects(s.T().Context(), s.Storer, []plumbing.Hash{treeHash}, nil)
 	s.NoError(err)
 
 	gotSet := make(map[string]bool, len(got))
@@ -338,7 +340,7 @@ func testMakeTree(t *testing.T, s storer.EncodedObjectStorer, entries []object.T
 	obj := s.NewEncodedObject()
 	obj.SetType(plumbing.TreeObject)
 	require.NoError(t, tree.Encode(obj))
-	hash, err := s.SetEncodedObject(obj)
+	hash, err := s.SetEncodedObject(t.Context(), obj)
 	require.NoError(t, err)
 	return hash
 }
@@ -362,7 +364,7 @@ func testMakeCommitAt(t *testing.T, s storer.EncodedObjectStorer, treeHash plumb
 	obj := s.NewEncodedObject()
 	obj.SetType(plumbing.CommitObject)
 	require.NoError(t, c.Encode(obj))
-	hash, err := s.SetEncodedObject(obj)
+	hash, err := s.SetEncodedObject(t.Context(), obj)
 	require.NoError(t, err)
 	return hash
 }
@@ -379,7 +381,7 @@ func (s *RevListSuite) makeCommitAt(treeHash plumbing.Hash, when time.Time, pare
 	obj := s.Storer.NewEncodedObject()
 	obj.SetType(plumbing.CommitObject)
 	s.Require().NoError(c.Encode(obj))
-	hash, err := s.Storer.SetEncodedObject(obj)
+	hash, err := s.Storer.SetEncodedObject(s.T().Context(), obj)
 	s.Require().NoError(err)
 	return hash
 }
@@ -426,7 +428,7 @@ func (s *RevListSuite) TestRevListObjects_RevertedSubtreeMatchesRoot() {
 	})
 	cC := s.makeCommit(treeC, cP)
 
-	got, err := Objects(s.Storer, []plumbing.Hash{cC}, nil)
+	got, err := Objects(s.T().Context(), s.Storer, []plumbing.Hash{cC}, nil)
 	s.NoError(err)
 
 	gotSet := make(map[plumbing.Hash]bool, len(got))
@@ -484,7 +486,7 @@ func (s *RevListSuite) TestRevListObjects_SeenSubtreeDifferentParent() {
 	})
 	cNewer := s.makeCommit(treeNewer, cPNew)
 
-	got, err := Objects(s.Storer, []plumbing.Hash{cNewer}, nil)
+	got, err := Objects(s.T().Context(), s.Storer, []plumbing.Hash{cNewer}, nil)
 	s.NoError(err)
 
 	gotSet := make(map[plumbing.Hash]bool, len(got))
@@ -515,7 +517,7 @@ func (s *RevListSuite) TestRevListObjects_ReintroducedBlobInHaves() {
 	// Re-add LICENSE — same tree hash as initial commit.
 	cReAdd := s.makeCommit(initialTree, cRemove)
 
-	got, err := Objects(s.Storer, []plumbing.Hash{cReAdd}, []plumbing.Hash{haveCommit})
+	got, err := Objects(s.T().Context(), s.Storer, []plumbing.Hash{cReAdd}, []plumbing.Hash{haveCommit})
 	s.NoError(err)
 
 	gotSet := make(map[plumbing.Hash]bool, len(got))
@@ -559,7 +561,7 @@ func (s *RevListSuite) TestRevListObjects_ReintroducedBlobInHaveAncestor() {
 	})
 	want := testMakeCommit(t, sto, wantTree, have)
 
-	got, err := Objects(sto, []plumbing.Hash{want}, []plumbing.Hash{have})
+	got, err := Objects(s.T().Context(), sto, []plumbing.Hash{want}, []plumbing.Hash{have})
 	s.NoError(err)
 
 	gotSet := make(map[plumbing.Hash]bool, len(got))
@@ -630,7 +632,7 @@ func (s *RevListSuite) TestRevListObjects_MissingHaveAncestorIsTolerated() {
 	})
 	want := testMakeCommit(t, sto, wantTree, have)
 
-	got, err := Objects(sto, []plumbing.Hash{want}, []plumbing.Hash{have})
+	got, err := Objects(s.T().Context(), sto, []plumbing.Hash{want}, []plumbing.Hash{have})
 	s.NoError(err, "missing haves ancestors should be tolerated")
 
 	gotSet := make(map[plumbing.Hash]bool, len(got))
@@ -673,7 +675,7 @@ func (s *RevListSuite) TestRevListObjects_MissingWantAncestorErrors() {
 	s.Require().Error(gitErr, "git rev-list must error on missing want ancestor (otherwise this test's premise is wrong)")
 
 	// Objects() should match git's behavior and return an error.
-	_, err = Objects(sto, []plumbing.Hash{want}, []plumbing.Hash{have})
+	_, err = Objects(s.T().Context(), sto, []plumbing.Hash{want}, []plumbing.Hash{have})
 	s.Error(err, "Objects must error on missing want ancestor to match git rev-list")
 }
 
@@ -686,7 +688,7 @@ func (s *RevListSuite) TestRevListObjects_MissingWantParentTreeReturnsError() {
 	})
 	want := s.makeCommit(wantTree, parent)
 
-	_, err := Objects(s.Storer, []plumbing.Hash{want}, []plumbing.Hash{parent})
+	_, err := Objects(s.T().Context(), s.Storer, []plumbing.Hash{want}, []plumbing.Hash{parent})
 	s.Error(err, "missing trees for reachable want parents must not be ignored")
 }
 
@@ -712,7 +714,7 @@ func (s *RevListSuite) TestRevListObjects_SkewedCommitTimesDoNotResendCommonBase
 	})
 	want := s.makeCommitAt(wantTree, time.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC), base)
 
-	got, err := Objects(s.Storer, []plumbing.Hash{want}, []plumbing.Hash{have})
+	got, err := Objects(s.T().Context(), s.Storer, []plumbing.Hash{want}, []plumbing.Hash{have})
 	s.Require().NoError(err)
 
 	gotSet := make(map[plumbing.Hash]bool, len(got))
@@ -736,7 +738,7 @@ func (s *RevListSuite) TestRevListObjects_ShallowTaggedCommitStopsAtBoundary() {
 	_, err = blobWriter.Write([]byte("README\n"))
 	s.Require().NoError(err)
 	s.Require().NoError(blobWriter.Close())
-	blob, err := sto.SetEncodedObject(blobObj)
+	blob, err := sto.SetEncodedObject(s.T().Context(), blobObj)
 	s.Require().NoError(err)
 
 	tree := &object.Tree{Entries: []object.TreeEntry{
@@ -745,7 +747,7 @@ func (s *RevListSuite) TestRevListObjects_ShallowTaggedCommitStopsAtBoundary() {
 	treeObj := sto.NewEncodedObject()
 	treeObj.SetType(plumbing.TreeObject)
 	s.Require().NoError(tree.Encode(treeObj))
-	treeHash, err := sto.SetEncodedObject(treeObj)
+	treeHash, err := sto.SetEncodedObject(s.T().Context(), treeObj)
 	s.Require().NoError(err)
 
 	missingParent := plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
@@ -760,9 +762,9 @@ func (s *RevListSuite) TestRevListObjects_ShallowTaggedCommitStopsAtBoundary() {
 	commitObj := sto.NewEncodedObject()
 	commitObj.SetType(plumbing.CommitObject)
 	s.Require().NoError(commit.Encode(commitObj))
-	commitHash, err := sto.SetEncodedObject(commitObj)
+	commitHash, err := sto.SetEncodedObject(s.T().Context(), commitObj)
 	s.Require().NoError(err)
-	s.Require().NoError(sto.SetShallow([]plumbing.Hash{commitHash}))
+	s.Require().NoError(sto.SetShallow(s.T().Context(), []plumbing.Hash{commitHash}))
 
 	tag := &object.Tag{
 		Name:       "v0.0.1",
@@ -774,10 +776,10 @@ func (s *RevListSuite) TestRevListObjects_ShallowTaggedCommitStopsAtBoundary() {
 	tagObj := sto.NewEncodedObject()
 	tagObj.SetType(plumbing.TagObject)
 	s.Require().NoError(tag.Encode(tagObj))
-	tagHash, err := sto.SetEncodedObject(tagObj)
+	tagHash, err := sto.SetEncodedObject(s.T().Context(), tagObj)
 	s.Require().NoError(err)
 
-	got, err := Objects(sto, []plumbing.Hash{tagHash}, nil)
+	got, err := Objects(s.T().Context(), sto, []plumbing.Hash{tagHash}, nil)
 	s.Require().NoError(err)
 
 	gotSet := make(map[plumbing.Hash]bool, len(got))
@@ -824,7 +826,7 @@ func (s *RevListSuite) TestRevListObjects_ClockSkewedHaveAncestorMissingParentTo
 	})
 	want := s.makeCommitAt(wantTree, time.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC), b)
 
-	got, err := Objects(s.Storer, []plumbing.Hash{want}, []plumbing.Hash{have})
+	got, err := Objects(s.T().Context(), s.Storer, []plumbing.Hash{want}, []plumbing.Hash{have})
 	s.NoError(err, "missing parent of clock-skewed haves ancestor must be tolerated")
 
 	gotSet := make(map[plumbing.Hash]bool, len(got))
@@ -849,7 +851,7 @@ func benchFixture(b *testing.B) (storer.EncodedObjectStorer, plumbing.Hash, plum
 	sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
 	head := plumbing.NewHash("e8788ad9165781196e917292d6055cba1d78664e")
-	c, err := object.GetCommit(sto, head)
+	c, err := object.GetCommit(b.Context(), sto, head)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -859,7 +861,7 @@ func benchFixture(b *testing.B) (storer.EncodedObjectStorer, plumbing.Hash, plum
 		if c.NumParents() == 0 {
 			break
 		}
-		c, err = c.Parent(0)
+		c, err = c.Parent(b.Context(), 0)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -877,7 +879,7 @@ func BenchmarkObjects(b *testing.B) {
 	})
 	b.ResetTimer()
 	for b.Loop() {
-		_, err := Objects(s, []plumbing.Hash{want}, []plumbing.Hash{have})
+		_, err := Objects(b.Context(), s, []plumbing.Hash{want}, []plumbing.Hash{have})
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/plumbing/storer/index.go
+++ b/plumbing/storer/index.go
@@ -1,9 +1,13 @@
 package storer
 
-import "github.com/go-git/go-git/v6/plumbing/format/index"
+import (
+	"context"
+
+	"github.com/go-git/go-git/v6/plumbing/format/index"
+)
 
 // IndexStorer generic storage of index.Index
 type IndexStorer interface {
-	SetIndex(*index.Index) error
-	Index() (*index.Index, error)
+	SetIndex(ctx context.Context, idx *index.Index) error
+	Index(ctx context.Context) (*index.Index, error)
 }

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -204,7 +204,7 @@ func NewEncodedObjectSliceIter(series []plumbing.EncodedObject) *EncodedObjectSl
 // Next returns the next object from the iterator. If the iterator has reached
 // the end it will return io.EOF as an error. If the object is retrieved
 // successfully error will be nil.
-func (iter *EncodedObjectSliceIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
+func (iter *EncodedObjectSliceIter) Next(_ context.Context) (plumbing.EncodedObject, error) {
 	if len(iter.series) == 0 {
 		return nil, io.EOF
 	}

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -1,6 +1,7 @@
 package storer
 
 import (
+	"context"
 	"errors"
 	"io"
 	"time"
@@ -11,11 +12,15 @@ import (
 // ErrStop is used to stop a ForEach function in an Iter
 var ErrStop = errors.New("stop iter")
 
-// EncodedObjectStorer generic storage of objects
+// EncodedObjectStorer generic storage of objects.
+//
+// Implementations should honor cancellation of the provided context where
+// they perform I/O. Methods without a context parameter are guaranteed not
+// to perform I/O.
 type EncodedObjectStorer interface {
 	// RawObjectWriter returns a io.WriterCloser to write the object without the
 	// need of providing a plumbing.EncodedObject.
-	RawObjectWriter(typ plumbing.ObjectType, sz int64) (w io.WriteCloser, err error)
+	RawObjectWriter(ctx context.Context, typ plumbing.ObjectType, sz int64) (w io.WriteCloser, err error)
 	// NewEncodedObject returns a new plumbing.EncodedObject, the real type
 	// of the object can be a custom implementation or the default one,
 	// plumbing.MemoryObject.
@@ -23,7 +28,7 @@ type EncodedObjectStorer interface {
 	// SetEncodedObject saves an object into the storage, the object should
 	// be created with the NewEncodedObject, method, and file if the type is
 	// not supported.
-	SetEncodedObject(plumbing.EncodedObject) (plumbing.Hash, error)
+	SetEncodedObject(ctx context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error)
 	// EncodedObject gets an object by hash with the given
 	// plumbing.ObjectType. Implementors should return
 	// (nil, plumbing.ErrObjectNotFound) if an object doesn't exist with
@@ -32,18 +37,18 @@ type EncodedObjectStorer interface {
 	// Valid plumbing.ObjectType values are CommitObject, BlobObject, TagObject,
 	// TreeObject and AnyObject. If plumbing.AnyObject is given, the object must
 	// be looked up regardless of its type.
-	EncodedObject(plumbing.ObjectType, plumbing.Hash) (plumbing.EncodedObject, error)
+	EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error)
 	// IterObjects returns a custom EncodedObjectStorer over all the object
 	// on the storage.
 	//
 	// Valid plumbing.ObjectType values are CommitObject, BlobObject, TagObject,
-	IterEncodedObjects(plumbing.ObjectType) (EncodedObjectIter, error)
+	IterEncodedObjects(ctx context.Context, t plumbing.ObjectType) (EncodedObjectIter, error)
 	// HasEncodedObject returns ErrObjNotFound if the object doesn't
 	// exist.  If the object does exist, it returns nil.
-	HasEncodedObject(plumbing.Hash) error
+	HasEncodedObject(ctx context.Context, h plumbing.Hash) error
 	// EncodedObjectSize returns the plaintext size of the encoded object.
-	EncodedObjectSize(plumbing.Hash) (int64, error)
-	AddAlternate(remote string) error
+	EncodedObjectSize(ctx context.Context, h plumbing.Hash) (int64, error)
+	AddAlternate(ctx context.Context, remote string) error
 }
 
 // DeltaObjectStorer is an EncodedObjectStorer that can return delta
@@ -51,14 +56,14 @@ type EncodedObjectStorer interface {
 type DeltaObjectStorer interface {
 	// DeltaObject is the same as EncodedObject but without resolving deltas.
 	// Deltas will be returned as plumbing.DeltaObject instances.
-	DeltaObject(plumbing.ObjectType, plumbing.Hash) (plumbing.EncodedObject, error)
+	DeltaObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error)
 }
 
 // Transactioner is a optional method for ObjectStorer, it enables transactional read and write
 // operations.
 type Transactioner interface {
 	// Begin starts a transaction.
-	Begin() Transaction
+	Begin(ctx context.Context) Transaction
 }
 
 // LooseObjectStorer is an optional interface for managing "loose"
@@ -68,14 +73,14 @@ type LooseObjectStorer interface {
 	// in the repository without necessarily having to read those objects.
 	// Objects only inside pack files may be omitted.
 	// If ErrStop is sent the iteration is stop but no error is returned.
-	ForEachObjectHash(func(plumbing.Hash) error) error
+	ForEachObjectHash(ctx context.Context, cb func(plumbing.Hash) error) error
 	// LooseObjectTime looks up the (m)time associated with the
 	// loose object (that is not in a pack file). Some
 	// implementations (e.g. without loose objects)
 	// always return an error.
-	LooseObjectTime(plumbing.Hash) (time.Time, error)
+	LooseObjectTime(ctx context.Context, h plumbing.Hash) (time.Time, error)
 	// DeleteLooseObject deletes a loose object if it exists.
-	DeleteLooseObject(plumbing.Hash) error
+	DeleteLooseObject(ctx context.Context, h plumbing.Hash) error
 }
 
 // PackedObjectStorer is an optional interface for managing objects in
@@ -83,10 +88,10 @@ type LooseObjectStorer interface {
 type PackedObjectStorer interface {
 	// ObjectPacks returns hashes of object packs if the underlying
 	// implementation has pack files.
-	ObjectPacks() ([]plumbing.Hash, error)
+	ObjectPacks(ctx context.Context) ([]plumbing.Hash, error)
 	// DeleteOldObjectPackAndIndex deletes an object pack and the corresponding index file if they exist.
 	// Deletion is only performed if the pack is older than the supplied time (or the time is zero).
-	DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error
+	DeleteOldObjectPackAndIndex(ctx context.Context, h plumbing.Hash, t time.Time) error
 }
 
 // PackfileWriter is an optional method for ObjectStorer, it enables directly writing
@@ -96,22 +101,29 @@ type PackfileWriter interface {
 	//
 	// If the Storer not implements PackfileWriter the objects should be written
 	// using the Set method.
-	PackfileWriter() (io.WriteCloser, error)
+	PackfileWriter(ctx context.Context) (io.WriteCloser, error)
 }
 
 // EncodedObjectIter is a generic closable interface for iterating over objects.
+//
+// Close is intentionally context-free: it releases resources and must be
+// callable during cleanup, including after the iteration context has been
+// canceled.
 type EncodedObjectIter interface {
-	Next() (plumbing.EncodedObject, error)
-	ForEach(func(plumbing.EncodedObject) error) error
+	Next(ctx context.Context) (plumbing.EncodedObject, error)
+	ForEach(ctx context.Context, cb func(plumbing.EncodedObject) error) error
 	Close()
 }
 
 // Transaction is an in-progress storage transaction. A transaction must end
 // with a call to Commit or Rollback.
+//
+// Rollback is intentionally context-free: it must be usable to clean up
+// after the transaction's context has been canceled.
 type Transaction interface {
-	SetEncodedObject(plumbing.EncodedObject) (plumbing.Hash, error)
-	EncodedObject(plumbing.ObjectType, plumbing.Hash) (plumbing.EncodedObject, error)
-	Commit() error
+	SetEncodedObject(ctx context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error)
+	EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error)
+	Commit(ctx context.Context) error
 	Rollback() error
 }
 
@@ -145,13 +157,13 @@ func NewEncodedObjectLookupIter(
 // the end it will return io.EOF as an error. If the object can't be found in
 // the object storage, it will return plumbing.ErrObjectNotFound as an error.
 // If the object is retrieved successfully error will be nil.
-func (iter *EncodedObjectLookupIter) Next() (plumbing.EncodedObject, error) {
+func (iter *EncodedObjectLookupIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
 	if iter.pos >= len(iter.series) {
 		return nil, io.EOF
 	}
 
 	hash := iter.series[iter.pos]
-	obj, err := iter.storage.EncodedObject(iter.t, hash)
+	obj, err := iter.storage.EncodedObject(ctx, iter.t, hash)
 	if err == nil {
 		iter.pos++
 	}
@@ -162,8 +174,8 @@ func (iter *EncodedObjectLookupIter) Next() (plumbing.EncodedObject, error) {
 // ForEach call the cb function for each object contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *EncodedObjectLookupIter) ForEach(cb func(plumbing.EncodedObject) error) error {
-	return ForEachIterator(iter, cb)
+func (iter *EncodedObjectLookupIter) ForEach(ctx context.Context, cb func(plumbing.EncodedObject) error) error {
+	return ForEachIterator(ctx, iter, cb)
 }
 
 // Close releases any resources used by the iterator.
@@ -192,7 +204,7 @@ func NewEncodedObjectSliceIter(series []plumbing.EncodedObject) *EncodedObjectSl
 // Next returns the next object from the iterator. If the iterator has reached
 // the end it will return io.EOF as an error. If the object is retrieved
 // successfully error will be nil.
-func (iter *EncodedObjectSliceIter) Next() (plumbing.EncodedObject, error) {
+func (iter *EncodedObjectSliceIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
 	if len(iter.series) == 0 {
 		return nil, io.EOF
 	}
@@ -206,8 +218,8 @@ func (iter *EncodedObjectSliceIter) Next() (plumbing.EncodedObject, error) {
 // ForEach call the cb function for each object contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *EncodedObjectSliceIter) ForEach(cb func(plumbing.EncodedObject) error) error {
-	return ForEachIterator(iter, cb)
+func (iter *EncodedObjectSliceIter) ForEach(ctx context.Context, cb func(plumbing.EncodedObject) error) error {
+	return ForEachIterator(ctx, iter, cb)
 }
 
 // Close releases any resources used by the iterator.
@@ -232,16 +244,16 @@ func NewMultiEncodedObjectIter(iters []EncodedObjectIter) EncodedObjectIter {
 
 // Next returns the next object from the iterator, if one iterator reach io.EOF
 // is removed and the next one is used.
-func (iter *MultiEncodedObjectIter) Next() (plumbing.EncodedObject, error) {
+func (iter *MultiEncodedObjectIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
 	if len(iter.iters) == 0 {
 		return nil, io.EOF
 	}
 
-	obj, err := iter.iters[0].Next()
+	obj, err := iter.iters[0].Next(ctx)
 	if err == io.EOF {
 		iter.iters[0].Close()
 		iter.iters = iter.iters[1:]
-		return iter.Next()
+		return iter.Next(ctx)
 	}
 
 	return obj, err
@@ -250,8 +262,8 @@ func (iter *MultiEncodedObjectIter) Next() (plumbing.EncodedObject, error) {
 // ForEach call the cb function for each object contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *MultiEncodedObjectIter) ForEach(cb func(plumbing.EncodedObject) error) error {
-	return ForEachIterator(iter, cb)
+func (iter *MultiEncodedObjectIter) ForEach(ctx context.Context, cb func(plumbing.EncodedObject) error) error {
+	return ForEachIterator(ctx, iter, cb)
 }
 
 // Close releases any resources used by the iterator.
@@ -262,16 +274,20 @@ func (iter *MultiEncodedObjectIter) Close() {
 }
 
 type bareIterator interface {
-	Next() (plumbing.EncodedObject, error)
+	Next(ctx context.Context) (plumbing.EncodedObject, error)
 	Close()
 }
 
 // ForEachIterator is a helper function to build iterators without need to
 // rewrite the same ForEach function each time.
-func ForEachIterator(iter bareIterator, cb func(plumbing.EncodedObject) error) error {
+func ForEachIterator(ctx context.Context, iter bareIterator, cb func(plumbing.EncodedObject) error) error {
 	defer iter.Close()
 	for {
-		obj, err := iter.Next()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		obj, err := iter.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
 				return nil

--- a/plumbing/storer/object_test.go
+++ b/plumbing/storer/object_test.go
@@ -1,6 +1,7 @@
 package storer
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"testing"
@@ -49,7 +50,7 @@ func (s *ObjectSuite) TestMultiObjectIterNext() {
 	})
 
 	var i int
-	iter.ForEach(func(o plumbing.EncodedObject) error {
+	iter.ForEach(s.T().Context(), func(o plumbing.EncodedObject) error {
 		s.Equal(expected[i], o)
 		i++
 		return nil
@@ -70,7 +71,7 @@ func (s *ObjectSuite) TestObjectLookupIter() {
 
 	storage := &MockObjectStorage{s.Objects}
 	i := NewEncodedObjectLookupIter(storage, plumbing.CommitObject, s.Hash)
-	err := i.ForEach(func(o plumbing.EncodedObject) error {
+	err := i.ForEach(s.T().Context(), func(o plumbing.EncodedObject) error {
 		s.NotNil(o)
 		s.Equal(s.Hash[count].String(), o.Hash().String())
 		count++
@@ -85,7 +86,7 @@ func (s *ObjectSuite) TestObjectSliceIter() {
 	var count int
 
 	i := NewEncodedObjectSliceIter(s.Objects)
-	err := i.ForEach(func(o plumbing.EncodedObject) error {
+	err := i.ForEach(s.T().Context(), func(o plumbing.EncodedObject) error {
 		s.NotNil(o)
 		s.Equal(s.Hash[count].String(), o.Hash().String())
 		count++
@@ -101,7 +102,7 @@ func (s *ObjectSuite) TestObjectSliceIterStop() {
 	i := NewEncodedObjectSliceIter(s.Objects)
 
 	count := 0
-	err := i.ForEach(func(o plumbing.EncodedObject) error {
+	err := i.ForEach(s.T().Context(), func(o plumbing.EncodedObject) error {
 		s.NotNil(o)
 		s.Equal(s.Hash[count].String(), o.Hash().String())
 		count++
@@ -117,7 +118,7 @@ func (s *ObjectSuite) TestObjectSliceIterError() {
 		s.buildObject([]byte("foo")),
 	})
 
-	err := i.ForEach(func(plumbing.EncodedObject) error {
+	err := i.ForEach(s.T().Context(), func(plumbing.EncodedObject) error {
 		return fmt.Errorf("a random error")
 	})
 
@@ -128,7 +129,7 @@ type MockObjectStorage struct {
 	db []plumbing.EncodedObject
 }
 
-func (o *MockObjectStorage) RawObjectWriter(_ plumbing.ObjectType, _ int64) (w io.WriteCloser, err error) {
+func (o *MockObjectStorage) RawObjectWriter(_ context.Context, _ plumbing.ObjectType, _ int64) (w io.WriteCloser, err error) {
 	return nil, nil
 }
 
@@ -136,11 +137,11 @@ func (o *MockObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 	return nil
 }
 
-func (o *MockObjectStorage) SetEncodedObject(_ plumbing.EncodedObject) (plumbing.Hash, error) {
+func (o *MockObjectStorage) SetEncodedObject(_ context.Context, _ plumbing.EncodedObject) (plumbing.Hash, error) {
 	return plumbing.ZeroHash, nil
 }
 
-func (o *MockObjectStorage) HasEncodedObject(h plumbing.Hash) error {
+func (o *MockObjectStorage) HasEncodedObject(_ context.Context, h plumbing.Hash) error {
 	for _, o := range o.db {
 		if o.Hash() == h {
 			return nil
@@ -149,7 +150,7 @@ func (o *MockObjectStorage) HasEncodedObject(h plumbing.Hash) error {
 	return plumbing.ErrObjectNotFound
 }
 
-func (o *MockObjectStorage) EncodedObjectSize(h plumbing.Hash) (
+func (o *MockObjectStorage) EncodedObjectSize(_ context.Context, h plumbing.Hash) (
 	size int64, err error,
 ) {
 	for _, o := range o.db {
@@ -160,7 +161,7 @@ func (o *MockObjectStorage) EncodedObjectSize(h plumbing.Hash) (
 	return 0, plumbing.ErrObjectNotFound
 }
 
-func (o *MockObjectStorage) EncodedObject(_ plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (o *MockObjectStorage) EncodedObject(_ context.Context, _ plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	for _, o := range o.db {
 		if o.Hash() == h {
 			return o, nil
@@ -169,14 +170,14 @@ func (o *MockObjectStorage) EncodedObject(_ plumbing.ObjectType, h plumbing.Hash
 	return nil, plumbing.ErrObjectNotFound
 }
 
-func (o *MockObjectStorage) IterEncodedObjects(_ plumbing.ObjectType) (EncodedObjectIter, error) {
+func (o *MockObjectStorage) IterEncodedObjects(_ context.Context, _ plumbing.ObjectType) (EncodedObjectIter, error) {
 	return nil, nil
 }
 
-func (o *MockObjectStorage) Begin() Transaction {
+func (o *MockObjectStorage) Begin(_ context.Context) Transaction {
 	return nil
 }
 
-func (o *MockObjectStorage) AddAlternate(_ string) error {
+func (o *MockObjectStorage) AddAlternate(_ context.Context, _ string) error {
 	return nil
 }

--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -1,6 +1,7 @@
 package storer
 
 import (
+	"context"
 	"errors"
 	"io"
 
@@ -15,24 +16,31 @@ const MaxResolveRecursion = 1024
 var ErrMaxResolveRecursion = errors.New("max. recursion level reached")
 
 // ReferenceStorer is a generic storage of references.
+//
+// Implementations should honor cancellation of the provided context where
+// they perform I/O.
 type ReferenceStorer interface {
-	SetReference(*plumbing.Reference) error
+	SetReference(ctx context.Context, r *plumbing.Reference) error
 	// CheckAndSetReference sets the reference `new`, but if `old` is
 	// not `nil`, it first checks that the current stored value for
 	// `old.Name()` matches the given reference value in `old`.  If
 	// not, it returns an error and doesn't update `new`.
-	CheckAndSetReference(newRef, old *plumbing.Reference) error
-	Reference(plumbing.ReferenceName) (*plumbing.Reference, error)
-	IterReferences() (ReferenceIter, error)
-	RemoveReference(plumbing.ReferenceName) error
-	CountLooseRefs() (int, error)
-	PackRefs() error
+	CheckAndSetReference(ctx context.Context, newRef, old *plumbing.Reference) error
+	Reference(ctx context.Context, name plumbing.ReferenceName) (*plumbing.Reference, error)
+	IterReferences(ctx context.Context) (ReferenceIter, error)
+	RemoveReference(ctx context.Context, name plumbing.ReferenceName) error
+	CountLooseRefs(ctx context.Context) (int, error)
+	PackRefs(ctx context.Context) error
 }
 
 // ReferenceIter is a generic closable interface for iterating over references.
+//
+// Close is intentionally context-free: it releases resources and must be
+// callable during cleanup, including after the iteration context has been
+// canceled.
 type ReferenceIter interface {
-	Next() (*plumbing.Reference, error)
-	ForEach(func(*plumbing.Reference) error) error
+	Next(ctx context.Context) (*plumbing.Reference, error)
+	ForEach(ctx context.Context, cb func(*plumbing.Reference) error) error
 	Close()
 }
 
@@ -52,9 +60,13 @@ func NewReferenceFilteredIter(
 
 // Next returns the next reference from the iterator. If the iterator has reached
 // the end it will return io.EOF as an error.
-func (iter *referenceFilteredIter) Next() (*plumbing.Reference, error) {
+func (iter *referenceFilteredIter) Next(ctx context.Context) (*plumbing.Reference, error) {
 	for {
-		r, err := iter.iter.Next()
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		r, err := iter.iter.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -70,10 +82,10 @@ func (iter *referenceFilteredIter) Next() (*plumbing.Reference, error) {
 // ForEach call the cb function for each reference contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stopped but no error is returned. The iterator is closed.
-func (iter *referenceFilteredIter) ForEach(cb func(*plumbing.Reference) error) error {
+func (iter *referenceFilteredIter) ForEach(ctx context.Context, cb func(*plumbing.Reference) error) error {
 	defer iter.Close()
 	for {
-		r, err := iter.Next()
+		r, err := iter.Next(ctx)
 		if err == io.EOF {
 			break
 		}
@@ -119,7 +131,7 @@ func NewReferenceSliceIter(series []*plumbing.Reference) ReferenceIter {
 
 // Next returns the next reference from the iterator. If the iterator has
 // reached the end it will return io.EOF as an error.
-func (iter *ReferenceSliceIter) Next() (*plumbing.Reference, error) {
+func (iter *ReferenceSliceIter) Next(ctx context.Context) (*plumbing.Reference, error) {
 	if iter.pos >= len(iter.series) {
 		return nil, io.EOF
 	}
@@ -132,19 +144,23 @@ func (iter *ReferenceSliceIter) Next() (*plumbing.Reference, error) {
 // ForEach call the cb function for each reference contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *ReferenceSliceIter) ForEach(cb func(*plumbing.Reference) error) error {
-	return forEachReferenceIter(iter, cb)
+func (iter *ReferenceSliceIter) ForEach(ctx context.Context, cb func(*plumbing.Reference) error) error {
+	return forEachReferenceIter(ctx, iter, cb)
 }
 
 type bareReferenceIterator interface {
-	Next() (*plumbing.Reference, error)
+	Next(ctx context.Context) (*plumbing.Reference, error)
 	Close()
 }
 
-func forEachReferenceIter(iter bareReferenceIterator, cb func(*plumbing.Reference) error) error {
+func forEachReferenceIter(ctx context.Context, iter bareReferenceIterator, cb func(*plumbing.Reference) error) error {
 	defer iter.Close()
 	for {
-		obj, err := iter.Next()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		obj, err := iter.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
 				return nil
@@ -185,16 +201,16 @@ func NewMultiReferenceIter(iters []ReferenceIter) ReferenceIter {
 
 // Next returns the next reference from the iterator, if one iterator reach
 // io.EOF is removed and the next one is used.
-func (iter *MultiReferenceIter) Next() (*plumbing.Reference, error) {
+func (iter *MultiReferenceIter) Next(ctx context.Context) (*plumbing.Reference, error) {
 	if len(iter.iters) == 0 {
 		return nil, io.EOF
 	}
 
-	obj, err := iter.iters[0].Next()
+	obj, err := iter.iters[0].Next(ctx)
 	if err == io.EOF {
 		iter.iters[0].Close()
 		iter.iters = iter.iters[1:]
-		return iter.Next()
+		return iter.Next(ctx)
 	}
 
 	return obj, err
@@ -203,8 +219,8 @@ func (iter *MultiReferenceIter) Next() (*plumbing.Reference, error) {
 // ForEach call the cb function for each reference contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stop but no error is returned. The iterator is closed.
-func (iter *MultiReferenceIter) ForEach(cb func(*plumbing.Reference) error) error {
-	return forEachReferenceIter(iter, cb)
+func (iter *MultiReferenceIter) ForEach(ctx context.Context, cb func(*plumbing.Reference) error) error {
+	return forEachReferenceIter(ctx, iter, cb)
 }
 
 // Close releases any resources used by the iterator.
@@ -215,18 +231,18 @@ func (iter *MultiReferenceIter) Close() {
 }
 
 // ResolveReference resolves a SymbolicReference to a HashReference.
-func ResolveReference(s ReferenceStorer, n plumbing.ReferenceName) (*plumbing.Reference, error) {
-	r, err := s.Reference(n)
+func ResolveReference(ctx context.Context, s ReferenceStorer, n plumbing.ReferenceName) (*plumbing.Reference, error) {
+	r, err := s.Reference(ctx, n)
 	if err != nil {
 		return nil, err
 	}
 	if r == nil {
 		return nil, plumbing.ErrReferenceNotFound
 	}
-	return resolveReference(s, r, 0)
+	return resolveReference(ctx, s, r, 0)
 }
 
-func resolveReference(s ReferenceStorer, r *plumbing.Reference, recursion int) (*plumbing.Reference, error) {
+func resolveReference(ctx context.Context, s ReferenceStorer, r *plumbing.Reference, recursion int) (*plumbing.Reference, error) {
 	if r.Type() != plumbing.SymbolicReference {
 		return r, nil
 	}
@@ -235,11 +251,11 @@ func resolveReference(s ReferenceStorer, r *plumbing.Reference, recursion int) (
 		return nil, ErrMaxResolveRecursion
 	}
 
-	t, err := s.Reference(r.Target())
+	t, err := s.Reference(ctx, r.Target())
 	if err != nil {
 		return nil, err
 	}
 
 	recursion++
-	return resolveReference(s, t, recursion)
+	return resolveReference(ctx, s, t, recursion)
 }

--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -131,7 +131,7 @@ func NewReferenceSliceIter(series []*plumbing.Reference) ReferenceIter {
 
 // Next returns the next reference from the iterator. If the iterator has
 // reached the end it will return io.EOF as an error.
-func (iter *ReferenceSliceIter) Next(ctx context.Context) (*plumbing.Reference, error) {
+func (iter *ReferenceSliceIter) Next(_ context.Context) (*plumbing.Reference, error) {
 	if iter.pos >= len(iter.series) {
 		return nil, io.EOF
 	}

--- a/plumbing/storer/reference_test.go
+++ b/plumbing/storer/reference_test.go
@@ -26,15 +26,15 @@ func (s *ReferenceSuite) TestReferenceSliceIterNext() {
 	}
 
 	i := NewReferenceSliceIter(slice)
-	foo, err := i.Next()
+	foo, err := i.Next(s.T().Context())
 	s.NoError(err)
 	s.True(foo == slice[0])
 
-	bar, err := i.Next()
+	bar, err := i.Next(s.T().Context())
 	s.NoError(err)
 	s.True(bar == slice[1])
 
-	empty, err := i.Next()
+	empty, err := i.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 	s.Nil(empty)
 }
@@ -47,7 +47,7 @@ func (s *ReferenceSuite) TestReferenceSliceIterForEach() {
 
 	i := NewReferenceSliceIter(slice)
 	var count int
-	i.ForEach(func(r *plumbing.Reference) error {
+	i.ForEach(s.T().Context(), func(r *plumbing.Reference) error {
 		s.True(r == slice[count])
 		count++
 		return nil
@@ -65,7 +65,7 @@ func (s *ReferenceSuite) TestReferenceSliceIterForEachError() {
 	i := NewReferenceSliceIter(slice)
 	var count int
 	exampleErr := errors.New("SOME ERROR")
-	err := i.ForEach(func(r *plumbing.Reference) error {
+	err := i.ForEach(s.T().Context(), func(r *plumbing.Reference) error {
 		s.True(r == slice[count])
 		count++
 		if count == 2 {
@@ -88,7 +88,7 @@ func (s *ReferenceSuite) TestReferenceSliceIterForEachStop() {
 	i := NewReferenceSliceIter(slice)
 
 	var count int
-	i.ForEach(func(r *plumbing.Reference) error {
+	i.ForEach(s.T().Context(), func(r *plumbing.Reference) error {
 		s.True(r == slice[count])
 		count++
 		return ErrStop
@@ -106,12 +106,12 @@ func (s *ReferenceSuite) TestReferenceFilteredIterNext() {
 	i := NewReferenceFilteredIter(func(r *plumbing.Reference) bool {
 		return r.Name() == "bar"
 	}, NewReferenceSliceIter(slice))
-	foo, err := i.Next()
+	foo, err := i.Next(s.T().Context())
 	s.NoError(err)
 	s.False(foo == slice[0])
 	s.True(foo == slice[1])
 
-	empty, err := i.Next()
+	empty, err := i.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 	s.Nil(empty)
 }
@@ -126,7 +126,7 @@ func (s *ReferenceSuite) TestReferenceFilteredIterForEach() {
 		return r.Name() == "bar"
 	}, NewReferenceSliceIter(slice))
 	var count int
-	i.ForEach(func(r *plumbing.Reference) error {
+	i.ForEach(s.T().Context(), func(r *plumbing.Reference) error {
 		s.True(r == slice[1])
 		count++
 		return nil
@@ -146,7 +146,7 @@ func (s *ReferenceSuite) TestReferenceFilteredIterError() {
 	}, NewReferenceSliceIter(slice))
 	var count int
 	exampleErr := errors.New("SOME ERROR")
-	err := i.ForEach(func(r *plumbing.Reference) error {
+	err := i.ForEach(s.T().Context(), func(r *plumbing.Reference) error {
 		s.True(r == slice[1])
 		count++
 		if count == 1 {
@@ -171,7 +171,7 @@ func (s *ReferenceSuite) TestReferenceFilteredIterForEachStop() {
 	}, NewReferenceSliceIter(slice))
 
 	var count int
-	i.ForEach(func(r *plumbing.Reference) error {
+	i.ForEach(s.T().Context(), func(r *plumbing.Reference) error {
 		s.True(r == slice[1])
 		count++
 		return ErrStop
@@ -193,7 +193,7 @@ func (s *ReferenceSuite) TestMultiReferenceIterForEach() {
 	)
 
 	var result []string
-	err := i.ForEach(func(r *plumbing.Reference) error {
+	err := i.ForEach(s.T().Context(), func(r *plumbing.Reference) error {
 		result = append(result, r.Name().String())
 		return nil
 	})

--- a/plumbing/storer/reflog.go
+++ b/plumbing/storer/reflog.go
@@ -1,6 +1,8 @@
 package storer
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/reflog"
 )
@@ -9,11 +11,11 @@ import (
 type ReflogStorer interface {
 	// Reflog returns the reflog entries for the given reference,
 	// ordered from oldest to newest.
-	Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, error)
+	Reflog(ctx context.Context, name plumbing.ReferenceName) ([]*reflog.Entry, error)
 
 	// AppendReflog appends a single entry to the reflog for the given reference.
-	AppendReflog(name plumbing.ReferenceName, entry *reflog.Entry) error
+	AppendReflog(ctx context.Context, name plumbing.ReferenceName, entry *reflog.Entry) error
 
 	// DeleteReflog removes the entire reflog for the given reference.
-	DeleteReflog(name plumbing.ReferenceName) error
+	DeleteReflog(ctx context.Context, name plumbing.ReferenceName) error
 }

--- a/plumbing/storer/shallow.go
+++ b/plumbing/storer/shallow.go
@@ -1,10 +1,14 @@
 package storer
 
-import "github.com/go-git/go-git/v6/plumbing"
+import (
+	"context"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
 
 // ShallowStorer is a storage of references to shallow commits by hash,
 // meaning that these commits have missing parents because of a shallow fetch.
 type ShallowStorer interface {
-	SetShallow([]plumbing.Hash) error
-	Shallow() ([]plumbing.Hash, error)
+	SetShallow(ctx context.Context, hashes []plumbing.Hash) error
+	Shallow(ctx context.Context) ([]plumbing.Hash, error)
 }

--- a/plumbing/storer/storer.go
+++ b/plumbing/storer/storer.go
@@ -1,6 +1,8 @@
 package storer
 
 import (
+	"context"
+
 	"github.com/go-git/go-billy/v6"
 )
 
@@ -15,7 +17,7 @@ type Storer interface {
 type Initializer interface {
 	// Init performs initialization of the storer and returns the error, if
 	// any.
-	Init() error
+	Init(ctx context.Context) error
 }
 
 // FilesystemStorer is a storer that can be used to store objects and references

--- a/plumbing/transport/fetch.go
+++ b/plumbing/transport/fetch.go
@@ -36,7 +36,7 @@ func FetchPack(
 		reader = demuxer
 	}
 
-	if err := packfile.UpdateObjectStorage(st, reader); err != nil {
+	if err := packfile.UpdateObjectStorage(ctx, st, reader); err != nil {
 		return err
 	}
 
@@ -45,7 +45,7 @@ func FetchPack(
 	}
 
 	if shallowInfo != nil {
-		if err := updateShallow(st, shallowInfo); err != nil {
+		if err := updateShallow(ctx, st, shallowInfo); err != nil {
 			return err
 		}
 	}
@@ -53,8 +53,8 @@ func FetchPack(
 	return nil
 }
 
-func updateShallow(st storage.Storer, shallowInfo *packp.ShallowUpdate) error {
-	shallows, err := st.Shallow()
+func updateShallow(ctx context.Context, st storage.Storer, shallowInfo *packp.ShallowUpdate) error {
+	shallows, err := st.Shallow(ctx)
 	if err != nil {
 		return err
 	}
@@ -78,5 +78,5 @@ outer:
 		}
 	}
 
-	return st.SetShallow(shallows)
+	return st.SetShallow(ctx, shallows)
 }

--- a/plumbing/transport/file/file_integration_test.go
+++ b/plumbing/transport/file/file_integration_test.go
@@ -115,7 +115,7 @@ func TestFileTransport_Integration_V2(t *testing.T) {
 		Wants: []plumbing.Hash{master},
 	}))
 
-	obj, err := st.EncodedObject(plumbing.CommitObject, master)
+	obj, err := st.EncodedObject(t.Context(), plumbing.CommitObject, master)
 	require.NoError(t, err)
 	require.Equal(t, master, obj.Hash())
 }

--- a/plumbing/transport/http/backend_test.go
+++ b/plumbing/transport/http/backend_test.go
@@ -185,11 +185,11 @@ func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
 	require.NoError(t, sess.Fetch(context.Background(), st, &transport.FetchRequest{Wants: []plumbing.Hash{want}}))
 
 	// Verify by decoding the tip commit/tree (Fetch populates objects; no ref update at this layer).
-	cobj, err := st.EncodedObject(plumbing.CommitObject, want)
+	cobj, err := st.EncodedObject(t.Context(), plumbing.CommitObject, want)
 	require.NoError(t, err)
 	c, err := object.DecodeCommit(st, cobj)
 	require.NoError(t, err)
-	tobj, err := st.EncodedObject(plumbing.TreeObject, c.TreeHash)
+	tobj, err := st.EncodedObject(t.Context(), plumbing.TreeObject, c.TreeHash)
 	require.NoError(t, err)
 	trr, err := object.DecodeTree(st, tobj)
 	require.NoError(t, err)
@@ -220,11 +220,11 @@ func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
 	sess3.Close()
 
 	// Confirm the blob added by the CLI push is reachable in the newly fetched objects.
-	cobj3, err := st3.EncodedObject(plumbing.CommitObject, tip3)
+	cobj3, err := st3.EncodedObject(t.Context(), plumbing.CommitObject, tip3)
 	require.NoError(t, err)
 	c3, err := object.DecodeCommit(st3, cobj3)
 	require.NoError(t, err)
-	tobj3, err := st3.EncodedObject(plumbing.TreeObject, c3.TreeHash)
+	tobj3, err := st3.EncodedObject(t.Context(), plumbing.TreeObject, c3.TreeHash)
 	require.NoError(t, err)
 	t3, err := object.DecodeTree(st3, tobj3)
 	require.NoError(t, err)

--- a/plumbing/transport/http/dumb.go
+++ b/plumbing/transport/http/dumb.go
@@ -227,7 +227,7 @@ func (r *fetchWalker) process() error {
 
 	r.queue = append(r.queue, head)
 	for _, ref := range r.refs.References {
-		if r.st.HasEncodedObject(ref.Hash()) != nil {
+		if r.st.HasEncodedObject(r.ctx, ref.Hash()) != nil {
 			r.queue = append(r.queue, ref.Hash())
 		}
 	}
@@ -237,7 +237,7 @@ func (r *fetchWalker) process() error {
 }
 
 func (r *fetchWalker) fetchObject(objHash plumbing.Hash, obj plumbing.EncodedObject) (err error) {
-	if r.st.HasEncodedObject(objHash) == nil {
+	if r.st.HasEncodedObject(r.ctx, objHash) == nil {
 		return nil
 	}
 
@@ -394,7 +394,7 @@ LOOP:
 			return plumbing.ErrInvalidType
 		}
 
-		if _, err := r.st.SetEncodedObject(obj); err != nil {
+		if _, err := r.st.SetEncodedObject(r.ctx, obj); err != nil {
 			return err
 		}
 		processed[objHash.String()] = struct{}{}
@@ -406,7 +406,7 @@ LOOP:
 			return err
 		}
 
-		if err := packfile.UpdateObjectStorage(r.st, f); err != nil {
+		if err := packfile.UpdateObjectStorage(r.ctx, r.st, f); err != nil {
 			_ = f.Close()
 			return err
 		}

--- a/plumbing/transport/http/dumb_test.go
+++ b/plumbing/transport/http/dumb_test.go
@@ -83,8 +83,8 @@ func (s *dumbUploadPackSuite) SetupTest() {
 
 	s.Transport = NewTransport(Options{ForceDumb: true})
 
-	require.NoError(s.T(), transport.UpdateServerInfo(s.Storer, basicFS))
-	require.NoError(s.T(), transport.UpdateServerInfo(s.EmptyStorer, emptyFS))
+	require.NoError(s.T(), transport.UpdateServerInfo(s.T().Context(), s.Storer, basicFS))
+	require.NoError(s.T(), transport.UpdateServerInfo(s.T().Context(), s.EmptyStorer, emptyFS))
 }
 
 func (*dumbUploadPackSuite) TestDefaultBranch()                         {}

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -349,7 +349,7 @@ func (s *smartPackSession) fetchV2(ctx context.Context, st storage.Storer, req *
 	if req.Depth > 0 && !internal.FetchSupports(s.caps, "shallow") {
 		return transport.ErrShallowNotSupported
 	}
-	if err := transport.ReconcileObjectFormatV2(st, s.caps); err != nil {
+	if err := transport.ReconcileObjectFormatV2(ctx, st, s.caps); err != nil {
 		return err
 	}
 

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -46,28 +46,28 @@ func TestSmartMultiRoundFetch(t *testing.T) {
 	oldCommit := nthCommitFromHead(t, remoteStorage, plumbing.NewHash(fixture.Head), 50)
 
 	seedRef := plumbing.ReferenceName("refs/heads/seed-old")
-	require.NoError(t, remoteStorage.SetReference(plumbing.NewHashReference(seedRef, oldCommit)))
+	require.NoError(t, remoteStorage.SetReference(t.Context(), plumbing.NewHashReference(seedRef, oldCommit)))
 	seedPath := filepath.Join(t.TempDir(), "seed.git")
 	seedStorage := initBareStorage(t, seedPath)
 	defer func() { _ = seedStorage.Close() }()
 
 	fetchToStorage(t, remotePath, seedStorage, oldCommit)
-	require.NoError(t, seedStorage.SetReference(plumbing.NewHashReference(plumbing.Master, oldCommit)))
-	require.NoError(t, seedStorage.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))
-	require.NoError(t, remoteStorage.RemoveReference(seedRef))
+	require.NoError(t, seedStorage.SetReference(t.Context(), plumbing.NewHashReference(plumbing.Master, oldCommit)))
+	require.NoError(t, seedStorage.SetReference(t.Context(), plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))
+	require.NoError(t, remoteStorage.RemoveReference(t.Context(), seedRef))
 
 	clientPath := filepath.Join(t.TempDir(), "client.git")
 	clientStorage := initBareStorage(t, clientPath)
 	defer func() { _ = clientStorage.Close() }()
 
 	fetchToStorage(t, seedPath, clientStorage, oldCommit)
-	require.NoError(t, clientStorage.SetReference(plumbing.NewHashReference(plumbing.Master, oldCommit)))
-	require.NoError(t, clientStorage.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))
+	require.NoError(t, clientStorage.SetReference(t.Context(), plumbing.NewHashReference(plumbing.Master, oldCommit)))
+	require.NoError(t, clientStorage.SetReference(t.Context(), plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master)))
 	haves := commitHaves(t, clientStorage, oldCommit, 40)
 	require.Greater(t, len(haves), 20, "test setup must force multiple have rounds")
 
 	want := plumbing.NewHash(fixture.Head)
-	require.Error(t, clientStorage.HasEncodedObject(want), "seed client should not already have the remote tip")
+	require.Error(t, clientStorage.HasEncodedObject(t.Context(), want), "seed client should not already have the remote tip")
 
 	proxyURL, requests := setupCountingProxy(t, backend)
 
@@ -86,7 +86,7 @@ func TestSmartMultiRoundFetch(t *testing.T) {
 
 	err = session.Fetch(context.Background(), clientStorage, req)
 	require.NoError(t, err)
-	require.NoError(t, clientStorage.HasEncodedObject(want))
+	require.NoError(t, clientStorage.HasEncodedObject(t.Context(), want))
 
 	requests.mu.Lock()
 	defer requests.mu.Unlock()
@@ -260,7 +260,7 @@ func setupCountingProxy(t testing.TB, backendAddr *net.TCPAddr) (*url.URL, *uplo
 func nthCommitFromHead(t testing.TB, storage storer.EncodedObjectStorer, head plumbing.Hash, n int) plumbing.Hash {
 	t.Helper()
 
-	commit, err := object.GetCommit(storage, head)
+	commit, err := object.GetCommit(t.Context(), storage, head)
 	require.NoError(t, err)
 
 	iter := object.NewCommitPostorderIterFirstParent(commit, nil)
@@ -270,7 +270,7 @@ func nthCommitFromHead(t testing.TB, storage storer.EncodedObjectStorer, head pl
 		hash  plumbing.Hash
 		count int
 	)
-	err = iter.ForEach(func(c *object.Commit) error {
+	err = iter.ForEach(t.Context(), func(c *object.Commit) error {
 		hash = c.Hash
 		count++
 		if count == n {
@@ -286,14 +286,14 @@ func nthCommitFromHead(t testing.TB, storage storer.EncodedObjectStorer, head pl
 func commitHaves(t testing.TB, storage storer.EncodedObjectStorer, head plumbing.Hash, n int) []plumbing.Hash {
 	t.Helper()
 
-	commit, err := object.GetCommit(storage, head)
+	commit, err := object.GetCommit(t.Context(), storage, head)
 	require.NoError(t, err)
 
 	iter := object.NewCommitPostorderIterFirstParent(commit, nil)
 	defer iter.Close()
 
 	haves := make([]plumbing.Hash, 0, n)
-	err = iter.ForEach(func(c *object.Commit) error {
+	err = iter.ForEach(t.Context(), func(c *object.Commit) error {
 		haves = append(haves, c.Hash)
 		if len(haves) == n {
 			return storer.ErrStop
@@ -311,7 +311,7 @@ func initBareStorage(t testing.TB, path string) *filesystem.Storage {
 	st := filesystem.NewStorage(osfs.New(path), cache.NewObjectLRUDefault())
 	cfg := config.NewConfig()
 	cfg.Core.IsBare = true
-	require.NoError(t, st.SetConfig(cfg))
+	require.NoError(t, st.SetConfig(t.Context(), cfg))
 	return st
 }
 

--- a/plumbing/transport/http/v2_client_test.go
+++ b/plumbing/transport/http/v2_client_test.go
@@ -63,7 +63,7 @@ func TestBackend_HTTP_V2_GoGitClient(t *testing.T) {
 	require.NoError(t, sess.Fetch(context.Background(), st, &transport.FetchRequest{
 		Wants: []plumbing.Hash{want},
 	}))
-	cobj, err := st.EncodedObject(plumbing.CommitObject, want)
+	cobj, err := st.EncodedObject(t.Context(), plumbing.CommitObject, want)
 	require.NoError(t, err)
 	require.Equal(t, want, cobj.Hash())
 

--- a/plumbing/transport/loader_test.go
+++ b/plumbing/transport/loader_test.go
@@ -22,11 +22,11 @@ func TestFilesystemLoader_Load(t *testing.T) {
 	repoPath := filepath.Join(dir, "repo.git")
 	st := filesystem.NewStorage(osfs.New(repoPath), nil)
 	defer func() { _ = st.Close() }()
-	require.NoError(t, st.Init())
-	cfg, err := st.Config()
+	require.NoError(t, st.Init(t.Context()))
+	cfg, err := st.Config(t.Context())
 	require.NoError(t, err)
 	cfg.Core.IsBare = true
-	require.NoError(t, st.SetConfig(cfg))
+	require.NoError(t, st.SetConfig(t.Context(), cfg))
 
 	loader := NewFilesystemLoader(osfs.New(dir), false)
 
@@ -47,11 +47,11 @@ func TestFilesystemLoader_LoadBare(t *testing.T) {
 
 	st := filesystem.NewStorage(osfs.New(filepath.Join(dir, "bare.git")), nil)
 	defer func() { _ = st.Close() }()
-	require.NoError(t, st.Init())
-	cfg, err := st.Config()
+	require.NoError(t, st.Init(t.Context()))
+	cfg, err := st.Config(t.Context())
 	require.NoError(t, err)
 	cfg.Core.IsBare = true
-	require.NoError(t, st.SetConfig(cfg))
+	require.NoError(t, st.SetConfig(t.Context(), cfg))
 
 	loader := NewFilesystemLoader(osfs.New(dir), false)
 
@@ -133,7 +133,7 @@ func TestFilesystemLoader_LoadWithConfigDir(t *testing.T) {
 	require.NotNil(t, st)
 
 	// Verify it loaded the correct config
-	cfg, err := st.Config()
+	cfg, err := st.Config(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 }
@@ -169,7 +169,7 @@ func TestFilesystemLoader_LoadWithGitfile(t *testing.T) {
 	require.NotNil(t, st)
 
 	// Verify it loaded the correct config
-	cfg, err := st.Config()
+	cfg, err := st.Config(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 }
@@ -203,7 +203,7 @@ func TestFilesystemLoader_LoadWithRelativeGitfile(t *testing.T) {
 	require.NotNil(t, st)
 
 	// Verify it loaded the correct config
-	cfg, err := st.Config()
+	cfg, err := st.Config(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 }

--- a/plumbing/transport/negotiate.go
+++ b/plumbing/transport/negotiate.go
@@ -112,16 +112,16 @@ func NegotiatePack(
 			}
 		}
 
-		cfg, err := st.Config()
+		cfg, err := st.Config(ctx)
 		if err == nil {
 			clientFormat = cfg.Extensions.ObjectFormat
 		}
 
 		if clientFormat == config.UnsetObjectFormat && serverFormat == config.SHA256 {
-			ref, err := st.Reference(plumbing.HEAD)
+			ref, err := st.Reference(ctx, plumbing.HEAD)
 			if err == nil && ref.Target().String() == "refs/heads/.invalid" {
 				if setter, ok := st.(xstorage.ObjectFormatSetter); ok {
-					err := setter.SetObjectFormat(serverFormat)
+					err := setter.SetObjectFormat(ctx, serverFormat)
 					if err != nil {
 						return nil, fmt.Errorf("unable to set object format: %w", err)
 					}
@@ -169,7 +169,7 @@ func NegotiatePack(
 			return nil, ErrShallowNotSupported
 		}
 		upreq.Depth = packp.DepthRequest{Deepen: req.Depth}
-		upreq.Shallows, err = st.Shallow()
+		upreq.Shallows, err = st.Shallow(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -334,9 +334,9 @@ func readShallows(
 // failure. It mirrors NegotiatePack's v0/v1 object-format handling and git's
 // fetch-pack.c, including the case where the server omits object-format (it
 // only speaks sha1) but the client repository uses another algorithm.
-func ReconcileObjectFormatV2(st storage.Storer, caps capability.List) error {
+func ReconcileObjectFormatV2(ctx context.Context, st storage.Storer, caps capability.List) error {
 	var clientFormat config.ObjectFormat
-	if cfg, err := st.Config(); err == nil && cfg != nil {
+	if cfg, err := st.Config(ctx); err == nil && cfg != nil {
 		clientFormat = cfg.Extensions.ObjectFormat
 	}
 
@@ -374,9 +374,9 @@ func ReconcileObjectFormatV2(st storage.Storer, caps capability.List) error {
 	// Adopt the server format on a fresh clone: unset client + sha256 server,
 	// with HEAD still at the clone placeholder.
 	if clientFormat == config.UnsetObjectFormat && serverFormat == config.SHA256 {
-		if ref, err := st.Reference(plumbing.HEAD); err == nil && ref.Target().String() == "refs/heads/.invalid" {
+		if ref, err := st.Reference(ctx, plumbing.HEAD); err == nil && ref.Target().String() == "refs/heads/.invalid" {
 			if setter, ok := st.(xstorage.ObjectFormatSetter); ok {
-				if err := setter.SetObjectFormat(serverFormat); err != nil {
+				if err := setter.SetObjectFormat(ctx, serverFormat); err != nil {
 					return fmt.Errorf("unable to set object format: %w", err)
 				}
 				clientFormat = serverFormat

--- a/plumbing/transport/negotiate_test.go
+++ b/plumbing/transport/negotiate_test.go
@@ -409,36 +409,36 @@ func TestReconcileObjectFormatV2(t *testing.T) {
 
 	t.Run("unknown algorithm is rejected", func(t *testing.T) {
 		t.Parallel()
-		err := ReconcileObjectFormatV2(memory.NewStorage(), withFormat("sha999"))
+		err := ReconcileObjectFormatV2(t.Context(), memory.NewStorage(), withFormat("sha999"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported object-format")
 	})
 
 	t.Run("empty value is accepted for an sha1 client", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, ReconcileObjectFormatV2(memory.NewStorage(), withFormat("")))
+		require.NoError(t, ReconcileObjectFormatV2(t.Context(), memory.NewStorage(), withFormat("")))
 	})
 
 	t.Run("empty value rejects a sha256 client", func(t *testing.T) {
 		t.Parallel()
 		st := memory.NewStorage()
-		cfg, err := st.Config()
+		cfg, err := st.Config(t.Context())
 		require.NoError(t, err)
 		cfg.Extensions.ObjectFormat = formatcfg.SHA256
-		require.NoError(t, st.SetConfig(cfg))
+		require.NoError(t, st.SetConfig(t.Context(), cfg))
 
-		err = ReconcileObjectFormatV2(st, withFormat(""))
+		err = ReconcileObjectFormatV2(t.Context(), st, withFormat(""))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not support algorithm")
 	})
 
 	t.Run("sha1 server with unset client is accepted", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, ReconcileObjectFormatV2(memory.NewStorage(), withFormat("sha1")))
+		require.NoError(t, ReconcileObjectFormatV2(t.Context(), memory.NewStorage(), withFormat("sha1")))
 	})
 
 	t.Run("no advertisement is accepted for an sha1 client", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, ReconcileObjectFormatV2(memory.NewStorage(), capability.List{}))
+		require.NoError(t, ReconcileObjectFormatV2(t.Context(), memory.NewStorage(), capability.List{}))
 	})
 }

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -145,7 +145,7 @@ func (s *StreamSession) Fetch(ctx context.Context, st storage.Storer, req *Fetch
 		if req.Depth > 0 && !internal.FetchSupports(s.caps, "shallow") {
 			return ErrShallowNotSupported
 		}
-		if err := ReconcileObjectFormatV2(st, s.caps); err != nil {
+		if err := ReconcileObjectFormatV2(ctx, st, s.caps); err != nil {
 			return err
 		}
 		// Each negotiation round reuses the persistent stream: Command writes

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -161,7 +161,7 @@ func ReceivePack(
 	// Receive the packfile
 	var unpackErr error
 	if needPackfile {
-		unpackErr = packfile.UpdateObjectStorage(st, rd)
+		unpackErr = packfile.UpdateObjectStorage(ctx, st, rd)
 	}
 
 	// Done with the request, now close the reader
@@ -232,7 +232,7 @@ func ReceivePack(
 
 	var firstErr error
 	cmdStatus := make(map[plumbing.ReferenceName]error)
-	updateReferences(st, updreq, cmdStatus, &firstErr)
+	updateReferences(ctx, st, updreq, cmdStatus, &firstErr)
 
 	if opts.Hooks.PostReceive != nil {
 		applied := make([]*packp.Command, 0, len(updreq.Commands))
@@ -311,8 +311,8 @@ func setStatus(cmdStatus map[plumbing.ReferenceName]error, firstErr *error, ref 
 	}
 }
 
-func referenceExists(s storer.ReferenceStorer, n plumbing.ReferenceName) (bool, error) {
-	_, err := s.Reference(n)
+func referenceExists(ctx context.Context, s storer.ReferenceStorer, n plumbing.ReferenceName) (bool, error) {
+	_, err := s.Reference(ctx, n)
 	if err == plumbing.ErrReferenceNotFound {
 		return false, nil
 	}
@@ -320,9 +320,9 @@ func referenceExists(s storer.ReferenceStorer, n plumbing.ReferenceName) (bool, 
 	return err == nil, err
 }
 
-func updateReferences(st storage.Storer, req *packp.UpdateRequests, cmdStatus map[plumbing.ReferenceName]error, firstErr *error) {
+func updateReferences(ctx context.Context, st storage.Storer, req *packp.UpdateRequests, cmdStatus map[plumbing.ReferenceName]error, firstErr *error) {
 	for _, cmd := range req.Commands {
-		exists, err := referenceExists(st, cmd.Name)
+		exists, err := referenceExists(ctx, st, cmd.Name)
 		if err != nil {
 			setStatus(cmdStatus, firstErr, cmd.Name, err)
 			continue
@@ -336,7 +336,7 @@ func updateReferences(st storage.Storer, req *packp.UpdateRequests, cmdStatus ma
 			}
 
 			ref := plumbing.NewHashReference(cmd.Name, cmd.New)
-			err := st.SetReference(ref)
+			err := st.SetReference(ctx, ref)
 			setStatus(cmdStatus, firstErr, cmd.Name, err)
 		case packp.Delete:
 			if !exists {
@@ -344,7 +344,7 @@ func updateReferences(st storage.Storer, req *packp.UpdateRequests, cmdStatus ma
 				continue
 			}
 
-			err := st.RemoveReference(cmd.Name)
+			err := st.RemoveReference(ctx, cmd.Name)
 			setStatus(cmdStatus, firstErr, cmd.Name, err)
 		case packp.Update:
 			if !exists {
@@ -353,7 +353,7 @@ func updateReferences(st storage.Storer, req *packp.UpdateRequests, cmdStatus ma
 			}
 
 			ref := plumbing.NewHashReference(cmd.Name, cmd.New)
-			err := st.SetReference(ref)
+			err := st.SetReference(ctx, ref)
 			setStatus(cmdStatus, firstErr, cmd.Name, err)
 		}
 	}

--- a/plumbing/transport/receive_pack_test.go
+++ b/plumbing/transport/receive_pack_test.go
@@ -51,7 +51,7 @@ func deleteCmd(ref plumbing.ReferenceName, hash plumbing.Hash) *packp.Command {
 func seedRef(t *testing.T, ref plumbing.ReferenceName, hash plumbing.Hash) storage.Storer {
 	t.Helper()
 	st := memory.NewStorage()
-	require.NoError(t, st.SetReference(plumbing.NewHashReference(ref, hash)))
+	require.NoError(t, st.SetReference(t.Context(), plumbing.NewHashReference(ref, hash)))
 	return st
 }
 
@@ -75,7 +75,7 @@ func TestReceivePackNilHooksDeleteRef(t *testing.T) {
 	assert.Contains(t, out.String(), "unpack ok")
 	assert.Contains(t, out.String(), "ok refs/heads/main")
 
-	_, err = st.Reference(ref)
+	_, err = st.Reference(t.Context(), ref)
 	assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
 }
 
@@ -151,7 +151,7 @@ func TestReceivePackPreReceiveRejectsRef(t *testing.T) {
 	assert.Contains(t, out.String(), "ng refs/heads/main policy blocks main")
 	assert.False(t, postReceiveCalled, "PostReceive must not run when PreReceive rejects")
 
-	got, err := st.Reference(ref)
+	got, err := st.Reference(t.Context(), ref)
 	require.NoError(t, err)
 	assert.Equal(t, hash, got.Hash(), "ref must not move when PreReceive rejects")
 }
@@ -178,7 +178,7 @@ func TestReceivePackPostReceiveRunsAfterUpdate(t *testing.T) {
 			Hooks: ReceivePackHooks{
 				PostReceive: func(_ context.Context, i *PostReceiveInfo) error {
 					info = i
-					_, refErr := i.Storer.Reference(ref)
+					_, refErr := i.Storer.Reference(t.Context(), ref)
 					refMissing = errors.Is(refErr, plumbing.ErrReferenceNotFound)
 					return nil
 				},

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -28,7 +28,7 @@ var ErrUpdateReference = errors.New("failed to update ref")
 // the "# service=..." smart-reply line for the v2 request (http-backend.c
 // get_info_refs). Both behaviours are reproduced below.
 func AdvertiseRefs(
-	_ context.Context,
+	ctx context.Context,
 	st storage.Storer,
 	w io.Writer,
 	service string,
@@ -65,11 +65,11 @@ func AdvertiseRefs(
 		ar.Capabilities.Set(capability.Sideband)
 		ar.Capabilities.Set(capability.NoProgress)
 		ar.Capabilities.Set(capability.Shallow)
-		ar.Capabilities.Set(capability.ObjectFormat, objectFormat(st).String())
+		ar.Capabilities.Set(capability.ObjectFormat, objectFormat(ctx, st).String())
 	}
 
 	// Set references
-	if err := addReferences(st, ar, !forPush); err != nil {
+	if err := addReferences(ctx, st, ar, !forPush); err != nil {
 		return err
 	}
 
@@ -109,14 +109,14 @@ func AdvertiseRefs(
 // emit the smart-HTTP "# service=..." prefix: git omits that line for v2
 // (http-backend.c get_info_refs), the response starts directly with the version
 // packet.
-func AdvertiseCapabilities(_ context.Context, st storage.Storer, w io.Writer, service string) error {
+func AdvertiseCapabilities(ctx context.Context, st storage.Storer, w io.Writer, service string) error {
 	if service != UploadPackService {
 		return fmt.Errorf("%w: %s", ErrUnsupportedService, service)
 	}
 
 	adv := &packp.CapabilityAdv{
 		Version:      protocol.V2,
-		Capabilities: serverV2Capabilities(st),
+		Capabilities: serverV2Capabilities(ctx, st),
 	}
 	return adv.Encode(w)
 }
@@ -139,19 +139,19 @@ func AdvertiseCapabilities(_ context.Context, st storage.Storer, w io.Writer, se
 //   - fetch=wait-for-done  negotiate-only fetch (git fetch --negotiate-only)
 //   - server-option        process client "server-option" lines
 //   - object-info          object size/type queries without a fetch
-func serverV2Capabilities(st storage.Storer) capability.List {
+func serverV2Capabilities(ctx context.Context, st storage.Storer) capability.List {
 	var caps capability.List
 	caps.Set(capability.Agent, capability.DefaultAgent())
 	caps.Set(capability.LsRefs)
 	caps.Set(capability.FetchCmd, "shallow")
-	caps.Set(capability.ObjectFormat, objectFormat(st).String())
+	caps.Set(capability.ObjectFormat, objectFormat(ctx, st).String())
 	return caps
 }
 
 // objectFormat returns the repository's configured object format, defaulting to
 // the package default when the config is missing or unset.
-func objectFormat(st storage.Storer) config.ObjectFormat {
-	cfg, err := st.Config()
+func objectFormat(ctx context.Context, st storage.Storer) config.ObjectFormat {
+	cfg, err := st.Config(ctx)
 	if err != nil || cfg == nil {
 		return config.DefaultObjectFormat
 	}
@@ -161,17 +161,17 @@ func objectFormat(st storage.Storer) config.ObjectFormat {
 	return cfg.Extensions.ObjectFormat
 }
 
-func addReferences(st storage.Storer, ar *packp.AdvRefs, addHead bool) error {
-	iter, err := st.IterReferences()
+func addReferences(ctx context.Context, st storage.Storer, ar *packp.AdvRefs, addHead bool) error {
+	iter, err := st.IterReferences(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Add references and their peeled values
-	return iter.ForEach(func(r *plumbing.Reference) error {
+	return iter.ForEach(ctx, func(r *plumbing.Reference) error {
 		hash, name := r.Hash(), r.Name()
 		if r.Type() == plumbing.SymbolicReference {
-			ref, err := storer.ResolveReference(st, r.Target())
+			ref, err := storer.ResolveReference(ctx, st, r.Target())
 			if errors.Is(err, plumbing.ErrReferenceNotFound) {
 				return nil
 			}
@@ -196,7 +196,7 @@ func addReferences(st storage.Storer, ar *packp.AdvRefs, addHead bool) error {
 		}
 		ar.References = append(ar.References, plumbing.NewHashReference(name, hash))
 		if r.Name().IsTag() {
-			if tag, err := object.GetTag(st, hash); err == nil {
+			if tag, err := object.GetTag(ctx, st, hash); err == nil {
 				ar.References = append(ar.References, plumbing.NewHashReference(
 					plumbing.ReferenceName(name.String()+"^{}"), tag.Target,
 				))

--- a/plumbing/transport/serverinfo.go
+++ b/plumbing/transport/serverinfo.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-git/go-billy/v6"
@@ -15,7 +16,7 @@ import (
 // It generates a list of available refs for the repository.
 // Used by git http transport (dumb), for more information refer to:
 // https://git-scm.com/book/id/v2/Git-Internals-Transfer-Protocols#_the_dumb_protocol
-func UpdateServerInfo(s storage.Storer, fs billy.Filesystem) error {
+func UpdateServerInfo(ctx context.Context, s storage.Storer, fs billy.Filesystem) error {
 	pos, ok := s.(storer.PackedObjectStorer)
 	if !ok {
 		return ErrPackedObjectsNotSupported
@@ -28,14 +29,14 @@ func UpdateServerInfo(s storage.Storer, fs billy.Filesystem) error {
 
 	defer func() { _ = infoRefs.Close() }()
 
-	refsIter, err := s.IterReferences()
+	refsIter, err := s.IterReferences(ctx)
 	if err != nil {
 		return err
 	}
 
 	defer refsIter.Close()
 
-	if err := repository.WriteInfoRefs(infoRefs, s); err != nil {
+	if err := repository.WriteInfoRefs(ctx, infoRefs, s); err != nil {
 		return fmt.Errorf("failed to write info/refs: %w", err)
 	}
 
@@ -46,7 +47,7 @@ func UpdateServerInfo(s storage.Storer, fs billy.Filesystem) error {
 
 	defer func() { _ = infoPacks.Close() }()
 
-	if err := repository.WriteObjectsInfoPacks(infoPacks, pos); err != nil {
+	if err := repository.WriteObjectsInfoPacks(ctx, infoPacks, pos); err != nil {
 		return fmt.Errorf("failed to write objects/info/packs: %w", err)
 	}
 

--- a/plumbing/transport/serverinfo_test.go
+++ b/plumbing/transport/serverinfo_test.go
@@ -30,7 +30,7 @@ func TestServerInfoSuite(t *testing.T) {
 func (s *ServerInfoSuite) TestUpdateServerInfoInit() {
 	fs := memfs.New()
 	st := memory.NewStorage()
-	err := UpdateServerInfo(st, fs)
+	err := UpdateServerInfo(s.T().Context(), st, fs)
 	s.NoError(err)
 }
 
@@ -42,7 +42,7 @@ func (s *ServerInfoSuite) TestUpdateServerInfoTags() {
 	defer func() { _ = st.Close() }()
 	fs := memfs.New()
 
-	err = UpdateServerInfo(st, fs)
+	err = UpdateServerInfo(s.T().Context(), st, fs)
 	s.NoError(err)
 	assertInfoRefs(s, st, fs)
 	assertObjectPacks(s, st, fs)
@@ -56,7 +56,7 @@ func (s *ServerInfoSuite) TestUpdateServerInfoBasic() {
 	defer func() { _ = st.Close() }()
 	fs := memfs.New()
 
-	err = UpdateServerInfo(st, fs)
+	err = UpdateServerInfo(s.T().Context(), st, fs)
 	s.NoError(err)
 	assertInfoRefs(s, st, fs)
 	assertObjectPacks(s, st, fs)
@@ -70,23 +70,23 @@ func (s *ServerInfoSuite) TestUpdateServerInfoBasicChange() {
 	defer func() { _ = st.Close() }()
 	fs := memfs.New()
 
-	err = UpdateServerInfo(st, fs)
+	err = UpdateServerInfo(s.T().Context(), st, fs)
 	s.NoError(err)
 	assertInfoRefs(s, st, fs)
 	assertObjectPacks(s, st, fs)
 
-	head, err := st.Reference(plumbing.HEAD)
+	head, err := st.Reference(s.T().Context(), plumbing.HEAD)
 	s.NoError(err)
 
 	ref := plumbing.NewHashReference("refs/heads/my-branch", head.Hash())
-	err = st.SetReference(ref)
+	err = st.SetReference(s.T().Context(), ref)
 	s.NoError(err)
 
 	tag := plumbing.NewHashReference("refs/tags/test-tag", head.Hash())
-	err = st.SetReference(tag)
+	err = st.SetReference(s.T().Context(), tag)
 	s.NoError(err)
 
-	err = UpdateServerInfo(st, fs)
+	err = UpdateServerInfo(s.T().Context(), st, fs)
 	s.NoError(err)
 	assertInfoRefs(s, st, fs)
 	assertObjectPacks(s, st, fs)
@@ -112,10 +112,10 @@ func assertInfoRefs(s *ServerInfoSuite, st storage.Storer, fs billy.Filesystem) 
 		localRefs[name] = hash
 	}
 
-	refs, err := st.IterReferences()
+	refs, err := st.IterReferences(s.T().Context())
 	s.NoError(err)
 
-	err = refs.ForEach(func(ref *plumbing.Reference) error {
+	err = refs.ForEach(s.T().Context(), func(ref *plumbing.Reference) error {
 		name := ref.Name()
 		hash := ref.Hash()
 		switch ref.Type() {
@@ -123,7 +123,7 @@ func assertInfoRefs(s *ServerInfoSuite, st storage.Storer, fs billy.Filesystem) 
 			if name == plumbing.HEAD {
 				return nil
 			}
-			ref, err := st.Reference(ref.Target())
+			ref, err := st.Reference(s.T().Context(), ref.Target())
 			s.NoError(err)
 			hash = ref.Hash()
 			fallthrough
@@ -132,7 +132,7 @@ func assertInfoRefs(s *ServerInfoSuite, st storage.Storer, fs billy.Filesystem) 
 			s.True(ok)
 			s.Equal(hash, h)
 			if name.IsTag() {
-				tag, err := object.GetTag(st, hash)
+				tag, err := object.GetTag(s.T().Context(), st, hash)
 				if err == nil {
 					t, ok := localRefs[name+"^{}"]
 					s.True(ok)
@@ -156,7 +156,7 @@ func assertObjectPacks(s *ServerInfoSuite, st storage.Storer, fs billy.Filesyste
 	pos, ok := st.(storer.PackedObjectStorer)
 	s.True(ok)
 	localPacks := make(map[string]struct{})
-	packs, err := pos.ObjectPacks()
+	packs, err := pos.ObjectPacks(s.T().Context())
 	s.NoError(err)
 
 	for line := range strings.SplitSeq(string(bts), "\n") {

--- a/plumbing/transport/upload_archive.go
+++ b/plumbing/transport/upload_archive.go
@@ -134,12 +134,12 @@ func UploadArchive(
 		return muxError(mux, w, fmt.Errorf("no tree-ish specified"))
 	}
 
-	tree, commitHash, commitTime, err := archive.ResolveTreeish(st, treeish, allowUnreachable)
+	tree, commitHash, commitTime, err := archive.ResolveTreeish(ctx, st, treeish, allowUnreachable)
 	if err != nil {
 		return muxError(mux, w, err)
 	}
 
-	if err = archive.WriteArchive(st, mux, tree, commitHash, commitTime, format, prefix, paths); err != nil {
+	if err = archive.WriteArchive(ctx, st, mux, tree, commitHash, commitTime, format, prefix, paths); err != nil {
 		return muxError(mux, w, err)
 	}
 

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -131,7 +131,7 @@ func UploadPack(
 			}
 
 			// Find common commits/objects
-			havesWithRef, err = revlist.ObjectsWithRef(st, wants, nil)
+			havesWithRef, err = revlist.ObjectsWithRef(ctx, st, wants, nil)
 			if err != nil {
 				return fmt.Errorf("getting objects with ref: %w", err)
 			}
@@ -145,7 +145,7 @@ func UploadPack(
 				var shupd packp.ShallowUpdate
 				if !upreq.Depth.IsZero() {
 					if upreq.Depth.Deepen > 0 {
-						if err := getShallowCommits(st, wants, upreq.Depth.Deepen, &shupd); err != nil {
+						if err := getShallowCommits(ctx, st, wants, upreq.Depth.Deepen, &shupd); err != nil {
 							writec <- fmt.Errorf("getting shallow commits: %w", err)
 							return
 						}
@@ -266,7 +266,7 @@ func UploadPack(
 		return fmt.Errorf("closing reader: %w", err)
 	}
 
-	objs, err := objectsToUpload(st, wants, haves)
+	objs, err := objectsToUpload(ctx, st, wants, haves)
 	if err != nil {
 		_ = w.Close()
 		return fmt.Errorf("getting objects to upload: %w", err)
@@ -289,14 +289,14 @@ func UploadPack(
 	var packWindow uint
 	if opts.SkipDeltaCompression {
 		packWindow = 0
-	} else if cfg, cerr := st.Config(); cerr == nil && cfg != nil {
+	} else if cfg, cerr := st.Config(ctx); cerr == nil && cfg != nil {
 		packWindow = cfg.Pack.Window
 	} else {
 		packWindow = config.DefaultPackWindow
 	}
 
-	e := packfile.NewEncoder(writer, st, false)
-	_, err = e.Encode(objs, packWindow)
+	e := packfile.NewEncoder(ctx, writer, st, false)
+	_, err = e.Encode(ctx, objs, packWindow)
 	if err != nil {
 		return fmt.Errorf("encoding packfile: %w", err)
 	}
@@ -314,11 +314,11 @@ func UploadPack(
 	return nil
 }
 
-func objectsToUpload(st storage.Storer, wants, haves []plumbing.Hash) ([]plumbing.Hash, error) {
-	return revlist.Objects(st, wants, haves)
+func objectsToUpload(ctx context.Context, st storage.Storer, wants, haves []plumbing.Hash) ([]plumbing.Hash, error) {
+	return revlist.Objects(ctx, st, wants, haves)
 }
 
-func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd *packp.ShallowUpdate) error {
+func getShallowCommits(ctx context.Context, st storage.Storer, heads []plumbing.Hash, depth int, upd *packp.ShallowUpdate) error {
 	var i, curDepth int
 	var commit *object.Commit
 	depths := map[*object.Commit]int{}
@@ -327,7 +327,7 @@ func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd 
 	for commit != nil || i < len(heads) || len(stack) > 0 {
 		if commit == nil {
 			if i < len(heads) {
-				obj, err := st.EncodedObject(plumbing.CommitObject, heads[i])
+				obj, err := st.EncodedObject(ctx, plumbing.CommitObject, heads[i])
 				i++
 				if err != nil {
 					continue
@@ -361,7 +361,7 @@ func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd 
 		parents := commit.Parents()
 		commit = nil
 		for {
-			parent, err := parents.Next()
+			parent, err := parents.Next(ctx)
 			if err == io.EOF {
 				break
 			}
@@ -375,7 +375,7 @@ func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd 
 
 			depths[parent] = curDepth
 
-			if _, err := parents.Next(); err == nil {
+			if _, err := parents.Next(ctx); err == nil {
 				stack = append(stack, parent)
 			} else {
 				commit = parent
@@ -392,7 +392,7 @@ func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd 
 // reachable. It mirrors upstream get_shallows_depth (shallow.c): the value
 // offsets a deepen-relative request so the new depth is measured from the
 // client's existing shallow boundary rather than from the tips.
-func shallowFrontierDepth(st storage.Storer, heads, shallows []plumbing.Hash) (int, error) {
+func shallowFrontierDepth(ctx context.Context, st storage.Storer, heads, shallows []plumbing.Hash) (int, error) {
 	shallowSet := make(map[plumbing.Hash]struct{}, len(shallows))
 	for _, h := range shallows {
 		shallowSet[h] = struct{}{}
@@ -406,7 +406,7 @@ func shallowFrontierDepth(st storage.Storer, heads, shallows []plumbing.Hash) (i
 	}
 	var stack []frame
 	for _, h := range heads {
-		if c, ok := peelToCommit(st, h); ok {
+		if c, ok := peelToCommit(ctx, st, h); ok {
 			stack = append(stack, frame{c.Hash, 0})
 		}
 	}
@@ -427,7 +427,7 @@ func shallowFrontierDepth(st storage.Storer, heads, shallows []plumbing.Hash) (i
 			// walk continues past it, matching upstream get_shallows_or_depth.
 		}
 
-		c, err := object.GetCommit(st, f.hash)
+		c, err := object.GetCommit(ctx, st, f.hash)
 		if err != nil {
 			continue
 		}
@@ -507,15 +507,15 @@ func serveUploadPackV2(ctx context.Context, st storage.Storer, rd *bufio.Reader,
 // attribute, which a single plumbing.Reference (hash XOR symbolic) cannot
 // represent. writeV2Ref resolves the symref's hash from the storer, matching
 // upstream git's send_ref.
-func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, args *packp.LsRefsArgs) error {
-	iter, err := st.IterReferences()
+func serveLsRefsV2(ctx context.Context, st storage.Storer, w io.Writer, args *packp.LsRefsArgs) error {
+	iter, err := st.IterReferences(ctx)
 	if err != nil {
 		return err
 	}
 	defer iter.Close()
 
 	var refs []*plumbing.Reference
-	_ = iter.ForEach(func(r *plumbing.Reference) error {
+	_ = iter.ForEach(ctx, func(r *plumbing.Reference) error {
 		refs = append(refs, r)
 		return nil
 	})
@@ -528,7 +528,7 @@ func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, args *pack
 	for _, r := range refs {
 		if r.Name() == plumbing.HEAD {
 			if len(prefixes) == 0 || refMatchesAnyPrefix(r.Name().String(), prefixes) {
-				if err := writeV2Ref(w, st, r, args.Symrefs, args.Peel); err != nil {
+				if err := writeV2Ref(ctx, w, st, r, args.Symrefs, args.Peel); err != nil {
 					return err
 				}
 			}
@@ -543,7 +543,7 @@ func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, args *pack
 		if len(prefixes) > 0 && !refMatchesAnyPrefix(r.Name().String(), prefixes) {
 			continue
 		}
-		if err := writeV2Ref(w, st, r, args.Symrefs, args.Peel); err != nil {
+		if err := writeV2Ref(ctx, w, st, r, args.Symrefs, args.Peel); err != nil {
 			return err
 		}
 	}
@@ -560,11 +560,11 @@ func refMatchesAnyPrefix(name string, prefixes []string) bool {
 	return false
 }
 
-func writeV2Ref(w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, peel bool) error {
+func writeV2Ref(ctx context.Context, w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, peel bool) error {
 	var hash plumbing.Hash
 	var target string
 	if r.Type() == plumbing.SymbolicReference {
-		ref, err := storer.ResolveReference(st, r.Target())
+		ref, err := storer.ResolveReference(ctx, st, r.Target())
 		if err == nil {
 			hash = ref.Hash()
 		}
@@ -590,7 +590,7 @@ func writeV2Ref(w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, 
 		// refs/tags/*, and resolve all the way to the underlying non-tag object
 		// — matching upstream's reference_get_peeled_oid (ls-refs.c). Lightweight
 		// tags and branches don't point at tag objects, so they emit no attribute.
-		if peeled, ok := peelToNonTag(st, hash); ok {
+		if peeled, ok := peelToNonTag(ctx, st, hash); ok {
 			line += " peeled:" + peeled.String()
 		}
 	}
@@ -604,14 +604,14 @@ func writeV2Ref(w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, 
 // object, mirroring upstream's reference_get_peeled_oid. It returns the peeled
 // hash and true when h points at one or more tag objects; false when h is not a
 // tag (a lightweight tag, branch, etc.) so no "peeled" attribute is emitted.
-func peelToNonTag(st storage.Storer, h plumbing.Hash) (plumbing.Hash, bool) {
-	tag, err := object.GetTag(st, h)
+func peelToNonTag(ctx context.Context, st storage.Storer, h plumbing.Hash) (plumbing.Hash, bool) {
+	tag, err := object.GetTag(ctx, st, h)
 	if err != nil {
 		return plumbing.ZeroHash, false
 	}
 	for {
 		next := tag.Target
-		inner, err := object.GetTag(st, next)
+		inner, err := object.GetTag(ctx, st, next)
 		if err != nil {
 			// next is a non-tag object (or missing); return it as the peeled
 			// value, as upstream's peel does.
@@ -632,7 +632,7 @@ func peelToNonTag(st storage.Storer, h plumbing.Hash) (plumbing.Hash, bool) {
 // left open, so the caller loops to read the client's next command=fetch round
 // (the stateful negotiation continues until the server is ready). A stateless
 // (HTTP) round always concludes, since the client re-POSTs each round.
-func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *packp.FetchArgs, opts *UploadPackRequest) (concluded bool, err error) {
+func serveFetchV2(ctx context.Context, st storage.Storer, w io.WriteCloser, args *packp.FetchArgs, opts *UploadPackRequest) (concluded bool, err error) {
 	wants := args.Wants
 	haves := args.Haves
 	clientShallows := args.Shallows
@@ -662,7 +662,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 	if !done && len(haves) > 0 {
 		var common []plumbing.Hash
 		for _, h := range haves {
-			if _, err := st.EncodedObject(plumbing.AnyObject, h); err == nil {
+			if _, err := st.EncodedObject(ctx, plumbing.AnyObject, h); err == nil {
 				common = append(common, h)
 			}
 		}
@@ -674,7 +674,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 		// ready (including no common object at all, which encodes as NAK), the
 		// acknowledgments section stands alone and the client refines its haves
 		// in the next request.
-		if len(common) == 0 || !wantsReachableFromHaves(st, wants, common) {
+		if len(common) == 0 || !wantsReachableFromHaves(ctx, st, wants, common) {
 			if err := out.Encode(w); err != nil {
 				return true, err
 			}
@@ -701,7 +701,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 	// already-shallow client the depth is offset by the existing boundary's
 	// distance from the wants (see the deepen-relative handling below).
 	since := args.DeepenSince
-	notTips, err := resolveDeepenNot(st, args.DeepenNot)
+	notTips, err := resolveDeepenNot(ctx, st, args.DeepenNot)
 	if err != nil {
 		_ = w.Close()
 		return true, fmt.Errorf("resolving deepen-not: %w", err)
@@ -724,7 +724,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 		var shupd packp.ShallowUpdate
 		computed := true
 		if revList {
-			err = getShallowCommitsByRevList(st, wants, since, notTips, &shupd)
+			err = getShallowCommitsByRevList(ctx, st, wants, since, notTips, &shupd)
 		} else {
 			effectiveDepth := depth
 			if args.DeepenRelative && len(clientShallows) > 0 {
@@ -732,7 +732,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 				// shallow boundary, not from the wants. Mirror upstream
 				// get_shallow_commits (shallow.c): offset the absolute depth by
 				// the depth at which that boundary sits from the wants.
-				cur, derr := shallowFrontierDepth(st, wants, clientShallows)
+				cur, derr := shallowFrontierDepth(ctx, st, wants, clientShallows)
 				if derr != nil {
 					_ = w.Close()
 					return true, fmt.Errorf("computing shallow frontier depth: %w", derr)
@@ -747,7 +747,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 				}
 			}
 			if computed {
-				err = getShallowCommits(st, wants, effectiveDepth, &shupd)
+				err = getShallowCommits(ctx, st, wants, effectiveDepth, &shupd)
 			}
 		}
 		if err != nil {
@@ -779,12 +779,12 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 			// full history grafts nothing and unshallows the old boundary.
 			boundary = newBoundary
 		}
-		newView, nerr := objectsToUpload(&shallowBoundaryStorer{Storer: st, boundary: boundary}, wants, nil)
+		newView, nerr := objectsToUpload(ctx, &shallowBoundaryStorer{Storer: st, boundary: boundary}, wants, nil)
 		if nerr != nil {
 			_ = w.Close()
 			return true, fmt.Errorf("getting objects to upload: %w", nerr)
 		}
-		clientView, cerr := objectsToUpload(&shallowBoundaryStorer{Storer: st, boundary: clientShallows}, haves, nil)
+		clientView, cerr := objectsToUpload(ctx, &shallowBoundaryStorer{Storer: st, boundary: clientShallows}, haves, nil)
 		if cerr != nil {
 			_ = w.Close()
 			return true, fmt.Errorf("getting client objects: %w", cerr)
@@ -802,7 +802,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 			out.ShallowInfo = &packp.ShallowInfo{Shallows: newBoundary}
 			packSt = &shallowBoundaryStorer{Storer: st, boundary: newBoundary}
 		}
-		objs, err = objectsToUpload(packSt, wants, haves)
+		objs, err = objectsToUpload(ctx, packSt, wants, haves)
 		if err != nil {
 			_ = w.Close()
 			return true, fmt.Errorf("getting objects to upload: %w", err)
@@ -812,7 +812,7 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 	// include-tag: add annotated tags whose target is in the pack (auto-tag
 	// following), mirroring upstream pack-objects --include-tag.
 	if args.IncludeTag {
-		objs, err = includeReachableTags(st, objs)
+		objs, err = includeReachableTags(ctx, st, objs)
 		if err != nil {
 			_ = w.Close()
 			return true, fmt.Errorf("collecting include-tag objects: %w", err)
@@ -834,14 +834,14 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 	var packWindow uint
 	if opts.SkipDeltaCompression {
 		packWindow = 0
-	} else if cfg, cerr := st.Config(); cerr == nil && cfg != nil {
+	} else if cfg, cerr := st.Config(ctx); cerr == nil && cfg != nil {
 		packWindow = cfg.Pack.Window
 	} else {
 		packWindow = config.DefaultPackWindow
 	}
 
-	e := packfile.NewEncoder(writer, st, false)
-	if _, err := e.Encode(objs, packWindow); err != nil {
+	e := packfile.NewEncoder(ctx, writer, st, false)
+	if _, err := e.Encode(ctx, objs, packWindow); err != nil {
 		return true, fmt.Errorf("encoding packfile: %w", err)
 	}
 
@@ -899,24 +899,24 @@ func unshallowedCommits(clientShallows, newBoundary, newView []plumbing.Hash) []
 // resolveDeepenNot resolves each deepen-not argument (a ref name or an object
 // id) to a commit hash, peeling annotated tags, mirroring how upstream feeds
 // "--not <oid>" to rev-list (upload-pack.c send_shallow_list).
-func resolveDeepenNot(st storage.Storer, refs []string) ([]plumbing.Hash, error) {
+func resolveDeepenNot(ctx context.Context, st storage.Storer, refs []string) ([]plumbing.Hash, error) {
 	if len(refs) == 0 {
 		return nil, nil
 	}
 	out := make([]plumbing.Hash, 0, len(refs))
 	for _, r := range refs {
 		var h plumbing.Hash
-		if ref, err := storer.ResolveReference(st, plumbing.ReferenceName(r)); err == nil {
+		if ref, err := storer.ResolveReference(ctx, st, plumbing.ReferenceName(r)); err == nil {
 			h = ref.Hash()
 		} else if oid, ok := plumbing.FromHex(r); ok {
-			if _, err := st.EncodedObject(plumbing.AnyObject, oid); err != nil {
+			if _, err := st.EncodedObject(ctx, plumbing.AnyObject, oid); err != nil {
 				return nil, fmt.Errorf("cannot resolve deepen-not %q", r)
 			}
 			h = oid
 		} else {
 			return nil, fmt.Errorf("cannot resolve deepen-not %q", r)
 		}
-		if peeled, ok := peelToNonTag(st, h); ok {
+		if peeled, ok := peelToNonTag(ctx, st, h); ok {
 			h = peeled
 		}
 		out = append(out, h)
@@ -926,7 +926,7 @@ func resolveDeepenNot(st storage.Storer, refs []string) ([]plumbing.Hash, error)
 
 // reachableCommits returns the set of commits reachable from tips (inclusive),
 // used as the exclusion set for deepen-not.
-func reachableCommits(st storage.Storer, tips []plumbing.Hash) (map[plumbing.Hash]struct{}, error) {
+func reachableCommits(ctx context.Context, st storage.Storer, tips []plumbing.Hash) (map[plumbing.Hash]struct{}, error) {
 	seen := make(map[plumbing.Hash]struct{})
 	stack := append([]plumbing.Hash(nil), tips...)
 	for len(stack) > 0 {
@@ -936,7 +936,7 @@ func reachableCommits(st storage.Storer, tips []plumbing.Hash) (map[plumbing.Has
 			continue
 		}
 		seen[h] = struct{}{}
-		c, err := object.GetCommit(st, h)
+		c, err := object.GetCommit(ctx, st, h)
 		if err != nil {
 			continue
 		}
@@ -954,8 +954,8 @@ func reachableCommits(st storage.Storer, tips []plumbing.Hash) (map[plumbing.Has
 // Unlike git's rev-list traversal it does not apply the date "slop" used to
 // tolerate out-of-order committer timestamps, so under clock skew the boundary
 // may differ by a few commits; the resulting shallow clone is still valid.
-func getShallowCommitsByRevList(st storage.Storer, heads []plumbing.Hash, since time.Time, notTips []plumbing.Hash, upd *packp.ShallowUpdate) error {
-	exclude, err := reachableCommits(st, notTips)
+func getShallowCommitsByRevList(ctx context.Context, st storage.Storer, heads []plumbing.Hash, since time.Time, notTips []plumbing.Hash, upd *packp.ShallowUpdate) error {
+	exclude, err := reachableCommits(ctx, st, notTips)
 	if err != nil {
 		return err
 	}
@@ -974,7 +974,7 @@ func getShallowCommitsByRevList(st storage.Storer, heads []plumbing.Hash, since 
 		if _, ex := exclude[h]; ex {
 			continue
 		}
-		c, err := object.GetCommit(st, h)
+		c, err := object.GetCommit(ctx, st, h)
 		if err != nil {
 			continue
 		}
@@ -1002,20 +1002,20 @@ func getShallowCommitsByRevList(st storage.Storer, heads []plumbing.Hash, since 
 // annotated tag whose (peeled) target is already in objs, it adds the tag
 // object and every tag object along the chain, mirroring upstream pack-objects
 // --include-tag. Lightweight tags have no tag object and are skipped.
-func includeReachableTags(st storage.Storer, objs []plumbing.Hash) ([]plumbing.Hash, error) {
+func includeReachableTags(ctx context.Context, st storage.Storer, objs []plumbing.Hash) ([]plumbing.Hash, error) {
 	have := make(map[plumbing.Hash]struct{}, len(objs))
 	for _, h := range objs {
 		have[h] = struct{}{}
 	}
 
-	iter, err := st.IterReferences()
+	iter, err := st.IterReferences(ctx)
 	if err != nil {
 		return objs, err
 	}
 	defer iter.Close()
 
 	added := objs
-	err = iter.ForEach(func(ref *plumbing.Reference) error {
+	err = iter.ForEach(ctx, func(ref *plumbing.Reference) error {
 		if ref.Type() != plumbing.HashReference || !ref.Name().IsTag() {
 			return nil
 		}
@@ -1038,7 +1038,7 @@ func includeReachableTags(st storage.Storer, objs []plumbing.Hash) ([]plumbing.H
 				break // defend against a tag cycle in a malformed repo
 			}
 			seen[cur] = struct{}{}
-			tag, terr := object.GetTag(st, cur)
+			tag, terr := object.GetTag(ctx, st, cur)
 			if terr != nil {
 				break // non-tag object not in the pack: nothing to add
 			}
@@ -1064,8 +1064,8 @@ type shallowBoundaryStorer struct {
 	boundary []plumbing.Hash
 }
 
-func (s *shallowBoundaryStorer) Shallow() ([]plumbing.Hash, error) {
-	base, err := s.Storer.Shallow()
+func (s *shallowBoundaryStorer) Shallow(ctx context.Context) ([]plumbing.Hash, error) {
+	base, err := s.Storer.Shallow(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1081,18 +1081,18 @@ func (s *shallowBoundaryStorer) Shallow() ([]plumbing.Hash, error) {
 // can reach a have by walking parents. Tags are peeled to commits first, as the
 // ancestry walk operates on commits. Returns false (keep negotiating) if any
 // want cannot be resolved to a commit or is not yet anchored.
-func wantsReachableFromHaves(st storage.Storer, wants, commonHaves []plumbing.Hash) bool {
+func wantsReachableFromHaves(ctx context.Context, st storage.Storer, wants, commonHaves []plumbing.Hash) bool {
 	haveSet := make(map[plumbing.Hash]struct{}, len(commonHaves))
 	haveCommits := make([]*object.Commit, 0, len(commonHaves))
 	for _, h := range commonHaves {
 		haveSet[h] = struct{}{}
-		if c, ok := peelToCommit(st, h); ok {
+		if c, ok := peelToCommit(ctx, st, h); ok {
 			haveCommits = append(haveCommits, c)
 		}
 	}
 
 	for _, wHash := range wants {
-		wc, ok := peelToCommit(st, wHash)
+		wc, ok := peelToCommit(ctx, st, wHash)
 		if !ok {
 			return false
 		}
@@ -1105,7 +1105,7 @@ func wantsReachableFromHaves(st storage.Storer, wants, commonHaves []plumbing.Ha
 				anchored = true
 				break
 			}
-			if isAnc, err := hc.IsAncestor(wc); err == nil && isAnc {
+			if isAnc, err := hc.IsAncestor(ctx, wc); err == nil && isAnc {
 				anchored = true
 				break
 			}
@@ -1119,24 +1119,24 @@ func wantsReachableFromHaves(st storage.Storer, wants, commonHaves []plumbing.Ha
 
 // peelToCommit resolves h to a commit, following annotated tags. It returns
 // false when h is missing or does not peel to a commit.
-func peelToCommit(st storage.Storer, h plumbing.Hash) (*object.Commit, bool) {
-	obj, err := st.EncodedObject(plumbing.AnyObject, h)
+func peelToCommit(ctx context.Context, st storage.Storer, h plumbing.Hash) (*object.Commit, bool) {
+	obj, err := st.EncodedObject(ctx, plumbing.AnyObject, h)
 	if err != nil {
 		return nil, false
 	}
 	switch obj.Type() {
 	case plumbing.CommitObject:
-		c, err := object.GetCommit(st, h)
+		c, err := object.GetCommit(ctx, st, h)
 		if err != nil {
 			return nil, false
 		}
 		return c, true
 	case plumbing.TagObject:
-		tag, err := object.GetTag(st, h)
+		tag, err := object.GetTag(ctx, st, h)
 		if err != nil {
 			return nil, false
 		}
-		return peelToCommit(st, tag.Target)
+		return peelToCommit(ctx, st, tag.Target)
 	default:
 		return nil, false
 	}

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -55,10 +55,10 @@ func (s *UploadPackServeSuite) TestUploadPackAlwaysUseSidebandWhenAvailable() {
 	upreq := &packp.UploadRequest{}
 	upreq.Capabilities.Add(capability.Sideband64k)
 	upreq.Capabilities.Add(capability.NoProgress)
-	iter, err := st.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := st.IterEncodedObjects(s.T().Context(), plumbing.AnyObject)
 	require.NoError(s.T(), err)
 	defer iter.Close()
-	obj, err := iter.Next()
+	obj, err := iter.Next(s.T().Context())
 	require.NoError(s.T(), err)
 	upreq.Wants = append(upreq.Wants, obj.Hash())
 
@@ -84,7 +84,7 @@ func (s *UploadPackServeSuite) TestUploadPackSkipDeltaCompression() {
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 	defer func() { _ = st.Close() }()
 
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(s.T().Context(), st, plumbing.HEAD)
 	require.NoError(s.T(), err)
 	wantHash := head.Hash()
 
@@ -140,9 +140,9 @@ func (s *UploadPackServeSuite) TestUploadPackStatefulMultiRoundSendsFinalACK() {
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 	s.T().Cleanup(func() { _ = st.Close() })
 
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(s.T().Context(), st, plumbing.HEAD)
 	s.Require().NoError(err)
-	headCommit, err := object.GetCommit(st, head.Hash())
+	headCommit, err := object.GetCommit(s.T().Context(), st, head.Hash())
 	s.Require().NoError(err)
 	s.Require().NotEmpty(headCommit.ParentHashes)
 	common := headCommit.ParentHashes[0]
@@ -250,7 +250,7 @@ func (s *UploadPackServeSuite) TestUploadPackStatelessRPCUnreachableHavesEmitsSi
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 	defer func() { _ = st.Close() }()
 
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(s.T().Context(), st, plumbing.HEAD)
 	s.Require().NoError(err)
 
 	var upreq packp.UploadRequest

--- a/plumbing/transport/upload_pack_v2_deepen_test.go
+++ b/plumbing/transport/upload_pack_v2_deepen_test.go
@@ -23,9 +23,9 @@ import (
 func TestUploadPackV2FetchDeepenSince(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
-	c, err := object.GetCommit(st, head.Hash())
+	c, err := object.GetCommit(t.Context(), st, head.Hash())
 	require.NoError(t, err)
 
 	// since == HEAD's committer time: only the tip qualifies; its older parents
@@ -46,9 +46,9 @@ func TestUploadPackV2FetchDeepenSince(t *testing.T) {
 func TestUploadPackV2FetchDeepenNot(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
-	c, err := object.GetCommit(st, head.Hash())
+	c, err := object.GetCommit(t.Context(), st, head.Hash())
 	require.NoError(t, err)
 	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
 	parent := c.ParentHashes[0]
@@ -68,7 +68,7 @@ func TestUploadPackV2FetchDeepenNot(t *testing.T) {
 func TestUploadPackV2FetchDeepenRelative(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	// deepen-relative with depth 1 on a fresh fetch (no haves) is the same as
@@ -86,7 +86,7 @@ func TestUploadPackV2FetchDeepenRelative(t *testing.T) {
 func TestUploadPackV2FetchDeepenAndSinceConflict(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	var out bytes.Buffer
@@ -107,24 +107,24 @@ func TestUploadPackV2FetchDeepenAndSinceConflict(t *testing.T) {
 func TestGetShallowCommitsByRevListInvariants(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
-	c, err := object.GetCommit(st, head.Hash())
+	c, err := object.GetCommit(t.Context(), st, head.Hash())
 	require.NoError(t, err)
 	since := c.Committer.When
 
 	var upd packp.ShallowUpdate
-	require.NoError(t, getShallowCommitsByRevList(st, []plumbing.Hash{head.Hash()}, since, nil, &upd))
+	require.NoError(t, getShallowCommitsByRevList(t.Context(), st, []plumbing.Hash{head.Hash()}, since, nil, &upd))
 
 	require.NotEmpty(t, upd.Shallows)
 	for _, h := range upd.Shallows {
-		sc, err := object.GetCommit(st, h)
+		sc, err := object.GetCommit(t.Context(), st, h)
 		require.NoError(t, err)
 		require.False(t, sc.Committer.When.Before(since),
 			"a shallow commit must satisfy the deepen-since cutoff")
 		olderParent := false
 		for _, p := range sc.ParentHashes {
-			if pc, err := object.GetCommit(st, p); err == nil && pc.Committer.When.Before(since) {
+			if pc, err := object.GetCommit(t.Context(), st, p); err == nil && pc.Committer.When.Before(since) {
 				olderParent = true
 			}
 		}
@@ -137,16 +137,16 @@ func TestIncludeReachableTags(t *testing.T) {
 	st := v2StorageFromFixture(t, fixtures.ByTag("tags").One())
 
 	var tagHash, target plumbing.Hash
-	iter, err := st.IterReferences()
+	iter, err := st.IterReferences(t.Context())
 	require.NoError(t, err)
-	_ = iter.ForEach(func(ref *plumbing.Reference) error {
+	_ = iter.ForEach(t.Context(), func(ref *plumbing.Reference) error {
 		if !tagHash.IsZero() || ref.Type() != plumbing.HashReference || !ref.Name().IsTag() {
 			return nil
 		}
-		if _, err := object.GetTag(st, ref.Hash()); err != nil {
+		if _, err := object.GetTag(t.Context(), st, ref.Hash()); err != nil {
 			return nil // lightweight tag
 		}
-		if peeled, ok := peelToNonTag(st, ref.Hash()); ok {
+		if peeled, ok := peelToNonTag(t.Context(), st, ref.Hash()); ok {
 			tagHash, target = ref.Hash(), peeled
 		}
 		return nil
@@ -155,13 +155,13 @@ func TestIncludeReachableTags(t *testing.T) {
 	require.False(t, tagHash.IsZero(), "tags fixture must contain an annotated tag")
 
 	// Target in the pack: the annotated tag is auto-included.
-	withTag, err := includeReachableTags(st, []plumbing.Hash{target})
+	withTag, err := includeReachableTags(t.Context(), st, []plumbing.Hash{target})
 	require.NoError(t, err)
 	require.Contains(t, withTag, tagHash,
 		"annotated tag whose target is packed must be included")
 
 	// Target absent: the tag is not added.
-	without, err := includeReachableTags(st, nil)
+	without, err := includeReachableTags(t.Context(), st, nil)
 	require.NoError(t, err)
 	require.NotContains(t, without, tagHash,
 		"annotated tag whose target is not packed must be omitted")
@@ -170,9 +170,9 @@ func TestIncludeReachableTags(t *testing.T) {
 func TestUploadPackV2FetchDeepenExistingShallow(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
-	c, err := object.GetCommit(st, head.Hash())
+	c, err := object.GetCommit(t.Context(), st, head.Hash())
 	require.NoError(t, err)
 	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
 	parent := c.ParentHashes[0]
@@ -199,9 +199,9 @@ func TestUploadPackV2FetchDeepenExistingShallow(t *testing.T) {
 func TestUploadPackV2FetchDeepenRelativeExistingShallow(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
-	c, err := object.GetCommit(st, head.Hash())
+	c, err := object.GetCommit(t.Context(), st, head.Hash())
 	require.NoError(t, err)
 	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
 	parent := c.ParentHashes[0]
@@ -230,9 +230,9 @@ func TestUploadPackV2FetchDeepenRelativeExistingShallow(t *testing.T) {
 func TestUploadPackV2FetchDeepenExistingShallowToFullHistory(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
-	c, err := object.GetCommit(st, head.Hash())
+	c, err := object.GetCommit(t.Context(), st, head.Hash())
 	require.NoError(t, err)
 	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
 
@@ -256,7 +256,7 @@ func TestUploadPackV2FetchDeepenExistingShallowToFullHistory(t *testing.T) {
 func TestUploadPackV2FetchNoProgressEmitsNoProgressBand(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer

--- a/plumbing/transport/upload_pack_v2_test.go
+++ b/plumbing/transport/upload_pack_v2_test.go
@@ -114,7 +114,7 @@ func TestUploadPackV2LsRefsPeeledInline(t *testing.T) {
 func TestUploadPackV2FetchShallowDeepen(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	// A depth-1 fetch: the tip is the shallow boundary. The response carries a
@@ -135,18 +135,19 @@ func TestUploadPackV2FetchShallowDeepen(t *testing.T) {
 func TestObjectsToUploadShallowBounded(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
-	c, err := object.GetCommit(st, head.Hash())
+	c, err := object.GetCommit(t.Context(), st, head.Hash())
 	require.NoError(t, err)
 	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
 	parent := c.ParentHashes[0]
 
-	full, err := objectsToUpload(st, []plumbing.Hash{head.Hash()}, nil)
+	full, err := objectsToUpload(t.Context(), st, []plumbing.Hash{head.Hash()}, nil)
 	require.NoError(t, err)
 	require.Contains(t, full, parent, "unbounded pack should include the parent commit")
 
 	bounded, err := objectsToUpload(
+		t.Context(),
 		&shallowBoundaryStorer{Storer: st, boundary: []plumbing.Hash{head.Hash()}},
 		[]plumbing.Hash{head.Hash()}, nil,
 	)
@@ -159,7 +160,7 @@ func TestObjectsToUploadShallowBounded(t *testing.T) {
 func TestUploadPackV2FetchNoDeepenNoShallowInfo(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
@@ -174,7 +175,7 @@ func TestUploadPackV2FetchNoDeepenNoShallowInfo(t *testing.T) {
 func TestUploadPackV2FetchCloneNoHaves(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
@@ -190,7 +191,7 @@ func TestUploadPackV2FetchCloneNoHaves(t *testing.T) {
 func TestUploadPackV2FetchReadyWithCommonHave(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	out := serveUploadPackV2Test(t, st, v2Request(t, "fetch", nil, []string{
@@ -211,9 +212,9 @@ func TestUploadPackV2FetchReadyWithCommonHave(t *testing.T) {
 func TestUploadPackV2FetchCommonButNotReady(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
-	c, err := object.GetCommit(st, head.Hash())
+	c, err := object.GetCommit(t.Context(), st, head.Hash())
 	require.NoError(t, err)
 	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
 	parent := c.ParentHashes[0]
@@ -246,7 +247,7 @@ func TestUploadPackV2LsRefsHeadResolvedOID(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
 
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	out := serveUploadPackV2Test(t, st, v2Request(t, "ls-refs", nil, []string{"symrefs"}))
@@ -275,7 +276,7 @@ func TestUploadPackV2LsRefsHeadFilteredByPrefix(t *testing.T) {
 func TestUploadPackV2FetchNotReadyContinuesNegotiation(t *testing.T) {
 	t.Parallel()
 	st := basicV2Storage(t)
-	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	head, err := storer.ResolveReference(t.Context(), st, plumbing.HEAD)
 	require.NoError(t, err)
 
 	// A have the server does not know about: no common base yet, so the

--- a/plumbing/transport/v2_fetch_test.go
+++ b/plumbing/transport/v2_fetch_test.go
@@ -29,10 +29,10 @@ func TestV2FetchClone(t *testing.T) {
 	clientSt := memory.NewStorage()
 	s := newV2Session(t, serveUploadPackV2Once(serverSt))
 
-	err := s.Fetch(context.TODO(), clientSt, &FetchRequest{Wants: []plumbing.Hash{want}})
+	err := s.Fetch(t.Context(), clientSt, &FetchRequest{Wants: []plumbing.Hash{want}})
 	require.NoError(t, err)
 
-	obj, err := clientSt.EncodedObject(plumbing.CommitObject, want)
+	obj, err := clientSt.EncodedObject(t.Context(), plumbing.CommitObject, want)
 	require.NoError(t, err)
 	require.Equal(t, want, obj.Hash())
 }
@@ -72,7 +72,7 @@ func TestV2FetchManyRounds(t *testing.T) {
 			rounds++
 			args := req.Args.(*packp.FetchArgs)
 			if args.Done {
-				return writeV2PackfileSection(w, serverSt, args.Wants, args.Haves)
+				return writeV2PackfileSection(t.Context(), w, serverSt, args.Wants, args.Haves)
 			}
 			if _, err := pktline.WriteString(w, "acknowledgments\n"); err != nil {
 				return err
@@ -89,14 +89,14 @@ func TestV2FetchManyRounds(t *testing.T) {
 	clientSt := memory.NewStorage()
 	s := newV2Session(t, serve)
 
-	err := s.Fetch(context.TODO(), clientSt, &FetchRequest{
+	err := s.Fetch(t.Context(), clientSt, &FetchRequest{
 		Wants: []plumbing.Hash{want},
 		Haves: haves,
 	})
 	require.NoError(t, err)
 	require.Greater(t, rounds, 2, "incremental have batching should take more than two rounds")
 
-	_, err = clientSt.EncodedObject(plumbing.CommitObject, want)
+	_, err = clientSt.EncodedObject(t.Context(), plumbing.CommitObject, want)
 	require.NoError(t, err)
 }
 
@@ -148,20 +148,20 @@ func TestV2FetchNegotiationRounds(t *testing.T) {
 		if !args.Done {
 			return errors.New("expected done on second round")
 		}
-		return writeV2PackfileSection(w, serverSt, args.Wants, args.Haves)
+		return writeV2PackfileSection(t.Context(), w, serverSt, args.Wants, args.Haves)
 	}
 
 	clientSt := memory.NewStorage()
 	s := newV2Session(t, serve)
 
-	err := s.Fetch(context.TODO(), clientSt, &FetchRequest{
+	err := s.Fetch(t.Context(), clientSt, &FetchRequest{
 		Wants: []plumbing.Hash{want},
 		Haves: []plumbing.Hash{have},
 	})
 	require.NoError(t, err)
 	require.True(t, sawNegotiation)
 
-	_, err = clientSt.EncodedObject(plumbing.CommitObject, want)
+	_, err = clientSt.EncodedObject(t.Context(), plumbing.CommitObject, want)
 	require.NoError(t, err)
 }
 
@@ -171,30 +171,30 @@ func TestV2FetchUnsupportedFeatures(t *testing.T) {
 	// A v2 session whose server advertised no fetch features.
 	s := &StreamSession{version: protocol.V2}
 
-	err := s.Fetch(context.TODO(), memory.NewStorage(), &FetchRequest{
+	err := s.Fetch(t.Context(), memory.NewStorage(), &FetchRequest{
 		Wants:  []plumbing.Hash{plumbing.NewHash(basicMasterHash)},
 		Filter: "blob:none",
 	})
 	require.ErrorIs(t, err, ErrFilterNotSupported)
 
-	err = s.Fetch(context.TODO(), memory.NewStorage(), &FetchRequest{
+	err = s.Fetch(t.Context(), memory.NewStorage(), &FetchRequest{
 		Wants: []plumbing.Hash{plumbing.NewHash(basicMasterHash)},
 		Depth: 1,
 	})
 	require.ErrorIs(t, err, ErrShallowNotSupported)
 }
 
-func writeV2PackfileSection(w net.Conn, st storage.Storer, wants, haves []plumbing.Hash) error {
+func writeV2PackfileSection(ctx context.Context, w net.Conn, st storage.Storer, wants, haves []plumbing.Hash) error {
 	if _, err := pktline.WriteString(w, "packfile\n"); err != nil {
 		return err
 	}
-	objs, err := objectsToUpload(st, wants, haves)
+	objs, err := objectsToUpload(ctx, st, wants, haves)
 	if err != nil {
 		return err
 	}
 	mux := sideband.NewMuxer(sideband.Sideband64k, w)
-	e := packfile.NewEncoder(mux, st, false)
-	if _, err := e.Encode(objs, 10); err != nil {
+	e := packfile.NewEncoder(ctx, mux, st, false)
+	if _, err := e.Encode(ctx, objs, 10); err != nil {
 		return err
 	}
 	return pktline.WriteFlush(w)

--- a/prune.go
+++ b/prune.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -26,29 +27,29 @@ var ErrLooseObjectsNotSupported = errors.New("loose objects not supported")
 
 // DeleteObject deletes an object from a repository.
 // The type conveniently matches PruneHandler.
-func (r *Repository) DeleteObject(hash plumbing.Hash) error {
+func (r *Repository) DeleteObject(ctx context.Context, hash plumbing.Hash) error {
 	los, ok := r.Storer.(storer.LooseObjectStorer)
 	if !ok {
 		return ErrLooseObjectsNotSupported
 	}
 
-	return los.DeleteLooseObject(hash)
+	return los.DeleteLooseObject(ctx, hash)
 }
 
 // Prune removes unreferenced loose objects from the repository.
-func (r *Repository) Prune(opt PruneOptions) error {
+func (r *Repository) Prune(ctx context.Context, opt PruneOptions) error {
 	los, ok := r.Storer.(storer.LooseObjectStorer)
 	if !ok {
 		return ErrLooseObjectsNotSupported
 	}
 
 	pw := newObjectWalker(r.Storer)
-	err := pw.walkAllRefs()
+	err := pw.walkAllRefs(ctx)
 	if err != nil {
 		return err
 	}
 	// Now walk all (loose) objects in storage.
-	return los.ForEachObjectHash(func(hash plumbing.Hash) error {
+	return los.ForEachObjectHash(ctx, func(hash plumbing.Hash) error {
 		// Get out if we have seen this object.
 		if pw.isSeen(hash) {
 			return nil
@@ -58,7 +59,7 @@ func (r *Repository) Prune(opt PruneOptions) error {
 		if !opt.OnlyObjectsOlderThan.IsZero() {
 			// Errors here are non-fatal. The object may be e.g. packed.
 			// Or concurrently deleted. Skip such objects.
-			t, err := los.LooseObjectTime(hash)
+			t, err := los.LooseObjectTime(ctx, hash)
 			if err != nil {
 				return nil
 			}

--- a/prune_test.go
+++ b/prune_test.go
@@ -32,31 +32,33 @@ func (s *PruneSuite) testPrune(deleteTime time.Time) {
 	s.NotNil(los)
 
 	count := 0
-	err = los.ForEachObjectHash(func(_ plumbing.Hash) error {
+	err = los.ForEachObjectHash(s.T().Context(), func(_ plumbing.Hash) error {
 		count++
 		return nil
 	})
 	s.NoError(err)
 
-	r, err := Open(sto, srcFs)
+	r, err := Open(s.T().Context(), sto, srcFs)
 	s.NoError(err)
 	s.NotNil(r)
 	defer func() { _ = r.Close() }()
 
 	// Remove a branch so we can prune some objects.
-	err = sto.RemoveReference(plumbing.ReferenceName("refs/heads/v4"))
+	err = sto.RemoveReference(s.T().Context(), plumbing.ReferenceName("refs/heads/v4"))
 	s.NoError(err)
-	err = sto.RemoveReference(plumbing.ReferenceName("refs/remotes/origin/v4"))
+	err = sto.RemoveReference(s.T().Context(), plumbing.ReferenceName("refs/remotes/origin/v4"))
 	s.NoError(err)
 
-	err = r.Prune(PruneOptions{
+	err = r.Prune(s.T().Context(), PruneOptions{
 		OnlyObjectsOlderThan: deleteTime,
-		Handler:              r.DeleteObject,
+		Handler: func(h plumbing.Hash) error {
+			return r.DeleteObject(s.T().Context(), h)
+		},
 	})
 	s.NoError(err)
 
 	newCount := 0
-	err = los.ForEachObjectHash(func(_ plumbing.Hash) error {
+	err = los.ForEachObjectHash(s.T().Context(), func(_ plumbing.Hash) error {
 		newCount++
 		return nil
 	})

--- a/remote.go
+++ b/remote.go
@@ -76,19 +76,12 @@ func (r *Remote) String() string {
 	return fmt.Sprintf("%s\t%s (fetch)\n%[1]s\t%[3]s (push)", r.c.Name, fetch, push)
 }
 
-// Push performs a push to the remote. Returns NoErrAlreadyUpToDate if the
-// remote was already up-to-date.
-func (r *Remote) Push(o *PushOptions) error {
-	return r.PushContext(context.Background(), o)
-}
-
-// PushContext performs a push to the remote. Returns NoErrAlreadyUpToDate if
+// Push performs a push to the remote. Returns NoErrAlreadyUpToDate if
 // the remote was already up-to-date.
 //
 // The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
+// operation is complete, an error is returned.
+func (r *Remote) Push(ctx context.Context, o *PushOptions) (err error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -125,8 +118,8 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 		return err
 	}
 
-	remoteRefs := referenceStorageFromRefs(rRefs.References, true)
-	if err := r.checkRequireRemoteRefs(o.RequireRemoteRefs, remoteRefs); err != nil {
+	remoteRefs := referenceStorageFromRefs(ctx, rRefs.References, true)
+	if err := r.checkRequireRemoteRefs(ctx, o.RequireRemoteRefs, remoteRefs); err != nil {
 		return err
 	}
 
@@ -162,18 +155,18 @@ func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRef
 		}
 	}
 
-	localRefs, err := reference.References(r.s)
+	localRefs, err := reference.References(ctx, r.s)
 	if err != nil {
 		return err
 	}
 
 	cmds := make([]*packp.Command, 0)
-	if err := r.addReferencesToUpdate(o.RefSpecs, localRefs, remoteRefs, &cmds, o.Prune, o.ForceWithLease); err != nil {
+	if err := r.addReferencesToUpdate(ctx, o.RefSpecs, localRefs, remoteRefs, &cmds, o.Prune, o.ForceWithLease); err != nil {
 		return err
 	}
 
 	if o.FollowTags {
-		if err := r.addReachableTags(localRefs, remoteRefs, &cmds); err != nil {
+		if err := r.addReachableTags(ctx, localRefs, remoteRefs, &cmds); err != nil {
 			return err
 		}
 	}
@@ -183,12 +176,12 @@ func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRef
 	}
 
 	objects := objectsToPush(cmds)
-	haves, err := referencesToHashes(remoteRefs)
+	haves, err := referencesToHashes(ctx, remoteRefs)
 	if err != nil {
 		return err
 	}
 
-	stop, err := r.s.Shallow()
+	stop, err := r.s.Shallow(ctx)
 	if err != nil {
 		return err
 	}
@@ -200,7 +193,7 @@ func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRef
 	var hashesToPush []plumbing.Hash
 	// Avoid the expensive revlist operation if we're only doing deletes.
 	if !allDelete {
-		hashesToPush, err = revlist.Objects(r.s, objects, haves)
+		hashesToPush, err = revlist.Objects(ctx, r.s, objects, haves)
 		if err != nil {
 			return err
 		}
@@ -220,14 +213,14 @@ func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRef
 		return err
 	}
 
-	return r.updateRemoteReferenceStorage(cmds)
+	return r.updateRemoteReferenceStorage(ctx, cmds)
 }
 
 func (r *Remote) useRefDeltas(ar *packp.AdvRefs) bool {
 	return !ar.Capabilities.Supports(capability.OFSDelta)
 }
 
-func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer, cmds *[]*packp.Command) error {
+func (r *Remote) addReachableTags(ctx context.Context, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer, cmds *[]*packp.Command) error {
 	tags := make(map[plumbing.Reference]struct{})
 	// get a list of all tags locally
 	for _, ref := range localRefs {
@@ -236,13 +229,13 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 		}
 	}
 
-	remoteRefIter, err := remoteRefs.IterReferences()
+	remoteRefIter, err := remoteRefs.IterReferences(ctx)
 	if err != nil {
 		return err
 	}
 
 	// remove any that are already on the remote
-	if err := remoteRefIter.ForEach(func(reference *plumbing.Reference) error {
+	if err := remoteRefIter.ForEach(ctx, func(reference *plumbing.Reference) error {
 		delete(tags, *reference)
 		return nil
 	}); err != nil {
@@ -250,7 +243,7 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 	}
 
 	for tag := range tags {
-		tagObject, err := object.GetObject(r.s, tag.Hash())
+		tagObject, err := object.GetObject(ctx, r.s, tag.Hash())
 		var tagCommit *object.Commit
 		if err != nil {
 			return fmt.Errorf("get tag object: %w", err)
@@ -265,7 +258,7 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 			return errors.New("could not get annotated tag object")
 		}
 
-		tagCommit, err = object.GetCommit(r.s, annotatedTag.Target)
+		tagCommit, err = object.GetCommit(ctx, r.s, annotatedTag.Target)
 		if err != nil {
 			return fmt.Errorf("get annotated tag commit: %w", err)
 		}
@@ -281,12 +274,12 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 				continue
 			}
 
-			c, err := object.GetCommit(r.s, cmd.New)
+			c, err := object.GetCommit(ctx, r.s, cmd.New)
 			if err != nil {
 				return fmt.Errorf("get commit %v: %w", cmd.Name, err)
 			}
 
-			if isAncestor, err := tagCommit.IsAncestor(c); err == nil && isAncestor {
+			if isAncestor, err := tagCommit.IsAncestor(ctx, c); err == nil && isAncestor {
 				*cmds = append(*cmds, &packp.Command{Name: tag.Name(), New: tag.Hash()})
 			}
 		}
@@ -296,6 +289,7 @@ func (r *Remote) addReachableTags(localRefs []*plumbing.Reference, remoteRefs st
 }
 
 func (r *Remote) updateRemoteReferenceStorage(
+	ctx context.Context,
 	cmds []*packp.Command,
 ) error {
 	for _, spec := range r.c.Fetch {
@@ -308,11 +302,11 @@ func (r *Remote) updateRemoteReferenceStorage(
 			ref := plumbing.NewHashReference(local, c.New)
 			switch c.Action() {
 			case packp.Create, packp.Update:
-				if err := r.s.SetReference(ref); err != nil {
+				if err := r.s.SetReference(ctx, ref); err != nil {
 					return err
 				}
 			case packp.Delete:
-				if err := r.s.RemoveReference(local); err != nil {
+				if err := r.s.RemoveReference(ctx, local); err != nil {
 					return err
 				}
 			}
@@ -320,20 +314,6 @@ func (r *Remote) updateRemoteReferenceStorage(
 	}
 
 	return nil
-}
-
-// FetchContext fetches references along with the objects necessary to complete
-// their histories.
-//
-// Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
-// no changes to be fetched, or an error.
-//
-// The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func (r *Remote) FetchContext(ctx context.Context, o *FetchOptions) error {
-	_, err := r.fetch(ctx, o)
-	return err
 }
 
 // fetchRefPrefixes derives the ls-refs "ref-prefix" hints for a fetch from its
@@ -406,8 +386,12 @@ func fetchRefPrefixes(specs []config.RefSpec, tags plumbing.TagMode) []string {
 //
 // Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
 // no changes to be fetched, or an error.
-func (r *Remote) Fetch(o *FetchOptions) error {
-	return r.FetchContext(context.Background(), o)
+//
+// The provided Context must be non-nil. If the context expires before the
+// operation is complete, an error is returned.
+func (r *Remote) Fetch(ctx context.Context, o *FetchOptions) error {
+	_, err := r.fetch(ctx, o)
+	return err
 }
 
 func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.ReferenceStorer, err error) {
@@ -444,7 +428,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	}
 
 	req.Command = transport.UploadPackService
-	req.Protocol = r.transportProtocol()
+	req.Protocol = r.transportProtocol(ctx)
 	sess, err := cl.Handshake(ctx, req)
 	if err != nil {
 		return nil, err
@@ -462,19 +446,19 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		return nil, err
 	}
 
-	remoteRefs := referenceStorageFromRefs(rRefs.References, true)
-	localRefs, err := reference.References(r.s)
+	remoteRefs := referenceStorageFromRefs(ctx, rRefs.References, true)
+	localRefs, err := reference.References(ctx, r.s)
 	if err != nil {
 		return nil, err
 	}
-	refs, specToRefs, err := calculateRefs(o.RefSpecs, remoteRefs, o.Tags)
+	refs, specToRefs, err := calculateRefs(ctx, o.RefSpecs, remoteRefs, o.Tags)
 	if err != nil {
 		return nil, err
 	}
 
 	var shallows []plumbing.Hash
 	if o.Depth != 0 {
-		shallows, err = r.s.Shallow()
+		shallows, err = r.s.Shallow(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -489,9 +473,9 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	}
 
 	var haves []plumbing.Hash
-	wants, _ := getWants(r.s, refs, o.Depth)
+	wants, _ := getWants(ctx, r.s, refs, o.Depth)
 	if len(wants) > 0 {
-		haves, err = getHaves(localRefs, remoteRefs, r.s, o.Depth)
+		haves, err = getHaves(ctx, localRefs, remoteRefs, r.s, o.Depth)
 		if err != nil {
 			return nil, err
 		}
@@ -536,19 +520,19 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 
 	var updatedPrune bool
 	if o.Prune {
-		updatedPrune, err = r.pruneRemotes(o.RefSpecs, localRefs, remoteRefs)
+		updatedPrune, err = r.pruneRemotes(ctx, o.RefSpecs, localRefs, remoteRefs)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	updated, err := r.updateLocalReferenceStorage(o.RefSpecs, refs, remoteRefs, specToRefs, o.Tags, o.Force)
+	updated, err := r.updateLocalReferenceStorage(ctx, o.RefSpecs, refs, remoteRefs, specToRefs, o.Tags, o.Force)
 	if err != nil {
 		return nil, err
 	}
 
 	if !updated {
-		updated, err = depthChanged(shallows, r.s)
+		updated, err = depthChanged(ctx, shallows, r.s)
 		if err != nil {
 			return nil, fmt.Errorf("error checking depth change: %v", err)
 		}
@@ -557,7 +541,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	if !updated && !updatedPrune {
 		// No references updated, but may have fetched new objects, check if we now have any of our wants
 		for _, hash := range wants {
-			exists, _ := objectExists(r.s, hash)
+			exists, _ := objectExists(ctx, r.s, hash)
 			if exists {
 				updated = true
 				break
@@ -572,19 +556,19 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 	return remoteRefs, nil
 }
 
-func referenceStorageFromRefs(refs []*plumbing.Reference, filterPeeled bool) memory.ReferenceStorage {
+func referenceStorageFromRefs(ctx context.Context, refs []*plumbing.Reference, filterPeeled bool) memory.ReferenceStorage {
 	refStore := memory.ReferenceStorage{}
 	for _, ref := range refs {
 		if filterPeeled && strings.HasSuffix(ref.Name().String(), peeledSuffix) {
 			continue
 		}
-		_ = refStore.SetReference(ref)
+		_ = refStore.SetReference(ctx, ref)
 	}
 	return refStore
 }
 
-func depthChanged(before []plumbing.Hash, s storage.Storer) (bool, error) {
-	after, err := s.Shallow()
+func depthChanged(ctx context.Context, before []plumbing.Hash, s storage.Storer) (bool, error) {
+	after, err := s.Shallow(ctx)
 	if err != nil {
 		return false, err
 	}
@@ -620,18 +604,18 @@ func newClient(rawURL string, opts []client.Option) (*client.Client, *transport.
 // remote's repository (the protocol.version setting), defaulting to
 // config.DefaultProtocolVersion. It is used for ref discovery and fetch;
 // push always uses v0/v1, since protocol v2 has no push.
-func (r *Remote) transportProtocol() protocol.Version {
+func (r *Remote) transportProtocol(ctx context.Context) protocol.Version {
 	if r.s == nil {
 		return config.DefaultProtocolVersion
 	}
-	cfg, err := r.s.Config()
+	cfg, err := r.s.Config(ctx)
 	if err != nil || cfg == nil {
 		return config.DefaultProtocolVersion
 	}
 	return cfg.Protocol.Version
 }
 
-func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer) (bool, error) {
+func (r *Remote) pruneRemotes(ctx context.Context, specs []config.RefSpec, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer) (bool, error) {
 	var updatedPrune bool
 	for _, spec := range specs {
 		rev := spec.Reverse()
@@ -639,10 +623,10 @@ func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Refe
 			if !rev.Match(ref.Name()) {
 				continue
 			}
-			_, err := remoteRefs.Reference(rev.Dst(ref.Name()))
+			_, err := remoteRefs.Reference(ctx, rev.Dst(ref.Name()))
 			if errors.Is(err, plumbing.ErrReferenceNotFound) {
 				updatedPrune = true
-				err := r.s.RemoveReference(ref.Name())
+				err := r.s.RemoveReference(ctx, ref.Name())
 				if err != nil {
 					return false, err
 				}
@@ -653,6 +637,7 @@ func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Refe
 }
 
 func (r *Remote) addReferencesToUpdate(
+	ctx context.Context,
 	refspecs []config.RefSpec,
 	localRefs []*plumbing.Reference,
 	remoteRefs storer.ReferenceStorer,
@@ -668,17 +653,17 @@ func (r *Remote) addReferencesToUpdate(
 
 	for _, rs := range refspecs {
 		if rs.IsDelete() {
-			if err := r.deleteReferences(rs, remoteRefs, refsDict, cmds, false); err != nil {
+			if err := r.deleteReferences(ctx, rs, remoteRefs, refsDict, cmds, false); err != nil {
 				return err
 			}
 		} else {
-			err := r.addOrUpdateReferences(rs, localRefs, refsDict, remoteRefs, cmds, forceWithLease)
+			err := r.addOrUpdateReferences(ctx, rs, localRefs, refsDict, remoteRefs, cmds, forceWithLease)
 			if err != nil {
 				return err
 			}
 
 			if prune {
-				if err := r.deleteReferences(rs, remoteRefs, refsDict, cmds, true); err != nil {
+				if err := r.deleteReferences(ctx, rs, remoteRefs, refsDict, cmds, true); err != nil {
 					return err
 				}
 			}
@@ -689,6 +674,7 @@ func (r *Remote) addReferencesToUpdate(
 }
 
 func (r *Remote) addOrUpdateReferences(
+	ctx context.Context,
 	rs config.RefSpec,
 	localRefs []*plumbing.Reference,
 	refsDict map[string]*plumbing.Reference,
@@ -701,18 +687,18 @@ func (r *Remote) addOrUpdateReferences(
 	if !rs.IsWildcard() {
 		ref, ok := refsDict[rs.Src()]
 		if !ok {
-			object, err := object.GetObject(r.s, plumbing.NewHash(rs.Src()))
+			object, err := object.GetObject(ctx, r.s, plumbing.NewHash(rs.Src()))
 			if err == nil {
-				return r.addObject(rs, remoteRefs, object.ID(), cmds)
+				return r.addObject(ctx, rs, remoteRefs, object.ID(), cmds)
 			}
 			return nil
 		}
 
-		return r.addReferenceIfRefSpecMatches(rs, remoteRefs, ref, cmds, forceWithLease)
+		return r.addReferenceIfRefSpecMatches(ctx, rs, remoteRefs, ref, cmds, forceWithLease)
 	}
 
 	for _, ref := range localRefs {
-		err := r.addReferenceIfRefSpecMatches(rs, remoteRefs, ref, cmds, forceWithLease)
+		err := r.addReferenceIfRefSpecMatches(ctx, rs, remoteRefs, ref, cmds, forceWithLease)
 		if err != nil {
 			return err
 		}
@@ -721,18 +707,18 @@ func (r *Remote) addOrUpdateReferences(
 	return nil
 }
 
-func (r *Remote) deleteReferences(rs config.RefSpec,
+func (r *Remote) deleteReferences(ctx context.Context, rs config.RefSpec,
 	remoteRefs storer.ReferenceStorer,
 	refsDict map[string]*plumbing.Reference,
 	cmds *[]*packp.Command,
 	prune bool,
 ) error {
-	iter, err := remoteRefs.IterReferences()
+	iter, err := remoteRefs.IterReferences(ctx)
 	if err != nil {
 		return err
 	}
 
-	return iter.ForEach(func(ref *plumbing.Reference) error {
+	return iter.ForEach(ctx, func(ref *plumbing.Reference) error {
 		if ref.Type() != plumbing.HashReference {
 			return nil
 		}
@@ -760,7 +746,7 @@ func (r *Remote) deleteReferences(rs config.RefSpec,
 	})
 }
 
-func (r *Remote) addObject(rs config.RefSpec,
+func (r *Remote) addObject(ctx context.Context, rs config.RefSpec,
 	remoteRefs storer.ReferenceStorer, localObject plumbing.Hash,
 	cmds *[]*packp.Command,
 ) error {
@@ -773,7 +759,7 @@ func (r *Remote) addObject(rs config.RefSpec,
 		Old:  plumbing.ZeroHash,
 		New:  localObject,
 	}
-	remoteRef, err := remoteRefs.Reference(cmd.Name)
+	remoteRef, err := remoteRefs.Reference(ctx, cmd.Name)
 	if err == nil {
 		if remoteRef.Type() != plumbing.HashReference {
 			// TODO: check actual git behavior here
@@ -791,7 +777,7 @@ func (r *Remote) addObject(rs config.RefSpec,
 		if err := checkTagUpdate(cmd); err != nil {
 			return err
 		}
-		if err := checkFastForwardUpdate(r.s, remoteRefs, cmd); err != nil {
+		if err := checkFastForwardUpdate(ctx, r.s, remoteRefs, cmd); err != nil {
 			return err
 		}
 	}
@@ -800,7 +786,7 @@ func (r *Remote) addObject(rs config.RefSpec,
 	return nil
 }
 
-func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
+func (r *Remote) addReferenceIfRefSpecMatches(ctx context.Context, rs config.RefSpec,
 	remoteRefs storer.ReferenceStorer, localRef *plumbing.Reference,
 	cmds *[]*packp.Command, forceWithLease *ForceWithLease,
 ) error {
@@ -818,7 +804,7 @@ func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
 		New:  localRef.Hash(),
 	}
 
-	remoteRef, err := remoteRefs.Reference(cmd.Name)
+	remoteRef, err := remoteRefs.Reference(ctx, cmd.Name)
 	if err == nil {
 		if remoteRef.Type() != plumbing.HashReference {
 			// TODO: check actual git behavior here
@@ -835,14 +821,14 @@ func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
 	}
 
 	if forceWithLease != nil {
-		if err = r.checkForceWithLease(localRef, cmd, forceWithLease); err != nil {
+		if err = r.checkForceWithLease(ctx, localRef, cmd, forceWithLease); err != nil {
 			return err
 		}
 	} else if !rs.IsForceUpdate() {
 		if err := checkTagUpdate(cmd); err != nil {
 			return err
 		}
-		if err := checkFastForwardUpdate(r.s, remoteRefs, cmd); err != nil {
+		if err := checkFastForwardUpdate(ctx, r.s, remoteRefs, cmd); err != nil {
 			return err
 		}
 	}
@@ -851,10 +837,11 @@ func (r *Remote) addReferenceIfRefSpecMatches(rs config.RefSpec,
 	return nil
 }
 
-func (r *Remote) checkForceWithLease(localRef *plumbing.Reference, cmd *packp.Command, forceWithLease *ForceWithLease) error {
+func (r *Remote) checkForceWithLease(ctx context.Context, localRef *plumbing.Reference, cmd *packp.Command, forceWithLease *ForceWithLease) error {
 	remotePrefix := fmt.Sprintf("refs/remotes/%s/", r.Config().Name)
 
 	ref, err := storer.ResolveReference(
+		ctx,
 		r.s,
 		plumbing.ReferenceName(remotePrefix+strings.ReplaceAll(localRef.Name().String(), "refs/heads/", "")))
 	if err != nil {
@@ -884,15 +871,15 @@ func checkTagUpdate(cmd *packp.Command) error {
 	return nil
 }
 
-func getRemoteRefsFromStorer(remoteRefStorer storer.ReferenceStorer) (
+func getRemoteRefsFromStorer(ctx context.Context, remoteRefStorer storer.ReferenceStorer) (
 	map[plumbing.Hash]bool, error,
 ) {
 	remoteRefs := map[plumbing.Hash]bool{}
-	iter, err := remoteRefStorer.IterReferences()
+	iter, err := remoteRefStorer.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
-	err = iter.ForEach(func(ref *plumbing.Reference) error {
+	err = iter.ForEach(ctx, func(ref *plumbing.Reference) error {
 		if ref.Type() != plumbing.HashReference {
 			return nil
 		}
@@ -908,6 +895,7 @@ func getRemoteRefsFromStorer(remoteRefStorer storer.ReferenceStorer) (
 // getHavesFromRef populates the given `haves` map with the given
 // reference, and up to `maxHavesToVisitPerRef` ancestor commits.
 func getHavesFromRef(
+	ctx context.Context,
 	ref *plumbing.Reference,
 	remoteRefs map[plumbing.Hash]bool,
 	s storage.Storer,
@@ -919,7 +907,7 @@ func getHavesFromRef(
 		return nil
 	}
 
-	commit, err := object.GetCommit(s, h)
+	commit, err := object.GetCommit(ctx, s, h)
 	if err != nil {
 		if !errors.Is(err, plumbing.ErrObjectNotFound) {
 			// Ignore the error if this isn't a commit.
@@ -939,7 +927,7 @@ func getHavesFromRef(
 	}
 	// It is safe to ignore any error here as we are just trying to find the references that we already have
 	// An example of a legitimate failure is we have a shallow clone and don't have the previous commit(s)
-	_ = walker.ForEach(func(c *object.Commit) error {
+	_ = walker.ForEach(ctx, func(c *object.Commit) error {
 		haves[c.Hash] = true
 		toVisit--
 		// If toVisit starts out at 0 (indicating there is no
@@ -955,6 +943,7 @@ func getHavesFromRef(
 }
 
 func getHaves(
+	ctx context.Context,
 	localRefs []*plumbing.Reference,
 	remoteRefStorer storer.ReferenceStorer,
 	s storage.Storer,
@@ -965,7 +954,7 @@ func getHaves(
 	// Build a map of all the remote references, to avoid loading too
 	// many parent commits for references we know don't need to be
 	// transferred.
-	remoteRefs, err := getRemoteRefsFromStorer(remoteRefStorer)
+	remoteRefs, err := getRemoteRefsFromStorer(ctx, remoteRefStorer)
 	if err != nil {
 		return nil, err
 	}
@@ -979,7 +968,7 @@ func getHaves(
 			continue
 		}
 
-		err = getHavesFromRef(ref, remoteRefs, s, haves, depth)
+		err = getHavesFromRef(ctx, ref, remoteRefs, s, haves, depth)
 		if err != nil {
 			return nil, err
 		}
@@ -996,6 +985,7 @@ func getHaves(
 const refspecAllTags = "refs/tags/*:refs/tags/*"
 
 func calculateRefs(
+	ctx context.Context,
 	spec []config.RefSpec,
 	remoteRefs storer.ReferenceStorer,
 	tagMode plumbing.TagMode,
@@ -1009,7 +999,7 @@ func calculateRefs(
 	specToRefs := make([][]*plumbing.Reference, len(spec))
 	for i := range spec {
 		var err error
-		specToRefs[i], err = doCalculateRefs(spec[i], remoteRefs, refs)
+		specToRefs[i], err = doCalculateRefs(ctx, spec[i], remoteRefs, refs)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1019,6 +1009,7 @@ func calculateRefs(
 }
 
 func doCalculateRefs(
+	ctx context.Context,
 	s config.RefSpec,
 	remoteRefs storer.ReferenceStorer,
 	refs memory.ReferenceStorage,
@@ -1029,13 +1020,13 @@ func doCalculateRefs(
 		ref := plumbing.NewHashReference(s.Dst(""), plumbing.NewHash(s.Src()))
 
 		refList = append(refList, ref)
-		return refList, refs.SetReference(ref)
+		return refList, refs.SetReference(ctx, ref)
 	}
 
 	var matched bool
 	onMatched := func(ref *plumbing.Reference) error {
 		if ref.Type() == plumbing.SymbolicReference {
-			target, err := storer.ResolveReference(remoteRefs, ref.Name())
+			target, err := storer.ResolveReference(ctx, remoteRefs, ref.Name())
 			if err != nil {
 				return err
 			}
@@ -1049,16 +1040,16 @@ func doCalculateRefs(
 
 		matched = true
 		refList = append(refList, ref)
-		return refs.SetReference(ref)
+		return refs.SetReference(ctx, ref)
 	}
 
 	var ret error
 	if s.IsWildcard() {
-		iter, err := remoteRefs.IterReferences()
+		iter, err := remoteRefs.IterReferences(ctx)
 		if err != nil {
 			return nil, err
 		}
-		ret = iter.ForEach(func(ref *plumbing.Reference) error {
+		ret = iter.ForEach(ctx, func(ref *plumbing.Reference) error {
 			if !s.Match(ref.Name()) {
 				return nil
 			}
@@ -1068,7 +1059,7 @@ func doCalculateRefs(
 	} else {
 		var resolvedRef *plumbing.Reference
 		src := s.Src()
-		resolvedRef, ret = repository.ExpandRef(remoteRefs, plumbing.ReferenceName(src))
+		resolvedRef, ret = repository.ExpandRef(ctx, remoteRefs, plumbing.ReferenceName(src))
 		if ret == nil {
 			ret = onMatched(resolvedRef)
 		}
@@ -1081,12 +1072,12 @@ func doCalculateRefs(
 	return refList, ret
 }
 
-func getWants(localStorer storage.Storer, refs memory.ReferenceStorage, depth int) ([]plumbing.Hash, error) {
+func getWants(ctx context.Context, localStorer storage.Storer, refs memory.ReferenceStorage, depth int) ([]plumbing.Hash, error) {
 	// If depth is anything other than 1 and the repo has shallow commits then just because we have the commit
 	// at the reference doesn't mean that we don't still need to fetch the parents
 	shallow := false
 	if depth != 1 {
-		if s, _ := localStorer.Shallow(); len(s) > 0 {
+		if s, _ := localStorer.Shallow(ctx); len(s) > 0 {
 			shallow = true
 		}
 	}
@@ -1094,7 +1085,7 @@ func getWants(localStorer storage.Storer, refs memory.ReferenceStorage, depth in
 	wants := map[plumbing.Hash]bool{}
 	for _, ref := range refs {
 		hash := ref.Hash()
-		exists, err := objectExists(localStorer, ref.Hash())
+		exists, err := objectExists(ctx, localStorer, ref.Hash())
 		if err != nil {
 			return nil, err
 		}
@@ -1112,8 +1103,8 @@ func getWants(localStorer storage.Storer, refs memory.ReferenceStorage, depth in
 	return result, nil
 }
 
-func objectExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
-	_, err := s.EncodedObject(plumbing.AnyObject, h)
+func objectExists(ctx context.Context, s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
+	_, err := s.EncodedObject(ctx, plumbing.AnyObject, h)
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		return false, nil
 	}
@@ -1121,9 +1112,9 @@ func objectExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
 	return true, err
 }
 
-func checkFastForwardUpdate(s storer.EncodedObjectStorer, remoteRefs storer.ReferenceStorer, cmd *packp.Command) error {
+func checkFastForwardUpdate(ctx context.Context, s storer.EncodedObjectStorer, remoteRefs storer.ReferenceStorer, cmd *packp.Command) error {
 	if cmd.Old == plumbing.ZeroHash {
-		_, err := remoteRefs.Reference(cmd.Name)
+		_, err := remoteRefs.Reference(ctx, cmd.Name)
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return nil
 		}
@@ -1137,10 +1128,10 @@ func checkFastForwardUpdate(s storer.EncodedObjectStorer, remoteRefs storer.Refe
 
 	var shallows []plumbing.Hash
 	if ss, ok := s.(storer.ShallowStorer); ok {
-		shallows, _ = ss.Shallow()
+		shallows, _ = ss.Shallow(ctx)
 	}
 
-	ff, err := isFastForward(s, cmd.Old, cmd.New, shallows)
+	ff, err := isFastForward(ctx, s, cmd.Old, cmd.New, shallows)
 	if err != nil {
 		return err
 	}
@@ -1163,8 +1154,8 @@ func checkFastForwardUpdate(s storer.EncodedObjectStorer, remoteRefs storer.Refe
 // shallow boundary. This mirrors git(1)'s behavior for shallow fetches:
 // ancestry checks are relaxed once history is truncated, at the cost of
 // not being able to prove fast-forward strictly from local data.
-func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, shallows []plumbing.Hash) (bool, error) {
-	c, err := object.GetCommit(s, newHash)
+func isFastForward(ctx context.Context, s storer.EncodedObjectStorer, old, newHash plumbing.Hash, shallows []plumbing.Hash) (bool, error) {
+	c, err := object.GetCommit(ctx, s, newHash)
 	if err != nil {
 		return false, err
 	}
@@ -1180,7 +1171,7 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, sha
 	// the walker never tries to load commits that are not stored locally.
 	parentsToIgnore := make([]plumbing.Hash, 0, len(shallows))
 	for _, sh := range shallows {
-		shallowCommit, err := object.GetCommit(s, sh)
+		shallowCommit, err := object.GetCommit(ctx, s, sh)
 		if err != nil {
 			if errors.Is(err, plumbing.ErrObjectNotFound) {
 				// Shallow marker may reference a commit we no longer have; skip.
@@ -1194,7 +1185,7 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, sha
 	found := false
 	boundedByShallow := false
 	iter := object.NewCommitPreorderIter(c, nil, parentsToIgnore)
-	err = iter.ForEach(func(c *object.Commit) error {
+	err = iter.ForEach(ctx, func(c *object.Commit) error {
 		if _, isShallow := shallowsSet[c.Hash]; isShallow {
 			// The walk reached a shallow commit; history is truncated here.
 			boundedByShallow = true
@@ -1239,6 +1230,7 @@ func (r *Remote) isSupportedRefSpec(refs []config.RefSpec, caps *capability.List
 }
 
 func (r *Remote) updateLocalReferenceStorage(
+	ctx context.Context,
 	specs []config.RefSpec,
 	fetchedRefs, remoteRefs memory.ReferenceStorage,
 	specToRefs [][]*plumbing.Reference,
@@ -1248,7 +1240,7 @@ func (r *Remote) updateLocalReferenceStorage(
 	isWildcard := true
 	forceNeeded := false
 
-	shallows, _ := r.s.Shallow()
+	shallows, _ := r.s.Shallow(ctx)
 
 	for i, spec := range specs {
 		if !spec.IsWildcard() {
@@ -1274,7 +1266,7 @@ func (r *Remote) updateLocalReferenceStorage(
 				}
 				localName = plumbing.NewBranchReferenceName(localName.String())
 			}
-			old, _ := storer.ResolveReference(r.s, localName)
+			old, _ := storer.ResolveReference(ctx, r.s, localName)
 			newRef := plumbing.NewHashReference(localName, ref.Hash())
 
 			if old != nil && localName.IsTag() && old.Hash() != newRef.Hash() && !force && !spec.IsForceUpdate() {
@@ -1285,7 +1277,7 @@ func (r *Remote) updateLocalReferenceStorage(
 			// If the ref exists locally as a non-tag and force is not
 			// specified, only update if the new ref is an ancestor of the old
 			if old != nil && !old.Name().IsTag() && !force && !spec.IsForceUpdate() {
-				ff, err := isFastForward(r.s, old.Hash(), newRef.Hash(), shallows)
+				ff, err := isFastForward(ctx, r.s, old.Hash(), newRef.Hash(), shallows)
 				if err != nil {
 					return updated, err
 				}
@@ -1296,7 +1288,7 @@ func (r *Remote) updateLocalReferenceStorage(
 				}
 			}
 
-			refUpdated, err := checkAndUpdateReferenceStorerIfNeeded(r.s, newRef, old)
+			refUpdated, err := checkAndUpdateReferenceStorerIfNeeded(ctx, r.s, newRef, old)
 			if err != nil {
 				return updated, err
 			}
@@ -1315,7 +1307,7 @@ func (r *Remote) updateLocalReferenceStorage(
 	if isWildcard {
 		tags = remoteRefs
 	}
-	tagUpdated, tagForceNeeded, err := r.buildFetchedTags(tags, tagMode == plumbing.AllTags, force)
+	tagUpdated, tagForceNeeded, err := r.buildFetchedTags(ctx, tags, tagMode == plumbing.AllTags, force)
 	if err != nil {
 		return updated, err
 	}
@@ -1334,13 +1326,13 @@ func (r *Remote) updateLocalReferenceStorage(
 	return updated, err
 }
 
-func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage, allTags, force bool) (updated, forceNeeded bool, err error) {
+func (r *Remote) buildFetchedTags(ctx context.Context, refs memory.ReferenceStorage, allTags, force bool) (updated, forceNeeded bool, err error) {
 	for _, ref := range refs {
 		if !ref.Name().IsTag() {
 			continue
 		}
 
-		_, err := r.s.EncodedObject(plumbing.AnyObject, ref.Hash())
+		_, err := r.s.EncodedObject(ctx, plumbing.AnyObject, ref.Hash())
 		if errors.Is(err, plumbing.ErrObjectNotFound) {
 			continue
 		}
@@ -1349,7 +1341,7 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage, allTags, force b
 			return updated, forceNeeded, err
 		}
 
-		old, err := r.s.Reference(ref.Name())
+		old, err := r.s.Reference(ctx, ref.Name())
 		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return updated, forceNeeded, err
 		}
@@ -1365,7 +1357,7 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage, allTags, force b
 			}
 		}
 
-		refUpdated, err := updateReferenceStorerIfNeeded(r.s, ref)
+		refUpdated, err := updateReferenceStorerIfNeeded(ctx, r.s, ref)
 		if err != nil {
 			return updated, forceNeeded, err
 		}
@@ -1378,27 +1370,21 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage, allTags, force b
 	return updated, forceNeeded, err
 }
 
-// ListContext lists the references on the remote repository.
-// The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects to the
-// transport operations.
-func (r *Remote) ListContext(ctx context.Context, o *ListOptions) (rfs []*plumbing.Reference, err error) {
-	return r.list(ctx, o)
-}
-
 // List lists the references on the remote repository.
-func (r *Remote) List(o *ListOptions) (rfs []*plumbing.Reference, err error) {
+// The provided Context must be non-nil. If the context expires before the
+// operation is complete, an error is returned.
+// If ListOptions.Timeout is set, the context is additionally bounded by it.
+func (r *Remote) List(ctx context.Context, o *ListOptions) (rfs []*plumbing.Reference, err error) {
 	timeout := o.Timeout
-	// Default to the old hardcoded 10s value if a timeout is not explicitly set.
-	if timeout == 0 {
-		timeout = 10
-	}
 	if timeout < 0 {
 		return nil, fmt.Errorf("invalid timeout: %d", timeout)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
-	defer cancel()
-	return r.ListContext(ctx, o)
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
+	return r.list(ctx, o)
 }
 
 func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Reference, err error) {
@@ -1412,7 +1398,7 @@ func (r *Remote) list(ctx context.Context, o *ListOptions) (rfs []*plumbing.Refe
 	}
 
 	req.Command = transport.UploadPackService
-	req.Protocol = r.transportProtocol()
+	req.Protocol = r.transportProtocol(ctx)
 	sess, err := cl.Handshake(ctx, req)
 	if err != nil {
 		return nil, err
@@ -1456,14 +1442,14 @@ func objectsToPush(commands []*packp.Command) []plumbing.Hash {
 	return objects
 }
 
-func referencesToHashes(refs storer.ReferenceStorer) ([]plumbing.Hash, error) {
-	iter, err := refs.IterReferences()
+func referencesToHashes(ctx context.Context, refs storer.ReferenceStorer) ([]plumbing.Hash, error) {
+	iter, err := refs.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	var hs []plumbing.Hash
-	err = iter.ForEach(func(ref *plumbing.Reference) error {
+	err = iter.ForEach(ctx, func(ref *plumbing.Reference) error {
 		if ref.Type() != plumbing.HashReference {
 			return nil
 		}
@@ -1490,7 +1476,7 @@ func pushHashes(
 	useRefDeltas := !sess.Capabilities().Supports(capability.OFSDelta)
 	rd, wr := io.Pipe()
 
-	config, err := s.Config()
+	config, err := s.Config(ctx)
 	if err != nil {
 		return err
 	}
@@ -1510,8 +1496,8 @@ func pushHashes(
 	if !allDelete {
 		req.Packfile = rd
 		go func() {
-			e := packfile.NewEncoder(wr, s, useRefDeltas)
-			if _, err := e.Encode(hs, config.Pack.Window); err != nil {
+			e := packfile.NewEncoder(ctx, wr, s, useRefDeltas)
+			if _, err := e.Encode(ctx, hs, config.Pack.Window); err != nil {
 				done <- wr.CloseWithError(err)
 				return
 			}
@@ -1535,14 +1521,14 @@ func pushHashes(
 	return nil
 }
 
-func (r *Remote) checkRequireRemoteRefs(requires []config.RefSpec, remoteRefs storer.ReferenceStorer) error {
+func (r *Remote) checkRequireRemoteRefs(ctx context.Context, requires []config.RefSpec, remoteRefs storer.ReferenceStorer) error {
 	for _, require := range requires {
 		if require.IsWildcard() {
 			return fmt.Errorf("wildcards not supported in RequireRemoteRefs, got %s", require.String())
 		}
 
 		name := require.Dst("")
-		remote, err := remoteRefs.Reference(name)
+		remote, err := remoteRefs.Reference(ctx, name)
 		if err != nil {
 			return fmt.Errorf("remote ref %s required to be %s but is absent", name.String(), require.Src())
 		}
@@ -1551,7 +1537,7 @@ func (r *Remote) checkRequireRemoteRefs(requires []config.RefSpec, remoteRefs st
 		if require.IsExactSHA1() {
 			requireHash = require.Src()
 		} else {
-			target, err := storer.ResolveReference(remoteRefs, plumbing.ReferenceName(require.Src()))
+			target, err := storer.ResolveReference(ctx, remoteRefs, plumbing.ReferenceName(require.Src()))
 			if err != nil {
 				return fmt.Errorf("could not resolve ref %s in RequireRemoteRefs", require.Src())
 			}

--- a/remote_test.go
+++ b/remote_test.go
@@ -287,7 +287,7 @@ func (s *RemoteSuite) TestFetchDoesNotClobberExistingTag() {
 
 	// A tag the user has already pinned to a specific object.
 	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
-	s.Require().NoError(sto.SetReference(pinned))
+	s.Require().NoError(sto.SetReference(s.T().Context(), pinned))
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
@@ -295,14 +295,14 @@ func (s *RemoteSuite) TestFetchDoesNotClobberExistingTag() {
 
 	// The remote advertises refs/tags/v1.0.0 at a different object. A default
 	// fetch auto-follows tags, but must not move a tag that already exists.
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 	})
 	s.NoError(err)
 
-	got, err := sto.Reference("refs/tags/v1.0.0")
+	got, err := sto.Reference(s.T().Context(), "refs/tags/v1.0.0")
 	s.Require().NoError(err)
 	s.Equal(pinned.Hash(), got.Hash())
 }
@@ -311,20 +311,20 @@ func (s *RemoteSuite) TestFetchTagRefSpecDoesNotClobberExistingTag() {
 	sto := memory.NewStorage()
 
 	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
-	s.Require().NoError(sto.SetReference(pinned))
+	s.Require().NoError(sto.SetReference(s.T().Context(), pinned))
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("refs/tags/*:refs/tags/*"),
 		},
 	})
 	s.ErrorIs(err, ErrForceNeeded)
 
-	got, err := sto.Reference("refs/tags/v1.0.0")
+	got, err := sto.Reference(s.T().Context(), "refs/tags/v1.0.0")
 	s.Require().NoError(err)
 	s.Equal(pinned.Hash(), got.Hash())
 }
@@ -333,7 +333,7 @@ func (s *RemoteSuite) TestFetchForcedTagRefSpecClobbersExistingTag() {
 	sto := memory.NewStorage()
 
 	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
-	s.Require().NoError(sto.SetReference(pinned))
+	s.Require().NoError(sto.SetReference(s.T().Context(), pinned))
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
@@ -341,14 +341,14 @@ func (s *RemoteSuite) TestFetchForcedTagRefSpecClobbersExistingTag() {
 
 	// A forced tag refspec is the user asking for the update, so it must still
 	// move an existing tag.
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/tags/*:refs/tags/*"),
 		},
 	})
 	s.NoError(err)
 
-	got, err := sto.Reference("refs/tags/v1.0.0")
+	got, err := sto.Reference(s.T().Context(), "refs/tags/v1.0.0")
 	s.Require().NoError(err)
 	s.Equal(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), got.Hash())
 }
@@ -357,13 +357,13 @@ func (s *RemoteSuite) TestFetchAllTagsDoesNotClobberExistingTag() {
 	sto := memory.NewStorage()
 
 	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
-	s.Require().NoError(sto.SetReference(pinned))
+	s.Require().NoError(sto.SetReference(s.T().Context(), pinned))
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		Tags: AllTags,
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
@@ -371,7 +371,7 @@ func (s *RemoteSuite) TestFetchAllTagsDoesNotClobberExistingTag() {
 	})
 	s.ErrorIs(err, ErrForceNeeded)
 
-	got, err := sto.Reference("refs/tags/v1.0.0")
+	got, err := sto.Reference(s.T().Context(), "refs/tags/v1.0.0")
 	s.Require().NoError(err)
 	s.Equal(pinned.Hash(), got.Hash())
 }
@@ -380,13 +380,13 @@ func (s *RemoteSuite) TestFetchForcedAllTagsClobbersExistingTag() {
 	sto := memory.NewStorage()
 
 	pinned := plumbing.NewReferenceFromStrings("refs/tags/v1.0.0", "918c48b83bd081e863dbe1b80f8998f058cd8294")
-	s.Require().NoError(sto.SetReference(pinned))
+	s.Require().NoError(sto.SetReference(s.T().Context(), pinned))
 
 	r := NewRemote(sto, &config.RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		Force: true,
 		Tags:  AllTags,
 		RefSpecs: []config.RefSpec{
@@ -395,7 +395,7 @@ func (s *RemoteSuite) TestFetchForcedAllTagsClobbersExistingTag() {
 	})
 	s.NoError(err)
 
-	got, err := sto.Reference("refs/tags/v1.0.0")
+	got, err := sto.Reference(s.T().Context(), "refs/tags/v1.0.0")
 	s.Require().NoError(err)
 	s.Equal(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), got.Hash())
 }
@@ -1119,10 +1119,10 @@ func (s *RemoteSuite) TestPushRejectNonFastForward() {
 func (s *RemoteSuite) TestPushRejectExistingTagUpdate() {
 	server, local, remote, oldHash, newHash := s.newPushExistingTagUpdate()
 
-	err := local.Storer.SetReference(plumbing.NewHashReference("refs/tags/v1", newHash))
+	err := local.Storer.SetReference(s.T().Context(), plumbing.NewHashReference("refs/tags/v1", newHash))
 	s.Require().NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"refs/tags/v1:refs/tags/v1",
 	}})
 	s.ErrorContains(err, "tag already exists: refs/tags/v1")
@@ -1135,7 +1135,7 @@ func (s *RemoteSuite) TestPushRejectExistingTagUpdate() {
 func (s *RemoteSuite) TestPushRejectExistingTagUpdateByOID() {
 	server, _, remote, oldHash, newHash := s.newPushExistingTagUpdate()
 
-	err := remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err := remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		config.RefSpec(newHash.String() + ":refs/tags/v1"),
 	}})
 	s.ErrorContains(err, "tag already exists: refs/tags/v1")
@@ -1148,13 +1148,13 @@ func (s *RemoteSuite) TestPushRejectExistingTagUpdateByOID() {
 func (s *RemoteSuite) TestPushRejectExistingTagUpdateToAnnotatedTag() {
 	server, local, remote, oldHash, newHash := s.newPushExistingTagUpdate()
 
-	_, err := local.CreateTag("v1-annotated", newHash, &CreateTagOptions{
+	_, err := local.CreateTag(s.T().Context(), "v1-annotated", newHash, &CreateTagOptions{
 		Tagger:  defaultSignature(),
 		Message: "annotated tag",
 	})
 	s.Require().NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"refs/tags/v1-annotated:refs/tags/v1",
 	}})
 	s.ErrorContains(err, "tag already exists: refs/tags/v1")
@@ -1167,10 +1167,10 @@ func (s *RemoteSuite) TestPushRejectExistingTagUpdateToAnnotatedTag() {
 func (s *RemoteSuite) TestPushForceUpdatesExistingTag() {
 	server, local, remote, _, newHash := s.newPushExistingTagUpdate()
 
-	err := local.Storer.SetReference(plumbing.NewHashReference("refs/tags/v1", newHash))
+	err := local.Storer.SetReference(s.T().Context(), plumbing.NewHashReference("refs/tags/v1", newHash))
 	s.Require().NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"+refs/tags/v1:refs/tags/v1",
 	}})
 	s.NoError(err)
@@ -1186,27 +1186,27 @@ func (s *RemoteSuite) newPushExistingTagUpdate() (*Repository, *Repository, *Rem
 	dir := s.T().TempDir()
 	remoteURL := filepath.Join(dir, "remote")
 
-	server, err := PlainInit(remoteURL, true)
+	server, err := PlainInit(s.T().Context(), remoteURL, true)
 	s.Require().NoError(err)
 	s.T().Cleanup(func() { _ = server.Close() })
 
-	local, err := PlainInit(filepath.Join(dir, "local"), false)
+	local, err := PlainInit(s.T().Context(), filepath.Join(dir, "local"), false)
 	s.Require().NoError(err)
 	s.T().Cleanup(func() { _ = local.Close() })
 
 	oldHash := CommitNewFile(s.T(), local, "old")
 	newHash := CommitNewFile(s.T(), local, "new")
 
-	_, err = local.CreateTag("v1", oldHash, nil)
+	_, err = local.CreateTag(s.T().Context(), "v1", oldHash, nil)
 	s.Require().NoError(err)
 
-	remote, err := local.CreateRemote(&config.RemoteConfig{
+	remote, err := local.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{remoteURL},
 	})
 	s.Require().NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"refs/tags/v1:refs/tags/v1",
 	}})
 	s.Require().NoError(err)

--- a/remote_test.go
+++ b/remote_test.go
@@ -43,32 +43,32 @@ func TestRemoteSuite(t *testing.T) {
 
 func (s *RemoteSuite) TestFetchInvalidEndpoint() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"http://\\"}})
-	err := r.Fetch(&FetchOptions{RemoteName: "foo"})
+	err := r.Fetch(s.T().Context(), &FetchOptions{RemoteName: "foo"})
 	s.ErrorContains(err, "invalid character")
 }
 
 func (s *RemoteSuite) TestFetchNonExistentEndpoint() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"ssh://non-existent/foo.git"}})
-	err := r.Fetch(&FetchOptions{})
+	err := r.Fetch(s.T().Context(), &FetchOptions{})
 	s.NotNil(err)
 }
 
 func (s *RemoteSuite) TestFetchInvalidSchemaEndpoint() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
-	err := r.Fetch(&FetchOptions{})
+	err := r.Fetch(s.T().Context(), &FetchOptions{})
 	s.ErrorContains(err, "unsupported scheme")
 }
 
 func (s *RemoteSuite) TestFetchOverriddenEndpoint() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"http://perfectly-valid-url.example.com"}})
-	err := r.Fetch(&FetchOptions{RemoteURL: "http://\\"})
+	err := r.Fetch(s.T().Context(), &FetchOptions{RemoteURL: "http://\\"})
 	s.ErrorContains(err, "invalid character")
 }
 
 func (s *RemoteSuite) TestFetchInvalidFetchOptions() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
 	invalid := config.RefSpec("^*$ñ")
-	err := r.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{invalid}})
+	err := r.Fetch(s.T().Context(), &FetchOptions{RefSpecs: []config.RefSpec{invalid}})
 	s.ErrorIs(err, config.ErrRefSpecMalformedSeparator)
 }
 
@@ -108,16 +108,16 @@ func (s *RemoteSuite) TestFetchExactSHA1_NotSupported() {
 	// v2's fetch command accepts any "want <oid>", so there is no unsupported
 	// case to assert there; pin this to v0.
 	st := memory.NewStorage()
-	cfg, err := st.Config()
+	cfg, err := st.Config(s.T().Context())
 	s.Require().NoError(err)
 	cfg.Protocol.Version = protocol.V0
-	s.Require().NoError(st.SetConfig(cfg))
+	s.Require().NoError(st.SetConfig(s.T().Context(), cfg))
 
 	r := NewRemote(st, &config.RemoteConfig{
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	err = r.Fetch(&FetchOptions{
+	err = r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("35e85108805c84807bc66a02d91535e1e24b38b9:refs/heads/foo"),
 		},
@@ -221,7 +221,7 @@ func (s *RemoteSuite) TestFetchNonExistentReference() {
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
 	})
 
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/foo:refs/remotes/origin/foo"),
 		},
@@ -238,7 +238,7 @@ func (s *RemoteSuite) TestFetchContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := r.FetchContext(ctx, &FetchOptions{
+	err := r.Fetch(ctx, &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
 		},
@@ -254,7 +254,7 @@ func (s *RemoteSuite) TestFetchContextCanceled() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err := r.FetchContext(ctx, &FetchOptions{
+	err := r.Fetch(ctx, &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
 		},
@@ -470,19 +470,19 @@ func (s *RemoteSuite) TestFetchWithDepthChange() {
 
 func (s *RemoteSuite) testFetch(r *Remote, o *FetchOptions, expected []*plumbing.Reference) {
 	s.T().Helper()
-	err := r.Fetch(o)
+	err := r.Fetch(s.T().Context(), o)
 	s.NoError(err)
 
 	var refs int
-	l, err := r.s.IterReferences()
+	l, err := r.s.IterReferences(s.T().Context())
 	s.Require().NoError(err)
-	err = l.ForEach(func(*plumbing.Reference) error { refs++; return nil })
+	err = l.ForEach(s.T().Context(), func(*plumbing.Reference) error { refs++; return nil })
 	s.Require().NoError(err)
 
 	s.Len(expected, refs)
 
 	for _, exp := range expected {
-		r, err := r.s.Reference(exp.Name())
+		r, err := r.s.Reference(s.T().Context(), exp.Name())
 		s.Require().NoError(err)
 		s.Equal(exp.String(), r.String())
 	}
@@ -495,20 +495,20 @@ func (s *RemoteSuite) TestFetchOfMissingObjects() {
 
 	storage := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
-	r, err := Open(storage, nil)
+	r, err := Open(s.T().Context(), storage, nil)
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
 	// Confirm we are missing a commit
-	_, err = r.CommitObject(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+	_, err = r.CommitObject(s.T().Context(), plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 	s.Require().ErrorIs(err, plumbing.ErrObjectNotFound)
 
 	// Refetch to get all the missing objects
-	err = r.Fetch(&FetchOptions{})
+	err = r.Fetch(s.T().Context(), &FetchOptions{})
 	s.NoError(err)
 
 	// Confirm we now have the commit
-	_, err = r.CommitObject(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+	_, err = r.CommitObject(s.T().Context(), plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
 	s.NoError(err)
 }
 
@@ -525,7 +525,7 @@ func (s *RemoteSuite) TestFetchWithProgress() {
 	r := NewRemote(sto, &config.RemoteConfig{Name: "foo", URLs: []string{url}})
 
 	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{refspec},
 		Progress: buf,
 	})
@@ -541,9 +541,9 @@ type mockPackfileWriter struct {
 	PackfileWriterCalled bool
 }
 
-func (m *mockPackfileWriter) PackfileWriter() (io.WriteCloser, error) {
+func (m *mockPackfileWriter) PackfileWriter(ctx context.Context) (io.WriteCloser, error) {
 	m.PackfileWriterCalled = true
-	return m.Storer.(storer.PackfileWriter).PackfileWriter()
+	return m.Storer.(storer.PackfileWriter).PackfileWriter(ctx)
 }
 
 func (s *RemoteSuite) TestFetchWithPackfileWriter() {
@@ -557,17 +557,17 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter() {
 	r := NewRemote(mock, &config.RemoteConfig{Name: "foo", URLs: []string{url}})
 
 	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{refspec},
 	})
 
 	s.NoError(err)
 
 	var count int
-	iter, err := mock.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := mock.IterEncodedObjects(s.T().Context(), plumbing.AnyObject)
 	s.NoError(err)
 
-	iter.ForEach(func(plumbing.EncodedObject) error {
+	iter.ForEach(s.T().Context(), func(plumbing.EncodedObject) error {
 		count++
 		return nil
 	})
@@ -592,22 +592,22 @@ func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDateButStillUpdateLocalRemoteRefs
 		},
 	}
 
-	err := r.Fetch(o)
+	err := r.Fetch(s.T().Context(), o)
 	s.NoError(err)
 
 	// Simulate an out of date remote ref even though we have the new commit locally
-	r.s.SetReference(plumbing.NewReferenceFromStrings(
+	r.s.SetReference(s.T().Context(), plumbing.NewReferenceFromStrings(
 		"refs/remotes/origin/master", "918c48b83bd081e863dbe1b80f8998f058cd8294",
 	))
 
-	err = r.Fetch(o)
+	err = r.Fetch(s.T().Context(), o)
 	s.NoError(err)
 
 	exp := plumbing.NewReferenceFromStrings(
 		"refs/remotes/origin/master", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
 	)
 
-	ref, err := r.s.Reference("refs/remotes/origin/master")
+	ref, err := r.s.Reference(s.T().Context(), "refs/remotes/origin/master")
 	s.NoError(err)
 	s.Equal(ref.String(), exp.String())
 }
@@ -627,9 +627,9 @@ func (s *RemoteSuite) doTestFetchNoErrAlreadyUpToDate(url string) {
 		},
 	}
 
-	err := r.Fetch(o)
+	err := r.Fetch(s.T().Context(), o)
 	s.NoError(err)
-	err = r.Fetch(o)
+	err = r.Fetch(s.T().Context(), o)
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
 }
 
@@ -647,7 +647,7 @@ func (s *RemoteSuite) testFetchFastForward(sto storage.Storer) {
 	})
 
 	// First make sure that we error correctly when a force is required.
-	err := r.Fetch(&FetchOptions{
+	err := r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("refs/heads/branch:refs/heads/master"),
 		},
@@ -655,7 +655,7 @@ func (s *RemoteSuite) testFetchFastForward(sto storage.Storer) {
 	s.ErrorIs(err, ErrForceNeeded)
 
 	// And that forcing it fixes the problem.
-	err = r.Fetch(&FetchOptions{
+	err = r.Fetch(s.T().Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/branch:refs/heads/master"),
 		},
@@ -663,7 +663,7 @@ func (s *RemoteSuite) testFetchFastForward(sto storage.Storer) {
 	s.NoError(err)
 
 	// Now test that a fast-forward, non-force fetch works.
-	r.s.SetReference(plumbing.NewReferenceFromStrings(
+	r.s.SetReference(s.T().Context(), plumbing.NewReferenceFromStrings(
 		"refs/heads/master", "918c48b83bd081e863dbe1b80f8998f058cd8294",
 	))
 	s.testFetch(r, &FetchOptions{
@@ -704,7 +704,7 @@ func (s *RemoteSuite) TestString() {
 
 func (s *RemoteSuite) TestPushToEmptyRepository() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -719,16 +719,16 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 	})
 
 	rs := config.RefSpec("refs/heads/*:refs/heads/*")
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{rs},
 	})
 	s.NoError(err)
 
-	iter, err := r.s.IterReferences()
+	iter, err := r.s.IterReferences(s.T().Context())
 	s.NoError(err)
 
 	expected := make(map[string]string)
-	iter.ForEach(func(ref *plumbing.Reference) error {
+	iter.ForEach(s.T().Context(), func(ref *plumbing.Reference) error {
 		if !ref.Name().IsBranch() {
 			return nil
 		}
@@ -743,7 +743,7 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 
 func (s *RemoteSuite) TestPushContext() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -762,7 +762,7 @@ func (s *RemoteSuite) TestPushContext() {
 
 	numGoroutines := runtime.NumGoroutine()
 
-	err = r.PushContext(ctx, &PushOptions{
+	err = r.Push(ctx, &PushOptions{
 		RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"},
 	})
 	s.NoError(err)
@@ -774,7 +774,7 @@ func (s *RemoteSuite) TestPushContext() {
 
 func (s *RemoteSuite) TestPushPushOptions() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -790,7 +790,7 @@ func (s *RemoteSuite) TestPushPushOptions() {
 
 	// TODO: Validate the push options was received by the server and implement
 	// server-side hooks.
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		Options: []string{
 			"iam-a-push-option",
 		},
@@ -813,7 +813,7 @@ func eventually(s *RemoteSuite, condition func() bool) {
 
 func (s *RemoteSuite) TestPushContextCanceled() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -832,7 +832,7 @@ func (s *RemoteSuite) TestPushContextCanceled() {
 
 	numGoroutines := runtime.NumGoroutine()
 
-	err = r.PushContext(ctx, &PushOptions{
+	err = r.Push(ctx, &PushOptions{
 		RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"},
 	})
 	s.ErrorIs(err, context.Canceled)
@@ -844,7 +844,7 @@ func (s *RemoteSuite) TestPushContextCanceled() {
 
 func (s *RemoteSuite) TestPushTags() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -858,7 +858,7 @@ func (s *RemoteSuite) TestPushTags() {
 		URLs: []string{url},
 	})
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"},
 	})
 	s.NoError(err)
@@ -875,7 +875,7 @@ func (s *RemoteSuite) TestPushTags() {
 func (s *RemoteSuite) TestPushTagsByOID() {
 	url := s.T().TempDir()
 
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -889,7 +889,7 @@ func (s *RemoteSuite) TestPushTagsByOID() {
 		URLs: []string{url},
 	})
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{
 			"f7b877701fbf855b44c0a9e86f3fdce2c298b07f:refs/tags/lightweight-tag-copy",
 			"b742a2a9fa0afcfa9a6fad080980fbc26b007c69:refs/tags/annotated-tag-copy",
@@ -913,7 +913,7 @@ func (s *RemoteSuite) TestPushTagsByOID() {
 func (s *RemoteSuite) testPushByOID(oid, refName string) {
 	url := s.T().TempDir()
 
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -927,7 +927,7 @@ func (s *RemoteSuite) testPushByOID(oid, refName string) {
 		URLs: []string{url},
 	})
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec(oid + ":" + refName),
 		},
@@ -950,7 +950,7 @@ func (s *RemoteSuite) TestPushTreeByOID() {
 
 func (s *RemoteSuite) TestPushFollowTags() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -966,6 +966,7 @@ func (s *RemoteSuite) TestPushFollowTags() {
 	localRepo := newRepository(sto, fs)
 	defer func() { _ = localRepo.Close() }()
 	tipTag, err := localRepo.CreateTag(
+		s.T().Context(),
 		"tip",
 		plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
 		&CreateTagOptions{
@@ -975,6 +976,7 @@ func (s *RemoteSuite) TestPushFollowTags() {
 	s.NoError(err)
 
 	initialTag, err := localRepo.CreateTag(
+		s.T().Context(),
 		"initial-commit",
 		plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
 		&CreateTagOptions{
@@ -984,6 +986,7 @@ func (s *RemoteSuite) TestPushFollowTags() {
 	s.NoError(err)
 
 	_, err = localRepo.CreateTag(
+		s.T().Context(),
 		"master-tag",
 		plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
 		&CreateTagOptions{
@@ -992,7 +995,7 @@ func (s *RemoteSuite) TestPushFollowTags() {
 	)
 	s.NoError(err)
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs:   []config.RefSpec{"+refs/heads/branch:refs/heads/branch"},
 		FollowTags: true,
 	})
@@ -1020,7 +1023,7 @@ func (s *RemoteSuite) TestPushNoErrAlreadyUpToDate() {
 		URLs: []string{fs.Root()},
 	})
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{"refs/heads/*:refs/heads/*"},
 	})
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
@@ -1032,25 +1035,25 @@ func (s *RemoteSuite) TestPushDeleteReference() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
+	r, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{
 		URL:  fs.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remote, err := r.Remote(DefaultRemoteName)
+	remote, err := r.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{
+	err = remote.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{":refs/heads/branch"},
 	})
 	s.NoError(err)
 
-	_, err = sto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	_, err = sto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 
-	_, err = r.Storer.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	_, err = r.Storer.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
@@ -1061,26 +1064,26 @@ func (s *RemoteSuite) TestForcePushDeleteReference() {
 	sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
+	r, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{
 		URL:  fs.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remote, err := r.Remote(DefaultRemoteName)
+	remote, err := r.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{
+	err = remote.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{":refs/heads/branch"},
 		Force:    true,
 	})
 	s.NoError(err)
 
-	_, err = sto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	_, err = sto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 
-	_, err = r.Storer.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	_, err = r.Storer.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
@@ -1091,24 +1094,24 @@ func (s *RemoteSuite) TestPushRejectNonFastForward() {
 	server := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = server.Close() }()
 
-	r, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: fs.Root(), Bare: true})
+	r, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{URL: fs.Root(), Bare: true})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remote, err := r.Remote(DefaultRemoteName)
+	remote, err := r.Remote(s.T().Context(), DefaultRemoteName)
 	s.Require().NoError(err)
 
 	branch := plumbing.ReferenceName("refs/heads/branch")
-	oldRef, err := server.Reference(branch)
+	oldRef, err := server.Reference(s.T().Context(), branch)
 	s.NoError(err)
 	s.NotNil(oldRef)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"refs/heads/master:refs/heads/branch",
 	}})
 	s.ErrorContains(err, "non-fast-forward update: refs/heads/branch")
 
-	newRef, err := server.Reference(branch)
+	newRef, err := server.Reference(s.T().Context(), branch)
 	s.NoError(err)
 	s.Equal(oldRef, newRef)
 }
@@ -1228,16 +1231,16 @@ func (s *RemoteSuite) TestPushForce() {
 		URLs: []string{dstFs.Root()},
 	})
 
-	oldRef, err := dstSto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	oldRef, err := dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.NoError(err)
 	s.NotNil(oldRef)
 
-	err = r.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = r.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		config.RefSpec("+refs/heads/master:refs/heads/branch"),
 	}})
 	s.NoError(err)
 
-	newRef, err := dstSto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	newRef, err := dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.NoError(err)
 	s.NotEqual(oldRef, newRef)
 }
@@ -1259,17 +1262,17 @@ func (s *RemoteSuite) TestPushForceWithOption() {
 		URLs: []string{dstFs.Root()},
 	})
 
-	oldRef, err := dstSto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	oldRef, err := dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.NoError(err)
 	s.NotNil(oldRef)
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{"refs/heads/master:refs/heads/branch"},
 		Force:    true,
 	})
 	s.NoError(err)
 
-	newRef, err := dstSto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	newRef, err := dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.NoError(err)
 	s.NotEqual(oldRef, newRef)
 }
@@ -1315,9 +1318,9 @@ func (s *RemoteSuite) TestPushForceWithLease_success() {
 		newCommit := plumbing.NewHashReference(
 			"refs/heads/branch", plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
 		)
-		s.Nil(sto.SetReference(newCommit))
+		s.Nil(sto.SetReference(s.T().Context(), newCommit))
 
-		ref, err := sto.Reference("refs/heads/branch")
+		ref, err := sto.Reference(s.T().Context(), "refs/heads/branch")
 		s.NoError(err)
 		s.T().Log(ref.String())
 
@@ -1326,16 +1329,16 @@ func (s *RemoteSuite) TestPushForceWithLease_success() {
 			URLs: []string{dstFs.Root()},
 		})
 
-		oldRef, err := dstSto.Reference("refs/heads/branch")
+		oldRef, err := dstSto.Reference(s.T().Context(), "refs/heads/branch")
 		s.NoError(err)
 		s.NotNil(oldRef)
 
-		s.NoError(r.Push(&PushOptions{
+		s.NoError(r.Push(s.T().Context(), &PushOptions{
 			RefSpecs:       []config.RefSpec{"refs/heads/branch:refs/heads/branch"},
 			ForceWithLease: &ForceWithLease{},
 		}))
 
-		newRef, err := dstSto.Reference("refs/heads/branch")
+		newRef, err := dstSto.Reference(s.T().Context(), "refs/heads/branch")
 		s.NoError(err)
 		s.Equal(newCommit, newRef)
 	}
@@ -1374,7 +1377,7 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 		sto := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 		defer func() { _ = sto.Close() }()
 		s.NoError(sto.SetReference(
-			plumbing.NewHashReference(
+			s.T().Context(), plumbing.NewHashReference(
 				"refs/heads/branch", plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
 			),
 		))
@@ -1384,7 +1387,7 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 		dstSto := filesystem.NewStorage(dstFs, cache.NewObjectLRUDefault())
 		defer func() { _ = dstSto.Close() }()
 		s.NoError(dstSto.SetReference(
-			plumbing.NewHashReference(
+			s.T().Context(), plumbing.NewHashReference(
 				"refs/heads/branch", plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc"),
 			),
 		))
@@ -1394,48 +1397,48 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 			URLs: []string{dstFs.Root()},
 		})
 
-		oldRef, err := dstSto.Reference("refs/heads/branch")
+		oldRef, err := dstSto.Reference(s.T().Context(), "refs/heads/branch")
 		s.NoError(err)
 		s.NotNil(oldRef)
 
-		err = r.Push(&PushOptions{
+		err = r.Push(s.T().Context(), &PushOptions{
 			RefSpecs:       []config.RefSpec{"refs/heads/branch:refs/heads/branch"},
 			ForceWithLease: &ForceWithLease{},
 		})
 
 		s.ErrorContains(err, "non-fast-forward update: refs/heads/branch")
 
-		newRef, err := dstSto.Reference("refs/heads/branch")
+		newRef, err := dstSto.Reference(s.T().Context(), "refs/heads/branch")
 		s.NoError(err)
 		s.NotEqual(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"), newRef)
 	}
 }
 
 func (s *RemoteSuite) TestPushPrune() {
-	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	server, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
-	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
+	r, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	tag, err := r.Reference(plumbing.ReferenceName("refs/tags/v1.0.0"), true)
+	tag, err := r.Reference(s.T().Context(), plumbing.ReferenceName("refs/tags/v1.0.0"), true)
 	s.NoError(err)
 
-	err = r.DeleteTag("v1.0.0")
+	err = r.DeleteTag(s.T().Context(), "v1.0.0")
 	s.NoError(err)
 
-	remote, err := r.Remote(DefaultRemoteName)
+	remote, err := r.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 
-	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
+	ref, err := r.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{
+	err = remote.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("refs/heads/*:refs/heads/*"),
 		},
@@ -1447,7 +1450,7 @@ func (s *RemoteSuite) TestPushPrune() {
 		"refs/tags/v1.0.0": tag.Hash().String(),
 	})
 
-	err = remote.Push(&PushOptions{
+	err = remote.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("*:*"),
 		},
@@ -1463,29 +1466,29 @@ func (s *RemoteSuite) TestPushPrune() {
 		"refs/remotes/origin/master": ref.Hash().String(),
 	})
 
-	_, err = server.Reference(plumbing.ReferenceName("refs/tags/v1.0.0"), true)
+	_, err = server.Reference(s.T().Context(), plumbing.ReferenceName("refs/tags/v1.0.0"), true)
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
 func (s *RemoteSuite) TestPushNewReference() {
-	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	server, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
-	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
+	r, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remote, err := r.Remote(DefaultRemoteName)
+	remote, err := r.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 
-	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
+	ref, err := r.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"refs/heads/master:refs/heads/branch2",
 	}})
 	s.NoError(err)
@@ -1500,24 +1503,24 @@ func (s *RemoteSuite) TestPushNewReference() {
 }
 
 func (s *RemoteSuite) TestPushNewReferenceAndDeleteInBatch() {
-	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	server, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
-	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
+	r, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{
 		URL:  server.wt.Root(),
 		Bare: true,
 	})
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remote, err := r.Remote(DefaultRemoteName)
+	remote, err := r.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 
-	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
+	ref, err := r.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"refs/heads/master:refs/heads/branch2",
 		":refs/heads/branch",
 	}})
@@ -1531,38 +1534,38 @@ func (s *RemoteSuite) TestPushNewReferenceAndDeleteInBatch() {
 		"refs/remotes/origin/branch2": ref.Hash().String(),
 	})
 
-	_, err = server.Storer.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	_, err = server.Storer.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
 func (s *RemoteSuite) TestPushInvalidEndpoint() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"http://\\"}})
-	err := r.Push(&PushOptions{RemoteName: "foo"})
+	err := r.Push(s.T().Context(), &PushOptions{RemoteName: "foo"})
 	s.ErrorContains(err, "invalid character")
 }
 
 func (s *RemoteSuite) TestPushNonExistentEndpoint() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"ssh://non-existent/foo.git"}})
-	err := r.Push(&PushOptions{})
+	err := r.Push(s.T().Context(), &PushOptions{})
 	s.NotNil(err)
 }
 
 func (s *RemoteSuite) TestPushOverriddenEndpoint() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "origin", URLs: []string{"http://perfectly-valid-url.example.com"}})
-	err := r.Push(&PushOptions{RemoteURL: "http://\\"})
+	err := r.Push(s.T().Context(), &PushOptions{RemoteURL: "http://\\"})
 	s.ErrorContains(err, "invalid character")
 }
 
 func (s *RemoteSuite) TestPushInvalidSchemaEndpoint() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "origin", URLs: []string{"qux://foo"}})
-	err := r.Push(&PushOptions{})
+	err := r.Push(s.T().Context(), &PushOptions{})
 	s.ErrorContains(err, "unsupported scheme")
 }
 
 func (s *RemoteSuite) TestPushInvalidFetchOptions() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"qux://foo"}})
 	invalid := config.RefSpec("^*$ñ")
-	err := r.Push(&PushOptions{RefSpecs: []config.RefSpec{invalid}})
+	err := r.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{invalid}})
 	s.ErrorIs(err, config.ErrRefSpecMalformedSeparator)
 }
 
@@ -1573,7 +1576,7 @@ func (s *RemoteSuite) TestPushInvalidRefSpec() {
 	})
 
 	rs := config.RefSpec("^*$**")
-	err := r.Push(&PushOptions{
+	err := r.Push(s.T().Context(), &PushOptions{
 		RefSpecs: []config.RefSpec{rs},
 	})
 	s.ErrorIs(err, config.ErrRefSpecMalformedSeparator)
@@ -1585,7 +1588,7 @@ func (s *RemoteSuite) TestPushWrongRemoteName() {
 		URLs: []string{"some-url"},
 	})
 
-	err := r.Push(&PushOptions{
+	err := r.Push(s.T().Context(), &PushOptions{
 		RemoteName: "other-remote",
 	})
 	s.ErrorContains(err, "remote names don't match")
@@ -1616,7 +1619,7 @@ func (s *RemoteSuite) TestGetHaves() {
 		),
 	}
 
-	l, err := getHaves(localRefs, memory.NewStorage(), sto, 0)
+	l, err := getHaves(s.T().Context(), localRefs, memory.NewStorage(), sto, 0)
 	s.NoError(err)
 	s.Len(l, 2)
 }
@@ -1628,7 +1631,7 @@ func (s *RemoteSuite) TestList() {
 		URLs: []string{repo.URL},
 	})
 
-	refs, err := remote.List(&ListOptions{})
+	refs, err := remote.List(s.T().Context(), &ListOptions{})
 	s.NoError(err)
 
 	expected := []*plumbing.Reference{
@@ -1667,7 +1670,7 @@ func (s *RemoteSuite) TestListPeeling() {
 		{peelingOption: IgnorePeeled, expectPeeled: false, expectNonPeeled: true},
 		{peelingOption: OnlyPeeled, expectPeeled: true, expectNonPeeled: false},
 	} {
-		refs, err := remote.List(&ListOptions{
+		refs, err := remote.List(s.T().Context(), &ListOptions{
 			PeelingOption: tc.peelingOption,
 		})
 		s.NoError(err)
@@ -1703,7 +1706,7 @@ func (s *RemoteSuite) TestListTimeout() {
 		URLs: []string{srv.URL},
 	})
 
-	_, err := remote.ListContext(ctx, &ListOptions{})
+	_, err := remote.List(ctx, &ListOptions{})
 	s.ErrorIs(err, context.DeadlineExceeded)
 }
 
@@ -1762,7 +1765,7 @@ func (s *RemoteSuite) TestUpdateShallows() {
 
 func (s *RemoteSuite) TestUseRefDeltas() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
@@ -1803,49 +1806,49 @@ func (s *RemoteSuite) TestPushRequireRemoteRefs() {
 		URLs: []string{url},
 	})
 
-	oldRef, err := dstSto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	oldRef, err := dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.NoError(err)
 	s.NotNil(oldRef)
 
-	otherRef, err := dstSto.Reference(plumbing.ReferenceName("refs/heads/master"))
+	otherRef, err := dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/master"))
 	s.NoError(err)
 	s.NotNil(otherRef)
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs:          []config.RefSpec{"refs/heads/master:refs/heads/branch"},
 		RequireRemoteRefs: []config.RefSpec{config.RefSpec(otherRef.Hash().String() + ":refs/heads/branch")},
 	})
 	s.ErrorContains(err, "remote ref refs/heads/branch required to be 6ecf0ef2c2dffb796033e5a02219af86ec6584e5 but is e8d3ffab552895c19b9fcf7aa264d277cde33881")
 
-	newRef, err := dstSto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	newRef, err := dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.NoError(err)
 	s.Equal(oldRef, newRef)
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs:          []config.RefSpec{"refs/heads/master:refs/heads/branch"},
 		RequireRemoteRefs: []config.RefSpec{config.RefSpec(oldRef.Hash().String() + ":refs/heads/branch")},
 	})
 	s.ErrorContains(err, "non-fast-forward update: ")
 
-	newRef, err = dstSto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	newRef, err = dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.NoError(err)
 	s.Equal(oldRef, newRef)
 
-	err = r.Push(&PushOptions{
+	err = r.Push(s.T().Context(), &PushOptions{
 		RefSpecs:          []config.RefSpec{"refs/heads/master:refs/heads/branch"},
 		RequireRemoteRefs: []config.RefSpec{config.RefSpec(oldRef.Hash().String() + ":refs/heads/branch")},
 		Force:             true,
 	})
 	s.NoError(err)
 
-	newRef, err = dstSto.Reference(plumbing.ReferenceName("refs/heads/branch"))
+	newRef, err = dstSto.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"))
 	s.NoError(err)
 	s.NotEqual(oldRef, newRef)
 }
 
 func (s *RemoteSuite) TestFetchPrune() {
 	url := s.T().TempDir()
-	urlRepo, err := PlainClone(url, &CloneOptions{
+	urlRepo, err := PlainClone(s.T().Context(), url, &CloneOptions{
 		URL:  s.GetBasicLocalRepositoryURL(),
 		Bare: true,
 	})
@@ -1853,26 +1856,26 @@ func (s *RemoteSuite) TestFetchPrune() {
 	defer func() { _ = urlRepo.Close() }()
 
 	dir := s.T().TempDir()
-	r, err := PlainClone(dir, &CloneOptions{
+	r, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL:  url,
 		Bare: true,
 	})
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remote, err := r.Remote(DefaultRemoteName)
+	remote, err := r.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 
-	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
+	ref, err := r.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"refs/heads/master:refs/heads/branch",
 	}})
 	s.NoError(err)
 
 	dirSave := s.T().TempDir()
-	rSave, err := PlainClone(dirSave, &CloneOptions{
+	rSave, err := PlainClone(s.T().Context(), dirSave, &CloneOptions{
 		URL:  url,
 		Bare: true,
 	})
@@ -1883,7 +1886,7 @@ func (s *RemoteSuite) TestFetchPrune() {
 		"refs/remotes/origin/branch": ref.Hash().String(),
 	})
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		":refs/heads/branch",
 	}})
 	s.NoError(err)
@@ -1892,16 +1895,16 @@ func (s *RemoteSuite) TestFetchPrune() {
 		"refs/remotes/origin/branch": ref.Hash().String(),
 	})
 
-	err = rSave.Fetch(&FetchOptions{Prune: true})
+	err = rSave.Fetch(s.T().Context(), &FetchOptions{Prune: true})
 	s.NoError(err)
 
-	_, err = rSave.Reference("refs/remotes/origin/branch", true)
+	_, err = rSave.Reference(s.T().Context(), "refs/remotes/origin/branch", true)
 	s.ErrorContains(err, "reference not found")
 }
 
 func (s *RemoteSuite) TestFetchPruneTags() {
 	url := s.T().TempDir()
-	urlRepo, err := PlainClone(url, &CloneOptions{
+	urlRepo, err := PlainClone(s.T().Context(), url, &CloneOptions{
 		URL:  s.GetBasicLocalRepositoryURL(),
 		Bare: true,
 	})
@@ -1909,26 +1912,26 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 	defer func() { _ = urlRepo.Close() }()
 
 	dir := s.T().TempDir()
-	r, err := PlainClone(dir, &CloneOptions{
+	r, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL:  url,
 		Bare: true,
 	})
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remote, err := r.Remote(DefaultRemoteName)
+	remote, err := r.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 
-	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
+	ref, err := r.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/master"), true)
 	s.NoError(err)
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		"refs/heads/master:refs/tags/v1",
 	}})
 	s.NoError(err)
 
 	dirSave := s.T().TempDir()
-	rSave, err := PlainClone(dirSave, &CloneOptions{
+	rSave, err := PlainClone(s.T().Context(), dirSave, &CloneOptions{
 		URL:  url,
 		Bare: true,
 	})
@@ -1939,7 +1942,7 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 		"refs/tags/v1": ref.Hash().String(),
 	})
 
-	err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+	err = remote.Push(s.T().Context(), &PushOptions{RefSpecs: []config.RefSpec{
 		":refs/tags/v1",
 	}})
 	s.NoError(err)
@@ -1948,10 +1951,10 @@ func (s *RemoteSuite) TestFetchPruneTags() {
 		"refs/tags/v1": ref.Hash().String(),
 	})
 
-	err = rSave.Fetch(&FetchOptions{Prune: true, RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"}})
+	err = rSave.Fetch(s.T().Context(), &FetchOptions{Prune: true, RefSpecs: []config.RefSpec{"refs/tags/*:refs/tags/*"}})
 	s.NoError(err)
 
-	_, err = rSave.Reference("refs/tags/v1", true)
+	_, err = rSave.Reference(s.T().Context(), "refs/tags/v1", true)
 	s.ErrorContains(err, "reference not found")
 }
 
@@ -1961,19 +1964,19 @@ func (s *RemoteSuite) TestCanPushShasToReference() {
 	// remote currently forces a plain path for path based remotes inside the PushContext function.
 	// This makes it impossible, in the current state to use memfs.
 	// For the sake of readability, use the same osFS everywhere and use plain git repositories on temporary files
-	remote, err := PlainInit(filepath.Join(d, "remote"), true)
+	remote, err := PlainInit(s.T().Context(), filepath.Join(d, "remote"), true)
 	s.NoError(err)
 	s.NotNil(remote)
 	defer func() { _ = remote.Close() }()
 
-	repo, err := PlainInit(filepath.Join(d, "repo"), false)
+	repo, err := PlainInit(s.T().Context(), filepath.Join(d, "repo"), false)
 	s.NoError(err)
 	s.NotNil(repo)
 	defer func() { _ = repo.Close() }()
 
 	sha := CommitNewFile(s.T(), repo, "README.md")
 
-	gitremote, err := repo.CreateRemote(&config.RemoteConfig{
+	gitremote, err := repo.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: "local",
 		URLs: []string{filepath.Join(d, "remote")},
 	})
@@ -1982,7 +1985,7 @@ func (s *RemoteSuite) TestCanPushShasToReference() {
 		return
 	}
 
-	err = gitremote.Push(&PushOptions{
+	err = gitremote.Push(s.T().Context(), &PushOptions{
 		RemoteName: "local",
 		RefSpecs: []config.RefSpec{
 			// TODO: check with short hashes that this is still respected
@@ -1994,7 +1997,7 @@ func (s *RemoteSuite) TestCanPushShasToReference() {
 		return
 	}
 
-	ref, err := remote.Reference(plumbing.ReferenceName("refs/heads/branch"), false)
+	ref, err := remote.Reference(s.T().Context(), plumbing.ReferenceName("refs/heads/branch"), false)
 	s.NoError(err)
 	if err != nil {
 		return
@@ -2008,7 +2011,7 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 	repoDir := filepath.Join(tempDir, "repo")
 
 	// Create a new repo and add more than 1 commit (so we can have a shallow commit)
-	remote, err := PlainInit(remoteURL, false)
+	remote, err := PlainInit(s.T().Context(), remoteURL, false)
 	s.Require().NoError(err)
 	s.Require().NotNil(remote)
 	defer func() { _ = remote.Close() }()
@@ -2017,7 +2020,7 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 	_ = CommitNewFile(s.T(), remote, "File2")
 
 	// Clone the repo with a depth of 1
-	repo, err := PlainClone(repoDir, &CloneOptions{
+	repo, err := PlainClone(s.T().Context(), repoDir, &CloneOptions{
 		URL:           remoteURL,
 		Depth:         1,
 		Tags:          plumbing.NoTags,
@@ -2032,7 +2035,7 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 	sha4 := CommitNewFile(s.T(), remote, "File4")
 
 	// Try fetch with depth of 1 again (note, we need to ensure no remote branch remains pointing at the old commit)
-	r, err := repo.Remote(DefaultRemoteName)
+	r, err := repo.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 	s.testFetch(r, &FetchOptions{
 		Depth: 2,
@@ -2052,7 +2055,7 @@ func (s *RemoteSuite) TestFetchAfterShallowClone() {
 	sha5 := CommitNewFile(s.T(), remote, "File5")
 
 	// Try fetch with depth of 2 this time (to reach a commit that we don't have locally)
-	r, err = repo.Remote(DefaultRemoteName)
+	r, err = repo.Remote(s.T().Context(), DefaultRemoteName)
 	s.NoError(err)
 	s.testFetch(r, &FetchOptions{
 		Depth: 1,
@@ -2085,14 +2088,14 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 	repoDir := filepath.Join(tempDir, "repo")
 
 	// Build a remote with two commits so we can take a shallow clone.
-	remoteRepo, err := PlainInit(remoteURL, false)
+	remoteRepo, err := PlainInit(s.T().Context(), remoteURL, false)
 	s.Require().NoError(err)
 	defer func() { _ = remoteRepo.Close() }()
 	_ = CommitNewFile(s.T(), remoteRepo, "File1")
 	_ = CommitNewFile(s.T(), remoteRepo, "File2")
 
 	// Shallow clone at depth=1 — only the latest commit is stored locally.
-	repo, err := PlainClone(repoDir, &CloneOptions{
+	repo, err := PlainClone(s.T().Context(), repoDir, &CloneOptions{
 		URL:           remoteURL,
 		Depth:         1,
 		Tags:          plumbing.NoTags,
@@ -2110,10 +2113,10 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 	// This means only File4's commit is fetched; File3's commit is absent
 	// locally, so the ancestry walk from sha4 back to our current tip would
 	// hit a missing object without the fix.
-	r, err := repo.Remote(DefaultRemoteName)
+	r, err := repo.Remote(s.T().Context(), DefaultRemoteName)
 	s.Require().NoError(err)
 
-	err = r.Fetch(&FetchOptions{
+	err = r.Fetch(s.T().Context(), &FetchOptions{
 		Depth: 1,
 		Tags:  plumbing.NoTags,
 		RefSpecs: []config.RefSpec{
@@ -2125,7 +2128,7 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 	s.Require().NoError(err, "shallow fetch with non-force refspec must not return an error")
 
 	// Confirm the local branch was updated to the new tip.
-	head, err := repo.Reference(plumbing.NewBranchReferenceName("master"), true)
+	head, err := repo.Reference(s.T().Context(), plumbing.NewBranchReferenceName("master"), true)
 	s.Require().NoError(err)
 	s.Equal(sha4, head.Hash(), "local master must point to the new remote tip")
 }
@@ -2135,7 +2138,7 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	customRef := "refs/custom/branch"
 	// 1. Set up a remote with a URL
 	remoteURL := t.TempDir()
-	remoteRepo, err := PlainInit(remoteURL, true)
+	remoteRepo, err := PlainInit(t.Context(), remoteURL, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2145,20 +2148,20 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	emptyTreeID := writeEmptyTree(t, remoteRepo)
 	writeCommitToRef(t, remoteRepo, "refs/heads/master", emptyTreeID, time.Now())
 	writeCommitToRef(t, remoteRepo, customRef, emptyTreeID, time.Now())
-	if err := remoteRepo.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/master")); err != nil {
+	if err := remoteRepo.Storer.SetReference(t.Context(), plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/master")); err != nil {
 		t.Fatal(err)
 	}
 
 	// 3. Clone repo, then fetch the custom ref
 	// Note that using custom ref in ReferenceName has an IsBranch issue
-	localRepo, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
+	localRepo, err := Clone(t.Context(), memory.NewStorage(), memfs.New(), &CloneOptions{
 		URL: remoteURL,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = localRepo.Close() }()
-	if err := localRepo.Fetch(&FetchOptions{
+	if err := localRepo.Fetch(t.Context(), &FetchOptions{
 		RefSpecs: []config.RefSpec{
 			config.RefSpec(fmt.Sprintf("%s:%s", customRef, customRef)),
 		},
@@ -2174,12 +2177,12 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	writeCommitToRef(t, localRepo, customRef, emptyTreeID, time.Now().Add(time.Second))
 
 	// 5. Try to fetch with fast-forward only mode
-	remote, err := localRepo.Remote(DefaultRemoteName)
+	remote, err := localRepo.Remote(t.Context(), DefaultRemoteName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = remote.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{
+	err = remote.Fetch(t.Context(), &FetchOptions{RefSpecs: []config.RefSpec{
 		config.RefSpec(fmt.Sprintf("%s:%s", customRef, customRef)),
 	}})
 	if !errors.Is(err, ErrForceNeeded) {
@@ -2187,7 +2190,7 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	}
 
 	// 6. Fetch with force
-	err = remote.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{
+	err = remote.Fetch(t.Context(), &FetchOptions{RefSpecs: []config.RefSpec{
 		config.RefSpec(fmt.Sprintf("+%s:%s", customRef, customRef)),
 	}})
 	if err != nil {
@@ -2195,7 +2198,7 @@ func TestFetchFastForwardForCustomRef(t *testing.T) {
 	}
 
 	// 7. Assert commit ID matches
-	ref, err := localRepo.Reference(plumbing.ReferenceName(customRef), true)
+	ref, err := localRepo.Reference(t.Context(), plumbing.ReferenceName(customRef), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2215,7 +2218,7 @@ func writeEmptyTree(t *testing.T, repo *Repository) plumbing.Hash {
 		t.Fatal(err)
 	}
 
-	treeID, err := repo.Storer.SetEncodedObject(obj)
+	treeID, err := repo.Storer.SetEncodedObject(t.Context(), obj)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2226,14 +2229,14 @@ func writeEmptyTree(t *testing.T, repo *Repository) plumbing.Hash {
 func writeCommitToRef(t *testing.T, repo *Repository, refName string, treeID plumbing.Hash, when time.Time) plumbing.Hash {
 	t.Helper()
 
-	ref, err := repo.Reference(plumbing.ReferenceName(refName), true)
+	ref, err := repo.Reference(t.Context(), plumbing.ReferenceName(refName), true)
 	if err != nil {
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
-			if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(refName), plumbing.ZeroHash)); err != nil {
+			if err := repo.Storer.SetReference(t.Context(), plumbing.NewHashReference(plumbing.ReferenceName(refName), plumbing.ZeroHash)); err != nil {
 				t.Fatal(err)
 			}
 
-			ref, err = repo.Reference(plumbing.ReferenceName(refName), true)
+			ref, err = repo.Reference(t.Context(), plumbing.ReferenceName(refName), true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2257,13 +2260,13 @@ func writeCommitToRef(t *testing.T, repo *Repository, refName string, treeID plu
 		t.Fatal(err)
 	}
 
-	commitID, err := repo.Storer.SetEncodedObject(obj)
+	commitID, err := repo.Storer.SetEncodedObject(t.Context(), obj)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	newRef := plumbing.NewHashReference(plumbing.ReferenceName(refName), commitID)
-	if err := repo.Storer.CheckAndSetReference(newRef, ref); err != nil {
+	if err := repo.Storer.CheckAndSetReference(t.Context(), newRef, ref); err != nil {
 		t.Fatal(err)
 	}
 

--- a/remote_v2_test.go
+++ b/remote_v2_test.go
@@ -13,18 +13,18 @@ import (
 
 func (s *RemoteSuite) TestTransportProtocolDefault() {
 	r := NewRemote(nil, &config.RemoteConfig{Name: "foo", URLs: []string{"https://example.com/foo.git"}})
-	s.Equal(config.DefaultProtocolVersion, r.transportProtocol())
+	s.Equal(config.DefaultProtocolVersion, r.transportProtocol(s.T().Context()))
 }
 
 func (s *RemoteSuite) TestTransportProtocolFromConfig() {
 	st := memory.NewStorage()
-	cfg, err := st.Config()
+	cfg, err := st.Config(s.T().Context())
 	s.Require().NoError(err)
 	cfg.Protocol.Version = protocol.V2
-	s.Require().NoError(st.SetConfig(cfg))
+	s.Require().NoError(st.SetConfig(s.T().Context(), cfg))
 
 	r := NewRemote(st, &config.RemoteConfig{Name: "foo", URLs: []string{"https://example.com/foo.git"}})
-	s.Equal(protocol.V2, r.transportProtocol())
+	s.Equal(protocol.V2, r.transportProtocol(s.T().Context()))
 }
 
 func TestFetchRefPrefixes(t *testing.T) {

--- a/repository.go
+++ b/repository.go
@@ -141,7 +141,7 @@ func withPartialInit() InitOption {
 // Init creates an empty git repository, based on the given Storer and worktree.
 // The worktree Filesystem is optional, if nil a bare repository is created. If
 // the given storer is not empty ErrTargetDirNotEmpty is returned
-func Init(s storage.Storer, opts ...InitOption) (*Repository, error) {
+func Init(ctx context.Context, s storage.Storer, opts ...InitOption) (*Repository, error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -156,7 +156,7 @@ func Init(s storage.Storer, opts ...InitOption) (*Repository, error) {
 		}
 	}
 
-	if err := initStorer(s); err != nil {
+	if err := initStorer(ctx, s); err != nil {
 		if closer, ok := s.(io.Closer); ok {
 			_ = closer.Close()
 		}
@@ -171,7 +171,7 @@ func Init(s storage.Storer, opts ...InitOption) (*Repository, error) {
 	}
 
 	r := newRepository(s, options.workTree)
-	_, err := r.Reference(plumbing.HEAD, false)
+	_, err := r.Reference(ctx, plumbing.HEAD, false)
 	switch err {
 	case plumbing.ErrReferenceNotFound:
 	case nil:
@@ -183,29 +183,29 @@ func Init(s storage.Storer, opts ...InitOption) (*Repository, error) {
 	}
 
 	if options.partialInit {
-		return r.setInvalidHEAD()
+		return r.setInvalidHEAD(ctx)
 	}
 
 	h := plumbing.NewSymbolicReference(plumbing.HEAD, options.defaultBranch)
-	if err := s.SetReference(h); err != nil {
+	if err := s.SetReference(ctx, h); err != nil {
 		_ = r.Close()
 		return nil, err
 	}
 
-	return r, r.setWorktreeAndStoragePaths()
+	return r, r.setWorktreeAndStoragePaths(ctx)
 }
 
-func initStorer(s storer.Storer) error {
+func initStorer(ctx context.Context, s storer.Storer) error {
 	if i, ok := s.(storer.Initializer); ok {
-		return i.Init()
+		return i.Init(ctx)
 	}
 
 	return nil
 }
 
-func (r *Repository) setWorktreeAndStoragePaths() error {
+func (r *Repository) setWorktreeAndStoragePaths(ctx context.Context) error {
 	if r.wt == nil {
-		_ = r.setIsBare(true)
+		_ = r.setIsBare(ctx, true)
 		return nil
 	}
 
@@ -224,7 +224,7 @@ func (r *Repository) setWorktreeAndStoragePaths() error {
 		return err
 	}
 
-	return setConfigWorktree(r, r.wt, fs.Filesystem())
+	return setConfigWorktree(ctx, r, r.wt, fs.Filesystem())
 }
 
 func createDotGitFile(worktree, storage billy.Filesystem) error {
@@ -248,7 +248,7 @@ func createDotGitFile(worktree, storage billy.Filesystem) error {
 	return err
 }
 
-func setConfigWorktree(r *Repository, worktree, storage billy.Filesystem) error {
+func setConfigWorktree(ctx context.Context, r *Repository, worktree, storage billy.Filesystem) error {
 	path, err := filepath.Rel(storage.Root(), worktree.Root())
 	if err != nil {
 		path = worktree.Root()
@@ -259,13 +259,13 @@ func setConfigWorktree(r *Repository, worktree, storage billy.Filesystem) error 
 		return nil
 	}
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return err
 	}
 
 	cfg.Core.Worktree = path
-	return r.Storer.SetConfig(cfg)
+	return r.Storer.SetConfig(ctx, cfg)
 }
 
 // Open opens a git repository using the given Storer and worktree filesystem,
@@ -273,7 +273,7 @@ func setConfigWorktree(r *Repository, worktree, storage billy.Filesystem) error 
 // The worktree can be nil when the repository being opened is bare, if the
 // repository is a normal one (not bare) and worktree is nil the err
 // ErrWorktreeNotProvided is returned
-func Open(s storage.Storer, worktree billy.Filesystem) (*Repository, error) {
+func Open(ctx context.Context, s storage.Storer, worktree billy.Filesystem) (*Repository, error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -281,12 +281,12 @@ func Open(s storage.Storer, worktree billy.Filesystem) (*Repository, error) {
 		}()
 	}
 
-	_, err := s.Reference(plumbing.HEAD)
+	_, err := s.Reference(ctx, plumbing.HEAD)
 	if err == plumbing.ErrReferenceNotFound {
 		return nil, ErrRepositoryNotExists
 	}
 
-	cfg, err := s.Config()
+	cfg, err := s.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -302,21 +302,13 @@ func Open(s storage.Storer, worktree billy.Filesystem) (*Repository, error) {
 // Clone a repository into the given Storer and worktree Filesystem with the
 // given options, if worktree is nil a bare repository is created. If the given
 // storer is not empty ErrTargetDirNotEmpty is returned.
-func Clone(s storage.Storer, worktree billy.Filesystem, o *CloneOptions) (*Repository, error) {
-	return CloneContext(context.Background(), s, worktree, o)
-}
-
-// CloneContext a repository into the given Storer and worktree Filesystem with
-// the given options, if worktree is nil a bare repository is created. If the
-// given storer is not empty ErrTargetDirNotEmpty is returned.
 //
 // The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func CloneContext(
+// operation is complete, an error is returned.
+func Clone(
 	ctx context.Context, s storage.Storer, worktree billy.Filesystem, o *CloneOptions,
 ) (*Repository, error) {
-	r, err := Init(s, withPartialInit())
+	r, err := Init(ctx, s, withPartialInit())
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +324,7 @@ func CloneContext(
 // PlainInit create an empty git repository at the given path. isBare defines
 // if the repository will have worktree (non-bare) or not (bare), if the path
 // is not empty ErrTargetDirNotEmpty is returned.
-func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, error) {
+func PlainInit(ctx context.Context, path string, isBare bool, options ...InitOption) (*Repository, error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -360,7 +352,7 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 	if isBare {
 		dot = osfs.New(path, osfs.WithBoundOS())
 		initFn = func(s *filesystem.Storage) (*Repository, error) {
-			return Init(s, options...)
+			return Init(ctx, s, options...)
 		}
 	} else {
 		wt = osfs.New(path, osfs.WithBoundOS())
@@ -369,7 +361,7 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 			oo := make([]InitOption, 0, 1+len(options))
 			oo = append(oo, WithWorkTree(wt))
 			oo = append(oo, options...)
-			return Init(s, oo...)
+			return Init(ctx, s, oo...)
 		}
 	}
 	s := filesystem.NewStorageWithOptions(dot, cache.NewObjectLRUDefault(), filesystem.Options{
@@ -381,16 +373,16 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 	}
 
 	if o.partialInit {
-		return r.setInvalidHEAD()
+		return r.setInvalidHEAD(ctx)
 	}
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		_ = r.Close()
 		return nil, err
 	}
 
-	err = r.Storer.SetConfig(cfg)
+	err = r.Storer.SetConfig(ctx, cfg)
 	if err != nil {
 		_ = r.Close()
 		return nil, err
@@ -408,10 +400,10 @@ func PlainInit(path string, isBare bool, options ...InitOption) (*Repository, er
 //     repository - regardless of its ObjectFormat being set explicitly or not.
 //
 // https://github.com/git/git/blob/ab380cb80b0727f7f2d7f6b17592ae6783e9820c/builtin/clone.c#L1216C60-L1216C68
-func (r *Repository) setInvalidHEAD() (*Repository, error) {
+func (r *Repository) setInvalidHEAD(ctx context.Context) (*Repository, error) {
 	h := plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Invalid)
 
-	err := r.Storer.SetReference(h)
+	err := r.Storer.SetReference(ctx, h)
 	if err != nil {
 		return nil, err
 	}
@@ -422,13 +414,13 @@ func (r *Repository) setInvalidHEAD() (*Repository, error) {
 // PlainOpen opens a git repository from the given path. It detects if the
 // repository is bare or a normal one. If the path doesn't contain a valid
 // repository ErrRepositoryNotExists is returned
-func PlainOpen(path string) (*Repository, error) {
-	return PlainOpenWithOptions(path, &PlainOpenOptions{})
+func PlainOpen(ctx context.Context, path string) (*Repository, error) {
+	return PlainOpenWithOptions(ctx, path, &PlainOpenOptions{})
 }
 
 // PlainOpenWithOptions opens a git repository from the given path with specific
 // options. See PlainOpen for more info.
-func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error) {
+func PlainOpenWithOptions(ctx context.Context, path string, o *PlainOpenOptions) (*Repository, error) {
 	if o == nil {
 		o = &PlainOpenOptions{}
 	}
@@ -458,7 +450,7 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 		AlternatesFS: o.AlternatesFS,
 	})
 
-	r, err := Open(s, wt)
+	r, err := Open(ctx, s, wt)
 	if err != nil {
 		_ = s.Close()
 		return nil, err
@@ -589,18 +581,10 @@ func dotGitCommonDirectory(fs billy.Filesystem) (commonDir billy.Filesystem, err
 // PlainClone a repository into the path with the given options, isBare defines
 // if the new repository will be bare or normal. If the path is not empty
 // ErrTargetDirNotEmpty is returned.
-func PlainClone(path string, o *CloneOptions) (*Repository, error) {
-	return PlainCloneContext(context.Background(), path, o)
-}
-
-// PlainCloneContext a repository into the path with the given options, isBare
-// defines if the new repository will be bare or normal. If the path is not empty
-// ErrTargetDirNotEmpty is returned.
 //
 // The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func PlainCloneContext(ctx context.Context, path string, o *CloneOptions) (*Repository, error) {
+// operation is complete, an error is returned.
+func PlainClone(ctx context.Context, path string, o *CloneOptions) (*Repository, error) {
 	empty, err := checkTargetDirIsEmpty(path)
 	if err != nil {
 		return nil, err
@@ -625,7 +609,7 @@ func PlainCloneContext(ctx context.Context, path string, o *CloneOptions) (*Repo
 		initOptions = append(initOptions, withPartialInit())
 	}
 
-	r, err := PlainInit(path, isBare, initOptions...)
+	r, err := PlainInit(ctx, path, isBare, initOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -696,25 +680,25 @@ func (r *Repository) Close() error {
 
 // Config return the repository config. In a filesystem backed repository this
 // means read the `.git/config`.
-func (r *Repository) Config() (*config.Config, error) {
-	return r.Storer.Config()
+func (r *Repository) Config(ctx context.Context) (*config.Config, error) {
+	return r.Storer.Config(ctx)
 }
 
 // SetConfig marshall and writes the repository config. In a filesystem backed
 // repository this means write the `.git/config`. This function should be called
 // with the result of `Repository.Config` and never with the output of
 // `Repository.ConfigScoped`.
-func (r *Repository) SetConfig(cfg *config.Config) error {
-	return r.Storer.SetConfig(cfg)
+func (r *Repository) SetConfig(ctx context.Context, cfg *config.Config) error {
+	return r.Storer.SetConfig(ctx, cfg)
 }
 
 // ConfigScoped returns the repository config, merged with requested scope and
 // lower. For example if, config.GlobalScope is given the local and global config
 // are returned merged in one config value.
-func (r *Repository) ConfigScoped(scope config.Scope) (*config.Config, error) {
+func (r *Repository) ConfigScoped(ctx context.Context, scope config.Scope) (*config.Config, error) {
 	// TODO(mcuadros): v6, add this as ConfigOptions.Scoped
 
-	local, err := r.Storer.Config()
+	local, err := r.Storer.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -742,7 +726,7 @@ func (r *Repository) ConfigScoped(scope config.Scope) (*config.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		system, err = ss.Config()
+		system, err = ss.Config(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -754,7 +738,7 @@ func (r *Repository) ConfigScoped(scope config.Scope) (*config.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		global, err = gs.Config()
+		global, err = gs.Config(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -765,8 +749,8 @@ func (r *Repository) ConfigScoped(scope config.Scope) (*config.Config, error) {
 }
 
 // Remote return a remote if exists
-func (r *Repository) Remote(name string) (*Remote, error) {
-	cfg, err := r.Config()
+func (r *Repository) Remote(ctx context.Context, name string) (*Remote, error) {
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -780,8 +764,8 @@ func (r *Repository) Remote(name string) (*Remote, error) {
 }
 
 // Remotes returns a list with all the remotes
-func (r *Repository) Remotes() ([]*Remote, error) {
-	cfg, err := r.Config()
+func (r *Repository) Remotes(ctx context.Context) ([]*Remote, error) {
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -798,14 +782,14 @@ func (r *Repository) Remotes() ([]*Remote, error) {
 }
 
 // CreateRemote creates a new remote
-func (r *Repository) CreateRemote(c *config.RemoteConfig) (*Remote, error) {
+func (r *Repository) CreateRemote(ctx context.Context, c *config.RemoteConfig) (*Remote, error) {
 	if err := c.Validate(); err != nil {
 		return nil, err
 	}
 
 	remote := NewRemote(r.Storer, c)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -815,7 +799,7 @@ func (r *Repository) CreateRemote(c *config.RemoteConfig) (*Remote, error) {
 	}
 
 	cfg.Remotes[c.Name] = c
-	return remote, r.Storer.SetConfig(cfg)
+	return remote, r.Storer.SetConfig(ctx, cfg)
 }
 
 // CreateRemoteAnonymous creates a new anonymous remote. c.Name must be "anonymous".
@@ -835,8 +819,8 @@ func (r *Repository) CreateRemoteAnonymous(c *config.RemoteConfig) (*Remote, err
 }
 
 // DeleteRemote delete a remote from the repository and delete the config
-func (r *Repository) DeleteRemote(name string) error {
-	cfg, err := r.Config()
+func (r *Repository) DeleteRemote(ctx context.Context, name string) error {
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return err
 	}
@@ -846,12 +830,12 @@ func (r *Repository) DeleteRemote(name string) error {
 	}
 
 	delete(cfg.Remotes, name)
-	return r.Storer.SetConfig(cfg)
+	return r.Storer.SetConfig(ctx, cfg)
 }
 
 // Branch return a Branch if exists
-func (r *Repository) Branch(name string) (*config.Branch, error) {
-	cfg, err := r.Config()
+func (r *Repository) Branch(ctx context.Context, name string) (*config.Branch, error) {
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -865,12 +849,12 @@ func (r *Repository) Branch(name string) (*config.Branch, error) {
 }
 
 // CreateBranch creates a new Branch
-func (r *Repository) CreateBranch(c *config.Branch) error {
+func (r *Repository) CreateBranch(ctx context.Context, c *config.Branch) error {
 	if err := c.Validate(); err != nil {
 		return err
 	}
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return err
 	}
@@ -880,14 +864,14 @@ func (r *Repository) CreateBranch(c *config.Branch) error {
 	}
 
 	cfg.Branches[c.Name] = c
-	return r.Storer.SetConfig(cfg)
+	return r.Storer.SetConfig(ctx, cfg)
 }
 
 // DeleteBranch delete a Branch from the repository and delete the config
-func (r *Repository) DeleteBranch(name string) error {
+func (r *Repository) DeleteBranch(ctx context.Context, name string) error {
 	name = strings.TrimPrefix(name, "refs/heads/")
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return err
 	}
@@ -897,18 +881,18 @@ func (r *Repository) DeleteBranch(name string) error {
 	}
 
 	delete(cfg.Branches, name)
-	return r.Storer.SetConfig(cfg)
+	return r.Storer.SetConfig(ctx, cfg)
 }
 
 // CreateTag creates a tag. If opts is included, the tag is an annotated tag,
 // otherwise a lightweight tag is created.
-func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagOptions) (*plumbing.Reference, error) {
+func (r *Repository) CreateTag(ctx context.Context, name string, hash plumbing.Hash, opts *CreateTagOptions) (*plumbing.Reference, error) {
 	rname := plumbing.NewTagReferenceName(name)
 	if err := rname.Validate(); err != nil {
 		return nil, err
 	}
 
-	_, err := r.Storer.Reference(rname)
+	_, err := r.Storer.Reference(ctx, rname)
 	switch err {
 	case nil:
 		// Tag exists, this is an error
@@ -922,7 +906,7 @@ func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagO
 
 	var target plumbing.Hash
 	if opts != nil {
-		target, err = r.createTagObject(name, hash, opts)
+		target, err = r.createTagObject(ctx, name, hash, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -931,19 +915,19 @@ func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagO
 	}
 
 	ref := plumbing.NewHashReference(rname, target)
-	if err = r.Storer.SetReference(ref); err != nil {
+	if err = r.Storer.SetReference(ctx, ref); err != nil {
 		return nil, err
 	}
 
 	return ref, nil
 }
 
-func (r *Repository) createTagObject(name string, hash plumbing.Hash, opts *CreateTagOptions) (plumbing.Hash, error) {
-	if err := opts.Validate(r, hash); err != nil {
+func (r *Repository) createTagObject(ctx context.Context, name string, hash plumbing.Hash, opts *CreateTagOptions) (plumbing.Hash, error) {
+	if err := opts.Validate(ctx, r, hash); err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	rawobj, err := object.GetObject(r.Storer, hash)
+	rawobj, err := object.GetObject(ctx, r.Storer, hash)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -958,7 +942,7 @@ func (r *Repository) createTagObject(name string, hash plumbing.Hash, opts *Crea
 
 	signer := opts.Signer
 	if signer == nil {
-		cfg, err := r.ConfigScoped(config.SystemScope)
+		cfg, err := r.ConfigScoped(ctx, config.SystemScope)
 		if err == nil && cfg != nil && cfg.Tag.GpgSign.IsTrue() {
 			// Use Has before Get so the key is not frozen when no plugin is
 			// registered, allowing callers to register one later.
@@ -974,7 +958,7 @@ func (r *Repository) createTagObject(name string, hash plumbing.Hash, opts *Crea
 	}
 
 	if signer != nil {
-		sig, err := r.buildTagSignature(tag, signer)
+		sig, err := r.buildTagSignature(ctx, tag, signer)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
@@ -987,10 +971,10 @@ func (r *Repository) createTagObject(name string, hash plumbing.Hash, opts *Crea
 		return plumbing.ZeroHash, err
 	}
 
-	return r.Storer.SetEncodedObject(obj)
+	return r.Storer.SetEncodedObject(ctx, obj)
 }
 
-func (r *Repository) buildTagSignature(tag *object.Tag, signer Signer) (string, error) {
+func (r *Repository) buildTagSignature(ctx context.Context, tag *object.Tag, signer Signer) (string, error) {
 	encoded := &plumbing.MemoryObject{}
 	if err := tag.Encode(encoded); err != nil {
 		return "", err
@@ -1001,8 +985,7 @@ func (r *Repository) buildTagSignature(tag *object.Tag, signer Signer) (string, 
 		return "", err
 	}
 
-	// TODO: thread a caller-supplied context once CreateTag accepts one.
-	b, err := signer.Sign(context.TODO(), rdr)
+	b, err := signer.Sign(ctx, rdr)
 	if err != nil {
 		return "", err
 	}
@@ -1015,12 +998,12 @@ func (r *Repository) buildTagSignature(tag *object.Tag, signer Signer) (string, 
 // If you want to check to see if the tag is an annotated tag, you can call
 // TagObject on the hash of the reference in ForEach:
 //
-//	ref, err := r.Tag("v0.1.0")
+//	ref, err := r.Tag(ctx, "v0.1.0")
 //	if err != nil {
 //	  // Handle error
 //	}
 //
-//	obj, err := r.TagObject(ref.Hash())
+//	obj, err := r.TagObject(ctx, ref.Hash())
 //	switch err {
 //	case nil:
 //	  // Tag object present
@@ -1029,8 +1012,8 @@ func (r *Repository) buildTagSignature(tag *object.Tag, signer Signer) (string, 
 //	default:
 //	  // Some other error
 //	}
-func (r *Repository) Tag(name string) (*plumbing.Reference, error) {
-	ref, err := r.Reference(plumbing.ReferenceName(path.Join("refs", "tags", name)), false)
+func (r *Repository) Tag(ctx context.Context, name string) (*plumbing.Reference, error) {
+	ref, err := r.Reference(ctx, plumbing.ReferenceName(path.Join("refs", "tags", name)), false)
 	if err != nil {
 		if err == plumbing.ErrReferenceNotFound {
 			// Return a friendly error for this one, versus just ReferenceNotFound.
@@ -1044,17 +1027,17 @@ func (r *Repository) Tag(name string) (*plumbing.Reference, error) {
 }
 
 // DeleteTag deletes a tag from the repository.
-func (r *Repository) DeleteTag(name string) error {
-	_, err := r.Tag(name)
+func (r *Repository) DeleteTag(ctx context.Context, name string) error {
+	_, err := r.Tag(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	return r.Storer.RemoveReference(plumbing.ReferenceName(path.Join("refs", "tags", name)))
+	return r.Storer.RemoveReference(ctx, plumbing.ReferenceName(path.Join("refs", "tags", name)))
 }
 
-func (r *Repository) resolveToCommitHash(h plumbing.Hash) (plumbing.Hash, error) {
-	obj, err := r.Storer.EncodedObject(plumbing.AnyObject, h)
+func (r *Repository) resolveToCommitHash(ctx context.Context, h plumbing.Hash) (plumbing.Hash, error) {
+	obj, err := r.Storer.EncodedObject(ctx, plumbing.AnyObject, h)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -1064,7 +1047,7 @@ func (r *Repository) resolveToCommitHash(h plumbing.Hash) (plumbing.Hash, error)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
-		return r.resolveToCommitHash(t.Target)
+		return r.resolveToCommitHash(ctx, t.Target)
 	case plumbing.CommitObject:
 		return h, nil
 	default:
@@ -1103,7 +1086,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		Mirror: o.Mirror,
 	}
 
-	if _, err := r.CreateRemote(c); err != nil {
+	if _, err := r.CreateRemote(ctx, c); err != nil {
 		return err
 	}
 
@@ -1115,19 +1098,19 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 			return ErrAlternatePathNotSupported
 		}
 		altpath := o.URL
-		remoteRepo, err := PlainOpen(o.URL)
+		remoteRepo, err := PlainOpen(ctx, o.URL)
 		if err != nil {
 			return fmt.Errorf("failed to open remote repository: %w", err)
 		}
 		defer func() { _ = remoteRepo.Close() }()
-		conf, err := remoteRepo.Config()
+		conf, err := remoteRepo.Config(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to read remote repository configuration: %w", err)
 		}
 		if !conf.Core.IsBare {
 			altpath = path.Join(altpath, GitDirName)
 		}
-		if err := r.Storer.AddAlternate(altpath); err != nil {
+		if err := r.Storer.AddAlternate(ctx, altpath); err != nil {
 			return fmt.Errorf("failed to add alternate file to git objects dir: %w", err)
 		}
 	}
@@ -1142,32 +1125,32 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		Filter:        o.Filter,
 	}, o.ReferenceName)
 
-	hr, err1 := r.Storer.Reference(plumbing.HEAD)
+	hr, err1 := r.Storer.Reference(ctx, plumbing.HEAD)
 	if err1 == nil && hr.Target() == plumbing.Invalid {
-		_ = r.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master))
+		_ = r.Storer.SetReference(ctx, plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.Master))
 	}
 
 	if err != nil {
 		return err
 	}
 
-	err = r.setWorktreeAndStoragePaths()
+	err = r.setWorktreeAndStoragePaths(ctx)
 	if err != nil {
 		return err
 	}
 
 	if r.wt != nil && !o.NoCheckout {
-		w, err := r.Worktree()
+		w, err := r.Worktree(ctx)
 		if err != nil {
 			return err
 		}
 
-		head, err := r.Head()
+		head, err := r.Head(ctx)
 		if err != nil {
 			return err
 		}
 
-		if err := w.Reset(&ResetOptions{
+		if err := w.Reset(ctx, &ResetOptions{
 			Mode:   MergeReset,
 			Commit: head.Hash(),
 		}); err != nil {
@@ -1190,7 +1173,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		}
 	}
 
-	if err := r.updateRemoteConfigIfNeeded(o, c, ref); err != nil {
+	if err := r.updateRemoteConfigIfNeeded(ctx, o, c, ref); err != nil {
 		return err
 	}
 
@@ -1209,7 +1192,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 			b.Remote = o.RemoteName
 		}
 
-		if err := r.CreateBranch(b); err != nil {
+		if err := r.CreateBranch(ctx, b); err != nil {
 			return err
 		}
 	}
@@ -1246,30 +1229,30 @@ func (r *Repository) cloneRefSpec(o *CloneOptions) []config.RefSpec {
 	}
 }
 
-func (r *Repository) setIsBare(isBare bool) error {
-	cfg, err := r.Config()
+func (r *Repository) setIsBare(ctx context.Context, isBare bool) error {
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return err
 	}
 
 	cfg.Core.IsBare = isBare
-	return r.Storer.SetConfig(cfg)
+	return r.Storer.SetConfig(ctx, cfg)
 }
 
-func (r *Repository) updateRemoteConfigIfNeeded(o *CloneOptions, c *config.RemoteConfig, _ *plumbing.Reference) error {
+func (r *Repository) updateRemoteConfigIfNeeded(ctx context.Context, o *CloneOptions, c *config.RemoteConfig, _ *plumbing.Reference) error {
 	if !o.SingleBranch {
 		return nil
 	}
 
 	c.Fetch = r.cloneRefSpec(o)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return err
 	}
 
 	cfg.Remotes[c.Name] = c
-	return r.Storer.SetConfig(cfg)
+	return r.Storer.SetConfig(ctx, cfg)
 }
 
 func (r *Repository) fetchAndUpdateReferences(
@@ -1279,7 +1262,7 @@ func (r *Repository) fetchAndUpdateReferences(
 		return nil, err
 	}
 
-	remote, err := r.Remote(o.RemoteName)
+	remote, err := r.Remote(ctx, o.RemoteName)
 	if err != nil {
 		return nil, err
 	}
@@ -1297,12 +1280,12 @@ func (r *Repository) fetchAndUpdateReferences(
 		return nil, err
 	}
 
-	resolvedRef, err := expandRef(remoteRefs, ref)
+	resolvedRef, err := expandRef(ctx, remoteRefs, ref)
 	if err != nil {
 		return nil, err
 	}
 
-	refsUpdated, err := r.updateReferences(remote.c.Fetch, resolvedRef)
+	refsUpdated, err := r.updateReferences(ctx, remote.c.Fetch, resolvedRef)
 	if err != nil {
 		return nil, err
 	}
@@ -1314,20 +1297,20 @@ func (r *Repository) fetchAndUpdateReferences(
 	return resolvedRef, nil
 }
 
-func (r *Repository) updateReferences(spec []config.RefSpec,
+func (r *Repository) updateReferences(ctx context.Context, spec []config.RefSpec,
 	resolvedRef *plumbing.Reference,
 ) (updated bool, err error) {
 	if !resolvedRef.Name().IsBranch() {
 		// Detached HEAD mode
-		h, err := r.resolveToCommitHash(resolvedRef.Hash())
+		h, err := r.resolveToCommitHash(ctx, resolvedRef.Hash())
 		if err != nil {
 			return false, err
 		}
 		head := plumbing.NewHashReference(plumbing.HEAD, h)
-		return updateReferenceStorerIfNeeded(r.Storer, head)
+		return updateReferenceStorerIfNeeded(ctx, r.Storer, head)
 	}
 
-	remoteHeadRefs := r.calculateRemoteHeadReference(spec, resolvedRef)
+	remoteHeadRefs := r.calculateRemoteHeadReference(ctx, spec, resolvedRef)
 	refs := make([]*plumbing.Reference, 0, 2+len(remoteHeadRefs))
 	refs = append(refs,
 		// Create local reference for the resolved ref
@@ -1338,7 +1321,7 @@ func (r *Repository) updateReferences(spec []config.RefSpec,
 	refs = append(refs, remoteHeadRefs...)
 
 	for _, ref := range refs {
-		u, err := updateReferenceStorerIfNeeded(r.Storer, ref)
+		u, err := updateReferenceStorerIfNeeded(ctx, r.Storer, ref)
 		if err != nil {
 			return updated, err
 		}
@@ -1351,7 +1334,7 @@ func (r *Repository) updateReferences(spec []config.RefSpec,
 	return updated, err
 }
 
-func (r *Repository) calculateRemoteHeadReference(spec []config.RefSpec,
+func (r *Repository) calculateRemoteHeadReference(ctx context.Context, spec []config.RefSpec,
 	resolvedHead *plumbing.Reference,
 ) []*plumbing.Reference {
 	var refs []*plumbing.Reference
@@ -1365,7 +1348,7 @@ func (r *Repository) calculateRemoteHeadReference(spec []config.RefSpec,
 		}
 
 		name = rs.Dst(name)
-		_, err := r.Storer.Reference(name)
+		_, err := r.Storer.Reference(ctx, name)
 		if err == plumbing.ErrReferenceNotFound {
 			refs = append(refs, plumbing.NewHashReference(name, resolvedHead.Hash()))
 		}
@@ -1375,17 +1358,17 @@ func (r *Repository) calculateRemoteHeadReference(spec []config.RefSpec,
 }
 
 func checkAndUpdateReferenceStorerIfNeeded(
-	s storer.ReferenceStorer, r, old *plumbing.Reference) (
+	ctx context.Context, s storer.ReferenceStorer, r, old *plumbing.Reference) (
 	updated bool, err error,
 ) {
-	p, err := s.Reference(r.Name())
+	p, err := s.Reference(ctx, r.Name())
 	if err != nil && err != plumbing.ErrReferenceNotFound {
 		return false, err
 	}
 
 	// we use the string method to compare references, is the easiest way
 	if err == plumbing.ErrReferenceNotFound || r.String() != p.String() {
-		if err := s.CheckAndSetReference(r, old); err != nil {
+		if err := s.CheckAndSetReference(ctx, r, old); err != nil {
 			return false, err
 		}
 
@@ -1396,9 +1379,9 @@ func checkAndUpdateReferenceStorerIfNeeded(
 }
 
 func updateReferenceStorerIfNeeded(
-	s storer.ReferenceStorer, r *plumbing.Reference,
+	ctx context.Context, s storer.ReferenceStorer, r *plumbing.Reference,
 ) (updated bool, err error) {
-	return checkAndUpdateReferenceStorerIfNeeded(s, r, nil)
+	return checkAndUpdateReferenceStorerIfNeeded(ctx, s, r, nil)
 }
 
 // Fetch fetches references along with the objects necessary to complete
@@ -1406,57 +1389,39 @@ func updateReferenceStorerIfNeeded(
 //
 // Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
 // no changes to be fetched, or an error.
-func (r *Repository) Fetch(o *FetchOptions) error {
-	return r.FetchContext(context.Background(), o)
-}
-
-// FetchContext fetches references along with the objects necessary to complete
-// their histories, from the remote named as FetchOptions.RemoteName.
-//
-// Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
-// no changes to be fetched, or an error.
 //
 // The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func (r *Repository) FetchContext(ctx context.Context, o *FetchOptions) error {
+// operation is complete, an error is returned.
+func (r *Repository) Fetch(ctx context.Context, o *FetchOptions) error {
 	if err := o.Validate(); err != nil {
 		return err
 	}
 
-	remote, err := r.Remote(o.RemoteName)
+	remote, err := r.Remote(ctx, o.RemoteName)
 	if err != nil {
 		return err
 	}
 
-	return remote.FetchContext(ctx, o)
+	return remote.Fetch(ctx, o)
 }
 
 // Push performs a push to the remote. Returns NoErrAlreadyUpToDate if
 // the remote was already up-to-date, from the remote named as
 // FetchOptions.RemoteName.
-func (r *Repository) Push(o *PushOptions) error {
-	return r.PushContext(context.Background(), o)
-}
-
-// PushContext performs a push to the remote. Returns NoErrAlreadyUpToDate if
-// the remote was already up-to-date, from the remote named as
-// FetchOptions.RemoteName.
 //
 // The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func (r *Repository) PushContext(ctx context.Context, o *PushOptions) error {
+// operation is complete, an error is returned.
+func (r *Repository) Push(ctx context.Context, o *PushOptions) error {
 	if err := o.Validate(); err != nil {
 		return err
 	}
 
-	remote, err := r.Remote(o.RemoteName)
+	remote, err := r.Remote(ctx, o.RemoteName)
 	if err != nil {
 		return err
 	}
 
-	return remote.PushContext(ctx, o)
+	return remote.Push(ctx, o)
 }
 
 // ArchiveOptions stores the options for the Archive operation.
@@ -1497,13 +1462,8 @@ func (o *ArchiveOptions) Validate() error {
 // Archive creates an archive from the local repository.
 // It returns an io.ReadCloser that yields the archive data.
 // The caller must close the returned ReadCloser.
-func (r *Repository) Archive(o *ArchiveOptions) (io.ReadCloser, error) {
-	return r.ArchiveContext(context.Background(), o)
-}
-
-// ArchiveContext creates an archive from the local repository.
 // The provided Context can be used to cancel the operation.
-func (r *Repository) ArchiveContext(ctx context.Context, o *ArchiveOptions) (io.ReadCloser, error) {
+func (r *Repository) Archive(ctx context.Context, o *ArchiveOptions) (io.ReadCloser, error) {
 	if o == nil {
 		o = &ArchiveOptions{}
 	}
@@ -1521,7 +1481,7 @@ func (r *Repository) ArchiveContext(ctx context.Context, o *ArchiveOptions) (io.
 	}
 
 	// Always allow unreachable refs for local archives.
-	tree, commitHash, commitTime, err := archive.ResolveTreeish(r.Storer, o.Treeish, true)
+	tree, commitHash, commitTime, err := archive.ResolveTreeish(ctx, r.Storer, o.Treeish, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1532,7 +1492,7 @@ func (r *Repository) ArchiveContext(ctx context.Context, o *ArchiveOptions) (io.
 	pr, pw := io.Pipe()
 	cw := ioutil.NewContextWriter(ctx, pw)
 	go func() {
-		err := archive.WriteArchive(r.Storer, cw, tree, commitHash, commitTime, format, prefix, paths)
+		err := archive.WriteArchive(ctx, r.Storer, cw, tree, commitHash, commitTime, format, prefix, paths)
 		_ = pw.CloseWithError(err)
 	}()
 
@@ -1540,7 +1500,7 @@ func (r *Repository) ArchiveContext(ctx context.Context, o *ArchiveOptions) (io.
 }
 
 // Log returns the commit history from the given LogOptions.
-func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
+func (r *Repository) Log(ctx context.Context, o *LogOptions) (object.CommitIter, error) {
 	fn := commitIterFunc(o.Order)
 	if fn == nil {
 		return nil, fmt.Errorf("invalid Order=%v", o.Order)
@@ -1551,9 +1511,9 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		err error
 	)
 	if o.All {
-		it, err = r.logAll(fn)
+		it, err = r.logAll(ctx, fn)
 	} else {
-		it, err = r.log(o.From, fn)
+		it, err = r.log(ctx, o.From, fn)
 	}
 
 	if err != nil {
@@ -1576,10 +1536,10 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 	return it, nil
 }
 
-func (r *Repository) log(from plumbing.Hash, commitIterFunc func(*object.Commit) object.CommitIter) (object.CommitIter, error) {
+func (r *Repository) log(ctx context.Context, from plumbing.Hash, commitIterFunc func(*object.Commit) object.CommitIter) (object.CommitIter, error) {
 	h := from
 	if from == plumbing.ZeroHash {
-		head, err := r.Head()
+		head, err := r.Head(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -1587,15 +1547,15 @@ func (r *Repository) log(from plumbing.Hash, commitIterFunc func(*object.Commit)
 		h = head.Hash()
 	}
 
-	commit, err := r.CommitObject(h)
+	commit, err := r.CommitObject(ctx, h)
 	if err != nil {
 		return nil, err
 	}
 	return commitIterFunc(commit), nil
 }
 
-func (r *Repository) logAll(commitIterFunc func(*object.Commit) object.CommitIter) (object.CommitIter, error) {
-	return object.NewCommitAllIter(r.Storer, commitIterFunc)
+func (r *Repository) logAll(ctx context.Context, commitIterFunc func(*object.Commit) object.CommitIter) (object.CommitIter, error) {
+	return object.NewCommitAllIter(ctx, r.Storer, commitIterFunc)
 }
 
 func (*Repository) logWithFile(fileName string, commitIter object.CommitIter, checkParent bool) object.CommitIter {
@@ -1655,13 +1615,13 @@ func commitIterFunc(order LogOrder) func(c *object.Commit) object.CommitIter {
 // If you want to check to see if the tag is an annotated tag, you can call
 // TagObject on the hash Reference passed in through ForEach:
 //
-//	iter, err := r.Tags()
+//	iter, err := r.Tags(ctx)
 //	if err != nil {
 //	  // Handle error
 //	}
 //
-//	if err := iter.ForEach(func (ref *plumbing.Reference) error {
-//	  obj, err := r.TagObject(ref.Hash())
+//	if err := iter.ForEach(ctx, func (ref *plumbing.Reference) error {
+//	  obj, err := r.TagObject(ctx, ref.Hash())
 //	  switch err {
 //	  case nil:
 //	    // Tag object present
@@ -1674,8 +1634,8 @@ func commitIterFunc(order LogOrder) func(c *object.Commit) object.CommitIter {
 //	}); err != nil {
 //	  // Handle outer iterator error
 //	}
-func (r *Repository) Tags() (storer.ReferenceIter, error) {
-	refIter, err := r.Storer.IterReferences()
+func (r *Repository) Tags(ctx context.Context) (storer.ReferenceIter, error) {
+	refIter, err := r.Storer.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1687,8 +1647,8 @@ func (r *Repository) Tags() (storer.ReferenceIter, error) {
 }
 
 // Branches returns all the References that are Branches.
-func (r *Repository) Branches() (storer.ReferenceIter, error) {
-	refIter, err := r.Storer.IterReferences()
+func (r *Repository) Branches(ctx context.Context) (storer.ReferenceIter, error) {
+	refIter, err := r.Storer.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1701,8 +1661,8 @@ func (r *Repository) Branches() (storer.ReferenceIter, error) {
 
 // Notes returns all the References that are notes. For more information:
 // https://git-scm.com/docs/git-notes
-func (r *Repository) Notes() (storer.ReferenceIter, error) {
-	refIter, err := r.Storer.IterReferences()
+func (r *Repository) Notes(ctx context.Context) (storer.ReferenceIter, error) {
+	refIter, err := r.Storer.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1715,13 +1675,13 @@ func (r *Repository) Notes() (storer.ReferenceIter, error) {
 
 // TreeObject return a Tree with the given hash. If not found
 // plumbing.ErrObjectNotFound is returned
-func (r *Repository) TreeObject(h plumbing.Hash) (*object.Tree, error) {
-	return object.GetTree(r.Storer, h)
+func (r *Repository) TreeObject(ctx context.Context, h plumbing.Hash) (*object.Tree, error) {
+	return object.GetTree(ctx, r.Storer, h)
 }
 
 // TreeObjects returns an unsorted TreeIter with all the trees in the repository
-func (r *Repository) TreeObjects() (*object.TreeIter, error) {
-	iter, err := r.Storer.IterEncodedObjects(plumbing.TreeObject)
+func (r *Repository) TreeObjects(ctx context.Context) (*object.TreeIter, error) {
+	iter, err := r.Storer.IterEncodedObjects(ctx, plumbing.TreeObject)
 	if err != nil {
 		return nil, err
 	}
@@ -1731,13 +1691,13 @@ func (r *Repository) TreeObjects() (*object.TreeIter, error) {
 
 // CommitObject return a Commit with the given hash. If not found
 // plumbing.ErrObjectNotFound is returned.
-func (r *Repository) CommitObject(h plumbing.Hash) (*object.Commit, error) {
-	return object.GetCommit(r.Storer, h)
+func (r *Repository) CommitObject(ctx context.Context, h plumbing.Hash) (*object.Commit, error) {
+	return object.GetCommit(ctx, r.Storer, h)
 }
 
 // CommitObjects returns an unsorted CommitIter with all the commits in the repository.
-func (r *Repository) CommitObjects() (object.CommitIter, error) {
-	iter, err := r.Storer.IterEncodedObjects(plumbing.CommitObject)
+func (r *Repository) CommitObjects(ctx context.Context) (object.CommitIter, error) {
+	iter, err := r.Storer.IterEncodedObjects(ctx, plumbing.CommitObject)
 	if err != nil {
 		return nil, err
 	}
@@ -1747,13 +1707,13 @@ func (r *Repository) CommitObjects() (object.CommitIter, error) {
 
 // BlobObject returns a Blob with the given hash. If not found
 // plumbing.ErrObjectNotFound is returned.
-func (r *Repository) BlobObject(h plumbing.Hash) (*object.Blob, error) {
-	return object.GetBlob(r.Storer, h)
+func (r *Repository) BlobObject(ctx context.Context, h plumbing.Hash) (*object.Blob, error) {
+	return object.GetBlob(ctx, r.Storer, h)
 }
 
 // BlobObjects returns an unsorted BlobIter with all the blobs in the repository.
-func (r *Repository) BlobObjects() (*object.BlobIter, error) {
-	iter, err := r.Storer.IterEncodedObjects(plumbing.BlobObject)
+func (r *Repository) BlobObjects(ctx context.Context) (*object.BlobIter, error) {
+	iter, err := r.Storer.IterEncodedObjects(ctx, plumbing.BlobObject)
 	if err != nil {
 		return nil, err
 	}
@@ -1764,14 +1724,14 @@ func (r *Repository) BlobObjects() (*object.BlobIter, error) {
 // TagObject returns a Tag with the given hash. If not found
 // plumbing.ErrObjectNotFound is returned. This method only returns
 // annotated Tags, no lightweight Tags.
-func (r *Repository) TagObject(h plumbing.Hash) (*object.Tag, error) {
-	return object.GetTag(r.Storer, h)
+func (r *Repository) TagObject(ctx context.Context, h plumbing.Hash) (*object.Tag, error) {
+	return object.GetTag(ctx, r.Storer, h)
 }
 
 // TagObjects returns a unsorted TagIter that can step through all of the annotated
 // tags in the repository.
-func (r *Repository) TagObjects() (*object.TagIter, error) {
-	iter, err := r.Storer.IterEncodedObjects(plumbing.TagObject)
+func (r *Repository) TagObjects(ctx context.Context) (*object.TagIter, error) {
+	iter, err := r.Storer.IterEncodedObjects(ctx, plumbing.TagObject)
 	if err != nil {
 		return nil, err
 	}
@@ -1781,18 +1741,18 @@ func (r *Repository) TagObjects() (*object.TagIter, error) {
 
 // Object returns an Object with the given hash. If not found
 // plumbing.ErrObjectNotFound is returned.
-func (r *Repository) Object(t plumbing.ObjectType, h plumbing.Hash) (object.Object, error) {
-	obj, err := r.Storer.EncodedObject(t, h)
+func (r *Repository) Object(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (object.Object, error) {
+	obj, err := r.Storer.EncodedObject(ctx, t, h)
 	if err != nil {
 		return nil, err
 	}
 
-	return object.DecodeObject(r.Storer, obj)
+	return object.DecodeObject(ctx, r.Storer, obj)
 }
 
 // Objects returns an unsorted ObjectIter with all the objects in the repository.
-func (r *Repository) Objects() (*object.ObjectIter, error) {
-	iter, err := r.Storer.IterEncodedObjects(plumbing.AnyObject)
+func (r *Repository) Objects(ctx context.Context) (*object.ObjectIter, error) {
+	iter, err := r.Storer.IterEncodedObjects(ctx, plumbing.AnyObject)
 	if err != nil {
 		return nil, err
 	}
@@ -1801,37 +1761,37 @@ func (r *Repository) Objects() (*object.ObjectIter, error) {
 }
 
 // Head returns the reference where HEAD is pointing to.
-func (r *Repository) Head() (*plumbing.Reference, error) {
-	return storer.ResolveReference(r.Storer, plumbing.HEAD)
+func (r *Repository) Head(ctx context.Context) (*plumbing.Reference, error) {
+	return storer.ResolveReference(ctx, r.Storer, plumbing.HEAD)
 }
 
 // Reference returns the reference for a given reference name. If resolved is
 // true, any symbolic reference will be resolved.
-func (r *Repository) Reference(name plumbing.ReferenceName, resolved bool) (
+func (r *Repository) Reference(ctx context.Context, name plumbing.ReferenceName, resolved bool) (
 	*plumbing.Reference, error,
 ) {
 	if resolved {
-		return storer.ResolveReference(r.Storer, name)
+		return storer.ResolveReference(ctx, r.Storer, name)
 	}
 
-	return r.Storer.Reference(name)
+	return r.Storer.Reference(ctx, name)
 }
 
 // References returns an unsorted ReferenceIter for all references.
-func (r *Repository) References() (storer.ReferenceIter, error) {
-	return r.Storer.IterReferences()
+func (r *Repository) References(ctx context.Context) (storer.ReferenceIter, error) {
+	return r.Storer.IterReferences(ctx)
 }
 
 // Worktree returns a worktree based on the given fs, if nil the default
 // worktree will be used.
-func (r *Repository) Worktree() (*Worktree, error) {
+func (r *Repository) Worktree(ctx context.Context) (*Worktree, error) {
 	if r.wt == nil {
 		return nil, ErrIsBareRepository
 	}
 
 	protectNTFS := defaultProtectNTFS()
 	protectHFS := defaultProtectHFS()
-	if cfg, err := r.Config(); err == nil {
+	if cfg, err := r.Config(ctx); err == nil {
 		if cfg.Core.ProtectNTFS.IsSet() {
 			protectNTFS = cfg.Core.ProtectNTFS.IsTrue()
 		}
@@ -1843,12 +1803,12 @@ func (r *Repository) Worktree() (*Worktree, error) {
 	return &Worktree{r: r, filesystem: newWorktreeFilesystem(r.wt, protectNTFS, protectHFS)}, nil
 }
 
-func expandRef(s storer.ReferenceStorer, ref plumbing.ReferenceName) (*plumbing.Reference, error) {
+func expandRef(ctx context.Context, s storer.ReferenceStorer, ref plumbing.ReferenceName) (*plumbing.Reference, error) {
 	// For improving troubleshooting, this preserves the error for the provided `ref`,
 	// and returns the error for that specific ref in case all parse rules fails.
 	var ret error
 	for _, rule := range plumbing.RefRevParseRules {
-		resolvedRef, err := storer.ResolveReference(s, plumbing.ReferenceName(fmt.Sprintf(rule, ref)))
+		resolvedRef, err := storer.ResolveReference(ctx, s, plumbing.ReferenceName(fmt.Sprintf(rule, ref)))
 
 		if err == nil {
 			return resolvedRef, nil
@@ -1865,7 +1825,7 @@ func expandRef(s storer.ReferenceStorer, ref plumbing.ReferenceName) (*plumbing.
 //
 // Implemented resolvers : HEAD, branch, tag, heads/branch, refs/heads/branch,
 // refs/tags/tag, refs/remotes/origin/branch, refs/remotes/origin/HEAD, tilde and caret (HEAD~1, master~^, tag~2, ref/heads/master~1, ...), selection by text (HEAD^{/fix nasty bug}), hash (prefix and full)
-func (r *Repository) ResolveRevision(in plumbing.Revision) (*plumbing.Hash, error) {
+func (r *Repository) ResolveRevision(ctx context.Context, in plumbing.Revision) (*plumbing.Hash, error) {
 	rev := in.String()
 	if rev == "" {
 		return &plumbing.ZeroHash, plumbing.ErrReferenceNotFound
@@ -1886,9 +1846,9 @@ func (r *Repository) ResolveRevision(in plumbing.Revision) (*plumbing.Hash, erro
 
 			var tryHashes []plumbing.Hash
 
-			tryHashes = append(tryHashes, r.resolveHashPrefix(string(revisionRef))...)
+			tryHashes = append(tryHashes, r.resolveHashPrefix(ctx, string(revisionRef))...)
 
-			ref, err := expandRef(r.Storer, plumbing.ReferenceName(revisionRef))
+			ref, err := expandRef(ctx, r.Storer, plumbing.ReferenceName(revisionRef))
 			if err == nil {
 				tryHashes = append(tryHashes, ref.Hash())
 			}
@@ -1900,19 +1860,19 @@ func (r *Repository) ResolveRevision(in plumbing.Revision) (*plumbing.Hash, erro
 			// priority that git would.
 			gotOne := false
 			for _, hash := range tryHashes {
-				commitObj, err := r.CommitObject(hash)
+				commitObj, err := r.CommitObject(ctx, hash)
 				if err == nil {
 					commit = commitObj
 					gotOne = true
 					break
 				}
 
-				tagObj, err := r.TagObject(hash)
+				tagObj, err := r.TagObject(ctx, hash)
 				if err == nil {
 					// If the tag target lookup fails here, this most likely
 					// represents some sort of repo corruption, so let the
 					// error bubble up.
-					tagCommit, err := tagObj.Commit()
+					tagCommit, err := tagObj.Commit(ctx)
 					if err != nil {
 						return &plumbing.ZeroHash, err
 					}
@@ -1935,7 +1895,7 @@ func (r *Repository) ResolveRevision(in plumbing.Revision) (*plumbing.Hash, erro
 
 			iter := commit.Parents()
 
-			c, err := iter.Next()
+			c, err := iter.Next(ctx)
 			if err != nil {
 				return &plumbing.ZeroHash, err
 			}
@@ -1946,7 +1906,7 @@ func (r *Repository) ResolveRevision(in plumbing.Revision) (*plumbing.Hash, erro
 				break
 			}
 
-			c, err = iter.Next()
+			c, err = iter.Next(ctx)
 			if err != nil {
 				return &plumbing.ZeroHash, err
 			}
@@ -1954,7 +1914,7 @@ func (r *Repository) ResolveRevision(in plumbing.Revision) (*plumbing.Hash, erro
 			commit = c
 		case revision.TildePath:
 			for i := 0; i < item.Depth; i++ {
-				c, err := commit.Parents().Next()
+				c, err := commit.Parents().Next(ctx)
 				if err != nil {
 					return &plumbing.ZeroHash, err
 				}
@@ -1969,7 +1929,7 @@ func (r *Repository) ResolveRevision(in plumbing.Revision) (*plumbing.Hash, erro
 
 			var c *object.Commit
 
-			err := history.ForEach(func(hc *object.Commit) error {
+			err := history.ForEach(ctx, func(hc *object.Commit) error {
 				if !negate && re.MatchString(hc.Message) {
 					c = hc
 					return storer.ErrStop
@@ -2003,7 +1963,7 @@ func (r *Repository) ResolveRevision(in plumbing.Revision) (*plumbing.Hash, erro
 
 // resolveHashPrefix returns a list of potential hashes that the given string
 // is a prefix of. It quietly swallows errors, returning nil.
-func (r *Repository) resolveHashPrefix(hashStr string) []plumbing.Hash {
+func (r *Repository) resolveHashPrefix(ctx context.Context, hashStr string) []plumbing.Hash {
 	// Handle complete and partial hashes.
 	// plumbing.NewHash forces args into a full 20 byte hash, which isn't suitable
 	// for partial hashes since they will become zero-filled.
@@ -2026,7 +1986,7 @@ func (r *Repository) resolveHashPrefix(hashStr string) []plumbing.Hash {
 	if err != nil {
 		return nil
 	}
-	candidates := expandPartialHash(r.Storer, hexb)
+	candidates := expandPartialHash(ctx, r.Storer, hexb)
 	if len(evenHex) == len(hashStr) {
 		// The prefix was an exact number of bytes.
 		return candidates
@@ -2052,20 +2012,20 @@ type RepackConfig struct {
 }
 
 // RepackObjects repacks all objects in the repository into a single packfile.
-func (r *Repository) RepackObjects(cfg *RepackConfig) (err error) {
+func (r *Repository) RepackObjects(ctx context.Context, cfg *RepackConfig) (err error) {
 	pos, ok := r.Storer.(storer.PackedObjectStorer)
 	if !ok {
 		return ErrPackedObjectsNotSupported
 	}
 
 	// Get the existing object packs.
-	hs, err := pos.ObjectPacks()
+	hs, err := pos.ObjectPacks(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Create a new pack.
-	nh, err := r.createNewObjectPack(cfg)
+	nh, err := r.createNewObjectPack(ctx, cfg)
 	if err != nil {
 		return err
 	}
@@ -2076,7 +2036,7 @@ func (r *Repository) RepackObjects(cfg *RepackConfig) (err error) {
 		if h == nh {
 			continue
 		}
-		err = pos.DeleteOldObjectPackAndIndex(h, cfg.OnlyDeletePacksOlderThan)
+		err = pos.DeleteOldObjectPackAndIndex(ctx, h, cfg.OnlyDeletePacksOlderThan)
 		if err != nil {
 			return err
 		}
@@ -2091,20 +2051,20 @@ func (r *Repository) RepackObjects(cfg *RepackConfig) (err error) {
 // the HEAD for the current branch. Possible errors include:
 //   - The merge strategy is not supported.
 //   - The specific strategy cannot be used (e.g. using FastForwardMerge when one is not possible).
-func (r *Repository) Merge(ref plumbing.Reference, opts MergeOptions) error {
+func (r *Repository) Merge(ctx context.Context, ref plumbing.Reference, opts MergeOptions) error {
 	if opts.Strategy != FastForwardMerge {
 		return ErrUnsupportedMergeStrategy
 	}
 
 	// Ignore error as not having a shallow list is optional here.
-	shallowList, _ := r.Storer.Shallow()
+	shallowList, _ := r.Storer.Shallow(ctx)
 
-	head, err := r.Head()
+	head, err := r.Head(ctx)
 	if err != nil {
 		return err
 	}
 
-	ff, err := isFastForward(r.Storer, head.Hash(), ref.Hash(), shallowList)
+	ff, err := isFastForward(ctx, r.Storer, head.Hash(), ref.Hash(), shallowList)
 	if err != nil {
 		return err
 	}
@@ -2113,15 +2073,15 @@ func (r *Repository) Merge(ref plumbing.Reference, opts MergeOptions) error {
 		return ErrFastForwardMergeNotPossible
 	}
 
-	return r.Storer.SetReference(plumbing.NewHashReference(head.Name(), ref.Hash()))
+	return r.Storer.SetReference(ctx, plumbing.NewHashReference(head.Name(), ref.Hash()))
 }
 
 // createNewObjectPack is a helper for RepackObjects taking care
 // of creating a new pack. It is used so the PackfileWriter
 // deferred close has the right scope.
-func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, err error) {
+func (r *Repository) createNewObjectPack(ctx context.Context, cfg *RepackConfig) (h plumbing.Hash, err error) {
 	ow := newObjectWalker(r.Storer)
-	err = ow.walkAllRefs()
+	err = ow.walkAllRefs(ctx)
 	if err != nil {
 		return h, err
 	}
@@ -2133,26 +2093,26 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 	if !ok {
 		return h, fmt.Errorf("Repository storer is not a storer.PackfileWriter")
 	}
-	wc, err := pfw.PackfileWriter()
+	wc, err := pfw.PackfileWriter(ctx)
 	if err != nil {
 		return h, err
 	}
 	defer ioutil.CheckClose(wc, &err)
-	scfg, err := r.Config()
+	scfg, err := r.Config(ctx)
 	if err != nil {
 		return h, err
 	}
-	enc := packfile.NewEncoder(wc, r.Storer, cfg.UseRefDeltas)
-	h, err = enc.Encode(objs, scfg.Pack.Window)
+	enc := packfile.NewEncoder(ctx, wc, r.Storer, cfg.UseRefDeltas)
+	h, err = enc.Encode(ctx, objs, scfg.Pack.Window)
 	if err != nil {
 		return h, err
 	}
 
 	// Delete the packed, loose objects.
 	if los, ok := r.Storer.(storer.LooseObjectStorer); ok {
-		err = los.ForEachObjectHash(func(hash plumbing.Hash) error {
+		err = los.ForEachObjectHash(ctx, func(hash plumbing.Hash) error {
 			if ow.isSeen(hash) {
-				err = los.DeleteLooseObject(hash)
+				err = los.DeleteLooseObject(ctx, hash)
 				if err != nil {
 					return err
 				}
@@ -2167,7 +2127,7 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 	return h, err
 }
 
-func expandPartialHash(st storer.EncodedObjectStorer, prefix []byte) (hashes []plumbing.Hash) {
+func expandPartialHash(ctx context.Context, st storer.EncodedObjectStorer, prefix []byte) (hashes []plumbing.Hash) {
 	// The fast version is implemented by storage/filesystem.ObjectStorage.
 	type fastIter interface {
 		HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
@@ -2181,11 +2141,11 @@ func expandPartialHash(st storer.EncodedObjectStorer, prefix []byte) (hashes []p
 	}
 
 	// Slow path.
-	iter, err := st.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := st.IterEncodedObjects(ctx, plumbing.AnyObject)
 	if err != nil {
 		return nil
 	}
-	_ = iter.ForEach(func(obj plumbing.EncodedObject) error {
+	_ = iter.ForEach(ctx, func(obj plumbing.EncodedObject) error {
 		h := obj.Hash()
 		if h.HasPrefix(prefix) {
 			hashes = append(hashes, h)

--- a/repository_common_test.go
+++ b/repository_common_test.go
@@ -31,7 +31,7 @@ func forEachFormat(t *testing.T, fnT func(*testing.T, formatcfg.ObjectFormat)) {
 
 func createCommit(t *testing.T, r *Repository) plumbing.Hash {
 	// Create a commit so there is a HEAD to check
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(t.Context())
 	require.NoError(t, err)
 
 	f, err := wt.filesystem.Create("foo.txt")
@@ -42,7 +42,7 @@ func createCommit(t *testing.T, r *Repository) plumbing.Hash {
 	_, err = f.Write([]byte("foo text"))
 	require.NoError(t, err)
 
-	_, err = wt.Add("foo.txt")
+	_, err = wt.Add(t.Context(), "foo.txt")
 	require.NoError(t, err)
 
 	author := object.Signature{
@@ -51,7 +51,7 @@ func createCommit(t *testing.T, r *Repository) plumbing.Hash {
 		When:  time.Now(),
 	}
 
-	h, err := wt.Commit("test commit message", &CommitOptions{
+	h, err := wt.Commit(t.Context(), "test commit message", &CommitOptions{
 		All:               true,
 		Author:            &author,
 		Committer:         &author,

--- a/repository_extensions_test.go
+++ b/repository_extensions_test.go
@@ -72,18 +72,18 @@ func TestVerifyExtensions(t *testing.T) {
 
 			st := memory.NewStorage()
 
-			r, err := Init(st)
+			r, err := Init(t.Context(), st)
 			require.NoError(t, err)
 			require.NotNil(t, r)
 
-			cfg, err := st.Config()
+			cfg, err := st.Config(t.Context())
 			require.NoError(t, err)
 
 			tt.setup(t, cfg)
-			require.NoError(t, st.SetConfig(cfg))
+			require.NoError(t, st.SetConfig(t.Context(), cfg))
 
 			_ = r.Close()
-			r, err = Open(st, nil)
+			r, err = Open(t.Context(), st, nil)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/repository_test.go
+++ b/repository_test.go
@@ -3136,6 +3136,7 @@ func (s *RepositorySuite) TestCommit() {
 	s.Equal("daniel@lordran.local", commit.Author.Email)
 }
 
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *RepositorySuite) TestCommits() {
 	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
@@ -3183,6 +3184,7 @@ func (s *RepositorySuite) TestBlob() {
 	s.Equal(plumbing.BlobObject, blob.Type())
 }
 
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *RepositorySuite) TestBlobs() {
 	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
@@ -3226,6 +3228,7 @@ func (s *RepositorySuite) TestTagObject() {
 	s.Equal(plumbing.TagObject, tag.Type())
 }
 
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *RepositorySuite) TestTags() {
 	url := s.GetLocalRepositoryURL(
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
@@ -3602,6 +3605,7 @@ func (s *RepositorySuite) TestBranches() {
 	s.Equal(8, count)
 }
 
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *RepositorySuite) TestNotes() {
 	// TODO add fixture with Notes
 	url := s.GetLocalRepositoryURL(

--- a/repository_test.go
+++ b/repository_test.go
@@ -84,12 +84,12 @@ func TestInit(t *testing.T) {
 				t.Parallel()
 
 				opts := append(tc.opts(), WithObjectFormat(of))
-				r, err := Init(memory.NewStorage(memory.WithObjectFormat(of)), opts...)
+				r, err := Init(t.Context(), memory.NewStorage(memory.WithObjectFormat(of)), opts...)
 				require.NotNil(t, r)
 				require.NoError(t, err)
 				defer func() { _ = r.Close() }()
 
-				cfg, err := r.Config()
+				cfg, err := r.Config(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, tc.wantBare, cfg.Core.IsBare)
 				assert.Equal(t, of, cfg.Extensions.ObjectFormat, "object format mismatch")
@@ -103,7 +103,7 @@ func TestInit(t *testing.T) {
 						wantBranch = plumbing.Master.String()
 					}
 
-					ref, err := r.Head()
+					ref, err := r.Head(t.Context())
 					require.NoError(t, err)
 					require.Equal(t, wantBranch, ref.Name().String())
 				}
@@ -152,12 +152,12 @@ func TestPlainInitAndPlainOpen(t *testing.T) {
 				opts := append(tc.opts(), WithObjectFormat(of))
 				rdir := t.TempDir()
 
-				r, err := PlainInit(rdir, tc.wantBare, opts...)
+				r, err := PlainInit(t.Context(), rdir, tc.wantBare, opts...)
 				require.NotNil(t, r)
 				require.NoError(t, err)
 				defer func() { _ = r.Close() }()
 
-				cfg, err := r.Config()
+				cfg, err := r.Config(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, tc.wantBare, cfg.Core.IsBare)
 
@@ -170,18 +170,18 @@ func TestPlainInitAndPlainOpen(t *testing.T) {
 						wantBranch = plumbing.Master.String()
 					}
 
-					ref, err := r.Head()
+					ref, err := r.Head(t.Context())
 					require.NoError(t, err)
 					require.Equal(t, wantBranch, ref.Name().String())
 				}
 
-				ro, err := PlainOpen(rdir)
+				ro, err := PlainOpen(t.Context(), rdir)
 				require.NotNil(t, ro)
 				require.NoError(t, err)
 				defer func() { _ = ro.Close() }()
 
 				if !tc.wantBare {
-					ref, err := ro.Head()
+					ref, err := ro.Head(t.Context())
 					require.NoError(t, err)
 					assert.Equal(t, of.HexSize(), len(ref.Hash().String()))
 				}
@@ -200,7 +200,7 @@ func TestRepositorySuite(t *testing.T) {
 }
 
 func (s *RepositorySuite) TestInitWithInvalidDefaultBranch() {
-	r, err := Init(memory.NewStorage(), WithWorkTree(memfs.New()),
+	r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()),
 		WithDefaultBranch("foo"),
 	)
 	if r != nil {
@@ -216,7 +216,7 @@ func (s *RepositorySuite) TestInitNonStandardDotGit() {
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 
 	wt, _ := fs.Chroot("worktree")
-	r, err := Init(st, WithWorkTree(wt))
+	r, err := Init(s.T().Context(), st, WithWorkTree(wt))
 	s.NoError(err)
 	s.NotNil(r)
 	defer func() { _ = r.Close() }()
@@ -229,7 +229,7 @@ func (s *RepositorySuite) TestInitNonStandardDotGit() {
 	s.NoError(err)
 	s.Equal(string(all), fmt.Sprintf("gitdir: %s\n", filepath.Join("..", "storage")))
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Equal(cfg.Core.Worktree, filepath.Join("..", "worktree"))
 }
@@ -240,7 +240,7 @@ func (s *RepositorySuite) TestInitStandardDotGit() {
 	dot, _ := fs.Chroot(".git")
 	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 
-	r, err := Init(st, WithWorkTree(fs))
+	r, err := Init(s.T().Context(), st, WithWorkTree(fs))
 	s.NoError(err)
 	s.NotNil(r)
 	defer func() { _ = r.Close() }()
@@ -249,7 +249,7 @@ func (s *RepositorySuite) TestInitStandardDotGit() {
 	s.NoError(err)
 	s.True(len(l) > 0)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Equal("", cfg.Core.Worktree)
 }
@@ -257,12 +257,12 @@ func (s *RepositorySuite) TestInitStandardDotGit() {
 func (s *RepositorySuite) TestInitAlreadyExists() {
 	st := memory.NewStorage()
 
-	r, err := Init(st)
+	r, err := Init(s.T().Context(), st)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 
-	r, err = Init(st)
+	r, err = Init(s.T().Context(), st)
 	if r != nil {
 		defer func() { _ = r.Close() }()
 	}
@@ -273,12 +273,12 @@ func (s *RepositorySuite) TestInitAlreadyExists() {
 func (s *RepositorySuite) TestOpen() {
 	st := memory.NewStorage()
 
-	r, err := Init(st, WithWorkTree(memfs.New()))
+	r, err := Init(s.T().Context(), st, WithWorkTree(memfs.New()))
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 
-	r, err = Open(st, memfs.New())
+	r, err = Open(s.T().Context(), st, memfs.New())
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
@@ -287,12 +287,12 @@ func (s *RepositorySuite) TestOpen() {
 func (s *RepositorySuite) TestOpenBare() {
 	st := memory.NewStorage()
 
-	r, err := Init(st)
+	r, err := Init(s.T().Context(), st)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 
-	r, err = Open(st, nil)
+	r, err = Open(s.T().Context(), st, nil)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
@@ -301,32 +301,32 @@ func (s *RepositorySuite) TestOpenBare() {
 func (s *RepositorySuite) TestOpenBareMissingWorktree() {
 	st := memory.NewStorage()
 
-	r, err := Init(st, WithWorkTree(memfs.New()))
+	r, err := Init(s.T().Context(), st, WithWorkTree(memfs.New()))
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 
-	r, err = Open(st, nil)
+	r, err = Open(s.T().Context(), st, nil)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 }
 
 func (s *RepositorySuite) TestOpenNotExists() {
-	r, err := Open(memory.NewStorage(), nil)
+	r, err := Open(s.T().Context(), memory.NewStorage(), nil)
 	s.ErrorIs(err, ErrRepositoryNotExists)
 	s.Nil(r)
 }
 
 func (s *RepositorySuite) TestClone() {
-	r, err := Clone(memory.NewStorage(), nil, &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), nil, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Len(remotes, 1)
 }
@@ -362,9 +362,9 @@ func TestCloneAll(t *testing.T) {
 
 				var r *Repository
 				if tc.plainClone {
-					r, err = PlainClone(t.TempDir(), &CloneOptions{URL: endpoint})
+					r, err = PlainClone(t.Context(), t.TempDir(), &CloneOptions{URL: endpoint})
 				} else {
-					r, err = Clone(memory.NewStorage(), nil, &CloneOptions{
+					r, err = Clone(t.Context(), memory.NewStorage(), nil, &CloneOptions{
 						URL: endpoint,
 					})
 				}
@@ -372,29 +372,29 @@ func TestCloneAll(t *testing.T) {
 				require.NotNil(t, r, "repository must not be nil")
 				defer func() { _ = r.Close() }()
 
-				remotes, err := r.Remotes()
+				remotes, err := r.Remotes(t.Context())
 				require.NoError(t, err)
 				assert.Len(t, remotes, 1)
 
-				iter, err := r.References()
+				iter, err := r.References(t.Context())
 				require.NoError(t, err)
 
 				refs := 0
-				iter.ForEach(func(_ *plumbing.Reference) error {
+				iter.ForEach(t.Context(), func(_ *plumbing.Reference) error {
 					refs++
 					return nil
 				})
 				assert.Equal(t, tc.refs, refs)
 
-				cfg, err := r.Config()
+				cfg, err := r.Config(t.Context())
 				require.NoError(t, err)
 
 				assert.Equal(t, tc.format, cfg.Extensions.ObjectFormat)
 
-				ref, err := r.Head()
+				ref, err := r.Head(t.Context())
 				require.NoError(t, err, "failed to get repository HEAD ref")
 
-				c, err := r.CommitObject(ref.Hash())
+				c, err := r.CommitObject(t.Context(), ref.Hash())
 				require.NoError(t, err, "failed to get commit object")
 				assert.NotNil(t, c)
 			}
@@ -457,17 +457,17 @@ func TestFetchMustNotUpdateObjectFormat(t *testing.T) {
 					st = memory.NewStorage(memory.WithObjectFormat(tc.clientFormat))
 				}
 
-				r, err := Init(st)
+				r, err := Init(t.Context(), st)
 				require.NoError(t, err)
 				defer func() { _ = r.Close() }()
 
-				_, err = r.CreateRemote(&config.RemoteConfig{
+				_, err = r.CreateRemote(t.Context(), &config.RemoteConfig{
 					Name: DefaultRemoteName,
 					URLs: []string{endpoint},
 				})
 				require.NoError(t, err)
 
-				err = r.Fetch(&FetchOptions{})
+				err = r.Fetch(t.Context(), &FetchOptions{})
 				if tc.wantErr {
 					require.Error(t, err)
 					assert.Contains(t, err.Error(), "mismatched algorithms")
@@ -525,7 +525,7 @@ func TestFetchByHashThenResolveRevision(t *testing.T) {
 
 	// Step 1: clone the default branch at depth=1.
 	// commitSHA is a deep ancestor excluded by the shallow depth limit.
-	r, err := PlainClone(tmp, &CloneOptions{
+	r, err := PlainClone(t.Context(), tmp, &CloneOptions{
 		URL:   repoURL,
 		Depth: 1,
 		Tags:  NoTags,
@@ -534,14 +534,14 @@ func TestFetchByHashThenResolveRevision(t *testing.T) {
 	defer func() { _ = r.Close() }()
 
 	// Confirm the target commit is not yet available.
-	_, err = r.CommitObject(plumbing.NewHash(commitSHA))
+	_, err = r.CommitObject(t.Context(), plumbing.NewHash(commitSHA))
 	require.Error(t, err, "commit should NOT be present in a shallow clone of master")
 
 	// Step 2: fetch the specific commit by hash using "+<hash>:<hash>".
 	// This is the standard refspec for fetching an arbitrary commit that is not
 	// the tip of a branch or tag.
 	refSpec := config.RefSpec("+" + commitSHA + ":" + commitSHA)
-	err = r.Fetch(&FetchOptions{
+	err = r.Fetch(t.Context(), &FetchOptions{
 		Depth:    1,
 		Force:    true,
 		RefSpecs: []config.RefSpec{refSpec},
@@ -550,7 +550,7 @@ func TestFetchByHashThenResolveRevision(t *testing.T) {
 	require.NoError(t, err, "fetch should succeed")
 
 	// Step 3: the commit object MUST now be present in the object store.
-	_, err = r.CommitObject(plumbing.NewHash(commitSHA))
+	_, err = r.CommitObject(t.Context(), plumbing.NewHash(commitSHA))
 	assert.NoError(t, err,
 		"commit object must be present in the object store after a successful Fetch with '+<hash>:<hash>'",
 	)
@@ -558,14 +558,14 @@ func TestFetchByHashThenResolveRevision(t *testing.T) {
 	// Step 4: regression 2 — no spurious refs/heads/<sha> must be created.
 	// Before the fix, updateLocalReferenceStorage created refs/heads/<sha>
 	// pointing to the zero hash for any bare-hash dst refspec.
-	_, refErr := r.Storer.Reference(plumbing.NewBranchReferenceName(commitSHA))
+	_, refErr := r.Storer.Reference(t.Context(), plumbing.NewBranchReferenceName(commitSHA))
 	assert.Error(t, refErr,
 		"fetching by hash must NOT create a branch named after the hash")
 
 	// Step 5: the commit must also be resolvable as a revision.
 	// Before the fix, the spurious branch caused ResolveRevision to return
 	// the zero hash.
-	hash, err := r.ResolveRevision(plumbing.Revision(commitSHA))
+	hash, err := r.ResolveRevision(t.Context(), plumbing.Revision(commitSHA))
 	assert.NoError(t, err,
 		"ResolveRevision with a full SHA must succeed when the commit object is present",
 	)
@@ -574,9 +574,9 @@ func TestFetchByHashThenResolveRevision(t *testing.T) {
 	}
 
 	// Step 6: downstream effect — Worktree.Checkout must also succeed.
-	w, err := r.Worktree()
+	w, err := r.Worktree(t.Context())
 	require.NoError(t, err)
-	err = w.Checkout(&CheckoutOptions{
+	err = w.Checkout(t.Context(), &CheckoutOptions{
 		Hash:  plumbing.NewHash(commitSHA),
 		Force: true,
 	})
@@ -597,7 +597,7 @@ func TestPlainCloneContext_FailedCloneRemovesCreatedDirectory(t *testing.T) {
 	// dest does not exist yet; PlainCloneContext must create and then remove it.
 	dest := filepath.Join(t.TempDir(), "repo")
 
-	_, err := PlainCloneContext(context.Background(), dest, &CloneOptions{
+	_, err := PlainClone(context.Background(), dest, &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	require.Error(t, err)
@@ -616,7 +616,7 @@ func TestPlainCloneContext_FailedClonePreservesPreexistingEmptyDirectory(t *test
 	// dest exists and is empty before the clone attempt.
 	dest := t.TempDir()
 
-	_, err := PlainCloneContext(context.Background(), dest, &CloneOptions{
+	_, err := PlainClone(context.Background(), dest, &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	require.Error(t, err)
@@ -637,12 +637,12 @@ func TestPlainCloneContext_EmptyRemoteReturnsError(t *testing.T) {
 	t.Parallel()
 
 	remote := filepath.Join(t.TempDir(), "remote.git")
-	remoteRepo, err := PlainInit(remote, true)
+	remoteRepo, err := PlainInit(t.Context(), remote, true)
 	require.NoError(t, err)
 	_ = remoteRepo.Close()
 
 	dest := filepath.Join(t.TempDir(), "clone")
-	_, err = PlainCloneContext(context.Background(), dest, &CloneOptions{
+	_, err = PlainClone(context.Background(), dest, &CloneOptions{
 		URL: remote,
 	})
 	require.ErrorIs(t, err, transport.ErrEmptyRemoteRepository)
@@ -655,12 +655,12 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 
 	// Create a bare empty repository to use as the remote.
 	remote := filepath.Join(t.TempDir(), "remote.git")
-	remoteRepo, err := PlainInit(remote, true)
+	remoteRepo, err := PlainInit(t.Context(), remote, true)
 	require.NoError(t, err)
 	defer func() { _ = remoteRepo.Close() }()
 
 	dest := filepath.Join(t.TempDir(), "clone")
-	r, err := PlainCloneContext(context.Background(), dest, &CloneOptions{
+	r, err := PlainClone(context.Background(), dest, &CloneOptions{
 		URL:            remote,
 		AllowEmptyRepo: true,
 	})
@@ -669,7 +669,7 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 	defer func() { _ = r.Close() }()
 
 	// The cloned repo should have the "origin" remote configured.
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(t.Context())
 	require.NoError(t, err)
 	require.Len(t, remotes, 1)
 	assert.Equal(t, "origin", remotes[0].Config().Name)
@@ -681,7 +681,7 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 
 	// HEAD must be a valid symbolic reference (not .invalid), because
 	// AllowEmptyRepo skips withPartialInit and fully initialises the repo.
-	head, err := r.Reference(plumbing.HEAD, false)
+	head, err := r.Reference(t.Context(), plumbing.HEAD, false)
 	require.NoError(t, err)
 	assert.Equal(t, plumbing.SymbolicReference, head.Type())
 	assert.NotEqual(t, plumbing.Invalid, head.Target(),
@@ -689,10 +689,10 @@ func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {
 
 	// The repository should be re-openable — a fully initialised repo has
 	// its config persisted (unlike a partialInit repo).
-	reopened, err := PlainOpen(dest)
+	reopened, err := PlainOpen(t.Context(), dest)
 	require.NoError(t, err)
 	defer func() { _ = reopened.Close() }()
-	reopenedRemotes, err := reopened.Remotes()
+	reopenedRemotes, err := reopened.Remotes(t.Context())
 	require.NoError(t, err)
 	require.Len(t, reopenedRemotes, 1)
 	assert.Equal(t, "origin", reopenedRemotes[0].Config().Name)
@@ -712,34 +712,34 @@ func TestPlainCloneContext_DetachedHeadSource(t *testing.T) {
 	// ── Build the source repo using PlainInit + Worktree.Commit ──────────
 	// Self-contained: no network access required.
 	srcDir := t.TempDir()
-	src, err := PlainInit(srcDir, false)
+	src, err := PlainInit(t.Context(), srcDir, false)
 	require.NoError(t, err)
 	defer func() { _ = src.Close() }()
 
-	wt, err := src.Worktree()
+	wt, err := src.Worktree(t.Context())
 	require.NoError(t, err)
 
 	// Write a file and create an initial commit so HEAD resolves to a real hash.
 	err = os.WriteFile(filepath.Join(srcDir, "README.md"), []byte("hello"), 0o644)
 	require.NoError(t, err)
-	_, err = wt.Add("README.md")
+	_, err = wt.Add(t.Context(), "README.md")
 	require.NoError(t, err)
-	commitHash, err := wt.Commit("initial commit", &CommitOptions{
+	commitHash, err := wt.Commit(t.Context(), "initial commit", &CommitOptions{
 		Author: &object.Signature{Name: "Test", Email: "t@t.com"},
 	})
 	require.NoError(t, err)
 
 	// Verify HEAD is a symbolic reference before detaching.
-	rawHead, err := src.Storer.Reference(plumbing.HEAD)
+	rawHead, err := src.Storer.Reference(t.Context(), plumbing.HEAD)
 	require.NoError(t, err)
 	require.Equal(t, plumbing.SymbolicReference, rawHead.Type(),
 		"HEAD should be a symbolic ref after commit")
 
 	// Detach HEAD by checking out by hash.
-	err = wt.Checkout(&CheckoutOptions{Hash: commitHash, Force: true})
+	err = wt.Checkout(t.Context(), &CheckoutOptions{Hash: commitHash, Force: true})
 	require.NoError(t, err)
 
-	detachedHead, err := src.Storer.Reference(plumbing.HEAD)
+	detachedHead, err := src.Storer.Reference(t.Context(), plumbing.HEAD)
 	require.NoError(t, err)
 	require.Equal(t, plumbing.HashReference, detachedHead.Type(),
 		"HEAD must be a hash-reference (detached) after Checkout{Hash:...}")
@@ -750,7 +750,7 @@ func TestPlainCloneContext_DetachedHeadSource(t *testing.T) {
 	// `git clone` does — by advertising the available refs rather than
 	// requiring HEAD to be symbolic.
 	dstDir := filepath.Join(t.TempDir(), "dst")
-	dst, err := PlainCloneContext(context.Background(), dstDir, &CloneOptions{
+	dst, err := PlainClone(context.Background(), dstDir, &CloneOptions{
 		URL: srcDir,
 	})
 	assert.NoError(t, err,
@@ -762,12 +762,12 @@ func TestPlainCloneContext_DetachedHeadSource(t *testing.T) {
 	require.NotNil(t, dst, "cloned repository must not be nil")
 	defer func() { _ = dst.Close() }()
 
-	rawClonedHead, err := dst.Storer.Reference(plumbing.HEAD)
+	rawClonedHead, err := dst.Storer.Reference(t.Context(), plumbing.HEAD)
 	require.NoError(t, err)
 	assert.Equal(t, plumbing.SymbolicReference, rawClonedHead.Type(),
 		"cloned repo HEAD must be a symbolic ref (as git clone produces), not detached")
 
-	resolvedHead, err := dst.Head()
+	resolvedHead, err := dst.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, commitHash, resolvedHead.Hash(),
 		"cloned repo HEAD must resolve to the same commit as the source")
@@ -801,7 +801,7 @@ func TestFailSafeUnsupportedStorage(t *testing.T) {
 			_, okGetter := storage.Storer(st).(xstorage.ExtensionChecker)
 			assert.False(t, okGetter, "sha1OnlyStorage must not implement ExtensionChecker")
 
-			r, err := Clone(st, nil, &CloneOptions{URL: endpoint})
+			r, err := Clone(t.Context(), st, nil, &CloneOptions{URL: endpoint})
 			if r != nil {
 				defer func() { _ = r.Close() }()
 			}
@@ -825,7 +825,7 @@ func TestFailSafeUnsupportedStorage(t *testing.T) {
 		_, okGetter := storage.Storer(wrapped).(xstorage.ExtensionChecker)
 		assert.False(t, okGetter, "sha1OnlyStorage must not implement ExtensionChecker")
 
-		r, err := Open(wrapped, nil)
+		r, err := Open(t.Context(), wrapped, nil)
 		assert.Error(t, err)
 		assert.Nil(t, r)
 	})
@@ -835,7 +835,7 @@ func (s *RepositorySuite) TestCloneContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	r, err := CloneContext(ctx, memory.NewStorage(), nil, &CloneOptions{
+	r, err := Clone(ctx, memory.NewStorage(), nil, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
@@ -845,7 +845,7 @@ func (s *RepositorySuite) TestCloneContext() {
 }
 
 func (s *RepositorySuite) TestCloneMirror() {
-	r, err := Clone(memory.NewStorage(), nil, &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), nil, &CloneOptions{
 		URL:    fixtures.Basic().One().URL,
 		Mirror: true,
 	})
@@ -853,9 +853,9 @@ func (s *RepositorySuite) TestCloneMirror() {
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	refs, err := r.References()
+	refs, err := r.References(s.T().Context())
 	var count int
-	refs.ForEach(func(r *plumbing.Reference) error { s.T().Log(r); count++; return nil })
+	refs.ForEach(s.T().Context(), func(r *plumbing.Reference) error { s.T().Log(r); count++; return nil })
 	s.NoError(err)
 	// 6 refs total from github.com/git-fixtures/basic.git:
 	//  - HEAD
@@ -866,7 +866,7 @@ func (s *RepositorySuite) TestCloneMirror() {
 	//  - refs/pull/2/merge
 	s.Equal(6, count)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 
 	s.True(cfg.Core.IsBare)
@@ -879,37 +879,37 @@ func (s *RepositorySuite) TestCloneWithTags() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, err := Clone(memory.NewStorage(), nil, &CloneOptions{URL: url, Tags: NoTags})
+	r, err := Clone(s.T().Context(), memory.NewStorage(), nil, &CloneOptions{URL: url, Tags: NoTags})
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Len(remotes, 1)
 
-	i, err := r.References()
+	i, err := r.References(s.T().Context())
 	s.NoError(err)
 
 	var count int
-	i.ForEach(func(*plumbing.Reference) error { count++; return nil })
+	i.ForEach(s.T().Context(), func(*plumbing.Reference) error { count++; return nil })
 
 	s.Equal(3, count)
 }
 
 func (s *RepositorySuite) TestCloneSparse() {
 	fs := memfs.New()
-	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), fs, &CloneOptions{
 		URL:        s.GetBasicLocalRepositoryURL(),
 		NoCheckout: true,
 	})
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	sparseCheckoutDirectories := []string{"go", "json", "php"}
-	s.NoError(w.Checkout(&CheckoutOptions{
+	s.NoError(w.Checkout(s.T().Context(), &CheckoutOptions{
 		Branch:                    "refs/heads/master",
 		SparseCheckoutDirectories: sparseCheckoutDirectories,
 	}))
@@ -930,9 +930,9 @@ func (s *RepositorySuite) TestCloneSparse() {
 }
 
 func (s *RepositorySuite) TestCreateRemoteAndRemote() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	remote, err := r.CreateRemote(&config.RemoteConfig{
+	remote, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: "foo",
 		URLs: []string{"http://foo/foo.git"},
 	})
@@ -940,23 +940,23 @@ func (s *RepositorySuite) TestCreateRemoteAndRemote() {
 	s.NoError(err)
 	s.Equal("foo", remote.Config().Name)
 
-	alt, err := r.Remote("foo")
+	alt, err := r.Remote(s.T().Context(), "foo")
 	s.NoError(err)
 	s.NotSame(remote, alt)
 	s.Equal("foo", alt.Config().Name)
 }
 
 func (s *RepositorySuite) TestCreateRemoteInvalid() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	remote, err := r.CreateRemote(&config.RemoteConfig{})
+	remote, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{})
 
 	s.ErrorIs(err, config.ErrRemoteConfigEmptyName)
 	s.Nil(remote)
 }
 
 func (s *RepositorySuite) TestCreateRemoteAnonymous() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	remote, err := r.CreateRemoteAnonymous(&config.RemoteConfig{
 		Name: "anonymous",
@@ -968,7 +968,7 @@ func (s *RepositorySuite) TestCreateRemoteAnonymous() {
 }
 
 func (s *RepositorySuite) TestCreateRemoteAnonymousInvalidName() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	remote, err := r.CreateRemoteAnonymous(&config.RemoteConfig{
 		Name: "not_anonymous",
@@ -980,7 +980,7 @@ func (s *RepositorySuite) TestCreateRemoteAnonymousInvalidName() {
 }
 
 func (s *RepositorySuite) TestCreateRemoteAnonymousInvalid() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	remote, err := r.CreateRemoteAnonymous(&config.RemoteConfig{})
 
@@ -989,35 +989,35 @@ func (s *RepositorySuite) TestCreateRemoteAnonymousInvalid() {
 }
 
 func (s *RepositorySuite) TestDeleteRemote() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: "foo",
 		URLs: []string{"http://foo/foo.git"},
 	})
 
 	s.NoError(err)
 
-	err = r.DeleteRemote("foo")
+	err = r.DeleteRemote(s.T().Context(), "foo")
 	s.NoError(err)
 
-	alt, err := r.Remote("foo")
+	alt, err := r.Remote(s.T().Context(), "foo")
 	s.ErrorIs(err, ErrRemoteNotFound)
 	s.Nil(alt)
 }
 
 func (s *RepositorySuite) TestEmptyCreateBranch() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	err := r.CreateBranch(&config.Branch{})
+	err := r.CreateBranch(s.T().Context(), &config.Branch{})
 
 	s.NotNil(err)
 }
 
 func (s *RepositorySuite) TestInvalidCreateBranch() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	err := r.CreateBranch(&config.Branch{
+	err := r.CreateBranch(s.T().Context(), &config.Branch{
 		Name: "-foo",
 	})
 
@@ -1025,17 +1025,17 @@ func (s *RepositorySuite) TestInvalidCreateBranch() {
 }
 
 func (s *RepositorySuite) TestCreateBranchAndBranch() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	testBranch := &config.Branch{
 		Name:   "foo",
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
 	}
-	err := r.CreateBranch(testBranch)
+	err := r.CreateBranch(s.T().Context(), testBranch)
 
 	s.NoError(err)
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 1)
 	branch := cfg.Branches["foo"]
@@ -1043,7 +1043,7 @@ func (s *RepositorySuite) TestCreateBranchAndBranch() {
 	s.Equal(testBranch.Remote, branch.Remote)
 	s.Equal(testBranch.Merge, branch.Merge)
 
-	branch, err = r.Branch("foo")
+	branch, err = r.Branch(s.T().Context(), "foo")
 	s.NoError(err)
 	s.Equal(testBranch.Name, branch.Name)
 	s.Equal(testBranch.Remote, branch.Remote)
@@ -1051,7 +1051,7 @@ func (s *RepositorySuite) TestCreateBranchAndBranch() {
 }
 
 func (s *RepositorySuite) TestMergeFF() {
-	r, err := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	s.NoError(err)
 	s.NotNil(r)
 	defer func() { _ = r.Close() }()
@@ -1061,11 +1061,11 @@ func (s *RepositorySuite) TestMergeFF() {
 	createCommit(s.T(), r)
 	lastCommit := createCommit(s.T(), r)
 
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	targetBranch := plumbing.NewBranchReferenceName("foo")
-	err = wt.Checkout(&CheckoutOptions{
+	err = wt.Checkout(s.T().Context(), &CheckoutOptions{
 		Hash:   lastCommit,
 		Create: true,
 		Branch: targetBranch,
@@ -1076,30 +1076,30 @@ func (s *RepositorySuite) TestMergeFF() {
 	fooHash := createCommit(s.T(), r)
 
 	// Checkout the master branch so that we can try to merge foo into it.
-	err = wt.Checkout(&CheckoutOptions{
+	err = wt.Checkout(s.T().Context(), &CheckoutOptions{
 		Branch: plumbing.Master,
 	})
 	s.NoError(err)
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal(lastCommit, head.Hash())
 
 	targetRef := plumbing.NewHashReference(targetBranch, fooHash)
 	s.NotNil(targetRef)
 
-	err = r.Merge(*targetRef, MergeOptions{
+	err = r.Merge(s.T().Context(), *targetRef, MergeOptions{
 		Strategy: FastForwardMerge,
 	})
 	s.NoError(err)
 
-	head, err = r.Head()
+	head, err = r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal(fooHash, head.Hash())
 }
 
 func (s *RepositorySuite) TestMergeFF_Invalid() {
-	r, err := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	s.NoError(err)
 	s.NotNil(r)
 	defer func() { _ = r.Close() }()
@@ -1112,11 +1112,11 @@ func (s *RepositorySuite) TestMergeFF_Invalid() {
 	createCommit(s.T(), r)
 	lastCommit := createCommit(s.T(), r)
 
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	targetBranch := plumbing.NewBranchReferenceName("foo")
-	err = wt.Checkout(&CheckoutOptions{
+	err = wt.Checkout(s.T().Context(), &CheckoutOptions{
 		Hash:   firstCommit,
 		Create: true,
 		Branch: targetBranch,
@@ -1128,38 +1128,38 @@ func (s *RepositorySuite) TestMergeFF_Invalid() {
 	h := createCommit(s.T(), r)
 
 	// Checkout the master branch so that we can try to merge foo into it.
-	err = wt.Checkout(&CheckoutOptions{
+	err = wt.Checkout(s.T().Context(), &CheckoutOptions{
 		Branch: plumbing.Master,
 	})
 	s.NoError(err)
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal(lastCommit, head.Hash())
 
 	targetRef := plumbing.NewHashReference(targetBranch, h)
 	s.NotNil(targetRef)
 
-	err = r.Merge(*targetRef, MergeOptions{
+	err = r.Merge(s.T().Context(), *targetRef, MergeOptions{
 		Strategy: MergeStrategy(10),
 	})
 	s.ErrorIs(err, ErrUnsupportedMergeStrategy)
 
 	// Failed merge operations must not change HEAD.
-	head, err = r.Head()
+	head, err = r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal(lastCommit, head.Hash())
 
-	err = r.Merge(*targetRef, MergeOptions{})
+	err = r.Merge(s.T().Context(), *targetRef, MergeOptions{})
 	s.ErrorIs(err, ErrFastForwardMergeNotPossible)
 
-	head, err = r.Head()
+	head, err = r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal(lastCommit, head.Hash())
 }
 
 func (s *RepositorySuite) TestCreateBranchUnmarshal() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 
 	expected := []byte(`[core]
@@ -1176,7 +1176,7 @@ func (s *RepositorySuite) TestCreateBranchUnmarshal() {
 	merge = refs/heads/master
 `)
 
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: "foo",
 		URLs: []string{"http://foo/foo.git"},
 	})
@@ -1191,12 +1191,12 @@ func (s *RepositorySuite) TestCreateBranchUnmarshal() {
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
 	}
-	err = r.CreateBranch(testBranch1)
+	err = r.CreateBranch(s.T().Context(), testBranch1)
 	s.NoError(err)
-	err = r.CreateBranch(testBranch2)
+	err = r.CreateBranch(s.T().Context(), testBranch2)
 	s.NoError(err)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	marshaled, err := cfg.Marshal()
 	s.NoError(err)
@@ -1204,18 +1204,18 @@ func (s *RepositorySuite) TestCreateBranchUnmarshal() {
 }
 
 func (s *RepositorySuite) TestBranchInvalid() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	branch, err := r.Branch("foo")
+	branch, err := r.Branch(s.T().Context(), "foo")
 
 	s.NotNil(err)
 	s.Nil(branch)
 }
 
 func (s *RepositorySuite) TestCreateBranchInvalid() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	err := r.CreateBranch(&config.Branch{})
+	err := r.CreateBranch(s.T().Context(), &config.Branch{})
 
 	s.NotNil(err)
 
@@ -1224,62 +1224,62 @@ func (s *RepositorySuite) TestCreateBranchInvalid() {
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
 	}
-	err = r.CreateBranch(testBranch)
+	err = r.CreateBranch(s.T().Context(), testBranch)
 	s.NoError(err)
-	err = r.CreateBranch(testBranch)
+	err = r.CreateBranch(s.T().Context(), testBranch)
 	s.NotNil(err)
 }
 
 func (s *RepositorySuite) TestDeleteBranch() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	testBranch := &config.Branch{
 		Name:   "foo",
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
 	}
-	err := r.CreateBranch(testBranch)
+	err := r.CreateBranch(s.T().Context(), testBranch)
 
 	s.NoError(err)
 
-	err = r.DeleteBranch("foo")
+	err = r.DeleteBranch(s.T().Context(), "foo")
 	s.NoError(err)
 
-	b, err := r.Branch("foo")
+	b, err := r.Branch(s.T().Context(), "foo")
 	s.ErrorIs(err, ErrBranchNotFound)
 	s.Nil(b)
 
-	err = r.DeleteBranch("foo")
+	err = r.DeleteBranch(s.T().Context(), "foo")
 	s.ErrorIs(err, ErrBranchNotFound)
 }
 
 func (s *RepositorySuite) TestDeleteBranchFullRefName() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	testBranch := &config.Branch{
 		Name:   "foo",
 		Remote: "origin",
 		Merge:  "refs/heads/foo",
 	}
-	err := r.CreateBranch(testBranch)
+	err := r.CreateBranch(s.T().Context(), testBranch)
 	s.NoError(err)
 
-	err = r.DeleteBranch("refs/heads/foo")
+	err = r.DeleteBranch(s.T().Context(), "refs/heads/foo")
 	s.NoError(err)
 
-	b, err := r.Branch("foo")
+	b, err := r.Branch(s.T().Context(), "foo")
 	s.ErrorIs(err, ErrBranchNotFound)
 	s.Nil(b)
 }
 
 func (s *RepositorySuite) TestPlainInitAlreadyExists() {
 	dir := s.T().TempDir()
-	r, err := PlainInit(dir, true)
+	r, err := PlainInit(s.T().Context(), dir, true)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 
-	r, err = PlainInit(dir, true)
+	r, err = PlainInit(s.T().Context(), dir, true)
 	s.ErrorIs(err, ErrTargetDirNotEmpty)
 	s.Nil(r)
 }
@@ -1288,7 +1288,7 @@ func (s *RepositorySuite) TestPlainOpenTildePath() {
 	dir, clean := s.TemporalHomeDir()
 	defer clean()
 
-	r, err := PlainInit(dir, false)
+	r, err := PlainInit(s.T().Context(), dir, false)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
@@ -1302,7 +1302,7 @@ func (s *RepositorySuite) TestPlainOpenTildePath() {
 	for _, home := range homes {
 		path := strings.Replace(dir, strings.Split(dir, ".tmp")[0], home, 1)
 
-		r, err = PlainOpen(path)
+		r, err = PlainOpen(s.T().Context(), path)
 		s.NoError(err)
 		s.NotNil(r)
 		_ = r.Close()
@@ -1315,7 +1315,7 @@ func (s *RepositorySuite) testPlainOpenGitFile(f func(string, string) string) {
 	dir, err := util.TempDir(fs, "", "plain-open")
 	s.NoError(err)
 
-	r, err := PlainInit(fs.Join(fs.Root(), dir), true)
+	r, err := PlainInit(s.T().Context(), fs.Join(fs.Root(), dir), true)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
@@ -1330,7 +1330,7 @@ func (s *RepositorySuite) testPlainOpenGitFile(f func(string, string) string) {
 
 	s.NoError(err)
 
-	r, err = PlainOpen(fs.Join(fs.Root(), altDir))
+	r, err = PlainOpen(s.T().Context(), fs.Join(fs.Root(), altDir))
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
@@ -1370,7 +1370,7 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage() {
 	dir, err := util.TempDir(fs, "", "")
 	s.NoError(err)
 
-	r, err := PlainInit(dir, true)
+	r, err := PlainInit(s.T().Context(), dir, true)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
@@ -1384,7 +1384,7 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage() {
 	)
 	s.NoError(err)
 
-	r2, err := PlainOpen(altDir)
+	r2, err := PlainOpen(s.T().Context(), altDir)
 	s.ErrorIs(err, ErrRepositoryNotExists)
 	s.Nil(r2)
 }
@@ -1395,7 +1395,7 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileBadPrefix() {
 	dir, err := util.TempDir(fs, "", "")
 	s.NoError(err)
 
-	r, err := PlainInit(fs.Join(fs.Root(), dir), true)
+	r, err := PlainInit(s.T().Context(), fs.Join(fs.Root(), dir), true)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
@@ -1409,13 +1409,13 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileBadPrefix() {
 
 	s.NoError(err)
 
-	r, err = PlainOpen(fs.Join(fs.Root(), altDir))
+	r, err = PlainOpen(s.T().Context(), fs.Join(fs.Root(), altDir))
 	s.ErrorContains(err, "gitdir")
 	s.Nil(r)
 }
 
 func (s *RepositorySuite) TestPlainOpenNotExists() {
-	r, err := PlainOpen("/not-exists/")
+	r, err := PlainOpen(s.T().Context(), "/not-exists/")
 	s.ErrorIs(err, ErrRepositoryNotExists)
 	s.Nil(r)
 }
@@ -1435,24 +1435,24 @@ func (s *RepositorySuite) TestPlainOpenDetectDotGit() {
 	s.NoError(err)
 	f.Close()
 
-	r, err := PlainInit(fs.Join(fs.Root(), dir), false)
+	r, err := PlainInit(s.T().Context(), fs.Join(fs.Root(), dir), false)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 
 	opt := &PlainOpenOptions{DetectDotGit: true}
-	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), subdir), opt)
+	r, err = PlainOpenWithOptions(s.T().Context(), fs.Join(fs.Root(), subdir), opt)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 
-	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), file), opt)
+	r, err = PlainOpenWithOptions(s.T().Context(), fs.Join(fs.Root(), file), opt)
 	s.NoError(err)
 	s.NotNil(r)
 	_ = r.Close()
 
 	optnodetect := &PlainOpenOptions{DetectDotGit: false}
-	r, err = PlainOpenWithOptions(fs.Join(fs.Root(), file), optnodetect)
+	r, err = PlainOpenWithOptions(s.T().Context(), fs.Join(fs.Root(), file), optnodetect)
 	s.NotNil(err)
 	s.Nil(r)
 }
@@ -1460,7 +1460,7 @@ func (s *RepositorySuite) TestPlainOpenDetectDotGit() {
 func (s *RepositorySuite) TestPlainOpenNotExistsDetectDotGit() {
 	dir := s.T().TempDir()
 	opt := &PlainOpenOptions{DetectDotGit: true}
-	r, err := PlainOpenWithOptions(dir, opt)
+	r, err := PlainOpenWithOptions(s.T().Context(), dir, opt)
 	s.ErrorIs(err, ErrRepositoryNotExists)
 	s.Nil(r)
 }
@@ -1470,13 +1470,13 @@ func (s *RepositorySuite) TestPlainOpenAlternatesFS() {
 	src := filepath.Join(root, "src")
 	shared := filepath.Join(root, "shared")
 
-	srcRepo, err := PlainClone(src, &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	srcRepo, err := PlainClone(s.T().Context(), src, &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
 
-	head, err := srcRepo.Head()
+	head, err := srcRepo.Head(s.T().Context())
 	s.Require().NoError(err)
 
-	_, err = PlainInit(shared, false)
+	_, err = PlainInit(s.T().Context(), shared, false)
 	s.Require().NoError(err)
 
 	infoDir := filepath.Join(shared, GitDirName, "objects", "info")
@@ -1486,17 +1486,17 @@ func (s *RepositorySuite) TestPlainOpenAlternatesFS() {
 
 	// Without AlternatesFS the absolute alternate path cannot be resolved
 	// from within the .git filesystem.
-	r, err := PlainOpen(shared)
+	r, err := PlainOpen(s.T().Context(), shared)
 	s.Require().NoError(err)
-	_, err = r.CommitObject(head.Hash())
+	_, err = r.CommitObject(s.T().Context(), head.Hash())
 	s.Error(err)
 
-	r, err = PlainOpenWithOptions(shared, &PlainOpenOptions{
+	r, err = PlainOpenWithOptions(s.T().Context(), shared, &PlainOpenOptions{
 		AlternatesFS: osfs.New(root),
 	})
 	s.Require().NoError(err)
 
-	commit, err := r.CommitObject(head.Hash())
+	commit, err := r.CommitObject(s.T().Context(), head.Hash())
 	s.NoError(err)
 	s.NotNil(commit)
 }
@@ -1510,17 +1510,17 @@ func (s *RepositorySuite) TestPlainClone() {
 		os.RemoveAll(dir)
 	})
 
-	r, err := PlainClone(dir, &CloneOptions{
+	r, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Len(remotes, 1)
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 1)
 	s.Equal("master", cfg.Branches["master"].Name)
@@ -1530,7 +1530,7 @@ func (s *RepositorySuite) TestPlainCloneBareAndShared() {
 	dir := s.T().TempDir()
 	remote := s.GetBasicLocalRepositoryURL()
 
-	r, err := PlainClone(dir, &CloneOptions{
+	r, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL:    remote,
 		Shared: true,
 		Bare:   true,
@@ -1548,7 +1548,7 @@ func (s *RepositorySuite) TestPlainCloneBareAndShared() {
 	line := path.Join(remote, GitDirName, "objects") + "\n"
 	s.Equal(line, string(data))
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 1)
 	s.Equal("master", cfg.Branches["master"].Name)
@@ -1558,7 +1558,7 @@ func (s *RepositorySuite) TestPlainCloneShared() {
 	dir := s.T().TempDir()
 	remote := s.GetBasicLocalRepositoryURL()
 
-	r, err := PlainClone(dir, &CloneOptions{
+	r, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL:    remote,
 		Shared: true,
 	})
@@ -1575,7 +1575,7 @@ func (s *RepositorySuite) TestPlainCloneShared() {
 	line := path.Join(remote, GitDirName, "objects") + "\n"
 	s.Equal(line, string(data))
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 1)
 	s.Equal("master", cfg.Branches["master"].Name)
@@ -1585,7 +1585,7 @@ func (s *RepositorySuite) TestPlainCloneSharedHttpShouldReturnError() {
 	dir := s.T().TempDir()
 	remote := "http://somerepo"
 
-	_, err := PlainClone(dir, &CloneOptions{
+	_, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL:    remote,
 		Shared: true,
 	})
@@ -1596,7 +1596,7 @@ func (s *RepositorySuite) TestPlainCloneSharedHttpsShouldReturnError() {
 	dir := s.T().TempDir()
 	remote := "https://somerepo"
 
-	_, err := PlainClone(dir, &CloneOptions{
+	_, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL:    remote,
 		Shared: true,
 	})
@@ -1607,7 +1607,7 @@ func (s *RepositorySuite) TestPlainCloneSharedSSHShouldReturnError() {
 	dir := s.T().TempDir()
 	remote := "ssh://somerepo"
 
-	_, err := PlainClone(dir, &CloneOptions{
+	_, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL:    remote,
 		Shared: true,
 	})
@@ -1616,7 +1616,7 @@ func (s *RepositorySuite) TestPlainCloneSharedSSHShouldReturnError() {
 
 func (s *RepositorySuite) TestPlainCloneWithRemoteName() {
 	dir := s.T().TempDir()
-	r, err := PlainClone(dir, &CloneOptions{
+	r, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL:        s.GetBasicLocalRepositoryURL(),
 		RemoteName: "test",
 	})
@@ -1624,19 +1624,19 @@ func (s *RepositorySuite) TestPlainCloneWithRemoteName() {
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	remote, err := r.Remote("test")
+	remote, err := r.Remote(s.T().Context(), "test")
 	s.NoError(err)
 	s.NotNil(remote)
 }
 
 func (s *RepositorySuite) TestPlainCloneOverExistingGitDirectory() {
 	dir := s.T().TempDir()
-	r, err := PlainInit(dir, false)
+	r, err := PlainInit(s.T().Context(), dir, false)
 	s.NotNil(r)
 	s.NoError(err)
 	_ = r.Close()
 
-	r, err = PlainClone(dir, &CloneOptions{
+	r, err = PlainClone(s.T().Context(), dir, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	s.Nil(r)
@@ -1648,11 +1648,14 @@ func (s *RepositorySuite) TestPlainCloneContextCancel() {
 	cancel()
 
 	dir := s.T().TempDir()
-	r, err := PlainCloneContext(ctx, dir, &CloneOptions{
+	r, err := PlainClone(ctx, dir, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 
-	s.NotNil(r)
+	// With ctx-first storers the cancellation is observed before the
+	// repository is initialized, so no partially-initialized repository
+	// is returned.
+	s.Nil(r)
 	s.ErrorIs(err, context.Canceled)
 }
 
@@ -1665,7 +1668,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithExistentDir() {
 	dir, err := util.TempDir(fs, "", "")
 	s.NoError(err)
 
-	r, err := PlainCloneContext(ctx, dir, &CloneOptions{
+	r, err := PlainClone(ctx, dir, &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	s.NotNil(r)
@@ -1690,7 +1693,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNonExistentDir() {
 
 	repoDir := filepath.Join(tmpDir, "repoDir")
 
-	r, err := PlainCloneContext(ctx, repoDir, &CloneOptions{
+	r, err := PlainClone(ctx, repoDir, &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	s.NotNil(r)
@@ -1715,7 +1718,7 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistentWithNotDir() {
 	s.NoError(err)
 	s.Nil(f.Close())
 
-	r, err := PlainCloneContext(ctx, fs.Join(fs.Root(), repoDir), &CloneOptions{
+	r, err := PlainClone(ctx, fs.Join(fs.Root(), repoDir), &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	s.Nil(r)
@@ -1743,7 +1746,7 @@ func (s *RepositorySuite) TestPlainCloneContextFailedClonePreservesExistingDir()
 	err = util.WriteFile(fs, dummyFile, []byte("dummyContent"), 0o644)
 	s.NoError(err)
 
-	r, err := PlainCloneContext(ctx, fs.Join(fs.Root(), repoDir), &CloneOptions{
+	r, err := PlainClone(ctx, fs.Join(fs.Root(), repoDir), &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	s.Nil(r)
@@ -1758,12 +1761,12 @@ func (s *RepositorySuite) TestPlainCloneContextNonExistingOverExistingGitDirecto
 	defer cancel()
 
 	dir := s.T().TempDir()
-	r, err := PlainInit(dir, false)
+	r, err := PlainInit(s.T().Context(), dir, false)
 	s.NotNil(r)
 	s.NoError(err)
 	_ = r.Close()
 
-	r, err = PlainCloneContext(ctx, dir, &CloneOptions{
+	r, err = PlainClone(ctx, dir, &CloneOptions{
 		URL: "incorrectOnPurpose",
 	})
 	s.Nil(r)
@@ -1778,14 +1781,14 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules() {
 	fixtures.ByTag("submodule").Run(s.T(), func(t *testing.T, f *fixtures.Fixture) {
 		t.Parallel()
 
-		r, err := PlainClone(t.TempDir(), &CloneOptions{
+		r, err := PlainClone(s.T().Context(), t.TempDir(), &CloneOptions{
 			URL:               s.GetLocalRepositoryURL(f),
 			RecurseSubmodules: DefaultSubmoduleRecursionDepth,
 		})
 		require.NoError(t, err)
 		defer func() { _ = r.Close() }()
 
-		cfg, err := r.Config()
+		cfg, err := r.Config(s.T().Context())
 		require.NoError(t, err)
 		assert.Len(t, cfg.Remotes, 1)
 		assert.Len(t, cfg.Branches, 1)
@@ -1807,7 +1810,7 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules() {
 		t.Parallel()
 
 		dir := t.TempDir()
-		mainRepo, err := PlainClone(dir, &CloneOptions{
+		mainRepo, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 			URL:               s.GetLocalRepositoryURL(f),
 			RecurseSubmodules: 1,
 			ShallowSubmodules: true,
@@ -1815,21 +1818,21 @@ func (s *RepositorySuite) TestPlainCloneWithShallowSubmodules() {
 		require.NoError(t, err)
 		defer func() { _ = mainRepo.Close() }()
 
-		mainWorktree, err := mainRepo.Worktree()
+		mainWorktree, err := mainRepo.Worktree(s.T().Context())
 		require.NoError(t, err)
 
-		submodule, err := mainWorktree.Submodule(primaryFixtureSubmoduleName(f))
+		submodule, err := mainWorktree.Submodule(s.T().Context(), primaryFixtureSubmoduleName(f))
 		require.NoError(t, err)
 
-		subRepo, err := submodule.Repository()
+		subRepo, err := submodule.Repository(s.T().Context())
 		require.NoError(t, err)
 		defer subRepo.Close()
 
-		lr, err := subRepo.Log(&LogOptions{})
+		lr, err := subRepo.Log(s.T().Context(), &LogOptions{})
 		require.NoError(t, err)
 
 		commitCount := 0
-		for _, err := lr.Next(); err == nil; _, err = lr.Next() {
+		for _, err := lr.Next(s.T().Context()); err == nil; _, err = lr.Next(s.T().Context()) {
 			commitCount++
 		}
 		require.NoError(t, err)
@@ -1843,7 +1846,7 @@ func (s *RepositorySuite) TestPlainCloneNoCheckout() {
 
 		dir := t.TempDir()
 
-		r, err := PlainClone(dir, &CloneOptions{
+		r, err := PlainClone(s.T().Context(), dir, &CloneOptions{
 			URL:               s.GetLocalRepositoryURL(f),
 			NoCheckout:        true,
 			RecurseSubmodules: DefaultSubmoduleRecursionDepth,
@@ -1851,7 +1854,7 @@ func (s *RepositorySuite) TestPlainCloneNoCheckout() {
 		require.NoError(t, err)
 		defer func() { _ = r.Close() }()
 
-		h, err := r.Head()
+		h, err := r.Head(s.T().Context())
 		require.NoError(t, err)
 		if f.Head != "" {
 			assert.Equal(t, f.Head, h.Hash().String())
@@ -1866,23 +1869,23 @@ func (s *RepositorySuite) TestPlainCloneNoCheckout() {
 }
 
 func (s *RepositorySuite) TestFetch() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 	s.NoError(err)
-	s.Nil(r.Fetch(&FetchOptions{}))
+	s.Nil(r.Fetch(s.T().Context(), &FetchOptions{}))
 
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Len(remotes, 1)
 
-	_, err = r.Head()
+	_, err = r.Head(s.T().Context())
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 
-	branch, err := r.Reference("refs/remotes/origin/master", false)
+	branch, err := r.Reference(s.T().Context(), "refs/remotes/origin/master", false)
 	s.NoError(err)
 	s.NotNil(branch)
 	s.Equal(plumbing.HashReference, branch.Type())
@@ -1890,9 +1893,9 @@ func (s *RepositorySuite) TestFetch() {
 }
 
 func (s *RepositorySuite) TestFetchContext() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
@@ -1901,37 +1904,37 @@ func (s *RepositorySuite) TestFetchContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	s.NotNil(r.FetchContext(ctx, &FetchOptions{}))
+	s.NotNil(r.Fetch(ctx, &FetchOptions{}))
 }
 
 func (s *RepositorySuite) TestFetchWithFilters() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 	s.NoError(err)
 
-	err = r.Fetch(&FetchOptions{
+	err = r.Fetch(s.T().Context(), &FetchOptions{
 		Filter: packp.FilterBlobNone(),
 	})
 	s.ErrorIs(err, transport.ErrFilterNotSupported)
 }
 
 func (s *RepositorySuite) TestFetchWithFiltersReal() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{"https://github.com/git-fixtures/basic.git"},
 	})
 	s.NoError(err)
-	err = r.Fetch(&FetchOptions{
+	err = r.Fetch(s.T().Context(), &FetchOptions{
 		Filter: packp.FilterBlobNone(),
 	})
 	s.NoError(err)
-	blob, err := r.BlobObject(plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"))
+	blob, err := r.BlobObject(s.T().Context(), plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"))
 	s.NotNil(err)
 	s.Nil(blob)
 }
@@ -1943,7 +1946,7 @@ func (s *RepositorySuite) TestCloneWithProgress() {
 	fs := memfs.New()
 
 	buf := bytes.NewBuffer(nil)
-	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), fs, &CloneOptions{
 		URL:      s.GetBasicLocalRepositoryURL(),
 		Progress: buf,
 	})
@@ -1955,10 +1958,10 @@ func (s *RepositorySuite) TestCloneWithProgress() {
 
 func (s *RepositorySuite) TestCloneDeep() {
 	fs := memfs.New()
-	r, _ := Init(memory.NewStorage(), WithWorkTree(fs))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(fs))
 	defer func() { _ = r.Close() }()
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 	s.Nil(head)
 
@@ -1968,22 +1971,22 @@ func (s *RepositorySuite) TestCloneDeep() {
 
 	s.NoError(err)
 
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Len(remotes, 1)
 
-	head, err = r.Reference(plumbing.HEAD, false)
+	head, err = r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.NotNil(head)
 	s.Equal(plumbing.SymbolicReference, head.Type())
 	s.Equal("refs/heads/master", head.Target().String())
 
-	branch, err := r.Reference(head.Target(), false)
+	branch, err := r.Reference(s.T().Context(), head.Target(), false)
 	s.NoError(err)
 	s.NotNil(branch)
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branch.Hash().String())
 
-	branch, err = r.Reference("refs/remotes/origin/master", false)
+	branch, err = r.Reference(s.T().Context(), "refs/remotes/origin/master", false)
 	s.NoError(err)
 	s.NotNil(branch)
 	s.Equal(plumbing.HashReference, branch.Type())
@@ -1995,10 +1998,10 @@ func (s *RepositorySuite) TestCloneDeep() {
 }
 
 func (s *RepositorySuite) TestCloneConfig() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 	s.Nil(head)
 
@@ -2008,7 +2011,7 @@ func (s *RepositorySuite) TestCloneConfig() {
 
 	s.NoError(err)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 
 	s.True(cfg.Core.IsBare)
@@ -2028,10 +2031,10 @@ func (s *RepositorySuite) TestCloneSingleBranchAndNonHEADAndNonFull() {
 }
 
 func (s *RepositorySuite) testCloneSingleBranchAndNonHEADReference(ref string) {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 	s.Nil(head)
 
@@ -2043,29 +2046,29 @@ func (s *RepositorySuite) testCloneSingleBranchAndNonHEADReference(ref string) {
 
 	s.NoError(err)
 
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Len(remotes, 1)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 1)
 	s.Equal("branch", cfg.Branches["branch"].Name)
 	s.Equal("origin", cfg.Branches["branch"].Remote)
 	s.Equal(plumbing.ReferenceName("refs/heads/branch"), cfg.Branches["branch"].Merge)
 
-	head, err = r.Reference(plumbing.HEAD, false)
+	head, err = r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.NotNil(head)
 	s.Equal(plumbing.SymbolicReference, head.Type())
 	s.Equal("refs/heads/branch", head.Target().String())
 
-	branch, err := r.Reference(head.Target(), false)
+	branch, err := r.Reference(s.T().Context(), head.Target(), false)
 	s.NoError(err)
 	s.NotNil(branch)
 	s.Equal("e8d3ffab552895c19b9fcf7aa264d277cde33881", branch.Hash().String())
 
-	branch, err = r.Reference("refs/remotes/origin/branch", false)
+	branch, err = r.Reference(s.T().Context(), "refs/remotes/origin/branch", false)
 	s.NoError(err)
 	s.NotNil(branch)
 	s.Equal(plumbing.HashReference, branch.Type())
@@ -2073,10 +2076,10 @@ func (s *RepositorySuite) testCloneSingleBranchAndNonHEADReference(ref string) {
 }
 
 func (s *RepositorySuite) TestCloneSingleBranchHEADMain() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 	s.Nil(head)
 
@@ -2087,29 +2090,29 @@ func (s *RepositorySuite) TestCloneSingleBranchHEADMain() {
 
 	s.NoError(err)
 
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Len(remotes, 1)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 1)
 	s.Equal("main", cfg.Branches["main"].Name)
 	s.Equal("origin", cfg.Branches["main"].Remote)
 	s.Equal(plumbing.ReferenceName("refs/heads/main"), cfg.Branches["main"].Merge)
 
-	head, err = r.Reference(plumbing.HEAD, false)
+	head, err = r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.NotNil(head)
 	s.Equal(plumbing.SymbolicReference, head.Type())
 	s.Equal("refs/heads/main", head.Target().String())
 
-	branch, err := r.Reference(head.Target(), false)
+	branch, err := r.Reference(s.T().Context(), head.Target(), false)
 	s.NoError(err)
 	s.NotNil(branch)
 	s.Equal("786dafbd351e587da1ae97e5fb9fbdf868b4a28f", branch.Hash().String())
 
-	branch, err = r.Reference("refs/remotes/origin/HEAD", false)
+	branch, err = r.Reference(s.T().Context(), "refs/remotes/origin/HEAD", false)
 	s.NoError(err)
 	s.NotNil(branch)
 	s.Equal(plumbing.HashReference, branch.Type())
@@ -2117,10 +2120,10 @@ func (s *RepositorySuite) TestCloneSingleBranchHEADMain() {
 }
 
 func (s *RepositorySuite) TestCloneSingleBranch() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 	s.Nil(head)
 
@@ -2131,31 +2134,31 @@ func (s *RepositorySuite) TestCloneSingleBranch() {
 
 	s.NoError(err)
 
-	remotes, err := r.Remotes()
+	remotes, err := r.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Len(remotes, 1)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 1)
 	s.Equal("master", cfg.Branches["master"].Name)
 	s.Equal("origin", cfg.Branches["master"].Remote)
 	s.Equal(plumbing.ReferenceName("refs/heads/master"), cfg.Branches["master"].Merge)
 
-	head, err = r.Reference(plumbing.HEAD, false)
+	head, err = r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.NotNil(head)
 	s.Equal(plumbing.SymbolicReference, head.Type())
 	s.Equal("refs/heads/master", head.Target().String())
 
-	branch, err := r.Reference(head.Target(), false)
+	branch, err := r.Reference(s.T().Context(), head.Target(), false)
 	s.NoError(err)
 	s.NotNil(branch)
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branch.Hash().String())
 }
 
 func (s *RepositorySuite) TestCloneSingleTag() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 
 	url := s.GetLocalRepositoryURL(
@@ -2169,11 +2172,11 @@ func (s *RepositorySuite) TestCloneSingleTag() {
 	})
 	s.NoError(err)
 
-	branch, err := r.Reference("refs/tags/commit-tag", false)
+	branch, err := r.Reference(s.T().Context(), "refs/tags/commit-tag", false)
 	s.NoError(err)
 	s.NotNil(branch)
 
-	conf, err := r.Config()
+	conf, err := r.Config(s.T().Context())
 	s.NoError(err)
 	originRemote := conf.Remotes["origin"]
 	s.NotNil(originRemote)
@@ -2182,7 +2185,7 @@ func (s *RepositorySuite) TestCloneSingleTag() {
 }
 
 func (s *RepositorySuite) TestCloneDetachedHEAD() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL:           s.GetBasicLocalRepositoryURL(),
@@ -2190,25 +2193,25 @@ func (s *RepositorySuite) TestCloneDetachedHEAD() {
 	})
 	s.NoError(err)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 0)
 
-	head, err := r.Reference(plumbing.HEAD, false)
+	head, err := r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.NotNil(head)
 	s.Equal(plumbing.HashReference, head.Type())
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", head.Hash().String())
 
 	count := 0
-	objects, err := r.Objects()
+	objects, err := r.Objects(s.T().Context())
 	s.NoError(err)
-	objects.ForEach(func(object.Object) error { count++; return nil })
+	objects.ForEach(s.T().Context(), func(object.Object) error { count++; return nil })
 	s.Equal(28, count)
 }
 
 func (s *RepositorySuite) TestCloneDetachedHEADAndSingle() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL:           s.GetBasicLocalRepositoryURL(),
@@ -2217,20 +2220,20 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndSingle() {
 	})
 	s.NoError(err)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 0)
 
-	head, err := r.Reference(plumbing.HEAD, false)
+	head, err := r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.NotNil(head)
 	s.Equal(plumbing.HashReference, head.Type())
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", head.Hash().String())
 
 	count := 0
-	objects, err := r.Objects()
+	objects, err := r.Objects(s.T().Context())
 	s.NoError(err)
-	objects.ForEach(func(object.Object) error { count++; return nil })
+	objects.ForEach(s.T().Context(), func(object.Object) error { count++; return nil })
 	s.Equal(28, count)
 }
 
@@ -2239,7 +2242,7 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndShallow() {
 		"yet. Since we're using local repositories here, the test will use the" +
 		"server-side implementation. See transport/upload_pack.go and" +
 		"packfile/encoder.go")
-	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL:           s.GetBasicLocalRepositoryURL(),
@@ -2249,25 +2252,25 @@ func (s *RepositorySuite) TestCloneDetachedHEADAndShallow() {
 
 	s.NoError(err)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 0)
 
-	head, err := r.Reference(plumbing.HEAD, false)
+	head, err := r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.NotNil(head)
 	s.Equal(plumbing.HashReference, head.Type())
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", head.Hash().String())
 
 	count := 0
-	objects, err := r.Objects()
+	objects, err := r.Objects(s.T().Context())
 	s.NoError(err)
-	objects.ForEach(func(object.Object) error { count++; return nil })
+	objects.ForEach(s.T().Context(), func(object.Object) error { count++; return nil })
 	s.Equal(15, count)
 }
 
 func (s *RepositorySuite) TestCloneDetachedHEADAnnotatedTag() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL:           s.GetLocalRepositoryURL(fixtures.ByTag("tags").One()),
@@ -2275,25 +2278,25 @@ func (s *RepositorySuite) TestCloneDetachedHEADAnnotatedTag() {
 	})
 	s.NoError(err)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Branches, 0)
 
-	head, err := r.Reference(plumbing.HEAD, false)
+	head, err := r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.NotNil(head)
 	s.Equal(plumbing.HashReference, head.Type())
 	s.Equal("f7b877701fbf855b44c0a9e86f3fdce2c298b07f", head.Hash().String())
 
 	count := 0
-	objects, err := r.Objects()
+	objects, err := r.Objects(s.T().Context())
 	s.NoError(err)
-	objects.ForEach(func(object.Object) error { count++; return nil })
+	objects.ForEach(s.T().Context(), func(object.Object) error { count++; return nil })
 	s.Equal(7, count)
 }
 
 func (s *RepositorySuite) TestCloneWithFilter() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 
 	err := r.clone(context.Background(), &CloneOptions{
@@ -2301,24 +2304,24 @@ func (s *RepositorySuite) TestCloneWithFilter() {
 		Filter: packp.FilterTreeDepth(0),
 	})
 	s.Require().NoError(err)
-	blob, err := r.BlobObject(plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"))
+	blob, err := r.BlobObject(s.T().Context(), plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492"))
 	s.Require().Error(err)
 	s.Nil(blob)
 }
 
 func (s *RepositorySuite) TestPush() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
-	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
+	_, err = s.Repository.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: "test",
 		URLs: []string{url},
 	})
 	s.NoError(err)
 
-	err = s.Repository.Push(&PushOptions{
+	err = s.Repository.Push(s.T().Context(), &PushOptions{
 		RemoteName: "test",
 	})
 	s.NoError(err)
@@ -2336,11 +2339,11 @@ func (s *RepositorySuite) TestPush() {
 
 func (s *RepositorySuite) TestPushContext() {
 	url := s.T().TempDir()
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	_ = server.Close()
 
-	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
+	_, err = s.Repository.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: "foo",
 		URLs: []string{url},
 	})
@@ -2349,7 +2352,7 @@ func (s *RepositorySuite) TestPushContext() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	err = s.Repository.PushContext(ctx, &PushOptions{
+	err = s.Repository.Push(ctx, &PushOptions{
 		RemoteName: "foo",
 	})
 	s.NotNil(err)
@@ -2378,21 +2381,21 @@ func (s *RepositorySuite) TestPushWithProgress() {
 
 	url := fs.Join(fs.Root(), path)
 
-	server, err := PlainInit(url, true)
+	server, err := PlainInit(s.T().Context(), url, true)
 	s.NoError(err)
 	defer func() { _ = server.Close() }()
 
 	m := "Receiving..."
 	installPreReceiveHook(s, fs, path, m)
 
-	_, err = s.Repository.CreateRemote(&config.RemoteConfig{
+	_, err = s.Repository.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: "bar",
 		URLs: []string{url},
 	})
 	s.NoError(err)
 
 	var p bytes.Buffer
-	err = s.Repository.Push(&PushOptions{
+	err = s.Repository.Push(s.T().Context(), &PushOptions{
 		RemoteName: "bar",
 		Progress:   &p,
 	})
@@ -2407,13 +2410,13 @@ func (s *RepositorySuite) TestPushWithProgress() {
 }
 
 func (s *RepositorySuite) TestPushDepth() {
-	server, err := PlainClone(s.T().TempDir(), &CloneOptions{
+	server, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
-	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), memfs.New(), &CloneOptions{
 		URL:   server.wt.Root(),
 		Depth: 1,
 	})
@@ -2423,19 +2426,19 @@ func (s *RepositorySuite) TestPushDepth() {
 	err = util.WriteFile(r.wt, "foo", nil, 0o755)
 	s.NoError(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.NoError(err)
 
-	hash, err := w.Commit("foo", &CommitOptions{
+	hash, err := w.Commit(s.T().Context(), "foo", &CommitOptions{
 		Author:    defaultSignature(),
 		Committer: defaultSignature(),
 	})
 	s.NoError(err)
 
-	err = r.Push(&PushOptions{})
+	err = r.Push(s.T().Context(), &PushOptions{})
 	s.NoError(err)
 
 	AssertReferences(s.T(), server, map[string]string{
@@ -2452,16 +2455,16 @@ func (s *RepositorySuite) TestPushNonExistentRemote() {
 	s.Require().NoError(err)
 	sto := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
 
-	r, err := Open(sto, srcFs)
+	r, err := Open(s.T().Context(), sto, srcFs)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	err = r.Push(&PushOptions{RemoteName: "myremote"})
+	err = r.Push(s.T().Context(), &PushOptions{RemoteName: "myremote"})
 	s.ErrorContains(err, "remote not found")
 }
 
 func (s *RepositorySuite) TestLog() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2469,7 +2472,7 @@ func (s *RepositorySuite) TestLog() {
 
 	s.NoError(err)
 
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		From: plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"),
 	})
 
@@ -2481,34 +2484,34 @@ func (s *RepositorySuite) TestLog() {
 	}
 
 	for _, o := range commitOrder {
-		commit, err := cIter.Next()
+		commit, err := cIter.Next(s.T().Context())
 		s.NoError(err)
 		s.Equal(o, commit.Hash)
 	}
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 }
 
 func (s *RepositorySuite) TestLogAll() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	s.NoError(err)
 
-	rIter, err := r.Storer.IterReferences()
+	rIter, err := r.Storer.IterReferences(s.T().Context())
 	s.NoError(err)
 
 	refCount := 0
-	err = rIter.ForEach(func(*plumbing.Reference) error {
+	err = rIter.ForEach(s.T().Context(), func(*plumbing.Reference) error {
 		refCount++
 		return nil
 	})
 	s.NoError(err)
 	s.Equal(5, refCount)
 
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		All: true,
 	})
 	s.NoError(err)
@@ -2526,70 +2529,70 @@ func (s *RepositorySuite) TestLogAll() {
 	}
 
 	for _, o := range commitOrder {
-		commit, err := cIter.Next()
+		commit, err := cIter.Next(s.T().Context())
 		s.NoError(err)
 		s.Equal(o, commit.Hash)
 	}
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 	cIter.Close()
 }
 
 func (s *RepositorySuite) TestLogAllMissingReferences() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	s.NoError(err)
-	err = r.Storer.RemoveReference(plumbing.HEAD)
+	err = r.Storer.RemoveReference(s.T().Context(), plumbing.HEAD)
 	s.NoError(err)
 
-	rIter, err := r.Storer.IterReferences()
+	rIter, err := r.Storer.IterReferences(s.T().Context())
 	s.NoError(err)
 
 	refCount := 0
-	err = rIter.ForEach(func(*plumbing.Reference) error {
+	err = rIter.ForEach(s.T().Context(), func(*plumbing.Reference) error {
 		refCount++
 		return nil
 	})
 	s.NoError(err)
 	s.Equal(4, refCount)
 
-	err = r.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("DUMMY"), plumbing.NewHash("DUMMY")))
+	err = r.Storer.SetReference(s.T().Context(), plumbing.NewHashReference(plumbing.ReferenceName("DUMMY"), plumbing.NewHash("DUMMY")))
 	s.NoError(err)
 
-	rIter, err = r.Storer.IterReferences()
+	rIter, err = r.Storer.IterReferences(s.T().Context())
 	s.NoError(err)
 
 	refCount = 0
-	err = rIter.ForEach(func(*plumbing.Reference) error {
+	err = rIter.ForEach(s.T().Context(), func(*plumbing.Reference) error {
 		refCount++
 		return nil
 	})
 	s.NoError(err)
 	s.Equal(5, refCount)
 
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		All: true,
 	})
 	s.NotNil(cIter)
 	s.NoError(err)
 
 	cCount := 0
-	cIter.ForEach(func(*object.Commit) error {
+	cIter.ForEach(s.T().Context(), func(*object.Commit) error {
 		cCount++
 		return nil
 	})
 	s.Equal(9, cCount)
 
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 	cIter.Close()
 }
 
 func (s *RepositorySuite) TestLogAllOrderByTime() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2597,7 +2600,7 @@ func (s *RepositorySuite) TestLogAllOrderByTime() {
 
 	s.NoError(err)
 
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		Order: LogOrderCommitterTime,
 		All:   true,
 	})
@@ -2616,17 +2619,17 @@ func (s *RepositorySuite) TestLogAllOrderByTime() {
 	}
 
 	for _, o := range commitOrder {
-		commit, err := cIter.Next()
+		commit, err := cIter.Next(s.T().Context())
 		s.NoError(err)
 		s.Equal(o, commit.Hash)
 	}
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 	cIter.Close()
 }
 
 func (s *RepositorySuite) TestLogHead() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2634,7 +2637,7 @@ func (s *RepositorySuite) TestLogHead() {
 
 	s.NoError(err)
 
-	cIter, err := r.Log(&LogOptions{})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{})
 
 	s.NoError(err)
 
@@ -2650,16 +2653,16 @@ func (s *RepositorySuite) TestLogHead() {
 	}
 
 	for _, o := range commitOrder {
-		commit, err := cIter.Next()
+		commit, err := cIter.Next(s.T().Context())
 		s.NoError(err)
 		s.Equal(o, commit.Hash)
 	}
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 }
 
 func (s *RepositorySuite) TestLogError() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2667,14 +2670,14 @@ func (s *RepositorySuite) TestLogError() {
 
 	s.NoError(err)
 
-	_, err = r.Log(&LogOptions{
+	_, err = r.Log(s.T().Context(), &LogOptions{
 		From: plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 	})
 	s.NotNil(err)
 }
 
 func (s *RepositorySuite) TestLogFileNext() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2683,7 +2686,7 @@ func (s *RepositorySuite) TestLogFileNext() {
 	s.NoError(err)
 
 	fileName := "vendor/foo.go"
-	cIter, err := r.Log(&LogOptions{FileName: &fileName})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{FileName: &fileName})
 
 	s.NoError(err)
 
@@ -2692,16 +2695,16 @@ func (s *RepositorySuite) TestLogFileNext() {
 	}
 
 	for _, o := range commitOrder {
-		commit, err := cIter.Next()
+		commit, err := cIter.Next(s.T().Context())
 		s.NoError(err)
 		s.Equal(o, commit.Hash)
 	}
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 }
 
 func (s *RepositorySuite) TestLogFileForEach() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2710,7 +2713,7 @@ func (s *RepositorySuite) TestLogFileForEach() {
 	s.NoError(err)
 
 	fileName := "php/crappy.php"
-	cIter, err := r.Log(&LogOptions{FileName: &fileName})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{FileName: &fileName})
 	s.NoError(err)
 	defer cIter.Close()
 
@@ -2719,7 +2722,7 @@ func (s *RepositorySuite) TestLogFileForEach() {
 	}
 
 	expectedIndex := 0
-	err = cIter.ForEach(func(commit *object.Commit) error {
+	err = cIter.ForEach(s.T().Context(), func(commit *object.Commit) error {
 		expectedCommitHash := commitOrder[expectedIndex]
 		s.Equal(expectedCommitHash.String(), commit.Hash.String())
 		expectedIndex++
@@ -2730,7 +2733,7 @@ func (s *RepositorySuite) TestLogFileForEach() {
 }
 
 func (s *RepositorySuite) TestLogNonHeadFile() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2739,16 +2742,16 @@ func (s *RepositorySuite) TestLogNonHeadFile() {
 	s.NoError(err)
 
 	fileName := "README"
-	cIter, err := r.Log(&LogOptions{FileName: &fileName})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{FileName: &fileName})
 	s.NoError(err)
 	defer cIter.Close()
 
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 }
 
 func (s *RepositorySuite) TestLogAllFileForEach() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2757,7 +2760,7 @@ func (s *RepositorySuite) TestLogAllFileForEach() {
 	s.NoError(err)
 
 	fileName := "README"
-	cIter, err := r.Log(&LogOptions{FileName: &fileName, All: true})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{FileName: &fileName, All: true})
 	s.NoError(err)
 	defer cIter.Close()
 
@@ -2766,7 +2769,7 @@ func (s *RepositorySuite) TestLogAllFileForEach() {
 	}
 
 	expectedIndex := 0
-	err = cIter.ForEach(func(commit *object.Commit) error {
+	err = cIter.ForEach(s.T().Context(), func(commit *object.Commit) error {
 		expectedCommitHash := commitOrder[expectedIndex]
 		s.Equal(expectedCommitHash.String(), commit.Hash.String())
 		expectedIndex++
@@ -2777,7 +2780,7 @@ func (s *RepositorySuite) TestLogAllFileForEach() {
 }
 
 func (s *RepositorySuite) TestLogInvalidFile() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2786,17 +2789,17 @@ func (s *RepositorySuite) TestLogInvalidFile() {
 
 	// Throwing in a file that does not exist
 	fileName := "vendor/foo12.go"
-	cIter, err := r.Log(&LogOptions{FileName: &fileName})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{FileName: &fileName})
 	// Not raising an error since `git log -- vendor/foo12.go` responds silently
 	s.NoError(err)
 	defer cIter.Close()
 
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 }
 
 func (s *RepositorySuite) TestLogFileInitialCommit() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2804,7 +2807,7 @@ func (s *RepositorySuite) TestLogFileInitialCommit() {
 	s.NoError(err)
 
 	fileName := "LICENSE"
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		Order:    LogOrderCommitterTime,
 		FileName: &fileName,
 	})
@@ -2816,7 +2819,7 @@ func (s *RepositorySuite) TestLogFileInitialCommit() {
 	}
 
 	expectedIndex := 0
-	err = cIter.ForEach(func(commit *object.Commit) error {
+	err = cIter.ForEach(s.T().Context(), func(commit *object.Commit) error {
 		expectedCommitHash := commitOrder[expectedIndex]
 		s.Equal(expectedCommitHash.String(), commit.Hash.String())
 		expectedIndex++
@@ -2827,7 +2830,7 @@ func (s *RepositorySuite) TestLogFileInitialCommit() {
 }
 
 func (s *RepositorySuite) TestLogFileWithOtherParamsFail() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2835,7 +2838,7 @@ func (s *RepositorySuite) TestLogFileWithOtherParamsFail() {
 	s.NoError(err)
 
 	fileName := "vendor/foo.go"
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		Order:    LogOrderCommitterTime,
 		FileName: &fileName,
 		From:     plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
@@ -2843,12 +2846,12 @@ func (s *RepositorySuite) TestLogFileWithOtherParamsFail() {
 	s.NoError(err)
 	defer cIter.Close()
 
-	_, iterErr := cIter.Next()
+	_, iterErr := cIter.Next(s.T().Context())
 	s.Equal(io.EOF, iterErr)
 }
 
 func (s *RepositorySuite) TestLogFileWithOtherParamsPass() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2856,27 +2859,27 @@ func (s *RepositorySuite) TestLogFileWithOtherParamsPass() {
 	s.NoError(err)
 
 	fileName := "LICENSE"
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		Order:    LogOrderCommitterTime,
 		FileName: &fileName,
 		From:     plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
 	})
 	s.NoError(err)
-	commitVal, iterErr := cIter.Next()
+	commitVal, iterErr := cIter.Next(s.T().Context())
 	s.Equal(nil, iterErr)
 	s.Equal("b029517f6300c2da0f4b651b8642506cd6aaf45d", commitVal.Hash.String())
 
-	_, iterErr = cIter.Next()
+	_, iterErr = cIter.Next(s.T().Context())
 	s.Equal(io.EOF, iterErr)
 }
 
 type mockErrCommitIter struct{}
 
-func (m *mockErrCommitIter) Next() (*object.Commit, error) {
+func (m *mockErrCommitIter) Next(context.Context) (*object.Commit, error) {
 	return nil, errors.New("mock next error")
 }
 
-func (m *mockErrCommitIter) ForEach(func(*object.Commit) error) error {
+func (m *mockErrCommitIter) ForEach(context.Context, func(*object.Commit) error) error {
 	return errors.New("mock foreach error")
 }
 
@@ -2887,7 +2890,7 @@ func (s *RepositorySuite) TestLogFileWithError() {
 	cIter := object.NewCommitFileIterFromIter(fileName, &mockErrCommitIter{}, false)
 	defer cIter.Close()
 
-	err := cIter.ForEach(func(*object.Commit) error {
+	err := cIter.ForEach(s.T().Context(), func(*object.Commit) error {
 		return nil
 	})
 	s.NotNil(err)
@@ -2901,7 +2904,7 @@ func (s *RepositorySuite) TestLogPathWithError() {
 	cIter := object.NewCommitPathIterFromIter(pathIter, &mockErrCommitIter{}, false)
 	defer cIter.Close()
 
-	err := cIter.ForEach(func(*object.Commit) error {
+	err := cIter.ForEach(s.T().Context(), func(*object.Commit) error {
 		return nil
 	})
 	s.NotNil(err)
@@ -2915,7 +2918,7 @@ func (s *RepositorySuite) TestLogPathRegexpWithError() {
 	cIter := object.NewCommitPathIterFromIter(pathIter, &mockErrCommitIter{}, false)
 	defer cIter.Close()
 
-	err := cIter.ForEach(func(*object.Commit) error {
+	err := cIter.ForEach(s.T().Context(), func(*object.Commit) error {
 		return nil
 	})
 	s.NotNil(err)
@@ -2927,7 +2930,7 @@ func (s *RepositorySuite) TestLogPathFilterRegexp() {
 		return pathRE.MatchString(path)
 	}
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2940,14 +2943,14 @@ func (s *RepositorySuite) TestLogPathFilterRegexp() {
 	}
 	commitIDs := []string{}
 
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		PathFilter: pathIter,
 		From:       plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
 	})
 	s.NoError(err)
 	defer cIter.Close()
 
-	cIter.ForEach(func(commit *object.Commit) error {
+	cIter.ForEach(s.T().Context(), func(commit *object.Commit) error {
 		commitIDs = append(commitIDs, commit.ID().String())
 		return nil
 	})
@@ -2958,7 +2961,7 @@ func (s *RepositorySuite) TestLogPathFilterRegexp() {
 }
 
 func (s *RepositorySuite) TestLogLimitNext() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2967,7 +2970,7 @@ func (s *RepositorySuite) TestLogLimitNext() {
 	s.NoError(err)
 
 	since := time.Date(2015, 4, 1, 0, 0, 0, 0, time.UTC)
-	cIter, err := r.Log(&LogOptions{Since: &since})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{Since: &since})
 
 	s.NoError(err)
 
@@ -2976,16 +2979,16 @@ func (s *RepositorySuite) TestLogLimitNext() {
 	}
 
 	for _, o := range commitOrder {
-		commit, err := cIter.Next()
+		commit, err := cIter.Next(s.T().Context())
 		s.NoError(err)
 		s.Equal(o, commit.Hash)
 	}
-	_, err = cIter.Next()
+	_, err = cIter.Next(s.T().Context())
 	s.ErrorIs(err, io.EOF)
 }
 
 func (s *RepositorySuite) TestLogLimitForEach() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -2995,7 +2998,7 @@ func (s *RepositorySuite) TestLogLimitForEach() {
 
 	since := time.Date(2015, 3, 31, 11, 54, 0, 0, time.UTC)
 	until := time.Date(2015, 4, 1, 0, 0, 0, 0, time.UTC)
-	cIter, err := r.Log(&LogOptions{Since: &since, Until: &until})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{Since: &since, Until: &until})
 	s.NoError(err)
 	defer cIter.Close()
 
@@ -3004,7 +3007,7 @@ func (s *RepositorySuite) TestLogLimitForEach() {
 	}
 
 	expectedIndex := 0
-	err = cIter.ForEach(func(commit *object.Commit) error {
+	err = cIter.ForEach(s.T().Context(), func(commit *object.Commit) error {
 		expectedCommitHash := commitOrder[expectedIndex]
 		s.Equal(expectedCommitHash.String(), commit.Hash.String())
 		expectedIndex++
@@ -3015,7 +3018,7 @@ func (s *RepositorySuite) TestLogLimitForEach() {
 }
 
 func (s *RepositorySuite) TestLogAllLimitForEach() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -3025,7 +3028,7 @@ func (s *RepositorySuite) TestLogAllLimitForEach() {
 
 	since := time.Date(2015, 3, 31, 11, 54, 0, 0, time.UTC)
 	until := time.Date(2015, 4, 1, 0, 0, 0, 0, time.UTC)
-	cIter, err := r.Log(&LogOptions{Since: &since, Until: &until, All: true})
+	cIter, err := r.Log(s.T().Context(), &LogOptions{Since: &since, Until: &until, All: true})
 	s.NoError(err)
 	defer cIter.Close()
 
@@ -3035,7 +3038,7 @@ func (s *RepositorySuite) TestLogAllLimitForEach() {
 	}
 
 	expectedIndex := 0
-	err = cIter.ForEach(func(commit *object.Commit) error {
+	err = cIter.ForEach(s.T().Context(), func(commit *object.Commit) error {
 		expectedCommitHash := commitOrder[expectedIndex]
 		s.Equal(expectedCommitHash.String(), commit.Hash.String())
 		expectedIndex++
@@ -3046,7 +3049,7 @@ func (s *RepositorySuite) TestLogAllLimitForEach() {
 }
 
 func (s *RepositorySuite) TestLogLimitWithOtherParamsFail() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -3054,7 +3057,7 @@ func (s *RepositorySuite) TestLogLimitWithOtherParamsFail() {
 	s.NoError(err)
 
 	since := time.Date(2015, 3, 31, 11, 54, 0, 0, time.UTC)
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		Order: LogOrderCommitterTime,
 		Since: &since,
 		From:  plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
@@ -3062,12 +3065,12 @@ func (s *RepositorySuite) TestLogLimitWithOtherParamsFail() {
 	s.NoError(err)
 	defer cIter.Close()
 
-	_, iterErr := cIter.Next()
+	_, iterErr := cIter.Next(s.T().Context())
 	s.Equal(io.EOF, iterErr)
 }
 
 func (s *RepositorySuite) TestLogLimitWithOtherParamsPass() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -3075,7 +3078,7 @@ func (s *RepositorySuite) TestLogLimitWithOtherParamsPass() {
 	s.NoError(err)
 
 	until := time.Date(2015, 3, 31, 11, 43, 0, 0, time.UTC)
-	cIter, err := r.Log(&LogOptions{
+	cIter, err := r.Log(s.T().Context(), &LogOptions{
 		Order: LogOrderCommitterTime,
 		Until: &until,
 		From:  plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
@@ -3083,33 +3086,33 @@ func (s *RepositorySuite) TestLogLimitWithOtherParamsPass() {
 	s.NoError(err)
 	defer cIter.Close()
 
-	commitVal, iterErr := cIter.Next()
+	commitVal, iterErr := cIter.Next(s.T().Context())
 	s.Equal(nil, iterErr)
 	s.Equal("b029517f6300c2da0f4b651b8642506cd6aaf45d", commitVal.Hash.String())
 
-	_, iterErr = cIter.Next()
+	_, iterErr = cIter.Next(s.T().Context())
 	s.Equal(io.EOF, iterErr)
 }
 
 func (s *RepositorySuite) TestConfigScoped() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
 	})
 	s.NoError(err)
 
-	cfg, err := r.ConfigScoped(config.LocalScope)
+	cfg, err := r.ConfigScoped(s.T().Context(), config.LocalScope)
 	s.NoError(err)
 	s.Equal("", cfg.User.Email)
 
-	cfg, err = r.ConfigScoped(config.SystemScope)
+	cfg, err = r.ConfigScoped(s.T().Context(), config.SystemScope)
 	s.NoError(err)
 	s.NotEqual("", cfg.User.Email)
 }
 
 func (s *RepositorySuite) TestCommit() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -3118,7 +3121,7 @@ func (s *RepositorySuite) TestCommit() {
 	s.NoError(err)
 
 	hash := plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47")
-	commit, err := r.CommitObject(hash)
+	commit, err := r.CommitObject(s.T().Context(), hash)
 	s.NoError(err)
 
 	s.False(commit.Hash.IsZero())
@@ -3126,7 +3129,7 @@ func (s *RepositorySuite) TestCommit() {
 	s.Equal(hash, commit.Hash)
 	s.Equal(plumbing.CommitObject, commit.Type())
 
-	tree, err := commit.Tree()
+	tree, err := commit.Tree(s.T().Context())
 	s.NoError(err)
 	s.False(tree.Hash.IsZero())
 
@@ -3134,16 +3137,16 @@ func (s *RepositorySuite) TestCommit() {
 }
 
 func (s *RepositorySuite) TestCommits() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
 	count := 0
-	commits, err := r.CommitObjects()
+	commits, err := r.CommitObjects(s.T().Context())
 	s.NoError(err)
 	for {
-		commit, err := commits.Next()
+		commit, err := commits.Next(s.T().Context())
 		if err != nil {
 			break
 		}
@@ -3158,7 +3161,7 @@ func (s *RepositorySuite) TestCommits() {
 }
 
 func (s *RepositorySuite) TestBlob() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -3166,12 +3169,12 @@ func (s *RepositorySuite) TestBlob() {
 
 	s.NoError(err)
 
-	blob, err := r.BlobObject(plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"))
+	blob, err := r.BlobObject(s.T().Context(), plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"))
 	s.NotNil(err)
 	s.Nil(blob)
 
 	blobHash := plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492")
-	blob, err = r.BlobObject(blobHash)
+	blob, err = r.BlobObject(s.T().Context(), blobHash)
 	s.NoError(err)
 
 	s.False(blob.Hash.IsZero())
@@ -3181,16 +3184,16 @@ func (s *RepositorySuite) TestBlob() {
 }
 
 func (s *RepositorySuite) TestBlobs() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
 	count := 0
-	blobs, err := r.BlobObjects()
+	blobs, err := r.BlobObjects(s.T().Context())
 	s.NoError(err)
 	for {
-		blob, err := blobs.Next()
+		blob, err := blobs.Next(s.T().Context())
 		if err != nil {
 			break
 		}
@@ -3209,13 +3212,13 @@ func (s *RepositorySuite) TestTagObject() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
 	hash := plumbing.NewHash("ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc")
-	tag, err := r.TagObject(hash)
+	tag, err := r.TagObject(s.T().Context(), hash)
 	s.NoError(err)
 
 	s.False(tag.Hash.IsZero())
@@ -3228,16 +3231,16 @@ func (s *RepositorySuite) TestTags() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
 	count := 0
-	tags, err := r.Tags()
+	tags, err := r.Tags(s.T().Context())
 	s.NoError(err)
 
-	tags.ForEach(func(tag *plumbing.Reference) error {
+	tags.ForEach(s.T().Context(), func(tag *plumbing.Reference) error {
 		count++
 		s.False(tag.Hash().IsZero())
 		s.True(tag.Name().IsTag())
@@ -3252,19 +3255,19 @@ func (s *RepositorySuite) TestCreateTagLightweight() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	expected, err := r.Head()
+	expected, err := r.Head(s.T().Context())
 	s.NoError(err)
 
-	ref, err := r.CreateTag("foobar", expected.Hash(), nil)
+	ref, err := r.CreateTag(s.T().Context(), "foobar", expected.Hash(), nil)
 	s.NoError(err)
 	s.NotNil(ref)
 
-	actual, err := r.Tag("foobar")
+	actual, err := r.Tag(s.T().Context(), "foobar")
 	s.NoError(err)
 
 	s.Equal(actual.Hash(), expected.Hash())
@@ -3275,15 +3278,15 @@ func (s *RepositorySuite) TestCreateTagLightweightExists() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	expected, err := r.Head()
+	expected, err := r.Head(s.T().Context())
 	s.NoError(err)
 
-	ref, err := r.CreateTag("lightweight-tag", expected.Hash(), nil)
+	ref, err := r.CreateTag(s.T().Context(), "lightweight-tag", expected.Hash(), nil)
 	s.Nil(ref)
 	s.ErrorIs(err, ErrTagExists)
 }
@@ -3293,26 +3296,26 @@ func (s *RepositorySuite) TestCreateTagAnnotated() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	h, err := r.Head()
+	h, err := r.Head(s.T().Context())
 	s.NoError(err)
 
 	expectedHash := h.Hash()
 
-	ref, err := r.CreateTag("foobar", expectedHash, &CreateTagOptions{
+	ref, err := r.CreateTag(s.T().Context(), "foobar", expectedHash, &CreateTagOptions{
 		Tagger:  defaultSignature(),
 		Message: "foo bar baz qux",
 	})
 	s.NoError(err)
 
-	tag, err := r.Tag("foobar")
+	tag, err := r.Tag(s.T().Context(), "foobar")
 	s.NoError(err)
 
-	obj, err := r.TagObject(tag.Hash())
+	obj, err := r.TagObject(s.T().Context(), tag.Hash())
 	s.NoError(err)
 
 	s.Equal(tag, ref)
@@ -3326,17 +3329,17 @@ func (s *RepositorySuite) TestCreateTagAnnotatedBadOpts() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	h, err := r.Head()
+	h, err := r.Head(s.T().Context())
 	s.NoError(err)
 
 	expectedHash := h.Hash()
 
-	ref, err := r.CreateTag("foobar", expectedHash, &CreateTagOptions{})
+	ref, err := r.CreateTag(s.T().Context(), "foobar", expectedHash, &CreateTagOptions{})
 	s.Nil(ref)
 	s.ErrorIs(err, ErrMissingMessage)
 }
@@ -3346,12 +3349,12 @@ func (s *RepositorySuite) TestCreateTagAnnotatedBadHash() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	ref, err := r.CreateTag("foobar", plumbing.ZeroHash, &CreateTagOptions{
+	ref, err := r.CreateTag(s.T().Context(), "foobar", plumbing.ZeroHash, &CreateTagOptions{
 		Tagger:  defaultSignature(),
 		Message: "foo bar baz qux",
 	})
@@ -3364,24 +3367,24 @@ func (s *RepositorySuite) TestCreateTagCanonicalize() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	h, err := r.Head()
+	h, err := r.Head(s.T().Context())
 	s.NoError(err)
 
-	_, err = r.CreateTag("foobar", h.Hash(), &CreateTagOptions{
+	_, err = r.CreateTag(s.T().Context(), "foobar", h.Hash(), &CreateTagOptions{
 		Tagger:  defaultSignature(),
 		Message: "\n\nfoo bar baz qux\n\nsome message here",
 	})
 	s.NoError(err)
 
-	tag, err := r.Tag("foobar")
+	tag, err := r.Tag(s.T().Context(), "foobar")
 	s.NoError(err)
 
-	obj, err := r.TagObject(tag.Hash())
+	obj, err := r.TagObject(s.T().Context(), tag.Hash())
 	s.NoError(err)
 
 	// Assert the new canonicalized message.
@@ -3393,14 +3396,14 @@ func (s *RepositorySuite) TestTagLightweight() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
 	expected := plumbing.NewHash("f7b877701fbf855b44c0a9e86f3fdce2c298b07f")
 
-	tag, err := r.Tag("lightweight-tag")
+	tag, err := r.Tag(s.T().Context(), "lightweight-tag")
 	s.NoError(err)
 
 	actual := tag.Hash()
@@ -3412,12 +3415,12 @@ func (s *RepositorySuite) TestTagLightweightMissingTag() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	tag, err := r.Tag("lightweight-tag-tag")
+	tag, err := r.Tag(s.T().Context(), "lightweight-tag-tag")
 	s.Nil(tag)
 	s.ErrorIs(err, ErrTagNotFound)
 }
@@ -3427,15 +3430,15 @@ func (s *RepositorySuite) TestDeleteTag() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	err = r.DeleteTag("lightweight-tag")
+	err = r.DeleteTag(s.T().Context(), "lightweight-tag")
 	s.NoError(err)
 
-	_, err = r.Tag("lightweight-tag")
+	_, err = r.Tag(s.T().Context(), "lightweight-tag")
 	s.ErrorIs(err, ErrTagNotFound)
 }
 
@@ -3444,12 +3447,12 @@ func (s *RepositorySuite) TestDeleteTagMissingTag() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	err = r.DeleteTag("lightweight-tag-tag")
+	err = r.DeleteTag(s.T().Context(), "lightweight-tag-tag")
 	s.ErrorIs(err, ErrTagNotFound)
 }
 
@@ -3462,42 +3465,44 @@ func (s *RepositorySuite) TestDeleteTagAnnotated() {
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
-	r, _ := Init(fss)
+	r, _ := Init(s.T().Context(), fss)
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	ref, err := r.Tag("annotated-tag")
+	ref, err := r.Tag(s.T().Context(), "annotated-tag")
 	s.NotNil(ref)
 	s.NoError(err)
 
-	obj, err := r.TagObject(ref.Hash())
+	obj, err := r.TagObject(s.T().Context(), ref.Hash())
 	s.NotNil(obj)
 	s.NoError(err)
 
-	err = r.DeleteTag("annotated-tag")
+	err = r.DeleteTag(s.T().Context(), "annotated-tag")
 	s.NoError(err)
 
-	_, err = r.Tag("annotated-tag")
+	_, err = r.Tag(s.T().Context(), "annotated-tag")
 	s.ErrorIs(err, ErrTagNotFound)
 
 	// Run a prune (and repack, to ensure that we are GCing everything regardless
 	// of the fixture in use) and try to get the tag object again.
 	//
 	// The repo needs to be re-opened after the repack.
-	err = r.Prune(PruneOptions{Handler: r.DeleteObject})
+	err = r.Prune(s.T().Context(), PruneOptions{Handler: func(h plumbing.Hash) error {
+		return r.DeleteObject(s.T().Context(), h)
+	}})
 	s.NoError(err)
 
-	err = r.RepackObjects(&RepackConfig{})
+	err = r.RepackObjects(s.T().Context(), &RepackConfig{})
 	s.NoError(err)
 
 	_ = r.Close()
-	r, err = PlainOpen(fs.Root())
+	r, err = PlainOpen(s.T().Context(), fs.Root())
 	s.NotNil(r)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
 	// Now check to see if the GC was effective in removing the tag object.
-	obj, err = r.TagObject(ref.Hash())
+	obj, err = r.TagObject(s.T().Context(), ref.Hash())
 	s.Nil(obj)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 }
@@ -3511,7 +3516,7 @@ func (s *RepositorySuite) TestDeleteTagAnnotatedUnpacked() {
 
 	fss := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
-	r, _ := Init(fss)
+	r, _ := Init(s.T().Context(), fss)
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
@@ -3520,43 +3525,45 @@ func (s *RepositorySuite) TestDeleteTagAnnotatedUnpacked() {
 	// object will be unpacked (as we aren't doing anything that should pack it),
 	// so that we can effectively test that a prune deletes it, without having to
 	// resort to a repack.
-	h, err := r.Head()
+	h, err := r.Head(s.T().Context())
 	s.NoError(err)
 
 	expectedHash := h.Hash()
 
-	ref, err := r.CreateTag("foobar", expectedHash, &CreateTagOptions{
+	ref, err := r.CreateTag(s.T().Context(), "foobar", expectedHash, &CreateTagOptions{
 		Tagger:  defaultSignature(),
 		Message: "foo bar baz qux",
 	})
 	s.NoError(err)
 
-	tag, err := r.Tag("foobar")
+	tag, err := r.Tag(s.T().Context(), "foobar")
 	s.NoError(err)
 
-	obj, err := r.TagObject(tag.Hash())
+	obj, err := r.TagObject(s.T().Context(), tag.Hash())
 	s.NotNil(obj)
 	s.NoError(err)
 
-	err = r.DeleteTag("foobar")
+	err = r.DeleteTag(s.T().Context(), "foobar")
 	s.NoError(err)
 
-	_, err = r.Tag("foobar")
+	_, err = r.Tag(s.T().Context(), "foobar")
 	s.ErrorIs(err, ErrTagNotFound)
 
 	// As mentioned, only run a prune. We are not testing for packed objects
 	// here.
-	err = r.Prune(PruneOptions{Handler: r.DeleteObject})
+	err = r.Prune(s.T().Context(), PruneOptions{Handler: func(h plumbing.Hash) error {
+		return r.DeleteObject(s.T().Context(), h)
+	}})
 	s.NoError(err)
 
 	// Now check to see if the GC was effective in removing the tag object.
-	obj, err = r.TagObject(ref.Hash())
+	obj, err = r.TagObject(s.T().Context(), ref.Hash())
 	s.Nil(obj)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 }
 
 func (s *RepositorySuite) TestInvalidTagName() {
-	r, err := Init(memory.NewStorage())
+	r, err := Init(s.T().Context(), memory.NewStorage())
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 	for i, name := range []string{
@@ -3565,7 +3572,7 @@ func (s *RepositorySuite) TestInvalidTagName() {
 		"foo\tbar",
 		"foo\nbar",
 	} {
-		_, err = r.CreateTag(name, plumbing.ZeroHash, nil)
+		_, err = r.CreateTag(s.T().Context(), name, plumbing.ZeroHash, nil)
 		s.Error(err, fmt.Sprintf("case %d %q", i, name))
 	}
 }
@@ -3577,15 +3584,15 @@ func (s *RepositorySuite) TestBranches() {
 	sto := filesystem.NewStorage(dotgit1, cache.NewObjectLRUDefault())
 	dotgit2, err := f.DotGit()
 	s.Require().NoError(err)
-	r, err := Open(sto, dotgit2)
+	r, err := Open(s.T().Context(), sto, dotgit2)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
 	count := 0
-	branches, err := r.Branches()
+	branches, err := r.Branches(s.T().Context())
 	s.NoError(err)
 
-	branches.ForEach(func(branch *plumbing.Reference) error {
+	branches.ForEach(s.T().Context(), func(branch *plumbing.Reference) error {
 		count++
 		s.False(branch.Hash().IsZero())
 		s.True(branch.Name().IsBranch())
@@ -3601,16 +3608,16 @@ func (s *RepositorySuite) TestNotes() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
 	count := 0
-	notes, err := r.Notes()
+	notes, err := r.Notes(s.T().Context())
 	s.NoError(err)
 
-	notes.ForEach(func(note *plumbing.Reference) error {
+	notes.ForEach(s.T().Context(), func(note *plumbing.Reference) error {
 		count++
 		s.False(note.Hash().IsZero())
 		s.True(note.Name().IsNote())
@@ -3621,7 +3628,7 @@ func (s *RepositorySuite) TestNotes() {
 }
 
 func (s *RepositorySuite) TestTree() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),
@@ -3629,12 +3636,12 @@ func (s *RepositorySuite) TestTree() {
 	s.NoError(err)
 
 	invalidHash := plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	tree, err := r.TreeObject(invalidHash)
+	tree, err := r.TreeObject(s.T().Context(), invalidHash)
 	s.Nil(tree)
 	s.NotNil(err)
 
 	hash := plumbing.NewHash("dbd3641b371024f44d0e469a9c8f5457b0660de1")
-	tree, err = r.TreeObject(hash)
+	tree, err = r.TreeObject(s.T().Context(), hash)
 	s.NoError(err)
 
 	s.False(tree.Hash.IsZero())
@@ -3645,16 +3652,16 @@ func (s *RepositorySuite) TestTree() {
 }
 
 func (s *RepositorySuite) TestTrees() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
 	count := 0
-	trees, err := r.TreeObjects()
+	trees, err := r.TreeObjects(s.T().Context())
 	s.NoError(err)
 	for {
-		tree, err := trees.Next()
+		tree, err := trees.Next(s.T().Context())
 		if err != nil {
 			break
 		}
@@ -3674,16 +3681,16 @@ func (s *RepositorySuite) TestTagObjects() {
 		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
 	count := 0
-	tags, err := r.TagObjects()
+	tags, err := r.TagObjects(s.T().Context())
 	s.NoError(err)
 
-	tags.ForEach(func(tag *object.Tag) error {
+	tags.ForEach(s.T().Context(), func(tag *object.Tag) error {
 		count++
 
 		s.False(tag.Hash.IsZero())
@@ -3691,8 +3698,8 @@ func (s *RepositorySuite) TestTagObjects() {
 		return nil
 	})
 
-	refs, _ := r.References()
-	refs.ForEach(func(*plumbing.Reference) error {
+	refs, _ := r.References(s.T().Context())
+	refs.ForEach(s.T().Context(), func(*plumbing.Reference) error {
 		return nil
 	})
 
@@ -3700,52 +3707,52 @@ func (s *RepositorySuite) TestTagObjects() {
 }
 
 func (s *RepositorySuite) TestCommitIterClosePanic() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
-	commits, err := r.CommitObjects()
+	commits, err := r.CommitObjects(s.T().Context())
 	s.NoError(err)
 	commits.Close()
 }
 
 func (s *RepositorySuite) TestRef() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
-	ref, err := r.Reference(plumbing.HEAD, false)
+	ref, err := r.Reference(s.T().Context(), plumbing.HEAD, false)
 	s.NoError(err)
 	s.Equal(plumbing.HEAD, ref.Name())
 
-	ref, err = r.Reference(plumbing.HEAD, true)
+	ref, err = r.Reference(s.T().Context(), plumbing.HEAD, true)
 	s.NoError(err)
 	s.Equal(plumbing.ReferenceName("refs/heads/master"), ref.Name())
 }
 
 func (s *RepositorySuite) TestRefs() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
 	s.NoError(err)
 
-	iter, err := r.References()
+	iter, err := r.References(s.T().Context())
 	s.NoError(err)
 	s.NotNil(iter)
 }
 
 func (s *RepositorySuite) TestObject() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
 	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	o, err := r.Object(plumbing.CommitObject, hash)
+	o, err := r.Object(s.T().Context(), plumbing.CommitObject, hash)
 	s.NoError(err)
 
 	s.False(o.ID().IsZero())
@@ -3753,16 +3760,16 @@ func (s *RepositorySuite) TestObject() {
 }
 
 func (s *RepositorySuite) TestObjects() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
 	count := 0
-	objects, err := r.Objects()
+	objects, err := r.Objects(s.T().Context())
 	s.NoError(err)
 	for {
-		o, err := objects.Next()
+		o, err := objects.Next(s.T().Context())
 		if err != nil {
 			break
 		}
@@ -3776,30 +3783,30 @@ func (s *RepositorySuite) TestObjects() {
 }
 
 func (s *RepositorySuite) TestObjectNotFound() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.NoError(err)
 
 	hash := plumbing.NewHash("0a3fb06ff80156fb153bcdcc58b5e16c2d27625c")
-	tag, err := r.Object(plumbing.TagObject, hash)
+	tag, err := r.Object(s.T().Context(), plumbing.TagObject, hash)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 	s.Nil(tag)
 }
 
 func (s *RepositorySuite) TestWorktree() {
 	def := memfs.New()
-	r, _ := Init(memory.NewStorage(), WithWorkTree(def))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(def))
 	defer func() { _ = r.Close() }()
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 	s.Equal(def, w.Filesystem())
 }
 
 func (s *RepositorySuite) TestWorktreeBare() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.ErrorIs(err, ErrIsBareRepository)
 	s.Nil(w)
 }
@@ -3811,7 +3818,7 @@ func (s *RepositorySuite) TestResolveRevision() {
 	sto := filesystem.NewStorage(dotgit1, cache.NewObjectLRUDefault())
 	dotgit2, err := f.DotGit()
 	s.Require().NoError(err)
-	r, err := Open(sto, dotgit2)
+	r, err := Open(s.T().Context(), sto, dotgit2)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
@@ -3840,7 +3847,7 @@ func (s *RepositorySuite) TestResolveRevision() {
 	}
 
 	for rev, hash := range datas {
-		h, err := r.ResolveRevision(plumbing.Revision(rev))
+		h, err := r.ResolveRevision(s.T().Context(), plumbing.Revision(rev))
 
 		s.NoError(err, fmt.Sprintf("while checking %s", rev))
 		s.Equal(hash, h.String(), fmt.Sprintf("while checking %s", rev))
@@ -3854,7 +3861,7 @@ func (s *RepositorySuite) TestResolveRevisionAnnotated() {
 	sto := filesystem.NewStorage(dotgit1, cache.NewObjectLRUDefault())
 	dotgit2, err := f.DotGit()
 	s.Require().NoError(err)
-	r, err := Open(sto, dotgit2)
+	r, err := Open(s.T().Context(), sto, dotgit2)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
@@ -3864,7 +3871,7 @@ func (s *RepositorySuite) TestResolveRevisionAnnotated() {
 	}
 
 	for rev, hash := range datas {
-		h, err := r.ResolveRevision(plumbing.Revision(rev))
+		h, err := r.ResolveRevision(s.T().Context(), plumbing.Revision(rev))
 
 		s.NoError(err, fmt.Sprintf("while checking %s", rev))
 		s.Equal(hash, h.String(), fmt.Sprintf("while checking %s", rev))
@@ -3876,16 +3883,16 @@ func (s *RepositorySuite) TestResolveRevisionWithErrors() {
 		fixtures.ByURL("https://github.com/git-fixtures/basic.git").One(),
 	)
 
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{URL: url})
 	s.NoError(err)
 
-	headRef, err := r.Head()
+	headRef, err := r.Head(s.T().Context())
 	s.NoError(err)
 
 	ref := plumbing.NewHashReference("refs/heads/918c48b83bd081e863dbe1b80f8998f058cd8294", headRef.Hash())
-	err = r.Storer.SetReference(ref)
+	err = r.Storer.SetReference(s.T().Context(), ref)
 	s.NoError(err)
 
 	datas := map[string]string{
@@ -3896,7 +3903,7 @@ func (s *RepositorySuite) TestResolveRevisionWithErrors() {
 	}
 
 	for rev, rerr := range datas {
-		_, err := r.ResolveRevision(plumbing.Revision(rev))
+		_, err := r.ResolveRevision(s.T().Context(), plumbing.Revision(rev))
 		s.NotNil(err)
 		s.Equal(rerr, err.Error())
 	}
@@ -3911,7 +3918,7 @@ func (s *RepositorySuite) testRepackObjects(deleteTime time.Time, expectedPacks 
 	s.NotNil(los)
 
 	numLooseStart := 0
-	err = los.ForEachObjectHash(func(_ plumbing.Hash) error {
+	err = los.ForEachObjectHash(s.T().Context(), func(_ plumbing.Hash) error {
 		numLooseStart++
 		return nil
 	})
@@ -3921,30 +3928,30 @@ func (s *RepositorySuite) testRepackObjects(deleteTime time.Time, expectedPacks 
 	pos := sto.(storer.PackedObjectStorer)
 	s.NotNil(los)
 
-	packs, err := pos.ObjectPacks()
+	packs, err := pos.ObjectPacks(s.T().Context())
 	s.NoError(err)
 	numPacksStart := len(packs)
 	s.True(numPacksStart > 1)
 
-	r, err := Open(sto, srcFs)
+	r, err := Open(s.T().Context(), sto, srcFs)
 	s.NoError(err)
 	s.NotNil(r)
 	defer func() { _ = r.Close() }()
 
-	err = r.RepackObjects(&RepackConfig{
+	err = r.RepackObjects(s.T().Context(), &RepackConfig{
 		OnlyDeletePacksOlderThan: deleteTime,
 	})
 	s.NoError(err)
 
 	numLooseEnd := 0
-	err = los.ForEachObjectHash(func(_ plumbing.Hash) error {
+	err = los.ForEachObjectHash(s.T().Context(), func(_ plumbing.Hash) error {
 		numLooseEnd++
 		return nil
 	})
 	s.NoError(err)
 	s.Equal(0, numLooseEnd)
 
-	packs, err = pos.ObjectPacks()
+	packs, err = pos.ObjectPacks(s.T().Context())
 	s.NoError(err)
 	numPacksEnd := len(packs)
 	s.Equal(expectedPacks, numPacksEnd)
@@ -3993,29 +4000,29 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch() {
 		"yet. Since we're using local repositories here, the test will use the" +
 		"server-side implementation. See transport/upload_pack.go and" +
 		"packfile/encoder.go")
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	_, err := r.CreateRemote(&config.RemoteConfig{
+	_, err := r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 	s.NoError(err)
 
-	s.NoError(r.Fetch(&FetchOptions{
+	s.NoError(r.Fetch(s.T().Context(), &FetchOptions{
 		Depth:    2,
 		RefSpecs: []config.RefSpec{config.RefSpec("refs/heads/master:refs/heads/master")},
 	}))
 
-	shallows, err := r.Storer.Shallow()
+	shallows, err := r.Storer.Shallow(s.T().Context())
 	s.NoError(err)
 	s.Len(shallows, 1)
 
-	ref, err := r.Reference("refs/heads/master", true)
+	ref, err := r.Reference(s.T().Context(), "refs/heads/master", true)
 	s.NoError(err)
-	cobj, err := r.CommitObject(ref.Hash())
+	cobj, err := r.CommitObject(s.T().Context(), ref.Hash())
 	s.NoError(err)
 	s.NotNil(cobj)
-	err = object.NewCommitPreorderIter(cobj, nil, nil).ForEach(func(c *object.Commit) error {
+	err = object.NewCommitPreorderIter(cobj, nil, nil).ForEach(s.T().Context(), func(c *object.Commit) error {
 		for _, ph := range c.ParentHashes {
 			if slices.Contains(shallows, ph) {
 				return storer.ErrStop
@@ -4026,21 +4033,21 @@ func (s *RepositorySuite) TestBrokenMultipleShallowFetch() {
 	})
 	s.NoError(err)
 
-	s.NoError(r.Fetch(&FetchOptions{
+	s.NoError(r.Fetch(s.T().Context(), &FetchOptions{
 		Depth:    5,
 		RefSpecs: []config.RefSpec{config.RefSpec("refs/heads/*:refs/heads/*")},
 	}))
 
-	shallows, err = r.Storer.Shallow()
+	shallows, err = r.Storer.Shallow(s.T().Context())
 	s.NoError(err)
 	s.Len(shallows, 3)
 
-	ref, err = r.Reference("refs/heads/master", true)
+	ref, err = r.Reference(s.T().Context(), "refs/heads/master", true)
 	s.NoError(err)
-	cobj, err = r.CommitObject(ref.Hash())
+	cobj, err = r.CommitObject(s.T().Context(), ref.Hash())
 	s.NoError(err)
 	s.NotNil(cobj)
-	err = object.NewCommitPreorderIter(cobj, nil, nil).ForEach(func(c *object.Commit) error {
+	err = object.NewCommitPreorderIter(cobj, nil, nil).ForEach(s.T().Context(), func(c *object.Commit) error {
 		for _, ph := range c.ParentHashes {
 			if slices.Contains(shallows, ph) {
 				return storer.ErrStop
@@ -4058,9 +4065,9 @@ func (s *RepositorySuite) TestDotGitToOSFilesystemsInvalidPath() {
 }
 
 func (s *RepositorySuite) TestIssue674() {
-	r, _ := Init(memory.NewStorage())
+	r, _ := Init(s.T().Context(), memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	h, err := r.ResolveRevision(plumbing.Revision(""))
+	h, err := r.ResolveRevision(s.T().Context(), plumbing.Revision(""))
 
 	s.NotNil(err)
 	s.NotNil(h)
@@ -4085,20 +4092,20 @@ func BenchmarkObjects(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			repo, err := Open(st, worktree)
+			repo, err := Open(b.Context(), st, worktree)
 			if err != nil {
 				b.Fatal(err)
 			}
 			defer func() { _ = repo.Close() }()
 
 			for b.Loop() {
-				iter, err := repo.Objects()
+				iter, err := repo.Objects(b.Context())
 				if err != nil {
 					b.Fatal(err)
 				}
 
 				for {
-					_, err := iter.Next()
+					_, err := iter.Next(b.Context())
 					if err == io.EOF {
 						break
 					}
@@ -4117,7 +4124,7 @@ func BenchmarkObjects(b *testing.B) {
 func BenchmarkPlainClone(b *testing.B) {
 	b.StopTimer()
 	clone := func(b *testing.B) {
-		r, err := PlainClone(b.TempDir(), &CloneOptions{
+		r, err := PlainClone(b.Context(), b.TempDir(), &CloneOptions{
 			URL:          "https://github.com/go-git/go-git.git",
 			Depth:        1,
 			Tags:         plumbing.NoTags,
@@ -4202,25 +4209,25 @@ func TestCreateTagSignerSelection(t *testing.T) { //nolint:paralleltest // modif
 			// This must happen before registering the plugin signer,
 			// otherwise buildCommitObject would call the plugin signer.
 			fs := memfs.New()
-			r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+			r, err := Init(t.Context(), memory.NewStorage(), WithWorkTree(fs))
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
 
-			cfg, err := r.Config()
+			cfg, err := r.Config(t.Context())
 			require.NoError(t, err)
 
 			cfg.Tag.GpgSign = tt.tagSignGpg
-			err = r.SetConfig(cfg)
+			err = r.SetConfig(t.Context(), cfg)
 			require.NoError(t, err)
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(t.Context())
 			require.NoError(t, err)
 
 			util.WriteFile(fs, "file.txt", []byte("content"), 0o644)
-			_, err = w.Add("file.txt")
+			_, err = w.Add(t.Context(), "file.txt")
 			require.NoError(t, err)
 
-			commitHash, err := w.Commit("initial commit\n", &CommitOptions{
+			commitHash, err := w.Commit(t.Context(), "initial commit\n", &CommitOptions{
 				Author: defaultSignature(),
 			})
 			require.NoError(t, err)
@@ -4232,7 +4239,7 @@ func TestCreateTagSignerSelection(t *testing.T) { //nolint:paralleltest // modif
 				require.NoError(t, err)
 			}
 
-			_, err = r.CreateTag("test-tag", commitHash, &CreateTagOptions{
+			_, err = r.CreateTag(t.Context(), "test-tag", commitHash, &CreateTagOptions{
 				Tagger:  defaultSignature(),
 				Message: "tag message",
 				Signer:  tt.optionsSigner,
@@ -4244,10 +4251,10 @@ func TestCreateTagSignerSelection(t *testing.T) { //nolint:paralleltest // modif
 				return // no need to carry on
 			}
 
-			tagRef, err := r.Tag("test-tag")
+			tagRef, err := r.Tag(t.Context(), "test-tag")
 			require.NoError(t, err)
 
-			tagObj, err := r.TagObject(tagRef.Hash())
+			tagObj, err := r.TagObject(t.Context(), tagRef.Hash())
 			require.NoError(t, err)
 
 			if tt.wantSignature {
@@ -4387,7 +4394,7 @@ func TestRepository_Archive(t *testing.T) {
 			r := setupArchiveRepo(t)
 			defer func() { _ = r.Close() }()
 
-			rc, err := r.Archive(&tt.opts)
+			rc, err := r.Archive(t.Context(), &tt.opts)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -4426,14 +4433,14 @@ func TestRepository_ArchiveContext_Cancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	ar, err := r.ArchiveContext(ctx, &ArchiveOptions{
+	ar, err := r.Archive(ctx, &ArchiveOptions{
 		Format:  "tar",
 		Treeish: "master",
 	})
-	assert.NoError(t, err)
-	t.Cleanup(func() { ar.Close() })
-	_, err = io.Copy(io.Discard, ar)
+	// With ctx-first storers, a canceled context now fails at treeish
+	// resolution instead of surfacing later during streaming.
 	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, ar)
 }
 
 // archiveFileNames extracts file names from an archive based on format.
@@ -4493,7 +4500,7 @@ func setupArchiveRepo(t *testing.T) *Repository {
 	dotgit, err := f.DotGit()
 	require.NoError(t, err)
 	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
-	r, err := Open(st, memfs.New())
+	r, err := Open(t.Context(), st, memfs.New())
 	require.NoError(t, err)
 	return r
 }

--- a/repository_unix_test.go
+++ b/repository_unix_test.go
@@ -19,11 +19,11 @@ func preReceiveHook(m string) []byte {
 func TestPlainInitFileMode(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	r, err := PlainInit(dir, false)
+	r, err := PlainInit(t.Context(), dir, false)
 	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(t.Context())
 	require.NoError(t, err)
 	assert.True(t, cfg.Core.FileMode)
 }

--- a/repository_wasi_test.go
+++ b/repository_wasi_test.go
@@ -16,14 +16,14 @@ func TestWasmInit(t *testing.T) {
 	st := memory.NewStorage()
 	wt := memfs.New()
 
-	r, err := Init(st, WithWorkTree(wt))
+	r, err := Init(t.Context(), st, WithWorkTree(wt))
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 
 	h := createCommit(t, r)
 	assert.False(t, h.IsZero())
 
-	ref, err := r.Head()
+	ref, err := r.Head(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, ref)
 	assert.False(t, ref.Hash().IsZero())

--- a/repository_windows_test.go
+++ b/repository_windows_test.go
@@ -26,20 +26,20 @@ func TestCloneFileUrlWindows(t *testing.T) {
 
 	dir := t.TempDir()
 
-	r, err := PlainInit(dir, false)
+	r, err := PlainInit(t.Context(), dir, false)
 	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
 
 	err = util.WriteFile(r.wt, "foo", nil, 0o755)
 	require.NoError(t, err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(t.Context())
 	require.NoError(t, err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(t.Context(), "foo")
 	require.NoError(t, err)
 
-	_, err = w.Commit("foo", &CommitOptions{
+	_, err = w.Commit(t.Context(), "foo", &CommitOptions{
 		Author:    defaultSignature(),
 		Committer: defaultSignature(),
 	})
@@ -61,7 +61,7 @@ func TestCloneFileUrlWindows(t *testing.T) {
 
 	for _, tc := range tests {
 		assert.Regexp(t, regexp.MustCompile(tc.pattern), tc.url)
-		clonedRepo, err := Clone(memory.NewStorage(), nil, &CloneOptions{
+		clonedRepo, err := Clone(t.Context(), memory.NewStorage(), nil, &CloneOptions{
 			URL: tc.url,
 		})
 

--- a/signer.go
+++ b/signer.go
@@ -22,7 +22,7 @@ type Signer interface {
 	Sign(ctx context.Context, message io.Reader) ([]byte, error)
 }
 
-func signObject(signer Signer, obj signableObject) ([]byte, error) {
+func signObject(ctx context.Context, signer Signer, obj signableObject) ([]byte, error) {
 	encoded := &plumbing.MemoryObject{}
 	if err := obj.EncodeWithoutSignature(encoded); err != nil {
 		return nil, err
@@ -32,6 +32,5 @@ func signObject(signer Signer, obj signableObject) ([]byte, error) {
 		return nil, err
 	}
 
-	// TODO: thread a caller-supplied context once Worktree.Commit accepts one.
-	return signer.Sign(context.TODO(), r)
+	return signer.Sign(ctx, r)
 }

--- a/signer_test.go
+++ b/signer_test.go
@@ -28,16 +28,17 @@ func (b64signer) Sign(_ context.Context, message io.Reader) ([]byte, error) {
 }
 
 func ExampleSigner() {
-	repo, err := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	ctx := context.Background()
+	repo, err := Init(ctx, memory.NewStorage(), WithWorkTree(memfs.New()))
 	if err != nil {
 		panic(err)
 	}
 	defer func() { _ = repo.Close() }()
-	w, err := repo.Worktree()
+	w, err := repo.Worktree(ctx)
 	if err != nil {
 		panic(err)
 	}
-	commit, err := w.Commit("example commit", &CommitOptions{
+	commit, err := w.Commit(ctx, "example commit", &CommitOptions{
 		Author: &object.Signature{
 			Name:  "John Doe",
 			Email: "john@example.com",
@@ -50,7 +51,7 @@ func ExampleSigner() {
 		panic(err)
 	}
 
-	obj, err := repo.CommitObject(commit)
+	obj, err := repo.CommitObject(ctx, commit)
 	if err != nil {
 		panic(err)
 	}

--- a/status.go
+++ b/status.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -109,23 +110,23 @@ const (
 	Preload StatusStrategy = 1
 )
 
-func (s StatusStrategy) new(w *Worktree) (Status, error) {
+func (s StatusStrategy) new(ctx context.Context, w *Worktree) (Status, error) {
 	switch s {
 	case Preload:
-		return preloadStatus(w)
+		return preloadStatus(ctx, w)
 	case Empty:
 		return make(Status), nil
 	}
 	return nil, fmt.Errorf("%w: %+v", ErrUnsupportedStatusStrategy, s)
 }
 
-func preloadStatus(w *Worktree) (Status, error) {
-	idx, err := w.r.Storer.Index()
+func preloadStatus(ctx context.Context, w *Worktree) (Status, error) {
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := w.r.Config()
+	c, err := w.r.Config(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/status_test.go
+++ b/status_test.go
@@ -72,11 +72,11 @@ func TestStatusReturnsFullPaths(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r, err := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+			r, err := Init(t.Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(t.Context())
 			require.NoError(t, err)
 
 			for _, fname := range files {
@@ -87,11 +87,11 @@ func TestStatusReturnsFullPaths(t *testing.T) {
 				require.NoError(t, err)
 				file.Close()
 
-				_, err = w.Add(file.Name())
+				_, err = w.Add(t.Context(), file.Name())
 				require.NoError(t, err)
 			}
 
-			_, err = w.Commit("foo", &CommitOptions{All: true})
+			_, err = w.Commit(t.Context(), "foo", &CommitOptions{All: true})
 			require.NoError(t, err)
 
 			if tc.doChange {
@@ -108,7 +108,7 @@ func TestStatusReturnsFullPaths(t *testing.T) {
 			}
 
 			status, err := w.StatusWithOptions(
-				StatusOptions{
+				t.Context(), StatusOptions{
 					Strategy: tc.strategy,
 				},
 			)

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -23,7 +24,7 @@ type ConfigStorage struct {
 // When the worktreeConfig extension is active and a config.worktree file
 // exists, the returned config would be the worktree config overlayed over
 // the commonDir config.
-func (c *ConfigStorage) Config() (conf *config.Config, err error) {
+func (c *ConfigStorage) Config(ctx context.Context) (conf *config.Config, err error) {
 	f, err := c.dir.Config()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -79,7 +80,7 @@ func (c *ConfigStorage) Config() (conf *config.Config, err error) {
 // config is left untouched in that case. This mirrors the behaviour of
 // `git config --worktree`: worktree-specific overrides live in
 // config.worktree while shared settings remain in the common config.
-func (c *ConfigStorage) SetConfig(cfg *config.Config) (err error) {
+func (c *ConfigStorage) SetConfig(ctx context.Context, cfg *config.Config) (err error) {
 	if err = cfg.Validate(); err != nil {
 		return err
 	}

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -25,6 +25,10 @@ type ConfigStorage struct {
 // exists, the returned config would be the worktree config overlayed over
 // the commonDir config.
 func (c *ConfigStorage) Config(ctx context.Context) (conf *config.Config, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	f, err := c.dir.Config()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -81,6 +85,10 @@ func (c *ConfigStorage) Config(ctx context.Context) (conf *config.Config, err er
 // `git config --worktree`: worktree-specific overrides live in
 // config.worktree while shared settings remain in the common config.
 func (c *ConfigStorage) SetConfig(ctx context.Context, cfg *config.Config) (err error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if err = cfg.Validate(); err != nil {
 		return err
 	}

--- a/storage/filesystem/config_test.go
+++ b/storage/filesystem/config_test.go
@@ -41,7 +41,7 @@ func (s *ConfigSuite) TestRemotes() {
 	dir := dotgit.New(dotgitFs)
 	storer := &ConfigStorage{dir: dir}
 
-	cfg, err := storer.Config()
+	cfg, err := storer.Config(s.T().Context())
 	s.Require().NoError(err)
 
 	remotes := cfg.Remotes
@@ -84,7 +84,7 @@ func TestWorktreeConfigRead(t *testing.T) {
 		require.NoError(t, util.WriteFile(commonFs, "config", []byte(baseConfig), 0o644))
 		require.NoError(t, util.WriteFile(wtFs, "config.worktree", []byte(wtConfig), 0o644))
 
-		cfg, err := newDualStorer(commonFs, wtFs).Config()
+		cfg, err := newDualStorer(commonFs, wtFs).Config(t.Context())
 		require.NoError(t, err)
 
 		assert.Equal(t, "wt-user", cfg.User.Name)
@@ -98,7 +98,7 @@ func TestWorktreeConfigRead(t *testing.T) {
 		commonFs, wtFs := memfs.New(), memfs.New()
 		require.NoError(t, util.WriteFile(commonFs, "config", []byte(baseConfig), 0o644))
 
-		cfg, err := newDualStorer(commonFs, wtFs).Config()
+		cfg, err := newDualStorer(commonFs, wtFs).Config(t.Context())
 		require.NoError(t, err)
 
 		assert.Equal(t, "base-user", cfg.User.Name)
@@ -115,7 +115,7 @@ func TestWorktreeConfigRead(t *testing.T) {
 		require.NoError(t, util.WriteFile(commonFs, "config", []byte(noExtBase), 0o644))
 		require.NoError(t, util.WriteFile(wtFs, "config.worktree", []byte(wtConfig), 0o644))
 
-		cfg, err := newDualStorer(commonFs, wtFs).Config()
+		cfg, err := newDualStorer(commonFs, wtFs).Config(t.Context())
 		require.NoError(t, err)
 
 		assert.Equal(t, "base-user", cfg.User.Name)
@@ -137,11 +137,11 @@ func TestWorktreeConfigSetConfig(t *testing.T) {
 		require.NoError(t, util.WriteFile(commonFs, "config", []byte(baseConfig), 0o644))
 
 		cs := newDualStorer(commonFs, wtFs)
-		cfg, err := cs.Config()
+		cfg, err := cs.Config(t.Context())
 		require.NoError(t, err)
 
 		cfg.User.Email = "written@example.com"
-		require.NoError(t, cs.SetConfig(cfg))
+		require.NoError(t, cs.SetConfig(t.Context(), cfg))
 
 		data, err := util.ReadFile(commonFs, "config")
 		require.NoError(t, err)
@@ -161,13 +161,13 @@ func TestWorktreeConfigSetConfig(t *testing.T) {
 		require.NoError(t, util.WriteFile(wtFs, "config.worktree", []byte(existingWTConfig), 0o644))
 
 		cs := newDualStorer(commonFs, wtFs)
-		cfg, err := cs.Config()
+		cfg, err := cs.Config(t.Context())
 		require.NoError(t, err)
 
 		cfg.Core.Worktree = "/new/path"
 		cfg.Author.Name = "Worktree Author"
 
-		require.NoError(t, cs.SetConfig(cfg))
+		require.NoError(t, cs.SetConfig(t.Context(), cfg))
 
 		data, err := util.ReadFile(wtFs, "config.worktree")
 		require.NoError(t, err)
@@ -198,11 +198,11 @@ func TestWorktreeConfigSetConfig(t *testing.T) {
 		require.NoError(t, util.WriteFile(wtFs, "config.worktree", []byte(existingWTConfig), 0o644))
 
 		cs := newDualStorer(commonFs, wtFs)
-		cfg, err := cs.Config()
+		cfg, err := cs.Config(t.Context())
 		require.NoError(t, err)
 
 		cfg.Core.Worktree = "/new/path"
-		require.NoError(t, cs.SetConfig(cfg))
+		require.NoError(t, cs.SetConfig(t.Context(), cfg))
 
 		data, err := util.ReadFile(commonFs, "config")
 		require.NoError(t, err)

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -1,6 +1,7 @@
 package dotgit
 
 import (
+	"context"
 	"crypto"
 	"errors"
 	"fmt"
@@ -73,7 +74,9 @@ func (w *PackWriter) buildIndex() {
 		packfile.WithScannerObservers(w.writer),
 		packfile.WithObjectFormat(w.format))
 
-	h, err := w.parser.Parse()
+	// TODO(ctx): dotgit does not thread contexts yet; the index build
+	// goroutine runs detached from any caller context.
+	h, err := w.parser.Parse(context.Background())
 	if err != nil {
 		w.result <- err
 		return

--- a/storage/filesystem/fsobject_packhandle_test.go
+++ b/storage/filesystem/fsobject_packhandle_test.go
@@ -81,7 +81,7 @@ func TestIntegration_FSObjectReadsReusePooledFD(t *testing.T) {
 	const iter = 100
 	for range iter {
 		for _, h := range hashes {
-			obj, err := stor.EncodedObject(plumbing.AnyObject, h)
+			obj, err := stor.EncodedObject(t.Context(), plumbing.AnyObject, h)
 			require.NoError(t, err)
 			r, err := obj.Reader()
 			require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestIntegration_FSObjectSurvivesCleanPackList(t *testing.T) {
 	target := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 
 	// Prime the object cache with an FSObject.
-	obj, err := stor.EncodedObject(plumbing.AnyObject, target)
+	obj, err := stor.EncodedObject(t.Context(), plumbing.AnyObject, target)
 	require.NoError(t, err)
 
 	// Drop every handle in dotgit's pack-handle store the same way
@@ -169,7 +169,7 @@ func TestIntegration_ConcurrentReaderDuringStorageClose(t *testing.T) {
 	// resolver path on the read goroutines.
 	objs := make([]plumbing.EncodedObject, 0, len(hashes))
 	for _, h := range hashes {
-		obj, err := stor.EncodedObject(plumbing.AnyObject, h)
+		obj, err := stor.EncodedObject(t.Context(), plumbing.AnyObject, h)
 		require.NoError(t, err)
 		objs = append(objs, obj)
 	}
@@ -237,7 +237,7 @@ func TestIntegration_PackMissingFromDiskSurfaces(t *testing.T) {
 	// Prime the index — guarantees we find the object in the pack
 	// before we delete the file.
 	target := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	_, err = stor.EncodedObject(plumbing.AnyObject, target)
+	_, err = stor.EncodedObject(t.Context(), plumbing.AnyObject, target)
 	require.NoError(t, err)
 
 	// Locate and delete the on-disk .pack file.
@@ -258,6 +258,6 @@ func TestIntegration_PackMissingFromDiskSurfaces(t *testing.T) {
 
 	// The lookup must fail — index claims this pack holds the
 	// object, but the .pack file is gone.
-	_, err = stor.EncodedObject(plumbing.AnyObject, target)
+	_, err = stor.EncodedObject(t.Context(), plumbing.AnyObject, target)
 	require.Error(t, err)
 }

--- a/storage/filesystem/index.go
+++ b/storage/filesystem/index.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"hash"
 	"os"
@@ -22,7 +23,9 @@ type IndexStorage struct {
 }
 
 // SetIndex writes the index to disk and updates the cache.
-func (s *IndexStorage) SetIndex(idx *index.Index) (err error) {
+//
+// TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
+func (s *IndexStorage) SetIndex(ctx context.Context, idx *index.Index) (err error) {
 	if err := s.writeIndex(idx); err != nil {
 		return err
 	}
@@ -65,7 +68,7 @@ func (s *IndexStorage) writeIndex(idx *index.Index) (err error) {
 }
 
 // Index reads the index from disk, using the cache when available.
-func (s *IndexStorage) Index() (i *index.Index, err error) {
+func (s *IndexStorage) Index(ctx context.Context) (i *index.Index, err error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {

--- a/storage/filesystem/index.go
+++ b/storage/filesystem/index.go
@@ -26,6 +26,10 @@ type IndexStorage struct {
 //
 // TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
 func (s *IndexStorage) SetIndex(ctx context.Context, idx *index.Index) (err error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if err := s.writeIndex(idx); err != nil {
 		return err
 	}
@@ -69,6 +73,10 @@ func (s *IndexStorage) writeIndex(idx *index.Index) (err error) {
 
 // Index reads the index from disk, using the cache when available.
 func (s *IndexStorage) Index(ctx context.Context) (i *index.Index, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {

--- a/storage/filesystem/index_test.go
+++ b/storage/filesystem/index_test.go
@@ -27,11 +27,11 @@ func TestIndexCacheHit(t *testing.T) {
 			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
 		},
 	}
-	require.NoError(t, sto.SetIndex(orig))
+	require.NoError(t, sto.SetIndex(t.Context(), orig))
 	assert.Equal(t, 1, spy.sets) // write-through
 
 	// First Index() — cache hit from write-through.
-	idx1, err := sto.Index()
+	idx1, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, idx1.Entries, 1)
 	assert.Equal(t, "foo.go", idx1.Entries[0].Name)
@@ -39,7 +39,7 @@ func TestIndexCacheHit(t *testing.T) {
 	assert.Equal(t, 0, spy.misses)
 
 	// Second Index() — still a cache hit.
-	idx2, err := sto.Index()
+	idx2, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, idx2.Entries, 1)
 	assert.Equal(t, "foo.go", idx1.Entries[0].Name)
@@ -52,19 +52,19 @@ func TestIndexCacheReturnsCopy(t *testing.T) {
 	sto, spy := newIndexStorageWithSpy(t)
 	defer func() { _ = sto.Close() }()
 
-	require.NoError(t, sto.SetIndex(&index.Index{
+	require.NoError(t, sto.SetIndex(t.Context(), &index.Index{
 		Version: 2,
 		Entries: []*index.Entry{
 			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
 		},
 	}))
 
-	idx1, err := sto.Index()
+	idx1, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 1, spy.hits)
 	idx1.Version = 99
 
-	idx2, err := sto.Index()
+	idx2, err := sto.Index(t.Context())
 	assert.Equal(t, 2, spy.hits)
 	require.NoError(t, err)
 	assert.NotSame(t, idx1, idx2)
@@ -76,14 +76,14 @@ func TestIndexCacheIsolatesEntrySliceMutation(t *testing.T) {
 	sto, spy := newIndexStorageWithSpy(t)
 	defer func() { _ = sto.Close() }()
 
-	require.NoError(t, sto.SetIndex(&index.Index{
+	require.NoError(t, sto.SetIndex(t.Context(), &index.Index{
 		Version: 2,
 		Entries: []*index.Entry{
 			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
 		},
 	}))
 
-	idx1, err := sto.Index()
+	idx1, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 1, spy.hits)
 
@@ -93,7 +93,7 @@ func TestIndexCacheIsolatesEntrySliceMutation(t *testing.T) {
 	})
 	assert.Len(t, idx1.Entries, 2)
 
-	idx2, err := sto.Index()
+	idx2, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 2, spy.hits)
 	assert.Len(t, idx2.Entries, 1)
@@ -111,7 +111,7 @@ func TestIndexCacheIsolatesSetIndexCallerMutation(t *testing.T) {
 			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
 		},
 	}
-	require.NoError(t, sto.SetIndex(idx))
+	require.NoError(t, sto.SetIndex(t.Context(), idx))
 	assert.Equal(t, 1, spy.sets)
 
 	// Caller mutates the index after SetIndex — simulates worktree code.
@@ -122,7 +122,7 @@ func TestIndexCacheIsolatesSetIndexCallerMutation(t *testing.T) {
 	idx.Version = 3
 
 	// The cache must be unaffected - only SetIndex can update the cached index.
-	got, err := sto.Index()
+	got, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 1, spy.hits)
 	assert.Equal(t, uint32(2), got.Version)
@@ -135,14 +135,14 @@ func TestIndexCacheInvalidatedByExternalChange(t *testing.T) {
 	sto, spy := newIndexStorageWithSpy(t)
 	defer func() { _ = sto.Close() }()
 
-	require.NoError(t, sto.SetIndex(&index.Index{
+	require.NoError(t, sto.SetIndex(t.Context(), &index.Index{
 		Version: 2,
 		Entries: []*index.Entry{
 			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
 		},
 	}))
 
-	_, err := sto.Index()
+	_, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 1, spy.hits)
 
@@ -150,7 +150,7 @@ func TestIndexCacheInvalidatedByExternalChange(t *testing.T) {
 	err = os.Chtimes(filepath.Join(sto.Filesystem().Root(), "index"), lastHour, lastHour)
 	require.NoError(t, err)
 
-	idx, err := sto.Index()
+	idx, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, idx.Entries, 1)
 	assert.Equal(t, 1, spy.hits)
@@ -162,7 +162,7 @@ func TestIndexCacheWriteThrough(t *testing.T) {
 	sto, spy := newIndexStorageWithSpy(t)
 	defer func() { _ = sto.Close() }()
 
-	require.NoError(t, sto.SetIndex(&index.Index{
+	require.NoError(t, sto.SetIndex(t.Context(), &index.Index{
 		Version: 2,
 		Entries: []*index.Entry{
 			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "a.go"},
@@ -170,7 +170,7 @@ func TestIndexCacheWriteThrough(t *testing.T) {
 	}))
 	assert.Equal(t, 1, spy.sets)
 
-	got, err := sto.Index()
+	got, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Len(t, got.Entries, 1)
 	assert.Equal(t, "a.go", got.Entries[0].Name)
@@ -183,7 +183,7 @@ func TestIndexCacheMissingFile(t *testing.T) {
 	sto, spy := newIndexStorageWithSpy(t)
 	defer func() { _ = sto.Close() }()
 
-	idx, err := sto.Index()
+	idx, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, uint32(2), idx.Version)
 	assert.Empty(t, idx.Entries)
@@ -200,23 +200,23 @@ func TestIndexCacheClearedWhenFileDeleted(t *testing.T) {
 	spy := newSpyIndexCache()
 	sto := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{IndexCache: spy})
 	defer func() { _ = sto.Close() }()
-	require.NoError(t, sto.Init())
+	require.NoError(t, sto.Init(t.Context()))
 
-	require.NoError(t, sto.SetIndex(&index.Index{
+	require.NoError(t, sto.SetIndex(t.Context(), &index.Index{
 		Version: 2,
 		Entries: []*index.Entry{
 			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "a.go"},
 		},
 	}))
 
-	_, err := sto.Index()
+	_, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 1, spy.hits)
 
 	err = os.Remove(filepath.Join(sto.Filesystem().Root(), "index"))
 	require.NoError(t, err)
 
-	got, err := sto.Index()
+	got, err := sto.Index(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, uint32(2), got.Version)
 	assert.Empty(t, got.Entries)
@@ -263,7 +263,7 @@ func newIndexStorageWithSpy(t *testing.T) (*filesystem.Storage, *spyIndexCache) 
 	fs := osfs.New(tmp)
 	spy := newSpyIndexCache()
 	sto := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{IndexCache: spy})
-	require.NoError(t, sto.Init())
+	require.NoError(t, sto.Init(t.Context()))
 
 	return sto, spy
 }

--- a/storage/filesystem/module.go
+++ b/storage/filesystem/module.go
@@ -19,6 +19,10 @@ type ModuleStorage struct {
 
 // Module returns the storage for the named submodule.
 func (s *ModuleStorage) Module(ctx context.Context, name string) (storage.Storer, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	fs, err := s.dir.Module(name)
 	if err != nil {
 		return nil, err

--- a/storage/filesystem/module.go
+++ b/storage/filesystem/module.go
@@ -1,6 +1,8 @@
 package filesystem
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/storage"
@@ -8,13 +10,15 @@ import (
 )
 
 // ModuleStorage implements storage for git submodules.
+//
+// TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
 type ModuleStorage struct {
 	dir          *dotgit.DotGit
 	objectFormat formatcfg.ObjectFormat
 }
 
 // Module returns the storage for the named submodule.
-func (s *ModuleStorage) Module(name string) (storage.Storer, error) {
+func (s *ModuleStorage) Module(ctx context.Context, name string) (storage.Storer, error) {
 	fs, err := s.dir.Module(name)
 	if err != nil {
 		return nil, err

--- a/storage/filesystem/multipack_fixture_test.go
+++ b/storage/filesystem/multipack_fixture_test.go
@@ -63,7 +63,7 @@ func makeMultiPackFixture(tb testing.TB, nPacks, objPerPack int) (billy.Filesyst
 			if err := w.Close(); err != nil {
 				tb.Fatalf("close writer: %v", err)
 			}
-			h, err := stage.SetEncodedObject(o)
+			h, err := stage.SetEncodedObject(tb.Context(), o)
 			if err != nil {
 				tb.Fatalf("stage object: %v", err)
 			}
@@ -75,8 +75,8 @@ func makeMultiPackFixture(tb testing.TB, nPacks, objPerPack int) (billy.Filesyst
 		// disables delta compression — bench fixtures want every
 		// read to resolve in a single offset lookup.
 		var buf bytes.Buffer
-		enc := packfile.NewEncoder(&buf, stage, false)
-		if _, err := enc.Encode(hashes, 0); err != nil {
+		enc := packfile.NewEncoder(tb.Context(), &buf, stage, false)
+		if _, err := enc.Encode(tb.Context(), hashes, 0); err != nil {
 			tb.Fatalf("encode pack %d: %v", p, err)
 		}
 

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -160,7 +160,7 @@ func (s *ObjectStorage) resetAlternates() {
 // the result and cancels the remaining searches. The read lock on muA is
 // held for the duration to prevent resetAlternates from closing in-use
 // alternates.
-func findInAlternates[T any](s *ObjectStorage, fn func(*ObjectStorage) (T, error)) (T, error) {
+func findInAlternates[T any](ctx context.Context, s *ObjectStorage, fn func(*ObjectStorage) (T, error)) (T, error) {
 	var zero T
 
 	if err := s.initAlternates(); err != nil {
@@ -178,7 +178,7 @@ func findInAlternates[T any](s *ObjectStorage, fn func(*ObjectStorage) (T, error
 		return fn(s.alternates[0])
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	g := new(errgroup.Group)
@@ -412,7 +412,9 @@ func (s *ObjectStorage) loadMemoryIndexValue(h plumbing.Hash) (idx idxfile.Index
 }
 
 // RawObjectWriter returns a writer for a new loose object of the given type and size.
-func (s *ObjectStorage) RawObjectWriter(typ plumbing.ObjectType, sz int64) (w io.WriteCloser, err error) {
+//
+// TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
+func (s *ObjectStorage) RawObjectWriter(ctx context.Context, typ plumbing.ObjectType, sz int64) (w io.WriteCloser, err error) {
 	ow, err := s.dir.NewObject()
 	if err != nil {
 		return nil, err
@@ -432,7 +434,7 @@ func (s *ObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 }
 
 // PackfileWriter returns a writer for creating a new packfile.
-func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
+func (s *ObjectStorage) PackfileWriter(ctx context.Context) (io.WriteCloser, error) {
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
@@ -465,7 +467,7 @@ func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
 }
 
 // SetEncodedObject adds a new object to the storage.
-func (s *ObjectStorage) SetEncodedObject(o plumbing.EncodedObject) (h plumbing.Hash, err error) {
+func (s *ObjectStorage) SetEncodedObject(ctx context.Context, o plumbing.EncodedObject) (h plumbing.Hash, err error) {
 	if o.Type() == plumbing.OFSDeltaObject || o.Type() == plumbing.REFDeltaObject {
 		return plumbing.ZeroHash, plumbing.ErrInvalidType
 	}
@@ -510,7 +512,7 @@ func (s *ObjectStorage) LazyWriter() (w io.WriteCloser, wh func(typ plumbing.Obj
 
 // HasEncodedObject returns nil if the object exists, without actually
 // reading the object data from storage.
-func (s *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
+func (s *ObjectStorage) HasEncodedObject(ctx context.Context, h plumbing.Hash) (err error) {
 	// Pack-membership-first when the index is healthy: a hit on
 	// the in-memory fanout shortcut avoids a loose Stat. If the
 	// index fails to load (e.g. a corrupt .idx on disk), fall
@@ -536,8 +538,8 @@ func (s *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
 		return idxErr
 	}
 
-	_, err = findInAlternates(s, func(alt *ObjectStorage) (struct{}, error) {
-		return struct{}{}, alt.HasEncodedObject(h)
+	_, err = findInAlternates(ctx, s, func(alt *ObjectStorage) (struct{}, error) {
+		return struct{}{}, alt.HasEncodedObject(ctx, h)
 	})
 	return err
 }
@@ -576,7 +578,7 @@ func (s *ObjectStorage) packfile(idx idxfile.Index, pack plumbing.Hash) (*packfi
 
 // EncodedObjectSize returns the plaintext size of the given object,
 // without actually reading the full object data from storage.
-func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (size int64, err error) {
+func (s *ObjectStorage) EncodedObjectSize(ctx context.Context, h plumbing.Hash) (size int64, err error) {
 	// Pack-membership-first when the index is healthy: a single
 	// in-memory fanout probe routes packed reads through the pack
 	// reader and skips the loose Stat. If the index fails to load
@@ -615,14 +617,14 @@ func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (size int64, err erro
 		return 0, idxErr
 	}
 
-	return findInAlternates(s, func(alt *ObjectStorage) (int64, error) {
-		return alt.EncodedObjectSize(h)
+	return findInAlternates(ctx, s, func(alt *ObjectStorage) (int64, error) {
+		return alt.EncodedObjectSize(ctx, h)
 	})
 }
 
 // EncodedObject returns the object with the given hash, by searching for it in
 // the packfile and the git object directories.
-func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (s *ObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	var obj plumbing.EncodedObject
 	var err error
 
@@ -653,8 +655,8 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 	}
 
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
-		obj, err = findInAlternates(s, func(alt *ObjectStorage) (plumbing.EncodedObject, error) {
-			return alt.EncodedObject(t, h)
+		obj, err = findInAlternates(ctx, s, func(alt *ObjectStorage) (plumbing.EncodedObject, error) {
+			return alt.EncodedObject(ctx, t, h)
 		})
 		if errors.Is(err, plumbing.ErrObjectNotFound) && idxErr != nil {
 			return nil, idxErr
@@ -674,7 +676,7 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 
 // DeltaObject returns the object with the given hash, by searching for
 // it in the packfile and the git object directories.
-func (s *ObjectStorage) DeltaObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (s *ObjectStorage) DeltaObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, err := s.getFromUnpacked(h)
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		obj, err = s.getFromPackfile(h, true)
@@ -963,7 +965,7 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 
 // IterEncodedObjects returns an iterator for all the objects in the packfile
 // with the given type.
-func (s *ObjectStorage) IterEncodedObjects(t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
+func (s *ObjectStorage) IterEncodedObjects(ctx context.Context, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
 	objects, err := s.dir.Objects()
 	if err != nil {
 		return nil, err
@@ -1110,7 +1112,7 @@ func hashListAsMap(l []plumbing.Hash) map[plumbing.Hash]struct{} {
 }
 
 // ForEachObjectHash iterates over every object hash in the storage.
-func (s *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
+func (s *ObjectStorage) ForEachObjectHash(ctx context.Context, fun func(plumbing.Hash) error) error {
 	err := s.dir.ForEachObjectHash(fun)
 	if err == storer.ErrStop {
 		return nil
@@ -1119,7 +1121,7 @@ func (s *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 }
 
 // LooseObjectTime returns the modification time of a loose object.
-func (s *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {
+func (s *ObjectStorage) LooseObjectTime(ctx context.Context, hash plumbing.Hash) (time.Time, error) {
 	fi, err := s.dir.ObjectStat(hash)
 	if err != nil {
 		return time.Time{}, err
@@ -1128,12 +1130,12 @@ func (s *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {
 }
 
 // DeleteLooseObject removes a loose object from storage.
-func (s *ObjectStorage) DeleteLooseObject(hash plumbing.Hash) error {
+func (s *ObjectStorage) DeleteLooseObject(ctx context.Context, hash plumbing.Hash) error {
 	return s.dir.ObjectDelete(hash)
 }
 
 // ObjectPacks returns the list of packfile hashes.
-func (s *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
+func (s *ObjectStorage) ObjectPacks(ctx context.Context) ([]plumbing.Hash, error) {
 	return s.dir.ObjectPacks()
 }
 
@@ -1143,7 +1145,7 @@ func (s *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
 // findObjectInPackfile no longer claim membership for a hash that
 // lives only in the now-deleted pack. If the MRU hint pointed at the
 // deleted slot, invalidate it.
-func (s *ObjectStorage) DeleteOldObjectPackAndIndex(h plumbing.Hash, t time.Time) error {
+func (s *ObjectStorage) DeleteOldObjectPackAndIndex(ctx context.Context, h plumbing.Hash, t time.Time) error {
 	if err := s.dir.DeleteOldObjectPackAndIndex(h, t); err != nil {
 		return err
 	}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -415,6 +415,10 @@ func (s *ObjectStorage) loadMemoryIndexValue(h plumbing.Hash) (idx idxfile.Index
 //
 // TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
 func (s *ObjectStorage) RawObjectWriter(ctx context.Context, typ plumbing.ObjectType, sz int64) (w io.WriteCloser, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	ow, err := s.dir.NewObject()
 	if err != nil {
 		return nil, err
@@ -435,6 +439,10 @@ func (s *ObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 
 // PackfileWriter returns a writer for creating a new packfile.
 func (s *ObjectStorage) PackfileWriter(ctx context.Context) (io.WriteCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
@@ -693,6 +701,10 @@ func (s *ObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType
 // DeltaObject returns the object with the given hash, by searching for
 // it in the packfile and the git object directories.
 func (s *ObjectStorage) DeltaObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	obj, err := s.getFromUnpacked(h)
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
 		obj, err = s.getFromPackfile(h, true)
@@ -1133,6 +1145,10 @@ func hashListAsMap(l []plumbing.Hash) map[plumbing.Hash]struct{} {
 
 // ForEachObjectHash iterates over every object hash in the storage.
 func (s *ObjectStorage) ForEachObjectHash(ctx context.Context, fun func(plumbing.Hash) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	err := s.dir.ForEachObjectHash(fun)
 	if err == storer.ErrStop {
 		return nil
@@ -1142,6 +1158,10 @@ func (s *ObjectStorage) ForEachObjectHash(ctx context.Context, fun func(plumbing
 
 // LooseObjectTime returns the modification time of a loose object.
 func (s *ObjectStorage) LooseObjectTime(ctx context.Context, hash plumbing.Hash) (time.Time, error) {
+	if err := ctx.Err(); err != nil {
+		return time.Time{}, err
+	}
+
 	fi, err := s.dir.ObjectStat(hash)
 	if err != nil {
 		return time.Time{}, err
@@ -1151,11 +1171,19 @@ func (s *ObjectStorage) LooseObjectTime(ctx context.Context, hash plumbing.Hash)
 
 // DeleteLooseObject removes a loose object from storage.
 func (s *ObjectStorage) DeleteLooseObject(ctx context.Context, hash plumbing.Hash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return s.dir.ObjectDelete(hash)
 }
 
 // ObjectPacks returns the list of packfile hashes.
 func (s *ObjectStorage) ObjectPacks(ctx context.Context) ([]plumbing.Hash, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	return s.dir.ObjectPacks()
 }
 
@@ -1166,6 +1194,10 @@ func (s *ObjectStorage) ObjectPacks(ctx context.Context) ([]plumbing.Hash, error
 // lives only in the now-deleted pack. If the MRU hint pointed at the
 // deleted slot, invalidate it.
 func (s *ObjectStorage) DeleteOldObjectPackAndIndex(ctx context.Context, h plumbing.Hash, t time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if err := s.dir.DeleteOldObjectPackAndIndex(h, t); err != nil {
 		return err
 	}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -468,6 +468,10 @@ func (s *ObjectStorage) PackfileWriter(ctx context.Context) (io.WriteCloser, err
 
 // SetEncodedObject adds a new object to the storage.
 func (s *ObjectStorage) SetEncodedObject(ctx context.Context, o plumbing.EncodedObject) (h plumbing.Hash, err error) {
+	if err := ctx.Err(); err != nil {
+		return plumbing.ZeroHash, err
+	}
+
 	if o.Type() == plumbing.OFSDeltaObject || o.Type() == plumbing.REFDeltaObject {
 		return plumbing.ZeroHash, plumbing.ErrInvalidType
 	}
@@ -513,6 +517,10 @@ func (s *ObjectStorage) LazyWriter() (w io.WriteCloser, wh func(typ plumbing.Obj
 // HasEncodedObject returns nil if the object exists, without actually
 // reading the object data from storage.
 func (s *ObjectStorage) HasEncodedObject(ctx context.Context, h plumbing.Hash) (err error) {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Pack-membership-first when the index is healthy: a hit on
 	// the in-memory fanout shortcut avoids a loose Stat. If the
 	// index fails to load (e.g. a corrupt .idx on disk), fall
@@ -579,6 +587,10 @@ func (s *ObjectStorage) packfile(idx idxfile.Index, pack plumbing.Hash) (*packfi
 // EncodedObjectSize returns the plaintext size of the given object,
 // without actually reading the full object data from storage.
 func (s *ObjectStorage) EncodedObjectSize(ctx context.Context, h plumbing.Hash) (size int64, err error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	// Pack-membership-first when the index is healthy: a single
 	// in-memory fanout probe routes packed reads through the pack
 	// reader and skips the loose Stat. If the index fails to load
@@ -625,6 +637,10 @@ func (s *ObjectStorage) EncodedObjectSize(ctx context.Context, h plumbing.Hash) 
 // EncodedObject returns the object with the given hash, by searching for it in
 // the packfile and the git object directories.
 func (s *ObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	var obj plumbing.EncodedObject
 	var err error
 
@@ -966,6 +982,10 @@ func (s *ObjectStorage) HashesWithPrefix(prefix []byte) ([]plumbing.Hash, error)
 // IterEncodedObjects returns an iterator for all the objects in the packfile
 // with the given type.
 func (s *ObjectStorage) IterEncodedObjects(ctx context.Context, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	objects, err := s.dir.Objects()
 	if err != nil {
 		return nil, err

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -64,7 +64,7 @@ func BenchmarkAlternatesObjectLookup(b *testing.B) {
 	b.Run("EncodedObject", func(b *testing.B) {
 		for b.Loop() {
 			for _, hash := range commitHashes {
-				if _, err := storage.EncodedObject(plumbing.AnyObject, hash); err != nil {
+				if _, err := storage.EncodedObject(b.Context(), plumbing.AnyObject, hash); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -74,7 +74,7 @@ func BenchmarkAlternatesObjectLookup(b *testing.B) {
 	b.Run("HasEncodedObject", func(b *testing.B) {
 		for b.Loop() {
 			for _, hash := range commitHashes {
-				if err := storage.HasEncodedObject(hash); err != nil {
+				if err := storage.HasEncodedObject(b.Context(), hash); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -84,7 +84,7 @@ func BenchmarkAlternatesObjectLookup(b *testing.B) {
 	b.Run("EncodedObjectSize", func(b *testing.B) {
 		for b.Loop() {
 			for _, hash := range commitHashes {
-				if _, err := storage.EncodedObjectSize(hash); err != nil {
+				if _, err := storage.EncodedObjectSize(b.Context(), hash); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -153,7 +153,7 @@ func BenchmarkObjectStorage_PackHandle(b *testing.B) {
 		// Serial warm-up: build the pack index and prime the PackHandle
 		// FD pool before the timed parallel region starts.
 		for _, h := range hashes {
-			if _, err := stor.EncodedObject(plumbing.AnyObject, h); err != nil {
+			if _, err := stor.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 				b.Fatalf("setupStorage warm-up: %v", err)
 			}
 		}
@@ -175,7 +175,7 @@ func BenchmarkObjectStorage_PackHandle(b *testing.B) {
 			b.ResetTimer()
 			var i int
 			for b.Loop() {
-				if _, err := stor.EncodedObject(
+				if _, err := stor.EncodedObject(b.Context(),
 					plumbing.AnyObject,
 					hashes[i%len(hashes)],
 				); err != nil {
@@ -194,7 +194,7 @@ func BenchmarkObjectStorage_PackHandle(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				var i int
 				for pb.Next() {
-					if _, err := stor.EncodedObject(
+					if _, err := stor.EncodedObject(b.Context(),
 						plumbing.AnyObject,
 						hashes[i%len(hashes)],
 					); err != nil {
@@ -211,7 +211,7 @@ func BenchmarkObjectStorage_PackHandle(b *testing.B) {
 			b.ResetTimer()
 			var i int
 			for b.Loop() {
-				if err := stor.HasEncodedObject(hashes[i%len(hashes)]); err != nil {
+				if err := stor.HasEncodedObject(b.Context(), hashes[i%len(hashes)]); err != nil {
 					b.Fatal(err)
 				}
 				i++
@@ -227,7 +227,7 @@ func BenchmarkObjectStorage_PackHandle(b *testing.B) {
 			b.RunParallel(func(pb *testing.PB) {
 				var i int
 				for pb.Next() {
-					if err := stor.HasEncodedObject(hashes[i%len(hashes)]); err != nil {
+					if err := stor.HasEncodedObject(b.Context(), hashes[i%len(hashes)]); err != nil {
 						b.Fatal(err)
 					}
 					i++
@@ -301,7 +301,7 @@ func BenchmarkObjectStorage_ColdEncodedObject(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		s := NewStorage(diskFS, cache.NewObjectLRUDefault())
-		if _, err := s.EncodedObject(plumbing.AnyObject, target); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, target); err != nil {
 			b.Fatal(err)
 		}
 		_ = s.Close()
@@ -321,11 +321,11 @@ func BenchmarkObjectStorage_ReindexThenRead(b *testing.B) {
 	s := NewStorage(dir, cache.NewObjectLRUDefault())
 	b.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(b.Context(), plumbing.AnyObject)
 	if err != nil {
 		b.Fatal(err)
 	}
-	obj, err := iter.Next()
+	obj, err := iter.Next(b.Context())
 	iter.Close()
 	if err != nil {
 		b.Fatal(err)
@@ -336,7 +336,7 @@ func BenchmarkObjectStorage_ReindexThenRead(b *testing.B) {
 		if err := s.Reindex(); err != nil {
 			b.Fatal(err)
 		}
-		if _, err := s.EncodedObject(plumbing.AnyObject, obj.Hash()); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, obj.Hash()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -355,13 +355,13 @@ func BenchmarkObjectStorage_ParallelReads(b *testing.B) {
 	s := NewStorage(dir, cache.NewObjectLRUDefault())
 	b.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(b.Context(), plumbing.AnyObject)
 	if err != nil {
 		b.Fatal(err)
 	}
 	var hashes []plumbing.Hash
 	for range 32 {
-		obj, err := iter.Next()
+		obj, err := iter.Next(b.Context())
 		if err != nil {
 			break
 		}
@@ -372,7 +372,7 @@ func BenchmarkObjectStorage_ParallelReads(b *testing.B) {
 		b.Fatal("fixture must have objects")
 	}
 
-	if _, err := s.EncodedObject(plumbing.AnyObject, hashes[0]); err != nil {
+	if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, hashes[0]); err != nil {
 		b.Fatal(err)
 	}
 
@@ -381,7 +381,7 @@ func BenchmarkObjectStorage_ParallelReads(b *testing.B) {
 		var i int64
 		for pb.Next() {
 			h := hashes[i%int64(len(hashes))]
-			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 				b.Fatal(err)
 			}
 			i++
@@ -442,7 +442,7 @@ func BenchmarkStorage_PoolPressure(b *testing.B) {
 		// s.index so the timed loop is not paying a cold populate
 		// on iteration 1.
 		for _, h := range hashes {
-			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -453,7 +453,7 @@ func BenchmarkStorage_PoolPressure(b *testing.B) {
 		var i int
 		for b.Loop() {
 			h := hashes[i%len(hashes)]
-			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 				b.Fatal(err)
 			}
 			i++
@@ -511,7 +511,7 @@ func BenchmarkStorage_PackHandleCacheContention(b *testing.B) {
 		// LazyIndex so the timed loop measures only the cache
 		// lookup + read, not first-touch index loads.
 		for _, h := range hashes {
-			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -525,7 +525,7 @@ func BenchmarkStorage_PackHandleCacheContention(b *testing.B) {
 		var i int
 		for b.Loop() {
 			h := hashes[i%len(hashes)]
-			if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+			if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 				b.Fatal(err)
 			}
 			i++
@@ -540,7 +540,7 @@ func BenchmarkStorage_PackHandleCacheContention(b *testing.B) {
 			var i int
 			for pb.Next() {
 				h := hashes[i%len(hashes)]
-				if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+				if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 					b.Fatal(err)
 				}
 				i++
@@ -586,7 +586,7 @@ func BenchmarkObjectStorage_FSObjectReader(b *testing.B) {
 
 		// Serial warm-up: build the index and prime FSObject caches.
 		for _, h := range hashes {
-			obj, err := stor.EncodedObject(plumbing.AnyObject, h)
+			obj, err := stor.EncodedObject(b.Context(), plumbing.AnyObject, h)
 			if err != nil {
 				b.Fatalf("warm-up EncodedObject: %v", err)
 			}
@@ -617,7 +617,7 @@ func BenchmarkObjectStorage_FSObjectReader(b *testing.B) {
 			b.ResetTimer()
 			var i int
 			for b.Loop() {
-				obj, err := stor.EncodedObject(
+				obj, err := stor.EncodedObject(b.Context(),
 					plumbing.AnyObject, hashes[i%len(hashes)])
 				if err != nil {
 					b.Fatal(err)
@@ -668,7 +668,7 @@ func BenchmarkFindObjectInPackfile_FanoutMiss(b *testing.B) {
 	// Warm: ensure every pack's idx is loaded so the timed loop
 	// is not paying a cold populate on iteration 1.
 	for _, h := range hashes {
-		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -677,7 +677,7 @@ func BenchmarkFindObjectInPackfile_FanoutMiss(b *testing.B) {
 	var i int
 	for b.Loop() {
 		h := hashes[i%len(hashes)]
-		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
 		i++
@@ -712,20 +712,20 @@ func BenchmarkEncodedObject_LooseHit(b *testing.B) {
 	if err := w.Close(); err != nil {
 		b.Fatal(err)
 	}
-	h, err := s.SetEncodedObject(o)
+	h, err := s.SetEncodedObject(b.Context(), o)
 	if err != nil {
 		b.Fatal(err)
 	}
 
 	// Warm the index so the per-iteration call doesn't pay a
 	// cold-load.
-	if err := s.HasEncodedObject(h); err != nil {
+	if err := s.HasEncodedObject(b.Context(), h); err != nil {
 		b.Fatal(err)
 	}
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -792,7 +792,7 @@ func BenchmarkFindObjectInPackfile_MRU_Hit(b *testing.B) {
 
 	// Warm: seeds lastHitPackIdx on pack 0.
 	for _, h := range hashes {
-		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -801,7 +801,7 @@ func BenchmarkFindObjectInPackfile_MRU_Hit(b *testing.B) {
 	var i int
 	for b.Loop() {
 		h := hashes[i%len(hashes)]
-		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
 		i++
@@ -841,7 +841,7 @@ func BenchmarkFindObjectInPackfile_MRU_Churn(b *testing.B) {
 	// Warm: ensure every hot pack's idx is loaded so the timed loop
 	// is not paying a cold populate on the first cycle.
 	for _, h := range hashes {
-		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -850,7 +850,7 @@ func BenchmarkFindObjectInPackfile_MRU_Churn(b *testing.B) {
 	var i int
 	for b.Loop() {
 		h := hashes[i%hotPacks]
-		if _, err := s.EncodedObject(plumbing.AnyObject, h); err != nil {
+		if _, err := s.EncodedObject(b.Context(), plumbing.AnyObject, h); err != nil {
 			b.Fatal(err)
 		}
 		i++

--- a/storage/filesystem/object_iter.go
+++ b/storage/filesystem/object_iter.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"context"
 	"crypto"
 	"io"
 
@@ -20,7 +21,7 @@ type lazyPackfilesIter struct {
 	cur    storer.EncodedObjectIter
 }
 
-func (it *lazyPackfilesIter) Next() (plumbing.EncodedObject, error) {
+func (it *lazyPackfilesIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
 	for {
 		if it.cur == nil {
 			if len(it.hashes) == 0 {
@@ -37,7 +38,7 @@ func (it *lazyPackfilesIter) Next() (plumbing.EncodedObject, error) {
 			}
 			it.cur = sub
 		}
-		ob, err := it.cur.Next()
+		ob, err := it.cur.Next(ctx)
 		if err == io.EOF {
 			it.cur.Close()
 			it.cur = nil
@@ -51,8 +52,8 @@ func (it *lazyPackfilesIter) Next() (plumbing.EncodedObject, error) {
 	}
 }
 
-func (it *lazyPackfilesIter) ForEach(cb func(plumbing.EncodedObject) error) error {
-	return storer.ForEachIterator(it, cb)
+func (it *lazyPackfilesIter) ForEach(ctx context.Context, cb func(plumbing.EncodedObject) error) error {
+	return storer.ForEachIterator(ctx, it, cb)
 }
 
 func (it *lazyPackfilesIter) Close() {
@@ -138,9 +139,9 @@ func newPackfileIter(
 	}, nil
 }
 
-func (iter *packfileIter) Next() (plumbing.EncodedObject, error) {
+func (iter *packfileIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
 	for {
-		obj, err := iter.iter.Next()
+		obj, err := iter.iter.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -154,10 +155,10 @@ func (iter *packfileIter) Next() (plumbing.EncodedObject, error) {
 	}
 }
 
-func (iter *packfileIter) ForEach(cb func(plumbing.EncodedObject) error) error {
+func (iter *packfileIter) ForEach(ctx context.Context, cb func(plumbing.EncodedObject) error) error {
 	defer iter.Close()
 	for {
-		o, err := iter.Next()
+		o, err := iter.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
 				return nil
@@ -184,7 +185,7 @@ type objectsIter struct {
 	h []plumbing.Hash
 }
 
-func (iter *objectsIter) Next() (plumbing.EncodedObject, error) {
+func (iter *objectsIter) Next(ctx context.Context) (plumbing.EncodedObject, error) {
 	if len(iter.h) == 0 {
 		return nil, io.EOF
 	}
@@ -197,16 +198,16 @@ func (iter *objectsIter) Next() (plumbing.EncodedObject, error) {
 	}
 
 	if iter.t != plumbing.AnyObject && iter.t != obj.Type() {
-		return iter.Next()
+		return iter.Next(ctx)
 	}
 
 	return obj, err
 }
 
-func (iter *objectsIter) ForEach(cb func(plumbing.EncodedObject) error) error {
+func (iter *objectsIter) ForEach(ctx context.Context, cb func(plumbing.EncodedObject) error) error {
 	defer iter.Close()
 	for {
-		o, err := iter.Next()
+		o, err := iter.Next(ctx)
 		if err != nil {
 			if err == io.EOF {
 				return nil

--- a/storage/filesystem/object_iter_test.go
+++ b/storage/filesystem/object_iter_test.go
@@ -47,7 +47,7 @@ func TestPackfileIter_SeenSkips(t *testing.T) {
 			require.NoError(t, err)
 
 			var got int
-			require.NoError(t, iter.ForEach(func(plumbing.EncodedObject) error {
+			require.NoError(t, iter.ForEach(t.Context(), func(plumbing.EncodedObject) error {
 				got++
 				return nil
 			}))
@@ -69,7 +69,7 @@ func TestPackfileIter_SharedSeenDedupsAcrossIterators(t *testing.T) {
 		require.NoError(t, err)
 
 		var n int
-		require.NoError(t, iter.ForEach(func(plumbing.EncodedObject) error {
+		require.NoError(t, iter.ForEach(t.Context(), func(plumbing.EncodedObject) error {
 			n++
 			return nil
 		}))
@@ -127,7 +127,7 @@ func TestPackfileIter_ForEachClosesPack(t *testing.T) {
 			require.NoError(t, err)
 
 			var i int
-			err = iter.ForEach(func(plumbing.EncodedObject) error {
+			err = iter.ForEach(t.Context(), func(plumbing.EncodedObject) error {
 				defer func() { i++ }()
 				return tc.cb(i)
 			})
@@ -151,7 +151,7 @@ func TestPackfileIter_ForEachKeepsPackOpen(t *testing.T) {
 		cache.NewObjectLRUDefault(), true, crypto.SHA1.Size())
 	require.NoError(t, err)
 
-	require.NoError(t, iter.ForEach(func(plumbing.EncodedObject) error { return nil }))
+	require.NoError(t, iter.ForEach(t.Context(), func(plumbing.EncodedObject) error { return nil }))
 	require.Zero(t, pack.closed, "keepPack=true must not close the underlying file")
 }
 
@@ -208,7 +208,7 @@ func TestObjectsIter_ForEachClosesOnError(t *testing.T) {
 			require.NotEmpty(t, objects)
 
 			iter := &objectsIter{s: o, t: plumbing.AnyObject, h: append([]plumbing.Hash{}, objects...)}
-			err = iter.ForEach(tc.cb)
+			err = iter.ForEach(t.Context(), tc.cb)
 			if tc.wantErr == nil {
 				require.NoError(t, err)
 			} else {

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -46,7 +46,7 @@ func (s *FsSuite) TestGetFromObjectFile() {
 	o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 
 	expected := plumbing.NewHash("f3dfe29d268303fc6e1bbce268605fc99573406e")
-	obj, err := o.EncodedObject(plumbing.AnyObject, expected)
+	obj, err := o.EncodedObject(s.T().Context(), plumbing.AnyObject, expected)
 	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 }
@@ -58,7 +58,7 @@ func (s *FsSuite) TestGetFromPackfile() {
 		o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 
 		expected := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-		obj, err := o.EncodedObject(plumbing.AnyObject, expected)
+		obj, err := o.EncodedObject(s.T().Context(), plumbing.AnyObject, expected)
 		s.Require().NoError(err)
 		s.Equal(expected, obj.Hash())
 	}
@@ -71,12 +71,12 @@ func (s *FsSuite) TestIterEncodedObjectsSHA256HashesRoundTrip() {
 	o := NewStorage(fs, cache.NewObjectLRUDefault())
 	defer func() { _ = o.Close() }()
 
-	iter, err := o.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := o.IterEncodedObjects(s.T().Context(), plumbing.AnyObject)
 	s.Require().NoError(err)
 	defer iter.Close()
 
-	err = iter.ForEach(func(obj plumbing.EncodedObject) error {
-		roundTrip, err := o.EncodedObject(plumbing.AnyObject, obj.Hash())
+	err = iter.ForEach(s.T().Context(), func(obj plumbing.EncodedObject) error {
+		roundTrip, err := o.EncodedObject(s.T().Context(), plumbing.AnyObject, obj.Hash())
 		s.Require().NoError(err)
 		s.Equal(obj.Hash(), roundTrip.Hash())
 		return nil
@@ -91,7 +91,7 @@ func (s *FsSuite) TestSetEncodedObjectSHA256LooseObjectRoundTrip() {
 		cache.NewObjectLRUDefault(),
 		Options{ObjectFormat: formatcfg.SHA256},
 	)
-	s.Require().NoError(o.Init())
+	s.Require().NoError(o.Init(s.T().Context()))
 	defer func() { _ = o.Close() }()
 
 	obj := o.NewEncodedObject()
@@ -104,13 +104,13 @@ func (s *FsSuite) TestSetEncodedObjectSHA256LooseObjectRoundTrip() {
 	s.Require().NoError(err)
 	s.Require().NoError(writer.Close())
 
-	hash, err := o.SetEncodedObject(obj)
+	hash, err := o.SetEncodedObject(s.T().Context(), obj)
 	s.Require().NoError(err)
 	s.Equal("2928cdcdc8b78c930378ceba09ce9ca8b888fbfe1bffb2cceb42bdff9421cb52", hash.String())
-	s.Require().NoError(o.HasEncodedObject(hash))
+	s.Require().NoError(o.HasEncodedObject(s.T().Context(), hash))
 	s.Require().FileExists(filepath.Join(fs.Root(), "objects", hash.String()[:2], hash.String()[2:]))
 
-	roundTrip, err := o.EncodedObject(plumbing.BlobObject, hash)
+	roundTrip, err := o.EncodedObject(s.T().Context(), plumbing.BlobObject, hash)
 	s.Require().NoError(err)
 	reader, err := roundTrip.Reader()
 	s.Require().NoError(err)
@@ -152,7 +152,7 @@ func (s *FsSuite) TestMismatchIdxFile() {
 	s.Require().NoError(err)
 
 	expected := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	obj, err := o.EncodedObject(plumbing.AnyObject, expected)
+	obj, err := o.EncodedObject(s.T().Context(), plumbing.AnyObject, expected)
 	s.Require().Nil(obj)
 	s.ErrorContains(err, "malformed idx file: packfile mismatch: ")
 }
@@ -180,7 +180,7 @@ func (s *FsSuite) TestMismatchIdxFile_LooseFallback() {
 	_, err = w.Write([]byte("loose object behind a broken idx\n"))
 	s.Require().NoError(err)
 	s.Require().NoError(w.Close())
-	loose, err := o.SetEncodedObject(obj)
+	loose, err := o.SetEncodedObject(s.T().Context(), obj)
 	s.Require().NoError(err)
 
 	// Corrupt the only idx in the same way TestMismatchIdxFile does.
@@ -200,12 +200,12 @@ func (s *FsSuite) TestMismatchIdxFile_LooseFallback() {
 	o2 := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 	defer func() { _ = o2.Close() }()
 
-	s.Require().NoError(o2.HasEncodedObject(loose),
+	s.Require().NoError(o2.HasEncodedObject(s.T().Context(), loose),
 		"loose object must answer existence even when the idx is broken")
-	size, err := o2.EncodedObjectSize(loose)
+	size, err := o2.EncodedObjectSize(s.T().Context(), loose)
 	s.Require().NoError(err)
 	s.Greater(size, int64(0))
-	got, err := o2.EncodedObject(plumbing.AnyObject, loose)
+	got, err := o2.EncodedObject(s.T().Context(), plumbing.AnyObject, loose)
 	s.Require().NoError(err)
 	s.Equal(loose, got.Hash())
 
@@ -213,7 +213,7 @@ func (s *FsSuite) TestMismatchIdxFile_LooseFallback() {
 	// idx error so genuine on-disk corruption is not silently
 	// swallowed when there is no answer to give the caller.
 	missing := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
-	err = o2.HasEncodedObject(missing)
+	err = o2.HasEncodedObject(s.T().Context(), missing)
 	s.ErrorContains(err, "malformed idx file: packfile mismatch: ")
 }
 
@@ -224,7 +224,7 @@ func (s *FsSuite) TestGetSizeOfObjectFile() {
 
 	// Get the size of `tree_walker.go`.
 	expected := plumbing.NewHash("cbd81c47be12341eb1185b379d1c82675aeded6a")
-	size, err := o.EncodedObjectSize(expected)
+	size, err := o.EncodedObjectSize(s.T().Context(), expected)
 	s.Require().NoError(err)
 	s.Equal(int64(2412), size)
 }
@@ -237,7 +237,7 @@ func (s *FsSuite) TestGetSizeFromPackfile() {
 
 		// Get the size of `binary.jpg`.
 		expected := plumbing.NewHash("d5c0f4ab811897cadf03aec358ae60d21f91c50d")
-		size, err := o.EncodedObjectSize(expected)
+		size, err := o.EncodedObjectSize(s.T().Context(), expected)
 		s.Require().NoError(err)
 		s.Equal(int64(76110), size)
 	}
@@ -249,8 +249,8 @@ func (s *FsSuite) TestGetSizeOfAllObjectFiles() {
 	o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 
 	// Get the size of `tree_walker.go`.
-	err = o.ForEachObjectHash(func(h plumbing.Hash) error {
-		size, err := o.EncodedObjectSize(h)
+	err = o.ForEachObjectHash(s.T().Context(), func(h plumbing.Hash) error {
+		size, err := o.EncodedObjectSize(s.T().Context(), h)
 		s.Require().NoError(err)
 		s.NotEqual(int64(0), size)
 		return nil
@@ -297,11 +297,11 @@ func (s *FsSuite) TestIter() {
 		o := NewStorage(fs, cache.NewObjectLRUDefault())
 		defer func() { _ = o.Close() }()
 
-		iter, err := o.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := o.IterEncodedObjects(s.T().Context(), plumbing.AnyObject)
 		s.Require().NoError(err)
 
 		var count int32
-		err = iter.ForEach(func(_ plumbing.EncodedObject) error {
+		err = iter.ForEach(s.T().Context(), func(_ plumbing.EncodedObject) error {
 			count++
 			return nil
 		})
@@ -318,11 +318,11 @@ func (s *FsSuite) TestIterLargeObjectThreshold() {
 		o := NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), Options{LargeObjectThreshold: 1})
 		defer func() { _ = o.Close() }()
 
-		iter, err := o.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := o.IterEncodedObjects(s.T().Context(), plumbing.AnyObject)
 		s.Require().NoError(err)
 
 		var count int32
-		err = iter.ForEach(func(_ plumbing.EncodedObject) error {
+		err = iter.ForEach(s.T().Context(), func(_ plumbing.EncodedObject) error {
 			count++
 			return nil
 		})
@@ -340,10 +340,10 @@ func (s *FsSuite) TestIterWithType() {
 			o := NewStorage(fs, cache.NewObjectLRUDefault())
 			s.T().Cleanup(func() { _ = o.Close() })
 
-			iter, err := o.IterEncodedObjects(t)
+			iter, err := o.IterEncodedObjects(s.T().Context(), t)
 			s.Require().NoError(err)
 
-			err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+			err = iter.ForEach(s.T().Context(), func(obj plumbing.EncodedObject) error {
 				s.Equal(t, obj.Type())
 				return nil
 			})
@@ -374,7 +374,7 @@ func (s *FsSuite) TestPackfileIter() {
 				iter, err := NewPackfileIter(fs, f, idxf, t, false, 0, objectIDSize)
 				s.Require().NoError(err)
 
-				err = iter.ForEach(func(o plumbing.EncodedObject) error {
+				err = iter.ForEach(s.T().Context(), func(o plumbing.EncodedObject) error {
 					s.Equal(t, o.Type())
 					return nil
 				})
@@ -429,7 +429,7 @@ func (s *FsSuite) TestPackfileReindex() {
 		defer func() { _ = storer.Close() }()
 
 		// check that our test object is NOT found
-		_, err = storer.EncodedObject(plumbing.CommitObject, testObjectHash)
+		_, err = storer.EncodedObject(s.T().Context(), plumbing.CommitObject, testObjectHash)
 		s.ErrorIs(err, plumbing.ErrObjectNotFound)
 
 		// add the external packfile+idx to the packs folder
@@ -438,13 +438,13 @@ func (s *FsSuite) TestPackfileReindex() {
 		s.Require().NoError(copyFile(fs, filepath.Join("objects", "pack", fmt.Sprintf("pack-%s.idx", packFilename)), idxFile))
 
 		// check that we cannot still retrieve the test object
-		_, err = storer.EncodedObject(plumbing.CommitObject, testObjectHash)
+		_, err = storer.EncodedObject(s.T().Context(), plumbing.CommitObject, testObjectHash)
 		s.ErrorIs(err, plumbing.ErrObjectNotFound)
 
 		storer.Reindex() // actually reindex
 
 		// Now check that the test object can be retrieved
-		_, err = storer.EncodedObject(plumbing.CommitObject, testObjectHash)
+		_, err = storer.EncodedObject(s.T().Context(), plumbing.CommitObject, testObjectHash)
 		s.Require().NoError(err)
 	}
 }
@@ -460,11 +460,11 @@ func (s *FsSuite) TestGetFromObjectFileSharedCache() {
 	o2 := NewObjectStorage(dotgit.New(f2), ch)
 
 	expected := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-	obj, err := o1.EncodedObject(plumbing.CommitObject, expected)
+	obj, err := o1.EncodedObject(s.T().Context(), plumbing.CommitObject, expected)
 	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
-	_, err = o2.EncodedObject(plumbing.CommitObject, expected)
+	_, err = o2.EncodedObject(s.T().Context(), plumbing.CommitObject, expected)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 }
 
@@ -474,7 +474,7 @@ func (s *FsSuite) TestHashesWithPrefix() {
 	s.Require().NoError(err)
 	o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 	expected := plumbing.NewHash("f3dfe29d268303fc6e1bbce268605fc99573406e")
-	obj, err := o.EncodedObject(plumbing.AnyObject, expected)
+	obj, err := o.EncodedObject(s.T().Context(), plumbing.AnyObject, expected)
 	s.Require().NoError(err)
 	s.Equal(expected, obj.Hash())
 
@@ -533,7 +533,7 @@ func BenchmarkPackfileIter(b *testing.B) {
 							b.Fatal(err)
 						}
 
-						err = iter.ForEach(func(o plumbing.EncodedObject) error {
+						err = iter.ForEach(b.Context(), func(o plumbing.EncodedObject) error {
 							if o.Type() != t {
 								b.Errorf("expecting %s, got %s", t, o.Type())
 							}
@@ -581,7 +581,7 @@ func BenchmarkPackfileIterReadContent(b *testing.B) {
 							b.Fatal(err)
 						}
 
-						err = iter.ForEach(func(o plumbing.EncodedObject) error {
+						err = iter.ForEach(b.Context(), func(o plumbing.EncodedObject) error {
 							if o.Type() != t {
 								b.Errorf("expecting %s, got %s", t, o.Type())
 							}
@@ -617,7 +617,7 @@ func BenchmarkGetObjectFromPackfile(b *testing.B) {
 			o := NewObjectStorage(dotgit.New(fs), cache.NewObjectLRUDefault())
 			for i := 0; i < b.N; i++ {
 				expected := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-				obj, err := o.EncodedObject(plumbing.AnyObject, expected)
+				obj, err := o.EncodedObject(b.Context(), plumbing.AnyObject, expected)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -642,7 +642,7 @@ func (s *FsSuite) TestGetFromUnpackedCachesObjects() {
 	s.False(ok)
 
 	// Load the object
-	obj, err := objectStorage.EncodedObject(plumbing.AnyObject, hash)
+	obj, err := objectStorage.EncodedObject(s.T().Context(), plumbing.AnyObject, hash)
 	s.Require().NoError(err)
 	s.Equal(hash, obj.Hash())
 
@@ -726,11 +726,11 @@ func (s *FsSuite) TestObjectStorageMultipleAlternates() {
 	dg := dotgit.NewWithOptions(workFs, dotgit.Options{AlternatesFS: rootFs})
 	storage := NewObjectStorage(dg, cache.NewObjectLRUDefault())
 
-	obj1, err := storage.EncodedObject(plumbing.AnyObject, commitHash1)
+	obj1, err := storage.EncodedObject(s.T().Context(), plumbing.AnyObject, commitHash1)
 	s.Require().NoError(err)
 	s.Equal(commitHash1, obj1.Hash())
 
-	obj2, err := storage.EncodedObject(plumbing.AnyObject, commitHash2)
+	obj2, err := storage.EncodedObject(s.T().Context(), plumbing.AnyObject, commitHash2)
 	s.Require().NoError(err)
 	s.Equal(commitHash2, obj2.Hash())
 
@@ -761,10 +761,10 @@ func (s *FsSuite) TestObjectStorageAlternatesHasEncodedObject() {
 	dg := dotgit.NewWithOptions(workFs, dotgit.Options{AlternatesFS: rootFs})
 	storage := NewObjectStorage(dg, cache.NewObjectLRUDefault())
 
-	err = storage.HasEncodedObject(commitHash)
+	err = storage.HasEncodedObject(s.T().Context(), commitHash)
 	s.NoError(err)
 
-	err = storage.HasEncodedObject(nonExistentHash)
+	err = storage.HasEncodedObject(s.T().Context(), nonExistentHash)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 
 	err = storage.Close()
@@ -824,7 +824,7 @@ func (s *FsSuite) TestObjectStorageAlternatesEncodedObjectSize() {
 	dg := dotgit.NewWithOptions(workFs, dotgit.Options{AlternatesFS: rootFs})
 	storage := NewObjectStorage(dg, cache.NewObjectLRUDefault())
 
-	size, err := storage.EncodedObjectSize(commitHash)
+	size, err := storage.EncodedObjectSize(s.T().Context(), commitHash)
 	s.NoError(err)
 	s.Greater(size, int64(0))
 
@@ -846,18 +846,18 @@ func (s *FsSuite) TestObjectStorageAlternatesReset() {
 
 	storage := NewStorageWithOptions(workFs, cache.NewObjectLRUDefault(), Options{AlternatesFS: rootFs})
 	s.T().Cleanup(func() { storage.Close() })
-	s.Require().NoError(storage.Init())
+	s.Require().NoError(storage.Init(s.T().Context()))
 
-	err = storage.HasEncodedObject(commitHash)
+	err = storage.HasEncodedObject(s.T().Context(), commitHash)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 
-	err = storage.AddAlternate(templateFs.Root())
+	err = storage.AddAlternate(s.T().Context(), templateFs.Root())
 	s.Require().NoError(err)
 
-	err = storage.HasEncodedObject(commitHash)
+	err = storage.HasEncodedObject(s.T().Context(), commitHash)
 	s.NoError(err)
 
-	obj, err := storage.EncodedObject(plumbing.AnyObject, commitHash)
+	obj, err := storage.EncodedObject(s.T().Context(), plumbing.AnyObject, commitHash)
 	s.NoError(err)
 	s.Equal(commitHash, obj.Hash())
 }
@@ -890,15 +890,15 @@ func (s *FsSuite) TestObjectStorageAlternatesInitError() {
 	storage := NewObjectStorage(dg, cache.NewObjectLRUDefault())
 	s.T().Cleanup(func() { storage.Close() })
 
-	err = storage.HasEncodedObject(commitHash)
+	err = storage.HasEncodedObject(s.T().Context(), commitHash)
 	s.Error(err)
 	s.NotErrorIs(err, plumbing.ErrObjectNotFound)
 
-	_, err = storage.EncodedObjectSize(commitHash)
+	_, err = storage.EncodedObjectSize(s.T().Context(), commitHash)
 	s.Error(err)
 	s.NotErrorIs(err, plumbing.ErrObjectNotFound)
 
-	_, err = storage.EncodedObject(plumbing.AnyObject, commitHash)
+	_, err = storage.EncodedObject(s.T().Context(), plumbing.AnyObject, commitHash)
 	s.Error(err)
 	s.NotErrorIs(err, plumbing.ErrObjectNotFound)
 }
@@ -917,20 +917,20 @@ func TestObjectStorageCloseIdleDescriptors(t *testing.T) {
 		t.Cleanup(func() { _ = s.Close() })
 
 		// Get one hash to read.
-		iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		require.NoError(t, err)
-		obj1, err := iter.Next()
+		obj1, err := iter.Next(t.Context())
 		require.NoError(t, err)
 		iter.Close()
 
 		// Read once to warm caches.
-		_, err = s.EncodedObject(plumbing.AnyObject, obj1.Hash())
+		_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj1.Hash())
 		require.NoError(t, err)
 
 		require.NoError(t, s.CloseIdleDescriptors())
 
 		// Second read still works.
-		obj2, err := s.EncodedObject(plumbing.AnyObject, obj1.Hash())
+		obj2, err := s.EncodedObject(t.Context(), plumbing.AnyObject, obj1.Hash())
 		require.NoError(t, err)
 		assert.Equal(t, obj1.Hash(), obj2.Hash())
 	})
@@ -944,13 +944,13 @@ func TestObjectStorageCloseIdleDescriptors(t *testing.T) {
 		t.Cleanup(func() { _ = s.Close() })
 
 		// Force population of s.index.
-		iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		require.NoError(t, err)
-		obj1, err := iter.Next()
+		obj1, err := iter.Next(t.Context())
 		require.NoError(t, err)
 		iter.Close()
 
-		_, err = s.EncodedObject(plumbing.AnyObject, obj1.Hash())
+		_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj1.Hash())
 		require.NoError(t, err)
 
 		s.muI.RLock()
@@ -1003,11 +1003,11 @@ func TestObjectStorageCloseIdleDescriptors(t *testing.T) {
 		t.Cleanup(func() { _ = s.Close() })
 
 		// Collect a working set of hashes.
-		iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		require.NoError(t, err)
 		var hashes []plumbing.Hash
 		for range 16 {
-			obj, err := iter.Next()
+			obj, err := iter.Next(t.Context())
 			if err != nil {
 				break
 			}
@@ -1021,7 +1021,7 @@ func TestObjectStorageCloseIdleDescriptors(t *testing.T) {
 		// incomingChecked without a lock. One serial lookup here
 		// ensures the field is set before the concurrent herd,
 		// sidestepping the pre-existing race in hasIncomingObjects.
-		_, err = s.EncodedObject(plumbing.AnyObject, hashes[0])
+		_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, hashes[0])
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -1030,7 +1030,7 @@ func TestObjectStorageCloseIdleDescriptors(t *testing.T) {
 		for range 8 {
 			wg.Go(func() {
 				for _, h := range hashes {
-					obj, err := s.EncodedObject(plumbing.AnyObject, h)
+					obj, err := s.EncodedObject(t.Context(), plumbing.AnyObject, h)
 					if err != nil || obj == nil {
 						failures.Add(1)
 						// Continue rather than return so a single
@@ -1067,13 +1067,13 @@ func TestObjectStorage_PopulateIndex_FirstReadHotMap(t *testing.T) {
 	s := NewStorage(dir, cache.NewObjectLRUDefault())
 	t.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	obj, err := iter.Next()
+	obj, err := iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
 
-	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj.Hash())
 	require.NoError(t, err)
 
 	s.muI.RLock()
@@ -1094,13 +1094,13 @@ func TestObjectStorage_ReindexPrewarms(t *testing.T) {
 	s := NewStorage(dir, cache.NewObjectLRUDefault())
 	t.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	obj, err := iter.Next()
+	obj, err := iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
 
-	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj.Hash())
 	require.NoError(t, err)
 
 	require.NoError(t, s.Reindex())
@@ -1113,7 +1113,7 @@ func TestObjectStorage_ReindexPrewarms(t *testing.T) {
 		"Reindex should leave s.index pre-warmed for the next read")
 
 	// And the next read should still succeed.
-	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj.Hash())
 	require.NoError(t, err)
 }
 
@@ -1135,9 +1135,9 @@ func TestObjectStorage_ConcurrentReindex_NoRace(t *testing.T) {
 
 	// Pre-warm so a concurrent reader can RLock muI without first
 	// racing requireIndex against the Reindex herd.
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	obj, err := iter.Next()
+	obj, err := iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
 	h := obj.Hash()
@@ -1152,7 +1152,7 @@ func TestObjectStorage_ConcurrentReindex_NoRace(t *testing.T) {
 	// during the Reindex herd.
 	for range 8 {
 		wg.Go(func() {
-			_, err := s.EncodedObject(plumbing.AnyObject, h)
+			_, err := s.EncodedObject(t.Context(), plumbing.AnyObject, h)
 			assert.NoError(t, err)
 		})
 	}
@@ -1162,7 +1162,7 @@ func TestObjectStorage_ConcurrentReindex_NoRace(t *testing.T) {
 	assert.NotEmpty(t, s.index, "after the Reindex herd s.index must be populated")
 	s.muI.RUnlock()
 
-	_, err = s.EncodedObject(plumbing.AnyObject, h)
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, h)
 	require.NoError(t, err, "reads after the Reindex herd must still succeed")
 }
 
@@ -1180,9 +1180,9 @@ func TestObjectStorage_ConcurrentEncodedObject_NoRace(t *testing.T) {
 	s := NewStorage(dir, cache.NewObjectLRUDefault())
 	t.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	obj, err := iter.Next()
+	obj, err := iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
 	h := obj.Hash()
@@ -1192,13 +1192,13 @@ func TestObjectStorage_ConcurrentEncodedObject_NoRace(t *testing.T) {
 	// without a lock. One serial call here ensures the field is set
 	// before the concurrent herd, avoiding a pre-existing race in
 	// hasIncomingObjects on cold startup.
-	_, err = s.EncodedObject(plumbing.AnyObject, h)
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, h)
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
 	for range 32 {
 		wg.Go(func() {
-			_, err := s.EncodedObject(plumbing.AnyObject, h)
+			_, err := s.EncodedObject(t.Context(), plumbing.AnyObject, h)
 			assert.NoError(t, err)
 		})
 	}
@@ -1219,13 +1219,13 @@ func TestEncodedObject_PackedRoundTrip(t *testing.T) {
 
 	// Warm the index so EncodedObject doesn't race through the
 	// cold dotgit path (matches the convention of existing tests).
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	obj, err := iter.Next()
+	obj, err := iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
 
-	got, err := s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	got, err := s.EncodedObject(t.Context(), plumbing.AnyObject, obj.Hash())
 	require.NoError(t, err)
 	assert.Equal(t, obj.Hash(), got.Hash())
 }
@@ -1248,10 +1248,10 @@ func TestEncodedObject_LooseRoundTrip(t *testing.T) {
 	_, err = w.Write([]byte("loose-prefer-test"))
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
-	h, err := s.SetEncodedObject(o)
+	h, err := s.SetEncodedObject(t.Context(), o)
 	require.NoError(t, err)
 
-	got, err := s.EncodedObject(plumbing.AnyObject, h)
+	got, err := s.EncodedObject(t.Context(), plumbing.AnyObject, h)
 	require.NoError(t, err)
 	assert.Equal(t, h, got.Hash())
 }
@@ -1265,12 +1265,12 @@ func TestEncodedObject_NotFound(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	// Warm index to avoid the cold dotgit race.
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
 	iter.Close()
 
 	missing := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
-	_, err = s.EncodedObject(plumbing.AnyObject, missing)
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, missing)
 	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 }
 
@@ -1283,12 +1283,12 @@ func TestEncodedObjectSize_NotFound(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	// Warm index to avoid the cold dotgit race.
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
 	iter.Close()
 
 	missing := plumbing.NewHash("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
-	_, err = s.EncodedObjectSize(missing)
+	_, err = s.EncodedObjectSize(t.Context(), missing)
 	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 }
 
@@ -1300,13 +1300,13 @@ func TestEncodedObjectSize_Packed(t *testing.T) {
 	s := NewStorage(dir, cache.NewObjectLRUDefault())
 	t.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	obj, err := iter.Next()
+	obj, err := iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
 
-	size, err := s.EncodedObjectSize(obj.Hash())
+	size, err := s.EncodedObjectSize(t.Context(), obj.Hash())
 	require.NoError(t, err)
 	assert.Greater(t, size, int64(0))
 }
@@ -1320,9 +1320,9 @@ func TestFindObjectInPackfile_MRU_SeedsAndUses(t *testing.T) {
 	t.Cleanup(func() { _ = s.Close() })
 
 	// Pre-warm the index (cold dotgit race avoidance).
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	obj, err := iter.Next()
+	obj, err := iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
 
@@ -1330,7 +1330,7 @@ func TestFindObjectInPackfile_MRU_SeedsAndUses(t *testing.T) {
 	require.Equal(t, int32(0), s.lastHitPackIdx.Load())
 
 	// First lookup seeds the hint.
-	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj.Hash())
 	require.NoError(t, err)
 
 	hint := s.lastHitPackIdx.Load()
@@ -1338,7 +1338,7 @@ func TestFindObjectInPackfile_MRU_SeedsAndUses(t *testing.T) {
 		"first successful lookup should seed lastHitPackIdx")
 
 	// Second lookup should not change the hint (still the same pack).
-	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj.Hash())
 	require.NoError(t, err)
 	assert.Equal(t, hint, s.lastHitPackIdx.Load(),
 		"single-pack fixture: hint should stay stable")

--- a/storage/filesystem/packhandle_integration_test.go
+++ b/storage/filesystem/packhandle_integration_test.go
@@ -86,7 +86,7 @@ func TestIntegration_PackFDIsPooledAcrossCalls(t *testing.T) {
 	// Three separate passes — 12 total lookups.
 	for range 3 {
 		for range 4 {
-			obj, err := storage.EncodedObject(plumbing.AnyObject, target)
+			obj, err := storage.EncodedObject(t.Context(), plumbing.AnyObject, target)
 			require.NoError(t, err)
 			assert.Equal(t, target, obj.Hash())
 		}
@@ -140,7 +140,7 @@ func TestIntegration_ConcurrentObjectReads(t *testing.T) {
 
 	// Warm the PackHandle so the first cursor open is not on the
 	// hot path of any goroutine.
-	_, err = storage.EncodedObject(plumbing.AnyObject, target)
+	_, err = storage.EncodedObject(t.Context(), plumbing.AnyObject, target)
 	require.NoError(t, err)
 
 	const perG = 200
@@ -150,7 +150,7 @@ func TestIntegration_ConcurrentObjectReads(t *testing.T) {
 	for range goroutines {
 		wg.Go(func() {
 			for range perG {
-				obj, err := storage.EncodedObject(plumbing.AnyObject, target)
+				obj, err := storage.EncodedObject(t.Context(), plumbing.AnyObject, target)
 				require.NoError(t, err)
 				require.Equal(t, target, obj.Hash())
 			}
@@ -205,11 +205,11 @@ func TestIntegration_ReindexInvalidatesPackHandles(t *testing.T) {
 
 	// Confirm we can EncodedObject before deletion.
 	target := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	_, err = storage.EncodedObject(plumbing.AnyObject, target)
+	_, err = storage.EncodedObject(t.Context(), plumbing.AnyObject, target)
 	require.NoError(t, err, "EncodedObject should succeed before deletion")
 
 	// Delete the pack with a future time so the mod-time check passes.
-	require.NoError(t, storage.DeleteOldObjectPackAndIndex(h, time.Now().Add(time.Hour)))
+	require.NoError(t, storage.DeleteOldObjectPackAndIndex(t.Context(), h, time.Now().Add(time.Hour)))
 
 	// The in-flight reader's underlying sharedFile was closed by
 	// PackHandle.Close. The reader's cursor holds the now-closed
@@ -233,7 +233,7 @@ func TestIntegration_ReindexInvalidatesPackHandles(t *testing.T) {
 
 	// EncodedObject must also fail since ExclusiveAccess prevents
 	// scanning the now-empty pack directory.
-	_, err = storage.EncodedObject(plumbing.AnyObject, target)
+	_, err = storage.EncodedObject(t.Context(), plumbing.AnyObject, target)
 	assert.Error(t, err,
 		"EncodedObject should fail after the pack is deleted")
 }
@@ -261,11 +261,11 @@ func TestIntegration_CloseIdleDescriptorsDropsAndReopens(t *testing.T) {
 	t.Cleanup(func() { _ = storage.Close() })
 
 	// Warm: read enough objects to open every pack's FDs.
-	iter, err := storage.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := storage.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
 	var probe plumbing.Hash
 	for range 8 {
-		obj, err := iter.Next()
+		obj, err := iter.Next(t.Context())
 		if err != nil {
 			break
 		}
@@ -279,7 +279,7 @@ func TestIntegration_CloseIdleDescriptorsDropsAndReopens(t *testing.T) {
 	// Touch the object via EncodedObject to ensure pack and idx
 	// sharedFiles have been Acquired and their FDs are open in
 	// the grace window.
-	_, err = storage.EncodedObject(plumbing.AnyObject, probe)
+	_, err = storage.EncodedObject(t.Context(), plumbing.AnyObject, probe)
 	require.NoError(t, err)
 
 	warm := openFDCount(t)
@@ -292,7 +292,7 @@ func TestIntegration_CloseIdleDescriptorsDropsAndReopens(t *testing.T) {
 	assert.Less(t, after, warm, "CloseIdleDescriptors should drop FDs")
 
 	// Subsequent reads pay a reopen but succeed.
-	_, err = storage.EncodedObject(plumbing.AnyObject, probe)
+	_, err = storage.EncodedObject(t.Context(), plumbing.AnyObject, probe)
 	require.NoError(t, err)
 }
 

--- a/storage/filesystem/reference.go
+++ b/storage/filesystem/reference.go
@@ -58,15 +58,27 @@ func (r *ReferenceStorage) IterReferences(ctx context.Context) (storer.Reference
 
 // RemoveReference deletes the reference with the given name.
 func (r *ReferenceStorage) RemoveReference(ctx context.Context, n plumbing.ReferenceName) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return r.dir.RemoveRef(n)
 }
 
 // CountLooseRefs returns the number of loose references.
 func (r *ReferenceStorage) CountLooseRefs(ctx context.Context) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	return r.dir.CountLooseRefs()
 }
 
 // PackRefs packs all loose references into a single packed-refs file.
 func (r *ReferenceStorage) PackRefs(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return r.dir.PackRefs()
 }

--- a/storage/filesystem/reference.go
+++ b/storage/filesystem/reference.go
@@ -1,33 +1,37 @@
 package filesystem
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
 )
 
 // ReferenceStorage implements storer.ReferenceStorer for filesystem storage.
+//
+// TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
 type ReferenceStorage struct {
 	dir *dotgit.DotGit
 }
 
 // SetReference stores a reference.
-func (r *ReferenceStorage) SetReference(ref *plumbing.Reference) error {
+func (r *ReferenceStorage) SetReference(ctx context.Context, ref *plumbing.Reference) error {
 	return r.dir.SetRef(ref, nil)
 }
 
 // CheckAndSetReference stores a reference after verifying the old value matches.
-func (r *ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
+func (r *ReferenceStorage) CheckAndSetReference(ctx context.Context, ref, old *plumbing.Reference) error {
 	return r.dir.SetRef(ref, old)
 }
 
 // Reference returns the reference with the given name.
-func (r *ReferenceStorage) Reference(n plumbing.ReferenceName) (*plumbing.Reference, error) {
+func (r *ReferenceStorage) Reference(ctx context.Context, n plumbing.ReferenceName) (*plumbing.Reference, error) {
 	return r.dir.Ref(n)
 }
 
 // IterReferences returns an iterator over all references.
-func (r *ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
+func (r *ReferenceStorage) IterReferences(ctx context.Context) (storer.ReferenceIter, error) {
 	refs, err := r.dir.Refs()
 	if err != nil {
 		return nil, err
@@ -37,16 +41,16 @@ func (r *ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 }
 
 // RemoveReference deletes the reference with the given name.
-func (r *ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
+func (r *ReferenceStorage) RemoveReference(ctx context.Context, n plumbing.ReferenceName) error {
 	return r.dir.RemoveRef(n)
 }
 
 // CountLooseRefs returns the number of loose references.
-func (r *ReferenceStorage) CountLooseRefs() (int, error) {
+func (r *ReferenceStorage) CountLooseRefs(ctx context.Context) (int, error) {
 	return r.dir.CountLooseRefs()
 }
 
 // PackRefs packs all loose references into a single packed-refs file.
-func (r *ReferenceStorage) PackRefs() error {
+func (r *ReferenceStorage) PackRefs(ctx context.Context) error {
 	return r.dir.PackRefs()
 }

--- a/storage/filesystem/reference.go
+++ b/storage/filesystem/reference.go
@@ -17,21 +17,37 @@ type ReferenceStorage struct {
 
 // SetReference stores a reference.
 func (r *ReferenceStorage) SetReference(ctx context.Context, ref *plumbing.Reference) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return r.dir.SetRef(ref, nil)
 }
 
 // CheckAndSetReference stores a reference after verifying the old value matches.
 func (r *ReferenceStorage) CheckAndSetReference(ctx context.Context, ref, old *plumbing.Reference) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return r.dir.SetRef(ref, old)
 }
 
 // Reference returns the reference with the given name.
 func (r *ReferenceStorage) Reference(ctx context.Context, n plumbing.ReferenceName) (*plumbing.Reference, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	return r.dir.Ref(n)
 }
 
 // IterReferences returns an iterator over all references.
 func (r *ReferenceStorage) IterReferences(ctx context.Context) (storer.ReferenceIter, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	refs, err := r.dir.Refs()
 	if err != nil {
 		return nil, err

--- a/storage/filesystem/reflog.go
+++ b/storage/filesystem/reflog.go
@@ -1,6 +1,8 @@
 package filesystem
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/reflog"
 	"github.com/go-git/go-git/v6/storage/filesystem/dotgit"
@@ -8,12 +10,14 @@ import (
 )
 
 // ReflogStorage implements storer.ReflogStorer backed by the filesystem.
+//
+// TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
 type ReflogStorage struct {
 	dir *dotgit.DotGit
 }
 
 // Reflog returns all reflog entries for the given reference, oldest first.
-func (r *ReflogStorage) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, error) {
+func (r *ReflogStorage) Reflog(ctx context.Context, name plumbing.ReferenceName) ([]*reflog.Entry, error) {
 	f, err := r.dir.ReflogReader(name)
 	if f == nil || err != nil {
 		return nil, err
@@ -25,7 +29,7 @@ func (r *ReflogStorage) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, er
 }
 
 // AppendReflog appends a single entry to the reflog for the given reference.
-func (r *ReflogStorage) AppendReflog(name plumbing.ReferenceName, entry *reflog.Entry) error {
+func (r *ReflogStorage) AppendReflog(ctx context.Context, name plumbing.ReferenceName, entry *reflog.Entry) error {
 	f, err := r.dir.ReflogWriter(name)
 	if err != nil {
 		return err
@@ -36,6 +40,6 @@ func (r *ReflogStorage) AppendReflog(name plumbing.ReferenceName, entry *reflog.
 }
 
 // DeleteReflog removes the entire reflog for the given reference.
-func (r *ReflogStorage) DeleteReflog(name plumbing.ReferenceName) error {
+func (r *ReflogStorage) DeleteReflog(ctx context.Context, name plumbing.ReferenceName) error {
 	return r.dir.DeleteReflog(name)
 }

--- a/storage/filesystem/reflog.go
+++ b/storage/filesystem/reflog.go
@@ -18,6 +18,10 @@ type ReflogStorage struct {
 
 // Reflog returns all reflog entries for the given reference, oldest first.
 func (r *ReflogStorage) Reflog(ctx context.Context, name plumbing.ReferenceName) ([]*reflog.Entry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	f, err := r.dir.ReflogReader(name)
 	if f == nil || err != nil {
 		return nil, err
@@ -30,6 +34,10 @@ func (r *ReflogStorage) Reflog(ctx context.Context, name plumbing.ReferenceName)
 
 // AppendReflog appends a single entry to the reflog for the given reference.
 func (r *ReflogStorage) AppendReflog(ctx context.Context, name plumbing.ReferenceName, entry *reflog.Entry) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	f, err := r.dir.ReflogWriter(name)
 	if err != nil {
 		return err
@@ -41,5 +49,9 @@ func (r *ReflogStorage) AppendReflog(ctx context.Context, name plumbing.Referenc
 
 // DeleteReflog removes the entire reflog for the given reference.
 func (r *ReflogStorage) DeleteReflog(ctx context.Context, name plumbing.ReferenceName) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return r.dir.DeleteReflog(name)
 }

--- a/storage/filesystem/reflog_test.go
+++ b/storage/filesystem/reflog_test.go
@@ -19,7 +19,7 @@ func TestReflogReadNonExistent(t *testing.T) {
 	sto := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	entries, err := sto.Reflog(plumbing.ReferenceName("refs/heads/no-such-ref"))
+	entries, err := sto.Reflog(t.Context(), plumbing.ReferenceName("refs/heads/no-such-ref"))
 	require.NoError(t, err)
 	assert.Nil(t, entries)
 }
@@ -51,10 +51,10 @@ func TestReflogAppendAndRead(t *testing.T) {
 		Message: "commit: second",
 	}
 
-	require.NoError(t, sto.AppendReflog(ref, e1))
-	require.NoError(t, sto.AppendReflog(ref, e2))
+	require.NoError(t, sto.AppendReflog(t.Context(), ref, e1))
+	require.NoError(t, sto.AppendReflog(t.Context(), ref, e2))
 
-	entries, err := sto.Reflog(ref)
+	entries, err := sto.Reflog(t.Context(), ref)
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
 
@@ -70,7 +70,7 @@ func TestReflogDelete(t *testing.T) {
 	defer func() { _ = sto.Close() }()
 	ref := plumbing.ReferenceName("refs/heads/main")
 
-	require.NoError(t, sto.AppendReflog(ref, &reflog.Entry{
+	require.NoError(t, sto.AppendReflog(t.Context(), ref, &reflog.Entry{
 		OldHash: plumbing.ZeroHash,
 		NewHash: plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 		Committer: reflog.Signature{
@@ -81,9 +81,9 @@ func TestReflogDelete(t *testing.T) {
 		Message: "commit (initial): first",
 	}))
 
-	require.NoError(t, sto.DeleteReflog(ref))
+	require.NoError(t, sto.DeleteReflog(t.Context(), ref))
 
-	entries, err := sto.Reflog(ref)
+	entries, err := sto.Reflog(t.Context(), ref)
 	require.NoError(t, err)
 	assert.Nil(t, entries)
 }
@@ -93,6 +93,6 @@ func TestReflogDeleteNonExistent(t *testing.T) {
 	sto := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
 	defer func() { _ = sto.Close() }()
 
-	err := sto.DeleteReflog(plumbing.ReferenceName("refs/heads/no-such-ref"))
+	err := sto.DeleteReflog(t.Context(), plumbing.ReferenceName("refs/heads/no-such-ref"))
 	assert.NoError(t, err)
 }

--- a/storage/filesystem/shallow.go
+++ b/storage/filesystem/shallow.go
@@ -22,6 +22,10 @@ type ShallowStorage struct {
 // commit per line represented by 40-byte hexadecimal object terminated by a
 // newline.
 func (s *ShallowStorage) SetShallow(ctx context.Context, commits []plumbing.Hash) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	f, err := s.dir.ShallowWriter()
 	if err != nil {
 		return err
@@ -39,6 +43,10 @@ func (s *ShallowStorage) SetShallow(ctx context.Context, commits []plumbing.Hash
 
 // Shallow returns the shallow commits reading from shallo file from .git
 func (s *ShallowStorage) Shallow(ctx context.Context) ([]plumbing.Hash, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	f, err := s.dir.Shallow()
 	if f == nil || err != nil {
 		return nil, err

--- a/storage/filesystem/shallow.go
+++ b/storage/filesystem/shallow.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -11,6 +12,8 @@ import (
 
 // ShallowStorage where the shallow commits are stored, an internal to
 // manipulate the shallow file
+//
+// TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
 type ShallowStorage struct {
 	dir *dotgit.DotGit
 }
@@ -18,7 +21,7 @@ type ShallowStorage struct {
 // SetShallow save the shallows in the shallow file in the .git folder as one
 // commit per line represented by 40-byte hexadecimal object terminated by a
 // newline.
-func (s *ShallowStorage) SetShallow(commits []plumbing.Hash) error {
+func (s *ShallowStorage) SetShallow(ctx context.Context, commits []plumbing.Hash) error {
 	f, err := s.dir.ShallowWriter()
 	if err != nil {
 		return err
@@ -35,7 +38,7 @@ func (s *ShallowStorage) SetShallow(commits []plumbing.Hash) error {
 }
 
 // Shallow returns the shallow commits reading from shallo file from .git
-func (s *ShallowStorage) Shallow() ([]plumbing.Hash, error) {
+func (s *ShallowStorage) Shallow(ctx context.Context) ([]plumbing.Hash, error) {
 	f, err := s.dir.Shallow()
 	if f == nil || err != nil {
 		return nil, err

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -2,6 +2,7 @@
 package filesystem
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -215,7 +216,7 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 //
 // If the storage is empty and the new ObjectFormat is the same as the
 // current, this call will be treated as a no-op.
-func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
+func (s *Storage) SetObjectFormat(ctx context.Context, of formatcfg.ObjectFormat) error {
 	switch of {
 	case formatcfg.SHA1, formatcfg.SHA256:
 	default:
@@ -230,7 +231,7 @@ func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
 		return errors.New("cannot change object format of existing object storage")
 	}
 
-	cfg, err := s.Config()
+	cfg, err := s.Config(ctx)
 	if err != nil {
 		return err
 	}
@@ -238,7 +239,7 @@ func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
 	if cfg.Extensions.ObjectFormat != of {
 		cfg.Extensions.ObjectFormat = of
 		cfg.Core.RepositoryFormatVersion = formatcfg.Version1
-		err = s.SetConfig(cfg)
+		err = s.SetConfig(ctx, cfg)
 		if err != nil {
 			return fmt.Errorf("cannot set object format on config: %w", err)
 		}
@@ -283,13 +284,15 @@ func (s *Storage) Filesystem() billy.Filesystem {
 }
 
 // Init initializes .git directory
-func (s *Storage) Init() error {
+//
+// TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
+func (s *Storage) Init(ctx context.Context) error {
 	return s.dir.Initialize()
 }
 
 // AddAlternate adds an alternate object directory and resets the cached
 // alternate state so that subsequent object lookups pick up the new alternate.
-func (s *Storage) AddAlternate(remote string) error {
+func (s *Storage) AddAlternate(ctx context.Context, remote string) error {
 	if err := s.dir.AddAlternate(remote); err != nil {
 		return err
 	}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -287,12 +287,20 @@ func (s *Storage) Filesystem() billy.Filesystem {
 //
 // TODO(ctx): propagate ctx into dotgit; it currently stops at this boundary.
 func (s *Storage) Init(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	return s.dir.Initialize()
 }
 
 // AddAlternate adds an alternate object directory and resets the cached
 // alternate state so that subsequent object lookups pick up the new alternate.
 func (s *Storage) AddAlternate(ctx context.Context, remote string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if err := s.dir.AddAlternate(remote); err != nil {
 		return err
 	}

--- a/storage/filesystem/storage_pool_test.go
+++ b/storage/filesystem/storage_pool_test.go
@@ -33,12 +33,12 @@ func TestStorage_FDPool_PoolIsUsed(t *testing.T) {
 	assert.Equal(t, 0, pool.Stats().Active)
 
 	// Trigger a read; this opens at least the .pack and .idx.
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	obj, err := iter.Next()
+	obj, err := iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
-	_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj.Hash())
 	require.NoError(t, err)
 
 	assert.Greater(t, pool.Stats().Active, 0,
@@ -82,7 +82,7 @@ func TestStorage_FDPool_AlternatesShareParentPool(t *testing.T) {
 	// Force a lookup that misses on the (empty) primary and falls
 	// through to the alternate.
 	probe := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
-	_, err = s.EncodedObject(plumbing.AnyObject, probe)
+	_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, probe)
 	require.NoError(t, err)
 
 	// The alternate's PackHandle SharedFiles registered with our
@@ -112,12 +112,12 @@ func TestStorage_FDPool_SharedAcrossStorages(t *testing.T) {
 
 		// Trigger a read so the storage registers its SharedFiles
 		// in the shared pool.
-		iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		require.NoError(t, err)
-		obj, err := iter.Next()
+		obj, err := iter.Next(t.Context())
 		require.NoError(t, err)
 		iter.Close()
-		_, err = s.EncodedObject(plumbing.AnyObject, obj.Hash())
+		_, err = s.EncodedObject(t.Context(), plumbing.AnyObject, obj.Hash())
 		require.NoError(t, err)
 
 		assert.Greater(t, shared.Stats().Active, 0,
@@ -146,9 +146,9 @@ func TestStorage_FDPool_Disabled(t *testing.T) {
 		filesystem.Options{Pool: fdpool.New(0)})
 	t.Cleanup(func() { _ = s.Close() })
 
-	iter, err := s.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := s.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 	require.NoError(t, err)
-	_, err = iter.Next()
+	_, err = iter.Next(t.Context())
 	require.NoError(t, err)
 	iter.Close()
 }

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -132,9 +132,9 @@ func TestSetObjectFormat(t *testing.T) {
 				filesystem.Options{ObjectFormat: tt.initialFormat},
 			)
 			defer func() { _ = sto.Close() }()
-			require.NoError(t, sto.Init())
+			require.NoError(t, sto.Init(t.Context()))
 
-			err := sto.SetObjectFormat(tt.targetFormat)
+			err := sto.SetObjectFormat(t.Context(), tt.targetFormat)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -236,7 +236,7 @@ func TestNewStorageWithOptions(t *testing.T) {
 			)
 			defer func() { _ = sto.Close() }()
 
-			cfg, err := sto.Config()
+			cfg, err := sto.Config(t.Context())
 			require.NoError(t, err)
 
 			assert.Equal(t, tt.wantObjectFormat, cfg.Extensions.ObjectFormat)
@@ -288,11 +288,11 @@ func TestSetObjectFormatWithExistingPackfiles(t *testing.T) {
 			sto := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 			defer func() { _ = sto.Close() }()
 
-			packs, err := sto.ObjectPacks()
+			packs, err := sto.ObjectPacks(t.Context())
 			require.NoError(t, err)
 			require.Len(t, packs, 1)
 
-			err = sto.SetObjectFormat(tt.targetFormat)
+			err = sto.SetObjectFormat(t.Context(), tt.targetFormat)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "cannot change object format")
@@ -372,12 +372,12 @@ func TestStorage_ImplementsIdleReleaser(t *testing.T) {
 func getExplicitSHA1(t testing.TB) billy.Filesystem {
 	fs := osfs.New(t.TempDir())
 	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-	cfg, err := st.Config()
+	cfg, err := st.Config(t.Context())
 	require.NoError(t, err)
 
 	cfg.Extensions.ObjectFormat = formatcfg.SHA1
 	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
-	err = st.SetConfig(cfg)
+	err = st.SetConfig(t.Context(), cfg)
 	require.NoError(t, err)
 
 	_ = st.Close()

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -2,6 +2,7 @@
 package memory
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -62,7 +63,7 @@ func NewStorage(o ...StorageOption) *Storage {
 	}
 
 	if opts.objectFormat != formatcfg.UnsetObjectFormat {
-		cfg, _ := s.Config()
+		cfg := s.ConfigStorage.config()
 		cfg.Extensions.ObjectFormat = opts.objectFormat
 		cfg.Core.RepositoryFormatVersion = formatcfg.Version1
 		s.oh = plumbing.FromObjectFormat(opts.objectFormat)
@@ -74,7 +75,7 @@ func NewStorage(o ...StorageOption) *Storage {
 }
 
 // SetObjectFormat configures the object format for this storage.
-func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
+func (s *Storage) SetObjectFormat(ctx context.Context, of formatcfg.ObjectFormat) error {
 	switch of {
 	case formatcfg.SHA1, formatcfg.SHA256:
 	default:
@@ -96,7 +97,7 @@ func (s *Storage) SetObjectFormat(of formatcfg.ObjectFormat) error {
 		return nil
 	}
 
-	cfg, _ := s.Config()
+	cfg := s.ConfigStorage.config()
 	cfg.Extensions.ObjectFormat = of
 	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
 	s.options.objectFormat = of
@@ -121,26 +122,32 @@ func (s *Storage) SupportsExtension(name, value string) bool {
 
 // ConfigStorage implements config.ConfigStorer for in-memory storage.
 type ConfigStorage struct {
-	config *config.Config
+	cfg *config.Config
 }
 
 // SetConfig stores the given config.
-func (c *ConfigStorage) SetConfig(cfg *config.Config) error {
+func (c *ConfigStorage) SetConfig(ctx context.Context, cfg *config.Config) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
 
-	c.config = cfg
+	c.cfg = cfg
 	return nil
 }
 
 // Config returns the stored config.
-func (c *ConfigStorage) Config() (*config.Config, error) {
-	if c.config == nil {
-		c.config = config.NewConfig()
+func (c *ConfigStorage) Config(ctx context.Context) (*config.Config, error) {
+	return c.config(), nil
+}
+
+// config returns the stored config, initializing it if needed. It performs
+// no I/O and is used internally where no context is available.
+func (c *ConfigStorage) config() *config.Config {
+	if c.cfg == nil {
+		c.cfg = config.NewConfig()
 	}
 
-	return c.config, nil
+	return c.cfg
 }
 
 // IndexStorage implements storer.IndexStorer for in-memory storage.
@@ -150,7 +157,7 @@ type IndexStorage struct {
 
 // SetIndex stores the given index.
 // Note: this method sets idx.ModTime to simulate filesystem storage behavior.
-func (c *IndexStorage) SetIndex(idx *index.Index) error {
+func (c *IndexStorage) SetIndex(ctx context.Context, idx *index.Index) error {
 	// Set ModTime to enable racy git detection in the metadata optimization.
 	idx.ModTime = time.Now()
 	c.index = idx
@@ -158,7 +165,7 @@ func (c *IndexStorage) SetIndex(idx *index.Index) error {
 }
 
 // Index returns the stored index.
-func (c *IndexStorage) Index() (*index.Index, error) {
+func (c *IndexStorage) Index(ctx context.Context) (*index.Index, error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -184,6 +191,10 @@ type ObjectStorage struct {
 }
 
 type lazyCloser struct {
+	// ctx is the context of the RawObjectWriter call that created this
+	// closer; io.Closer has no context parameter, so the write operation's
+	// context is carried through to the deferred store.
+	ctx     context.Context
 	storage *ObjectStorage
 	obj     plumbing.EncodedObject
 	closer  io.Closer
@@ -195,12 +206,12 @@ func (c *lazyCloser) Close() error {
 		return fmt.Errorf("failed to close memory encoded object: %w", err)
 	}
 
-	_, err = c.storage.SetEncodedObject(c.obj)
+	_, err = c.storage.SetEncodedObject(c.ctx, c.obj)
 	return err
 }
 
 // RawObjectWriter returns a writer for writing a raw object.
-func (o *ObjectStorage) RawObjectWriter(typ plumbing.ObjectType, sz int64) (w io.WriteCloser, err error) {
+func (o *ObjectStorage) RawObjectWriter(ctx context.Context, typ plumbing.ObjectType, sz int64) (w io.WriteCloser, err error) {
 	obj := o.NewEncodedObject()
 	obj.SetType(typ)
 	obj.SetSize(sz)
@@ -211,7 +222,7 @@ func (o *ObjectStorage) RawObjectWriter(typ plumbing.ObjectType, sz int64) (w io
 	}
 
 	wc := ioutil.NewWriteCloser(w,
-		&lazyCloser{storage: o, obj: obj, closer: w},
+		&lazyCloser{ctx: ctx, storage: o, obj: obj, closer: w},
 	)
 
 	return wc, nil
@@ -223,7 +234,7 @@ func (o *ObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 }
 
 // SetEncodedObject stores the given EncodedObject.
-func (o *ObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.Hash, error) {
+func (o *ObjectStorage) SetEncodedObject(ctx context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error) {
 	h := obj.Hash()
 	o.Objects[h] = obj
 
@@ -244,7 +255,7 @@ func (o *ObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.H
 }
 
 // HasEncodedObject returns nil if the object exists, or an error otherwise.
-func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
+func (o *ObjectStorage) HasEncodedObject(ctx context.Context, h plumbing.Hash) (err error) {
 	if _, ok := o.Objects[h]; !ok {
 		return plumbing.ErrObjectNotFound
 	}
@@ -252,7 +263,7 @@ func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
 }
 
 // EncodedObjectSize returns the size of the object with the given hash.
-func (o *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (
+func (o *ObjectStorage) EncodedObjectSize(ctx context.Context, h plumbing.Hash) (
 	size int64, err error,
 ) {
 	obj, ok := o.Objects[h]
@@ -264,7 +275,7 @@ func (o *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (
 }
 
 // EncodedObject returns the object with the given type and hash.
-func (o *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (o *ObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, ok := o.Objects[h]
 	if !ok || (plumbing.AnyObject != t && obj.Type() != t) {
 		return nil, plumbing.ErrObjectNotFound
@@ -274,7 +285,7 @@ func (o *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 }
 
 // IterEncodedObjects returns an iterator for all objects of the given type.
-func (o *ObjectStorage) IterEncodedObjects(t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
+func (o *ObjectStorage) IterEncodedObjects(ctx context.Context, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
 	var series []plumbing.EncodedObject
 	switch t {
 	case plumbing.AnyObject:
@@ -301,7 +312,7 @@ func flattenObjectMap(m map[plumbing.Hash]plumbing.EncodedObject) []plumbing.Enc
 }
 
 // Begin returns a new transaction.
-func (o *ObjectStorage) Begin() storer.Transaction {
+func (o *ObjectStorage) Begin(ctx context.Context) storer.Transaction {
 	return &TxObjectStorage{
 		Storage: o,
 		Objects: make(map[plumbing.Hash]plumbing.EncodedObject),
@@ -309,7 +320,7 @@ func (o *ObjectStorage) Begin() storer.Transaction {
 }
 
 // ForEachObjectHash calls the given function for each object hash.
-func (o *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
+func (o *ObjectStorage) ForEachObjectHash(ctx context.Context, fun func(plumbing.Hash) error) error {
 	for h := range o.Objects {
 		err := fun(h)
 		if err != nil {
@@ -323,29 +334,29 @@ func (o *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 }
 
 // ObjectPacks returns the list of object packs (always empty for in-memory storage).
-func (o *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
+func (o *ObjectStorage) ObjectPacks(ctx context.Context) ([]plumbing.Hash, error) {
 	return nil, nil
 }
 
 // DeleteOldObjectPackAndIndex is a no-op for in-memory storage.
-func (o *ObjectStorage) DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error {
+func (o *ObjectStorage) DeleteOldObjectPackAndIndex(ctx context.Context, h plumbing.Hash, t time.Time) error {
 	return nil
 }
 
 var errNotSupported = fmt.Errorf("not supported")
 
 // LooseObjectTime returns an error as loose objects are not supported.
-func (o *ObjectStorage) LooseObjectTime(_ plumbing.Hash) (time.Time, error) {
+func (o *ObjectStorage) LooseObjectTime(ctx context.Context, _ plumbing.Hash) (time.Time, error) {
 	return time.Time{}, errNotSupported
 }
 
 // DeleteLooseObject returns an error as loose objects are not supported.
-func (o *ObjectStorage) DeleteLooseObject(plumbing.Hash) error {
+func (o *ObjectStorage) DeleteLooseObject(ctx context.Context, h plumbing.Hash) error {
 	return errNotSupported
 }
 
 // AddAlternate returns an error as alternates are not supported.
-func (o *ObjectStorage) AddAlternate(_ string) error {
+func (o *ObjectStorage) AddAlternate(ctx context.Context, _ string) error {
 	return errNotSupported
 }
 
@@ -356,7 +367,7 @@ type TxObjectStorage struct {
 }
 
 // SetEncodedObject stores the given EncodedObject in the transaction.
-func (tx *TxObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.Hash, error) {
+func (tx *TxObjectStorage) SetEncodedObject(ctx context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error) {
 	h := obj.Hash()
 	tx.Objects[h] = obj
 
@@ -364,7 +375,7 @@ func (tx *TxObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbin
 }
 
 // EncodedObject returns the object with the given type and hash from the transaction.
-func (tx *TxObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (tx *TxObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, ok := tx.Objects[h]
 	if !ok || (plumbing.AnyObject != t && obj.Type() != t) {
 		return nil, plumbing.ErrObjectNotFound
@@ -374,10 +385,10 @@ func (tx *TxObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash)
 }
 
 // Commit commits all objects in the transaction to the storage.
-func (tx *TxObjectStorage) Commit() error {
+func (tx *TxObjectStorage) Commit(ctx context.Context) error {
 	for h, obj := range tx.Objects {
 		delete(tx.Objects, h)
-		if _, err := tx.Storage.SetEncodedObject(obj); err != nil {
+		if _, err := tx.Storage.SetEncodedObject(ctx, obj); err != nil {
 			return err
 		}
 	}
@@ -395,7 +406,7 @@ func (tx *TxObjectStorage) Rollback() error {
 type ReferenceStorage map[plumbing.ReferenceName]*plumbing.Reference
 
 // SetReference stores the given reference.
-func (r ReferenceStorage) SetReference(ref *plumbing.Reference) error {
+func (r ReferenceStorage) SetReference(ctx context.Context, ref *plumbing.Reference) error {
 	if ref != nil {
 		r[ref.Name()] = ref
 	}
@@ -404,7 +415,7 @@ func (r ReferenceStorage) SetReference(ref *plumbing.Reference) error {
 }
 
 // CheckAndSetReference stores the reference if the old reference matches.
-func (r ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
+func (r ReferenceStorage) CheckAndSetReference(ctx context.Context, ref, old *plumbing.Reference) error {
 	if ref == nil {
 		return nil
 	}
@@ -420,7 +431,7 @@ func (r ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) err
 }
 
 // Reference returns the reference with the given name.
-func (r ReferenceStorage) Reference(n plumbing.ReferenceName) (*plumbing.Reference, error) {
+func (r ReferenceStorage) Reference(ctx context.Context, n plumbing.ReferenceName) (*plumbing.Reference, error) {
 	ref, ok := r[n]
 	if !ok {
 		return nil, plumbing.ErrReferenceNotFound
@@ -430,7 +441,7 @@ func (r ReferenceStorage) Reference(n plumbing.ReferenceName) (*plumbing.Referen
 }
 
 // IterReferences returns an iterator for all references.
-func (r ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
+func (r ReferenceStorage) IterReferences(ctx context.Context) (storer.ReferenceIter, error) {
 	refs := make([]*plumbing.Reference, 0, len(r))
 	for _, ref := range r {
 		refs = append(refs, ref)
@@ -440,17 +451,17 @@ func (r ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 }
 
 // CountLooseRefs returns the number of references.
-func (r ReferenceStorage) CountLooseRefs() (int, error) {
+func (r ReferenceStorage) CountLooseRefs(ctx context.Context) (int, error) {
 	return len(r), nil
 }
 
 // PackRefs is a no-op.
-func (r ReferenceStorage) PackRefs() error {
+func (r ReferenceStorage) PackRefs(ctx context.Context) error {
 	return nil
 }
 
 // RemoveReference removes the reference with the given name.
-func (r ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
+func (r ReferenceStorage) RemoveReference(ctx context.Context, n plumbing.ReferenceName) error {
 	delete(r, n)
 	return nil
 }
@@ -459,13 +470,13 @@ func (r ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 type ShallowStorage []plumbing.Hash
 
 // SetShallow stores the shallow commits.
-func (s *ShallowStorage) SetShallow(commits []plumbing.Hash) error {
+func (s *ShallowStorage) SetShallow(ctx context.Context, commits []plumbing.Hash) error {
 	*s = commits
 	return nil
 }
 
 // Shallow returns the shallow commits.
-func (s ShallowStorage) Shallow() ([]plumbing.Hash, error) {
+func (s ShallowStorage) Shallow(ctx context.Context) ([]plumbing.Hash, error) {
 	return s, nil
 }
 
@@ -473,7 +484,7 @@ func (s ShallowStorage) Shallow() ([]plumbing.Hash, error) {
 type ModuleStorage map[string]*Storage
 
 // Module returns the storage for the given submodule.
-func (s ModuleStorage) Module(name string) (storage.Storer, error) {
+func (s ModuleStorage) Module(ctx context.Context, name string) (storage.Storer, error) {
 	if m, ok := s[name]; ok {
 		return m, nil
 	}
@@ -490,7 +501,7 @@ type ReflogStorage struct {
 }
 
 // Reflog returns the reflog entries for the given reference.
-func (r *ReflogStorage) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, error) {
+func (r *ReflogStorage) Reflog(ctx context.Context, name plumbing.ReferenceName) ([]*reflog.Entry, error) {
 	if r.entries == nil {
 		return nil, nil
 	}
@@ -498,7 +509,7 @@ func (r *ReflogStorage) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, er
 }
 
 // AppendReflog appends a single entry to the reflog for the given reference.
-func (r *ReflogStorage) AppendReflog(name plumbing.ReferenceName, entry *reflog.Entry) error {
+func (r *ReflogStorage) AppendReflog(ctx context.Context, name plumbing.ReferenceName, entry *reflog.Entry) error {
 	if r.entries == nil {
 		r.entries = make(map[plumbing.ReferenceName][]*reflog.Entry)
 	}
@@ -507,7 +518,7 @@ func (r *ReflogStorage) AppendReflog(name plumbing.ReferenceName, entry *reflog.
 }
 
 // DeleteReflog removes the entire reflog for the given reference.
-func (r *ReflogStorage) DeleteReflog(name plumbing.ReferenceName) error {
+func (r *ReflogStorage) DeleteReflog(ctx context.Context, name plumbing.ReferenceName) error {
 	if r.entries != nil {
 		delete(r.entries, name)
 	}

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -63,7 +63,7 @@ func NewStorage(o ...StorageOption) *Storage {
 	}
 
 	if opts.objectFormat != formatcfg.UnsetObjectFormat {
-		cfg := s.ConfigStorage.config()
+		cfg := s.config()
 		cfg.Extensions.ObjectFormat = opts.objectFormat
 		cfg.Core.RepositoryFormatVersion = formatcfg.Version1
 		s.oh = plumbing.FromObjectFormat(opts.objectFormat)
@@ -75,7 +75,7 @@ func NewStorage(o ...StorageOption) *Storage {
 }
 
 // SetObjectFormat configures the object format for this storage.
-func (s *Storage) SetObjectFormat(ctx context.Context, of formatcfg.ObjectFormat) error {
+func (s *Storage) SetObjectFormat(_ context.Context, of formatcfg.ObjectFormat) error {
 	switch of {
 	case formatcfg.SHA1, formatcfg.SHA256:
 	default:
@@ -97,7 +97,7 @@ func (s *Storage) SetObjectFormat(ctx context.Context, of formatcfg.ObjectFormat
 		return nil
 	}
 
-	cfg := s.ConfigStorage.config()
+	cfg := s.config()
 	cfg.Extensions.ObjectFormat = of
 	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
 	s.options.objectFormat = of
@@ -126,7 +126,7 @@ type ConfigStorage struct {
 }
 
 // SetConfig stores the given config.
-func (c *ConfigStorage) SetConfig(ctx context.Context, cfg *config.Config) error {
+func (c *ConfigStorage) SetConfig(_ context.Context, cfg *config.Config) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (c *ConfigStorage) SetConfig(ctx context.Context, cfg *config.Config) error
 }
 
 // Config returns the stored config.
-func (c *ConfigStorage) Config(ctx context.Context) (*config.Config, error) {
+func (c *ConfigStorage) Config(_ context.Context) (*config.Config, error) {
 	return c.config(), nil
 }
 
@@ -157,7 +157,7 @@ type IndexStorage struct {
 
 // SetIndex stores the given index.
 // Note: this method sets idx.ModTime to simulate filesystem storage behavior.
-func (c *IndexStorage) SetIndex(ctx context.Context, idx *index.Index) error {
+func (c *IndexStorage) SetIndex(_ context.Context, idx *index.Index) error {
 	// Set ModTime to enable racy git detection in the metadata optimization.
 	idx.ModTime = time.Now()
 	c.index = idx
@@ -165,7 +165,7 @@ func (c *IndexStorage) SetIndex(ctx context.Context, idx *index.Index) error {
 }
 
 // Index returns the stored index.
-func (c *IndexStorage) Index(ctx context.Context) (*index.Index, error) {
+func (c *IndexStorage) Index(_ context.Context) (*index.Index, error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -234,7 +234,7 @@ func (o *ObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 }
 
 // SetEncodedObject stores the given EncodedObject.
-func (o *ObjectStorage) SetEncodedObject(ctx context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error) {
+func (o *ObjectStorage) SetEncodedObject(_ context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error) {
 	h := obj.Hash()
 	o.Objects[h] = obj
 
@@ -255,7 +255,7 @@ func (o *ObjectStorage) SetEncodedObject(ctx context.Context, obj plumbing.Encod
 }
 
 // HasEncodedObject returns nil if the object exists, or an error otherwise.
-func (o *ObjectStorage) HasEncodedObject(ctx context.Context, h plumbing.Hash) (err error) {
+func (o *ObjectStorage) HasEncodedObject(_ context.Context, h plumbing.Hash) (err error) {
 	if _, ok := o.Objects[h]; !ok {
 		return plumbing.ErrObjectNotFound
 	}
@@ -263,7 +263,7 @@ func (o *ObjectStorage) HasEncodedObject(ctx context.Context, h plumbing.Hash) (
 }
 
 // EncodedObjectSize returns the size of the object with the given hash.
-func (o *ObjectStorage) EncodedObjectSize(ctx context.Context, h plumbing.Hash) (
+func (o *ObjectStorage) EncodedObjectSize(_ context.Context, h plumbing.Hash) (
 	size int64, err error,
 ) {
 	obj, ok := o.Objects[h]
@@ -275,7 +275,7 @@ func (o *ObjectStorage) EncodedObjectSize(ctx context.Context, h plumbing.Hash) 
 }
 
 // EncodedObject returns the object with the given type and hash.
-func (o *ObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (o *ObjectStorage) EncodedObject(_ context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, ok := o.Objects[h]
 	if !ok || (plumbing.AnyObject != t && obj.Type() != t) {
 		return nil, plumbing.ErrObjectNotFound
@@ -285,7 +285,7 @@ func (o *ObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType
 }
 
 // IterEncodedObjects returns an iterator for all objects of the given type.
-func (o *ObjectStorage) IterEncodedObjects(ctx context.Context, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
+func (o *ObjectStorage) IterEncodedObjects(_ context.Context, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
 	var series []plumbing.EncodedObject
 	switch t {
 	case plumbing.AnyObject:
@@ -312,7 +312,7 @@ func flattenObjectMap(m map[plumbing.Hash]plumbing.EncodedObject) []plumbing.Enc
 }
 
 // Begin returns a new transaction.
-func (o *ObjectStorage) Begin(ctx context.Context) storer.Transaction {
+func (o *ObjectStorage) Begin(_ context.Context) storer.Transaction {
 	return &TxObjectStorage{
 		Storage: o,
 		Objects: make(map[plumbing.Hash]plumbing.EncodedObject),
@@ -320,7 +320,7 @@ func (o *ObjectStorage) Begin(ctx context.Context) storer.Transaction {
 }
 
 // ForEachObjectHash calls the given function for each object hash.
-func (o *ObjectStorage) ForEachObjectHash(ctx context.Context, fun func(plumbing.Hash) error) error {
+func (o *ObjectStorage) ForEachObjectHash(_ context.Context, fun func(plumbing.Hash) error) error {
 	for h := range o.Objects {
 		err := fun(h)
 		if err != nil {
@@ -334,29 +334,29 @@ func (o *ObjectStorage) ForEachObjectHash(ctx context.Context, fun func(plumbing
 }
 
 // ObjectPacks returns the list of object packs (always empty for in-memory storage).
-func (o *ObjectStorage) ObjectPacks(ctx context.Context) ([]plumbing.Hash, error) {
+func (o *ObjectStorage) ObjectPacks(_ context.Context) ([]plumbing.Hash, error) {
 	return nil, nil
 }
 
 // DeleteOldObjectPackAndIndex is a no-op for in-memory storage.
-func (o *ObjectStorage) DeleteOldObjectPackAndIndex(ctx context.Context, h plumbing.Hash, t time.Time) error {
+func (o *ObjectStorage) DeleteOldObjectPackAndIndex(_ context.Context, _ plumbing.Hash, _ time.Time) error {
 	return nil
 }
 
 var errNotSupported = fmt.Errorf("not supported")
 
 // LooseObjectTime returns an error as loose objects are not supported.
-func (o *ObjectStorage) LooseObjectTime(ctx context.Context, _ plumbing.Hash) (time.Time, error) {
+func (o *ObjectStorage) LooseObjectTime(_ context.Context, _ plumbing.Hash) (time.Time, error) {
 	return time.Time{}, errNotSupported
 }
 
 // DeleteLooseObject returns an error as loose objects are not supported.
-func (o *ObjectStorage) DeleteLooseObject(ctx context.Context, h plumbing.Hash) error {
+func (o *ObjectStorage) DeleteLooseObject(_ context.Context, _ plumbing.Hash) error {
 	return errNotSupported
 }
 
 // AddAlternate returns an error as alternates are not supported.
-func (o *ObjectStorage) AddAlternate(ctx context.Context, _ string) error {
+func (o *ObjectStorage) AddAlternate(_ context.Context, _ string) error {
 	return errNotSupported
 }
 
@@ -367,7 +367,7 @@ type TxObjectStorage struct {
 }
 
 // SetEncodedObject stores the given EncodedObject in the transaction.
-func (tx *TxObjectStorage) SetEncodedObject(ctx context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error) {
+func (tx *TxObjectStorage) SetEncodedObject(_ context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error) {
 	h := obj.Hash()
 	tx.Objects[h] = obj
 
@@ -375,7 +375,7 @@ func (tx *TxObjectStorage) SetEncodedObject(ctx context.Context, obj plumbing.En
 }
 
 // EncodedObject returns the object with the given type and hash from the transaction.
-func (tx *TxObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+func (tx *TxObjectStorage) EncodedObject(_ context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, ok := tx.Objects[h]
 	if !ok || (plumbing.AnyObject != t && obj.Type() != t) {
 		return nil, plumbing.ErrObjectNotFound
@@ -406,7 +406,7 @@ func (tx *TxObjectStorage) Rollback() error {
 type ReferenceStorage map[plumbing.ReferenceName]*plumbing.Reference
 
 // SetReference stores the given reference.
-func (r ReferenceStorage) SetReference(ctx context.Context, ref *plumbing.Reference) error {
+func (r ReferenceStorage) SetReference(_ context.Context, ref *plumbing.Reference) error {
 	if ref != nil {
 		r[ref.Name()] = ref
 	}
@@ -415,7 +415,7 @@ func (r ReferenceStorage) SetReference(ctx context.Context, ref *plumbing.Refere
 }
 
 // CheckAndSetReference stores the reference if the old reference matches.
-func (r ReferenceStorage) CheckAndSetReference(ctx context.Context, ref, old *plumbing.Reference) error {
+func (r ReferenceStorage) CheckAndSetReference(_ context.Context, ref, old *plumbing.Reference) error {
 	if ref == nil {
 		return nil
 	}
@@ -431,7 +431,7 @@ func (r ReferenceStorage) CheckAndSetReference(ctx context.Context, ref, old *pl
 }
 
 // Reference returns the reference with the given name.
-func (r ReferenceStorage) Reference(ctx context.Context, n plumbing.ReferenceName) (*plumbing.Reference, error) {
+func (r ReferenceStorage) Reference(_ context.Context, n plumbing.ReferenceName) (*plumbing.Reference, error) {
 	ref, ok := r[n]
 	if !ok {
 		return nil, plumbing.ErrReferenceNotFound
@@ -441,7 +441,7 @@ func (r ReferenceStorage) Reference(ctx context.Context, n plumbing.ReferenceNam
 }
 
 // IterReferences returns an iterator for all references.
-func (r ReferenceStorage) IterReferences(ctx context.Context) (storer.ReferenceIter, error) {
+func (r ReferenceStorage) IterReferences(_ context.Context) (storer.ReferenceIter, error) {
 	refs := make([]*plumbing.Reference, 0, len(r))
 	for _, ref := range r {
 		refs = append(refs, ref)
@@ -451,17 +451,17 @@ func (r ReferenceStorage) IterReferences(ctx context.Context) (storer.ReferenceI
 }
 
 // CountLooseRefs returns the number of references.
-func (r ReferenceStorage) CountLooseRefs(ctx context.Context) (int, error) {
+func (r ReferenceStorage) CountLooseRefs(_ context.Context) (int, error) {
 	return len(r), nil
 }
 
 // PackRefs is a no-op.
-func (r ReferenceStorage) PackRefs(ctx context.Context) error {
+func (r ReferenceStorage) PackRefs(_ context.Context) error {
 	return nil
 }
 
 // RemoveReference removes the reference with the given name.
-func (r ReferenceStorage) RemoveReference(ctx context.Context, n plumbing.ReferenceName) error {
+func (r ReferenceStorage) RemoveReference(_ context.Context, n plumbing.ReferenceName) error {
 	delete(r, n)
 	return nil
 }
@@ -470,13 +470,13 @@ func (r ReferenceStorage) RemoveReference(ctx context.Context, n plumbing.Refere
 type ShallowStorage []plumbing.Hash
 
 // SetShallow stores the shallow commits.
-func (s *ShallowStorage) SetShallow(ctx context.Context, commits []plumbing.Hash) error {
+func (s *ShallowStorage) SetShallow(_ context.Context, commits []plumbing.Hash) error {
 	*s = commits
 	return nil
 }
 
 // Shallow returns the shallow commits.
-func (s ShallowStorage) Shallow(ctx context.Context) ([]plumbing.Hash, error) {
+func (s ShallowStorage) Shallow(_ context.Context) ([]plumbing.Hash, error) {
 	return s, nil
 }
 
@@ -484,7 +484,7 @@ func (s ShallowStorage) Shallow(ctx context.Context) ([]plumbing.Hash, error) {
 type ModuleStorage map[string]*Storage
 
 // Module returns the storage for the given submodule.
-func (s ModuleStorage) Module(ctx context.Context, name string) (storage.Storer, error) {
+func (s ModuleStorage) Module(_ context.Context, name string) (storage.Storer, error) {
 	if m, ok := s[name]; ok {
 		return m, nil
 	}
@@ -501,7 +501,7 @@ type ReflogStorage struct {
 }
 
 // Reflog returns the reflog entries for the given reference.
-func (r *ReflogStorage) Reflog(ctx context.Context, name plumbing.ReferenceName) ([]*reflog.Entry, error) {
+func (r *ReflogStorage) Reflog(_ context.Context, name plumbing.ReferenceName) ([]*reflog.Entry, error) {
 	if r.entries == nil {
 		return nil, nil
 	}
@@ -509,7 +509,7 @@ func (r *ReflogStorage) Reflog(ctx context.Context, name plumbing.ReferenceName)
 }
 
 // AppendReflog appends a single entry to the reflog for the given reference.
-func (r *ReflogStorage) AppendReflog(ctx context.Context, name plumbing.ReferenceName, entry *reflog.Entry) error {
+func (r *ReflogStorage) AppendReflog(_ context.Context, name plumbing.ReferenceName, entry *reflog.Entry) error {
 	if r.entries == nil {
 		r.entries = make(map[plumbing.ReferenceName][]*reflog.Entry)
 	}
@@ -518,7 +518,7 @@ func (r *ReflogStorage) AppendReflog(ctx context.Context, name plumbing.Referenc
 }
 
 // DeleteReflog removes the entire reflog for the given reference.
-func (r *ReflogStorage) DeleteReflog(ctx context.Context, name plumbing.ReferenceName) error {
+func (r *ReflogStorage) DeleteReflog(_ context.Context, name plumbing.ReferenceName) error {
 	if r.entries != nil {
 		delete(r.entries, name)
 	}

--- a/storage/memory/storage_test.go
+++ b/storage/memory/storage_test.go
@@ -89,7 +89,7 @@ func TestSetObjectFormat(t *testing.T) {
 
 			sto := memory.NewStorage(memory.WithObjectFormat(tt.initialFormat))
 
-			err := sto.SetObjectFormat(tt.targetFormat)
+			err := sto.SetObjectFormat(t.Context(), tt.targetFormat)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -146,10 +146,10 @@ func TestSetObjectFormatWithExistingObjects(t *testing.T) {
 
 			obj := sto.NewEncodedObject()
 			obj.SetType(plumbing.BlobObject)
-			_, err := sto.SetEncodedObject(obj)
+			_, err := sto.SetEncodedObject(t.Context(), obj)
 			require.NoError(t, err)
 
-			err = sto.SetObjectFormat(tt.targetFormat)
+			err = sto.SetObjectFormat(t.Context(), tt.targetFormat)
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "cannot change object format")
@@ -216,7 +216,7 @@ func TestReflogStorage(t *testing.T) {
 	ref := plumbing.ReferenceName("refs/heads/main")
 
 	// Empty initially.
-	entries, err := s.Reflog(ref)
+	entries, err := s.Reflog(t.Context(), ref)
 	require.NoError(t, err)
 	assert.Empty(t, entries)
 
@@ -242,18 +242,18 @@ func TestReflogStorage(t *testing.T) {
 		Message: "commit: second",
 	}
 
-	require.NoError(t, s.AppendReflog(ref, e1))
-	require.NoError(t, s.AppendReflog(ref, e2))
+	require.NoError(t, s.AppendReflog(t.Context(), ref, e1))
+	require.NoError(t, s.AppendReflog(t.Context(), ref, e2))
 
-	entries, err = s.Reflog(ref)
+	entries, err = s.Reflog(t.Context(), ref)
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
 	assert.Equal(t, "commit: first", entries[0].Message)
 	assert.Equal(t, "commit: second", entries[1].Message)
 
 	// Delete.
-	require.NoError(t, s.DeleteReflog(ref))
-	entries, err = s.Reflog(ref)
+	require.NoError(t, s.DeleteReflog(t.Context(), ref))
+	entries, err = s.Reflog(t.Context(), ref)
 	require.NoError(t, err)
 	assert.Empty(t, entries)
 }

--- a/storage/storer.go
+++ b/storage/storer.go
@@ -3,6 +3,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 
 	"github.com/go-git/go-git/v6/config"
@@ -30,5 +31,5 @@ type Storer interface {
 type ModuleStorer interface {
 	// Module returns a Storer representing a submodule, if not exists returns a
 	// new empty Storer is returned
-	Module(name string) (Storer, error)
+	Module(ctx context.Context, name string) (Storer, error)
 }

--- a/storage/tests/storage_test.go
+++ b/storage/tests/storage_test.go
@@ -101,7 +101,7 @@ func TestPackfileWriter(t *testing.T) {
 			t.Skip("not a PackfileWriter")
 		}
 
-		pw, err := pwr.PackfileWriter()
+		pw, err := pwr.PackfileWriter(t.Context())
 		assert.NoError(t, err)
 
 		f := fixtures.Basic().One()
@@ -113,11 +113,11 @@ func TestPackfileWriter(t *testing.T) {
 		err = pw.Close()
 		assert.NoError(t, err)
 
-		iter, err := sto.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := sto.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		assert.NoError(t, err)
 		objects := 0
 
-		err = iter.ForEach(func(plumbing.EncodedObject) error {
+		err = iter.ForEach(t.Context(), func(plumbing.EncodedObject) error {
 			objects++
 			return nil
 		})
@@ -141,7 +141,7 @@ func TestDeltaObjectStorer(t *testing.T) {
 			t.Skip("not a storer.PackWriter")
 		}
 
-		pw, err := pwr.PackfileWriter()
+		pw, err := pwr.PackfileWriter(t.Context())
 		require.NoError(t, err)
 
 		f := fixtures.Basic().One()
@@ -154,12 +154,12 @@ func TestDeltaObjectStorer(t *testing.T) {
 		require.NoError(t, err)
 
 		h := plumbing.NewHash("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88")
-		obj, err := dos.DeltaObject(plumbing.AnyObject, h)
+		obj, err := dos.DeltaObject(t.Context(), plumbing.AnyObject, h)
 		require.NoError(t, err)
 		assert.Equal(t, plumbing.BlobObject, obj.Type())
 
 		h = plumbing.NewHash("aa9b383c260e1d05fbbf6b30a02914555e20c725")
-		obj, err = dos.DeltaObject(plumbing.AnyObject, h)
+		obj, err = dos.DeltaObject(t.Context(), plumbing.AnyObject, h)
 		require.NoError(t, err)
 		assert.Equal(t, plumbing.OFSDeltaObject.String(), obj.Type().String())
 
@@ -175,15 +175,15 @@ func TestSetEncodedObjectAndEncodedObject(t *testing.T) {
 		for _, to := range testObjects() {
 			comment := fmt.Sprintf("failed for type %s", to.Type.String())
 
-			h, err := sto.SetEncodedObject(to.Object)
+			h, err := sto.SetEncodedObject(t.Context(), to.Object)
 			require.NoError(t, err)
 			require.Equal(t, to.Hash, h.String(), comment)
 
-			o, err := sto.EncodedObject(to.Type, h)
+			o, err := sto.EncodedObject(t.Context(), to.Type, h)
 			require.NoError(t, err)
 			assert.EqualExportedValues(t, to.Object, o)
 
-			o, err = sto.EncodedObject(plumbing.AnyObject, h)
+			o, err = sto.EncodedObject(t.Context(), plumbing.AnyObject, h)
 			require.NoError(t, err)
 			assert.EqualExportedValues(t, to.Object, o)
 
@@ -192,7 +192,7 @@ func TestSetEncodedObjectAndEncodedObject(t *testing.T) {
 					continue
 				}
 
-				o, err = sto.EncodedObject(typ, h)
+				o, err = sto.EncodedObject(t.Context(), typ, h)
 				assert.Nil(t, o)
 				assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 			}
@@ -207,7 +207,7 @@ func TestSetEncodedObjectInvalid(t *testing.T) {
 		o := sto.NewEncodedObject()
 		o.SetType(plumbing.REFDeltaObject)
 
-		_, err := sto.SetEncodedObject(o)
+		_, err := sto.SetEncodedObject(t.Context(), o)
 		assert.Error(t, err)
 	})
 }
@@ -218,30 +218,30 @@ func TestIterEncodedObjects(t *testing.T) {
 	forEachStorage(t, func(sto Storer, t *testing.T) {
 		objs := testObjects()
 		for _, o := range objs {
-			h, err := sto.SetEncodedObject(o.Object)
+			h, err := sto.SetEncodedObject(t.Context(), o.Object)
 			require.NoError(t, err)
 			assert.Equal(t, o.Object.Hash(), h)
 		}
 
 		for _, typ := range validTypes() {
 			comment := fmt.Sprintf("failed for type %s)", typ.String())
-			i, err := sto.IterEncodedObjects(typ)
+			i, err := sto.IterEncodedObjects(t.Context(), typ)
 			require.NoError(t, err, comment)
 
-			o, err := i.Next()
+			o, err := i.Next(t.Context())
 			require.NoError(t, err)
 			assert.EqualExportedValues(t, objs[typ].Object, o)
 
-			o, err = i.Next()
+			o, err = i.Next(t.Context())
 			assert.Nil(t, o)
 			assert.ErrorIs(t, err, io.EOF, comment)
 		}
 
-		i, err := sto.IterEncodedObjects(plumbing.AnyObject)
+		i, err := sto.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		require.NoError(t, err)
 
 		foundObjects := []plumbing.EncodedObject{}
-		i.ForEach(func(o plumbing.EncodedObject) error {
+		i.ForEach(t.Context(), func(o plumbing.EncodedObject) error {
 			foundObjects = append(foundObjects, o)
 			return nil
 		})
@@ -269,26 +269,26 @@ func TestObjectStorerTxSetEncodedObjectAndCommit(t *testing.T) {
 			t.Skip("not a plumbing.ObjectStorerTx")
 		}
 
-		tx := storer.Begin()
+		tx := storer.Begin(t.Context())
 		for _, o := range testObjects() {
-			h, err := tx.SetEncodedObject(o.Object)
+			h, err := tx.SetEncodedObject(t.Context(), o.Object)
 			require.NoError(t, err)
 			assert.Equal(t, o.Hash, h.String())
 		}
 
-		iter, err := sto.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := sto.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		require.NoError(t, err)
-		_, err = iter.Next()
+		_, err = iter.Next(t.Context())
 		assert.ErrorIs(t, err, io.EOF)
 
-		err = tx.Commit()
+		err = tx.Commit(t.Context())
 		require.NoError(t, err)
 
-		iter, err = sto.IterEncodedObjects(plumbing.AnyObject)
+		iter, err = sto.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		require.NoError(t, err)
 
 		var count int
-		iter.ForEach(func(_ plumbing.EncodedObject) error {
+		iter.ForEach(t.Context(), func(_ plumbing.EncodedObject) error {
 			count++
 			return nil
 		})
@@ -306,13 +306,13 @@ func TestObjectStorerTxSetObjectAndGetObject(t *testing.T) {
 			t.Skip("not a plumbing.ObjectStorerTx")
 		}
 
-		tx := storer.Begin()
+		tx := storer.Begin(t.Context())
 		for _, expected := range testObjects() {
-			h, err := tx.SetEncodedObject(expected.Object)
+			h, err := tx.SetEncodedObject(t.Context(), expected.Object)
 			require.NoError(t, err)
 			assert.Equal(t, expected.Hash, h.String())
 
-			o, err := tx.EncodedObject(expected.Type, plumbing.NewHash(expected.Hash))
+			o, err := tx.EncodedObject(t.Context(), expected.Type, plumbing.NewHash(expected.Hash))
 			require.NoError(t, err)
 			assert.Equal(t, expected.Hash, o.Hash().String())
 		}
@@ -328,8 +328,8 @@ func TestObjectStorerTxGetObjectNotFound(t *testing.T) {
 			t.Skip("not a plumbing.ObjectStorerTx")
 		}
 
-		tx := storer.Begin()
-		o, err := tx.EncodedObject(plumbing.AnyObject, plumbing.ZeroHash)
+		tx := storer.Begin(t.Context())
+		o, err := tx.EncodedObject(t.Context(), plumbing.AnyObject, plumbing.ZeroHash)
 		assert.Nil(t, o)
 		assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
 	})
@@ -344,9 +344,9 @@ func TestObjectStorerTxSetObjectAndRollback(t *testing.T) {
 			t.Skip("not a plumbing.ObjectStorerTx")
 		}
 
-		tx := storer.Begin()
+		tx := storer.Begin(t.Context())
 		for _, o := range testObjects() {
-			h, err := tx.SetEncodedObject(o.Object)
+			h, err := tx.SetEncodedObject(t.Context(), o.Object)
 			require.NoError(t, err)
 			assert.Equal(t, o.Hash, h.String())
 		}
@@ -354,9 +354,9 @@ func TestObjectStorerTxSetObjectAndRollback(t *testing.T) {
 		err := tx.Rollback()
 		require.NoError(t, err)
 
-		iter, err := sto.IterEncodedObjects(plumbing.AnyObject)
+		iter, err := sto.IterEncodedObjects(t.Context(), plumbing.AnyObject)
 		require.NoError(t, err)
-		_, err = iter.Next()
+		_, err = iter.Next(t.Context())
 		assert.ErrorIs(t, err, io.EOF)
 	})
 }
@@ -365,17 +365,17 @@ func TestSetReferenceAndGetReference(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		err := sto.SetReference(
+		err := sto.SetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		)
 		require.NoError(t, err)
 
-		err = sto.SetReference(
+		err = sto.SetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/bar", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		require.NoError(t, err)
 
-		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
+		e, err := sto.Reference(t.Context(), plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	})
@@ -385,18 +385,18 @@ func TestCheckAndSetReference(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		err := sto.SetReference(
+		err := sto.SetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		require.NoError(t, err)
 
-		err = sto.CheckAndSetReference(
+		err = sto.CheckAndSetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 			plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		require.NoError(t, err)
 
-		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
+		e, err := sto.Reference(t.Context(), plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	})
@@ -406,18 +406,18 @@ func TestCheckAndSetReferenceNil(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		err := sto.SetReference(
+		err := sto.SetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		require.NoError(t, err)
 
-		err = sto.CheckAndSetReference(
+		err = sto.CheckAndSetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 			nil,
 		)
 		require.NoError(t, err)
 
-		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
+		e, err := sto.Reference(t.Context(), plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	})
@@ -427,18 +427,18 @@ func TestCheckAndSetReferenceError(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		err := sto.SetReference(
+		err := sto.SetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "c3f4688a08fd86f1bf8e055724c84b7a40a09733"),
 		)
 		require.NoError(t, err)
 
-		err = sto.CheckAndSetReference(
+		err = sto.CheckAndSetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 			plumbing.NewReferenceFromStrings("refs/foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 		)
 		assert.ErrorIs(t, err, storage.ErrReferenceHasChanged)
 
-		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
+		e, err := sto.Reference(t.Context(), plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "c3f4688a08fd86f1bf8e055724c84b7a40a09733")
 	})
@@ -448,15 +448,15 @@ func TestRemoveReference(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		err := sto.SetReference(
+		err := sto.SetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		)
 		require.NoError(t, err)
 
-		err = sto.RemoveReference(plumbing.ReferenceName("refs/foo"))
+		err = sto.RemoveReference(t.Context(), plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 
-		_, err = sto.Reference(plumbing.ReferenceName("refs/foo"))
+		_, err = sto.Reference(t.Context(), plumbing.ReferenceName("refs/foo"))
 		assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
 	})
 }
@@ -465,15 +465,15 @@ func TestRemoveReferenceNonExistent(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		err := sto.SetReference(
+		err := sto.SetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		)
 		require.NoError(t, err)
 
-		err = sto.RemoveReference(plumbing.ReferenceName("refs/nonexistent"))
+		err = sto.RemoveReference(t.Context(), plumbing.ReferenceName("refs/nonexistent"))
 		require.NoError(t, err)
 
-		e, err := sto.Reference(plumbing.ReferenceName("refs/foo"))
+		e, err := sto.Reference(t.Context(), plumbing.ReferenceName("refs/foo"))
 		require.NoError(t, err)
 		assert.Equal(t, "bc9968d75e48de59f0870ffb71f5e160bbbdcf52", e.Hash().String())
 	})
@@ -483,7 +483,7 @@ func TestGetReferenceNotFound(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		r, err := sto.Reference(plumbing.ReferenceName("refs/bar"))
+		r, err := sto.Reference(t.Context(), plumbing.ReferenceName("refs/bar"))
 		assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
 		assert.Nil(t, r)
 	})
@@ -493,19 +493,19 @@ func TestIterReferences(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		err := sto.SetReference(
+		err := sto.SetReference(t.Context(),
 			plumbing.NewReferenceFromStrings("refs/foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		)
 		require.NoError(t, err)
 
-		i, err := sto.IterReferences()
+		i, err := sto.IterReferences(t.Context())
 		require.NoError(t, err)
 
-		e, err := i.Next()
+		e, err := i.Next(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, e.Hash().String(), "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 
-		e, err = i.Next()
+		e, err = i.Next(t.Context())
 		assert.Nil(t, e)
 		assert.ErrorIs(t, err, io.EOF)
 	})
@@ -521,10 +521,10 @@ func TestSetShallowAndShallow(t *testing.T) {
 			plumbing.NewHash("c78874f116be67ecf54df225a613162b84cc6ebf"),
 		}
 
-		err := sto.SetShallow(expected)
+		err := sto.SetShallow(t.Context(), expected)
 		require.NoError(t, err)
 
-		result, err := sto.Shallow()
+		result, err := sto.Shallow(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, expected, result)
 	})
@@ -541,10 +541,10 @@ func TestSetConfigAndConfig(t *testing.T) {
 			URLs: []string{"http://foo/bar.git"},
 		}
 
-		err := sto.SetConfig(expected)
+		err := sto.SetConfig(t.Context(), expected)
 		require.NoError(t, err)
 
-		cfg, err := sto.Config()
+		cfg, err := sto.Config(t.Context())
 		require.NoError(t, err)
 
 		assert.Equal(t, expected.Core.IsBare, cfg.Core.IsBare)
@@ -559,7 +559,7 @@ func TestIndex(t *testing.T) {
 		expected := &index.Index{}
 		expected.Version = 2
 
-		idx, err := sto.Index()
+		idx, err := sto.Index(t.Context())
 		assert.NoError(t, err)
 		assert.Equal(t, expected, idx)
 	})
@@ -572,10 +572,10 @@ func TestSetIndexAndIndex(t *testing.T) {
 		expected := &index.Index{}
 		expected.Version = 2
 
-		err := sto.SetIndex(expected)
+		err := sto.SetIndex(t.Context(), expected)
 		require.NoError(t, err)
 
-		idx, err := sto.Index()
+		idx, err := sto.Index(t.Context())
 		require.NoError(t, err)
 		assert.NotNil(t, idx)
 
@@ -592,7 +592,7 @@ func TestSetConfigInvalid(t *testing.T) {
 		cfg := config.NewConfig()
 		cfg.Remotes["foo"] = &config.RemoteConfig{}
 
-		err := sto.SetConfig(cfg)
+		err := sto.SetConfig(t.Context(), cfg)
 		assert.Error(t, err)
 	})
 }
@@ -601,7 +601,7 @@ func TestModule(t *testing.T) {
 	t.Parallel()
 
 	forEachStorage(t, func(sto Storer, t *testing.T) {
-		storer, err := sto.Module("foo")
+		storer, err := sto.Module(t.Context(), "foo")
 		require.NoError(t, err)
 		defer func() {
 			if closer, ok := storer.(io.Closer); ok {
@@ -610,7 +610,7 @@ func TestModule(t *testing.T) {
 		}()
 		assert.NotNil(t, storer)
 
-		storer2, err := sto.Module("foo")
+		storer2, err := sto.Module(t.Context(), "foo")
 		require.NoError(t, err)
 		defer func() {
 			if closer, ok := storer2.(io.Closer); ok {

--- a/storage/transactional/config.go
+++ b/storage/transactional/config.go
@@ -1,6 +1,10 @@
 package transactional
 
-import "github.com/go-git/go-git/v6/config"
+import (
+	"context"
+
+	"github.com/go-git/go-git/v6/config"
+)
 
 // ConfigStorage implements the storer.ConfigStorage for the transactional package.
 type ConfigStorage struct {
@@ -17,8 +21,8 @@ func NewConfigStorage(s, temporal config.ConfigStorer) *ConfigStorage {
 }
 
 // SetConfig honors the storer.ConfigStorer interface.
-func (c *ConfigStorage) SetConfig(cfg *config.Config) error {
-	if err := c.temporal.SetConfig(cfg); err != nil {
+func (c *ConfigStorage) SetConfig(ctx context.Context, cfg *config.Config) error {
+	if err := c.temporal.SetConfig(ctx, cfg); err != nil {
 		return err
 	}
 
@@ -27,24 +31,24 @@ func (c *ConfigStorage) SetConfig(cfg *config.Config) error {
 }
 
 // Config honors the storer.ConfigStorer interface.
-func (c *ConfigStorage) Config() (*config.Config, error) {
+func (c *ConfigStorage) Config(ctx context.Context) (*config.Config, error) {
 	if !c.set {
-		return c.ConfigStorer.Config()
+		return c.ConfigStorer.Config(ctx)
 	}
 
-	return c.temporal.Config()
+	return c.temporal.Config(ctx)
 }
 
 // Commit it copies the config from the temporal storage into the base storage.
-func (c *ConfigStorage) Commit() error {
+func (c *ConfigStorage) Commit(ctx context.Context) error {
 	if !c.set {
 		return nil
 	}
 
-	cfg, err := c.temporal.Config()
+	cfg, err := c.temporal.Config(ctx)
 	if err != nil {
 		return err
 	}
 
-	return c.ConfigStorer.SetConfig(cfg)
+	return c.ConfigStorer.SetConfig(ctx, cfg)
 }

--- a/storage/transactional/config_test.go
+++ b/storage/transactional/config_test.go
@@ -23,13 +23,13 @@ func (s *ConfigSuite) TestSetConfigBase() {
 	cfg.Core.Worktree = "foo"
 
 	base := memory.NewStorage()
-	err := base.SetConfig(cfg)
+	err := base.SetConfig(s.T().Context(), cfg)
 	s.NoError(err)
 
 	temporal := memory.NewStorage()
 	cs := NewConfigStorage(base, temporal)
 
-	cfg, err = cs.Config()
+	cfg, err = cs.Config(s.T().Context())
 	s.NoError(err)
 	s.Equal("foo", cfg.Core.Worktree)
 }
@@ -39,7 +39,7 @@ func (s *ConfigSuite) TestSetConfigTemporal() {
 	cfg.Core.Worktree = "foo"
 
 	base := memory.NewStorage()
-	err := base.SetConfig(cfg)
+	err := base.SetConfig(s.T().Context(), cfg)
 	s.NoError(err)
 
 	temporal := memory.NewStorage()
@@ -48,18 +48,18 @@ func (s *ConfigSuite) TestSetConfigTemporal() {
 	cfg.Core.Worktree = "bar"
 
 	cs := NewConfigStorage(base, temporal)
-	err = cs.SetConfig(cfg)
+	err = cs.SetConfig(s.T().Context(), cfg)
 	s.NoError(err)
 
-	baseCfg, err := base.Config()
+	baseCfg, err := base.Config(s.T().Context())
 	s.NoError(err)
 	s.Equal("foo", baseCfg.Core.Worktree)
 
-	temporalCfg, err := temporal.Config()
+	temporalCfg, err := temporal.Config(s.T().Context())
 	s.NoError(err)
 	s.Equal("bar", temporalCfg.Core.Worktree)
 
-	cfg, err = cs.Config()
+	cfg, err = cs.Config(s.T().Context())
 	s.NoError(err)
 	s.Equal("bar", cfg.Core.Worktree)
 }
@@ -69,7 +69,7 @@ func (s *ConfigSuite) TestCommit() {
 	cfg.Core.Worktree = "foo"
 
 	base := memory.NewStorage()
-	err := base.SetConfig(cfg)
+	err := base.SetConfig(s.T().Context(), cfg)
 	s.NoError(err)
 
 	temporal := memory.NewStorage()
@@ -78,13 +78,13 @@ func (s *ConfigSuite) TestCommit() {
 	cfg.Core.Worktree = "bar"
 
 	cs := NewConfigStorage(base, temporal)
-	err = cs.SetConfig(cfg)
+	err = cs.SetConfig(s.T().Context(), cfg)
 	s.NoError(err)
 
-	err = cs.Commit()
+	err = cs.Commit(s.T().Context())
 	s.NoError(err)
 
-	baseCfg, err := base.Config()
+	baseCfg, err := base.Config(s.T().Context())
 	s.NoError(err)
 	s.Equal("bar", baseCfg.Core.Worktree)
 }

--- a/storage/transactional/index.go
+++ b/storage/transactional/index.go
@@ -1,6 +1,8 @@
 package transactional
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 )
@@ -23,8 +25,8 @@ func NewIndexStorage(s, temporal storer.IndexStorer) *IndexStorage {
 }
 
 // SetIndex honors the storer.IndexStorer interface.
-func (s *IndexStorage) SetIndex(idx *index.Index) (err error) {
-	if err := s.temporal.SetIndex(idx); err != nil {
+func (s *IndexStorage) SetIndex(ctx context.Context, idx *index.Index) (err error) {
+	if err := s.temporal.SetIndex(ctx, idx); err != nil {
 		return err
 	}
 
@@ -33,24 +35,24 @@ func (s *IndexStorage) SetIndex(idx *index.Index) (err error) {
 }
 
 // Index honors the storer.IndexStorer interface.
-func (s *IndexStorage) Index() (*index.Index, error) {
+func (s *IndexStorage) Index(ctx context.Context) (*index.Index, error) {
 	if !s.set {
-		return s.IndexStorer.Index()
+		return s.IndexStorer.Index(ctx)
 	}
 
-	return s.temporal.Index()
+	return s.temporal.Index(ctx)
 }
 
 // Commit it copies the index from the temporal storage into the base storage.
-func (s *IndexStorage) Commit() error {
+func (s *IndexStorage) Commit(ctx context.Context) error {
 	if !s.set {
 		return nil
 	}
 
-	idx, err := s.temporal.Index()
+	idx, err := s.temporal.Index(ctx)
 	if err != nil {
 		return err
 	}
 
-	return s.IndexStorer.SetIndex(idx)
+	return s.IndexStorer.SetIndex(ctx, idx)
 }

--- a/storage/transactional/index_test.go
+++ b/storage/transactional/index_test.go
@@ -23,13 +23,13 @@ func (s *IndexSuite) TestSetIndexBase() {
 	idx.Version = 2
 
 	base := memory.NewStorage()
-	err := base.SetIndex(idx)
+	err := base.SetIndex(s.T().Context(), idx)
 	s.NoError(err)
 
 	temporal := memory.NewStorage()
 	cs := NewIndexStorage(base, temporal)
 
-	idx, err = cs.Index()
+	idx, err = cs.Index(s.T().Context())
 	s.NoError(err)
 	s.Equal(uint32(2), idx.Version)
 }
@@ -39,7 +39,7 @@ func (s *IndexSuite) TestCommit() {
 	idx.Version = 2
 
 	base := memory.NewStorage()
-	err := base.SetIndex(idx)
+	err := base.SetIndex(s.T().Context(), idx)
 	s.NoError(err)
 
 	temporal := memory.NewStorage()
@@ -48,13 +48,13 @@ func (s *IndexSuite) TestCommit() {
 	idx.Version = 3
 
 	is := NewIndexStorage(base, temporal)
-	err = is.SetIndex(idx)
+	err = is.SetIndex(s.T().Context(), idx)
 	s.NoError(err)
 
-	err = is.Commit()
+	err = is.Commit(s.T().Context())
 	s.NoError(err)
 
-	baseIndex, err := base.Index()
+	baseIndex, err := base.Index(s.T().Context())
 	s.NoError(err)
 	s.Equal(uint32(3), baseIndex.Version)
 }

--- a/storage/transactional/object.go
+++ b/storage/transactional/object.go
@@ -1,6 +1,7 @@
 package transactional
 
 import (
+	"context"
 	"errors"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -20,48 +21,48 @@ func NewObjectStorage(base, temporal storer.EncodedObjectStorer) *ObjectStorage 
 }
 
 // SetEncodedObject honors the storer.EncodedObjectStorer interface.
-func (o *ObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.Hash, error) {
-	return o.temporal.SetEncodedObject(obj)
+func (o *ObjectStorage) SetEncodedObject(ctx context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error) {
+	return o.temporal.SetEncodedObject(ctx, obj)
 }
 
 // HasEncodedObject honors the storer.EncodedObjectStorer interface.
-func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) error {
-	err := o.EncodedObjectStorer.HasEncodedObject(h)
+func (o *ObjectStorage) HasEncodedObject(ctx context.Context, h plumbing.Hash) error {
+	err := o.EncodedObjectStorer.HasEncodedObject(ctx, h)
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
-		return o.temporal.HasEncodedObject(h)
+		return o.temporal.HasEncodedObject(ctx, h)
 	}
 
 	return err
 }
 
 // EncodedObjectSize honors the storer.EncodedObjectStorer interface.
-func (o *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (int64, error) {
-	sz, err := o.EncodedObjectStorer.EncodedObjectSize(h)
+func (o *ObjectStorage) EncodedObjectSize(ctx context.Context, h plumbing.Hash) (int64, error) {
+	sz, err := o.EncodedObjectStorer.EncodedObjectSize(ctx, h)
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
-		return o.temporal.EncodedObjectSize(h)
+		return o.temporal.EncodedObjectSize(ctx, h)
 	}
 
 	return sz, err
 }
 
 // EncodedObject honors the storer.EncodedObjectStorer interface.
-func (o *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
-	obj, err := o.EncodedObjectStorer.EncodedObject(t, h)
+func (o *ObjectStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	obj, err := o.EncodedObjectStorer.EncodedObject(ctx, t, h)
 	if errors.Is(err, plumbing.ErrObjectNotFound) {
-		return o.temporal.EncodedObject(t, h)
+		return o.temporal.EncodedObject(ctx, t, h)
 	}
 
 	return obj, err
 }
 
 // IterEncodedObjects honors the storer.EncodedObjectStorer interface.
-func (o *ObjectStorage) IterEncodedObjects(t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
-	baseIter, err := o.EncodedObjectStorer.IterEncodedObjects(t)
+func (o *ObjectStorage) IterEncodedObjects(ctx context.Context, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
+	baseIter, err := o.EncodedObjectStorer.IterEncodedObjects(ctx, t)
 	if err != nil {
 		return nil, err
 	}
 
-	temporalIter, err := o.temporal.IterEncodedObjects(t)
+	temporalIter, err := o.temporal.IterEncodedObjects(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -73,19 +74,19 @@ func (o *ObjectStorage) IterEncodedObjects(t plumbing.ObjectType) (storer.Encode
 }
 
 // Commit it copies the objects of the temporal storage into the base storage.
-func (o *ObjectStorage) Commit() error {
-	iter, err := o.temporal.IterEncodedObjects(plumbing.AnyObject)
+func (o *ObjectStorage) Commit(ctx context.Context) error {
+	iter, err := o.temporal.IterEncodedObjects(ctx, plumbing.AnyObject)
 	if err != nil {
 		return err
 	}
 
-	return iter.ForEach(func(obj plumbing.EncodedObject) error {
-		_, err := o.EncodedObjectStorer.SetEncodedObject(obj)
+	return iter.ForEach(ctx, func(obj plumbing.EncodedObject) error {
+		_, err := o.EncodedObjectStorer.SetEncodedObject(ctx, obj)
 		return err
 	})
 }
 
 // AddAlternate adds an alternate object directory.
-func (o *ObjectStorage) AddAlternate(remote string) error {
-	return o.temporal.AddAlternate(remote)
+func (o *ObjectStorage) AddAlternate(ctx context.Context, remote string) error {
+	return o.temporal.AddAlternate(ctx, remote)
 }

--- a/storage/transactional/object_test.go
+++ b/storage/transactional/object_test.go
@@ -27,24 +27,24 @@ func (s *ObjectSuite) TestHasEncodedObject() {
 	commit := base.NewEncodedObject()
 	commit.SetType(plumbing.CommitObject)
 
-	ch, err := base.SetEncodedObject(commit)
+	ch, err := base.SetEncodedObject(s.T().Context(), commit)
 	s.False(ch.IsZero())
 	s.NoError(err)
 
 	tree := base.NewEncodedObject()
 	tree.SetType(plumbing.TreeObject)
 
-	th, err := os.SetEncodedObject(tree)
+	th, err := os.SetEncodedObject(s.T().Context(), tree)
 	s.False(th.IsZero())
 	s.NoError(err)
 
-	err = os.HasEncodedObject(th)
+	err = os.HasEncodedObject(s.T().Context(), th)
 	s.NoError(err)
 
-	err = os.HasEncodedObject(ch)
+	err = os.HasEncodedObject(s.T().Context(), ch)
 	s.NoError(err)
 
-	err = base.HasEncodedObject(th)
+	err = base.HasEncodedObject(s.T().Context(), th)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 }
 
@@ -57,37 +57,37 @@ func (s *ObjectSuite) TestEncodedObjectAndEncodedObjectSize() {
 	commit := base.NewEncodedObject()
 	commit.SetType(plumbing.CommitObject)
 
-	ch, err := base.SetEncodedObject(commit)
+	ch, err := base.SetEncodedObject(s.T().Context(), commit)
 	s.False(ch.IsZero())
 	s.NoError(err)
 
 	tree := base.NewEncodedObject()
 	tree.SetType(plumbing.TreeObject)
 
-	th, err := os.SetEncodedObject(tree)
+	th, err := os.SetEncodedObject(s.T().Context(), tree)
 	s.False(th.IsZero())
 	s.NoError(err)
 
-	otree, err := os.EncodedObject(plumbing.TreeObject, th)
+	otree, err := os.EncodedObject(s.T().Context(), plumbing.TreeObject, th)
 	s.NoError(err)
 	s.Equal(tree.Hash(), otree.Hash())
 
-	treeSz, err := os.EncodedObjectSize(th)
+	treeSz, err := os.EncodedObjectSize(s.T().Context(), th)
 	s.NoError(err)
 	s.Equal(int64(0), treeSz)
 
-	ocommit, err := os.EncodedObject(plumbing.CommitObject, ch)
+	ocommit, err := os.EncodedObject(s.T().Context(), plumbing.CommitObject, ch)
 	s.NoError(err)
 	s.Equal(commit.Hash(), ocommit.Hash())
 
-	commitSz, err := os.EncodedObjectSize(ch)
+	commitSz, err := os.EncodedObjectSize(s.T().Context(), ch)
 	s.NoError(err)
 	s.Equal(int64(0), commitSz)
 
-	_, err = base.EncodedObject(plumbing.TreeObject, th)
+	_, err = base.EncodedObject(s.T().Context(), plumbing.TreeObject, th)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 
-	_, err = base.EncodedObjectSize(th)
+	_, err = base.EncodedObjectSize(s.T().Context(), th)
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 }
 
@@ -100,22 +100,22 @@ func (s *ObjectSuite) TestIterEncodedObjects() {
 	commit := base.NewEncodedObject()
 	commit.SetType(plumbing.CommitObject)
 
-	ch, err := base.SetEncodedObject(commit)
+	ch, err := base.SetEncodedObject(s.T().Context(), commit)
 	s.False(ch.IsZero())
 	s.NoError(err)
 
 	tree := base.NewEncodedObject()
 	tree.SetType(plumbing.TreeObject)
 
-	th, err := os.SetEncodedObject(tree)
+	th, err := os.SetEncodedObject(s.T().Context(), tree)
 	s.False(th.IsZero())
 	s.NoError(err)
 
-	iter, err := os.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := os.IterEncodedObjects(s.T().Context(), plumbing.AnyObject)
 	s.NoError(err)
 
 	var hashes []plumbing.Hash
-	err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+	err = iter.ForEach(s.T().Context(), func(obj plumbing.EncodedObject) error {
 		hashes = append(hashes, obj.Hash())
 		return nil
 	})
@@ -135,23 +135,23 @@ func (s *ObjectSuite) TestCommit() {
 	commit := base.NewEncodedObject()
 	commit.SetType(plumbing.CommitObject)
 
-	_, err := os.SetEncodedObject(commit)
+	_, err := os.SetEncodedObject(s.T().Context(), commit)
 	s.NoError(err)
 
 	tree := base.NewEncodedObject()
 	tree.SetType(plumbing.TreeObject)
 
-	_, err = os.SetEncodedObject(tree)
+	_, err = os.SetEncodedObject(s.T().Context(), tree)
 	s.NoError(err)
 
-	err = os.Commit()
+	err = os.Commit(s.T().Context())
 	s.NoError(err)
 
-	iter, err := base.IterEncodedObjects(plumbing.AnyObject)
+	iter, err := base.IterEncodedObjects(s.T().Context(), plumbing.AnyObject)
 	s.NoError(err)
 
 	var hashes []plumbing.Hash
-	err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+	err = iter.ForEach(s.T().Context(), func(obj plumbing.EncodedObject) error {
 		hashes = append(hashes, obj.Hash())
 		return nil
 	})

--- a/storage/transactional/reference.go
+++ b/storage/transactional/reference.go
@@ -1,6 +1,8 @@
 package transactional
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
@@ -29,20 +31,20 @@ func NewReferenceStorage(base, temporal storer.ReferenceStorer) *ReferenceStorag
 }
 
 // SetReference honors the storer.ReferenceStorer interface.
-func (r *ReferenceStorage) SetReference(ref *plumbing.Reference) error {
+func (r *ReferenceStorage) SetReference(ctx context.Context, ref *plumbing.Reference) error {
 	delete(r.deleted, ref.Name())
-	return r.temporal.SetReference(ref)
+	return r.temporal.SetReference(ctx, ref)
 }
 
 // CheckAndSetReference honors the storer.ReferenceStorer interface.
-func (r *ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
+func (r *ReferenceStorage) CheckAndSetReference(ctx context.Context, ref, old *plumbing.Reference) error {
 	if old == nil {
-		return r.SetReference(ref)
+		return r.SetReference(ctx, ref)
 	}
 
-	tmp, err := r.temporal.Reference(old.Name())
+	tmp, err := r.temporal.Reference(ctx, old.Name())
 	if err == plumbing.ErrReferenceNotFound {
-		tmp, err = r.ReferenceStorer.Reference(old.Name())
+		tmp, err = r.ReferenceStorer.Reference(ctx, old.Name())
 	}
 
 	if err != nil {
@@ -53,31 +55,31 @@ func (r *ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) er
 		return storage.ErrReferenceHasChanged
 	}
 
-	return r.SetReference(ref)
+	return r.SetReference(ctx, ref)
 }
 
 // Reference honors the storer.ReferenceStorer interface.
-func (r ReferenceStorage) Reference(n plumbing.ReferenceName) (*plumbing.Reference, error) {
+func (r ReferenceStorage) Reference(ctx context.Context, n plumbing.ReferenceName) (*plumbing.Reference, error) {
 	if _, deleted := r.deleted[n]; deleted {
 		return nil, plumbing.ErrReferenceNotFound
 	}
 
-	ref, err := r.temporal.Reference(n)
+	ref, err := r.temporal.Reference(ctx, n)
 	if err == plumbing.ErrReferenceNotFound {
-		return r.ReferenceStorer.Reference(n)
+		return r.ReferenceStorer.Reference(ctx, n)
 	}
 
 	return ref, err
 }
 
 // IterReferences honors the storer.ReferenceStorer interface.
-func (r ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
-	baseIter, err := r.ReferenceStorer.IterReferences()
+func (r ReferenceStorage) IterReferences(ctx context.Context) (storer.ReferenceIter, error) {
+	baseIter, err := r.ReferenceStorer.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	temporalIter, err := r.temporal.IterReferences()
+	temporalIter, err := r.temporal.IterReferences(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -89,13 +91,13 @@ func (r ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 }
 
 // CountLooseRefs honors the storer.ReferenceStorer interface.
-func (r ReferenceStorage) CountLooseRefs() (int, error) {
-	tc, err := r.temporal.CountLooseRefs()
+func (r ReferenceStorage) CountLooseRefs(ctx context.Context) (int, error) {
+	tc, err := r.temporal.CountLooseRefs(ctx)
 	if err != nil {
 		return -1, err
 	}
 
-	bc, err := r.ReferenceStorer.CountLooseRefs()
+	bc, err := r.ReferenceStorer.CountLooseRefs(ctx)
 	if err != nil {
 		return -1, err
 	}
@@ -104,31 +106,31 @@ func (r ReferenceStorage) CountLooseRefs() (int, error) {
 }
 
 // PackRefs honors the storer.ReferenceStorer interface.
-func (r ReferenceStorage) PackRefs() error {
+func (r ReferenceStorage) PackRefs(ctx context.Context) error {
 	return nil
 }
 
 // RemoveReference honors the storer.ReferenceStorer interface.
-func (r ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
+func (r ReferenceStorage) RemoveReference(ctx context.Context, n plumbing.ReferenceName) error {
 	r.deleted[n] = struct{}{}
-	return r.temporal.RemoveReference(n)
+	return r.temporal.RemoveReference(ctx, n)
 }
 
 // Commit it copies the reference information of the temporal storage into the
 // base storage.
-func (r ReferenceStorage) Commit() error {
+func (r ReferenceStorage) Commit(ctx context.Context) error {
 	for name := range r.deleted {
-		if err := r.ReferenceStorer.RemoveReference(name); err != nil {
+		if err := r.ReferenceStorer.RemoveReference(ctx, name); err != nil {
 			return err
 		}
 	}
 
-	iter, err := r.temporal.IterReferences()
+	iter, err := r.temporal.IterReferences(ctx)
 	if err != nil {
 		return err
 	}
 
-	return iter.ForEach(func(ref *plumbing.Reference) error {
-		return r.ReferenceStorer.SetReference(ref)
+	return iter.ForEach(ctx, func(ref *plumbing.Reference) error {
+		return r.ReferenceStorer.SetReference(ctx, ref)
 	})
 }

--- a/storage/transactional/reference.go
+++ b/storage/transactional/reference.go
@@ -106,7 +106,7 @@ func (r ReferenceStorage) CountLooseRefs(ctx context.Context) (int, error) {
 }
 
 // PackRefs honors the storer.ReferenceStorer interface.
-func (r ReferenceStorage) PackRefs(ctx context.Context) error {
+func (r ReferenceStorage) PackRefs(_ context.Context) error {
 	return nil
 }
 

--- a/storage/transactional/reference_test.go
+++ b/storage/transactional/reference_test.go
@@ -27,19 +27,19 @@ func (s *ReferenceSuite) TestReference() {
 	refA := plumbing.NewReferenceFromStrings("refs/a", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	refB := plumbing.NewReferenceFromStrings("refs/b", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 
-	err := base.SetReference(refA)
+	err := base.SetReference(s.T().Context(), refA)
 	s.NoError(err)
 
-	err = rs.SetReference(refB)
+	err = rs.SetReference(s.T().Context(), refB)
 	s.NoError(err)
 
-	_, err = rs.Reference("refs/a")
+	_, err = rs.Reference(s.T().Context(), "refs/a")
 	s.NoError(err)
 
-	_, err = rs.Reference("refs/b")
+	_, err = rs.Reference(s.T().Context(), "refs/b")
 	s.NoError(err)
 
-	_, err = base.Reference("refs/b")
+	_, err = base.Reference(s.T().Context(), "refs/b")
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
@@ -50,13 +50,13 @@ func (s *ReferenceSuite) TestRemoveReferenceTemporal() {
 	ref := plumbing.NewReferenceFromStrings("refs/a", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 
 	rs := NewReferenceStorage(base, temporal)
-	err := rs.SetReference(ref)
+	err := rs.SetReference(s.T().Context(), ref)
 	s.NoError(err)
 
-	err = rs.RemoveReference("refs/a")
+	err = rs.RemoveReference(s.T().Context(), "refs/a")
 	s.NoError(err)
 
-	_, err = rs.Reference("refs/a")
+	_, err = rs.Reference(s.T().Context(), "refs/a")
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
@@ -67,13 +67,13 @@ func (s *ReferenceSuite) TestRemoveReferenceBase() {
 	ref := plumbing.NewReferenceFromStrings("refs/a", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 
 	rs := NewReferenceStorage(base, temporal)
-	err := base.SetReference(ref)
+	err := base.SetReference(s.T().Context(), ref)
 	s.NoError(err)
 
-	err = rs.RemoveReference("refs/a")
+	err = rs.RemoveReference(s.T().Context(), "refs/a")
 	s.NoError(err)
 
-	_, err = rs.Reference("refs/a")
+	_, err = rs.Reference(s.T().Context(), "refs/a")
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
@@ -82,18 +82,18 @@ func (s *ReferenceSuite) TestCheckAndSetReferenceInBase() {
 	temporal := memory.NewStorage()
 	rs := NewReferenceStorage(base, temporal)
 
-	err := base.SetReference(
+	err := base.SetReference(s.T().Context(),
 		plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 	)
 	s.NoError(err)
 
-	err = rs.CheckAndSetReference(
+	err = rs.CheckAndSetReference(s.T().Context(),
 		plumbing.NewReferenceFromStrings("foo", "bc9968d75e48de59f0870ffb71f5e160bbbdcf52"),
 		plumbing.NewReferenceFromStrings("foo", "482e0eada5de4039e6f216b45b3c9b683b83bfa"),
 	)
 	s.NoError(err)
 
-	e, err := rs.Reference(plumbing.ReferenceName("foo"))
+	e, err := rs.Reference(s.T().Context(), plumbing.ReferenceName("foo"))
 	s.NoError(err)
 	s.Equal("bc9968d75e48de59f0870ffb71f5e160bbbdcf52", e.Hash().String())
 }
@@ -107,18 +107,18 @@ func (s *ReferenceSuite) TestCommit() {
 	refC := plumbing.NewReferenceFromStrings("refs/c", "c3f4688a08fd86f1bf8e055724c84b7a40a09733")
 
 	rs := NewReferenceStorage(base, temporal)
-	s.Nil(rs.SetReference(refA))
-	s.Nil(rs.SetReference(refB))
-	s.Nil(rs.SetReference(refC))
+	s.Nil(rs.SetReference(s.T().Context(), refA))
+	s.Nil(rs.SetReference(s.T().Context(), refB))
+	s.Nil(rs.SetReference(s.T().Context(), refC))
 
-	err := rs.Commit()
+	err := rs.Commit(s.T().Context())
 	s.NoError(err)
 
-	iter, err := base.IterReferences()
+	iter, err := base.IterReferences(s.T().Context())
 	s.NoError(err)
 
 	var count int
-	iter.ForEach(func(*plumbing.Reference) error {
+	iter.ForEach(s.T().Context(), func(*plumbing.Reference) error {
 		count++
 		return nil
 	})
@@ -135,30 +135,30 @@ func (s *ReferenceSuite) TestCommitDelete() {
 	refC := plumbing.NewReferenceFromStrings("refs/c", "c3f4688a08fd86f1bf8e055724c84b7a40a09733")
 
 	rs := NewReferenceStorage(base, temporal)
-	s.Nil(base.SetReference(refA))
-	s.Nil(base.SetReference(refB))
-	s.Nil(base.SetReference(refC))
+	s.Nil(base.SetReference(s.T().Context(), refA))
+	s.Nil(base.SetReference(s.T().Context(), refB))
+	s.Nil(base.SetReference(s.T().Context(), refC))
 
-	s.Nil(rs.RemoveReference(refA.Name()))
-	s.Nil(rs.RemoveReference(refB.Name()))
-	s.Nil(rs.RemoveReference(refC.Name()))
-	s.Nil(rs.SetReference(refC))
+	s.Nil(rs.RemoveReference(s.T().Context(), refA.Name()))
+	s.Nil(rs.RemoveReference(s.T().Context(), refB.Name()))
+	s.Nil(rs.RemoveReference(s.T().Context(), refC.Name()))
+	s.Nil(rs.SetReference(s.T().Context(), refC))
 
-	err := rs.Commit()
+	err := rs.Commit(s.T().Context())
 	s.NoError(err)
 
-	iter, err := base.IterReferences()
+	iter, err := base.IterReferences(s.T().Context())
 	s.NoError(err)
 
 	var count int
-	iter.ForEach(func(*plumbing.Reference) error {
+	iter.ForEach(s.T().Context(), func(*plumbing.Reference) error {
 		count++
 		return nil
 	})
 
 	s.Equal(1, count)
 
-	ref, err := rs.Reference(refC.Name())
+	ref, err := rs.Reference(s.T().Context(), refC.Name())
 	s.NoError(err)
 	s.Equal("c3f4688a08fd86f1bf8e055724c84b7a40a09733", ref.Hash().String())
 }

--- a/storage/transactional/reflog.go
+++ b/storage/transactional/reflog.go
@@ -1,6 +1,8 @@
 package transactional
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/reflog"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -31,7 +33,7 @@ func NewReflogStorage(base, temporal storer.ReflogStorer) *ReflogStorage {
 // Reflog honors the storer.ReflogStorer interface.
 // Returns base entries followed by temporal entries. If the reflog was
 // deleted during this transaction, only temporal entries (if any) are returned.
-func (s *ReflogStorage) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, error) {
+func (s *ReflogStorage) Reflog(ctx context.Context, name plumbing.ReferenceName) ([]*reflog.Entry, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -39,13 +41,13 @@ func (s *ReflogStorage) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, er
 	var base []*reflog.Entry
 	if _, ok := s.deleted[name]; !ok {
 		var err error
-		base, err = s.base.Reflog(name)
+		base, err = s.base.Reflog(ctx, name)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	temporal, err := s.temporal.Reflog(name)
+	temporal, err := s.temporal.Reflog(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -64,43 +66,43 @@ func (s *ReflogStorage) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, er
 }
 
 // AppendReflog honors the storer.ReflogStorer interface.
-func (s *ReflogStorage) AppendReflog(name plumbing.ReferenceName, entry *reflog.Entry) error {
+func (s *ReflogStorage) AppendReflog(ctx context.Context, name plumbing.ReferenceName, entry *reflog.Entry) error {
 	if s == nil {
 		return nil
 	}
 	s.appended[name] = struct{}{}
-	return s.temporal.AppendReflog(name, entry)
+	return s.temporal.AppendReflog(ctx, name, entry)
 }
 
 // DeleteReflog honors the storer.ReflogStorer interface.
-func (s *ReflogStorage) DeleteReflog(name plumbing.ReferenceName) error {
+func (s *ReflogStorage) DeleteReflog(ctx context.Context, name plumbing.ReferenceName) error {
 	if s == nil {
 		return nil
 	}
 	delete(s.appended, name)
 	s.deleted[name] = struct{}{}
-	return s.temporal.DeleteReflog(name)
+	return s.temporal.DeleteReflog(ctx, name)
 }
 
 // Commit flushes the transactional reflog changes into the base storage.
-func (s *ReflogStorage) Commit() error {
+func (s *ReflogStorage) Commit(ctx context.Context) error {
 	if s == nil {
 		return nil
 	}
 
 	for name := range s.deleted {
-		if err := s.base.DeleteReflog(name); err != nil {
+		if err := s.base.DeleteReflog(ctx, name); err != nil {
 			return err
 		}
 	}
 
 	for name := range s.appended {
-		entries, err := s.temporal.Reflog(name)
+		entries, err := s.temporal.Reflog(ctx, name)
 		if err != nil {
 			return err
 		}
 		for _, e := range entries {
-			if err := s.base.AppendReflog(name, e); err != nil {
+			if err := s.base.AppendReflog(ctx, name, e); err != nil {
 				return err
 			}
 		}

--- a/storage/transactional/reflog_test.go
+++ b/storage/transactional/reflog_test.go
@@ -1,6 +1,7 @@
 package transactional
 
 import (
+	"context"
 	"io"
 	"testing"
 	"time"
@@ -33,88 +34,88 @@ func (s noReflogStorage) NewEncodedObject() plumbing.EncodedObject {
 	return s.sto.NewEncodedObject()
 }
 
-func (s noReflogStorage) RawObjectWriter(typ plumbing.ObjectType, sz int64) (io.WriteCloser, error) {
-	return s.sto.RawObjectWriter(typ, sz)
+func (s noReflogStorage) RawObjectWriter(ctx context.Context, typ plumbing.ObjectType, sz int64) (io.WriteCloser, error) {
+	return s.sto.RawObjectWriter(ctx, typ, sz)
 }
 
-func (s noReflogStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.Hash, error) {
-	return s.sto.SetEncodedObject(obj)
+func (s noReflogStorage) SetEncodedObject(ctx context.Context, obj plumbing.EncodedObject) (plumbing.Hash, error) {
+	return s.sto.SetEncodedObject(ctx, obj)
 }
 
-func (s noReflogStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
-	return s.sto.EncodedObject(t, h)
+func (s noReflogStorage) EncodedObject(ctx context.Context, t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	return s.sto.EncodedObject(ctx, t, h)
 }
 
-func (s noReflogStorage) EncodedObjectSize(h plumbing.Hash) (int64, error) {
-	return s.sto.EncodedObjectSize(h)
+func (s noReflogStorage) EncodedObjectSize(ctx context.Context, h plumbing.Hash) (int64, error) {
+	return s.sto.EncodedObjectSize(ctx, h)
 }
 
-func (s noReflogStorage) AddAlternate(remote string) error {
-	return s.sto.AddAlternate(remote)
+func (s noReflogStorage) AddAlternate(ctx context.Context, remote string) error {
+	return s.sto.AddAlternate(ctx, remote)
 }
 
-func (s noReflogStorage) HasEncodedObject(h plumbing.Hash) error {
-	return s.sto.HasEncodedObject(h)
+func (s noReflogStorage) HasEncodedObject(ctx context.Context, h plumbing.Hash) error {
+	return s.sto.HasEncodedObject(ctx, h)
 }
 
-func (s noReflogStorage) IterEncodedObjects(t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
-	return s.sto.IterEncodedObjects(t)
+func (s noReflogStorage) IterEncodedObjects(ctx context.Context, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
+	return s.sto.IterEncodedObjects(ctx, t)
 }
 
-func (s noReflogStorage) SetReference(ref *plumbing.Reference) error {
-	return s.sto.SetReference(ref)
+func (s noReflogStorage) SetReference(ctx context.Context, ref *plumbing.Reference) error {
+	return s.sto.SetReference(ctx, ref)
 }
 
-func (s noReflogStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
-	return s.sto.CheckAndSetReference(ref, old)
+func (s noReflogStorage) CheckAndSetReference(ctx context.Context, ref, old *plumbing.Reference) error {
+	return s.sto.CheckAndSetReference(ctx, ref, old)
 }
 
-func (s noReflogStorage) Reference(name plumbing.ReferenceName) (*plumbing.Reference, error) {
-	return s.sto.Reference(name)
+func (s noReflogStorage) Reference(ctx context.Context, name plumbing.ReferenceName) (*plumbing.Reference, error) {
+	return s.sto.Reference(ctx, name)
 }
 
-func (s noReflogStorage) IterReferences() (storer.ReferenceIter, error) {
-	return s.sto.IterReferences()
+func (s noReflogStorage) IterReferences(ctx context.Context) (storer.ReferenceIter, error) {
+	return s.sto.IterReferences(ctx)
 }
 
-func (s noReflogStorage) CountLooseRefs() (int, error) {
-	return s.sto.CountLooseRefs()
+func (s noReflogStorage) CountLooseRefs(ctx context.Context) (int, error) {
+	return s.sto.CountLooseRefs(ctx)
 }
 
-func (s noReflogStorage) PackRefs() error {
-	return s.sto.PackRefs()
+func (s noReflogStorage) PackRefs(ctx context.Context) error {
+	return s.sto.PackRefs(ctx)
 }
 
-func (s noReflogStorage) RemoveReference(name plumbing.ReferenceName) error {
-	return s.sto.RemoveReference(name)
+func (s noReflogStorage) RemoveReference(ctx context.Context, name plumbing.ReferenceName) error {
+	return s.sto.RemoveReference(ctx, name)
 }
 
-func (s noReflogStorage) SetIndex(idx *index.Index) error {
-	return s.sto.SetIndex(idx)
+func (s noReflogStorage) SetIndex(ctx context.Context, idx *index.Index) error {
+	return s.sto.SetIndex(ctx, idx)
 }
 
-func (s noReflogStorage) Index() (*index.Index, error) {
-	return s.sto.Index()
+func (s noReflogStorage) Index(ctx context.Context) (*index.Index, error) {
+	return s.sto.Index(ctx)
 }
 
-func (s noReflogStorage) SetShallow(commits []plumbing.Hash) error {
-	return s.sto.SetShallow(commits)
+func (s noReflogStorage) SetShallow(ctx context.Context, commits []plumbing.Hash) error {
+	return s.sto.SetShallow(ctx, commits)
 }
 
-func (s noReflogStorage) Shallow() ([]plumbing.Hash, error) {
-	return s.sto.Shallow()
+func (s noReflogStorage) Shallow(ctx context.Context) ([]plumbing.Hash, error) {
+	return s.sto.Shallow(ctx)
 }
 
-func (s noReflogStorage) SetConfig(cfg *config.Config) error {
-	return s.sto.SetConfig(cfg)
+func (s noReflogStorage) SetConfig(ctx context.Context, cfg *config.Config) error {
+	return s.sto.SetConfig(ctx, cfg)
 }
 
-func (s noReflogStorage) Config() (*config.Config, error) {
-	return s.sto.Config()
+func (s noReflogStorage) Config(ctx context.Context) (*config.Config, error) {
+	return s.sto.Config(ctx)
 }
 
-func (s noReflogStorage) Module(name string) (storage.Storer, error) {
-	return s.sto.Module(name)
+func (s noReflogStorage) Module(ctx context.Context, name string) (storage.Storer, error) {
+	return s.sto.Module(ctx, name)
 }
 
 func newEntry(msg string) *reflog.Entry {
@@ -138,12 +139,12 @@ func (s *ReflogSuite) TestReflogReadsMergeBaseAndTemporal() {
 	rs := NewReflogStorage(base, temporal)
 
 	baseEntry := newEntry("commit: base")
-	s.NoError(base.AppendReflog(testRef, baseEntry))
+	s.NoError(base.AppendReflog(s.T().Context(), testRef, baseEntry))
 
 	tempEntry := newEntry("commit: temporal")
-	s.NoError(rs.AppendReflog(testRef, tempEntry))
+	s.NoError(rs.AppendReflog(s.T().Context(), testRef, tempEntry))
 
-	entries, err := rs.Reflog(testRef)
+	entries, err := rs.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Len(entries, 2)
 	s.Equal("commit: base", entries[0].Message)
@@ -155,9 +156,9 @@ func (s *ReflogSuite) TestReflogBaseOnly() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	s.NoError(base.AppendReflog(testRef, newEntry("commit: base")))
+	s.NoError(base.AppendReflog(s.T().Context(), testRef, newEntry("commit: base")))
 
-	entries, err := rs.Reflog(testRef)
+	entries, err := rs.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Len(entries, 1)
 	s.Equal("commit: base", entries[0].Message)
@@ -168,9 +169,9 @@ func (s *ReflogSuite) TestReflogTemporalOnly() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	s.NoError(rs.AppendReflog(testRef, newEntry("commit: temporal")))
+	s.NoError(rs.AppendReflog(s.T().Context(), testRef, newEntry("commit: temporal")))
 
-	entries, err := rs.Reflog(testRef)
+	entries, err := rs.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Len(entries, 1)
 	s.Equal("commit: temporal", entries[0].Message)
@@ -181,7 +182,7 @@ func (s *ReflogSuite) TestReflogEmpty() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	entries, err := rs.Reflog(testRef)
+	entries, err := rs.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Empty(entries)
 }
@@ -191,10 +192,10 @@ func (s *ReflogSuite) TestDeleteHidesBase() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	s.NoError(base.AppendReflog(testRef, newEntry("commit: base")))
-	s.NoError(rs.DeleteReflog(testRef))
+	s.NoError(base.AppendReflog(s.T().Context(), testRef, newEntry("commit: base")))
+	s.NoError(rs.DeleteReflog(s.T().Context(), testRef))
 
-	entries, err := rs.Reflog(testRef)
+	entries, err := rs.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Empty(entries)
 }
@@ -204,11 +205,11 @@ func (s *ReflogSuite) TestDeleteThenAppend() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	s.NoError(base.AppendReflog(testRef, newEntry("commit: old")))
-	s.NoError(rs.DeleteReflog(testRef))
-	s.NoError(rs.AppendReflog(testRef, newEntry("commit: new")))
+	s.NoError(base.AppendReflog(s.T().Context(), testRef, newEntry("commit: old")))
+	s.NoError(rs.DeleteReflog(s.T().Context(), testRef))
+	s.NoError(rs.AppendReflog(s.T().Context(), testRef, newEntry("commit: new")))
 
-	entries, err := rs.Reflog(testRef)
+	entries, err := rs.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Len(entries, 1)
 	s.Equal("commit: new", entries[0].Message)
@@ -219,12 +220,12 @@ func (s *ReflogSuite) TestCommitFlushesAppends() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	s.NoError(base.AppendReflog(testRef, newEntry("commit: base")))
-	s.NoError(rs.AppendReflog(testRef, newEntry("commit: temporal")))
-	s.NoError(rs.Commit())
+	s.NoError(base.AppendReflog(s.T().Context(), testRef, newEntry("commit: base")))
+	s.NoError(rs.AppendReflog(s.T().Context(), testRef, newEntry("commit: temporal")))
+	s.NoError(rs.Commit(s.T().Context()))
 
 	// Base should now have both entries.
-	entries, err := base.Reflog(testRef)
+	entries, err := base.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Len(entries, 2)
 	s.Equal("commit: base", entries[0].Message)
@@ -236,12 +237,12 @@ func (s *ReflogSuite) TestCommitFlushesDeletes() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	s.NoError(base.AppendReflog(testRef, newEntry("commit: base")))
-	s.NoError(rs.DeleteReflog(testRef))
-	s.NoError(rs.Commit())
+	s.NoError(base.AppendReflog(s.T().Context(), testRef, newEntry("commit: base")))
+	s.NoError(rs.DeleteReflog(s.T().Context(), testRef))
+	s.NoError(rs.Commit(s.T().Context()))
 
 	// Base should be empty for this ref.
-	entries, err := base.Reflog(testRef)
+	entries, err := base.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Empty(entries)
 }
@@ -251,13 +252,13 @@ func (s *ReflogSuite) TestCommitDeleteThenAppend() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	s.NoError(base.AppendReflog(testRef, newEntry("commit: old")))
-	s.NoError(rs.DeleteReflog(testRef))
-	s.NoError(rs.AppendReflog(testRef, newEntry("commit: new")))
-	s.NoError(rs.Commit())
+	s.NoError(base.AppendReflog(s.T().Context(), testRef, newEntry("commit: old")))
+	s.NoError(rs.DeleteReflog(s.T().Context(), testRef))
+	s.NoError(rs.AppendReflog(s.T().Context(), testRef, newEntry("commit: new")))
+	s.NoError(rs.Commit(s.T().Context()))
 
 	// Base should have only the new entry (old was deleted).
-	entries, err := base.Reflog(testRef)
+	entries, err := base.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Len(entries, 1)
 	s.Equal("commit: new", entries[0].Message)
@@ -268,10 +269,10 @@ func (s *ReflogSuite) TestBaseUntouchedBeforeCommit() {
 	temporal := memory.NewStorage()
 	rs := NewReflogStorage(base, temporal)
 
-	s.NoError(rs.AppendReflog(testRef, newEntry("commit: temporal")))
+	s.NoError(rs.AppendReflog(s.T().Context(), testRef, newEntry("commit: temporal")))
 
 	// Base should be unaffected before Commit.
-	entries, err := base.Reflog(testRef)
+	entries, err := base.Reflog(s.T().Context(), testRef)
 	s.NoError(err)
 	s.Empty(entries)
 }
@@ -287,7 +288,7 @@ func (s *ReflogSuite) TestTransactionalStorageDoesNotExposeReflogWithoutSupport(
 		}
 	}()
 	_, ok := st.(interface {
-		Reflog(plumbing.ReferenceName) ([]*reflog.Entry, error)
+		Reflog(context.Context, plumbing.ReferenceName) ([]*reflog.Entry, error)
 	})
 	s.False(ok)
 }

--- a/storage/transactional/shallow.go
+++ b/storage/transactional/shallow.go
@@ -1,6 +1,8 @@
 package transactional
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 )
@@ -21,13 +23,13 @@ func NewShallowStorage(base, temporal storer.ShallowStorer) *ShallowStorage {
 }
 
 // SetShallow honors the storer.ShallowStorer interface.
-func (s *ShallowStorage) SetShallow(commits []plumbing.Hash) error {
-	return s.temporal.SetShallow(commits)
+func (s *ShallowStorage) SetShallow(ctx context.Context, commits []plumbing.Hash) error {
+	return s.temporal.SetShallow(ctx, commits)
 }
 
 // Shallow honors the storer.ShallowStorer interface.
-func (s *ShallowStorage) Shallow() ([]plumbing.Hash, error) {
-	shallow, err := s.temporal.Shallow()
+func (s *ShallowStorage) Shallow(ctx context.Context) ([]plumbing.Hash, error) {
+	shallow, err := s.temporal.Shallow(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -36,16 +38,16 @@ func (s *ShallowStorage) Shallow() ([]plumbing.Hash, error) {
 		return shallow, nil
 	}
 
-	return s.ShallowStorer.Shallow()
+	return s.ShallowStorer.Shallow(ctx)
 }
 
 // Commit it copies the shallow information of the temporal storage into the
 // base storage.
-func (s *ShallowStorage) Commit() error {
-	commits, err := s.temporal.Shallow()
+func (s *ShallowStorage) Commit(ctx context.Context) error {
+	commits, err := s.temporal.Shallow(ctx)
 	if err != nil || len(commits) == 0 {
 		return err
 	}
 
-	return s.ShallowStorer.SetShallow(commits)
+	return s.ShallowStorer.SetShallow(ctx, commits)
 }

--- a/storage/transactional/shallow_test.go
+++ b/storage/transactional/shallow_test.go
@@ -27,18 +27,18 @@ func (s *ShallowSuite) TestShallow() {
 	commitA := plumbing.NewHash("bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	commitB := plumbing.NewHash("aa9968d75e48de59f0870ffb71f5e160bbbdcf52")
 
-	err := base.SetShallow([]plumbing.Hash{commitA})
+	err := base.SetShallow(s.T().Context(), []plumbing.Hash{commitA})
 	s.NoError(err)
 
-	err = rs.SetShallow([]plumbing.Hash{commitB})
+	err = rs.SetShallow(s.T().Context(), []plumbing.Hash{commitB})
 	s.NoError(err)
 
-	commits, err := rs.Shallow()
+	commits, err := rs.Shallow(s.T().Context())
 	s.NoError(err)
 	s.Len(commits, 1)
 	s.Equal(commitB, commits[0])
 
-	commits, err = base.Shallow()
+	commits, err = base.Shallow(s.T().Context())
 	s.NoError(err)
 	s.Len(commits, 1)
 	s.Equal(commitA, commits[0])
@@ -53,17 +53,17 @@ func (s *ShallowSuite) TestCommit() {
 	commitA := plumbing.NewHash("bc9968d75e48de59f0870ffb71f5e160bbbdcf52")
 	commitB := plumbing.NewHash("aa9968d75e48de59f0870ffb71f5e160bbbdcf52")
 
-	s.Nil(base.SetShallow([]plumbing.Hash{commitA}))
-	s.Nil(rs.SetShallow([]plumbing.Hash{commitB}))
+	s.Nil(base.SetShallow(s.T().Context(), []plumbing.Hash{commitA}))
+	s.Nil(rs.SetShallow(s.T().Context(), []plumbing.Hash{commitB}))
 
-	s.Nil(rs.Commit())
+	s.Nil(rs.Commit(s.T().Context()))
 
-	commits, err := rs.Shallow()
+	commits, err := rs.Shallow(s.T().Context())
 	s.NoError(err)
 	s.Len(commits, 1)
 	s.Equal(commitB, commits[0])
 
-	commits, err = base.Shallow()
+	commits, err = base.Shallow(s.T().Context())
 	s.NoError(err)
 	s.Len(commits, 1)
 	s.Equal(commitB, commits[0])

--- a/storage/transactional/storage.go
+++ b/storage/transactional/storage.go
@@ -1,6 +1,7 @@
 package transactional
 
 import (
+	"context"
 	"io"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -17,7 +18,7 @@ import (
 // not considered stable nor production ready.
 type Storage interface {
 	storage.Storer
-	Commit() error
+	Commit(ctx context.Context) error
 }
 
 // basic implements the Storage interface.
@@ -92,13 +93,13 @@ func NewStorage(base, temporal storage.Storer) Storage {
 }
 
 // Module it honors the storage.ModuleStorer interface.
-func (s *basic) Module(name string) (storage.Storer, error) {
-	base, err := s.s.Module(name)
+func (s *basic) Module(ctx context.Context, name string) (storage.Storer, error) {
+	base, err := s.s.Module(ctx, name)
 	if err != nil {
 		return nil, err
 	}
 
-	temporal, err := s.temporal.Module(name)
+	temporal, err := s.temporal.Module(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -107,21 +108,23 @@ func (s *basic) Module(name string) (storage.Storer, error) {
 }
 
 // Commit it copies the content of the temporal storage into the base storage.
-func (s *basic) Commit() error {
-	for _, c := range []interface{ Commit() error }{
+func (s *basic) Commit(ctx context.Context) error {
+	for _, c := range []interface {
+		Commit(ctx context.Context) error
+	}{
 		s.ObjectStorage,
 		s.ReferenceStorage,
 		s.IndexStorage,
 		s.ShallowStorage,
 		s.ConfigStorage,
 	} {
-		if err := c.Commit(); err != nil {
+		if err := c.Commit(ctx); err != nil {
 			return err
 		}
 	}
 
 	if s.reflog != nil {
-		if err := s.reflog.Commit(); err != nil {
+		if err := s.reflog.Commit(ctx); err != nil {
 			return err
 		}
 	}
@@ -144,23 +147,23 @@ func (s *basic) Close() error {
 }
 
 // PackfileWriter honors storage.PackfileWriter.
-func (s *packageWriter) PackfileWriter() (io.WriteCloser, error) {
-	return s.pw.PackfileWriter()
+func (s *packageWriter) PackfileWriter(ctx context.Context) (io.WriteCloser, error) {
+	return s.pw.PackfileWriter(ctx)
 }
 
-func (s *reflogBasic) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, error) {
-	return s.reflog.Reflog(name)
+func (s *reflogBasic) Reflog(ctx context.Context, name plumbing.ReferenceName) ([]*reflog.Entry, error) {
+	return s.reflog.Reflog(ctx, name)
 }
 
-func (s *reflogBasic) AppendReflog(name plumbing.ReferenceName, entry *reflog.Entry) error {
-	return s.reflog.AppendReflog(name, entry)
+func (s *reflogBasic) AppendReflog(ctx context.Context, name plumbing.ReferenceName, entry *reflog.Entry) error {
+	return s.reflog.AppendReflog(ctx, name, entry)
 }
 
-func (s *reflogBasic) DeleteReflog(name plumbing.ReferenceName) error {
-	return s.reflog.DeleteReflog(name)
+func (s *reflogBasic) DeleteReflog(ctx context.Context, name plumbing.ReferenceName) error {
+	return s.reflog.DeleteReflog(ctx, name)
 }
 
 // PackfileWriter honors storer.PackfileWriter.
-func (s *reflogPackageWriter) PackfileWriter() (io.WriteCloser, error) {
-	return s.pw.PackfileWriter()
+func (s *reflogPackageWriter) PackfileWriter(ctx context.Context) (io.WriteCloser, error) {
+	return s.pw.PackfileWriter(ctx)
 }

--- a/storage/transactional/storage_test.go
+++ b/storage/transactional/storage_test.go
@@ -30,20 +30,20 @@ func TestCommit(t *testing.T) {
 	commit := base.NewEncodedObject()
 	commit.SetType(plumbing.CommitObject)
 
-	_, err := st.SetEncodedObject(commit)
+	_, err := st.SetEncodedObject(t.Context(), commit)
 	require.NoError(t, err)
 
 	ref := plumbing.NewHashReference("refs/a", commit.Hash())
-	require.NoError(t, st.SetReference(ref))
+	require.NoError(t, st.SetReference(t.Context(), ref))
 
-	err = st.Commit()
+	err = st.Commit(t.Context())
 	require.NoError(t, err)
 
-	ref, err = base.Reference(ref.Name())
+	ref, err = base.Reference(t.Context(), ref.Name())
 	require.NoError(t, err)
 	assert.Equal(t, commit.Hash(), ref.Hash())
 
-	obj, err := base.EncodedObject(plumbing.AnyObject, commit.Hash())
+	obj, err := base.EncodedObject(t.Context(), plumbing.AnyObject, commit.Hash())
 	require.NoError(t, err)
 	assert.Equal(t, commit.Hash(), obj.Hash())
 }

--- a/submodule.go
+++ b/submodule.go
@@ -40,8 +40,8 @@ func (s *Submodule) Config() *config.Submodule {
 
 // Init initialize the submodule reading the recorded Entry in the index for
 // the given submodule
-func (s *Submodule) Init() error {
-	cfg, err := s.w.r.Config()
+func (s *Submodule) Init(ctx context.Context) error {
+	cfg, err := s.w.r.Config(ctx)
 	if err != nil {
 		return err
 	}
@@ -54,20 +54,20 @@ func (s *Submodule) Init() error {
 	s.initialized = true
 
 	cfg.Submodules[s.c.Name] = s.c
-	return s.w.r.Storer.SetConfig(cfg)
+	return s.w.r.Storer.SetConfig(ctx, cfg)
 }
 
 // Status returns the status of the submodule.
-func (s *Submodule) Status() (*SubmoduleStatus, error) {
-	idx, err := s.w.r.Storer.Index()
+func (s *Submodule) Status(ctx context.Context) (*SubmoduleStatus, error) {
+	idx, err := s.w.r.Storer.Index(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.status(idx)
+	return s.status(ctx, idx)
 }
 
-func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
+func (s *Submodule) status(ctx context.Context, idx *index.Index) (*SubmoduleStatus, error) {
 	status := &SubmoduleStatus{
 		Path: s.c.Path,
 	}
@@ -85,13 +85,13 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 		return status, nil
 	}
 
-	r, err := s.Repository()
+	r, err := s.Repository(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = r.Close() }()
 
-	head, err := r.Head()
+	head, err := r.Head(ctx)
 	if err == nil {
 		status.Current = head.Hash()
 	}
@@ -104,17 +104,17 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 }
 
 // Repository returns the Repository represented by this submodule
-func (s *Submodule) Repository() (*Repository, error) {
+func (s *Submodule) Repository(ctx context.Context) (*Repository, error) {
 	if !s.initialized {
 		return nil, ErrSubmoduleNotInitialized
 	}
 
-	storer, err := s.w.r.Storer.Module(s.c.Name)
+	storer, err := s.w.r.Storer.Module(ctx, s.c.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = storer.Reference(plumbing.HEAD)
+	_, err = storer.Reference(ctx, plumbing.HEAD)
 	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return nil, err
 	}
@@ -140,10 +140,10 @@ func (s *Submodule) Repository() (*Repository, error) {
 	}
 
 	if exists {
-		return Open(storer, worktree)
+		return Open(ctx, storer, worktree)
 	}
 
-	r, err := Init(storer, WithWorkTree(worktree))
+	r, err := Init(ctx, storer, WithWorkTree(worktree))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 	}
 
 	if !path.IsAbs(moduleEndpoint.Path) && !filepath.IsAbs(moduleEndpoint.Path) && moduleEndpoint.Scheme == "file" {
-		base, err := defaultRemote(s.w.r)
+		base, err := defaultRemote(ctx, s.w.r)
 		if err != nil {
 			_ = r.Close()
 			return nil, fmt.Errorf("resolving relative submodule URL: %w", err)
@@ -171,7 +171,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 		*moduleEndpoint = *rootEndpoint
 	}
 
-	_, err = r.CreateRemote(&config.RemoteConfig{
+	_, err = r.CreateRemote(ctx, &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{moduleEndpoint.String()},
 	})
@@ -195,13 +195,13 @@ func (s *Submodule) Repository() (*Repository, error) {
 // Each rule falls through unconditionally: a branch lookup that
 // finds the branch but with an empty Remote does not short-circuit
 // rule (2). Returns an error when the chosen remote is not configured.
-func defaultRemote(r *Repository) (*config.RemoteConfig, error) {
-	cfg, err := r.Config()
+func defaultRemote(ctx context.Context, r *Repository) (*config.RemoteConfig, error) {
+	cfg, err := r.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if ref, err := r.Reference(plumbing.HEAD, false); err == nil &&
+	if ref, err := r.Reference(ctx, plumbing.HEAD, false); err == nil &&
 		ref.Type() == plumbing.SymbolicReference &&
 		ref.Target().IsBranch() {
 		if b, ok := cfg.Branches[ref.Target().Short()]; ok && b.Remote != "" {
@@ -231,19 +231,11 @@ func lookupRemote(cfg *config.Config, name string) (*config.RemoteConfig, error)
 
 // Update the registered submodule to match what the superproject expects, the
 // submodule should be initialized first calling the Init method or setting in
-// the options SubmoduleUpdateOptions.Init equals true
-func (s *Submodule) Update(o *SubmoduleUpdateOptions) error {
-	return s.UpdateContext(context.Background(), o)
-}
-
-// UpdateContext the registered submodule to match what the superproject
-// expects, the submodule should be initialized first calling the Init method or
-// setting in the options SubmoduleUpdateOptions.Init equals true.
+// the options SubmoduleUpdateOptions.Init equals true.
 //
 // The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func (s *Submodule) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions) error {
+// operation is complete, an error is returned.
+func (s *Submodule) Update(ctx context.Context, o *SubmoduleUpdateOptions) error {
 	return s.update(ctx, o, plumbing.ZeroHash)
 }
 
@@ -253,12 +245,12 @@ func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, force
 	}
 
 	if !s.initialized && o.Init {
-		if err := s.Init(); err != nil {
+		if err := s.Init(ctx); err != nil {
 			return err
 		}
 	}
 
-	idx, err := s.w.r.Storer.Index()
+	idx, err := s.w.r.Storer.Index(ctx)
 	if err != nil {
 		return err
 	}
@@ -273,7 +265,7 @@ func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, force
 		hash = e.Hash
 	}
 
-	r, err := s.Repository()
+	r, err := s.Repository(ctx)
 	if err != nil {
 		return err
 	}
@@ -291,12 +283,12 @@ func (s *Submodule) doRecursiveUpdate(ctx context.Context, r *Repository, o *Sub
 		return nil
 	}
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	if err != nil {
 		return err
 	}
 
-	l, err := w.Submodules()
+	l, err := w.Submodules(ctx)
 	if err != nil {
 		return err
 	}
@@ -305,20 +297,20 @@ func (s *Submodule) doRecursiveUpdate(ctx context.Context, r *Repository, o *Sub
 	*opts = *o
 
 	opts.RecurseSubmodules--
-	return l.UpdateContext(ctx, opts)
+	return l.Update(ctx, opts)
 }
 
 func (s *Submodule) fetchAndCheckout(
 	ctx context.Context, r *Repository, o *SubmoduleUpdateOptions, hash plumbing.Hash,
 ) error {
 	if !o.NoFetch {
-		err := r.FetchContext(ctx, &FetchOptions{ClientOptions: o.ClientOptions, Depth: o.Depth})
+		err := r.Fetch(ctx, &FetchOptions{ClientOptions: o.ClientOptions, Depth: o.Depth})
 		if err != nil && !errors.Is(err, NoErrAlreadyUpToDate) {
 			return err
 		}
 	}
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(ctx)
 	if err != nil {
 		return err
 	}
@@ -328,10 +320,10 @@ func (s *Submodule) fetchAndCheckout(
 	//
 	// [1]: https://git-scm.com/docs/protocol-capabilities#_allow_reachable_sha1_in_want
 	if !o.NoFetch {
-		if _, err := w.r.Object(plumbing.AnyObject, hash); err != nil {
+		if _, err := w.r.Object(ctx, plumbing.AnyObject, hash); err != nil {
 			refSpec := config.RefSpec("+" + hash.String() + ":" + hash.String())
 
-			err := r.FetchContext(ctx, &FetchOptions{
+			err := r.Fetch(ctx, &FetchOptions{
 				ClientOptions: o.ClientOptions,
 				RefSpecs:      []config.RefSpec{refSpec},
 				Depth:         o.Depth,
@@ -342,21 +334,21 @@ func (s *Submodule) fetchAndCheckout(
 		}
 	}
 
-	if err := w.Checkout(&CheckoutOptions{Hash: hash}); err != nil {
+	if err := w.Checkout(ctx, &CheckoutOptions{Hash: hash}); err != nil {
 		return err
 	}
 
 	head := plumbing.NewHashReference(plumbing.HEAD, hash)
-	return r.Storer.SetReference(head)
+	return r.Storer.SetReference(ctx, head)
 }
 
 // Submodules list of several submodules from the same repository.
 type Submodules []*Submodule
 
 // Init initializes the submodules in this list.
-func (s Submodules) Init() error {
+func (s Submodules) Init(ctx context.Context) error {
 	for _, sub := range s {
-		if err := sub.Init(); err != nil {
+		if err := sub.Init(ctx); err != nil {
 			return err
 		}
 	}
@@ -365,18 +357,12 @@ func (s Submodules) Init() error {
 }
 
 // Update updates all the submodules in this list.
-func (s Submodules) Update(o *SubmoduleUpdateOptions) error {
-	return s.UpdateContext(context.Background(), o)
-}
-
-// UpdateContext updates all the submodules in this list.
 //
 // The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func (s Submodules) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions) error {
+// operation is complete, an error is returned.
+func (s Submodules) Update(ctx context.Context, o *SubmoduleUpdateOptions) error {
 	for _, sub := range s {
-		if err := sub.UpdateContext(ctx, o); err != nil {
+		if err := sub.Update(ctx, o); err != nil {
 			return err
 		}
 	}
@@ -385,7 +371,7 @@ func (s Submodules) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions
 }
 
 // Status returns the status of the submodules.
-func (s Submodules) Status() (SubmodulesStatus, error) {
+func (s Submodules) Status(ctx context.Context) (SubmodulesStatus, error) {
 	var list SubmodulesStatus
 
 	var r *Repository
@@ -394,12 +380,12 @@ func (s Submodules) Status() (SubmodulesStatus, error) {
 			r = sub.w.r
 		}
 
-		idx, err := r.Storer.Index()
+		idx, err := r.Storer.Index(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		status, err := sub.status(idx)
+		status, err := sub.status(ctx, idx)
 		if err != nil {
 			return nil, err
 		}

--- a/submodule_config_test.go
+++ b/submodule_config_test.go
@@ -21,20 +21,20 @@ func TestSubmoduleRepositoryConfigIsIndependentFromParent(t *testing.T) {
 		r, wt := cloneFixture(t, f)
 		defer func() { _ = r.Close() }()
 
-		cfg, err := r.Config()
+		cfg, err := r.Config(t.Context())
 		require.NoError(t, err)
 		cfg.User.Name = "repo-user"
 		cfg.User.Email = "repo@example.com"
-		require.NoError(t, r.SetConfig(cfg))
+		require.NoError(t, r.SetConfig(t.Context(), cfg))
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
-		require.NoError(t, sm.Init())
+		require.NoError(t, sm.Init(t.Context()))
 
-		subRepo, err := sm.Repository()
+		subRepo, err := sm.Repository(t.Context())
 		require.NoError(t, err)
 		defer subRepo.Close()
 
-		subCfg, err := subRepo.Config()
+		subCfg, err := subRepo.Config(t.Context())
 		require.NoError(t, err)
 		assert.Empty(t, subCfg.User.Name)
 		assert.Empty(t, subCfg.User.Email)
@@ -51,20 +51,20 @@ func TestSubmoduleRepositoryConfigPersistsObjectFormatOnReopen(t *testing.T) {
 		defer func() { _ = r.Close() }()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
-		require.NoError(t, sm.Init())
+		require.NoError(t, sm.Init(t.Context()))
 
-		subRepo, err := sm.Repository()
+		subRepo, err := sm.Repository(t.Context())
 		require.NoError(t, err)
 
-		cfg, err := subRepo.Config()
+		cfg, err := subRepo.Config(t.Context())
 		require.NoError(t, err)
 		require.NoError(t, subRepo.Close())
 
-		reopened, err := sm.Repository()
+		reopened, err := sm.Repository(t.Context())
 		require.NoError(t, err)
 		defer reopened.Close()
 
-		reopenedCfg, err := reopened.Config()
+		reopenedCfg, err := reopened.Config(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, cfg.Core.RepositoryFormatVersion, reopenedCfg.Core.RepositoryFormatVersion)
 		assert.Equal(t, cfg.Extensions.ObjectFormat, reopenedCfg.Extensions.ObjectFormat)
@@ -81,19 +81,19 @@ func TestSubmoduleRepositoryCreateRemoteWritesModuleConfig(t *testing.T) {
 		defer func() { _ = r.Close() }()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
-		require.NoError(t, sm.Init())
+		require.NoError(t, sm.Init(t.Context()))
 
-		subRepo, err := sm.Repository()
+		subRepo, err := sm.Repository(t.Context())
 		require.NoError(t, err)
 		defer subRepo.Close()
 
-		_, err = subRepo.CreateRemote(&config.RemoteConfig{
+		_, err = subRepo.CreateRemote(t.Context(), &config.RemoteConfig{
 			Name: "module-only",
 			URLs: []string{"https://example.com/submodule.git"},
 		})
 		require.NoError(t, err)
 
-		parentCfg, err := r.Config()
+		parentCfg, err := r.Config(t.Context())
 		require.NoError(t, err)
 		_, ok := parentCfg.Remotes["module-only"]
 		assert.False(t, ok)
@@ -111,10 +111,10 @@ func cloneFixture(t *testing.T, f *fixtures.Fixture) (*Repository, *Worktree) {
 	dotgit, err := f.DotGit(fixtures.WithTargetDir(t.TempDir))
 	require.NoError(t, err)
 
-	r, err := PlainClone(t.TempDir(), &CloneOptions{URL: dotgit.Root()})
+	r, err := PlainClone(t.Context(), t.TempDir(), &CloneOptions{URL: dotgit.Root()})
 	require.NoError(t, err)
 
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(t.Context())
 	require.NoError(t, err)
 
 	return r, wt
@@ -123,7 +123,7 @@ func cloneFixture(t *testing.T, f *fixtures.Fixture) (*Repository, *Worktree) {
 func namedSubmodule(t *testing.T, wt *Worktree, name string) *Submodule {
 	t.Helper()
 
-	sm, err := wt.Submodule(name)
+	sm, err := wt.Submodule(t.Context(), name)
 	require.NoError(t, err)
 	return sm
 }

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -28,16 +28,16 @@ func TestSubmoduleInit(t *testing.T) {
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 
 		require.False(t, sm.initialized)
-		require.NoError(t, sm.Init())
+		require.NoError(t, sm.Init(t.Context()))
 		require.True(t, sm.initialized)
 
-		cfg, err := r.Config()
+		cfg, err := r.Config(t.Context())
 		require.NoError(t, err)
 
 		require.Len(t, cfg.Submodules, 1)
 		require.NotNil(t, cfg.Submodules[primaryFixtureSubmoduleName(f)])
 
-		status, err := sm.Status()
+		status, err := sm.Status(t.Context())
 		require.NoError(t, err)
 		require.False(t, status.IsClean())
 	})
@@ -57,17 +57,17 @@ func TestSubmoduleUpdate(t *testing.T) {
 		defer func() { _ = r.Close() }()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
-		require.NoError(t, sm.Update(&SubmoduleUpdateOptions{Init: true}))
+		require.NoError(t, sm.Update(t.Context(), &SubmoduleUpdateOptions{Init: true}))
 
-		subRepo, err := sm.Repository()
+		subRepo, err := sm.Repository(t.Context())
 		require.NoError(t, err)
 		defer subRepo.Close()
 
-		ref, err := subRepo.Reference(plumbing.HEAD, true)
+		ref, err := subRepo.Reference(t.Context(), plumbing.HEAD, true)
 		require.NoError(t, err)
 		require.Equal(t, submoduleHashFromIndex(t, r, primaryFixtureSubmoduleName(f)), ref.Hash())
 
-		status, err := sm.Status()
+		status, err := sm.Status(t.Context())
 		require.NoError(t, err)
 		require.True(t, status.IsClean())
 	})
@@ -84,7 +84,7 @@ func TestSubmoduleRepositoryWithoutInit(t *testing.T) {
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
 
-		subRepo, err := sm.Repository()
+		subRepo, err := sm.Repository(t.Context())
 		require.ErrorIs(t, err, ErrSubmoduleNotInitialized)
 		require.Nil(t, subRepo)
 	})
@@ -100,7 +100,7 @@ func TestSubmoduleUpdateWithoutInit(t *testing.T) {
 		defer func() { _ = r.Close() }()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
-		err := sm.Update(&SubmoduleUpdateOptions{})
+		err := sm.Update(t.Context(), &SubmoduleUpdateOptions{})
 		require.ErrorIs(t, err, ErrSubmoduleNotInitialized)
 	})
 }
@@ -115,7 +115,7 @@ func TestSubmoduleUpdateWithNotFetch(t *testing.T) {
 		defer func() { _ = r.Close() }()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
-		err := sm.Update(&SubmoduleUpdateOptions{
+		err := sm.Update(t.Context(), &SubmoduleUpdateOptions{
 			Init:    true,
 			NoFetch: true,
 		})
@@ -138,7 +138,7 @@ func TestSubmoduleUpdateWithRecursion(t *testing.T) {
 		defer func() { _ = r.Close() }()
 
 		sm := namedSubmodule(t, wt, "itself")
-		err := sm.Update(&SubmoduleUpdateOptions{
+		err := sm.Update(t.Context(), &SubmoduleUpdateOptions{
 			Init:              true,
 			RecurseSubmodules: 2,
 		})
@@ -164,26 +164,26 @@ func TestSubmoduleUpdateWithInitAndUpdate(t *testing.T) {
 		defer func() { _ = r.Close() }()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
-		require.NoError(t, sm.Update(&SubmoduleUpdateOptions{Init: true}))
+		require.NoError(t, sm.Update(t.Context(), &SubmoduleUpdateOptions{Init: true}))
 
-		subRepo, err := sm.Repository()
+		subRepo, err := sm.Repository(t.Context())
 		require.NoError(t, err)
 		defer subRepo.Close()
 
-		log, err := subRepo.Log(&LogOptions{})
+		log, err := subRepo.Log(t.Context(), &LogOptions{})
 		require.NoError(t, err)
 
-		_, err = log.Next()
+		_, err = log.Next(t.Context())
 		require.NoError(t, err)
 
-		previousCommit, err := log.Next()
+		previousCommit, err := log.Next(t.Context())
 		require.NoError(t, err)
 
-		subWorktree, err := subRepo.Worktree()
+		subWorktree, err := subRepo.Worktree(t.Context())
 		require.NoError(t, err)
-		require.NoError(t, subWorktree.Reset(&ResetOptions{Mode: HardReset}))
+		require.NoError(t, subWorktree.Reset(t.Context(), &ResetOptions{Mode: HardReset}))
 
-		idx, err := r.Storer.Index()
+		idx, err := r.Storer.Index(t.Context())
 		require.NoError(t, err)
 
 		previousHash := previousCommit.Hash
@@ -194,10 +194,10 @@ func TestSubmoduleUpdateWithInitAndUpdate(t *testing.T) {
 			}
 		}
 
-		require.NoError(t, r.Storer.SetIndex(idx))
-		require.NoError(t, sm.Update(&SubmoduleUpdateOptions{}))
+		require.NoError(t, r.Storer.SetIndex(t.Context(), idx))
+		require.NoError(t, sm.Update(t.Context(), &SubmoduleUpdateOptions{}))
 
-		ref, err := subRepo.Reference(plumbing.HEAD, true)
+		ref, err := subRepo.Reference(t.Context(), plumbing.HEAD, true)
 		require.NoError(t, err)
 		require.Equal(t, previousHash, ref.Hash())
 	})
@@ -212,11 +212,11 @@ func TestSubmodulesInit(t *testing.T) {
 		r, wt := cloneFixture(t, f)
 		defer func() { _ = r.Close() }()
 
-		sm, err := wt.Submodules()
+		sm, err := wt.Submodules(t.Context())
 		require.NoError(t, err)
-		require.NoError(t, sm.Init())
+		require.NoError(t, sm.Init(t.Context()))
 
-		sm, err = wt.Submodules()
+		sm, err = wt.Submodules(t.Context())
 		require.NoError(t, err)
 
 		for _, m := range sm {
@@ -247,7 +247,7 @@ func TestGitSubmodulesSymlink(t *testing.T) {
 		require.NoError(t, fs.Remove(gitmodulesFile))
 		require.NoError(t, fs.Symlink("badfile", gitmodulesFile))
 
-		_, err = wt.Submodules()
+		_, err = wt.Submodules(t.Context())
 		require.ErrorIs(t, err, ErrGitModulesSymlink)
 	})
 }
@@ -261,10 +261,10 @@ func TestSubmodulesStatus(t *testing.T) {
 		r, wt := cloneFixture(t, f)
 		defer func() { _ = r.Close() }()
 
-		sm, err := wt.Submodules()
+		sm, err := wt.Submodules(t.Context())
 		require.NoError(t, err)
 
-		status, err := sm.Status()
+		status, err := sm.Status(t.Context())
 		require.NoError(t, err)
 		require.Len(t, status, 2)
 	})
@@ -283,13 +283,13 @@ func TestSubmodulesUpdateContext(t *testing.T) {
 		r, wt := cloneFixture(t, f)
 		defer func() { _ = r.Close() }()
 
-		sm, err := wt.Submodules()
+		sm, err := wt.Submodules(t.Context())
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		err = sm.UpdateContext(ctx, &SubmoduleUpdateOptions{Init: true})
+		err = sm.Update(ctx, &SubmoduleUpdateOptions{Init: true})
 		require.Error(t, err)
 	})
 }
@@ -312,20 +312,20 @@ func TestSubmodulesFetchDepth(t *testing.T) {
 		defer func() { _ = r.Close() }()
 
 		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
-		require.NoError(t, sm.Update(&SubmoduleUpdateOptions{
+		require.NoError(t, sm.Update(t.Context(), &SubmoduleUpdateOptions{
 			Init:  true,
 			Depth: 1,
 		}))
 
-		subRepo, err := sm.Repository()
+		subRepo, err := sm.Repository(t.Context())
 		require.NoError(t, err)
 		defer subRepo.Close()
 
-		lr, err := subRepo.Log(&LogOptions{})
+		lr, err := subRepo.Log(t.Context(), &LogOptions{})
 		require.NoError(t, err)
 
 		commitCount := 0
-		for _, err := lr.Next(); err == nil; _, err = lr.Next() {
+		for _, err := lr.Next(t.Context()); err == nil; _, err = lr.Next(t.Context()) {
 			commitCount++
 		}
 		require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestSubmoduleParseScp(t *testing.T) {
 			URL:  "git@github.com:username/submodule_repo",
 		}
 
-		subRepo, err := submodule.Repository()
+		subRepo, err := submodule.Repository(t.Context())
 		require.NoError(t, err)
 		defer func() { _ = subRepo.Close() }()
 	})
@@ -444,7 +444,7 @@ func TestDefaultRemote(t *testing.T) {
 			t.Parallel()
 
 			r := &Repository{Storer: memory.NewStorage()}
-			cfg, err := r.Config()
+			cfg, err := r.Config(t.Context())
 			require.NoError(t, err)
 			for name, url := range tc.remotes {
 				cfg.Remotes[name] = &config.RemoteConfig{
@@ -455,13 +455,13 @@ func TestDefaultRemote(t *testing.T) {
 			for name, remote := range tc.branches {
 				cfg.Branches[name] = &config.Branch{Name: name, Remote: remote}
 			}
-			require.NoError(t, r.Storer.SetConfig(cfg))
+			require.NoError(t, r.Storer.SetConfig(t.Context(), cfg))
 
 			if tc.head != nil {
-				require.NoError(t, r.Storer.SetReference(tc.head))
+				require.NoError(t, r.Storer.SetReference(t.Context(), tc.head))
 			}
 
-			got, err := defaultRemote(r)
+			got, err := defaultRemote(t.Context(), r)
 			if tc.wantErrIn != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.wantErrIn)
@@ -486,7 +486,7 @@ func TestSubmoduleRelativeURLPicksOrigin(t *testing.T) {
 			Storer: memory.NewStorage(),
 			wt:     memfs.New(),
 		}
-		cfg, err := parent.Config()
+		cfg, err := parent.Config(t.Context())
 		require.NoError(t, err)
 		cfg.Remotes["origin"] = &config.RemoteConfig{
 			Name: "origin",
@@ -496,7 +496,7 @@ func TestSubmoduleRelativeURLPicksOrigin(t *testing.T) {
 			Name: "upstream",
 			URLs: []string{"file:///parent/upstream"},
 		}
-		require.NoError(t, parent.Storer.SetConfig(cfg))
+		require.NoError(t, parent.Storer.SetConfig(t.Context(), cfg))
 
 		sub := &Submodule{
 			initialized: true,
@@ -508,11 +508,11 @@ func TestSubmoduleRelativeURLPicksOrigin(t *testing.T) {
 			},
 		}
 
-		subRepo, err := sub.Repository()
+		subRepo, err := sub.Repository(t.Context())
 		require.NoError(t, err, "iteration %d", i)
 		defer func() { _ = subRepo.Close() }()
 
-		remotes, err := subRepo.Remotes()
+		remotes, err := subRepo.Remotes(t.Context())
 		require.NoError(t, err)
 		require.Len(t, remotes, 1, "iteration %d", i)
 		require.Equal(t,
@@ -536,7 +536,7 @@ func TestSubmoduleRelativeURLRemoteWithoutURLs(t *testing.T) {
 		Storer: memory.NewStorage(),
 		wt:     memfs.New(),
 	}
-	cfg, err := parent.Config()
+	cfg, err := parent.Config(t.Context())
 	require.NoError(t, err)
 	cfg.Remotes["origin"] = &config.RemoteConfig{Name: "origin", URLs: nil}
 
@@ -550,7 +550,7 @@ func TestSubmoduleRelativeURLRemoteWithoutURLs(t *testing.T) {
 		},
 	}
 
-	subRepo, err := sub.Repository()
+	subRepo, err := sub.Repository(t.Context())
 	require.Error(t, err)
 	require.Nil(t, subRepo)
 	require.ErrorContains(t, err, `remote "origin" has no configured URL`)
@@ -559,7 +559,7 @@ func TestSubmoduleRelativeURLRemoteWithoutURLs(t *testing.T) {
 func submoduleHashFromIndex(t *testing.T, r *Repository, name string) plumbing.Hash {
 	t.Helper()
 
-	idx, err := r.Storer.Index()
+	idx, err := r.Storer.Index(t.Context())
 	require.NoError(t, err)
 
 	for _, entry := range idx.Entries {
@@ -592,7 +592,7 @@ func newSubmoduleForRelativeURL(t *testing.T, parentRemoteURL, submoduleName, su
 		wt:     memfs.New(),
 	}
 	if parentRemoteURL != "" {
-		_, err := repo.CreateRemote(&config.RemoteConfig{
+		_, err := repo.CreateRemote(t.Context(), &config.RemoteConfig{
 			Name: DefaultRemoteName,
 			URLs: []string{parentRemoteURL},
 		})
@@ -659,7 +659,7 @@ func TestSubmoduleRepositoryURLResolution(t *testing.T) {
 
 			sm := newSubmoduleForRelativeURL(t, tc.parentURL, "basic", tc.submoduleURL)
 
-			r, err := sm.Repository()
+			r, err := sm.Repository(t.Context())
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
 				return
@@ -667,7 +667,7 @@ func TestSubmoduleRepositoryURLResolution(t *testing.T) {
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
 
-			remotes, err := r.Remotes()
+			remotes, err := r.Remotes(t.Context())
 			require.NoError(t, err)
 			require.Len(t, remotes, 1)
 			require.Equal(t, tc.wantRemote, remotes[0].Config().URLs[0])
@@ -687,14 +687,14 @@ func TestSubmoduleRepositoryRejectsEscapingName(t *testing.T) {
 	dotfs := memfs.New()
 	wtfs := memfs.New()
 	storer := filesystem.NewStorage(dotfs, cache.NewObjectLRUDefault())
-	r, err := Init(storer, WithWorkTree(wtfs))
+	r, err := Init(t.Context(), storer, WithWorkTree(wtfs))
 	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
 
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(t.Context())
 	require.NoError(t, err)
 
-	headBefore, err := storer.Reference(plumbing.HEAD)
+	headBefore, err := storer.Reference(t.Context(), plumbing.HEAD)
 	require.NoError(t, err)
 
 	sm := &Submodule{
@@ -707,12 +707,12 @@ func TestSubmoduleRepositoryRejectsEscapingName(t *testing.T) {
 		w: wt,
 	}
 
-	repo, err := sm.Repository()
+	repo, err := sm.Repository(t.Context())
 	require.Error(t, err)
 	require.ErrorIs(t, err, dotgit.ErrModuleNameEscape)
 	require.Nil(t, repo)
 
-	headAfter, err := storer.Reference(plumbing.HEAD)
+	headAfter, err := storer.Reference(t.Context(), plumbing.HEAD)
 	require.NoError(t, err)
 	require.Equal(t, headBefore.Target(), headAfter.Target(),
 		"parent HEAD must not be overwritten")

--- a/submodule_windows_test.go
+++ b/submodule_windows_test.go
@@ -32,13 +32,13 @@ func TestSubmoduleWindowsAbsoluteURLNotJoined(t *testing.T) {
 				Storer: memory.NewStorage(),
 				wt:     memfs.New(),
 			}
-			cfg, err := parent.Config()
+			cfg, err := parent.Config(t.Context())
 			require.NoError(t, err)
 			cfg.Remotes["origin"] = &config.RemoteConfig{
 				Name: "origin",
 				URLs: []string{"file:///parent/origin"},
 			}
-			require.NoError(t, parent.Storer.SetConfig(cfg))
+			require.NoError(t, parent.Storer.SetConfig(t.Context(), cfg))
 
 			sub := &Submodule{
 				initialized: true,
@@ -50,11 +50,11 @@ func TestSubmoduleWindowsAbsoluteURLNotJoined(t *testing.T) {
 				},
 			}
 
-			subRepo, err := sub.Repository()
+			subRepo, err := sub.Repository(t.Context())
 			require.NoError(t, err)
 			defer func() { _ = subRepo.Close() }()
 
-			remotes, err := subRepo.Remotes()
+			remotes, err := subRepo.Remotes(t.Context())
 			require.NoError(t, err)
 			require.Len(t, remotes, 1)
 

--- a/tests/objectverify/commit_test.go
+++ b/tests/objectverify/commit_test.go
@@ -123,10 +123,10 @@ func TestCommitVerifyAlignment(t *testing.T) {
 			hash := writeLooseObject(t, repo, "commit", signed)
 			gitErr := gitVerifyCommit(t, repo, hash)
 
-			r, err := git.PlainOpen(repo)
+			r, err := git.PlainOpen(t.Context(), repo)
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
-			commit, err := r.CommitObject(hash)
+			commit, err := r.CommitObject(t.Context(), hash)
 			ggDecodeErr := err
 			var ggVerifyErr error
 			if ggDecodeErr == nil {

--- a/tests/objectverify/tag_test.go
+++ b/tests/objectverify/tag_test.go
@@ -102,10 +102,10 @@ func TestTagVerifyAlignment(t *testing.T) {
 			hash := writeLooseObject(t, repo, "tag", signed)
 			gitErr := gitVerifyTag(t, repo, hash)
 
-			r, err := git.PlainOpen(repo)
+			r, err := git.PlainOpen(t.Context(), repo)
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
-			tag, err := r.TagObject(hash)
+			tag, err := r.TagObject(t.Context(), hash)
 			ggDecodeErr := err
 			var ggVerifyErr error
 			if ggDecodeErr == nil {

--- a/worktree.go
+++ b/worktree.go
@@ -96,20 +96,10 @@ func (w *Worktree) reusableRootFS() (*worktreeFilesystem, func()) {
 // no changes to be fetched, or an error.
 //
 // Pull only supports merges where the can be resolved as a fast-forward.
-func (w *Worktree) Pull(o *PullOptions) error {
-	return w.PullContext(context.Background(), o)
-}
-
-// PullContext incorporates changes from a remote repository into the current
-// branch. Returns nil if the operation is successful, NoErrAlreadyUpToDate if
-// there are no changes to be fetched, or an error.
-//
-// Pull only supports merges where the can be resolved as a fast-forward.
 //
 // The provided Context must be non-nil. If the context expires before the
-// operation is complete, an error is returned. The context only affects the
-// transport operations.
-func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
+// operation is complete, an error is returned.
+func (w *Worktree) Pull(ctx context.Context, o *PullOptions) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -121,7 +111,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		return err
 	}
 
-	remote, err := w.r.Remote(o.RemoteName)
+	remote, err := w.r.Remote(ctx, o.RemoteName)
 	if err != nil {
 		return err
 	}
@@ -142,17 +132,17 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		return err
 	}
 
-	ref, err := storer.ResolveReference(fetchHead, o.ReferenceName)
+	ref, err := storer.ResolveReference(ctx, fetchHead, o.ReferenceName)
 	if err != nil {
 		return err
 	}
 
-	head, err := w.r.Head()
+	head, err := w.r.Head(ctx)
 	if err == nil {
 		// if we don't have a shallows list, just ignore it
-		shallowList, _ := w.r.Storer.Shallow()
+		shallowList, _ := w.r.Storer.Shallow(ctx)
 
-		headAheadOfRef, err := isFastForward(w.r.Storer, ref.Hash(), head.Hash(), shallowList)
+		headAheadOfRef, err := isFastForward(ctx, w.r.Storer, ref.Hash(), head.Hash(), shallowList)
 		if err != nil {
 			return err
 		}
@@ -161,7 +151,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 			return NoErrAlreadyUpToDate
 		}
 
-		ff, err := isFastForward(w.r.Storer, head.Hash(), ref.Hash(), shallowList)
+		ff, err := isFastForward(ctx, w.r.Storer, head.Hash(), ref.Hash(), shallowList)
 		if err != nil {
 			return err
 		}
@@ -175,11 +165,11 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		return err
 	}
 
-	if err := w.updateHEAD(ref.Hash()); err != nil {
+	if err := w.updateHEAD(ctx, ref.Hash()); err != nil {
 		return err
 	}
 
-	if err := w.Reset(&ResetOptions{
+	if err := w.Reset(ctx, &ResetOptions{
 		Mode:   MergeReset,
 		Commit: ref.Hash(),
 	}); err != nil {
@@ -197,16 +187,16 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 }
 
 func (w *Worktree) updateSubmodules(ctx context.Context, o *SubmoduleUpdateOptions) error {
-	s, err := w.Submodules()
+	s, err := w.Submodules(ctx)
 	if err != nil {
 		return err
 	}
 	o.Init = true
-	return s.UpdateContext(ctx, o)
+	return s.Update(ctx, o)
 }
 
 // Checkout switch branches or restore working tree files.
-func (w *Worktree) Checkout(opts *CheckoutOptions) error {
+func (w *Worktree) Checkout(ctx context.Context, opts *CheckoutOptions) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -219,12 +209,12 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 	}
 
 	if opts.Create {
-		if err := w.createBranch(opts); err != nil {
+		if err := w.createBranch(ctx, opts); err != nil {
 			return err
 		}
 	}
 
-	c, err := w.getCommitFromCheckoutOptions(opts)
+	c, err := w.getCommitFromCheckoutOptions(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -241,24 +231,24 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 	}
 
 	if !opts.Hash.IsZero() && !opts.Create {
-		err = w.setHEADToCommit(opts.Hash)
+		err = w.setHEADToCommit(ctx, opts.Hash)
 	} else {
-		err = w.setHEADToBranch(opts.Branch, c)
+		err = w.setHEADToBranch(ctx, opts.Branch, c)
 	}
 
 	if err != nil {
 		return err
 	}
 
-	return w.Reset(ro)
+	return w.Reset(ctx, ro)
 }
 
-func (w *Worktree) createBranch(opts *CheckoutOptions) error {
+func (w *Worktree) createBranch(ctx context.Context, opts *CheckoutOptions) error {
 	if err := opts.Branch.Validate(); err != nil {
 		return err
 	}
 
-	_, err := w.r.Storer.Reference(opts.Branch)
+	_, err := w.r.Storer.Reference(ctx, opts.Branch)
 	if err == nil {
 		return fmt.Errorf("a branch named %q already exists", opts.Branch)
 	}
@@ -268,7 +258,7 @@ func (w *Worktree) createBranch(opts *CheckoutOptions) error {
 	}
 
 	if opts.Hash.IsZero() {
-		ref, err := w.r.Head()
+		ref, err := w.r.Head(ctx)
 		if err != nil {
 			return err
 		}
@@ -277,14 +267,15 @@ func (w *Worktree) createBranch(opts *CheckoutOptions) error {
 	}
 
 	return w.r.Storer.SetReference(
+		ctx,
 		plumbing.NewHashReference(opts.Branch, opts.Hash),
 	)
 }
 
-func (w *Worktree) getCommitFromCheckoutOptions(opts *CheckoutOptions) (plumbing.Hash, error) {
+func (w *Worktree) getCommitFromCheckoutOptions(ctx context.Context, opts *CheckoutOptions) (plumbing.Hash, error) {
 	hash := opts.Hash
 	if hash.IsZero() {
-		b, err := w.r.Reference(opts.Branch, true)
+		b, err := w.r.Reference(ctx, opts.Branch, true)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
@@ -292,7 +283,7 @@ func (w *Worktree) getCommitFromCheckoutOptions(opts *CheckoutOptions) (plumbing
 		hash = b.Hash()
 	}
 
-	o, err := w.r.Object(plumbing.AnyObject, hash)
+	o, err := w.r.Object(ctx, plumbing.AnyObject, hash)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -311,13 +302,13 @@ func (w *Worktree) getCommitFromCheckoutOptions(opts *CheckoutOptions) (plumbing
 	return plumbing.ZeroHash, fmt.Errorf("%w: %q", object.ErrUnsupportedObject, o.Type())
 }
 
-func (w *Worktree) setHEADToCommit(commit plumbing.Hash) error {
+func (w *Worktree) setHEADToCommit(ctx context.Context, commit plumbing.Hash) error {
 	head := plumbing.NewHashReference(plumbing.HEAD, commit)
-	return w.r.Storer.SetReference(head)
+	return w.r.Storer.SetReference(ctx, head)
 }
 
-func (w *Worktree) setHEADToBranch(branch plumbing.ReferenceName, commit plumbing.Hash) error {
-	target, err := w.r.Storer.Reference(branch)
+func (w *Worktree) setHEADToBranch(ctx context.Context, branch plumbing.ReferenceName, commit plumbing.Hash) error {
+	target, err := w.r.Storer.Reference(ctx, branch)
 	if err != nil {
 		return err
 	}
@@ -329,11 +320,11 @@ func (w *Worktree) setHEADToBranch(branch plumbing.ReferenceName, commit plumbin
 		head = plumbing.NewHashReference(plumbing.HEAD, commit)
 	}
 
-	return w.r.Storer.SetReference(head)
+	return w.r.Storer.SetReference(ctx, head)
 }
 
 // Reset the worktree to a specified state.
-func (w *Worktree) Reset(opts *ResetOptions) error {
+func (w *Worktree) Reset(ctx context.Context, opts *ResetOptions) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -341,17 +332,17 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		}()
 	}
 
-	if err := opts.Validate(w.r); err != nil {
+	if err := opts.Validate(ctx, w.r); err != nil {
 		return err
 	}
 
-	cfg, err := w.r.Config()
+	cfg, err := w.r.Config(ctx)
 	if err != nil {
 		return err
 	}
 
 	if opts.Mode == MergeReset {
-		unstaged, err := w.containsUnstagedChanges(cfg)
+		unstaged, err := w.containsUnstagedChanges(ctx, cfg)
 		if err != nil {
 			return err
 		}
@@ -362,16 +353,16 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	}
 
 	if opts.Mode == SoftReset {
-		return w.setHEADCommit(opts.Commit)
+		return w.setHEADCommit(ctx, opts.Commit)
 	}
 
-	t, err := w.r.getTreeFromCommitHash(opts.Commit)
+	t, err := w.r.getTreeFromCommitHash(ctx, opts.Commit)
 	if err != nil {
 		return err
 	}
 
 	if len(opts.SparseDirs) > 0 && !opts.SkipSparseDirValidation {
-		if !treeContainsDirs(t, opts.SparseDirs) {
+		if !treeContainsDirs(ctx, t, opts.SparseDirs) {
 			return ErrSparseResetDirectoryNotFound
 		}
 	}
@@ -382,37 +373,37 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	// files are invisible and are never deleted — matching real git reset --hard.
 	var prevTree *object.Tree
 	if opts.Mode == HardReset || opts.Mode == KeepReset {
-		prevTree, err = w.headTree()
+		prevTree, err = w.headTree(ctx)
 		if err != nil {
 			return err
 		}
 	}
 
 	if opts.Mode == KeepReset {
-		if err := w.checkKeepResetConflicts(prevTree, t, opts.SparseDirs, opts.Files); err != nil {
+		if err := w.checkKeepResetConflicts(ctx, prevTree, t, opts.SparseDirs, opts.Files); err != nil {
 			return err
 		}
 	}
 
-	if err := w.setHEADCommit(opts.Commit); err != nil {
+	if err := w.setHEADCommit(ctx, opts.Commit); err != nil {
 		return err
 	}
 
 	var removedFiles []string
 	if opts.Mode == MixedReset || opts.Mode == MergeReset || opts.Mode == HardReset || opts.Mode == KeepReset {
-		if removedFiles, err = w.resetIndex(t, opts.SparseDirs, opts.Files); err != nil {
+		if removedFiles, err = w.resetIndex(ctx, t, opts.SparseDirs, opts.Files); err != nil {
 			return err
 		}
 	}
 
 	if opts.Mode == MergeReset && len(removedFiles) > 0 {
-		if err := w.resetWorktree(cfg, t, removedFiles); err != nil {
+		if err := w.resetWorktree(ctx, cfg, t, removedFiles); err != nil {
 			return err
 		}
 	}
 
 	if opts.Mode == HardReset || opts.Mode == KeepReset {
-		if err := w.resetWorktreeToTree(cfg, prevTree, t, opts.Files); err != nil {
+		if err := w.resetWorktreeToTree(ctx, cfg, prevTree, t, opts.Files); err != nil {
 			return err
 		}
 	}
@@ -422,13 +413,13 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 
 // treeContainsDirs checks if the given tree contains all the directories.
 // if dirs is empty, it returns false.
-func treeContainsDirs(tree *object.Tree, dirs []string) bool {
+func treeContainsDirs(ctx context.Context, tree *object.Tree, dirs []string) bool {
 	if len(dirs) == 0 {
 		return false
 	}
 
 	for _, dir := range dirs {
-		entry, err := tree.FindEntry(dir)
+		entry, err := tree.FindEntry(ctx, dir)
 		if err != nil {
 			return false
 		}
@@ -451,7 +442,7 @@ func treeContainsDirs(tree *object.Tree, dirs []string) bool {
 // tree while leaving the stage untouched is not currently supported.
 //
 // Restore with no files specified will return ErrNoRestorePaths.
-func (w *Worktree) Restore(o *RestoreOptions) error {
+func (w *Worktree) Restore(ctx context.Context, o *RestoreOptions) error {
 	if err := o.Validate(); err != nil {
 		return err
 	}
@@ -469,21 +460,21 @@ func (w *Worktree) Restore(o *RestoreOptions) error {
 			opts.Mode = MixedReset
 		}
 
-		return w.Reset(opts)
+		return w.Reset(ctx, opts)
 	}
 
 	return ErrRestoreWorktreeOnlyNotSupported
 }
 
-func (w *Worktree) resetIndex(t *object.Tree, dirs, files []string) ([]string, error) {
-	idx, err := w.r.Storer.Index()
+func (w *Worktree) resetIndex(ctx context.Context, t *object.Tree, dirs, files []string) ([]string, error) {
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	b := newIndexBuilder(idx)
 
-	changes, err := w.diffTreeWithStaging(t, true)
+	changes, err := w.diffTreeWithStaging(ctx, t, true)
 	if err != nil {
 		return nil, err
 	}
@@ -502,7 +493,7 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs, files []string) ([]string, e
 		switch a {
 		case merkletrie.Modify, merkletrie.Insert:
 			name = ch.To.String()
-			e, err = t.FindEntry(name)
+			e, err = t.FindEntry(ctx, name)
 			if err != nil {
 				return nil, err
 			}
@@ -536,7 +527,7 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs, files []string) ([]string, e
 		idx.SkipUnless(dirs)
 	}
 
-	return removedFiles, w.r.Storer.SetIndex(idx)
+	return removedFiles, w.r.Storer.SetIndex(ctx, idx)
 }
 
 // inFiles checks if the given file is in the list of files. The incoming filepaths in files should be cleaned before calling this function.
@@ -548,19 +539,19 @@ func inFiles(files map[string]struct{}, v string) bool {
 
 // headTree returns the tree for the current HEAD commit.
 // Returns nil, nil if there is no HEAD yet (e.g. an unborn branch).
-func (w *Worktree) headTree() (*object.Tree, error) {
-	head, err := w.r.Head()
+func (w *Worktree) headTree(ctx context.Context) (*object.Tree, error) {
+	head, err := w.r.Head(ctx)
 	if err != nil {
 		if errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	c, err := w.r.CommitObject(head.Hash())
+	c, err := w.r.CommitObject(ctx, head.Hash())
 	if err != nil {
 		return nil, err
 	}
-	return c.Tree()
+	return c.Tree(ctx)
 }
 
 // checkKeepResetConflicts implements the safety check for KeepReset
@@ -577,8 +568,8 @@ func (w *Worktree) headTree() (*object.Tree, error) {
 //     become SkipWorktree because their path is no longer under any of the new
 //     sparse directories. Step 3 of resetWorktreeToTree removes them from disk,
 //     so KeepReset must refuse if they carry local modifications.
-func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparseDirs, files []string) error {
-	changes, err := diffTrees(fromTree, toTree)
+func (w *Worktree) checkKeepResetConflicts(ctx context.Context, fromTree, toTree *object.Tree, sparseDirs, files []string) error {
+	changes, err := diffTrees(ctx, fromTree, toTree)
 	if err != nil {
 		return err
 	}
@@ -617,7 +608,7 @@ func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparse
 	// falls outside the new sparse set will be removed from disk by step 3 of
 	// resetWorktreeToTree. KeepReset must refuse if such a file has local mods.
 	if len(sparseDirs) > 0 {
-		idx, err := w.r.Storer.Index()
+		idx, err := w.r.Storer.Index(ctx)
 		if err != nil {
 			return err
 		}
@@ -646,7 +637,7 @@ func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparse
 	}
 
 	// Check worktree status for local modifications on touched paths.
-	status, err := w.Status()
+	status, err := w.Status(ctx)
 	if err != nil {
 		return err
 	}
@@ -689,14 +680,14 @@ func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparse
 //     file with SkipWorktree=true must not exist in the worktree.
 //
 // files optionally restricts the operation to a specific subset of paths.
-func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *object.Tree, files []string) error {
+func (w *Worktree) resetWorktreeToTree(ctx context.Context, cfg *config.Config, fromTree, toTree *object.Tree, files []string) error {
 	filesMap := buildFilePathMap(files)
 
 	fs, closeFS := w.reusableRootFS()
 	defer closeFS()
 
 	// Step 1: delete files removed from the tracked tree.
-	treeChanges, err := diffTrees(fromTree, toTree)
+	treeChanges, err := diffTrees(ctx, fromTree, toTree)
 	if err != nil {
 		return err
 	}
@@ -730,12 +721,12 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 	// Delete actions. The observable result is unchanged because Delete
 	// actions are skipped by the loop below; the matcher only avoids the
 	// pointless lstat of every file under directories like node_modules.
-	worktreeChanges, err := w.diffStagingWithWorktree(cfg, true, true)
+	worktreeChanges, err := w.diffStagingWithWorktree(ctx, cfg, true, true)
 	if err != nil {
 		return err
 	}
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return err
 	}
@@ -762,7 +753,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 			}
 		}
 
-		if err := w.checkoutChange(cfg, fs, ch, toTree, b); err != nil {
+		if err := w.checkoutChange(ctx, cfg, fs, ch, toTree, b); err != nil {
 			return err
 		}
 	}
@@ -787,7 +778,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 	}
 
 	b.Write(idx)
-	return w.r.Storer.SetIndex(idx)
+	return w.r.Storer.SetIndex(ctx, idx)
 }
 
 // resetWorktree updates the worktree to match the staging area.
@@ -799,13 +790,13 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 // from the index in this same Reset is no longer in idxMap, so the
 // noder's IgnoreMatcher would prune it from the walk and the Delete
 // action needed to remove it from disk would never be emitted.
-func (w *Worktree) resetWorktree(cfg *config.Config, t *object.Tree, files []string) error {
-	changes, err := w.diffStagingWithWorktree(cfg, true, false)
+func (w *Worktree) resetWorktree(ctx context.Context, cfg *config.Config, t *object.Tree, files []string) error {
+	changes, err := w.diffStagingWithWorktree(ctx, cfg, true, false)
 	if err != nil {
 		return err
 	}
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return err
 	}
@@ -834,16 +825,16 @@ func (w *Worktree) resetWorktree(cfg *config.Config, t *object.Tree, files []str
 			}
 		}
 
-		if err := w.checkoutChange(cfg, fs, ch, t, b); err != nil {
+		if err := w.checkoutChange(ctx, cfg, fs, ch, t, b); err != nil {
 			return err
 		}
 	}
 
 	b.Write(idx)
-	return w.r.Storer.SetIndex(idx)
+	return w.r.Storer.SetIndex(ctx, idx)
 }
 
-func (w *Worktree) checkoutChange(cfg *config.Config, fs *worktreeFilesystem, ch merkletrie.Change, t *object.Tree, idx *indexBuilder) error {
+func (w *Worktree) checkoutChange(ctx context.Context, cfg *config.Config, fs *worktreeFilesystem, ch merkletrie.Change, t *object.Tree, idx *indexBuilder) error {
 	a, err := ch.Action()
 	if err != nil {
 		return err
@@ -859,7 +850,7 @@ func (w *Worktree) checkoutChange(cfg *config.Config, fs *worktreeFilesystem, ch
 		// FindEntry validates name via pathutil.ValidTreePath, so a
 		// dangerous tree-derived path is refused at the lookup
 		// boundary before we materialise anything.
-		e, err = t.FindEntry(name)
+		e, err = t.FindEntry(ctx, name)
 		if err != nil {
 			return err
 		}
@@ -878,14 +869,14 @@ func (w *Worktree) checkoutChange(cfg *config.Config, fs *worktreeFilesystem, ch
 	}
 
 	if isSubmodule {
-		return w.checkoutChangeSubmodule(fs, name, a, e, idx)
+		return w.checkoutChangeSubmodule(ctx, fs, name, a, e, idx)
 	}
 
-	return w.checkoutChangeRegularFile(cfg, fs, name, a, t, e, idx)
+	return w.checkoutChangeRegularFile(ctx, cfg, fs, name, a, t, e, idx)
 }
 
-func (w *Worktree) containsUnstagedChanges(cfg *config.Config) (bool, error) {
-	ch, err := w.diffStagingWithWorktree(cfg, false, true)
+func (w *Worktree) containsUnstagedChanges(ctx context.Context, cfg *config.Config) (bool, error) {
+	ch, err := w.diffStagingWithWorktree(ctx, cfg, false, true)
 	if err != nil {
 		return false, err
 	}
@@ -906,18 +897,18 @@ func (w *Worktree) containsUnstagedChanges(cfg *config.Config) (bool, error) {
 	return false, nil
 }
 
-func (w *Worktree) setHEADCommit(commit plumbing.Hash) error {
-	head, err := w.r.Reference(plumbing.HEAD, false)
+func (w *Worktree) setHEADCommit(ctx context.Context, commit plumbing.Hash) error {
+	head, err := w.r.Reference(ctx, plumbing.HEAD, false)
 	if err != nil {
 		return err
 	}
 
 	if head.Type() == plumbing.HashReference {
 		head = plumbing.NewHashReference(plumbing.HEAD, commit)
-		return w.r.Storer.SetReference(head)
+		return w.r.Storer.SetReference(ctx, head)
 	}
 
-	branch, err := w.r.Reference(head.Target(), false)
+	branch, err := w.r.Reference(ctx, head.Target(), false)
 	if err != nil {
 		return err
 	}
@@ -927,10 +918,10 @@ func (w *Worktree) setHEADCommit(commit plumbing.Hash) error {
 	}
 
 	branch = plumbing.NewHashReference(branch.Name(), commit)
-	return w.r.Storer.SetReference(branch)
+	return w.r.Storer.SetReference(ctx, branch)
 }
 
-func (w *Worktree) checkoutChangeSubmodule(fs *worktreeFilesystem,
+func (w *Worktree) checkoutChangeSubmodule(ctx context.Context, fs *worktreeFilesystem,
 	name string,
 	a merkletrie.Action,
 	e *object.TreeEntry,
@@ -938,7 +929,7 @@ func (w *Worktree) checkoutChangeSubmodule(fs *worktreeFilesystem,
 ) error {
 	switch a {
 	case merkletrie.Modify:
-		sub, err := w.Submodule(name)
+		sub, err := w.Submodule(ctx, name)
 		if err != nil {
 			return err
 		}
@@ -964,7 +955,7 @@ func (w *Worktree) checkoutChangeSubmodule(fs *worktreeFilesystem,
 	return nil
 }
 
-func (w *Worktree) checkoutChangeRegularFile(cfg *config.Config,
+func (w *Worktree) checkoutChangeRegularFile(ctx context.Context, cfg *config.Config,
 	fs *worktreeFilesystem,
 	name string,
 	a merkletrie.Action,
@@ -984,7 +975,7 @@ func (w *Worktree) checkoutChangeRegularFile(cfg *config.Config,
 
 		fallthrough
 	case merkletrie.Insert:
-		f, err := t.File(name)
+		f, err := t.File(ctx, name)
 		if err != nil {
 			return err
 		}
@@ -1129,13 +1120,13 @@ func (w *Worktree) addIndexFromFile(fs *worktreeFilesystem, name string, h plumb
 	return nil
 }
 
-func (r *Repository) getTreeFromCommitHash(commit plumbing.Hash) (*object.Tree, error) {
-	c, err := r.CommitObject(commit)
+func (r *Repository) getTreeFromCommitHash(ctx context.Context, commit plumbing.Hash) (*object.Tree, error) {
+	c, err := r.CommitObject(ctx, commit)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.Tree()
+	return c.Tree(ctx)
 }
 
 var fillSystemInfo func(e *index.Entry, sys any)
@@ -1143,8 +1134,8 @@ var fillSystemInfo func(e *index.Entry, sys any)
 const gitmodulesFile = ".gitmodules"
 
 // Submodule returns the submodule with the given name
-func (w *Worktree) Submodule(name string) (*Submodule, error) {
-	l, err := w.Submodules()
+func (w *Worktree) Submodule(ctx context.Context, name string) (*Submodule, error) {
+	l, err := w.Submodules(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1184,17 +1175,17 @@ func resolveModuleURL(originURL, moduleURL string) (string, error) {
 }
 
 // Submodules returns all the available submodules
-func (w *Worktree) Submodules() (Submodules, error) {
-	cfg, err := w.r.Config()
+func (w *Worktree) Submodules(ctx context.Context) (Submodules, error) {
+	cfg, err := w.r.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return w.submodulesWithConfig(cfg)
+	return w.submodulesWithConfig(ctx, cfg)
 }
 
 // submodulesWithConfig returns all the available submodules using an already-loaded config.
-func (w *Worktree) submodulesWithConfig(cfg *config.Config) (Submodules, error) {
+func (w *Worktree) submodulesWithConfig(ctx context.Context, cfg *config.Config) (Submodules, error) {
 	l := make(Submodules, 0)
 	m, err := w.readGitmodulesFile()
 	if err != nil || m == nil {
@@ -1202,7 +1193,7 @@ func (w *Worktree) submodulesWithConfig(cfg *config.Config) (Submodules, error) 
 	}
 
 	var originURL string
-	if origin, err := w.r.Remote(DefaultRemoteName); err == nil {
+	if origin, err := w.r.Remote(ctx, DefaultRemoteName); err == nil {
 		if origin.c != nil && len(origin.c.URLs) > 0 {
 			originURL = origin.c.URLs[0]
 		}
@@ -1273,8 +1264,8 @@ func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
 
 // Clean the worktree by removing untracked files.
 // An empty dir could be removed - this is what  `git clean -f -d .` does.
-func (w *Worktree) Clean(opts *CleanOptions) error {
-	s, err := w.Status()
+func (w *Worktree) Clean(ctx context.Context, opts *CleanOptions) error {
+	s, err := w.Status(ctx)
 	if err != nil {
 		return err
 	}
@@ -1341,8 +1332,8 @@ func (gr GrepResult) String() string {
 }
 
 // Grep performs grep on a repository.
-func (r *Repository) Grep(opts *GrepOptions) ([]GrepResult, error) {
-	if err := opts.validate(r); err != nil {
+func (r *Repository) Grep(ctx context.Context, opts *GrepOptions) ([]GrepResult, error) {
+	if err := opts.validate(ctx, r); err != nil {
 		return nil, err
 	}
 
@@ -1352,7 +1343,7 @@ func (r *Repository) Grep(opts *GrepOptions) ([]GrepResult, error) {
 	var treeName string
 
 	if opts.ReferenceName != "" {
-		ref, err := r.Reference(opts.ReferenceName, true)
+		ref, err := r.Reference(ctx, opts.ReferenceName, true)
 		if err != nil {
 			return nil, err
 		}
@@ -1365,27 +1356,27 @@ func (r *Repository) Grep(opts *GrepOptions) ([]GrepResult, error) {
 
 	// Obtain a tree from the commit hash and get a tracked files iterator from
 	// the tree.
-	tree, err := r.getTreeFromCommitHash(commitHash)
+	tree, err := r.getTreeFromCommitHash(ctx, commitHash)
 	if err != nil {
 		return nil, err
 	}
 	fileiter := tree.Files()
 
-	return findMatchInFiles(fileiter, treeName, opts)
+	return findMatchInFiles(ctx, fileiter, treeName, opts)
 }
 
 // Grep performs grep on a worktree.
-func (w *Worktree) Grep(opts *GrepOptions) ([]GrepResult, error) {
-	return w.r.Grep(opts)
+func (w *Worktree) Grep(ctx context.Context, opts *GrepOptions) ([]GrepResult, error) {
+	return w.r.Grep(ctx, opts)
 }
 
 // findMatchInFiles takes a FileIter, worktree name and GrepOptions, and
 // returns a slice of GrepResult containing the result of regex pattern matching
 // in content of all the files.
-func findMatchInFiles(fileiter *object.FileIter, treeName string, opts *GrepOptions) ([]GrepResult, error) {
+func findMatchInFiles(ctx context.Context, fileiter *object.FileIter, treeName string, opts *GrepOptions) ([]GrepResult, error) {
 	var results []GrepResult
 
-	err := fileiter.ForEach(func(file *object.File) error {
+	err := fileiter.ForEach(ctx, func(file *object.File) error {
 		var fileInPathSpec bool
 
 		// When no pathspecs are provided, search all the files.

--- a/worktree_clone_bench_test.go
+++ b/worktree_clone_bench_test.go
@@ -26,11 +26,11 @@ func BenchmarkCloneLargeRepo(b *testing.B) {
 	tmpDir := b.TempDir()
 	sourceDir := filepath.Join(tmpDir, "source")
 
-	sourceRepo, err := PlainInit(sourceDir, false)
+	sourceRepo, err := PlainInit(b.Context(), sourceDir, false)
 	require.NoError(b, err)
 	b.Cleanup(func() { _ = sourceRepo.Close() })
 
-	sourceWt, err := sourceRepo.Worktree()
+	sourceWt, err := sourceRepo.Worktree(b.Context())
 	require.NoError(b, err)
 
 	content := []byte("test content for benchmark\n")
@@ -66,7 +66,7 @@ func BenchmarkCloneLargeRepo(b *testing.B) {
 
 	// Add all files to index using AddGlob for each directory as Add is too slow at the moment.
 	for i := range numSubdirs {
-		err = sourceWt.AddGlob(fmt.Sprintf("dir%d/*", i))
+		err = sourceWt.AddGlob(b.Context(), fmt.Sprintf("dir%d/*", i))
 		require.NoError(b, err)
 	}
 
@@ -75,7 +75,7 @@ func BenchmarkCloneLargeRepo(b *testing.B) {
 		Email: "benchmark@test.com",
 		When:  time.Now(),
 	}
-	_, err = sourceWt.Commit("Initial commit with many files", &CommitOptions{
+	_, err = sourceWt.Commit(b.Context(), "Initial commit with many files", &CommitOptions{
 		Author:    sig,
 		Committer: sig,
 	})
@@ -84,7 +84,7 @@ func BenchmarkCloneLargeRepo(b *testing.B) {
 	i := 0
 	for b.Loop() {
 		cloneDir := filepath.Join(tmpDir, fmt.Sprintf("clone-%d", i))
-		clonedRepo, err := PlainClone(cloneDir, &CloneOptions{
+		clonedRepo, err := PlainClone(b.Context(), cloneDir, &CloneOptions{
 			URL:    sourceDir,
 			Shared: true,
 		})
@@ -108,11 +108,11 @@ func BenchmarkCloneDeepRepo(b *testing.B) {
 	tmpDir := b.TempDir()
 	sourceDir := filepath.Join(tmpDir, "source")
 
-	sourceRepo, err := PlainInit(sourceDir, false)
+	sourceRepo, err := PlainInit(b.Context(), sourceDir, false)
 	require.NoError(b, err)
 	b.Cleanup(func() { _ = sourceRepo.Close() })
 
-	sourceWt, err := sourceRepo.Worktree()
+	sourceWt, err := sourceRepo.Worktree(b.Context())
 	require.NoError(b, err)
 
 	content := []byte("test content for benchmark\n")
@@ -150,7 +150,7 @@ func BenchmarkCloneDeepRepo(b *testing.B) {
 	wg.Wait()
 
 	// Add all files to index using AddGlob as Add is too slow at the moment.
-	err = sourceWt.AddGlob("level0/*/*/*/*/*")
+	err = sourceWt.AddGlob(b.Context(), "level0/*/*/*/*/*")
 	require.NoError(b, err)
 
 	sig := &object.Signature{
@@ -158,7 +158,7 @@ func BenchmarkCloneDeepRepo(b *testing.B) {
 		Email: "benchmark@test.com",
 		When:  time.Now(),
 	}
-	_, err = sourceWt.Commit("Initial commit with many files", &CommitOptions{
+	_, err = sourceWt.Commit(b.Context(), "Initial commit with many files", &CommitOptions{
 		Author:    sig,
 		Committer: sig,
 	})
@@ -167,7 +167,7 @@ func BenchmarkCloneDeepRepo(b *testing.B) {
 	i := 0
 	for b.Loop() {
 		cloneDir := filepath.Join(tmpDir, fmt.Sprintf("clone-%d", i))
-		clonedRepo, err := PlainClone(cloneDir, &CloneOptions{
+		clonedRepo, err := PlainClone(b.Context(), cloneDir, &CloneOptions{
 			URL:    sourceDir,
 			Shared: true,
 		})

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -36,7 +37,7 @@ var (
 
 // Commit stores the current contents of the index in a new commit along with
 // a log message from the user describing the changes.
-func (w *Worktree) Commit(msg string, opts *CommitOptions) (plumbing.Hash, error) {
+func (w *Worktree) Commit(ctx context.Context, msg string, opts *CommitOptions) (plumbing.Hash, error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -44,22 +45,22 @@ func (w *Worktree) Commit(msg string, opts *CommitOptions) (plumbing.Hash, error
 		}()
 	}
 
-	if err := opts.Validate(w.r); err != nil {
+	if err := opts.Validate(ctx, w.r); err != nil {
 		return plumbing.ZeroHash, err
 	}
 
 	if opts.All {
-		if err := w.autoAddModifiedAndDeleted(); err != nil {
+		if err := w.autoAddModifiedAndDeleted(ctx); err != nil {
 			return plumbing.ZeroHash, err
 		}
 	}
 
 	if opts.Amend {
-		head, err := w.r.Head()
+		head, err := w.r.Head(ctx)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
-		headCommit, err := w.r.CommitObject(head.Hash())
+		headCommit, err := w.r.CommitObject(ctx, head.Hash())
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
@@ -67,7 +68,7 @@ func (w *Worktree) Commit(msg string, opts *CommitOptions) (plumbing.Hash, error
 		opts.Parents = headCommit.ParentHashes
 	}
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -82,14 +83,14 @@ func (w *Worktree) Commit(msg string, opts *CommitOptions) (plumbing.Hash, error
 		s:  w.r.Storer,
 	}
 
-	treeHash, err := h.BuildTree(idx, opts)
+	treeHash, err := h.BuildTree(ctx, idx, opts)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
 	previousTree := plumbing.ZeroHash
 	if len(opts.Parents) > 0 {
-		parentCommit, err := w.r.CommitObject(opts.Parents[0])
+		parentCommit, err := w.r.CommitObject(ctx, opts.Parents[0])
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
@@ -100,47 +101,47 @@ func (w *Worktree) Commit(msg string, opts *CommitOptions) (plumbing.Hash, error
 		return plumbing.ZeroHash, ErrEmptyCommit
 	}
 
-	commit, err := w.buildCommitObject(msg, opts, treeHash)
+	commit, err := w.buildCommitObject(ctx, msg, opts, treeHash)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	return commit, w.updateHEAD(commit)
+	return commit, w.updateHEAD(ctx, commit)
 }
 
 // CherryPick cherry picks commits and merge them into the worktree based on the selected
 // merge strategy. Each commit sits on the top of worktree's current head.
 // It resembles `git cherry-pick <commit-hash-1> <commit-hash-2> ... --strategy-option [theirs,ours]`
-func (w *Worktree) CherryPick(commitOpts *CommitOptions, ortStrategyOption OrtMergeStrategyOption, commits ...*object.Commit) error {
+func (w *Worktree) CherryPick(ctx context.Context, commitOpts *CommitOptions, ortStrategyOption OrtMergeStrategyOption, commits ...*object.Commit) error {
 	if commitOpts == nil {
 		return ErrCannotCherryPickWithoutCommitOptions
 	}
 
 	for _, commit := range commits {
 		var changes object.Changes
-		headRef, err := w.r.Head()
+		headRef, err := w.r.Head(ctx)
 		if err != nil {
 			return err
 		}
-		headCommit, err := w.r.CommitObject(headRef.Hash())
+		headCommit, err := w.r.CommitObject(ctx, headRef.Hash())
 		if err != nil {
 			return err
 		}
-		currentTree, err := headCommit.Tree()
+		currentTree, err := headCommit.Tree(ctx)
 		if err != nil {
 			return err
 		}
 
-		commitTree, err := commit.Tree()
+		commitTree, err := commit.Tree(ctx)
 		if err != nil {
 			return err
 		}
 
 		switch ortStrategyOption {
 		case TheirsMergeStrategy:
-			changes, err = currentTree.Diff(commitTree)
+			changes, err = currentTree.Diff(ctx, commitTree)
 		case OursMergeStrategy:
-			changes, err = commitTree.Diff(currentTree)
+			changes, err = commitTree.Diff(ctx, currentTree)
 		}
 
 		if err != nil {
@@ -154,11 +155,11 @@ func (w *Worktree) CherryPick(commitOpts *CommitOptions, ortStrategyOption OrtMe
 
 			switch action {
 			case merkletrie.Delete:
-				if _, err := w.Remove(change.From.Name); err != nil {
+				if _, err := w.Remove(ctx, change.From.Name); err != nil {
 					return err
 				}
 			case merkletrie.Insert, merkletrie.Modify:
-				_, to, err := change.Files()
+				_, to, err := change.Files(ctx)
 				if err != nil {
 					return err
 				}
@@ -178,12 +179,12 @@ func (w *Worktree) CherryPick(commitOpts *CommitOptions, ortStrategyOption OrtMe
 				if err != nil {
 					return err
 				}
-				if _, err := w.Add(name); err != nil {
+				if _, err := w.Add(ctx, name); err != nil {
 					return err
 				}
 			}
 		}
-		_, err = w.Commit(commit.Message, &CommitOptions{
+		_, err = w.Commit(ctx, commit.Message, &CommitOptions{
 			Author:            &commit.Author,
 			Committer:         commitOpts.Committer,
 			Signer:            commitOpts.Signer,
@@ -196,18 +197,18 @@ func (w *Worktree) CherryPick(commitOpts *CommitOptions, ortStrategyOption OrtMe
 	return nil
 }
 
-func (w *Worktree) autoAddModifiedAndDeleted() error {
-	cfg, err := w.r.Config()
+func (w *Worktree) autoAddModifiedAndDeleted(ctx context.Context) error {
+	cfg, err := w.r.Config(ctx)
 	if err != nil {
 		return err
 	}
 
-	s, err := w.Status()
+	s, err := w.Status(ctx)
 	if err != nil {
 		return err
 	}
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return err
 	}
@@ -217,16 +218,16 @@ func (w *Worktree) autoAddModifiedAndDeleted() error {
 			continue
 		}
 
-		if _, _, err := w.doAddFile(cfg, idx, s, path, nil); err != nil {
+		if _, _, err := w.doAddFile(ctx, cfg, idx, s, path, nil); err != nil {
 			return err
 		}
 	}
 
-	return w.r.Storer.SetIndex(idx)
+	return w.r.Storer.SetIndex(ctx, idx)
 }
 
-func (w *Worktree) updateHEAD(commit plumbing.Hash) error {
-	head, err := w.r.Storer.Reference(plumbing.HEAD)
+func (w *Worktree) updateHEAD(ctx context.Context, commit plumbing.Hash) error {
+	head, err := w.r.Storer.Reference(ctx, plumbing.HEAD)
 	if err != nil {
 		return err
 	}
@@ -237,10 +238,10 @@ func (w *Worktree) updateHEAD(commit plumbing.Hash) error {
 	}
 
 	ref := plumbing.NewHashReference(name, commit)
-	return w.r.Storer.SetReference(ref)
+	return w.r.Storer.SetReference(ctx, ref)
 }
 
-func (w *Worktree) buildCommitObject(msg string, opts *CommitOptions, tree plumbing.Hash) (plumbing.Hash, error) {
+func (w *Worktree) buildCommitObject(ctx context.Context, msg string, opts *CommitOptions, tree plumbing.Hash) (plumbing.Hash, error) {
 	commit := &object.Commit{
 		Author:       w.sanitize(*opts.Author),
 		Committer:    w.sanitize(*opts.Committer),
@@ -251,7 +252,7 @@ func (w *Worktree) buildCommitObject(msg string, opts *CommitOptions, tree plumb
 
 	signer := opts.Signer
 	if signer == nil {
-		cfg, err := w.r.ConfigScoped(config.SystemScope)
+		cfg, err := w.r.ConfigScoped(ctx, config.SystemScope)
 		if err == nil && cfg != nil && cfg.Commit.GpgSign.IsTrue() {
 			// Use Has before Get so the key is not frozen when no plugin is
 			// registered, allowing callers to register one later.
@@ -267,7 +268,7 @@ func (w *Worktree) buildCommitObject(msg string, opts *CommitOptions, tree plumb
 	}
 
 	if signer != nil {
-		sig, err := signObject(signer, commit)
+		sig, err := signObject(ctx, signer, commit)
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
@@ -278,7 +279,7 @@ func (w *Worktree) buildCommitObject(msg string, opts *CommitOptions, tree plumb
 	if err := commit.Encode(obj); err != nil {
 		return plumbing.ZeroHash, err
 	}
-	return w.r.Storer.SetEncodedObject(obj)
+	return w.r.Storer.SetEncodedObject(ctx, obj)
 }
 
 func (w *Worktree) sanitize(signature object.Signature) object.Signature {
@@ -302,7 +303,7 @@ type buildTreeHelper struct {
 
 // BuildTree builds the tree objects and push its to the storer, the hash
 // of the root tree is returned.
-func (h *buildTreeHelper) BuildTree(idx *index.Index, _ *CommitOptions) (plumbing.Hash, error) {
+func (h *buildTreeHelper) BuildTree(ctx context.Context, idx *index.Index, _ *CommitOptions) (plumbing.Hash, error) {
 	const rootNode = ""
 	h.trees = map[string]*object.Tree{rootNode: {}}
 	h.entries = map[string]*object.TreeEntry{}
@@ -313,7 +314,7 @@ func (h *buildTreeHelper) BuildTree(idx *index.Index, _ *CommitOptions) (plumbin
 		}
 	}
 
-	return h.copyTreeToStorageRecursive(rootNode, h.trees[rootNode])
+	return h.copyTreeToStorageRecursive(ctx, rootNode, h.trees[rootNode])
 }
 
 func (h *buildTreeHelper) commitIndexEntry(e *index.Entry) error {
@@ -372,7 +373,7 @@ func (se sortableEntries) Len() int           { return len(se) }
 func (se sortableEntries) Less(i, j int) bool { return se.sortName(se[i]) < se.sortName(se[j]) }
 func (se sortableEntries) Swap(i, j int)      { se[i], se[j] = se[j], se[i] }
 
-func (h *buildTreeHelper) copyTreeToStorageRecursive(parent string, t *object.Tree) (plumbing.Hash, error) {
+func (h *buildTreeHelper) copyTreeToStorageRecursive(ctx context.Context, parent string, t *object.Tree) (plumbing.Hash, error) {
 	sort.Sort(sortableEntries(t.Entries))
 	for i, e := range t.Entries {
 		if e.Mode != filemode.Dir {
@@ -382,7 +383,7 @@ func (h *buildTreeHelper) copyTreeToStorageRecursive(parent string, t *object.Tr
 		path := path.Join(parent, e.Name)
 
 		var err error
-		e.Hash, err = h.copyTreeToStorageRecursive(path, h.trees[path])
+		e.Hash, err = h.copyTreeToStorageRecursive(ctx, path, h.trees[path])
 		if err != nil {
 			return plumbing.ZeroHash, err
 		}
@@ -396,8 +397,8 @@ func (h *buildTreeHelper) copyTreeToStorageRecursive(parent string, t *object.Tr
 	}
 
 	hash := o.Hash()
-	if h.s.HasEncodedObject(hash) == nil {
+	if h.s.HasEncodedObject(ctx, hash) == nil {
 		return hash, nil
 	}
-	return h.s.SetEncodedObject(o)
+	return h.s.SetEncodedObject(ctx, o)
 }

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -63,29 +63,29 @@ func TestBuildTreeHelper_1773(t *testing.T) {
 		},
 	}
 
-	_, err := h.BuildTree(idx, &CommitOptions{})
+	_, err := h.BuildTree(t.Context(), idx, &CommitOptions{})
 	require.NoError(t, err)
 }
 
 func (s *WorktreeSuite) TestCommitEmptyOptions() {
 	fs := memfs.New()
-	r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+	r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(fs))
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	hash, err := w.Commit("foo", &CommitOptions{Author: defaultSignature()})
+	hash, err := w.Commit(s.T().Context(), "foo", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 	s.False(hash.IsZero())
 
-	commit, err := r.CommitObject(hash)
+	commit, err := r.CommitObject(s.T().Context(), hash)
 	s.Require().NoError(err)
 	s.NotEqual("", commit.Author.Name)
 }
@@ -96,19 +96,19 @@ func (s *WorktreeSuite) TestCommitInitial() {
 	fs := memfs.New()
 	storage := memory.NewStorage()
 
-	r, err := Init(storage, WithWorkTree(fs))
+	r, err := Init(s.T().Context(), storage, WithWorkTree(fs))
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	hash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+	hash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature()})
 	s.Equal(expected, hash)
 	s.Require().NoError(err)
 
@@ -139,38 +139,38 @@ func (s *WorktreeSuite) TestCommitInitialObjectFormats() {
 			fs := memfs.New()
 			storage := memory.NewStorage(memory.WithObjectFormat(tt.objectFormat))
 
-			r, err := Init(storage, WithWorkTree(fs), WithObjectFormat(tt.objectFormat))
+			r, err := Init(s.T().Context(), storage, WithWorkTree(fs), WithObjectFormat(tt.objectFormat))
 			s.Require().NoError(err)
 			defer func() { _ = r.Close() }()
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(s.T().Context())
 			s.Require().NoError(err)
 
 			err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 			s.Require().NoError(err)
 
-			_, err = w.Add("foo")
+			_, err = w.Add(s.T().Context(), "foo")
 			s.Require().NoError(err)
 
-			hash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+			hash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature()})
 			s.Require().NoError(err)
 			s.Equal(expected, hash)
 			s.Len(hash.String(), tt.objectFormat.HexSize())
-			s.Require().NoError(storage.HasEncodedObject(hash))
+			s.Require().NoError(storage.HasEncodedObject(s.T().Context(), hash))
 
-			commit, err := r.CommitObject(hash)
+			commit, err := r.CommitObject(s.T().Context(), hash)
 			s.Require().NoError(err)
 			s.Equal(hash, commit.Hash)
 			s.Equal("foo\n", commit.Message)
 			s.Len(commit.TreeHash.String(), tt.objectFormat.HexSize())
-			s.Require().NoError(storage.HasEncodedObject(commit.TreeHash))
+			s.Require().NoError(storage.HasEncodedObject(s.T().Context(), commit.TreeHash))
 
-			tree, err := commit.Tree()
+			tree, err := commit.Tree(s.T().Context())
 			s.Require().NoError(err)
-			file, err := tree.File("foo")
+			file, err := tree.File(s.T().Context(), "foo")
 			s.Require().NoError(err)
 			s.Len(file.Hash.String(), tt.objectFormat.HexSize())
-			s.Require().NoError(storage.HasEncodedObject(file.Hash))
+			s.Require().NoError(storage.HasEncodedObject(s.T().Context(), file.Hash))
 			content, err := file.Contents()
 			s.Require().NoError(err)
 			s.Equal("foo", content)
@@ -184,20 +184,20 @@ func (s *WorktreeSuite) TestSetReferencesInSHA256Repository() {
 	fs := memfs.New()
 	storage := memory.NewStorage(memory.WithObjectFormat(formatcfg.SHA256))
 
-	r, err := Init(storage, WithWorkTree(fs), WithObjectFormat(formatcfg.SHA256))
+	r, err := Init(s.T().Context(), storage, WithWorkTree(fs), WithObjectFormat(formatcfg.SHA256))
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.Require().NoError(err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	hash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+	hash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 	s.Len(hash.String(), formatcfg.SHA256.HexSize())
 
@@ -212,10 +212,10 @@ func (s *WorktreeSuite) TestSetReferencesInSHA256Repository() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			ref := plumbing.NewHashReference(tt.ref, hash)
-			err := r.Storer.SetReference(ref)
+			err := r.Storer.SetReference(s.T().Context(), ref)
 			s.Require().NoError(err)
 
-			got, err := r.Reference(tt.ref, false)
+			got, err := r.Reference(s.T().Context(), tt.ref, false)
 			s.Require().NoError(err)
 			s.Equal(ref.Name(), got.Name())
 			s.Equal(hash, got.Hash())
@@ -227,71 +227,71 @@ func (s *WorktreeSuite) TestSetReferencesInSHA256Repository() {
 func (s *WorktreeSuite) TestNothingToCommit() {
 	expected := plumbing.NewHash("838ea833ce893e8555907e5ef224aa076f5e274a")
 
-	r, err := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
-	hash, err := w.Commit("failed empty commit\n", &CommitOptions{Author: defaultSignature()})
+	hash, err := w.Commit(s.T().Context(), "failed empty commit\n", &CommitOptions{Author: defaultSignature()})
 	s.Equal(plumbing.ZeroHash, hash)
 	s.ErrorIs(err, ErrEmptyCommit)
 
-	hash, err = w.Commit("enable empty commits\n", &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true})
+	hash, err = w.Commit(s.T().Context(), "enable empty commits\n", &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true})
 	s.Equal(expected, hash)
 	s.Require().NoError(err)
 }
 
 func (s *WorktreeSuite) TestNothingToCommitNonEmptyRepo() {
 	fs := memfs.New()
-	r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+	r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(fs))
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.Require().NoError(err)
 
-	w.Add("foo")
-	_, err = w.Commit("previous commit\n", &CommitOptions{Author: defaultSignature()})
+	w.Add(s.T().Context(), "foo")
+	_, err = w.Commit(s.T().Context(), "previous commit\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
-	hash, err := w.Commit("failed empty commit\n", &CommitOptions{Author: defaultSignature()})
+	hash, err := w.Commit(s.T().Context(), "failed empty commit\n", &CommitOptions{Author: defaultSignature()})
 	s.Equal(plumbing.ZeroHash, hash)
 	s.ErrorIs(err, ErrEmptyCommit)
 
-	_, err = w.Commit("enable empty commits\n", &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true})
+	_, err = w.Commit(s.T().Context(), "enable empty commits\n", &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true})
 	s.Require().NoError(err)
 }
 
 func (s *WorktreeSuite) TestRemoveAndCommitToMakeEmptyRepo() {
 	fs := memfs.New()
-	r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+	r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(fs))
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.Require().NoError(err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	_, err = w.Commit("Add in Repo\n", &CommitOptions{Author: defaultSignature()})
+	_, err = w.Commit(s.T().Context(), "Add in Repo\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
 	err = fs.Remove("foo")
 	s.Require().NoError(err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	_, err = w.Commit("Remove foo\n", &CommitOptions{Author: defaultSignature()})
+	_, err = w.Commit(s.T().Context(), "Remove foo\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 }
 
@@ -304,16 +304,16 @@ func (s *WorktreeSuite) TestCommitParent() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.Require().NoError(err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	hash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+	hash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature()})
 	s.Equal(expected, hash)
 	s.Require().NoError(err)
 
@@ -327,28 +327,28 @@ func (s *WorktreeSuite) TestCommitAmendWithoutChanges() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.Require().NoError(err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	prevHash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+	prevHash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
-	amendedHash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature(), Amend: true})
+	amendedHash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature(), Amend: true})
 	s.Require().NoError(err)
 
-	headRef, err := w.r.Head()
+	headRef, err := w.r.Head(s.T().Context())
 	s.Require().NoError(err)
 
 	s.Equal(headRef.Hash(), amendedHash)
 	s.Equal(prevHash, amendedHash)
 
-	commit, err := w.r.CommitObject(headRef.Hash())
+	commit, err := w.r.CommitObject(s.T().Context(), headRef.Hash())
 	s.Require().NoError(err)
 	s.Equal("foo\n", commit.Message)
 
@@ -362,36 +362,36 @@ func (s *WorktreeSuite) TestCommitAmendWithChanges() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	_, err = w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+	_, err = w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
 	util.WriteFile(fs, "bar", []byte("bar"), 0o644)
 
-	_, err = w.Add("bar")
+	_, err = w.Add(s.T().Context(), "bar")
 	s.Require().NoError(err)
 
-	amendedHash, err := w.Commit("bar\n", &CommitOptions{Author: defaultSignature(), Amend: true})
+	amendedHash, err := w.Commit(s.T().Context(), "bar\n", &CommitOptions{Author: defaultSignature(), Amend: true})
 	s.Require().NoError(err)
 
-	headRef, err := w.r.Head()
+	headRef, err := w.r.Head(s.T().Context())
 	s.Require().NoError(err)
 
 	s.Equal(headRef.Hash(), amendedHash)
 
-	commit, err := w.r.CommitObject(headRef.Hash())
+	commit, err := w.r.CommitObject(s.T().Context(), headRef.Hash())
 	s.Require().NoError(err)
 	s.Equal("bar\n", commit.Message)
 	s.Equal(1, commit.NumParents())
 
-	stats, err := commit.Stats()
+	stats, err := commit.Stats(s.T().Context())
 	s.Require().NoError(err)
 	s.Len(stats, 2)
 	s.Equal(object.FileStat{
@@ -413,22 +413,22 @@ func (s *WorktreeSuite) TestCommitAmendNothingToCommit() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.Require().NoError(err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	prevHash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature()})
+	prevHash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
-	_, err = w.Commit("bar\n", &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true})
+	_, err = w.Commit(s.T().Context(), "bar\n", &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true})
 	s.Require().NoError(err)
 
-	amendedHash, err := w.Commit("foo\n", &CommitOptions{Author: defaultSignature(), Amend: true})
+	amendedHash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: defaultSignature(), Amend: true})
 	s.T().Log(prevHash, amendedHash)
 	s.ErrorIs(err, ErrEmptyCommit)
 	s.Equal(plumbing.ZeroHash, amendedHash)
@@ -437,44 +437,44 @@ func (s *WorktreeSuite) TestCommitAmendNothingToCommit() {
 func TestCount(t *testing.T) {
 	t.Parallel()
 	f := fixtures.Basic().One()
-	r := NewRepositoryWithEmptyWorktree(f)
+	r := NewRepositoryWithEmptyWorktree(t.Context(), f)
 	defer func() { _ = r.Close() }()
 
-	iter, err := r.CommitObjects()
+	iter, err := r.CommitObjects(t.Context())
 	require.NoError(t, err)
 
 	count := 0
-	iter.ForEach(func(*object.Commit) error {
+	iter.ForEach(t.Context(), func(*object.Commit) error {
 		count++
 		return nil
 	})
 	assert.Equal(t, 9, count, "commits mismatch")
 
-	trees, err := r.TreeObjects()
+	trees, err := r.TreeObjects(t.Context())
 	require.NoError(t, err)
 
 	count = 0
-	trees.ForEach(func(*object.Tree) error {
+	trees.ForEach(t.Context(), func(*object.Tree) error {
 		count++
 		return nil
 	})
 	assert.Equal(t, 12, count, "trees mismatch")
 
-	blobs, err := r.BlobObjects()
+	blobs, err := r.BlobObjects(t.Context())
 	require.NoError(t, err)
 
 	count = 0
-	blobs.ForEach(func(*object.Blob) error {
+	blobs.ForEach(t.Context(), func(*object.Blob) error {
 		count++
 		return nil
 	})
 	assert.Equal(t, 10, count, "blobs mismatch")
 
-	objects, err := r.Objects()
+	objects, err := r.Objects(t.Context())
 	require.NoError(t, err)
 
 	count = 0
-	objects.ForEach(func(object.Object) error {
+	objects.ForEach(t.Context(), func(object.Object) error {
 		count++
 		return nil
 	})
@@ -487,26 +487,26 @@ func TestAddAndCommitWithSkipStatus(t *testing.T) {
 
 	f := fixtures.Basic().One()
 	fs := memfs.New()
-	r := NewRepositoryWithEmptyWorktree(f)
+	r := NewRepositoryWithEmptyWorktree(t.Context(), f)
 	defer func() { _ = r.Close() }()
 	w := &Worktree{
 		r:          r,
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(t.Context(), &CheckoutOptions{})
 	require.NoError(t, err)
 
 	util.WriteFile(fs, "LICENSE", []byte("foo"), 0o644)
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
-	err = w.AddWithOptions(&AddOptions{
+	err = w.AddWithOptions(t.Context(), &AddOptions{
 		Path:       "foo",
 		SkipStatus: true,
 	})
 	require.NoError(t, err)
 
-	hash, err := w.Commit("commit foo only\n", &CommitOptions{
+	hash, err := w.Commit(t.Context(), "commit foo only\n", &CommitOptions{
 		Author: defaultSignature(),
 	})
 
@@ -520,18 +520,19 @@ func assertStorage(
 	t *testing.T, r *Repository,
 	treesCount, blobCount, commitCount int, head plumbing.Hash,
 ) {
-	trees, err := r.Storer.IterEncodedObjects(plumbing.TreeObject)
+	ctx := t.Context()
+	trees, err := r.Storer.IterEncodedObjects(ctx, plumbing.TreeObject)
 	require.NoError(t, err)
-	blobs, err := r.Storer.IterEncodedObjects(plumbing.BlobObject)
+	blobs, err := r.Storer.IterEncodedObjects(ctx, plumbing.BlobObject)
 	require.NoError(t, err)
-	commits, err := r.Storer.IterEncodedObjects(plumbing.CommitObject)
+	commits, err := r.Storer.IterEncodedObjects(ctx, plumbing.CommitObject)
 	require.NoError(t, err)
 
-	assert.Equal(t, treesCount, lenIterEncodedObjects(trees), "trees count mismatch")
-	assert.Equal(t, blobCount, lenIterEncodedObjects(blobs), "blobs count mismatch")
-	assert.Equal(t, commitCount, lenIterEncodedObjects(commits), "commits count mismatch")
+	assert.Equal(t, treesCount, lenIterEncodedObjects(ctx, trees), "trees count mismatch")
+	assert.Equal(t, blobCount, lenIterEncodedObjects(ctx, blobs), "blobs count mismatch")
+	assert.Equal(t, commitCount, lenIterEncodedObjects(ctx, commits), "commits count mismatch")
 
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, head.String(), ref.Hash().String())
 }
@@ -546,40 +547,40 @@ func (s *WorktreeSuite) TestAddAndCommitWithSkipStatusPathNotModified() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.Require().NoError(err)
 	foo := status.File("foo")
 	s.Equal(Untracked, foo.Staging)
 	s.Equal(Untracked, foo.Worktree)
 
-	err = w.AddWithOptions(&AddOptions{
+	err = w.AddWithOptions(s.T().Context(), &AddOptions{
 		Path:       "foo",
 		SkipStatus: true,
 	})
 	s.Require().NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.Require().NoError(err)
 	foo = status.File("foo")
 	s.Equal(Added, foo.Staging)
 	s.Equal(Unmodified, foo.Worktree)
 
-	hash, err := w.Commit("commit foo only\n", &CommitOptions{
+	hash, err := w.Commit(s.T().Context(), "commit foo only\n", &CommitOptions{
 		All:    true,
 		Author: defaultSignature(),
 	})
 	s.Equal(expected, hash)
 	s.Require().NoError(err)
 
-	commit1, err := w.r.CommitObject(hash)
+	commit1, err := w.r.CommitObject(s.T().Context(), hash)
 	s.Require().NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.Require().NoError(err)
 	foo = status.File("foo")
 	s.Equal(Untracked, foo.Staging)
@@ -587,35 +588,35 @@ func (s *WorktreeSuite) TestAddAndCommitWithSkipStatusPathNotModified() {
 
 	assertStorageStatus(s, s.Repository, 13, 11, 10, expected)
 
-	err = w.AddWithOptions(&AddOptions{
+	err = w.AddWithOptions(s.T().Context(), &AddOptions{
 		Path:       "foo",
 		SkipStatus: true,
 	})
 	s.Require().NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.Require().NoError(err)
 	foo = status.File("foo")
 	s.Equal(Untracked, foo.Staging)
 	s.Equal(Untracked, foo.Worktree)
 
-	hash, err = w.Commit("commit with no changes\n", &CommitOptions{
+	hash, err = w.Commit(s.T().Context(), "commit with no changes\n", &CommitOptions{
 		Author:            defaultSignature(),
 		AllowEmptyCommits: true,
 	})
 	s.Equal(expected2, hash)
 	s.Require().NoError(err)
 
-	commit2, err := w.r.CommitObject(hash)
+	commit2, err := w.r.CommitObject(s.T().Context(), hash)
 	s.Require().NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.Require().NoError(err)
 	foo = status.File("foo")
 	s.Equal(Untracked, foo.Staging)
 	s.Equal(Untracked, foo.Worktree)
 
-	patch, err := commit2.Patch(commit1)
+	patch, err := commit2.Patch(s.T().Context(), commit1)
 	s.Require().NoError(err)
 	files := patch.FilePatches()
 	s.Nil(files)
@@ -632,13 +633,13 @@ func (s *WorktreeSuite) TestCommitAll() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	util.WriteFile(fs, "LICENSE", []byte("foo"), 0o644)
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
-	hash, err := w.Commit("foo\n", &CommitOptions{
+	hash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{
 		All:    true,
 		Author: defaultSignature(),
 	})
@@ -658,14 +659,14 @@ func (s *WorktreeSuite) TestRemoveAndCommitAll() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	_, errFirst := w.Commit("Add in Repo\n", &CommitOptions{
+	_, errFirst := w.Commit(s.T().Context(), "Add in Repo\n", &CommitOptions{
 		Author: defaultSignature(),
 	})
 	s.Nil(errFirst)
@@ -673,7 +674,7 @@ func (s *WorktreeSuite) TestRemoveAndCommitAll() {
 	errRemove := fs.Remove("foo")
 	s.Nil(errRemove)
 
-	hash, errSecond := w.Commit("Remove foo\n", &CommitOptions{
+	hash, errSecond := w.Commit(s.T().Context(), "Remove foo\n", &CommitOptions{
 		All:    true,
 		Author: defaultSignature(),
 	})
@@ -688,18 +689,18 @@ func (s *WorktreeSuite) TestRemoveAndCommitAll() {
 func (s *WorktreeSuite) TestCherryPick() {
 	fs := memfs.New()
 
-	r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+	r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(fs))
 	s.Require().NoError(err, "init the repository")
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 	// add README.md to the worktree
 	err = util.WriteFile(fs, "README.md", []byte("README File"), 0o644)
 	s.Require().NoError(err)
-	w.Add("README.md")
+	w.Add(s.T().Context(), "README.md")
 
-	initHash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+	initHash, err := w.Commit(s.T().Context(), "initial commit\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
 	// add two files to worktree
@@ -709,30 +710,30 @@ func (s *WorktreeSuite) TestCherryPick() {
 	err = util.WriteFile(fs, "foobar", []byte("foo**bar"), 0o644)
 	s.Require().NoError(err)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
-	_, err = w.Add("foobar")
+	_, err = w.Add(s.T().Context(), "foobar")
 	s.Require().NoError(err)
 
 	// commit the changes
-	commitHash1, err := w.Commit("commit 1\n", &CommitOptions{Author: defaultSignature()})
+	commitHash1, err := w.Commit(s.T().Context(), "commit 1\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 	s.False(commitHash1.IsZero(), "commit hash is zero")
 	// modify the "foo" file
 	err = util.WriteFile(fs, "foo", []byte("foo=bar"), 0o644)
 	s.Require().NoError(err)
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 	// commit the new changes to "foo" file
-	commitHash2, err := w.Commit("commit 2\n", &CommitOptions{Author: defaultSignature()})
+	commitHash2, err := w.Commit(s.T().Context(), "commit 2\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 	s.False(commitHash2.IsZero(), "commit hash is zero")
 	// get commit objects to do cherry picking
-	commit1, err := r.CommitObject(commitHash1)
+	commit1, err := r.CommitObject(s.T().Context(), commitHash1)
 	s.Require().NoError(err)
 	s.NotEmpty(commit1)
 
-	commit2, err := r.CommitObject(commitHash2)
+	commit2, err := r.CommitObject(s.T().Context(), commitHash2)
 	s.Require().NoError(err)
 	s.NotEmpty(commit2)
 
@@ -740,17 +741,17 @@ func (s *WorktreeSuite) TestCherryPick() {
 	s.Require().NoError(err)
 	s.Equal("foo**bar", string(foobarFileContent))
 
-	err = w.Checkout(&CheckoutOptions{Hash: initHash})
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{Hash: initHash})
 	s.Require().NoError(err, "checkout to the default branch")
 
-	err = w.CherryPick(&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, TheirsMergeStrategy, commit1)
+	err = w.CherryPick(s.T().Context(), &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, TheirsMergeStrategy, commit1)
 	s.Require().NoError(err)
 
 	foobarFileContent, err = util.ReadFile(fs, "foobar")
 	s.Require().NoError(err)
 	s.Equal("foo**bar", string(foobarFileContent))
 
-	err = w.CherryPick(&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, TheirsMergeStrategy, commit2)
+	err = w.CherryPick(s.T().Context(), &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, TheirsMergeStrategy, commit2)
 	s.Require().NoError(err)
 
 	fooFileContent, err := util.ReadFile(fs, "foo")
@@ -758,23 +759,23 @@ func (s *WorktreeSuite) TestCherryPick() {
 	s.Equal("foo=bar", string(fooFileContent))
 
 	// delete the file
-	rmHash, err := w.Remove("foo")
+	rmHash, err := w.Remove(s.T().Context(), "foo")
 	s.Require().NoError(err)
 	s.False(rmHash.IsZero())
 
-	rmCommitHash, err := w.Commit("remove the file\n", &CommitOptions{Author: defaultSignature()})
+	rmCommitHash, err := w.Commit(s.T().Context(), "remove the file\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
-	rmCommit, err := r.CommitObject(rmCommitHash)
+	rmCommit, err := r.CommitObject(s.T().Context(), rmCommitHash)
 	s.Require().NoError(err)
 
 	// go back to commit 2 and cherry pick the latest commit
-	err = w.Checkout(&CheckoutOptions{
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{
 		Hash: commitHash2,
 	})
 	s.Require().NoError(err)
 
-	err = w.CherryPick(&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, TheirsMergeStrategy, rmCommit)
+	err = w.CherryPick(s.T().Context(), &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, TheirsMergeStrategy, rmCommit)
 	s.Require().NoError(err)
 
 	fooFileContent, err = util.ReadFile(fs, "foo")
@@ -782,19 +783,19 @@ func (s *WorktreeSuite) TestCherryPick() {
 	s.Nil(fooFileContent)
 
 	// go back to commit 1 and cherry pick with "ours" strategy option
-	err = w.Checkout(&CheckoutOptions{
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{
 		Hash: commitHash1,
 	})
 	s.Require().NoError(err)
 
-	err = w.CherryPick(&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, OursMergeStrategy, rmCommit)
+	err = w.CherryPick(s.T().Context(), &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, OursMergeStrategy, rmCommit)
 	s.Require().NoError(err)
 	fooFileContent, err = util.ReadFile(fs, "foo")
 	s.Require().NoError(err)
 	s.Equal("foo", string(fooFileContent))
 
 	// cherry-pick with no commit options
-	err = w.CherryPick(nil, OursMergeStrategy, rmCommit)
+	err = w.CherryPick(s.T().Context(), nil, OursMergeStrategy, rmCommit)
 	s.ErrorIs(err, ErrCannotCherryPickWithoutCommitOptions)
 }
 
@@ -802,22 +803,22 @@ func (s *WorktreeSuite) TestCherryPickRejectsInvalidPaths() {
 	fs := memfs.New()
 
 	storage := memory.NewStorage()
-	r, err := Init(storage, WithWorkTree(fs))
+	r, err := Init(s.T().Context(), storage, WithWorkTree(fs))
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	err = util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 	s.Require().NoError(err)
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	initHash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+	initHash, err := w.Commit(s.T().Context(), "initial commit\n", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
-	initCommit, err := r.CommitObject(initHash)
+	initCommit, err := r.CommitObject(s.T().Context(), initHash)
 	s.Require().NoError(err)
 
 	badContent := []byte("content")
@@ -830,10 +831,10 @@ func (s *WorktreeSuite) TestCherryPickRejectsInvalidPaths() {
 	} {
 		badCommit := s.buildChildCommit(storage, initCommit, initHash, name, blobHash)
 
-		err = w.Checkout(&CheckoutOptions{Hash: initHash})
+		err = w.Checkout(s.T().Context(), &CheckoutOptions{Hash: initHash})
 		s.Require().NoError(err)
 
-		err = w.CherryPick(&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, TheirsMergeStrategy, badCommit)
+		err = w.CherryPick(s.T().Context(), &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true}, TheirsMergeStrategy, badCommit)
 		s.Error(err, "expected cherry-pick to reject path %q", name)
 	}
 }
@@ -849,7 +850,7 @@ func (s *WorktreeSuite) storeBlob(storage *memory.Storage, content []byte) plumb
 	_, err = bw.Write(content)
 	s.Require().NoError(err)
 	s.Require().NoError(bw.Close())
-	h, err := storage.SetEncodedObject(obj)
+	h, err := storage.SetEncodedObject(s.T().Context(), obj)
 	s.Require().NoError(err)
 	return h
 }
@@ -857,7 +858,7 @@ func (s *WorktreeSuite) storeBlob(storage *memory.Storage, content []byte) plumb
 func (s *WorktreeSuite) buildChildCommit(storage *memory.Storage, parent *object.Commit, parentHash plumbing.Hash, filename string, blobHash plumbing.Hash) *object.Commit {
 	s.T().Helper()
 
-	parentTree, err := parent.Tree()
+	parentTree, err := parent.Tree(s.T().Context())
 	s.Require().NoError(err)
 
 	entries := slices.Clone(parentTree.Entries)
@@ -885,7 +886,7 @@ func (s *WorktreeSuite) buildChildCommit(storage *memory.Storage, parent *object
 	_, err = tw.Write(buf.Bytes())
 	s.Require().NoError(err)
 	s.Require().NoError(tw.Close())
-	treeHash, err := storage.SetEncodedObject(treeObj)
+	treeHash, err := storage.SetEncodedObject(s.T().Context(), treeObj)
 	s.Require().NoError(err)
 
 	commit := &object.Commit{
@@ -898,10 +899,10 @@ func (s *WorktreeSuite) buildChildCommit(storage *memory.Storage, parent *object
 	commitObj := storage.NewEncodedObject()
 	err = commit.Encode(commitObj)
 	s.Require().NoError(err)
-	commitHash, err := storage.SetEncodedObject(commitObj)
+	commitHash, err := storage.SetEncodedObject(s.T().Context(), commitObj)
 	s.Require().NoError(err)
 
-	result, err := object.GetCommit(storage, commitHash)
+	result, err := object.GetCommit(s.T().Context(), storage, commitHash)
 	s.Require().NoError(err)
 	return result
 }
@@ -910,17 +911,17 @@ func (s *WorktreeSuite) TestCommitTreeSort() {
 	fs := s.TemporalFilesystem()
 
 	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-	rInit, err := Init(st)
+	rInit, err := Init(s.T().Context(), st)
 	s.Require().NoError(err)
 	defer func() { _ = rInit.Close() }()
 
-	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), memfs.New(), &CloneOptions{
 		URL: fs.Root(),
 	})
 	s.ErrorIs(err, transport.ErrEmptyRemoteRepository)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	mfs := w.filesystem
@@ -930,17 +931,17 @@ func (s *WorktreeSuite) TestCommitTreeSort() {
 
 	for _, p := range []string{"delta_last", "Gamma", "delta/middle", "Beta", "delta-first", "alpha"} {
 		util.WriteFile(mfs, p, []byte("foo"), 0o644)
-		_, err = w.Add(p)
+		_, err = w.Add(s.T().Context(), p)
 		s.Require().NoError(err)
 	}
 
-	_, err = w.Commit("foo\n", &CommitOptions{
+	_, err = w.Commit(s.T().Context(), "foo\n", &CommitOptions{
 		All:    true,
 		Author: defaultSignature(),
 	})
 	s.Require().NoError(err)
 
-	err = r.Push(&PushOptions{})
+	err = r.Push(s.T().Context(), &PushOptions{})
 	s.Require().NoError(err)
 
 	cmd := exec.Command("git", "fsck")
@@ -962,20 +963,20 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 	s.Require().NoError(err)
 	storage := filesystem.NewStorage(fsDotgit, cache.NewObjectLRUDefault())
 
-	r, err := Init(storage, WithWorkTree(fs))
+	r, err := Init(s.T().Context(), storage, WithWorkTree(fs))
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	// Step 1: Write LICENSE
 	util.WriteFile(fs, "LICENSE", []byte("license"), 0o644)
-	hLicense, err := w.Add("LICENSE")
+	hLicense, err := w.Add(s.T().Context(), "LICENSE")
 	s.Require().NoError(err)
 	s.Equal(plumbing.NewHash("0484eba0d41636ba71fa612c78559cd6c3006cde"), hLicense)
 
-	hash, err := w.Commit("commit 1\n", &CommitOptions{
+	hash, err := w.Commit(s.T().Context(), "commit 1\n", &CommitOptions{
 		All:    true,
 		Author: defaultSignature(),
 	})
@@ -988,11 +989,11 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 	// Step 2: Write foo.
 	time.Sleep(5 * time.Millisecond) // uncool, but we need to get different timestamps...
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
-	hFoo, err := w.Add("foo")
+	hFoo, err := w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 	s.Equal(plumbing.NewHash("19102815663d23f8b75a47e7a01965dcdc96468c"), hFoo)
 
-	hash, err = w.Commit("commit 2\n", &CommitOptions{
+	hash, err = w.Commit(s.T().Context(), "commit 2\n", &CommitOptions{
 		All:    true,
 		Author: defaultSignature(),
 	})
@@ -1016,7 +1017,7 @@ func (s *WorktreeSuite) TestJustStoreObjectsNotAlreadyStored() {
 
 func (s *WorktreeSuite) TestCommitInvalidCharactersInAuthorInfos() {
 	f := fixtures.Basic().One()
-	s.Repository = NewRepositoryWithEmptyWorktree(f)
+	s.Repository = NewRepositoryWithEmptyWorktree(s.T().Context(), f)
 	r1 := s.Repository
 	s.T().Cleanup(func() { _ = r1.Close() })
 
@@ -1025,29 +1026,29 @@ func (s *WorktreeSuite) TestCommitInvalidCharactersInAuthorInfos() {
 	fs := memfs.New()
 	storage := memory.NewStorage()
 
-	r2, err := Init(storage, WithWorkTree(fs))
+	r2, err := Init(s.T().Context(), storage, WithWorkTree(fs))
 	s.Require().NoError(err)
 	defer func() { _ = r2.Close() }()
 
-	w, err := r2.Worktree()
+	w, err := r2.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	util.WriteFile(fs, "foo", []byte("foo"), 0o644)
 
-	_, err = w.Add("foo")
+	_, err = w.Add(s.T().Context(), "foo")
 	s.Require().NoError(err)
 
-	hash, err := w.Commit("foo\n", &CommitOptions{Author: invalidSignature()})
+	hash, err := w.Commit(s.T().Context(), "foo\n", &CommitOptions{Author: invalidSignature()})
 	s.Equal(expected, hash)
 	s.Require().NoError(err)
 
 	assertStorageStatus(s, r2, 1, 1, 1, expected)
 
 	// Check HEAD commit contains author informations with '<', '>' and '\n' stripped
-	lr, err := r2.Log(&LogOptions{})
+	lr, err := r2.Log(s.T().Context(), &LogOptions{})
 	s.Require().NoError(err)
 
-	commit, err := lr.Next()
+	commit, err := lr.Next(s.T().Context())
 	s.Require().NoError(err)
 
 	s.Equal("foo bad", commit.Author.Name)
@@ -1077,14 +1078,14 @@ func BenchmarkCommit(b *testing.B) {
 			err := util.WriteFile(wt.filesystem, fileName, fmt.Appendf(nil, "content %d", seq), 0o644)
 			require.NoError(b, err)
 
-			_, err = wt.Add(fileName)
+			_, err = wt.Add(b.Context(), fileName)
 			require.NoError(b, err)
 
 			sig.When = time.Now()
 
 			// Isolate the benchmark to the commit operation.
 			b.StartTimer()
-			_, err = wt.Commit(fmt.Sprintf("commit %d\n", seq), &CommitOptions{
+			_, err = wt.Commit(b.Context(), fmt.Sprintf("commit %d\n", seq), &CommitOptions{
 				Author:    sig,
 				Committer: sig,
 			})
@@ -1100,25 +1101,26 @@ func assertStorageStatus(
 	s *WorktreeSuite, r *Repository,
 	treesCount, blobCount, commitCount int, head plumbing.Hash,
 ) {
-	trees, err := r.Storer.IterEncodedObjects(plumbing.TreeObject)
+	ctx := s.T().Context()
+	trees, err := r.Storer.IterEncodedObjects(ctx, plumbing.TreeObject)
 	s.Require().NoError(err)
-	blobs, err := r.Storer.IterEncodedObjects(plumbing.BlobObject)
+	blobs, err := r.Storer.IterEncodedObjects(ctx, plumbing.BlobObject)
 	s.Require().NoError(err)
-	commits, err := r.Storer.IterEncodedObjects(plumbing.CommitObject)
+	commits, err := r.Storer.IterEncodedObjects(ctx, plumbing.CommitObject)
 	s.Require().NoError(err)
 
-	s.Equal(treesCount, lenIterEncodedObjects(trees))
-	s.Equal(blobCount, lenIterEncodedObjects(blobs))
-	s.Equal(commitCount, lenIterEncodedObjects(commits))
+	s.Equal(treesCount, lenIterEncodedObjects(ctx, trees))
+	s.Equal(blobCount, lenIterEncodedObjects(ctx, blobs))
+	s.Equal(commitCount, lenIterEncodedObjects(ctx, commits))
 
-	ref, err := r.Head()
+	ref, err := r.Head(ctx)
 	s.Require().NoError(err)
 	s.Equal(head, ref.Hash())
 }
 
-func lenIterEncodedObjects(iter storer.EncodedObjectIter) int {
+func lenIterEncodedObjects(ctx context.Context, iter storer.EncodedObjectIter) int {
 	count := 0
-	iter.ForEach(func(plumbing.EncodedObject) error {
+	iter.ForEach(ctx, func(plumbing.EncodedObject) error {
 		count++
 		return nil
 	})
@@ -1224,25 +1226,25 @@ func TestBuildCommitObjectSignerSelection(t *testing.T) { //nolint:paralleltest 
 			}
 
 			fs := memfs.New()
-			r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+			r, err := Init(t.Context(), memory.NewStorage(), WithWorkTree(fs))
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
 
-			cfg, err := r.Config()
+			cfg, err := r.Config(t.Context())
 			require.NoError(t, err)
 
 			cfg.Commit.GpgSign = tt.commitSignGpg
-			err = r.SetConfig(cfg)
+			err = r.SetConfig(t.Context(), cfg)
 			require.NoError(t, err)
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(t.Context())
 			require.NoError(t, err)
 
 			util.WriteFile(fs, "file.txt", []byte("content"), 0o644)
-			_, err = w.Add("file.txt")
+			_, err = w.Add(t.Context(), "file.txt")
 			require.NoError(t, err)
 
-			hash, err := w.Commit("test commit\n", &CommitOptions{
+			hash, err := w.Commit(t.Context(), "test commit\n", &CommitOptions{
 				Author: defaultSignature(),
 				Signer: tt.optionsSigner,
 			})
@@ -1253,7 +1255,7 @@ func TestBuildCommitObjectSignerSelection(t *testing.T) { //nolint:paralleltest 
 				return // no need to carry on
 			}
 
-			commit, err := r.CommitObject(hash)
+			commit, err := r.CommitObject(t.Context(), hash)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantSignature, commit.Signature)
 

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -171,11 +171,11 @@ func TestWorktreeFilesystemReturnsWorktreeFilesystem(t *testing.T) {
 		t.Parallel()
 
 		mfs := memfs.New()
-		r, err := Init(memory.NewStorage(), WithWorkTree(mfs))
+		r, err := Init(t.Context(), memory.NewStorage(), WithWorkTree(mfs))
 		require.NoError(t, err)
 		defer func() { _ = r.Close() }()
 
-		w, err := r.Worktree()
+		w, err := r.Worktree(t.Context())
 		require.NoError(t, err)
 
 		assert.Equal(t, mfs, w.Filesystem())
@@ -515,45 +515,45 @@ func TestCherryPickPathValidationMatchesGit(t *testing.T) {
 
 			dir := t.TempDir()
 
-			r1, err := PlainInit(dir, false)
+			r1, err := PlainInit(t.Context(), dir, false)
 			require.NoError(t, err)
 			defer func() { _ = r1.Close() }()
 
-			w, err := r1.Worktree()
+			w, err := r1.Worktree(t.Context())
 			require.NoError(t, err)
 
 			require.NoError(t, util.WriteFile(w.Filesystem(), "README", []byte("init"), 0o644))
-			_, err = w.Add("README")
+			_, err = w.Add(t.Context(), "README")
 			require.NoError(t, err)
 
-			initHash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+			initHash, err := w.Commit(t.Context(), "initial commit\n", &CommitOptions{Author: defaultSignature()})
 			require.NoError(t, err)
 
 			for k, v := range tc.config {
 				gitConfig(t, dir, k, v)
 			}
 
-			initCommit, err := r1.CommitObject(initHash)
+			initCommit, err := r1.CommitObject(t.Context(), initHash)
 			require.NoError(t, err)
 
 			badCommit := buildCommitWithEntry(t, r1.Storer, initCommit, initHash, tc.path, filemode.Regular)
 
 			// Re-open so config overrides take effect in the worktreeFilesystem.
-			r2, err := PlainOpen(dir)
+			r2, err := PlainOpen(t.Context(), dir)
 			require.NoError(t, err)
 			defer func() { _ = r2.Close() }()
 
-			w, err = r2.Worktree()
+			w, err = r2.Worktree(t.Context())
 			require.NoError(t, err)
 
 			goGitErr := w.CherryPick(
-				&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true},
+				t.Context(), &CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true},
 				TheirsMergeStrategy, badCommit,
 			)
 			assert.Error(t, goGitErr, "go-git should reject cherry-pick of %q", tc.path)
 
 			if !tc.skipGit {
-				require.NoError(t, w.Reset(&ResetOptions{Commit: initHash, Mode: HardReset}))
+				require.NoError(t, w.Reset(t.Context(), &ResetOptions{Commit: initHash, Mode: HardReset}))
 
 				gitErr := gitCherryPick(t, dir, badCommit.Hash.String())
 				assert.Error(t, gitErr, "git should reject cherry-pick of %q", tc.path)
@@ -574,7 +574,7 @@ func buildCommitWithEntry(t *testing.T, s storer.Storer, parent *object.Commit, 
 	_, err = bw.Write(content)
 	require.NoError(t, err)
 	require.NoError(t, bw.Close())
-	blobHash, err := s.SetEncodedObject(blobObj)
+	blobHash, err := s.SetEncodedObject(t.Context(), blobObj)
 	require.NoError(t, err)
 
 	// Build nested tree structure from leaf to root.
@@ -587,7 +587,7 @@ func buildCommitWithEntry(t *testing.T, s storer.Storer, parent *object.Commit, 
 		leafMode = filemode.Dir
 	}
 
-	parentTree, err := parent.Tree()
+	parentTree, err := parent.Tree(t.Context())
 	require.NoError(t, err)
 
 	entries := make([]object.TreeEntry, len(parentTree.Entries), len(parentTree.Entries)+1)
@@ -609,10 +609,10 @@ func buildCommitWithEntry(t *testing.T, s storer.Storer, parent *object.Commit, 
 	}
 	commitObj := s.NewEncodedObject()
 	require.NoError(t, commit.Encode(commitObj))
-	commitHash, err := s.SetEncodedObject(commitObj)
+	commitHash, err := s.SetEncodedObject(t.Context(), commitObj)
 	require.NoError(t, err)
 
-	result, err := object.GetCommit(s, commitHash)
+	result, err := object.GetCommit(t.Context(), s, commitHash)
 	require.NoError(t, err)
 	return result
 }
@@ -640,7 +640,7 @@ func storeRawTree(t *testing.T, s storer.Storer, entries []object.TreeEntry) plu
 	require.NoError(t, err)
 	require.NoError(t, w.Close())
 
-	hash, err := s.SetEncodedObject(obj)
+	hash, err := s.SetEncodedObject(t.Context(), obj)
 	require.NoError(t, err)
 	return hash
 }
@@ -725,26 +725,26 @@ func TestResetAcceptsLegitPaths(t *testing.T) {
 
 			dir := t.TempDir()
 
-			r, err := PlainInit(dir, false)
+			r, err := PlainInit(t.Context(), dir, false)
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(t.Context())
 			require.NoError(t, err)
 
 			require.NoError(t, util.WriteFile(w.Filesystem(), "README", []byte("init"), 0o644))
-			_, err = w.Add("README")
+			_, err = w.Add(t.Context(), "README")
 			require.NoError(t, err)
 
-			initHash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+			initHash, err := w.Commit(t.Context(), "initial commit\n", &CommitOptions{Author: defaultSignature()})
 			require.NoError(t, err)
 
-			initCommit, err := r.CommitObject(initHash)
+			initCommit, err := r.CommitObject(t.Context(), initHash)
 			require.NoError(t, err)
 
 			goodCommit := buildCommitWithEntry(t, r.Storer, initCommit, initHash, tc.path, filemode.Regular)
 
-			err = w.Reset(&ResetOptions{Commit: goodCommit.Hash, Mode: HardReset})
+			err = w.Reset(t.Context(), &ResetOptions{Commit: goodCommit.Hash, Mode: HardReset})
 			require.NoError(t, err, "Reset should accept legit path %q", tc.path)
 
 			_, err = os.Stat(filepath.Join(dir, filepath.FromSlash(tc.path)))
@@ -789,11 +789,11 @@ func TestAddRejectsDangerousPaths(t *testing.T) {
 			t.Parallel()
 
 			fs := memfs.New()
-			r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+			r, err := Init(t.Context(), memory.NewStorage(), WithWorkTree(fs))
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(t.Context())
 			require.NoError(t, err)
 			// Force the wrapper to its most tolerant configuration so
 			// every test case reaches the addOrUpdateFileToIndex gate
@@ -804,7 +804,7 @@ func TestAddRejectsDangerousPaths(t *testing.T) {
 
 			require.NoError(t, util.WriteFile(fs, tc.path, []byte("payload"), 0o644))
 
-			_, err = w.Add(tc.path)
+			_, err = w.Add(t.Context(), tc.path)
 			require.Error(t, err, "Add should reject %q", tc.path)
 			assert.ErrorIs(t, err, pathutil.ErrInvalidPath)
 		})
@@ -834,19 +834,19 @@ func TestMoveRejectsDangerousDestinations(t *testing.T) {
 			t.Parallel()
 
 			fs := memfs.New()
-			r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+			r, err := Init(t.Context(), memory.NewStorage(), WithWorkTree(fs))
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(t.Context())
 			require.NoError(t, err)
 			w.filesystem = newWorktreeFilesystem(fs, false, false)
 
 			require.NoError(t, util.WriteFile(fs, "src", []byte("payload"), 0o644))
-			_, err = w.Add("src")
+			_, err = w.Add(t.Context(), "src")
 			require.NoError(t, err)
 
-			_, err = w.Move("src", tc.to)
+			_, err = w.Move(t.Context(), "src", tc.to)
 			require.Error(t, err, "Move should reject destination %q", tc.to)
 			assert.ErrorIs(t, err, pathutil.ErrInvalidPath)
 		})

--- a/worktree_reset_bench_test.go
+++ b/worktree_reset_bench_test.go
@@ -32,14 +32,14 @@ func BenchmarkResetHardIgnoredDir(b *testing.B) {
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
 			wt := setupIgnoredDirRepo(b, tracked, tc.untracked)
-			ref, err := wt.r.Head()
+			ref, err := wt.r.Head(b.Context())
 			if err != nil {
 				b.Fatalf("head: %v", err)
 			}
 			head := ref.Hash()
 			b.ResetTimer()
 			for b.Loop() {
-				if err := wt.Reset(&ResetOptions{Mode: HardReset, Commit: head}); err != nil {
+				if err := wt.Reset(b.Context(), &ResetOptions{Mode: HardReset, Commit: head}); err != nil {
 					b.Fatalf("reset: %v", err)
 				}
 			}

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -177,9 +177,9 @@ func (w *Worktree) diffStagingWithWorktree(ctx context.Context, cfg *config.Conf
 	to := filesystem.NewRootNodeWithOptions(w.filesystem, submodules, fsOpts)
 
 	if reverse {
-		return merkletrie.DiffTree(to, from, diffTreeIsEquals)
+		return merkletrie.DiffTreeContext(ctx, to, from, diffTreeIsEquals)
 	}
-	return merkletrie.DiffTree(from, to, diffTreeIsEquals)
+	return merkletrie.DiffTreeContext(ctx, from, to, diffTreeIsEquals)
 }
 
 func (w *Worktree) collectIgnorePatterns() []gitignore.Pattern {
@@ -246,10 +246,10 @@ func (w *Worktree) diffTreeWithStaging(ctx context.Context, t *object.Tree, reve
 	to := mindex.NewRootNode(idx)
 
 	if reverse {
-		return merkletrie.DiffTree(to, from, diffTreeIsEquals)
+		return merkletrie.DiffTreeContext(ctx, to, from, diffTreeIsEquals)
 	}
 
-	return merkletrie.DiffTree(from, to, diffTreeIsEquals)
+	return merkletrie.DiffTreeContext(ctx, from, to, diffTreeIsEquals)
 }
 
 // diffTrees returns the changes between two tree objects.
@@ -262,7 +262,7 @@ func diffTrees(ctx context.Context, from, to *object.Tree) (merkletrie.Changes, 
 	if to != nil {
 		toNode = object.NewTreeRootNode(to)
 	}
-	return merkletrie.DiffTree(fromNode, toNode, diffTreeIsEquals)
+	return merkletrie.DiffTreeContext(ctx, fromNode, toNode, diffTreeIsEquals)
 }
 
 var emptyNoderHash = make([]byte, 24)

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -42,8 +43,8 @@ var (
 )
 
 // Status returns the working tree status.
-func (w *Worktree) Status() (Status, error) {
-	return w.StatusWithOptions(StatusOptions{Strategy: defaultStatusStrategy})
+func (w *Worktree) Status(ctx context.Context) (Status, error) {
+	return w.StatusWithOptions(ctx, StatusOptions{Strategy: defaultStatusStrategy})
 }
 
 // StatusOptions defines the options for Worktree.StatusWithOptions().
@@ -52,10 +53,10 @@ type StatusOptions struct {
 }
 
 // StatusWithOptions returns the working tree status.
-func (w *Worktree) StatusWithOptions(o StatusOptions) (Status, error) {
+func (w *Worktree) StatusWithOptions(ctx context.Context, o StatusOptions) (Status, error) {
 	var hash plumbing.Hash
 
-	ref, err := w.r.Head()
+	ref, err := w.r.Head(ctx)
 	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 		return nil, err
 	}
@@ -64,21 +65,21 @@ func (w *Worktree) StatusWithOptions(o StatusOptions) (Status, error) {
 		hash = ref.Hash()
 	}
 
-	cfg, err := w.r.Config()
+	cfg, err := w.r.Config(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return w.status(cfg, o.Strategy, hash)
+	return w.status(ctx, cfg, o.Strategy, hash)
 }
 
-func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing.Hash) (Status, error) {
-	s, err := ss.new(w)
+func (w *Worktree) status(ctx context.Context, cfg *config.Config, ss StatusStrategy, commit plumbing.Hash) (Status, error) {
+	s, err := ss.new(ctx, w)
 	if err != nil {
 		return nil, err
 	}
 
-	left, err := w.diffCommitWithStaging(commit, false)
+	left, err := w.diffCommitWithStaging(ctx, commit, false)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +103,7 @@ func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing
 		}
 	}
 
-	right, err := w.diffStagingWithWorktree(cfg, false, true)
+	right, err := w.diffStagingWithWorktree(ctx, cfg, false, true)
 	if err != nil {
 		return nil, err
 	}
@@ -141,8 +142,8 @@ func nameFromAction(ch *merkletrie.Change) string {
 	return name
 }
 
-func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeIgnoredChanges bool) (merkletrie.Changes, error) {
-	idx, err := w.r.Storer.Index()
+func (w *Worktree) diffStagingWithWorktree(ctx context.Context, cfg *config.Config, reverse, excludeIgnoredChanges bool) (merkletrie.Changes, error) {
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +151,7 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 	from := mindex.NewRootNodeWithOptions(idx, mindex.RootNodeOptions{
 		UpholdExecutableBit: cfg.Core.FileMode,
 	})
-	submodules, err := w.getSubmodulesStatus(cfg)
+	submodules, err := w.getSubmodulesStatus(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -189,15 +190,15 @@ func (w *Worktree) collectIgnorePatterns() []gitignore.Pattern {
 	return append(patterns, w.Excludes...)
 }
 
-func (w *Worktree) getSubmodulesStatus(cfg *config.Config) (map[string]plumbing.Hash, error) {
+func (w *Worktree) getSubmodulesStatus(ctx context.Context, cfg *config.Config) (map[string]plumbing.Hash, error) {
 	o := map[string]plumbing.Hash{}
 
-	sub, err := w.submodulesWithConfig(cfg)
+	sub, err := w.submodulesWithConfig(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	status, err := sub.Status()
+	status, err := sub.Status(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -214,30 +215,30 @@ func (w *Worktree) getSubmodulesStatus(cfg *config.Config) (map[string]plumbing.
 	return o, nil
 }
 
-func (w *Worktree) diffCommitWithStaging(commit plumbing.Hash, reverse bool) (merkletrie.Changes, error) {
+func (w *Worktree) diffCommitWithStaging(ctx context.Context, commit plumbing.Hash, reverse bool) (merkletrie.Changes, error) {
 	var t *object.Tree
 	if !commit.IsZero() {
-		c, err := w.r.CommitObject(commit)
+		c, err := w.r.CommitObject(ctx, commit)
 		if err != nil {
 			return nil, err
 		}
 
-		t, err = c.Tree()
+		t, err = c.Tree(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return w.diffTreeWithStaging(t, reverse)
+	return w.diffTreeWithStaging(ctx, t, reverse)
 }
 
-func (w *Worktree) diffTreeWithStaging(t *object.Tree, reverse bool) (merkletrie.Changes, error) {
+func (w *Worktree) diffTreeWithStaging(ctx context.Context, t *object.Tree, reverse bool) (merkletrie.Changes, error) {
 	var from noder.Noder
 	if t != nil {
 		from = object.NewTreeRootNode(t)
 	}
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +254,7 @@ func (w *Worktree) diffTreeWithStaging(t *object.Tree, reverse bool) (merkletrie
 
 // diffTrees returns the changes between two tree objects.
 // Either tree may be nil, which is treated as the empty tree.
-func diffTrees(from, to *object.Tree) (merkletrie.Changes, error) {
+func diffTrees(ctx context.Context, from, to *object.Tree) (merkletrie.Changes, error) {
 	var fromNode, toNode noder.Noder
 	if from != nil {
 		fromNode = object.NewTreeRootNode(from)
@@ -289,12 +290,12 @@ func diffTreeIsEquals(a, b noder.Hasher) bool {
 // directory given, adds the files and all his sub-directories recursively in
 // the worktree to the index. If any of the files is already staged in the index
 // no error is returned. When path is a file, the blob.Hash is returned.
-func (w *Worktree) Add(path string) (plumbing.Hash, error) {
+func (w *Worktree) Add(ctx context.Context, path string) (plumbing.Hash, error) {
 	// TODO(mcuadros): deprecate in favor of AddWithOption in v6.
-	return w.doAdd(path, make([]gitignore.Pattern, 0), false)
+	return w.doAdd(ctx, path, make([]gitignore.Pattern, 0), false)
 }
 
-func (w *Worktree) doAddDirectory(cfg *config.Config, idx *index.Index, s Status, directory string, ignorePattern []gitignore.Pattern) (added bool, err error) {
+func (w *Worktree) doAddDirectory(ctx context.Context, cfg *config.Config, idx *index.Index, s Status, directory string, ignorePattern []gitignore.Pattern) (added bool, err error) {
 	if len(ignorePattern) > 0 {
 		m := gitignore.NewMatcher(ignorePattern)
 		matchPath := strings.Split(directory, string(os.PathSeparator))
@@ -312,7 +313,7 @@ func (w *Worktree) doAddDirectory(cfg *config.Config, idx *index.Index, s Status
 		}
 
 		var a bool
-		a, _, err = w.doAddFile(cfg, idx, s, name, ignorePattern)
+		a, _, err = w.doAddFile(ctx, cfg, idx, s, name, ignorePattern)
 		if err != nil {
 			return added, err
 		}
@@ -335,25 +336,25 @@ func isPathInDirectory(path, directory string) bool {
 // some options it can also be used to add content with only part of the changes
 // made to the working tree files applied, or remove paths that do not exist in
 // the working tree anymore.
-func (w *Worktree) AddWithOptions(opts *AddOptions) error {
+func (w *Worktree) AddWithOptions(ctx context.Context, opts *AddOptions) error {
 	if err := opts.Validate(w.r); err != nil {
 		return err
 	}
 
 	if opts.All {
-		_, err := w.doAdd(".", w.Excludes, false)
+		_, err := w.doAdd(ctx, ".", w.Excludes, false)
 		return err
 	}
 
 	if opts.Glob != "" {
-		return w.AddGlob(opts.Glob)
+		return w.AddGlob(ctx, opts.Glob)
 	}
 
-	_, err := w.doAdd(opts.Path, make([]gitignore.Pattern, 0), opts.SkipStatus)
+	_, err := w.doAdd(ctx, opts.Path, make([]gitignore.Pattern, 0), opts.SkipStatus)
 	return err
 }
 
-func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipStatus bool) (plumbing.Hash, error) {
+func (w *Worktree) doAdd(ctx context.Context, path string, ignorePattern []gitignore.Pattern, skipStatus bool) (plumbing.Hash, error) {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -361,12 +362,12 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 		}()
 	}
 
-	cfg, err := w.r.Config()
+	cfg, err := w.r.Config(ctx)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -380,7 +381,7 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 	var s Status
 	var err2 error
 	if !skipStatus || fi == nil || fi.IsDir() {
-		s, err2 = w.Status()
+		s, err2 = w.Status(ctx)
 		if err2 != nil {
 			return plumbing.ZeroHash, err2
 		}
@@ -401,9 +402,9 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 	path = filepath.ToSlash(path)
 
 	if err != nil || !fi.IsDir() {
-		added, h, err = w.doAddFile(cfg, idx, s, path, ignorePattern)
+		added, h, err = w.doAddFile(ctx, cfg, idx, s, path, ignorePattern)
 	} else {
-		added, err = w.doAddDirectory(cfg, idx, s, path, ignorePattern)
+		added, err = w.doAddDirectory(ctx, cfg, idx, s, path, ignorePattern)
 	}
 
 	if err != nil {
@@ -414,13 +415,13 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 		return h, nil
 	}
 
-	return h, w.r.Storer.SetIndex(idx)
+	return h, w.r.Storer.SetIndex(ctx, idx)
 }
 
 // AddGlob adds all paths, matching pattern, to the index. If pattern matches a
 // directory path, all directory contents are added to the index recursively. No
 // error is returned if all matching paths are already staged in index.
-func (w *Worktree) AddGlob(pattern string) error {
+func (w *Worktree) AddGlob(ctx context.Context, pattern string) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -438,17 +439,17 @@ func (w *Worktree) AddGlob(pattern string) error {
 		return ErrGlobNoMatches
 	}
 
-	cfg, err := w.r.Config()
+	cfg, err := w.r.Config(ctx)
 	if err != nil {
 		return err
 	}
 
-	s, err := w.Status()
+	s, err := w.Status(ctx)
 	if err != nil {
 		return err
 	}
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return err
 	}
@@ -462,9 +463,9 @@ func (w *Worktree) AddGlob(pattern string) error {
 
 		var added bool
 		if fi.IsDir() {
-			added, err = w.doAddDirectory(cfg, idx, s, file, make([]gitignore.Pattern, 0))
+			added, err = w.doAddDirectory(ctx, cfg, idx, s, file, make([]gitignore.Pattern, 0))
 		} else {
-			added, _, err = w.doAddFile(cfg, idx, s, file, make([]gitignore.Pattern, 0))
+			added, _, err = w.doAddFile(ctx, cfg, idx, s, file, make([]gitignore.Pattern, 0))
 		}
 
 		if err != nil {
@@ -477,7 +478,7 @@ func (w *Worktree) AddGlob(pattern string) error {
 	}
 
 	if saveIndex {
-		return w.r.Storer.SetIndex(idx)
+		return w.r.Storer.SetIndex(ctx, idx)
 	}
 
 	return nil
@@ -486,7 +487,7 @@ func (w *Worktree) AddGlob(pattern string) error {
 // doAddFile create a new blob from path and update the index, added is true if
 // the file added is different from the index.
 // if s status is nil will skip the status check and update the index anyway
-func (w *Worktree) doAddFile(cfg *config.Config, idx *index.Index, s Status, path string, ignorePattern []gitignore.Pattern) (added bool, h plumbing.Hash, err error) {
+func (w *Worktree) doAddFile(ctx context.Context, cfg *config.Config, idx *index.Index, s Status, path string, ignorePattern []gitignore.Pattern) (added bool, h plumbing.Hash, err error) {
 	if s != nil && s.File(path).Worktree == Unmodified {
 		return false, h, nil
 	}
@@ -499,7 +500,7 @@ func (w *Worktree) doAddFile(cfg *config.Config, idx *index.Index, s Status, pat
 		}
 	}
 
-	h, err = w.copyFileToStorage(cfg, path)
+	h, err = w.copyFileToStorage(ctx, cfg, path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			added = true
@@ -516,7 +517,7 @@ func (w *Worktree) doAddFile(cfg *config.Config, idx *index.Index, s Status, pat
 	return true, h, err
 }
 
-func (w *Worktree) copyFileToStorage(cfg *config.Config, path string) (hash plumbing.Hash, err error) {
+func (w *Worktree) copyFileToStorage(ctx context.Context, cfg *config.Config, path string) (hash plumbing.Hash, err error) {
 	fi, err := w.filesystem.Lstat(path)
 	if err != nil {
 		return plumbing.ZeroHash, err
@@ -543,7 +544,7 @@ func (w *Worktree) copyFileToStorage(cfg *config.Config, path string) (hash plum
 		return plumbing.ZeroHash, err
 	}
 
-	return w.r.Storer.SetEncodedObject(obj)
+	return w.r.Storer.SetEncodedObject(ctx, obj)
 }
 
 func (w *Worktree) fillEncodedObjectFromFile(cfg *config.Config, dst io.Writer, path string, _ os.FileInfo) (err error) {
@@ -631,9 +632,9 @@ func (w *Worktree) doUpdateFileToIndex(e *index.Entry, filename string, h plumbi
 }
 
 // Remove removes files from the working tree and from the index.
-func (w *Worktree) Remove(path string) (plumbing.Hash, error) {
+func (w *Worktree) Remove(ctx context.Context, path string) (plumbing.Hash, error) {
 	// TODO(mcuadros): remove plumbing.Hash from signature at v5.
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -650,7 +651,7 @@ func (w *Worktree) Remove(path string) (plumbing.Hash, error) {
 		return h, err
 	}
 
-	return h, w.r.Storer.SetIndex(idx)
+	return h, w.r.Storer.SetIndex(ctx, idx)
 }
 
 func (w *Worktree) doRemoveDirectory(idx *index.Index, directory string) (removed bool, err error) {
@@ -728,8 +729,8 @@ func (w *Worktree) deleteFromFilesystem(path string) error {
 // RemoveGlob removes all paths, matching pattern, from the index. If pattern
 // matches a directory path, all directory contents are removed from the index
 // recursively.
-func (w *Worktree) RemoveGlob(pattern string) error {
-	idx, err := w.r.Storer.Index()
+func (w *Worktree) RemoveGlob(ctx context.Context, pattern string) error {
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return err
 	}
@@ -755,12 +756,12 @@ func (w *Worktree) RemoveGlob(pattern string) error {
 		}
 	}
 
-	return w.r.Storer.SetIndex(idx)
+	return w.r.Storer.SetIndex(ctx, idx)
 }
 
 // Move moves or rename a file in the worktree and the index, directories are
 // not supported.
-func (w *Worktree) Move(from, to string) (plumbing.Hash, error) {
+func (w *Worktree) Move(ctx context.Context, from, to string) (plumbing.Hash, error) {
 	// TODO(mcuadros): support directories and/or implement support for glob
 	if _, err := w.filesystem.Lstat(from); err != nil {
 		return plumbing.ZeroHash, err
@@ -770,7 +771,7 @@ func (w *Worktree) Move(from, to string) (plumbing.Hash, error) {
 		return plumbing.ZeroHash, ErrDestinationExists
 	}
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(ctx)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -788,5 +789,5 @@ func (w *Worktree) Move(from, to string) (plumbing.Hash, error) {
 		return hash, err
 	}
 
-	return hash, w.r.Storer.SetIndex(idx)
+	return hash, w.r.Storer.SetIndex(ctx, idx)
 }

--- a/worktree_status_bench_test.go
+++ b/worktree_status_bench_test.go
@@ -21,11 +21,11 @@ func setupBenchmarkRepo(b *testing.B, numFiles, numSubdirs, numGoroutines int) *
 	tmpDir := b.TempDir()
 	repoDir := filepath.Join(tmpDir, "repo")
 
-	repo, err := PlainInit(repoDir, false)
+	repo, err := PlainInit(b.Context(), repoDir, false)
 	require.NoError(b, err)
 	b.Cleanup(func() { _ = repo.Close() })
 
-	wt, err := repo.Worktree()
+	wt, err := repo.Worktree(b.Context())
 	require.NoError(b, err)
 
 	content := []byte("test content for benchmark\n")
@@ -61,7 +61,7 @@ func setupBenchmarkRepo(b *testing.B, numFiles, numSubdirs, numGoroutines int) *
 	wg.Wait()
 
 	for i := range numSubdirs {
-		err = wt.AddGlob(fmt.Sprintf("dir%d/*", i))
+		err = wt.AddGlob(b.Context(), fmt.Sprintf("dir%d/*", i))
 		require.NoError(b, err)
 	}
 
@@ -70,7 +70,7 @@ func setupBenchmarkRepo(b *testing.B, numFiles, numSubdirs, numGoroutines int) *
 		Email: "benchmark@test.com",
 		When:  time.Now(),
 	}
-	_, err = wt.Commit("Initial commit with many files", &CommitOptions{
+	_, err = wt.Commit(b.Context(), "Initial commit with many files", &CommitOptions{
 		Author:    sig,
 		Committer: sig,
 	})
@@ -100,7 +100,7 @@ func BenchmarkStatus(b *testing.B) {
 func benchmarkStatusClean(wt *Worktree) func(b *testing.B) {
 	return func(b *testing.B) {
 		for b.Loop() {
-			status, err := wt.Status()
+			status, err := wt.Status(b.Context())
 			if err != nil {
 				b.Fatalf("failed to get status: %v", err)
 			}
@@ -132,7 +132,7 @@ func benchmarkStatusModified(wt *Worktree, numFiles, numSubdirs int) func(b *tes
 		}
 
 		for b.Loop() {
-			status, err := wt.Status()
+			status, err := wt.Status(b.Context())
 			if err != nil {
 				b.Fatalf("failed to get status: %v", err)
 			}
@@ -179,11 +179,11 @@ func setupIgnoredDirRepo(b *testing.B, tracked, untracked int) *Worktree {
 	tmpDir := b.TempDir()
 	repoDir := filepath.Join(tmpDir, "repo")
 
-	repo, err := PlainInit(repoDir, false)
+	repo, err := PlainInit(b.Context(), repoDir, false)
 	require.NoError(b, err)
 	b.Cleanup(func() { _ = repo.Close() })
 
-	wt, err := repo.Worktree()
+	wt, err := repo.Worktree(b.Context())
 	require.NoError(b, err)
 
 	for i := range tracked {
@@ -195,8 +195,8 @@ func setupIgnoredDirRepo(b *testing.B, tracked, untracked int) *Worktree {
 	require.NoError(b, util.WriteFile(wt.Filesystem(), ".gitignore",
 		[]byte(ignoredDir+"/\n"), 0o644))
 
-	require.NoError(b, wt.AddGlob("src/*"))
-	_, err = wt.Add(".gitignore")
+	require.NoError(b, wt.AddGlob(b.Context(), "src/*"))
+	_, err = wt.Add(b.Context(), ".gitignore")
 	require.NoError(b, err)
 
 	sig := &object.Signature{
@@ -204,7 +204,7 @@ func setupIgnoredDirRepo(b *testing.B, tracked, untracked int) *Worktree {
 		Email: "bench@test.com",
 		When:  time.Now().Add(-time.Hour), // older than index modtime so the metadata fast-path engages
 	}
-	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	_, err = wt.Commit(b.Context(), "initial", &CommitOptions{Author: sig, Committer: sig})
 	require.NoError(b, err)
 
 	// Drop a large *gitignored* untracked tree. None of these files affect
@@ -243,7 +243,7 @@ func BenchmarkStatusIgnoredDir(b *testing.B) {
 			wt := setupIgnoredDirRepo(b, tracked, tc.untracked)
 			b.ResetTimer()
 			for b.Loop() {
-				s, err := wt.Status()
+				s, err := wt.Status(b.Context())
 				if err != nil {
 					b.Fatalf("status: %v", err)
 				}

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -26,12 +26,12 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
-	r, err := Init(s, WithWorkTree(w))
+	r, err := Init(t.Context(), s, WithWorkTree(w))
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	defer func() { _ = r.Close() }()
 
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, wt)
 
@@ -46,13 +46,13 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 	err = f.Close()
 	require.NoError(t, err)
 
-	_, err = wt.Add(file)
+	_, err = wt.Add(t.Context(), file)
 	require.NoError(t, err)
 
-	_, err = wt.Commit("add file", &CommitOptions{})
+	_, err = wt.Commit(t.Context(), "add file", &CommitOptions{})
 	require.NoError(t, err)
 
-	st, err := wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+	st, err := wt.StatusWithOptions(t.Context(), StatusOptions{Strategy: Preload})
 	require.NoError(t, err)
 	assert.Equal(t,
 		&FileStatus{Worktree: Unmodified, Staging: Unmodified},
@@ -72,7 +72,7 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 	err = f.Close()
 	require.NoError(t, err)
 
-	_, err = wt.Add(file)
+	_, err = wt.Add(t.Context(), file)
 	assert.NoError(t, err)
 
 	// go-git's Status diverges from "git status", so this check does not
@@ -80,13 +80,13 @@ func TestIndexEntrySizeUpdatedForNonRegularFiles(t *testing.T) {
 	// reports the unstaged file was modified while "git diff" would return
 	// empty, as the files are the same but the index has the incorrect file
 	// size.
-	st, err = wt.StatusWithOptions(StatusOptions{Strategy: Preload})
+	st, err = wt.StatusWithOptions(t.Context(), StatusOptions{Strategy: Preload})
 	assert.NoError(t, err)
 	assert.Equal(t,
 		&FileStatus{Worktree: Unmodified, Staging: Modified},
 		st.File(file))
 
-	idx, err := wt.r.Storer.Index()
+	idx, err := wt.r.Storer.Index(t.Context())
 	assert.NoError(t, err)
 	require.NotNil(t, idx)
 	require.Len(t, idx.Entries, 1)
@@ -105,11 +105,11 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	t.Parallel()
 
 	repoDir := filepath.Join(t.TempDir(), "repo")
-	repo, err := PlainInit(repoDir, false)
+	repo, err := PlainInit(t.Context(), repoDir, false)
 	require.NoError(t, err)
 	defer func() { _ = repo.Close() }()
 
-	wt, err := repo.Worktree()
+	wt, err := repo.Worktree(t.Context())
 	require.NoError(t, err)
 
 	write := func(name string, data []byte) {
@@ -122,12 +122,12 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	write(".gitignore", []byte("vendor/\n"))
 
 	for _, p := range []string{"src/main.go", "vendor/keep.go", ".gitignore"} {
-		_, err := wt.Add(p)
+		_, err := wt.Add(t.Context(), p)
 		require.NoError(t, err)
 	}
 
 	sig := &object.Signature{Name: "test", Email: "test@test.com"}
-	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	_, err = wt.Commit(t.Context(), "initial", &CommitOptions{Author: sig, Committer: sig})
 	require.NoError(t, err)
 
 	// Drop an untracked, ignored file alongside the tracked one. It must
@@ -137,7 +137,7 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	// Modify the tracked-but-ignored file. It MUST appear as Modified.
 	write("vendor/keep.go", []byte("changed\n"))
 
-	st, err := wt.Status()
+	st, err := wt.Status(t.Context())
 	require.NoError(t, err)
 
 	// Status.File auto-inserts a default entry for any path queried, so
@@ -160,20 +160,20 @@ func BenchmarkWorktreeStatus(b *testing.B) {
 	}
 	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
-	r, err := Open(st, memfs.New())
+	r, err := Open(b.Context(), st, memfs.New())
 	require.NoError(b, err)
 	defer func() { _ = r.Close() }()
 
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(b.Context())
 	require.NoError(b, err)
 
-	err = wt.Reset(&ResetOptions{Mode: HardReset})
+	err = wt.Reset(b.Context(), &ResetOptions{Mode: HardReset})
 	require.NoError(b, err)
 
 	b.StartTimer()
 
 	for b.Loop() {
-		wt.Status()
+		wt.Status(b.Context())
 	}
 }
 

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -185,20 +185,20 @@ func TestAddSubdirectoryForwardSlash(t *testing.T) {
 	t.Parallel()
 
 	repoDir := filepath.Join(t.TempDir(), "repo")
-	repo, err := PlainInit(repoDir, false)
+	repo, err := PlainInit(t.Context(), repoDir, false)
 	require.NoError(t, err)
 	defer func() { _ = repo.Close() }()
 
-	wt, err := repo.Worktree()
+	wt, err := repo.Worktree(t.Context())
 	require.NoError(t, err)
 
 	require.NoError(t, wt.Filesystem().MkdirAll("dir", 0o755))
 	require.NoError(t, util.WriteFile(wt.Filesystem(), "dir/foo", []byte("content"), 0o644))
 
-	_, err = wt.Add("dir/foo")
+	_, err = wt.Add(t.Context(), "dir/foo")
 	require.NoError(t, err)
 
-	idx, err := repo.Storer.Index()
+	idx, err := repo.Storer.Index(t.Context())
 	require.NoError(t, err)
 	e, err := idx.Entry("dir/foo")
 	require.NoError(t, err)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1435,6 +1435,7 @@ func (s *WorktreeSuite) TestResetWithUntracked() {
 	}
 }
 
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *WorktreeSuite) TestResetSoft() {
 	fs := memfs.New()
 	w := &Worktree{
@@ -1460,6 +1461,7 @@ func (s *WorktreeSuite) TestResetSoft() {
 	s.Equal(Added, status.File("CHANGELOG").Staging)
 }
 
+//nolint:dupl // intentional parallel structure with its sibling test
 func (s *WorktreeSuite) TestResetMixed() {
 	fs := memfs.New()
 	w := &Worktree{

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -62,7 +62,7 @@ func (s *WorktreeSuite) SetupSuite() {
 
 func (s *WorktreeSuite) SetupTest() {
 	f := fixtures.Basic().One()
-	r := NewRepositoryWithEmptyWorktree(f)
+	r := NewRepositoryWithEmptyWorktree(s.T().Context(), f)
 	s.T().Cleanup(func() {
 		_ = r.Close()
 	})
@@ -71,17 +71,17 @@ func (s *WorktreeSuite) SetupTest() {
 
 func (s *WorktreeSuite) TestPullCheckout() {
 	fs := memfs.New()
-	r, _ := Init(memory.NewStorage(), WithWorkTree(fs))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(fs))
 	defer func() { _ = r.Close() }()
-	r.CreateRemote(&config.RemoteConfig{
+	r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(s.T().Context(), &PullOptions{})
 	s.NoError(err)
 
 	fi, err := fs.ReadDir("")
@@ -92,28 +92,28 @@ func (s *WorktreeSuite) TestPullCheckout() {
 func (s *WorktreeSuite) TestPullFastForward() {
 	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
 
-	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
+	server, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
-	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
+	r, err := Clone(s.T().Context(), memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := server.Worktree()
+	w, err := server.Worktree(s.T().Context())
 	s.NoError(err)
 	s.NoError(util.WriteFile(w.filesystem, "foo", []byte("foo"), 0o755))
-	w.Add("foo")
-	hash, err := w.Commit("foo", &CommitOptions{Author: defaultSignature()})
+	w.Add(s.T().Context(), "foo")
+	hash, err := w.Commit(s.T().Context(), "foo", &CommitOptions{Author: defaultSignature()})
 	s.NoError(err)
 
-	w, err = r.Worktree()
+	w, err = r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(s.T().Context(), &PullOptions{})
 	s.NoError(err)
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal(hash, head.Hash())
 }
@@ -121,66 +121,66 @@ func (s *WorktreeSuite) TestPullFastForward() {
 func (s *WorktreeSuite) TestPullNonFastForward() {
 	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
 
-	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
+	server, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
-	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
+	r, err := Clone(s.T().Context(), memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := server.Worktree()
+	w, err := server.Worktree(s.T().Context())
 	s.NoError(err)
 	s.NoError(util.WriteFile(w.filesystem, "foo", []byte("foo"), 0o755))
-	w.Add("foo")
-	_, err = w.Commit("foo", &CommitOptions{Author: defaultSignature()})
+	w.Add(s.T().Context(), "foo")
+	_, err = w.Commit(s.T().Context(), "foo", &CommitOptions{Author: defaultSignature()})
 	s.NoError(err)
 
-	w, err = r.Worktree()
+	w, err = r.Worktree(s.T().Context())
 	s.NoError(err)
 	s.NoError(util.WriteFile(w.filesystem, "bar", []byte("bar"), 0o755))
-	w.Add("bar")
-	_, err = w.Commit("bar", &CommitOptions{Author: defaultSignature()})
+	w.Add(s.T().Context(), "bar")
+	_, err = w.Commit(s.T().Context(), "bar", &CommitOptions{Author: defaultSignature()})
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(s.T().Context(), &PullOptions{})
 	s.ErrorIs(err, ErrNonFastForwardUpdate)
 }
 
 func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded() {
-	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
-	r.CreateRemote(&config.RemoteConfig{
+	r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	err := r.Fetch(&FetchOptions{})
+	err := r.Fetch(s.T().Context(), &FetchOptions{})
 	s.NoError(err)
 
-	_, err = r.Reference("refs/heads/master", false)
+	_, err = r.Reference(s.T().Context(), "refs/heads/master", false)
 	s.NotNil(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(s.T().Context(), &PullOptions{})
 	s.NoError(err)
 
-	head, err := r.Reference(plumbing.HEAD, true)
+	head, err := r.Reference(s.T().Context(), plumbing.HEAD, true)
 	s.NoError(err)
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", head.Hash().String())
 
-	branch, err := r.Reference("refs/heads/master", false)
+	branch, err := r.Reference(s.T().Context(), "refs/heads/master", false)
 	s.NoError(err)
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branch.Hash().String())
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(s.T().Context(), &PullOptions{})
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
 }
 
 func (s *WorktreeSuite) TestPullInSingleBranch() {
-	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
 	err := r.clone(context.Background(), &CloneOptions{
 		URL:          s.GetBasicLocalRepositoryURL(),
@@ -189,17 +189,17 @@ func (s *WorktreeSuite) TestPullInSingleBranch() {
 
 	s.NoError(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(s.T().Context(), &PullOptions{})
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
 
-	branch, err := r.Reference("refs/heads/master", false)
+	branch, err := r.Reference(s.T().Context(), "refs/heads/master", false)
 	s.NoError(err)
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branch.Hash().String())
 
-	_, err = r.Reference("refs/remotes/foo/branch", false)
+	_, err = r.Reference(s.T().Context(), "refs/remotes/foo/branch", false)
 	s.NotNil(err)
 
 	storage := r.Storer.(*memory.Storage)
@@ -211,19 +211,19 @@ func (s *WorktreeSuite) TestPullProgress() {
 		"Local repositories use both server and client transport implementations. " +
 		"See upload-pack.go for details.")
 
-	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
 
-	r.CreateRemote(&config.RemoteConfig{
+	r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{s.GetBasicLocalRepositoryURL()},
 	})
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	buf := bytes.NewBuffer(nil)
-	err = w.Pull(&PullOptions{
+	err = w.Pull(s.T().Context(), &PullOptions{
 		Progress: buf,
 	})
 
@@ -238,22 +238,22 @@ func (s *WorktreeSuite) TestPullProgressWithRecursion() {
 
 	path := s.GetLocalRepositoryURL(fixtures.ByTag("submodule").One())
 
-	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
-	r.CreateRemote(&config.RemoteConfig{
+	r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URLs: []string{path},
 	})
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
-	err = w.Pull(&PullOptions{
+	err = w.Pull(s.T().Context(), &PullOptions{
 		RecurseSubmodules: DefaultSubmoduleRecursionDepth,
 	})
 	s.Require().NoError(err)
 
-	cfg, err := r.Config()
+	cfg, err := r.Config(s.T().Context())
 	s.NoError(err)
 	s.Len(cfg.Submodules, 2)
 }
@@ -261,18 +261,18 @@ func (s *WorktreeSuite) TestPullProgressWithRecursion() {
 func (s *RepositorySuite) TestPullAdd() {
 	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
 
-	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
+	server, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
-	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
+	r, err := Clone(s.T().Context(), memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
 	storage := r.Storer.(*memory.Storage)
 	s.Len(storage.Objects, 28)
 
-	branch, err := r.Reference("refs/heads/master", false)
+	branch, err := r.Reference(s.T().Context(), "refs/heads/master", false)
 	s.NoError(err)
 	s.Equal("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branch.Hash().String())
 
@@ -282,16 +282,16 @@ func (s *RepositorySuite) TestPullAdd() {
 		"git commit --no-gpg-sign -m foo foo",
 	)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{RemoteName: "origin"})
+	err = w.Pull(s.T().Context(), &PullOptions{RemoteName: "origin"})
 	s.NoError(err)
 
 	// the commit command has introduced a new commit, tree and blob
 	s.Len(storage.Objects, 31)
 
-	branch, err = r.Reference("refs/heads/master", false)
+	branch, err = r.Reference(s.T().Context(), "refs/heads/master", false)
 	s.NoError(err)
 	s.NotEqual("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branch.Hash().String())
 }
@@ -300,19 +300,19 @@ func (s *WorktreeSuite) TestPullAlreadyUptodate() {
 	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
 
 	fs := memfs.New()
-	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{URL: url})
+	r, err := Clone(s.T().Context(), memory.NewStorage(), fs, &CloneOptions{URL: url})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 	err = util.WriteFile(fs, "bar", []byte("bar"), 0o755)
 	s.NoError(err)
-	w.Add("bar")
-	_, err = w.Commit("bar", &CommitOptions{Author: defaultSignature()})
+	w.Add(s.T().Context(), "bar")
+	_, err = w.Commit(s.T().Context(), "bar", &CommitOptions{Author: defaultSignature()})
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(s.T().Context(), &PullOptions{})
 	s.ErrorIs(err, NoErrAlreadyUpToDate)
 }
 
@@ -321,16 +321,16 @@ func (s *WorktreeSuite) TestPullDepth() {
 		"yet. Since we're using local repositories here, the test will use the" +
 		"server-side implementation. See transport/upload_pack.go and" +
 		"packfile/encoder.go")
-	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), memfs.New(), &CloneOptions{
 		URL:   s.GetBasicLocalRepositoryURL(),
 		Depth: 1,
 	})
 
 	s.NoError(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
-	err = w.Pull(&PullOptions{})
+	err = w.Pull(s.T().Context(), &PullOptions{})
 	s.NoError(err)
 }
 
@@ -339,7 +339,7 @@ func (s *WorktreeSuite) TestPullAfterShallowClone() {
 	remoteURL := filepath.Join(tempDir, "remote")
 	repoDir := filepath.Join(tempDir, "repo")
 
-	remote, err := PlainInit(remoteURL, false)
+	remote, err := PlainInit(s.T().Context(), remoteURL, false)
 	s.NoError(err)
 	defer func() { _ = remote.Close() }()
 	s.NotNil(remote)
@@ -347,7 +347,7 @@ func (s *WorktreeSuite) TestPullAfterShallowClone() {
 	_ = CommitNewFile(s.T(), remote, "File1")
 	_ = CommitNewFile(s.T(), remote, "File2")
 
-	repo, err := PlainClone(repoDir, &CloneOptions{
+	repo, err := PlainClone(s.T().Context(), repoDir, &CloneOptions{
 		URL:           remoteURL,
 		Depth:         1,
 		Tags:          plumbing.NoTags,
@@ -360,10 +360,10 @@ func (s *WorktreeSuite) TestPullAfterShallowClone() {
 	_ = CommitNewFile(s.T(), remote, "File3")
 	_ = CommitNewFile(s.T(), remote, "File4")
 
-	w, err := repo.Worktree()
+	w, err := repo.Worktree(s.T().Context())
 	s.NoError(err)
 
-	err = w.Pull(&PullOptions{
+	err = w.Pull(s.T().Context(), &PullOptions{
 		RemoteName:    DefaultRemoteName,
 		SingleBranch:  true,
 		ReferenceName: plumbing.NewBranchReferenceName("master"),
@@ -379,14 +379,14 @@ func (s *WorktreeSuite) TestPullAfterShallowClone_UntrackedFilesPreserved() {
 	remoteURL := filepath.Join(tempDir, "remote")
 	repoDir := filepath.Join(tempDir, "repo")
 
-	remote, err := PlainInit(remoteURL, false)
+	remote, err := PlainInit(s.T().Context(), remoteURL, false)
 	s.Require().NoError(err)
 	defer func() { _ = remote.Close() }()
 
 	_ = CommitNewFile(s.T(), remote, "File1")
 	_ = CommitNewFile(s.T(), remote, "File2")
 
-	repo, err := PlainClone(repoDir, &CloneOptions{
+	repo, err := PlainClone(s.T().Context(), repoDir, &CloneOptions{
 		URL:           remoteURL,
 		Depth:         1,
 		Tags:          plumbing.NoTags,
@@ -404,11 +404,11 @@ func (s *WorktreeSuite) TestPullAfterShallowClone_UntrackedFilesPreserved() {
 	_ = CommitNewFile(s.T(), remote, "File3")
 	_ = CommitNewFile(s.T(), remote, "File4")
 
-	w, err := repo.Worktree()
+	w, err := repo.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	// Test without Force first.
-	err = w.Pull(&PullOptions{
+	err = w.Pull(s.T().Context(), &PullOptions{
 		RemoteName:    DefaultRemoteName,
 		SingleBranch:  true,
 		ReferenceName: plumbing.NewBranchReferenceName("master"),
@@ -422,7 +422,7 @@ func (s *WorktreeSuite) TestPullAfterShallowClone_UntrackedFilesPreserved() {
 	// Push another commit and test with Force: true.
 	_ = CommitNewFile(s.T(), remote, "File5")
 
-	err = w.Pull(&PullOptions{
+	err = w.Pull(s.T().Context(), &PullOptions{
 		RemoteName:    DefaultRemoteName,
 		SingleBranch:  true,
 		ReferenceName: plumbing.NewBranchReferenceName("master"),
@@ -441,7 +441,7 @@ func (s *WorktreeSuite) TestCheckout() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{
 		Force: true,
 	})
 	s.NoError(err)
@@ -457,7 +457,7 @@ func (s *WorktreeSuite) TestCheckout() {
 	s.NoError(err)
 	s.Equal("Initial changelog\n", string(content))
 
-	idx, err := s.Repository.Storer.Index()
+	idx, err := s.Repository.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 }
@@ -468,12 +468,12 @@ func (s *WorktreeSuite) TestCheckoutForce() {
 		filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	w.filesystem = newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS())
 
-	err = w.Checkout(&CheckoutOptions{
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{
 		Force: true,
 	})
 	s.NoError(err)
@@ -489,13 +489,13 @@ func (s *WorktreeSuite) TestCheckoutKeep() {
 		filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{
 		Force: true,
 	})
 	s.NoError(err)
 
 	// Create a new branch and create a new file.
-	err = w.Checkout(&CheckoutOptions{
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName("new-branch"),
 		Create: true,
 	})
@@ -509,11 +509,11 @@ func (s *WorktreeSuite) TestCheckoutKeep() {
 	s.Nil(f.Close())
 
 	// Add the file to staging.
-	_, err = w.Add("new-file.txt")
+	_, err = w.Add(s.T().Context(), "new-file.txt")
 	s.NoError(err)
 
 	// Switch branch to master, and verify that the new file was kept in staging.
-	err = w.Checkout(&CheckoutOptions{
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{
 		Keep: true,
 	})
 	s.NoError(err)
@@ -530,24 +530,24 @@ func (s *WorktreeSuite) TestCheckoutSymlink() {
 
 	dir := s.T().TempDir()
 
-	r, err := PlainInit(dir, false)
+	r, err := PlainInit(s.T().Context(), dir, false)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	w.filesystem.Symlink("not-exists", "bar")
-	w.Add("bar")
-	w.Commit("foo", &CommitOptions{Author: defaultSignature()})
+	w.Add(s.T().Context(), "bar")
+	w.Commit(s.T().Context(), "foo", &CommitOptions{Author: defaultSignature()})
 
-	r.Storer.SetIndex(&index.Index{Version: 2})
+	r.Storer.SetIndex(s.T().Context(), &index.Index{Version: 2})
 	w.filesystem = newWorktreeFilesystem(osfs.New(filepath.Join(dir, "worktree-empty")), defaultProtectNTFS(), defaultProtectHFS())
 
-	err = w.Checkout(&CheckoutOptions{})
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 
@@ -577,26 +577,26 @@ func TestCheckoutSymlinkArbitraryTarget(t *testing.T) {
 
 			dir := t.TempDir()
 
-			r, err := PlainInit(dir, false)
+			r, err := PlainInit(t.Context(), dir, false)
 			require.NoError(t, err)
 			defer func() { _ = r.Close() }()
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(t.Context())
 			require.NoError(t, err)
 
 			require.NoError(t, w.filesystem.Symlink(tc.target, "link"))
-			_, err = w.Add("link")
+			_, err = w.Add(t.Context(), "link")
 			require.NoError(t, err)
-			_, err = w.Commit("add symlink", &CommitOptions{Author: defaultSignature()})
+			_, err = w.Commit(t.Context(), "add symlink", &CommitOptions{Author: defaultSignature()})
 			require.NoError(t, err)
 
-			require.NoError(t, r.Storer.SetIndex(&index.Index{Version: 2}))
+			require.NoError(t, r.Storer.SetIndex(t.Context(), &index.Index{Version: 2}))
 			w.filesystem = newWorktreeFilesystem(
 				osfs.New(filepath.Join(dir, "worktree-empty")), true, true)
 
-			require.NoError(t, w.Checkout(&CheckoutOptions{}))
+			require.NoError(t, w.Checkout(t.Context(), &CheckoutOptions{}))
 
-			status, err := w.Status()
+			status, err := w.Status(t.Context())
 			require.NoError(t, err)
 			assert.True(t, status.IsClean())
 
@@ -609,18 +609,18 @@ func TestCheckoutSymlinkArbitraryTarget(t *testing.T) {
 
 func (s *WorktreeSuite) TestCheckoutSparse() {
 	fs := memfs.New()
-	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), fs, &CloneOptions{
 		URL:        s.GetBasicLocalRepositoryURL(),
 		NoCheckout: true,
 	})
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	sparseCheckoutDirectories := []string{"go", "json", "php"}
-	s.NoError(w.Checkout(&CheckoutOptions{
+	s.NoError(w.Checkout(s.T().Context(), &CheckoutOptions{
 		SparseCheckoutDirectories: sparseCheckoutDirectories,
 	}))
 
@@ -642,20 +642,20 @@ func (s *WorktreeSuite) TestCheckoutSparse() {
 
 func (s *WorktreeSuite) TestCheckoutCRLF() {
 	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
-		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())
+		r := NewRepositoryWithEmptyWorktree(s.T().Context(), fixtures.Basic().One())
 		defer func() { _ = r.Close() }()
 
-		cfg, err := r.Config()
+		cfg, err := r.Config(s.T().Context())
 		require.NoError(t, err)
 		cfg.Core.AutoCRLF = autoCRLF
-		require.NoError(t, r.SetConfig(cfg))
+		require.NoError(t, r.SetConfig(s.T().Context(), cfg))
 
-		wt, err := r.Worktree()
+		wt, err := r.Worktree(s.T().Context())
 		require.NoError(t, err)
 
-		require.NoError(t, wt.Checkout(&CheckoutOptions{}))
+		require.NoError(t, wt.Checkout(s.T().Context(), &CheckoutOptions{}))
 
-		status, err := wt.Status()
+		status, err := wt.Status(s.T().Context())
 		require.NoError(t, err)
 		require.True(t, status.IsClean(), status)
 
@@ -686,13 +686,13 @@ func (s *WorktreeSuite) TestFilenameNormalization() {
 
 	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
 
-	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: url})
+	server, err := PlainClone(s.T().Context(), s.T().TempDir(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
 	filename := "페"
 
-	w, err := server.Worktree()
+	w, err := server.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	writeFile := func(fs billy.Filesystem, path string) {
@@ -700,19 +700,19 @@ func (s *WorktreeSuite) TestFilenameNormalization() {
 	}
 
 	writeFile(w.filesystem, filename)
-	origHash, err := w.Add(filename)
+	origHash, err := w.Add(s.T().Context(), filename)
 	s.NoError(err)
-	_, err = w.Commit("foo", &CommitOptions{Author: defaultSignature()})
+	_, err = w.Commit(s.T().Context(), "foo", &CommitOptions{Author: defaultSignature()})
 	s.NoError(err)
 
-	r, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
+	r, err := Clone(s.T().Context(), memory.NewStorage(), memfs.New(), &CloneOptions{URL: server.wt.Root()})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err = r.Worktree()
+	w, err = r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 
@@ -722,49 +722,49 @@ func (s *WorktreeSuite) TestFilenameNormalization() {
 	modFilename := norm.NFKD.String(filename)
 	writeFile(w.filesystem, modFilename)
 
-	_, err = w.Add(filename)
+	_, err = w.Add(s.T().Context(), filename)
 	s.NoError(err)
-	modHash, err := w.Add(modFilename)
+	modHash, err := w.Add(s.T().Context(), modFilename)
 	s.NoError(err)
 	// At this point we've got two files with the same content.
 	// Hence their hashes must be the same.
 	s.True(origHash == modHash)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	// However, their names are different and the work tree is still dirty.
 	s.False(status.IsClean())
 
 	// Revert back the deletion of the first file.
 	writeFile(w.filesystem, filename)
-	_, err = w.Add(filename)
+	_, err = w.Add(s.T().Context(), filename)
 	s.NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	// Still dirty - the second file is added.
 	s.False(status.IsClean())
 
-	_, err = w.Remove(modFilename)
+	_, err = w.Remove(s.T().Context(), modFilename)
 	s.NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
 
 func (s *WorktreeSuite) TestCheckoutSubmodule() {
 	url := "https://github.com/git-fixtures/submodule.git"
-	r := NewRepositoryWithEmptyWorktree(fixtures.ByURL(url).One())
+	r := NewRepositoryWithEmptyWorktree(s.T().Context(), fixtures.ByURL(url).One())
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	err = w.Checkout(&CheckoutOptions{})
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -774,16 +774,16 @@ func (s *WorktreeSuite) TestCheckoutSubmoduleInitialized() {
 	r := s.NewRepository(fixtures.ByURL(url).One())
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	sub, err := w.Submodules()
+	sub, err := w.Submodules(s.T().Context())
 	s.NoError(err)
 
-	err = sub.Update(&SubmoduleUpdateOptions{Init: true})
+	err = sub.Update(s.T().Context(), &SubmoduleUpdateOptions{Init: true})
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -806,11 +806,11 @@ func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized() {
 	s.NoError(err)
 	s.NotEqual(0, n)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	w.Add(".gitmodules")
-	w.Commit("test", &CommitOptions{Author: defaultSignature()})
+	w.Add(s.T().Context(), ".gitmodules")
+	w.Commit(s.T().Context(), "test", &CommitOptions{Author: defaultSignature()})
 
 	// test submodule path
 	modules, err := w.readGitmodulesFile()
@@ -819,31 +819,31 @@ func (s *WorktreeSuite) TestCheckoutRelativePathSubmoduleInitialized() {
 	s.Equal("../basic.git", modules.Submodules["basic"].URL)
 	s.Equal("../submodule.git", modules.Submodules["itself"].URL)
 
-	basicSubmodule, err := w.Submodule("basic")
+	basicSubmodule, err := w.Submodule(s.T().Context(), "basic")
 	s.NoError(err)
-	basicRepo, err := basicSubmodule.Repository()
+	basicRepo, err := basicSubmodule.Repository(s.T().Context())
 	s.NoError(err)
 	defer basicRepo.Close()
-	basicRemotes, err := basicRepo.Remotes()
+	basicRemotes, err := basicRepo.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Equal("https://github.com/git-fixtures/basic.git", basicRemotes[0].Config().URLs[0])
 
-	itselfSubmodule, err := w.Submodule("itself")
+	itselfSubmodule, err := w.Submodule(s.T().Context(), "itself")
 	s.NoError(err)
-	itselfRepo, err := itselfSubmodule.Repository()
+	itselfRepo, err := itselfSubmodule.Repository(s.T().Context())
 	s.NoError(err)
 	defer itselfRepo.Close()
-	itselfRemotes, err := itselfRepo.Remotes()
+	itselfRemotes, err := itselfRepo.Remotes(s.T().Context())
 	s.NoError(err)
 	s.Equal("https://github.com/git-fixtures/submodule.git", itselfRemotes[0].Config().URLs[0])
 
-	sub, err := w.Submodules()
+	sub, err := w.Submodules(s.T().Context())
 	s.NoError(err)
 
-	err = sub.Update(&SubmoduleUpdateOptions{Init: true, RecurseSubmodules: DefaultSubmoduleRecursionDepth})
+	err = sub.Update(s.T().Context(), &SubmoduleUpdateOptions{Init: true, RecurseSubmodules: DefaultSubmoduleRecursionDepth})
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -855,10 +855,10 @@ func (s *WorktreeSuite) TestCheckoutIndexMem() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
-	idx, err := s.Repository.Storer.Index()
+	idx, err := s.Repository.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 	s.Equal("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88", idx.Entries[0].Hash.String())
@@ -883,10 +883,10 @@ func (s *WorktreeSuite) TestCheckoutIndexOS() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
-	idx, err := s.Repository.Storer.Index()
+	idx, err := s.Repository.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 	s.Equal("32858aad3c383ed1ff0a0f9bdf231d54a00c9e88", idx.Entries[0].Hash.String())
@@ -910,16 +910,16 @@ func (s *WorktreeSuite) TestCheckoutBranch() {
 		filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{
 		Branch: "refs/heads/branch",
 	})
 	s.NoError(err)
 
-	head, err := w.r.Head()
+	head, err := w.r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal("refs/heads/branch", head.Name().String())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -935,23 +935,23 @@ func (s *WorktreeSuite) TestCheckoutBranchUntracked() {
 	_, err = uf.Write([]byte("don't delete me"))
 	s.NoError(err)
 
-	err = w.Checkout(&CheckoutOptions{
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{
 		Branch: "refs/heads/branch",
 	})
 	s.NoError(err)
 
-	head, err := w.r.Head()
+	head, err := w.r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal("refs/heads/branch", head.Name().String())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	// The untracked file should still be there, so it's not clean
 	s.False(status.IsClean())
 	s.True(status.IsUntracked("untracked_file"))
 	err = w.filesystem.Remove("untracked_file")
 	s.NoError(err)
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	// After deleting the untracked file it should now be clean
 	s.True(status.IsClean())
@@ -966,7 +966,7 @@ func (s *WorktreeSuite) TestCheckoutForceUntracked() {
 	}
 
 	// Populate the worktree first.
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	// Create an untracked file.
@@ -977,10 +977,10 @@ func (s *WorktreeSuite) TestCheckoutForceUntracked() {
 	s.Require().NoError(uf.Close())
 
 	// Force checkout (HardReset) — should leave untracked files alone.
-	err = w.Checkout(&CheckoutOptions{Force: true})
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.Require().NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.Require().NoError(err)
 	// Untracked file must still be present.
 	s.True(status.IsUntracked("untracked_file"), "untracked file was deleted by Force checkout")
@@ -993,18 +993,18 @@ func (s *WorktreeSuite) TestCheckoutForceUntracked() {
 // and prints a warning).
 func (s *WorktreeSuite) TestCheckoutForceSparseUntrackedPreserved() {
 	fs := memfs.New()
-	r, err := Clone(memory.NewStorage(), fs, &CloneOptions{
+	r, err := Clone(s.T().Context(), memory.NewStorage(), fs, &CloneOptions{
 		URL:        s.GetBasicLocalRepositoryURL(),
 		NoCheckout: true,
 	})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	// Initial sparse checkout: only the "go" directory.
-	s.Require().NoError(w.Checkout(&CheckoutOptions{
+	s.Require().NoError(w.Checkout(s.T().Context(), &CheckoutOptions{
 		SparseCheckoutDirectories: []string{"go"},
 	}))
 
@@ -1023,7 +1023,7 @@ func (s *WorktreeSuite) TestCheckoutForceSparseUntrackedPreserved() {
 	// Force checkout: switch sparse set from "go" to "php".
 	// Real git removes tracked "go/" files from the worktree but preserves
 	// untracked files (showing a warning). go-git must match this behaviour.
-	s.Require().NoError(w.Checkout(&CheckoutOptions{
+	s.Require().NoError(w.Checkout(s.T().Context(), &CheckoutOptions{
 		Force:                     true,
 		SparseCheckoutDirectories: []string{"php"},
 	}))
@@ -1049,19 +1049,19 @@ func (s *WorktreeSuite) TestCheckoutCreateWithHash() {
 		filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{
 		Create: true,
 		Branch: "refs/heads/foo",
 		Hash:   plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
 	})
 	s.NoError(err)
 
-	head, err := w.r.Head()
+	head, err := w.r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal("refs/heads/foo", head.Name().String())
 	s.Equal(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"), head.Hash())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -1072,18 +1072,18 @@ func (s *WorktreeSuite) TestCheckoutCreate() {
 		filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{
 		Create: true,
 		Branch: "refs/heads/foo",
 	})
 	s.NoError(err)
 
-	head, err := w.r.Head()
+	head, err := w.r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal("refs/heads/foo", head.Name().String())
 	s.Equal(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), head.Hash())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -1094,7 +1094,7 @@ func (s *WorktreeSuite) TestCheckoutBranchAndHash() {
 		filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{
 		Branch: "refs/heads/foo",
 		Hash:   plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
 	})
@@ -1108,7 +1108,7 @@ func (s *WorktreeSuite) TestCheckoutCreateMissingBranch() {
 		filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{
 		Create: true,
 	})
 
@@ -1130,7 +1130,7 @@ func (s *WorktreeSuite) TestCheckoutCreateInvalidBranch() {
 		"refs/heads/a..b",
 		"refs/heads/.",
 	} {
-		err := w.Checkout(&CheckoutOptions{
+		err := w.Checkout(s.T().Context(), &CheckoutOptions{
 			Create: true,
 			Branch: name,
 		})
@@ -1141,47 +1141,47 @@ func (s *WorktreeSuite) TestCheckoutCreateInvalidBranch() {
 
 func (s *WorktreeSuite) TestCheckoutTag() {
 	f := fixtures.ByTag("tags").One()
-	r := NewRepositoryWithEmptyWorktree(f)
+	r := NewRepositoryWithEmptyWorktree(s.T().Context(), f)
 	defer func() { _ = r.Close() }()
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	err = w.Checkout(&CheckoutOptions{})
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
-	head, err := w.r.Head()
+	head, err := w.r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal("refs/heads/master", head.Name().String())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 
-	err = w.Checkout(&CheckoutOptions{Branch: "refs/tags/lightweight-tag"})
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{Branch: "refs/tags/lightweight-tag"})
 	s.NoError(err)
-	head, err = w.r.Head()
-	s.NoError(err)
-	s.Equal("HEAD", head.Name().String())
-	s.Equal("f7b877701fbf855b44c0a9e86f3fdce2c298b07f", head.Hash().String())
-
-	err = w.Checkout(&CheckoutOptions{Branch: "refs/tags/commit-tag"})
-	s.NoError(err)
-	head, err = w.r.Head()
+	head, err = w.r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal("HEAD", head.Name().String())
 	s.Equal("f7b877701fbf855b44c0a9e86f3fdce2c298b07f", head.Hash().String())
 
-	err = w.Checkout(&CheckoutOptions{Branch: "refs/tags/tree-tag"})
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{Branch: "refs/tags/commit-tag"})
+	s.NoError(err)
+	head, err = w.r.Head(s.T().Context())
+	s.NoError(err)
+	s.Equal("HEAD", head.Name().String())
+	s.Equal("f7b877701fbf855b44c0a9e86f3fdce2c298b07f", head.Hash().String())
+
+	err = w.Checkout(s.T().Context(), &CheckoutOptions{Branch: "refs/tags/tree-tag"})
 	s.NotNil(err)
-	head, err = w.r.Head()
+	head, err = w.r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal("HEAD", head.Name().String())
 }
 
 func (s *WorktreeSuite) TestCheckoutTagHash() {
 	f := fixtures.ByTag("tags").One()
-	r := NewRepositoryWithEmptyWorktree(f)
+	r := NewRepositoryWithEmptyWorktree(s.T().Context(), f)
 	defer func() { _ = r.Close() }()
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	for _, hash := range []string{
@@ -1189,15 +1189,15 @@ func (s *WorktreeSuite) TestCheckoutTagHash() {
 		"ad7897c0fb8e7d9a9ba41fa66072cf06095a6cfc", // commit tag
 		"f7b877701fbf855b44c0a9e86f3fdce2c298b07f", // lightweight tag
 	} {
-		err = w.Checkout(&CheckoutOptions{
+		err = w.Checkout(s.T().Context(), &CheckoutOptions{
 			Hash: plumbing.NewHash(hash),
 		})
 		s.NoError(err)
-		head, err := w.r.Head()
+		head, err := w.r.Head(s.T().Context())
 		s.NoError(err)
 		s.Equal("HEAD", head.Name().String())
 
-		status, err := w.Status()
+		status, err := w.Status(s.T().Context())
 		s.NoError(err)
 		s.True(status.IsClean())
 	}
@@ -1206,7 +1206,7 @@ func (s *WorktreeSuite) TestCheckoutTagHash() {
 		"fe6cb94756faa81e5ed9240f9191b833db5f40ae", // blob tag
 		"152175bf7e5580299fa1f0ba41ef6474cc043b70", // tree tag
 	} {
-		err = w.Checkout(&CheckoutOptions{
+		err = w.Checkout(s.T().Context(), &CheckoutOptions{
 			Hash: plumbing.NewHash(hash),
 		})
 		s.NotNil(err)
@@ -1229,20 +1229,20 @@ func (s *WorktreeSuite) TestCheckoutBisectSubmodules() {
 // checking every commit over the previous commit
 func (s *WorktreeSuite) testCheckoutBisect(url string) {
 	f := fixtures.ByURL(url).One()
-	r := NewRepositoryWithEmptyWorktree(f)
+	r := NewRepositoryWithEmptyWorktree(s.T().Context(), f)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	iter, err := w.r.Log(&LogOptions{})
+	iter, err := w.r.Log(s.T().Context(), &LogOptions{})
 	s.NoError(err)
 
-	iter.ForEach(func(commit *object.Commit) error {
-		err := w.Checkout(&CheckoutOptions{Hash: commit.Hash})
+	iter.ForEach(s.T().Context(), func(commit *object.Commit) error {
+		err := w.Checkout(s.T().Context(), &CheckoutOptions{Hash: commit.Hash})
 		s.NoError(err)
 
-		status, err := w.Status()
+		status, err := w.Status(s.T().Context())
 		s.NoError(err)
 		s.True(status.IsClean())
 
@@ -1257,7 +1257,7 @@ func (s *WorktreeSuite) TestStatus() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 
 	s.False(status.IsClean())
@@ -1268,14 +1268,14 @@ func (s *WorktreeSuite) TestStatusEmpty() {
 	fs := memfs.New()
 	storage := memory.NewStorage()
 
-	r, err := Init(storage, WithWorkTree(fs))
+	r, err := Init(s.T().Context(), storage, WithWorkTree(fs))
 	defer func() { _ = r.Close() }()
 	s.NoError(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 	s.NotNil(status)
@@ -1285,28 +1285,28 @@ func (s *WorktreeSuite) TestStatusCheckedInBeforeIgnored() {
 	fs := memfs.New()
 	storage := memory.NewStorage()
 
-	r, err := Init(storage, WithWorkTree(fs))
+	r, err := Init(s.T().Context(), storage, WithWorkTree(fs))
 	defer func() { _ = r.Close() }()
 	s.NoError(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	err = util.WriteFile(fs, "fileToIgnore", []byte("Initial data"), 0o755)
 	s.NoError(err)
-	_, err = w.Add("fileToIgnore")
+	_, err = w.Add(s.T().Context(), "fileToIgnore")
 	s.NoError(err)
 
-	_, err = w.Commit("Added file that will be ignored later", defaultTestCommitOptions())
+	_, err = w.Commit(s.T().Context(), "Added file that will be ignored later", defaultTestCommitOptions())
 	s.NoError(err)
 
 	err = util.WriteFile(fs, ".gitignore", []byte("fileToIgnore\nsecondIgnoredFile"), 0o755)
 	s.NoError(err)
-	_, err = w.Add(".gitignore")
+	_, err = w.Add(s.T().Context(), ".gitignore")
 	s.NoError(err)
-	_, err = w.Commit("Added .gitignore", defaultTestCommitOptions())
+	_, err = w.Commit(s.T().Context(), "Added .gitignore", defaultTestCommitOptions())
 	s.NoError(err)
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 	s.NotNil(status)
@@ -1314,7 +1314,7 @@ func (s *WorktreeSuite) TestStatusCheckedInBeforeIgnored() {
 	err = util.WriteFile(fs, "secondIgnoredFile", []byte("Should be completely ignored"), 0o755)
 	s.NoError(err)
 	status = nil
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 	s.NotNil(status)
@@ -1322,7 +1322,7 @@ func (s *WorktreeSuite) TestStatusCheckedInBeforeIgnored() {
 	err = util.WriteFile(fs, "fileToIgnore", []byte("Updated data"), 0o755)
 	s.NoError(err)
 	status = nil
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 	s.NotNil(status)
@@ -1335,14 +1335,14 @@ func (s *WorktreeSuite) TestStatusEmptyDirty() {
 
 	storage := memory.NewStorage()
 
-	r, err := Init(storage, WithWorkTree(fs))
+	r, err := Init(s.T().Context(), storage, WithWorkTree(fs))
 	defer func() { _ = r.Close() }()
 	s.NoError(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 	s.Len(status, 1)
@@ -1355,10 +1355,10 @@ func (s *WorktreeSuite) TestStatusUnmodified() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	status, err := w.StatusWithOptions(StatusOptions{Strategy: Preload})
+	status, err := w.StatusWithOptions(s.T().Context(), StatusOptions{Strategy: Preload})
 	s.NoError(err)
 	s.True(status.IsClean())
 	s.False(status.IsUntracked("LICENSE"))
@@ -1366,7 +1366,7 @@ func (s *WorktreeSuite) TestStatusUnmodified() {
 	s.Equal(Unmodified, status.File("LICENSE").Staging)
 	s.Equal(Unmodified, status.File("LICENSE").Worktree)
 
-	status, err = w.StatusWithOptions(StatusOptions{Strategy: Empty})
+	status, err = w.StatusWithOptions(s.T().Context(), StatusOptions{Strategy: Empty})
 	s.NoError(err)
 	s.True(status.IsClean())
 	s.False(status.IsUntracked("LICENSE"))
@@ -1384,21 +1384,21 @@ func (s *WorktreeSuite) TestReset() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
-	branch, err := w.r.Reference(plumbing.Master, false)
+	branch, err := w.r.Reference(s.T().Context(), plumbing.Master, false)
 	s.NoError(err)
 	s.NotEqual(commit, branch.Hash())
 
-	err = w.Reset(&ResetOptions{Mode: MergeReset, Commit: commit})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: MergeReset, Commit: commit})
 	s.NoError(err)
 
-	branch, err = w.r.Reference(plumbing.Master, false)
+	branch, err = w.r.Reference(s.T().Context(), plumbing.Master, false)
 	s.NoError(err)
 	s.Equal(commit, branch.Hash())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -1412,16 +1412,16 @@ func (s *WorktreeSuite) TestResetWithUntracked() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	err = util.WriteFile(fs, "foo", nil, 0o755)
 	s.NoError(err)
 
-	err = w.Reset(&ResetOptions{Mode: MergeReset, Commit: commit})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: MergeReset, Commit: commit})
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	for file, st := range status {
 		if file == "foo" {
@@ -1444,17 +1444,17 @@ func (s *WorktreeSuite) TestResetSoft() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
-	err = w.Reset(&ResetOptions{Mode: SoftReset, Commit: commit})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: SoftReset, Commit: commit})
 	s.NoError(err)
 
-	branch, err := w.r.Reference(plumbing.Master, false)
+	branch, err := w.r.Reference(s.T().Context(), plumbing.Master, false)
 	s.NoError(err)
 	s.Equal(commit, branch.Hash())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 	s.Equal(Added, status.File("CHANGELOG").Staging)
@@ -1469,17 +1469,17 @@ func (s *WorktreeSuite) TestResetMixed() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
-	err = w.Reset(&ResetOptions{Mode: MixedReset, Commit: commit})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: MixedReset, Commit: commit})
 	s.NoError(err)
 
-	branch, err := w.r.Reference(plumbing.Master, false)
+	branch, err := w.r.Reference(s.T().Context(), plumbing.Master, false)
 	s.NoError(err)
 	s.Equal(commit, branch.Hash())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 	s.Equal(Untracked, status.File("CHANGELOG").Staging)
@@ -1495,13 +1495,13 @@ func (s *WorktreeSuite) TestResetMerge() {
 	commitA := plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294")
 	commitB := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
-	err = w.Reset(&ResetOptions{Mode: MergeReset, Commit: commitA})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: MergeReset, Commit: commitA})
 	s.NoError(err)
 
-	branch, err := w.r.Reference(plumbing.Master, false)
+	branch, err := w.r.Reference(s.T().Context(), plumbing.Master, false)
 	s.NoError(err)
 	s.Equal(commitA, branch.Hash())
 
@@ -1512,10 +1512,10 @@ func (s *WorktreeSuite) TestResetMerge() {
 	err = f.Close()
 	s.NoError(err)
 
-	err = w.Reset(&ResetOptions{Mode: MergeReset, Commit: commitB})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: MergeReset, Commit: commitB})
 	s.ErrorIs(err, ErrUnstagedChanges)
 
-	branch, err = w.r.Reference(plumbing.Master, false)
+	branch, err = w.r.Reference(s.T().Context(), plumbing.Master, false)
 	s.NoError(err)
 	s.Equal(commitA, branch.Hash())
 }
@@ -1529,14 +1529,14 @@ func (s *WorktreeSuite) TestResetKeep() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	// KeepReset with no local changes should succeed and update the worktree.
-	err = w.Reset(&ResetOptions{Mode: KeepReset, Commit: commit})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: KeepReset, Commit: commit})
 	s.Require().NoError(err)
 
-	branch, err := w.r.Reference(plumbing.Master, false)
+	branch, err := w.r.Reference(s.T().Context(), plumbing.Master, false)
 	s.NoError(err)
 	s.Equal(commit, branch.Hash())
 
@@ -1553,23 +1553,23 @@ func (s *WorktreeSuite) TestResetKeepConflict() {
 	repoDir := filepath.Join(tempDir, "repo")
 
 	// Build a repo with two commits that both touch "tracked.txt".
-	r, err := PlainInit(repoDir, false)
+	r, err := PlainInit(s.T().Context(), repoDir, false)
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	commitA := CommitNewFile(s.T(), r, "tracked.txt")
 
 	// Advance to commitB by changing tracked.txt.
 	s.Require().NoError(util.WriteFile(w.filesystem, "tracked.txt", []byte("version B"), 0o644))
-	_, err = w.Add("tracked.txt")
+	_, err = w.Add(s.T().Context(), "tracked.txt")
 	s.Require().NoError(err)
-	commitB, err := w.Commit("second", &CommitOptions{Author: defaultSignature()})
+	commitB, err := w.Commit(s.T().Context(), "second", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
 	// Go back to commitA cleanly.
-	err = w.Reset(&ResetOptions{Mode: HardReset, Commit: commitA})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: HardReset, Commit: commitA})
 	s.Require().NoError(err)
 
 	// Make a local (unstaged) modification to tracked.txt, which differs
@@ -1577,11 +1577,11 @@ func (s *WorktreeSuite) TestResetKeepConflict() {
 	s.Require().NoError(util.WriteFile(w.filesystem, "tracked.txt", []byte("local change"), 0o644))
 
 	// KeepReset to commitB should be aborted.
-	err = w.Reset(&ResetOptions{Mode: KeepReset, Commit: commitB})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: KeepReset, Commit: commitB})
 	s.ErrorIs(err, ErrLocalChanges)
 
 	// HEAD must not have moved.
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal(commitA, head.Hash())
 }
@@ -1597,13 +1597,13 @@ func (s *WorktreeSuite) TestResetKeepUntrackedPreserved() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.Require().NoError(err)
 
 	// Create an untracked file.
 	s.Require().NoError(util.WriteFile(fs, "untracked.txt", []byte("keep me"), 0o644))
 
-	err = w.Reset(&ResetOptions{Mode: KeepReset, Commit: commit})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: KeepReset, Commit: commit})
 	s.Require().NoError(err)
 
 	_, statErr := fs.Stat("untracked.txt")
@@ -1622,7 +1622,7 @@ func (s *WorktreeSuite) TestResetKeepSparselyUntracked() {
 	}
 
 	// Sparse-populate the "go" directory first.
-	s.Require().NoError(w.Reset(&ResetOptions{Mode: KeepReset, SparseDirs: []string{"go"}}))
+	s.Require().NoError(w.Reset(s.T().Context(), &ResetOptions{Mode: KeepReset, SparseDirs: []string{"go"}}))
 
 	goFiles, err := fs.ReadDir("go")
 	s.Require().NoError(err)
@@ -1633,7 +1633,7 @@ func (s *WorktreeSuite) TestResetKeepSparselyUntracked() {
 
 	// Switch sparse set from "go" to "php" using KeepReset. There are no
 	// local modifications to tracked files, so the keep-check must pass.
-	s.Require().NoError(w.Reset(&ResetOptions{Mode: KeepReset, SparseDirs: []string{"php"}}))
+	s.Require().NoError(w.Reset(s.T().Context(), &ResetOptions{Mode: KeepReset, SparseDirs: []string{"php"}}))
 
 	// Tracked files in the removed "go" sparse dir must be removed from disk;
 	// git always removes SkipWorktree-marked files from the worktree.
@@ -1659,10 +1659,10 @@ func (s *WorktreeSuite) TestResetKeepConflictNotOnSparseExcluded() {
 	tempDir := s.T().TempDir()
 	repoDir := filepath.Join(tempDir, "repo")
 
-	r, err := PlainInit(repoDir, false)
+	r, err := PlainInit(s.T().Context(), repoDir, false)
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	// commitA: create tracked.txt and subdir/other.txt
@@ -1670,16 +1670,16 @@ func (s *WorktreeSuite) TestResetKeepConflictNotOnSparseExcluded() {
 
 	// commitB: change tracked.txt (so it appears in the tree-to-tree diff)
 	s.Require().NoError(util.WriteFile(w.filesystem, "tracked.txt", []byte("version B"), 0o644))
-	_, err = w.Add("tracked.txt")
+	_, err = w.Add(s.T().Context(), "tracked.txt")
 	s.Require().NoError(err)
-	commitB, err := w.Commit("second", &CommitOptions{Author: defaultSignature()})
+	commitB, err := w.Commit(s.T().Context(), "second", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
 	// Go back to commitA and apply a sparse checkout that excludes tracked.txt
 	// by resetting with a SparseDirs that doesn't contain it.
 	// We use a subdirectory "subdir" that doesn't actually exist in the tree;
 	// we skip validation so we can force SkipWorktree onto all files.
-	err = w.Reset(&ResetOptions{
+	err = w.Reset(s.T().Context(), &ResetOptions{
 		Mode:                    HardReset,
 		Commit:                  commitA,
 		SparseDirs:              []string{"subdir"},
@@ -1690,7 +1690,7 @@ func (s *WorktreeSuite) TestResetKeepConflictNotOnSparseExcluded() {
 	// Now tracked.txt should be SkipWorktree=true (not on disk). A KeepReset
 	// to commitB touches tracked.txt in the tree diff, but since it isn't
 	// locally modified (it's sparse-excluded), the check must pass.
-	err = w.Reset(&ResetOptions{
+	err = w.Reset(s.T().Context(), &ResetOptions{
 		Mode:                    KeepReset,
 		Commit:                  commitB,
 		SparseDirs:              []string{"subdir"},
@@ -1698,7 +1698,7 @@ func (s *WorktreeSuite) TestResetKeepConflictNotOnSparseExcluded() {
 	})
 	s.Require().NoError(err)
 
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.Require().NoError(err)
 	s.Equal(commitB, head.Hash(), "HEAD should advance to commitB")
 }
@@ -1714,7 +1714,7 @@ func (s *WorktreeSuite) TestResetKeepSparseConflict() {
 	}
 
 	// Sparse-populate the "go" directory so its tracked files are on disk.
-	s.Require().NoError(w.Reset(&ResetOptions{Mode: KeepReset, SparseDirs: []string{"go"}}))
+	s.Require().NoError(w.Reset(s.T().Context(), &ResetOptions{Mode: KeepReset, SparseDirs: []string{"go"}}))
 
 	// Find a tracked file inside go/ to dirty.
 	goFiles, err := fs.ReadDir("go")
@@ -1726,7 +1726,7 @@ func (s *WorktreeSuite) TestResetKeepSparseConflict() {
 
 	// Switching SparseDirs from "go" to "php" (same commit) would remove
 	// dirty go/ files from disk — KeepReset must refuse.
-	err = w.Reset(&ResetOptions{Mode: KeepReset, SparseDirs: []string{"php"}})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: KeepReset, SparseDirs: []string{"php"}})
 	s.ErrorIs(err, ErrLocalChanges, "KeepReset should abort when SparseDirs removal would discard local mods")
 }
 
@@ -1737,10 +1737,10 @@ func (s *WorktreeSuite) TestResetKeepUntrackedOverwrite() {
 	tempDir := s.T().TempDir()
 	repoDir := filepath.Join(tempDir, "repo")
 
-	r, err := PlainInit(repoDir, false)
+	r, err := PlainInit(s.T().Context(), repoDir, false)
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	// commitA: only tracked.txt exists.
@@ -1748,24 +1748,24 @@ func (s *WorktreeSuite) TestResetKeepUntrackedOverwrite() {
 
 	// commitB: add new.txt alongside tracked.txt.
 	s.Require().NoError(util.WriteFile(w.filesystem, "new.txt", []byte("tracked content"), 0o644))
-	_, err = w.Add("new.txt")
+	_, err = w.Add(s.T().Context(), "new.txt")
 	s.Require().NoError(err)
-	commitB, err := w.Commit("add new.txt", &CommitOptions{Author: defaultSignature()})
+	commitB, err := w.Commit(s.T().Context(), "add new.txt", &CommitOptions{Author: defaultSignature()})
 	s.Require().NoError(err)
 
 	// Go back to commitA so new.txt is absent from the worktree.
-	err = w.Reset(&ResetOptions{Mode: HardReset, Commit: commitA})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: HardReset, Commit: commitA})
 	s.Require().NoError(err)
 
 	// Place an untracked file at the path that commitB will insert.
 	s.Require().NoError(util.WriteFile(w.filesystem, "new.txt", []byte("untracked content"), 0o644))
 
 	// KeepReset to commitB must abort because new.txt would be overwritten.
-	err = w.Reset(&ResetOptions{Mode: KeepReset, Commit: commitB})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: KeepReset, Commit: commitB})
 	s.ErrorIs(err, ErrLocalChanges, "KeepReset should abort when an untracked file would be overwritten")
 
 	// HEAD must not have moved.
-	head, err := r.Head()
+	head, err := r.Head(s.T().Context())
 	s.NoError(err)
 	s.Equal(commitA, head.Hash())
 }
@@ -1779,7 +1779,7 @@ func (s *WorktreeSuite) TestResetHard() {
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	f, err := fs.Create(".gitignore")
@@ -1789,10 +1789,10 @@ func (s *WorktreeSuite) TestResetHard() {
 	err = f.Close()
 	s.NoError(err)
 
-	err = w.Reset(&ResetOptions{Mode: HardReset, Commit: commit})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: HardReset, Commit: commit})
 	s.NoError(err)
 
-	branch, err := w.r.Reference(plumbing.Master, false)
+	branch, err := w.r.Reference(s.T().Context(), plumbing.Master, false)
 	s.NoError(err)
 	s.Equal(commit, branch.Hash())
 }
@@ -1804,7 +1804,7 @@ func (s *WorktreeSuite) TestResetHardSubFolders() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	err = fs.MkdirAll("dir", os.ModePerm)
@@ -1815,22 +1815,22 @@ func (s *WorktreeSuite) TestResetHardSubFolders() {
 	s.NoError(err)
 	err = tf.Close()
 	s.NoError(err)
-	_, err = w.Add("dir/testfile.txt")
+	_, err = w.Add(s.T().Context(), "dir/testfile.txt")
 	s.NoError(err)
-	_, err = w.Commit("testcommit", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
+	_, err = w.Commit(s.T().Context(), "testcommit", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
 	s.NoError(err)
 
 	err = fs.Remove("dir/testfile.txt")
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 
-	err = w.Reset(&ResetOptions{Files: []string{"./dir/testfile.txt"}, Mode: HardReset})
+	err = w.Reset(s.T().Context(), &ResetOptions{Files: []string{"./dir/testfile.txt"}, Mode: HardReset})
 	s.NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -1842,7 +1842,7 @@ func (s *WorktreeSuite) TestResetHardWithGitIgnore() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	tf, err := fs.Create("newTestFile.txt")
@@ -1851,9 +1851,9 @@ func (s *WorktreeSuite) TestResetHardWithGitIgnore() {
 	s.NoError(err)
 	err = tf.Close()
 	s.NoError(err)
-	_, err = w.Add("newTestFile.txt")
+	_, err = w.Add(s.T().Context(), "newTestFile.txt")
 	s.NoError(err)
-	_, err = w.Commit("testcommit", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
+	_, err = w.Commit(s.T().Context(), "testcommit", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
 	s.NoError(err)
 
 	err = fs.Remove("newTestFile.txt")
@@ -1867,14 +1867,14 @@ func (s *WorktreeSuite) TestResetHardWithGitIgnore() {
 	err = f.Close()
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 
-	err = w.Reset(&ResetOptions{Mode: HardReset})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: HardReset})
 	s.NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -1891,7 +1891,7 @@ func (s *WorktreeSuite) TestResetHardTrackedFileInIgnoredDir() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	err = fs.MkdirAll("vendor", os.ModePerm)
@@ -1902,7 +1902,7 @@ func (s *WorktreeSuite) TestResetHardTrackedFileInIgnoredDir() {
 	s.NoError(err)
 	err = tf.Close()
 	s.NoError(err)
-	_, err = w.Add("vendor/keep.txt")
+	_, err = w.Add(s.T().Context(), "vendor/keep.txt")
 	s.NoError(err)
 
 	gi, err := fs.Create(".gitignore")
@@ -1911,23 +1911,23 @@ func (s *WorktreeSuite) TestResetHardTrackedFileInIgnoredDir() {
 	s.NoError(err)
 	err = gi.Close()
 	s.NoError(err)
-	_, err = w.Add(".gitignore")
+	_, err = w.Add(s.T().Context(), ".gitignore")
 	s.NoError(err)
 
-	_, err = w.Commit("testcommit", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
+	_, err = w.Commit(s.T().Context(), "testcommit", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
 	s.NoError(err)
 
 	err = fs.Remove("vendor/keep.txt")
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 
-	err = w.Reset(&ResetOptions{Mode: HardReset})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: HardReset})
 	s.NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 
@@ -1948,7 +1948,7 @@ func (s *WorktreeSuite) TestResetHardModifiedTrackedFileWithGitIgnore() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	tf, err := fs.Create("tracked.txt")
@@ -1957,7 +1957,7 @@ func (s *WorktreeSuite) TestResetHardModifiedTrackedFileWithGitIgnore() {
 	s.NoError(err)
 	err = tf.Close()
 	s.NoError(err)
-	_, err = w.Add("tracked.txt")
+	_, err = w.Add(s.T().Context(), "tracked.txt")
 	s.NoError(err)
 
 	gi, err := fs.Create(".gitignore")
@@ -1966,23 +1966,23 @@ func (s *WorktreeSuite) TestResetHardModifiedTrackedFileWithGitIgnore() {
 	s.NoError(err)
 	err = gi.Close()
 	s.NoError(err)
-	_, err = w.Add(".gitignore")
+	_, err = w.Add(s.T().Context(), ".gitignore")
 	s.NoError(err)
 
-	_, err = w.Commit("testcommit", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
+	_, err = w.Commit(s.T().Context(), "testcommit", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
 	s.NoError(err)
 
 	err = util.WriteFile(fs, "tracked.txt", []byte("v2 dirty"), 0o644)
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 
-	err = w.Reset(&ResetOptions{Mode: HardReset})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: HardReset})
 	s.NoError(err)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 
@@ -2006,7 +2006,7 @@ func (s *WorktreeSuite) TestMergeResetRemovesTrackedFileInIgnoredDir() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	gi, err := fs.Create(".gitignore")
@@ -2015,7 +2015,7 @@ func (s *WorktreeSuite) TestMergeResetRemovesTrackedFileInIgnoredDir() {
 	s.NoError(err)
 	err = gi.Close()
 	s.NoError(err)
-	_, err = w.Add(".gitignore")
+	_, err = w.Add(s.T().Context(), ".gitignore")
 	s.NoError(err)
 
 	err = fs.MkdirAll("vendor", os.ModePerm)
@@ -2026,25 +2026,25 @@ func (s *WorktreeSuite) TestMergeResetRemovesTrackedFileInIgnoredDir() {
 	s.NoError(err)
 	err = tf.Close()
 	s.NoError(err)
-	_, err = w.Add("vendor/keep.txt")
+	_, err = w.Add(s.T().Context(), "vendor/keep.txt")
 	s.NoError(err)
-	withFile, err := w.Commit("with file", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
+	withFile, err := w.Commit(s.T().Context(), "with file", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
 	s.NoError(err)
 
-	_, err = w.Remove("vendor/keep.txt")
+	_, err = w.Remove(s.T().Context(), "vendor/keep.txt")
 	s.NoError(err)
-	withoutFile, err := w.Commit("without file", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
+	withoutFile, err := w.Commit(s.T().Context(), "without file", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
 	s.NoError(err)
 
 	// HardReset back to "with file" so the tracked, gitignored path is on disk.
-	err = w.Reset(&ResetOptions{Mode: HardReset, Commit: withFile})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: HardReset, Commit: withFile})
 	s.NoError(err)
 	_, err = fs.Stat("vendor/keep.txt")
 	s.NoError(err)
 
 	// MergeReset to "without file" must remove the path even though the
 	// directory matches an ignore rule.
-	err = w.Reset(&ResetOptions{Mode: MergeReset, Commit: withoutFile})
+	err = w.Reset(s.T().Context(), &ResetOptions{Mode: MergeReset, Commit: withoutFile})
 	s.NoError(err)
 	_, err = fs.Stat("vendor/keep.txt")
 	s.True(os.IsNotExist(err), "vendor/keep.txt must be removed after MergeReset, got err=%v", err)
@@ -2059,7 +2059,7 @@ func (s *WorktreeSuite) TestResetSparsely() {
 
 	sparseResetDirs := []string{"php"}
 
-	err := w.Reset(&ResetOptions{Mode: HardReset, SparseDirs: sparseResetDirs})
+	err := w.Reset(s.T().Context(), &ResetOptions{Mode: HardReset, SparseDirs: sparseResetDirs})
 	s.NoError(err)
 
 	files, err := fs.ReadDir("/")
@@ -2104,7 +2104,7 @@ func (s *WorktreeSuite) TestResetSparselyInvalidDir() {
 
 	for _, test := range tests {
 		s.Run(test.name, func() {
-			err := w.Reset(&test.opts)
+			err := w.Reset(s.T().Context(), &test.opts)
 			if test.wantErr {
 				s.Require().ErrorIs(err, ErrSparseResetDirectoryNotFound)
 				return
@@ -2121,10 +2121,10 @@ func (s *WorktreeSuite) TestStatusAfterCheckout() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.True(status.IsClean())
 }
@@ -2136,13 +2136,13 @@ func (s *WorktreeSuite) TestStatusAfterSparseCheckout() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{
 		SparseCheckoutDirectories: []string{"php"},
 		Force:                     true,
 	})
 	s.Require().NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.Require().NoError(err)
 	s.True(status.IsClean(), status)
 }
@@ -2155,7 +2155,7 @@ func (s *WorktreeSuite) TestStatusModified() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	f, err := fs.Create(".gitignore")
@@ -2165,7 +2165,7 @@ func (s *WorktreeSuite) TestStatusModified() {
 	err = f.Close()
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 	s.Equal(Modified, status.File(".gitignore").Worktree)
@@ -2178,7 +2178,7 @@ func (s *WorktreeSuite) TestStatusIgnored() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	w.Checkout(&CheckoutOptions{})
+	w.Checkout(s.T().Context(), &CheckoutOptions{})
 
 	fs.MkdirAll("another", os.ModePerm)
 	f, _ := fs.Create("another/file")
@@ -2190,7 +2190,7 @@ func (s *WorktreeSuite) TestStatusIgnored() {
 	f, _ = fs.Create("vendor/gopkg.in/file")
 	f.Close()
 
-	status, _ := w.Status()
+	status, _ := w.Status(s.T().Context())
 	s.Len(status, 3)
 	_, ok := status["another/file"]
 	s.True(ok)
@@ -2206,7 +2206,7 @@ func (s *WorktreeSuite) TestStatusIgnored() {
 	f.Write([]byte("!github.com/\n"))
 	f.Close()
 
-	status, _ = w.Status()
+	status, _ = w.Status(s.T().Context())
 	s.Len(status, 4)
 	_, ok = status[".gitignore"]
 	s.True(ok)
@@ -2225,14 +2225,14 @@ func (s *WorktreeSuite) TestStatusUntracked() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
 	f, err := w.filesystem.Create("foo")
 	s.NoError(err)
 	s.Nil(f.Close())
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Equal(Untracked, status.File("foo").Staging)
 	s.Equal(Untracked, status.File("foo").Worktree)
@@ -2246,13 +2246,13 @@ func (s *WorktreeSuite) TestStatusDeleted() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{})
 	s.NoError(err)
 
 	err = fs.Remove(".gitignore")
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.False(status.IsClean())
 	s.Equal(Deleted, status.File(".gitignore").Worktree)
@@ -2261,27 +2261,27 @@ func (s *WorktreeSuite) TestStatusDeleted() {
 func (s *WorktreeSuite) TestStatusFileMode() {
 	runTest := func(t *testing.T, fileMode bool) string {
 		fs := memfs.New()
-		r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+		r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(fs))
 		defer func() { _ = r.Close() }()
 		require.NoError(t, err)
 
-		w, err := r.Worktree()
+		w, err := r.Worktree(s.T().Context())
 		require.NoError(t, err)
 
-		cfg, err := r.Config()
+		cfg, err := r.Config(s.T().Context())
 		require.NoError(t, err)
 
 		cfg.Core.FileMode = fileMode
-		err = r.SetConfig(cfg)
+		err = r.SetConfig(s.T().Context(), cfg)
 		require.NoError(t, err)
 
 		err = util.WriteFile(fs, "run.bash", []byte("#!/bin/bash\n"), 0o0755)
 		require.NoError(t, err)
 
-		_, err = w.Add("run.bash")
+		_, err = w.Add(s.T().Context(), "run.bash")
 		require.NoError(t, err)
 
-		_, err = w.Commit("Add an executable", defaultTestCommitOptions())
+		_, err = w.Commit(s.T().Context(), "Add an executable", defaultTestCommitOptions())
 		require.NoError(t, err)
 
 		err = util.RemoveAll(fs, "run.bash")
@@ -2290,7 +2290,7 @@ func (s *WorktreeSuite) TestStatusFileMode() {
 		err = util.WriteFile(fs, "run.bash", []byte("#!/bin/bash\n"), 0o0644)
 		require.NoError(t, err)
 
-		s, err := w.Status()
+		s, err := w.Status(s.T().Context())
 		require.NoError(t, err)
 
 		return s.String()
@@ -2313,14 +2313,14 @@ func (s *WorktreeSuite) TestSubmodule() {
 	gitdir, err := fs.Chroot(GitDirName)
 	s.Require().NoError(err)
 
-	r, err := Open(filesystem.NewStorage(gitdir, cache.NewObjectLRUDefault()), fs)
+	r, err := Open(s.T().Context(), filesystem.NewStorage(gitdir, cache.NewObjectLRUDefault()), fs)
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
-	m, err := w.Submodule("basic")
+	m, err := w.Submodule(s.T().Context(), "basic")
 	s.NoError(err)
 
 	s.Equal("basic", m.Config().Name)
@@ -2330,10 +2330,10 @@ func (s *WorktreeSuite) TestSubmodules() {
 	r := s.NewRepository(fixtures.ByTag("submodule").One())
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
-	l, err := w.Submodules()
+	l, err := w.Submodules(s.T().Context())
 	s.NoError(err)
 
 	s.Len(l, 2)
@@ -2395,23 +2395,23 @@ func (s *WorktreeSuite) TestSubmodules_URLResolution() {
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
 			fs := memfs.New()
-			r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+			r, err := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(fs))
 			defer func() { _ = r.Close() }()
 			s.NoError(err)
 
-			_, err = r.CreateRemote(&config.RemoteConfig{
+			_, err = r.CreateRemote(s.T().Context(), &config.RemoteConfig{
 				Name: "origin",
 				URLs: []string{tc.originURL},
 			})
 			s.NoError(err)
 
-			w, err := r.Worktree()
+			w, err := r.Worktree(s.T().Context())
 			s.NoError(err)
 
 			err = util.WriteFile(fs, ".gitmodules", []byte(tc.gitmodules), 0o644)
 			s.NoError(err)
 
-			submodules, err := w.Submodules()
+			submodules, err := w.Submodules(s.T().Context())
 			s.NoError(err)
 			s.Len(submodules, len(tc.expected))
 
@@ -2520,21 +2520,21 @@ func (s *WorktreeSuite) TestAddUntracked() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
 	err = util.WriteFile(w.filesystem, "foo", []byte("FOO"), 0o755)
 	s.NoError(err)
 
-	hash, err := w.Add("foo")
+	hash, err := w.Add(s.T().Context(), "foo")
 	s.Equal("d96c7efbfec2814ae0301ad054dc8d9fc416c9b5", hash.String())
 	s.NoError(err)
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 10)
 
@@ -2543,7 +2543,7 @@ func (s *WorktreeSuite) TestAddUntracked() {
 	s.Equal(hash, e.Hash)
 	s.Equal(filemode.Executable, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 1)
 
@@ -2551,7 +2551,7 @@ func (s *WorktreeSuite) TestAddUntracked() {
 	s.Equal(Added, file.Staging)
 	s.Equal(Unmodified, file.Worktree)
 
-	obj, err := w.r.Storer.EncodedObject(plumbing.BlobObject, hash)
+	obj, err := w.r.Storer.EncodedObject(s.T().Context(), plumbing.BlobObject, hash)
 	s.NoError(err)
 	s.NotNil(obj)
 	s.Equal(int64(3), obj.Size())
@@ -2560,21 +2560,21 @@ func (s *WorktreeSuite) TestAddUntracked() {
 func (s *WorktreeSuite) TestAddAbsolutePath() {
 	dir := s.T().TempDir()
 
-	r, err := PlainInit(dir, false)
+	r, err := PlainInit(s.T().Context(), dir, false)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	err = util.WriteFile(w.filesystem, "foo.txt", []byte("FOO"), 0o644)
 	s.NoError(err)
 
 	absPath := filepath.Join(dir, "foo.txt")
-	_, err = w.Add(absPath)
+	_, err = w.Add(s.T().Context(), absPath)
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 
 	_, err = idx.Entry("foo.txt")
@@ -2583,7 +2583,7 @@ func (s *WorktreeSuite) TestAddAbsolutePath() {
 	_, err = idx.Entry(absPath)
 	s.Error(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 
 	file := status.File("foo.txt")
@@ -2593,24 +2593,24 @@ func (s *WorktreeSuite) TestAddAbsolutePath() {
 
 func (s *WorktreeSuite) TestAddCRLF() {
 	runTest := func(t *testing.T, autoCRLF string) (result []byte) {
-		r := NewRepositoryWithEmptyWorktree(fixtures.Basic().One())
+		r := NewRepositoryWithEmptyWorktree(s.T().Context(), fixtures.Basic().One())
 		defer func() { _ = r.Close() }()
 
-		cfg, err := r.Config()
+		cfg, err := r.Config(s.T().Context())
 		require.NoError(t, err)
 		cfg.Core.AutoCRLF = autoCRLF
-		require.NoError(t, r.SetConfig(cfg))
+		require.NoError(t, r.SetConfig(s.T().Context(), cfg))
 
-		wt, err := r.Worktree()
+		wt, err := r.Worktree(s.T().Context())
 		require.NoError(t, err)
 
 		err = util.WriteFile(wt.filesystem, "foo", []byte("FOO\r\n"), 0o755)
 		require.NoError(t, err)
 
-		h, err := wt.Add("foo")
+		h, err := wt.Add(s.T().Context(), "foo")
 		require.NoError(t, err)
 
-		obj, err := r.Storer.EncodedObject(plumbing.BlobObject, h)
+		obj, err := r.Storer.EncodedObject(s.T().Context(), plumbing.BlobObject, h)
 		require.NoError(t, err)
 		require.NotNil(t, obj)
 
@@ -2645,17 +2645,17 @@ func (s *WorktreeSuite) TestIgnored() {
 	w.Excludes = make([]gitignore.Pattern, 0)
 	w.Excludes = append(w.Excludes, gitignore.ParsePattern("foo", nil))
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
 	err = util.WriteFile(w.filesystem, "foo", []byte("FOO"), 0o755)
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 0)
 
@@ -2684,7 +2684,7 @@ func (s *WorktreeSuite) TestExcludedNoGitignore() {
 	err = util.WriteFile(w.filesystem, "foo", []byte("FOO"), 0o755)
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 0)
 
@@ -2700,21 +2700,21 @@ func (s *WorktreeSuite) TestAddModified() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
 	err = util.WriteFile(w.filesystem, "LICENSE", []byte("FOO"), 0o644)
 	s.NoError(err)
 
-	hash, err := w.Add("LICENSE")
+	hash, err := w.Add(s.T().Context(), "LICENSE")
 	s.NoError(err)
 	s.Equal("d96c7efbfec2814ae0301ad054dc8d9fc416c9b5", hash.String())
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
@@ -2723,7 +2723,7 @@ func (s *WorktreeSuite) TestAddModified() {
 	s.Equal(hash, e.Hash)
 	s.Equal(filemode.Regular, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 1)
 
@@ -2739,10 +2739,10 @@ func (s *WorktreeSuite) TestAddUnmodified() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	hash, err := w.Add("LICENSE")
+	hash, err := w.Add(s.T().Context(), "LICENSE")
 	s.Equal("c192bd6a24ea1ab01d78686e417c8bdc7c3d197f", hash.String())
 	s.NoError(err)
 }
@@ -2754,17 +2754,17 @@ func (s *WorktreeSuite) TestAddRemoved() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
 	err = w.filesystem.Remove("LICENSE")
 	s.NoError(err)
 
-	hash, err := w.Add("LICENSE")
+	hash, err := w.Add(s.T().Context(), "LICENSE")
 	s.NoError(err)
 	s.Equal("c192bd6a24ea1ab01d78686e417c8bdc7c3d197f", hash.String())
 
@@ -2773,7 +2773,7 @@ func (s *WorktreeSuite) TestAddRemoved() {
 	s.Equal(hash, e.Hash)
 	s.Equal(filemode.Regular, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 1)
 
@@ -2788,10 +2788,10 @@ func (s *WorktreeSuite) testAddRemovedInDirectory(addPath string, expectedJSONSt
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
@@ -2801,7 +2801,7 @@ func (s *WorktreeSuite) testAddRemovedInDirectory(addPath string, expectedJSONSt
 	err = w.filesystem.Remove("json/short.json")
 	s.NoError(err)
 
-	hash, err := w.Add(addPath)
+	hash, err := w.Add(s.T().Context(), addPath)
 	s.NoError(err)
 	s.True(hash.IsZero())
 
@@ -2815,7 +2815,7 @@ func (s *WorktreeSuite) testAddRemovedInDirectory(addPath string, expectedJSONSt
 	s.Equal(plumbing.NewHash("c8f1d8c61f9da76f4cb49fd86322b6e685dba956"), e.Hash)
 	s.Equal(filemode.Regular, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 2)
 
@@ -2841,7 +2841,7 @@ func (s *WorktreeSuite) TestAddRemovedInDirectoryDot() {
 func (s *WorktreeSuite) TestAddSymlink() {
 	dir := s.T().TempDir()
 
-	r, err := PlainInit(dir, false)
+	r, err := PlainInit(s.T().Context(), dir, false)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 	err = util.WriteFile(r.wt, "foo", []byte("qux"), 0o644)
@@ -2849,17 +2849,17 @@ func (s *WorktreeSuite) TestAddSymlink() {
 	err = r.wt.Symlink("foo", "bar")
 	s.NoError(err)
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(s.T().Context())
 	s.NoError(err)
-	h, err := w.Add("foo")
+	h, err := w.Add(s.T().Context(), "foo")
 	s.NoError(err)
 	s.NotEqual(plumbing.NewHash("19102815663d23f8b75a47e7a01965dcdc96468c"), h)
 
-	h, err = w.Add("bar")
+	h, err = w.Add(s.T().Context(), "bar")
 	s.NoError(err)
 	s.Equal(plumbing.NewHash("19102815663d23f8b75a47e7a01965dcdc96468c"), h)
 
-	obj, err := w.r.Storer.EncodedObject(plumbing.BlobObject, h)
+	obj, err := w.r.Storer.EncodedObject(s.T().Context(), plumbing.BlobObject, h)
 	s.NoError(err)
 	s.NotNil(obj)
 	s.Equal(int64(3), obj.Size())
@@ -2872,10 +2872,10 @@ func (s *WorktreeSuite) TestAddDirectory() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
@@ -2884,11 +2884,11 @@ func (s *WorktreeSuite) TestAddDirectory() {
 	err = util.WriteFile(w.filesystem, "qux/baz/bar", []byte("BAR"), 0o755)
 	s.NoError(err)
 
-	h, err := w.Add("qux")
+	h, err := w.Add(s.T().Context(), "qux")
 	s.NoError(err)
 	s.True(h.IsZero())
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 11)
 
@@ -2900,7 +2900,7 @@ func (s *WorktreeSuite) TestAddDirectory() {
 	s.NoError(err)
 	s.Equal(filemode.Executable, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 2)
 
@@ -2914,11 +2914,11 @@ func (s *WorktreeSuite) TestAddDirectory() {
 }
 
 func (s *WorktreeSuite) TestAddDirectoryErrorNotFound() {
-	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
-	w, _ := r.Worktree()
+	w, _ := r.Worktree(s.T().Context())
 
-	h, err := w.Add("foo")
+	h, err := w.Add(s.T().Context(), "foo")
 	s.NotNil(err)
 	s.True(h.IsZero())
 }
@@ -2930,10 +2930,10 @@ func (s *WorktreeSuite) TestAddAll() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
@@ -2949,14 +2949,14 @@ func (s *WorktreeSuite) TestAddAll() {
 	w.Excludes = make([]gitignore.Pattern, 0)
 	w.Excludes = append(w.Excludes, gitignore.ParsePattern("file3", nil))
 
-	err = w.AddWithOptions(&AddOptions{All: true})
+	err = w.AddWithOptions(s.T().Context(), &AddOptions{All: true})
 	s.NoError(err)
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 11)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 2)
 
@@ -2976,10 +2976,10 @@ func (s *WorktreeSuite) TestAddGlob() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
@@ -2990,10 +2990,10 @@ func (s *WorktreeSuite) TestAddGlob() {
 	err = util.WriteFile(w.filesystem, "qux/bar/baz", []byte("BAZ"), 0o755)
 	s.NoError(err)
 
-	err = w.AddWithOptions(&AddOptions{Glob: w.filesystem.Join("qux", "b*")})
+	err = w.AddWithOptions(s.T().Context(), &AddOptions{Glob: w.filesystem.Join("qux", "b*")})
 	s.NoError(err)
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 11)
 
@@ -3005,7 +3005,7 @@ func (s *WorktreeSuite) TestAddGlob() {
 	s.NoError(err)
 	s.Equal(filemode.Executable, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 3)
 
@@ -3029,10 +3029,10 @@ func (s *WorktreeSuite) TestAddFilenameStartingWithDot() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
@@ -3043,16 +3043,16 @@ func (s *WorktreeSuite) TestAddFilenameStartingWithDot() {
 	err = util.WriteFile(w.filesystem, "foo/bar/baz", []byte("BAZ"), 0o755)
 	s.NoError(err)
 
-	_, err = w.Add("./qux")
+	_, err = w.Add(s.T().Context(), "./qux")
 	s.NoError(err)
 
-	_, err = w.Add("./baz")
+	_, err = w.Add(s.T().Context(), "./baz")
 	s.NoError(err)
 
-	_, err = w.Add("foo/bar/../bar/./baz")
+	_, err = w.Add(s.T().Context(), "foo/bar/../bar/./baz")
 	s.NoError(err)
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 12)
 
@@ -3064,7 +3064,7 @@ func (s *WorktreeSuite) TestAddFilenameStartingWithDot() {
 	s.NoError(err)
 	s.Equal(filemode.Executable, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 3)
 
@@ -3082,11 +3082,11 @@ func (s *WorktreeSuite) TestAddFilenameStartingWithDot() {
 }
 
 func (s *WorktreeSuite) TestAddGlobErrorNoMatches() {
-	r, _ := Init(memory.NewStorage(), WithWorkTree(memfs.New()))
+	r, _ := Init(s.T().Context(), memory.NewStorage(), WithWorkTree(memfs.New()))
 	defer func() { _ = r.Close() }()
-	w, _ := r.Worktree()
+	w, _ := r.Worktree(s.T().Context())
 
-	err := w.AddGlob("foo")
+	err := w.AddGlob(s.T().Context(), "foo")
 	s.ErrorIs(err, ErrGlobNoMatches)
 }
 
@@ -3097,20 +3097,20 @@ func (s *WorktreeSuite) testAddSkipStatus(filePath string, expectedEntries int, 
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
 	err = util.WriteFile(w.filesystem, filePath, []byte("file1"), 0o644)
 	s.NoError(err)
 
-	err = w.AddWithOptions(&AddOptions{Path: filePath, SkipStatus: true})
+	err = w.AddWithOptions(s.T().Context(), &AddOptions{Path: filePath, SkipStatus: true})
 	s.NoError(err)
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, expectedEntries)
 
@@ -3118,7 +3118,7 @@ func (s *WorktreeSuite) testAddSkipStatus(filePath string, expectedEntries int, 
 	s.NoError(err)
 	s.Equal(filemode.Regular, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 1)
 
@@ -3142,17 +3142,17 @@ func (s *WorktreeSuite) TestAddSkipStatusNonModifiedPath() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
-	err = w.AddWithOptions(&AddOptions{Path: "LICENSE", SkipStatus: true})
+	err = w.AddWithOptions(s.T().Context(), &AddOptions{Path: "LICENSE", SkipStatus: true})
 	s.NoError(err)
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
@@ -3160,7 +3160,7 @@ func (s *WorktreeSuite) TestAddSkipStatusNonModifiedPath() {
 	s.NoError(err)
 	s.Equal(filemode.Regular, e.Mode)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 0)
 
@@ -3176,24 +3176,24 @@ func (s *WorktreeSuite) TestAddSkipStatusWithIgnoredPath() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	idx, err := w.r.Storer.Index()
+	idx, err := w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 9)
 
 	err = util.WriteFile(fs, ".gitignore", []byte("fileToIgnore\n"), 0o755)
 	s.NoError(err)
-	_, err = w.Add(".gitignore")
+	_, err = w.Add(s.T().Context(), ".gitignore")
 	s.NoError(err)
-	_, err = w.Commit("Added .gitignore", defaultTestCommitOptions())
+	_, err = w.Commit(s.T().Context(), "Added .gitignore", defaultTestCommitOptions())
 	s.NoError(err)
 
 	err = util.WriteFile(fs, "fileToIgnore", []byte("file to ignore"), 0o644)
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 0)
 
@@ -3201,10 +3201,10 @@ func (s *WorktreeSuite) TestAddSkipStatusWithIgnoredPath() {
 	s.Equal(Untracked, file.Staging)
 	s.Equal(Untracked, file.Worktree)
 
-	err = w.AddWithOptions(&AddOptions{Path: "fileToIgnore", SkipStatus: true})
+	err = w.AddWithOptions(s.T().Context(), &AddOptions{Path: "fileToIgnore", SkipStatus: true})
 	s.NoError(err)
 
-	idx, err = w.r.Storer.Index()
+	idx, err = w.r.Storer.Index(s.T().Context())
 	s.NoError(err)
 	s.Len(idx.Entries, 10)
 
@@ -3212,7 +3212,7 @@ func (s *WorktreeSuite) TestAddSkipStatusWithIgnoredPath() {
 	s.NoError(err)
 	s.Equal(filemode.Regular, e.Mode)
 
-	status, err = w.Status()
+	status, err = w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 1)
 
@@ -3228,14 +3228,14 @@ func (s *WorktreeSuite) TestRemove() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	hash, err := w.Remove("LICENSE")
+	hash, err := w.Remove(s.T().Context(), "LICENSE")
 	s.Equal("c192bd6a24ea1ab01d78686e417c8bdc7c3d197f", hash.String())
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 1)
 	s.Equal(Deleted, status.File("LICENSE").Staging)
@@ -3248,10 +3248,10 @@ func (s *WorktreeSuite) TestRemoveNotExistentEntry() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	hash, err := w.Remove("not-exists")
+	hash, err := w.Remove(s.T().Context(), "not-exists")
 	s.True(hash.IsZero())
 	s.NotNil(err)
 }
@@ -3263,14 +3263,14 @@ func (s *WorktreeSuite) TestRemoveDirectory() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	hash, err := w.Remove("json")
+	hash, err := w.Remove(s.T().Context(), "json")
 	s.True(hash.IsZero())
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 2)
 	s.Equal(Deleted, status.File("json/long.json").Staging)
@@ -3287,17 +3287,17 @@ func (s *WorktreeSuite) TestRemoveDirectoryUntracked() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
 	err = util.WriteFile(w.filesystem, "json/foo", []byte("FOO"), 0o755)
 	s.NoError(err)
 
-	hash, err := w.Remove("json")
+	hash, err := w.Remove(s.T().Context(), "json")
 	s.True(hash.IsZero())
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 3)
 	s.Equal(Deleted, status.File("json/long.json").Staging)
@@ -3315,17 +3315,17 @@ func (s *WorktreeSuite) TestRemoveDeletedFromWorktree() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
 	err = fs.Remove("LICENSE")
 	s.NoError(err)
 
-	hash, err := w.Remove("LICENSE")
+	hash, err := w.Remove(s.T().Context(), "LICENSE")
 	s.Equal("c192bd6a24ea1ab01d78686e417c8bdc7c3d197f", hash.String())
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 1)
 	s.Equal(Deleted, status.File("LICENSE").Staging)
@@ -3338,13 +3338,13 @@ func (s *WorktreeSuite) TestRemoveGlob() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	err = w.RemoveGlob(w.filesystem.Join("json", "l*"))
+	err = w.RemoveGlob(s.T().Context(), w.filesystem.Join("json", "l*"))
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 1)
 	s.Equal(Deleted, status.File("json/long.json").Staging)
@@ -3357,13 +3357,13 @@ func (s *WorktreeSuite) TestRemoveGlobDirectory() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	err = w.RemoveGlob("js*")
+	err = w.RemoveGlob(s.T().Context(), "js*")
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 2)
 	s.Equal(Deleted, status.File("json/short.json").Staging)
@@ -3380,7 +3380,7 @@ func (s *WorktreeSuite) TestRemoveGlobDirectoryDeleted() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
 	err = fs.Remove("json/short.json")
@@ -3389,10 +3389,10 @@ func (s *WorktreeSuite) TestRemoveGlobDirectoryDeleted() {
 	err = util.WriteFile(w.filesystem, "json/foo", []byte("FOO"), 0o755)
 	s.NoError(err)
 
-	err = w.RemoveGlob("js*")
+	err = w.RemoveGlob(s.T().Context(), "js*")
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 3)
 	s.Equal(Deleted, status.File("json/short.json").Staging)
@@ -3406,14 +3406,14 @@ func (s *WorktreeSuite) TestMove() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	hash, err := w.Move("LICENSE", "foo")
+	hash, err := w.Move(s.T().Context(), "LICENSE", "foo")
 	s.Equal("c192bd6a24ea1ab01d78686e417c8bdc7c3d197f", hash.String())
 	s.NoError(err)
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 2)
 	s.Equal(Deleted, status.File("LICENSE").Staging)
@@ -3427,10 +3427,10 @@ func (s *WorktreeSuite) TestMoveNotExistentEntry() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	hash, err := w.Move("not-exists", "foo")
+	hash, err := w.Move(s.T().Context(), "not-exists", "foo")
 	s.True(hash.IsZero())
 	s.NotNil(err)
 }
@@ -3442,10 +3442,10 @@ func (s *WorktreeSuite) TestMoveToExistent() {
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{Force: true})
+	err := w.Checkout(s.T().Context(), &CheckoutOptions{Force: true})
 	s.NoError(err)
 
-	hash, err := w.Move(".gitignore", "LICENSE")
+	hash, err := w.Move(s.T().Context(), ".gitignore", "LICENSE")
 	s.True(hash.IsZero())
 	s.ErrorIs(err, ErrDestinationExists)
 }
@@ -3457,23 +3457,23 @@ func (s *WorktreeSuite) TestClean() {
 	// Open the repo.
 	fs, err = fs.Chroot("repo")
 	s.NoError(err)
-	r, err := PlainOpen(fs.Root())
+	r, err := PlainOpen(s.T().Context(), fs.Root())
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	// Status before cleaning.
-	status, err := wt.Status()
+	status, err := wt.Status(s.T().Context())
 	s.NoError(err)
 	s.Len(status, 2)
 
-	err = wt.Clean(&CleanOptions{})
+	err = wt.Clean(s.T().Context(), &CleanOptions{})
 	s.NoError(err)
 
 	// Status after cleaning.
-	status, err = wt.Status()
+	status, err = wt.Status(s.T().Context())
 	s.NoError(err)
 
 	s.Len(status, 1)
@@ -3483,10 +3483,10 @@ func (s *WorktreeSuite) TestClean() {
 	s.True(fi.IsDir())
 
 	// Clean with Dir: true.
-	err = wt.Clean(&CleanOptions{Dir: true})
+	err = wt.Clean(s.T().Context(), &CleanOptions{Dir: true})
 	s.NoError(err)
 
-	status, err = wt.Status()
+	status, err = wt.Status(s.T().Context())
 	s.NoError(err)
 
 	s.Len(status, 0)
@@ -3499,7 +3499,7 @@ func (s *WorktreeSuite) TestClean() {
 func (s *WorktreeSuite) TestCleanBare() {
 	storer := memory.NewStorage()
 
-	r, err := Init(storer)
+	r, err := Init(s.T().Context(), storer)
 	s.NoError(err)
 	s.NotNil(r)
 
@@ -3512,18 +3512,18 @@ func (s *WorktreeSuite) TestCleanBare() {
 	s.NoError(err)
 
 	_ = r.Close()
-	r, err = Open(storer, wtfs)
+	r, err = Open(s.T().Context(), storer, wtfs)
 	s.NoError(err)
 	defer func() { _ = r.Close() }()
 
-	wt, err := r.Worktree()
+	wt, err := r.Worktree(s.T().Context())
 	s.NoError(err)
 
 	_, err = wt.filesystem.Lstat(".")
 	s.NoError(err)
 
 	// Clean with Dir: true.
-	err = wt.Clean(&CleanOptions{Dir: true})
+	err = wt.Clean(s.T().Context(), &CleanOptions{Dir: true})
 	s.NoError(err)
 
 	// Root worktree directory must remain after cleaning
@@ -3540,7 +3540,7 @@ func TestAlternatesRepo(t *testing.T) {
 	rep1fs, err := fs.Chroot("rep1")
 	assert.NoError(t, err)
 	d, _ := rep1fs.Chroot(GitDirName)
-	rep1, err := Open(filesystem.NewStorage(d, cache.NewObjectLRUDefault()), nil)
+	rep1, err := Open(t.Context(), filesystem.NewStorage(d, cache.NewObjectLRUDefault()), nil)
 	require.NoError(t, err)
 	defer func() { _ = rep1.Close() }()
 
@@ -3552,20 +3552,20 @@ func TestAlternatesRepo(t *testing.T) {
 		cache.NewObjectLRUDefault(), filesystem.Options{
 			AlternatesFS: fs,
 		})
-	rep2, err := Open(storer, rep2fs)
+	rep2, err := Open(t.Context(), storer, rep2fs)
 	require.NoError(t, err)
 	defer func() { _ = rep2.Close() }()
 
 	// Get the HEAD commit from the main repo.
-	h, err := rep1.Head()
+	h, err := rep1.Head(t.Context())
 	assert.NoError(t, err)
-	commit1, err := rep1.CommitObject(h.Hash())
+	commit1, err := rep1.CommitObject(t.Context(), h.Hash())
 	assert.NoError(t, err)
 
 	// Get the HEAD commit from the shared repo.
-	h, err = rep2.Head()
+	h, err = rep2.Head(t.Context())
 	assert.NoError(t, err)
-	commit2, err := rep2.CommitObject(h.Hash())
+	commit2, err := rep2.CommitObject(t.Context(), h.Hash())
 	assert.NoError(t, err)
 
 	assert.Equal(t, commit1.String(), commit2.String())
@@ -3759,15 +3759,15 @@ func (s *WorktreeSuite) TestGrep() {
 
 	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
 
-	server, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: url})
+	server, err := Clone(s.T().Context(), memory.NewStorage(), memfs.New(), &CloneOptions{URL: url})
 	s.Require().NoError(err)
 	defer func() { _ = server.Close() }()
 
-	w, err := server.Worktree()
+	w, err := server.Worktree(s.T().Context())
 	s.Require().NoError(err)
 
 	for _, tc := range cases {
-		gr, err := w.Grep(&tc.options)
+		gr, err := w.Grep(s.T().Context(), &tc.options)
 		if tc.wantError != nil {
 			s.ErrorIs(err, tc.wantError)
 		} else {
@@ -3825,12 +3825,12 @@ func (s *WorktreeSuite) TestGrepBare() {
 
 	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
 
-	r, err := Clone(memory.NewStorage(), nil, &CloneOptions{URL: url, Bare: true})
+	r, err := Clone(s.T().Context(), memory.NewStorage(), nil, &CloneOptions{URL: url, Bare: true})
 	s.Require().NoError(err)
 	defer func() { _ = r.Close() }()
 
 	for _, tc := range cases {
-		gr, err := r.Grep(&tc.options)
+		gr, err := r.Grep(s.T().Context(), &tc.options)
 		if tc.wantError != nil {
 			s.ErrorIs(err, tc.wantError)
 		} else {
@@ -3864,32 +3864,32 @@ func (s *WorktreeSuite) TestResetLingeringDirectories() {
 		When:  time.Now(),
 	}}
 
-	repo, err := PlainInit(dir, false)
+	repo, err := PlainInit(s.T().Context(), dir, false)
 	s.NoError(err)
 	defer func() { _ = repo.Close() }()
 
-	w, err := repo.Worktree()
+	w, err := repo.Worktree(s.T().Context())
 	s.NoError(err)
 
 	os.WriteFile(filepath.Join(dir, "README"), []byte("placeholder"), 0o644)
 
-	_, err = w.Add(".")
+	_, err = w.Add(s.T().Context(), ".")
 	s.NoError(err)
 
-	initialHash, err := w.Commit("Initial commit", commitOpts)
+	initialHash, err := w.Commit(s.T().Context(), "Initial commit", commitOpts)
 	s.NoError(err)
 
 	os.MkdirAll(filepath.Join(dir, "a", "b"), 0o755)
 	os.WriteFile(filepath.Join(dir, "a", "b", "1"), []byte("1"), 0o644)
 
-	_, err = w.Add(".")
+	_, err = w.Add(s.T().Context(), ".")
 	s.NoError(err)
 
-	_, err = w.Commit("Add file in nested sub-directories", commitOpts)
+	_, err = w.Commit(s.T().Context(), "Add file in nested sub-directories", commitOpts)
 	s.NoError(err)
 
 	// reset to initial commit, which should remove a/b/1, a/b, and a
-	err = w.Reset(&ResetOptions{
+	err = w.Reset(s.T().Context(), &ResetOptions{
 		Commit: initialHash,
 		Mode:   HardReset,
 	})
@@ -3910,37 +3910,37 @@ func (s *WorktreeSuite) TestAddAndCommit() {
 
 	dir := s.T().TempDir()
 
-	repo, err := PlainInit(dir, false)
+	repo, err := PlainInit(s.T().Context(), dir, false)
 	s.NoError(err)
 	defer func() { _ = repo.Close() }()
 
-	w, err := repo.Worktree()
+	w, err := repo.Worktree(s.T().Context())
 	s.NoError(err)
 
 	os.WriteFile(filepath.Join(dir, "foo"), []byte("bar"), 0o644)
 	os.WriteFile(filepath.Join(dir, "bar"), []byte("foo"), 0o644)
 
-	_, err = w.Add(".")
+	_, err = w.Add(s.T().Context(), ".")
 	s.NoError(err)
 
-	_, err = w.Commit("Test Add And Commit", &CommitOptions{Author: &object.Signature{
+	_, err = w.Commit(s.T().Context(), "Test Add And Commit", &CommitOptions{Author: &object.Signature{
 		Name:  "foo",
 		Email: "foo@foo.foo",
 		When:  time.Now(),
 	}})
 	s.NoError(err)
 
-	iter, err := w.r.Log(&LogOptions{})
+	iter, err := w.r.Log(s.T().Context(), &LogOptions{})
 	s.NoError(err)
 
 	filesFound := 0
-	err = iter.ForEach(func(c *object.Commit) error {
-		files, err := c.Files()
+	err = iter.ForEach(s.T().Context(), func(c *object.Commit) error {
+		files, err := c.Files(s.T().Context())
 		if err != nil {
 			return err
 		}
 
-		err = files.ForEach(func(*object.File) error {
+		err = files.ForEach(s.T().Context(), func(*object.File) error {
 			filesFound++
 			return nil
 		})
@@ -3953,17 +3953,17 @@ func (s *WorktreeSuite) TestAddAndCommit() {
 func (s *WorktreeSuite) TestAddAndCommitEmpty() {
 	dir := s.T().TempDir()
 
-	repo, err := PlainInit(dir, false)
+	repo, err := PlainInit(s.T().Context(), dir, false)
 	s.NoError(err)
 	defer func() { _ = repo.Close() }()
 
-	w, err := repo.Worktree()
+	w, err := repo.Worktree(s.T().Context())
 	s.NoError(err)
 
-	_, err = w.Add(".")
+	_, err = w.Add(s.T().Context(), ".")
 	s.NoError(err)
 
-	_, err = w.Commit("Test Add And Commit", &CommitOptions{Author: &object.Signature{
+	_, err = w.Commit(s.T().Context(), "Test Add And Commit", &CommitOptions{Author: &object.Signature{
 		Name:  "foo",
 		Email: "foo@foo.foo",
 		When:  time.Now(),
@@ -3979,18 +3979,18 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 	{
 		fs, err := fs.Chroot("main")
 		s.Require().NoError(err)
-		repo, err := PlainOpenWithOptions(fs.Root(), nil)
+		repo, err := PlainOpenWithOptions(s.T().Context(), fs.Root(), nil)
 		s.Require().NoError(err)
 		defer func() { _ = repo.Close() }()
 
-		wt, err := repo.Worktree()
+		wt, err := repo.Worktree(s.T().Context())
 		s.NoError(err)
 
-		status, err := wt.Status()
+		status, err := wt.Status(s.T().Context())
 		s.NoError(err)
 		s.Len(status, 2) // 2 files
 
-		head, err := repo.Head()
+		head, err := repo.Head(s.T().Context())
 		s.NoError(err)
 		s.Equal("refs/heads/master", string(head.Name()))
 	}
@@ -3999,21 +3999,21 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 	{
 		fs, err := fs.Chroot("linked-worktree-1")
 		s.Require().NoError(err)
-		repo, err := PlainOpenWithOptions(fs.Root(), nil)
+		repo, err := PlainOpenWithOptions(s.T().Context(), fs.Root(), nil)
 		s.Require().NoError(err)
 		defer func() { _ = repo.Close() }()
 
-		wt, err := repo.Worktree()
+		wt, err := repo.Worktree(s.T().Context())
 		s.NoError(err)
 
-		status, err := wt.Status()
+		status, err := wt.Status(s.T().Context())
 		s.NoError(err)
 		s.Len(status, 3) // 3 files
 
 		_, ok := status["linked-worktree-1-unique-file.txt"]
 		s.True(ok)
 
-		head, err := repo.Head()
+		head, err := repo.Head(s.T().Context())
 		s.NoError(err)
 		s.Equal("refs/heads/linked-worktree-1", string(head.Name()))
 	}
@@ -4022,21 +4022,21 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 	{
 		fs, err := fs.Chroot("linked-worktree-2")
 		s.Require().NoError(err)
-		repo, err := PlainOpenWithOptions(fs.Root(), nil)
+		repo, err := PlainOpenWithOptions(s.T().Context(), fs.Root(), nil)
 		s.Require().NoError(err)
 		defer func() { _ = repo.Close() }()
 
-		wt, err := repo.Worktree()
+		wt, err := repo.Worktree(s.T().Context())
 		s.NoError(err)
 
-		status, err := wt.Status()
+		status, err := wt.Status(s.T().Context())
 		s.NoError(err)
 		s.Len(status, 3) // 3 files
 
 		_, ok := status["linked-worktree-2-unique-file.txt"]
 		s.True(ok)
 
-		head, err := repo.Head()
+		head, err := repo.Head(s.T().Context())
 		s.NoError(err)
 		s.Equal("refs/heads/branch-with-different-name", string(head.Name()))
 	}
@@ -4045,7 +4045,7 @@ func (s *WorktreeSuite) TestLinkedWorktree() {
 	{
 		fs, err := fs.Chroot("linked-worktree-invalid-commondir")
 		s.Require().NoError(err)
-		_, err = PlainOpenWithOptions(fs.Root(), nil)
+		_, err = PlainOpenWithOptions(s.T().Context(), fs.Root(), nil)
 		s.ErrorIs(err, ErrRepositoryIncomplete)
 	}
 }
@@ -4096,7 +4096,7 @@ func TestTreeContainsDirs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, test.expected, treeContainsDirs(buildTree(), test.dirs))
+			assert.Equal(t, test.expected, treeContainsDirs(t.Context(), buildTree(), test.dirs))
 		})
 	}
 }
@@ -4113,13 +4113,14 @@ var statusCodeNames = map[StatusCode]string{
 }
 
 func setupForRestore(s *WorktreeSuite) (fs billy.Filesystem, w *Worktree, names []string) {
+	ctx := s.T().Context()
 	fs = memfs.New()
 	w = &Worktree{
 		r:          s.Repository,
 		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
 	}
 
-	err := w.Checkout(&CheckoutOptions{})
+	err := w.Checkout(ctx, &CheckoutOptions{})
 	s.NoError(err)
 
 	names = []string{"foo", "CHANGELOG", "LICENSE", "binary.jpg"}
@@ -4148,7 +4149,7 @@ func setupForRestore(s *WorktreeSuite) (fs billy.Filesystem, w *Worktree, names 
 
 	// Stage all files and verify the updated status
 	for _, name := range names {
-		_, err = w.Add(name)
+		_, err = w.Add(ctx, name)
 		s.NoError(err)
 	}
 	verifyStatus(s, "Staged", w, names, []FileStatus{
@@ -4177,7 +4178,7 @@ func setupForRestore(s *WorktreeSuite) (fs billy.Filesystem, w *Worktree, names 
 func verifyStatus(s *WorktreeSuite, marker string, w *Worktree, files []string, statuses []FileStatus) {
 	s.Len(statuses, len(files))
 
-	status, err := w.Status()
+	status, err := w.Status(s.T().Context())
 	s.NoError(err)
 
 	for i, file := range files {
@@ -4193,12 +4194,12 @@ func (s *WorktreeSuite) TestRestoreStaged() {
 
 	// Attempt without files should throw an error like the git restore --staged
 	opts := RestoreOptions{Staged: true}
-	err := w.Restore(&opts)
+	err := w.Restore(s.T().Context(), &opts)
 	s.ErrorIs(err, ErrNoRestorePaths)
 
 	// Restore Staged files in 2 groups and confirm status
 	opts.Files = []string{names[0], "./" + names[1]}
-	err = w.Restore(&opts)
+	err = w.Restore(s.T().Context(), &opts)
 	s.NoError(err)
 	verifyStatus(s, "Restored First", w, names, []FileStatus{
 		{Worktree: Untracked, Staging: Untracked},
@@ -4213,7 +4214,7 @@ func (s *WorktreeSuite) TestRestoreStaged() {
 	s.Equal("Foo Bar:11", string(contents))
 
 	opts.Files = []string{"./" + names[2], names[3]}
-	err = w.Restore(&opts)
+	err = w.Restore(s.T().Context(), &opts)
 	s.NoError(err)
 	verifyStatus(s, "Restored Second", w, names, []FileStatus{
 		{Worktree: Untracked, Staging: Untracked},
@@ -4233,11 +4234,11 @@ func (s *WorktreeSuite) TestRestoreWorktree() {
 
 	// Attempt without files should throw an error like the git restore
 	opts := RestoreOptions{}
-	err := w.Restore(&opts)
+	err := w.Restore(s.T().Context(), &opts)
 	s.ErrorIs(err, ErrNoRestorePaths)
 
 	opts.Files = []string{names[0], names[1]}
-	err = w.Restore(&opts)
+	err = w.Restore(s.T().Context(), &opts)
 	s.ErrorIs(err, ErrRestoreWorktreeOnlyNotSupported)
 }
 
@@ -4246,12 +4247,12 @@ func (s *WorktreeSuite) TestRestoreBoth() {
 
 	// Attempt without files should throw an error like the git restore --staged --worktree
 	opts := RestoreOptions{Staged: true, Worktree: true}
-	err := w.Restore(&opts)
+	err := w.Restore(s.T().Context(), &opts)
 	s.ErrorIs(err, ErrNoRestorePaths)
 
 	// Restore Staged files in 2 groups and confirm status
 	opts.Files = []string{names[0], names[1]}
-	err = w.Restore(&opts)
+	err = w.Restore(s.T().Context(), &opts)
 	s.NoError(err)
 	verifyStatus(s, "Restored First", w, names, []FileStatus{
 		{Worktree: Untracked, Staging: Untracked},
@@ -4261,7 +4262,7 @@ func (s *WorktreeSuite) TestRestoreBoth() {
 	})
 
 	opts.Files = []string{names[2], names[3]}
-	err = w.Restore(&opts)
+	err = w.Restore(s.T().Context(), &opts)
 	s.NoError(err)
 	verifyStatus(s, "Restored Second", w, names, []FileStatus{
 		{Worktree: Untracked, Staging: Untracked},

--- a/x/plugin/config/auto_git_test.go
+++ b/x/plugin/config/auto_git_test.go
@@ -343,7 +343,7 @@ func loadUserName(t *testing.T, src *auto, scope config.Scope) string {
 	t.Helper()
 	s, err := src.Load(scope)
 	require.NoError(t, err)
-	cfg, err := s.Config()
+	cfg, err := s.Config(t.Context())
 	require.NoError(t, err)
 	return cfg.User.Name
 }
@@ -354,7 +354,7 @@ func loadUserEmail(t *testing.T, src *auto, scope config.Scope) string {
 	t.Helper()
 	s, err := src.Load(scope)
 	require.NoError(t, err)
-	cfg, err := s.Config()
+	cfg, err := s.Config(t.Context())
 	require.NoError(t, err)
 	return cfg.User.Email
 }

--- a/x/plugin/config/config_test.go
+++ b/x/plugin/config/config_test.go
@@ -14,7 +14,7 @@ func TestEmptyGlobal(t *testing.T) {
 	src := NewEmpty()
 	s, err := src.Load(config.GlobalScope)
 	require.NoError(t, err)
-	cfg, err := s.Config()
+	cfg, err := s.Config(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, config.NewConfig(), cfg)
 }
@@ -24,7 +24,7 @@ func TestEmptySystem(t *testing.T) {
 	src := NewEmpty()
 	s, err := src.Load(config.SystemScope)
 	require.NoError(t, err)
-	cfg, err := s.Config()
+	cfg, err := s.Config(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, config.NewConfig(), cfg)
 }
@@ -40,13 +40,13 @@ func TestStaticGlobalAndSystem(t *testing.T) {
 
 	gs, err := src.Load(config.GlobalScope)
 	require.NoError(t, err)
-	got, err := gs.Config()
+	got, err := gs.Config(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "GlobalUser", got.User.Name)
 
 	ss, err := src.Load(config.SystemScope)
 	require.NoError(t, err)
-	got, err = ss.Config()
+	got, err = ss.Config(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "SystemUser", got.User.Name)
 }
@@ -64,7 +64,7 @@ func TestStaticReturnsCopies(t *testing.T) {
 
 	gs, err := src.Load(config.GlobalScope)
 	require.NoError(t, err)
-	first, err := gs.Config()
+	first, err := gs.Config(t.Context())
 	require.NoError(t, err)
 	first.User.Name = "Mutated"
 	first.Remotes["upstream"] = &config.RemoteConfig{Name: "upstream"}
@@ -72,7 +72,7 @@ func TestStaticReturnsCopies(t *testing.T) {
 
 	gs2, err := src.Load(config.GlobalScope)
 	require.NoError(t, err)
-	second, err := gs2.Config()
+	second, err := gs2.Config(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "Original", second.User.Name)
 	assert.Contains(t, second.Remotes, "origin")
@@ -85,13 +85,13 @@ func TestStaticZeroValues(t *testing.T) {
 
 	gs, err := src.Load(config.GlobalScope)
 	require.NoError(t, err)
-	got, err := gs.Config()
+	got, err := gs.Config(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, config.NewConfig(), got)
 
 	ss, err := src.Load(config.SystemScope)
 	require.NoError(t, err)
-	got, err = ss.Config()
+	got, err = ss.Config(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, config.NewConfig(), got)
 }
@@ -111,6 +111,6 @@ func TestReadOnlyStorerRejectsWrite(t *testing.T) {
 	s, err := src.Load(config.GlobalScope)
 	require.NoError(t, err)
 
-	err = s.SetConfig(config.NewConfig())
+	err = s.SetConfig(t.Context(), config.NewConfig())
 	require.ErrorIs(t, err, ErrReadOnly)
 }

--- a/x/plugin/config/readonly.go
+++ b/x/plugin/config/readonly.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 
 	"github.com/go-git/go-git/v6/config"
@@ -16,11 +17,11 @@ type readOnlyStorer struct {
 }
 
 // Config returns a deep copy of the stored configuration.
-func (s *readOnlyStorer) Config() (*config.Config, error) {
+func (s *readOnlyStorer) Config(ctx context.Context) (*config.Config, error) {
 	return cloneConfig(&s.cfg), nil
 }
 
 // SetConfig always returns ErrReadOnly.
-func (s *readOnlyStorer) SetConfig(*config.Config) error {
+func (s *readOnlyStorer) SetConfig(ctx context.Context, c *config.Config) error {
 	return ErrReadOnly
 }

--- a/x/plugin/config/readonly.go
+++ b/x/plugin/config/readonly.go
@@ -17,11 +17,11 @@ type readOnlyStorer struct {
 }
 
 // Config returns a deep copy of the stored configuration.
-func (s *readOnlyStorer) Config(ctx context.Context) (*config.Config, error) {
+func (s *readOnlyStorer) Config(_ context.Context) (*config.Config, error) {
 	return cloneConfig(&s.cfg), nil
 }
 
 // SetConfig always returns ErrReadOnly.
-func (s *readOnlyStorer) SetConfig(ctx context.Context, c *config.Config) error {
+func (s *readOnlyStorer) SetConfig(_ context.Context, _ *config.Config) error {
 	return ErrReadOnly
 }

--- a/x/plumbing/worktree/worktree.go
+++ b/x/plumbing/worktree/worktree.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -83,7 +84,7 @@ func New(storer storage.Storer) (*Worktree, error) {
 // worktree, similar to the `git worktree add` command. The worktree will be
 // associated with the repository and can be used to work on a different commit
 // or branch simultaneously.
-func (w *Worktree) Add(wt billy.Filesystem, name string, opts ...Option) error {
+func (w *Worktree) Add(ctx context.Context, wt billy.Filesystem, name string, opts ...Option) error {
 	if wt == nil {
 		return errors.New("cannot add worktree: fs is nil")
 	}
@@ -98,7 +99,7 @@ func (w *Worktree) Add(wt billy.Filesystem, name string, opts ...Option) error {
 	}
 
 	if o.commit.IsZero() {
-		r, err := git.Open(w.storer.(storage.Storer), nil)
+		r, err := git.Open(ctx, w.storer.(storage.Storer), nil)
 		if err != nil {
 			return fmt.Errorf("unable to open repository: %w", err)
 		}
@@ -107,7 +108,7 @@ func (w *Worktree) Add(wt billy.Filesystem, name string, opts ...Option) error {
 			_ = r.Close()
 		}()
 
-		ref, err := r.Head()
+		ref, err := r.Head(ctx)
 		if err != nil {
 			return fmt.Errorf("invalid reference: %w", err)
 		}
@@ -142,13 +143,13 @@ func (w *Worktree) Add(wt billy.Filesystem, name string, opts ...Option) error {
 		return err
 	}
 
-	r, err := w.Open(wt)
+	r, err := w.Open(ctx, wt)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = r.Close() }()
 
-	work, err := r.Worktree()
+	work, err := r.Worktree(ctx)
 	if err != nil {
 		return err
 	}
@@ -161,7 +162,7 @@ func (w *Worktree) Add(wt billy.Filesystem, name string, opts ...Option) error {
 		opt.Create = true
 	}
 
-	return work.Checkout(opt)
+	return work.Checkout(ctx, opt)
 }
 
 // Remove deletes a linked worktree by removing its metadata dir within .git.
@@ -223,7 +224,7 @@ func (w *Worktree) List() ([]string, error) {
 //
 // When the target is not a linked worktree, it behaves just like git.Open.
 // This logic is likely going to be moved to git.Open in the future.
-func (w *Worktree) Open(wt billy.Filesystem) (*git.Repository, error) {
+func (w *Worktree) Open(ctx context.Context, wt billy.Filesystem) (*git.Repository, error) {
 	if wt == nil {
 		return nil, errors.New("worktree fs is nil")
 	}
@@ -234,7 +235,7 @@ func (w *Worktree) Open(wt billy.Filesystem) (*git.Repository, error) {
 	}
 
 	stor := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
-	repo, err := git.Open(stor, wt)
+	repo, err := git.Open(ctx, stor, wt)
 	if err != nil {
 		_ = stor.Close()
 		return nil, err

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -1308,6 +1308,8 @@ func TestWorktreeConfig(t *testing.T) {
 	})
 }
 
+// The fuzz targets use context.Background instead of t.Context: OSS-Fuzz
+// builds them with a shim testing.T that has no Context method.
 func FuzzAdd(f *testing.F) {
 	f.Add("test")
 	f.Add("test-worktree")
@@ -1338,7 +1340,7 @@ func FuzzAdd(f *testing.F) {
 		wtFS := memfs.New()
 		commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
 
-		_ = w.Add(t.Context(), wtFS, name, WithCommit(commit), WithDetachedHead())
+		_ = w.Add(context.Background(), wtFS, name, WithCommit(commit), WithDetachedHead())
 	})
 }
 
@@ -1369,7 +1371,7 @@ func FuzzOpen(f *testing.F) {
 		err = util.WriteFile(wtFS, ".git", []byte(gitFileContent), 0o644)
 		require.NoError(t, err, "failed to write .git file")
 
-		repo, err := w.Open(t.Context(), wtFS)
+		repo, err := w.Open(context.Background(), wtFS)
 		if repo != nil {
 			defer func() { _ = repo.Close() }()
 		}

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"context"
 	"io"
 	iofs "io/fs"
 	"os"
@@ -150,12 +151,12 @@ func TestAdd(t *testing.T) {
 				w, err := New(st)
 				require.NoError(t, err)
 
-				repo, err := w.Open(wt)
+				repo, err := w.Open(t.Context(), wt)
 				require.NoError(t, err)
 				defer func() { _ = repo.Close() }()
 
 				// Verify HEAD points to the commit (detached).
-				head, err := repo.Head()
+				head, err := repo.Head(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5", head.Hash().String())
 				assert.Equal(t, plumbing.ReferenceName("HEAD"), head.Name())
@@ -179,17 +180,17 @@ func TestAdd(t *testing.T) {
 				w, err := New(st)
 				require.NoError(t, err)
 
-				repo, err := w.Open(wt)
+				repo, err := w.Open(t.Context(), wt)
 				require.NoError(t, err)
 				defer func() { _ = repo.Close() }()
 
 				// Verify HEAD points to the branch.
-				head, err := repo.Head()
+				head, err := repo.Head(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5", head.Hash().String())
 				assert.Equal(t, plumbing.NewBranchReferenceName("branch-worktree"), head.Name())
 
-				branchRef, err := repo.Reference(plumbing.NewBranchReferenceName("branch-worktree"), true)
+				branchRef, err := repo.Reference(t.Context(), plumbing.NewBranchReferenceName("branch-worktree"), true)
 				require.NoError(t, err)
 				assert.Equal(t, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branchRef.Hash().String())
 			},
@@ -204,7 +205,7 @@ func TestAdd(t *testing.T) {
 				require.NoError(t, err)
 
 				wtFS := memfs.New()
-				err = w.Add(wtFS, "existing-worktree", WithCommit(plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
+				err = w.Add(t.Context(), wtFS, "existing-worktree", WithCommit(plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
 				require.NoError(t, err)
 
 				return storer
@@ -230,7 +231,7 @@ func TestAdd(t *testing.T) {
 				t.Fatalf("failed to create worktree: %v", err)
 			}
 
-			err = w.Add(wt, tt.name, tt.opts...)
+			err = w.Add(t.Context(), wt, tt.name, tt.opts...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Add() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -282,14 +283,14 @@ func checkWorktree(t *testing.T, storage, wt billy.Filesystem, path string) {
 	commonDir := storage
 	stor := filesystem.NewStorage(dotgit.NewRepositoryFilesystem(gitDir, commonDir),
 		cache.NewObjectLRUDefault())
-	r, err := git.Open(stor, wt)
+	r, err := git.Open(t.Context(), stor, wt)
 	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
 
-	w, err := r.Worktree()
+	w, err := r.Worktree(t.Context())
 	require.NoError(t, err)
 
-	st, err := w.Status()
+	st, err := w.Status(t.Context())
 	require.NoError(t, err)
 
 	assert.True(t, st.IsClean(), "worktree is not clean")
@@ -347,7 +348,7 @@ func TestRemove(t *testing.T) {
 				require.NoError(t, err)
 
 				wtFS := memfs.New()
-				err = w.Add(wtFS, "test-worktree", WithCommit(plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
+				err = w.Add(t.Context(), wtFS, "test-worktree", WithCommit(plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
 				require.NoError(t, err)
 
 				return storer
@@ -370,7 +371,7 @@ func TestRemove(t *testing.T) {
 				require.NoError(t, err)
 
 				wtFS := memfs.New()
-				err = w.Add(wtFS, "test-worktree", WithCommit(plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
+				err = w.Add(t.Context(), wtFS, "test-worktree", WithCommit(plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
 				require.NoError(t, err)
 
 				return storer
@@ -448,7 +449,7 @@ func TestRemove(t *testing.T) {
 				require.NoError(t, err)
 
 				wtFS := memfs.New()
-				err = w.Add(wtFS, "test-dash-name", WithCommit(plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
+				err = w.Add(t.Context(), wtFS, "test-dash-name", WithCommit(plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
 				require.NoError(t, err)
 
 				return storer
@@ -518,7 +519,7 @@ func TestList(t *testing.T) {
 				w, err := New(storer)
 				require.NoError(t, err)
 
-				err = w.Add(memfs.New(), "worktree-1",
+				err = w.Add(t.Context(), memfs.New(), "worktree-1",
 					WithCommit(
 						plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
 				require.NoError(t, err)
@@ -540,7 +541,7 @@ func TestList(t *testing.T) {
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
 
 				for _, name := range []string{"worktree-1", "worktree-2", "worktree-3"} {
-					err = w.Add(memfs.New(), name, WithCommit(commit))
+					err = w.Add(t.Context(), memfs.New(), name, WithCommit(commit))
 					require.NoError(t, err)
 				}
 
@@ -560,10 +561,10 @@ func TestList(t *testing.T) {
 
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
 
-				err = w.Add(memfs.New(), "feature-a", WithCommit(commit))
+				err = w.Add(t.Context(), memfs.New(), "feature-a", WithCommit(commit))
 				require.NoError(t, err)
 
-				err = w.Add(memfs.New(), "feature-b", WithCommit(commit))
+				err = w.Add(t.Context(), memfs.New(), "feature-b", WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer
@@ -583,7 +584,7 @@ func TestList(t *testing.T) {
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
 
 				for _, name := range []string{"wt-1", "wt-2", "wt-3"} {
-					err = w.Add(memfs.New(), name, WithCommit(commit))
+					err = w.Add(t.Context(), memfs.New(), name, WithCommit(commit))
 					require.NoError(t, err)
 				}
 
@@ -640,7 +641,7 @@ func TestOpen(t *testing.T) {
 				wtFS := memfs.New()
 				name := "test-worktree"
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-				err = w.Add(wtFS, name, WithCommit(commit))
+				err = w.Add(t.Context(), wtFS, name, WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer, wtFS
@@ -649,11 +650,11 @@ func TestOpen(t *testing.T) {
 			checkRepo: func(t *testing.T, repo *git.Repository, _ billy.Filesystem) {
 				require.NotNil(t, repo, "repository should not be nil")
 
-				wt, err := repo.Worktree()
+				wt, err := repo.Worktree(t.Context())
 				require.NoError(t, err)
 				require.NotNil(t, wt)
 
-				head, err := repo.Head()
+				head, err := repo.Head(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, "af2d6a6954d532f8ffb47615169c8fdf9d383a1a", head.Hash().String())
 			},
@@ -670,7 +671,7 @@ func TestOpen(t *testing.T) {
 				wtFS := memfs.New()
 				name := "test-worktree"
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-				err = w.Add(wtFS, name, WithCommit(commit))
+				err = w.Add(t.Context(), wtFS, name, WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer, wtFS
@@ -679,11 +680,11 @@ func TestOpen(t *testing.T) {
 			checkRepo: func(t *testing.T, repo *git.Repository, _ billy.Filesystem) {
 				require.NotNil(t, repo, "repository should not be nil")
 
-				wt, err := repo.Worktree()
+				wt, err := repo.Worktree(t.Context())
 				require.NoError(t, err)
 				require.NotNil(t, wt)
 
-				head, err := repo.Head()
+				head, err := repo.Head(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, "af2d6a6954d532f8ffb47615169c8fdf9d383a1a", head.Hash().String())
 			},
@@ -712,7 +713,7 @@ func TestOpen(t *testing.T) {
 			checkRepo: func(t *testing.T, repo *git.Repository, _ billy.Filesystem) {
 				require.NotNil(t, repo, "repository should not be nil")
 
-				_, err := repo.Head()
+				_, err := repo.Head(t.Context())
 				require.NoError(t, err)
 			},
 		},
@@ -728,7 +729,7 @@ func TestOpen(t *testing.T) {
 				wtFS := memfs.New()
 				name := "feature-branch"
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-				err = w.Add(wtFS, name, WithCommit(commit))
+				err = w.Add(t.Context(), wtFS, name, WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer, wtFS
@@ -741,11 +742,11 @@ func TestOpen(t *testing.T) {
 				require.NoError(t, err)
 				assert.False(t, fi.IsDir(), ".git should be a file, not a directory in linked worktree")
 
-				head, err := repo.Head()
+				head, err := repo.Head(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, "af2d6a6954d532f8ffb47615169c8fdf9d383a1a", head.Hash().String())
 
-				commit, err := repo.CommitObject(head.Hash())
+				commit, err := repo.CommitObject(t.Context(), head.Hash())
 				require.NoError(t, err)
 				require.NotNil(t, commit)
 			},
@@ -761,29 +762,29 @@ func TestOpen(t *testing.T) {
 
 				wtFS1 := memfs.New()
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-				err = w.Add(wtFS1, "worktree-1", WithCommit(commit))
+				err = w.Add(t.Context(), wtFS1, "worktree-1", WithCommit(commit))
 				require.NoError(t, err)
 
-				r, err := w.Open(wtFS1)
+				r, err := w.Open(t.Context(), wtFS1)
 				require.NoError(t, err)
 				defer func() { _ = r.Close() }()
 
-				wt, err := r.Worktree()
+				wt, err := r.Worktree(t.Context())
 				require.NoError(t, err)
 
 				err = util.WriteFile(wtFS1, "newfile.txt", []byte("foobar"), 0o644)
 				require.NoError(t, err)
 
-				_, err = wt.Add("newfile.txt")
+				_, err = wt.Add(t.Context(), "newfile.txt")
 				require.NoError(t, err)
 
-				_, err = wt.Commit("test commit", &git.CommitOptions{
+				_, err = wt.Commit(t.Context(), "test commit", &git.CommitOptions{
 					Author: &object.Signature{Name: "Test", Email: "test@test.com", When: time.Now()},
 				})
 				require.NoError(t, err)
 
 				wtFS2 := memfs.New()
-				err = w.Add(wtFS2, "worktree-2", WithCommit(commit))
+				err = w.Add(t.Context(), wtFS2, "worktree-2", WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer, wtFS1
@@ -792,7 +793,7 @@ func TestOpen(t *testing.T) {
 			checkRepo: func(t *testing.T, repo *git.Repository, _ billy.Filesystem) {
 				require.NotNil(t, repo, "repository should not be nil")
 
-				head, err := repo.Head()
+				head, err := repo.Head(t.Context())
 				require.NoError(t, err)
 				assert.NotEqual(t, "af2d6a6954d532f8ffb47615169c8fdf9d383a1a", head.Hash().String())
 			},
@@ -808,7 +809,7 @@ func TestOpen(t *testing.T) {
 			w, err := New(storer)
 			require.NoError(t, err)
 
-			repo, err := w.Open(wtFS)
+			repo, err := w.Open(t.Context(), wtFS)
 			if tt.wantErr {
 				require.Error(t, err, "Open() should return an error")
 				if tt.errContains != "" {
@@ -851,7 +852,7 @@ func TestInit(t *testing.T) {
 				wtFS := memfs.New()
 				name := "test-init"
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-				err = w.Add(wtFS, name, WithCommit(commit))
+				err = w.Add(t.Context(), wtFS, name, WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer, name
@@ -863,7 +864,7 @@ func TestInit(t *testing.T) {
 				w, err := New(storage)
 				require.NoError(t, err)
 
-				repo, err := w.Open(wt)
+				repo, err := w.Open(t.Context(), wt)
 				require.NoError(t, err)
 				defer func() { _ = repo.Close() }()
 				require.NotNil(t, repo)
@@ -885,7 +886,7 @@ func TestInit(t *testing.T) {
 				wtFS := memfs.New()
 				name := "cross-fs-init"
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-				err = w.Add(wtFS, name, WithCommit(commit))
+				err = w.Add(t.Context(), wtFS, name, WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer, name
@@ -897,7 +898,7 @@ func TestInit(t *testing.T) {
 				w, err := New(storage)
 				require.NoError(t, err)
 
-				repo, err := w.Open(wt)
+				repo, err := w.Open(t.Context(), wt)
 				require.NoError(t, err)
 				defer func() { _ = repo.Close() }()
 				require.NotNil(t, repo)
@@ -906,7 +907,7 @@ func TestInit(t *testing.T) {
 				require.NoError(t, err)
 				assert.False(t, fi.IsDir(), ".git should be a file")
 
-				head, err := repo.Head()
+				head, err := repo.Head(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, "af2d6a6954d532f8ffb47615169c8fdf9d383a1a", head.Hash().String())
 			},
@@ -923,7 +924,7 @@ func TestInit(t *testing.T) {
 				wtFS := memfs.New()
 				name := "reverse-cross-fs"
 				commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-				err = w.Add(wtFS, name, WithCommit(commit))
+				err = w.Add(t.Context(), wtFS, name, WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer, name
@@ -935,7 +936,7 @@ func TestInit(t *testing.T) {
 				w, err := New(storage)
 				require.NoError(t, err)
 
-				repo, err := w.Open(wt)
+				repo, err := w.Open(t.Context(), wt)
 				require.NoError(t, err)
 				defer func() { _ = repo.Close() }()
 				require.NotNil(t, repo)
@@ -982,7 +983,7 @@ func TestInit(t *testing.T) {
 				wtFS := memfs.New()
 				name := "specific-commit"
 				commit := plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294")
-				err = w.Add(wtFS, name, WithCommit(commit))
+				err = w.Add(t.Context(), wtFS, name, WithCommit(commit))
 				require.NoError(t, err)
 
 				return storer, name
@@ -994,17 +995,17 @@ func TestInit(t *testing.T) {
 				w, err := New(storage)
 				require.NoError(t, err)
 
-				repo, err := w.Open(wt)
+				repo, err := w.Open(t.Context(), wt)
 				require.NoError(t, err)
 				defer func() { _ = repo.Close() }()
 
-				head, err := repo.Head()
+				head, err := repo.Head(t.Context())
 				require.NoError(t, err)
 				assert.Equal(t, "918c48b83bd081e863dbe1b80f8998f058cd8294", head.Hash().String())
 
-				wtObj, err := repo.Worktree()
+				wtObj, err := repo.Worktree(t.Context())
 				require.NoError(t, err)
-				status, err := wtObj.Status()
+				status, err := wtObj.Status(t.Context())
 				require.NoError(t, err)
 
 				assert.False(t, status.IsClean())
@@ -1046,20 +1047,20 @@ func TestWorktreeIsolation(t *testing.T) {
 	mainRepoDir := t.TempDir()
 	mainRepoFS := osfs.New(mainRepoDir, osfs.WithBoundOS())
 
-	mainRepo, err := git.PlainInit(mainRepoDir, false)
+	mainRepo, err := git.PlainInit(t.Context(), mainRepoDir, false)
 	require.NoError(t, err)
 	defer func() { _ = mainRepo.Close() }()
 
-	mainWt, err := mainRepo.Worktree()
+	mainWt, err := mainRepo.Worktree(t.Context())
 	require.NoError(t, err)
 
 	err = util.WriteFile(mainRepoFS, "README.md", []byte("# Main Repo\n"), 0o644)
 	require.NoError(t, err)
 
-	_, err = mainWt.Add("README.md")
+	_, err = mainWt.Add(t.Context(), "README.md")
 	require.NoError(t, err)
 
-	initialCommit, err := mainWt.Commit("Initial commit", &git.CommitOptions{
+	initialCommit, err := mainWt.Commit(t.Context(), "Initial commit", &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "Test User",
 			Email: "test@example.com",
@@ -1070,17 +1071,17 @@ func TestWorktreeIsolation(t *testing.T) {
 
 	// Create a remote repository.
 	remoteDir := t.TempDir()
-	remoteRepo, err := git.PlainInit(remoteDir, true)
+	remoteRepo, err := git.PlainInit(t.Context(), remoteDir, true)
 	require.NoError(t, err)
 	defer func() { _ = remoteRepo.Close() }()
 
-	_, err = mainRepo.CreateRemote(&config.RemoteConfig{
+	_, err = mainRepo.CreateRemote(t.Context(), &config.RemoteConfig{
 		Name: "origin",
 		URLs: []string{remoteDir},
 	})
 	require.NoError(t, err)
 
-	err = mainRepo.Push(&git.PushOptions{
+	err = mainRepo.Push(t.Context(), &git.PushOptions{
 		RemoteName: "origin",
 		RefSpecs:   []config.RefSpec{"refs/heads/master:refs/heads/master"},
 	})
@@ -1093,23 +1094,23 @@ func TestWorktreeIsolation(t *testing.T) {
 	w, err := New(mainRepo.Storer)
 	require.NoError(t, err)
 
-	err = w.Add(worktreeFS, "feature-branch", WithCommit(initialCommit))
+	err = w.Add(t.Context(), worktreeFS, "feature-branch", WithCommit(initialCommit))
 	require.NoError(t, err)
 
-	wtRepo, err := w.Open(worktreeFS)
+	wtRepo, err := w.Open(t.Context(), worktreeFS)
 	require.NoError(t, err)
 	defer func() { _ = wtRepo.Close() }()
 
-	wtWorkTree, err := wtRepo.Worktree()
+	wtWorkTree, err := wtRepo.Worktree(t.Context())
 	require.NoError(t, err)
 
 	err = util.WriteFile(worktreeFS, "feature.txt", []byte("Feature implementation\n"), 0o644)
 	require.NoError(t, err)
 
-	_, err = wtWorkTree.Add("feature.txt")
+	_, err = wtWorkTree.Add(t.Context(), "feature.txt")
 	require.NoError(t, err)
 
-	featureCommit, err := wtWorkTree.Commit("Add feature", &git.CommitOptions{
+	featureCommit, err := wtWorkTree.Commit(t.Context(), "Add feature", &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "Test User",
 			Email: "test@example.com",
@@ -1119,13 +1120,13 @@ func TestWorktreeIsolation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Push worktree changes to the remote.
-	err = wtRepo.Push(&git.PushOptions{
+	err = wtRepo.Push(t.Context(), &git.PushOptions{
 		RemoteName: "origin",
 		RefSpecs:   []config.RefSpec{"refs/heads/feature-branch:refs/heads/feature-branch"},
 	})
 	require.NoError(t, err)
 
-	wtHead, err := wtRepo.Head()
+	wtHead, err := wtRepo.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, featureCommit.String(), wtHead.Hash().String(), "worktree should point to feature commit")
 
@@ -1133,7 +1134,7 @@ func TestWorktreeIsolation(t *testing.T) {
 	require.NoError(t, err, "feature.txt should exist in worktree")
 
 	// Main repository must remain unchanged, with HEAD at the initial commit.
-	mainHead, err := mainRepo.Head()
+	mainHead, err := mainRepo.Head(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, initialCommit.String(), mainHead.Hash().String(), "main repo should still point to initial commit")
 
@@ -1145,11 +1146,11 @@ func TestWorktreeIsolation(t *testing.T) {
 	assert.Equal(t, "# Main Repo\n", string(readmeContent), "README.md should be unchanged in main repo")
 
 	// remote must have both branches.
-	remoteRefs, err := remoteRepo.References()
+	remoteRefs, err := remoteRepo.References(t.Context())
 	require.NoError(t, err)
 
 	var foundMaster, foundFeature bool
-	err = remoteRefs.ForEach(func(ref *plumbing.Reference) error {
+	err = remoteRefs.ForEach(t.Context(), func(ref *plumbing.Reference) error {
 		if ref.Name() == plumbing.NewBranchReferenceName("master") {
 			foundMaster = true
 			assert.Equal(t, initialCommit.String(), ref.Hash().String(), "remote master should point to initial commit")
@@ -1181,11 +1182,11 @@ func TestWorktreeConfig(t *testing.T) {
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 		defer func() { _ = storer.Close() }()
 
-		cfg, err := storer.Config()
+		cfg, err := storer.Config(t.Context())
 		require.NoError(t, err)
 		cfg.Core.RepositoryFormatVersion = formatcfg.Version1
 		cfg.Extensions.WorktreeConfig = true
-		err = storer.SetConfig(cfg)
+		err = storer.SetConfig(t.Context(), cfg)
 		require.NoError(t, err)
 
 		w, err := New(storer)
@@ -1193,18 +1194,18 @@ func TestWorktreeConfig(t *testing.T) {
 
 		wtFS := memfs.New()
 		commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-		err = w.Add(wtFS, worktreeName, WithCommit(commit))
+		err = w.Add(t.Context(), wtFS, worktreeName, WithCommit(commit))
 		require.NoError(t, err)
 
 		cfgWorktreePath := filepath.Join("worktrees", worktreeName, "config.worktree")
 		err = util.WriteFile(storer.Filesystem(), cfgWorktreePath, []byte(worktreeConfigContent), 0o644)
 		require.NoError(t, err)
 
-		repo, err := w.Open(wtFS)
+		repo, err := w.Open(t.Context(), wtFS)
 		require.NoError(t, err)
 		defer func() { _ = repo.Close() }()
 
-		repoCfg, err := repo.Config()
+		repoCfg, err := repo.Config(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, customWorktreePath, repoCfg.Core.Worktree)
 
@@ -1219,10 +1220,10 @@ func TestWorktreeConfig(t *testing.T) {
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 		defer func() { _ = storer.Close() }()
 
-		cfg, err := storer.Config()
+		cfg, err := storer.Config(t.Context())
 		require.NoError(t, err)
 		cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
-		err = storer.SetConfig(cfg)
+		err = storer.SetConfig(t.Context(), cfg)
 		require.NoError(t, err)
 
 		w, err := New(storer)
@@ -1230,14 +1231,14 @@ func TestWorktreeConfig(t *testing.T) {
 
 		wtFS := memfs.New()
 		commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-		err = w.Add(wtFS, worktreeName, WithCommit(commit))
+		err = w.Add(t.Context(), wtFS, worktreeName, WithCommit(commit))
 		require.NoError(t, err)
 
-		repo, err := w.Open(wtFS)
+		repo, err := w.Open(t.Context(), wtFS)
 		require.NoError(t, err)
 		defer func() { _ = repo.Close() }()
 
-		repoCfg, err := repo.Config()
+		repoCfg, err := repo.Config(t.Context())
 		require.NoError(t, err)
 		assert.Empty(t, repoCfg.Core.Worktree)
 	})
@@ -1255,18 +1256,18 @@ func TestWorktreeConfig(t *testing.T) {
 
 		wtFS := memfs.New()
 		commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-		err = w.Add(wtFS, worktreeName, WithCommit(commit))
+		err = w.Add(t.Context(), wtFS, worktreeName, WithCommit(commit))
 		require.NoError(t, err)
 
 		cfgWorktreePath := filepath.Join("worktrees", worktreeName, "config.worktree")
 		err = util.WriteFile(storer.Filesystem(), cfgWorktreePath, []byte("[core]\n\tworktree = /ignored/path\n"), 0o644)
 		require.NoError(t, err)
 
-		repo, err := w.Open(wtFS)
+		repo, err := w.Open(t.Context(), wtFS)
 		require.NoError(t, err)
 		defer func() { _ = repo.Close() }()
 
-		repoCfg, err := repo.Config()
+		repoCfg, err := repo.Config(t.Context())
 		require.NoError(t, err)
 		assert.Empty(t, repoCfg.Core.Worktree)
 	})
@@ -1279,10 +1280,10 @@ func TestWorktreeConfig(t *testing.T) {
 		storer := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 		defer func() { _ = storer.Close() }()
 
-		cfg, err := storer.Config()
+		cfg, err := storer.Config(t.Context())
 		require.NoError(t, err)
 		cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
-		err = storer.SetConfig(cfg)
+		err = storer.SetConfig(t.Context(), cfg)
 		require.NoError(t, err)
 
 		w, err := New(storer)
@@ -1290,18 +1291,18 @@ func TestWorktreeConfig(t *testing.T) {
 
 		wtFS := memfs.New()
 		commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
-		err = w.Add(wtFS, worktreeName, WithCommit(commit))
+		err = w.Add(t.Context(), wtFS, worktreeName, WithCommit(commit))
 		require.NoError(t, err)
 
 		cfgWorktreePath := filepath.Join("worktrees", worktreeName, "config.worktree")
 		err = util.WriteFile(storer.Filesystem(), cfgWorktreePath, []byte(worktreeConfigContent), 0o644)
 		require.NoError(t, err)
 
-		repo, err := w.Open(wtFS)
+		repo, err := w.Open(t.Context(), wtFS)
 		require.NoError(t, err)
 		defer func() { _ = repo.Close() }()
 
-		repoCfg, err := repo.Config()
+		repoCfg, err := repo.Config(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, customWorktreePath, repoCfg.Core.Worktree)
 	})
@@ -1337,7 +1338,7 @@ func FuzzAdd(f *testing.F) {
 		wtFS := memfs.New()
 		commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
 
-		_ = w.Add(wtFS, name, WithCommit(commit), WithDetachedHead())
+		_ = w.Add(t.Context(), wtFS, name, WithCommit(commit), WithDetachedHead())
 	})
 }
 
@@ -1368,7 +1369,7 @@ func FuzzOpen(f *testing.F) {
 		err = util.WriteFile(wtFS, ".git", []byte(gitFileContent), 0o644)
 		require.NoError(t, err, "failed to write .git file")
 
-		repo, err := w.Open(wtFS)
+		repo, err := w.Open(t.Context(), wtFS)
 		if repo != nil {
 			defer func() { _ = repo.Close() }()
 		}
@@ -1396,19 +1397,19 @@ func ExampleWorktree_Open() {
 	commit := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
 
 	// Create linked worktree.
-	err = w.Add(worktreeFS, "feature-branch", WithCommit(commit))
+	err = w.Add(context.Background(), worktreeFS, "feature-branch", WithCommit(commit))
 	if err != nil {
 		panic(err)
 	}
 
 	// Open linked worktree repository.
-	r, err := w.Open(worktreeFS)
+	r, err := w.Open(context.Background(), worktreeFS)
 	if err != nil {
 		panic(err)
 	}
 	defer func() { _ = r.Close() }()
 
-	_, _ = r.Head()
+	_, _ = r.Head(context.Background())
 
 	// The linked worktree repository is now ready to be used.
 }
@@ -1452,12 +1453,12 @@ func ExampleWorktree_Init() {
 	}
 
 	// Open the worktree with the new filesystem.
-	r, err := w.Open(freshWtFS)
+	r, err := w.Open(context.Background(), freshWtFS)
 	if err != nil {
 		panic(err)
 	}
 	defer func() { _ = r.Close() }()
 
 	// The worktree is now connected and can be used.
-	_, _ = r.Head()
+	_, _ = r.Head(context.Background())
 }

--- a/x/storage/storer.go
+++ b/x/storage/storer.go
@@ -1,7 +1,11 @@
 // Package storage provides extended storage interfaces for experimental features.
 package storage
 
-import "github.com/go-git/go-git/v6/plumbing/format/config"
+import (
+	"context"
+
+	"github.com/go-git/go-git/v6/plumbing/format/config"
+)
 
 // ObjectFormatSetter is implemented by storage backends that support
 // configuring the object format (hash algorithm) used for the repository.
@@ -13,7 +17,7 @@ import "github.com/go-git/go-git/v6/plumbing/format/config"
 // For more info refer to #1832.
 type ObjectFormatSetter interface {
 	// SetObjectFormat configures the object format (hash algorithm) for this storage.
-	SetObjectFormat(config.ObjectFormat) error
+	SetObjectFormat(ctx context.Context, of config.ObjectFormat) error
 }
 
 // ExtensionChecker expands a Storer enabling it to confirm whether it supports


### PR DESCRIPTION
I have found that it's incredibly useful to be able to pass a `ctx` into the `Storer` interface to enable cancelling backend operations associated with any store work. E.g. passing metadata / logging or cancelling DB transactions proactively / downstream writes.

It's a fairly sizable refactor of the interfaces, but ahead of v6 I thought now would be a good time to propose it.