### PR TITLE
*: reject NTFS and HFS disguised ".." in tree and submodule paths

### DIFF
--- a/config/modules.go
+++ b/config/modules.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/go-git/go-git/v6/internal/pathutil"
@@ -22,9 +21,6 @@ var (
 	// for use as a path component.
 	ErrModuleBadName = errors.New("ignoring suspicious submodule name")
 )
-
-// Matches module paths with dotdot ".." components.
-var dotdotPath = regexp.MustCompile(`(^|[/\\])\.\.([/\\]|$)`)
 
 // Modules defines the submodules properties, represents a .gitmodules file
 // https://www.kernel.org/pub/software/scm/git/docs/gitmodules.html
@@ -113,8 +109,16 @@ func (m *Submodule) Validate() error {
 		return ErrModuleEmptyURL
 	}
 
-	if dotdotPath.MatchString(m.Path) {
-		return ErrModuleBadPath
+	// Reject any ".." path component, matching the check
+	// validSubmoduleName already applies to the name: a literal ".."
+	// and the NTFS/HFS+ spellings (trailing spaces/periods, Alternate
+	// Data Streams, ignorable code points) a filesystem folds back to
+	// a parent hop. m.Path is worktree-relative and attacker-controlled
+	// via .gitmodules, so both checks run regardless of host OS.
+	for _, seg := range strings.FieldsFunc(m.Path, isPathSep) {
+		if pathutil.IsHFSDot(seg, ".") || pathutil.IsNTFSDot(seg, ".", "") {
+			return ErrModuleBadPath
+		}
 	}
 
 	return nil

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -32,6 +32,20 @@ func (s *ModulesSuite) TestValidateBadPath() {
 		`foo/..`,
 		`foo/../`,
 		`foo/../bar`,
+
+		// HFS+ ignores certain Unicode code points during path
+		// normalisation, so these all resolve to ".." on macOS.
+		".\u200c.",     // ZWNJ between dots
+		"foo/.\u200c.", // hidden ".." mid-path
+
+		// NTFS strips trailing spaces, dots, and an alternate-data
+		// -stream suffix during canonicalisation, so these all
+		// resolve to ".." on Windows.
+		".. ",
+		"..  ",
+		".. .",
+		"..::$INDEX_ALLOCATION",
+		"foo/.. /bar",
 	}
 
 	for _, p := range input {
@@ -40,7 +54,18 @@ func (s *ModulesSuite) TestValidateBadPath() {
 			Path: p,
 			URL:  "https://example.com/",
 		}
-		s.Equal(ErrModuleBadPath, m.Validate())
+		s.Equal(ErrModuleBadPath, m.Validate(), "path %q", p)
+	}
+}
+
+func (s *ModulesSuite) TestValidateGoodPath() {
+	for _, p := range []string{"foo", "foo/bar", "a..b", "deps/x.y", "lib-foo/sub"} {
+		m := &Submodule{
+			Name: "ok",
+			Path: p,
+			URL:  "https://example.com/",
+		}
+		s.NoError(m.Validate(), "path %q", p)
 	}
 }
 

--- a/internal/pathutil/tree.go
+++ b/internal/pathutil/tree.go
@@ -15,18 +15,20 @@ var ErrInvalidPath = fmt.Errorf("invalid path")
 // worktree or rewrite repository metadata. It rejects:
 //
 //   - control characters (< 0x20, 0x7f);
-//   - empty paths and "." / ".." components;
+//   - empty paths and "." / ".." components, including the NTFS and
+//     HFS+ spellings that fold back to ".." (trailing spaces/periods,
+//     Alternate Data Streams, ignorable code points);
 //   - Windows volume name prefixes (e.g. C:);
 //   - .git, its 8.3 NTFS short-name git~1, plus their HFS+ and NTFS
 //     variants — at every position, not just the root.
 //
-// HFS+/NTFS variants of `.git` are always rejected at this layer
-// regardless of runtime config: tree paths are canonical UTF-8 with
-// no zero-width characters or NTFS short-name forms, so an entry
-// that looks like a disguised `.git` is suspicious anywhere. Windows
-// reserved device names (CON, NUL, etc.) are not policed here — they
-// are legitimate filenames on non-Windows filesystems and upstream
-// Git accepts them. The wrapper layer (validPath in package git)
+// HFS+/NTFS variants of `.git` and `..` are always rejected at this
+// layer regardless of runtime config: tree paths are canonical UTF-8
+// with no zero-width characters or NTFS short-name forms, so an entry
+// that looks like a disguised `.git` or `..` is suspicious anywhere.
+// Windows reserved device names (CON, NUL, etc.) are not policed here
+// — they are legitimate filenames on non-Windows filesystems and
+// upstream Git accepts them. The wrapper layer (validPath in package git)
 // rejects them at materialisation time when core.protectNTFS is on.
 //
 // Mirrors upstream Git's verify_path_internal at read-cache.c#L987
@@ -53,7 +55,9 @@ func ValidTreePath(p string) error {
 	}
 
 	for _, part := range parts {
-		if part == "." || part == ".." {
+		// IsHFSDot/IsNTFSDot with a "." needle match ".." and its
+		// disguises but not a bare ".", so reject that explicitly too.
+		if part == "." || IsHFSDot(part, ".") || IsNTFSDot(part, ".", "") {
 			return fmt.Errorf("%w %q: cannot use %q", ErrInvalidPath, p, part)
 		}
 

--- a/internal/pathutil/tree_test.go
+++ b/internal/pathutil/tree_test.go
@@ -26,6 +26,15 @@ func TestValidTreePath(t *testing.T) {
 		{"reject ..", "a/../b", true},
 		{"reject .", ".", true},
 		{"reject empty", "", true},
+
+		// NTFS folds trailing spaces/dots and an ADS suffix back to "..".
+		{"reject .. trailing space", ".. /x", true},
+		{"reject nested .. trailing space", "a/.. /b", true},
+		{"reject .. trailing dots", "...  /x", true},
+		{"reject ..:: ADS", "..::$INDEX_ALLOCATION/x", true},
+		// HFS+ ignores certain code points, so these resolve to "..".
+		{"reject .zwnj. hfs", ".\u200c./x", true},
+		{"reject nested .zwnj. hfs", "a/.\u200c./b", true},
 		{"reject control char SOH", "a\x01b", true},
 		{"reject DEL", "foo\x7fbar", true},
 


### PR DESCRIPTION
**Disguised ".." slips past the tree and submodule path checks**

`ValidTreePath` and `Submodule.Validate` reject a literal `..` component but not the NTFS/HFS+ spellings a filesystem folds back to it (trailing spaces or dots, an Alternate Data Stream like `..::$INDEX_ALLOCATION`, or an ignorable code point such as `.<U+200C>.`), so a crafted tree entry name or `.gitmodules` path can escape the worktree root on those systems during checkout or submodule init. The name side already closes this (`validSubmoduleName`, and `validReferenceName` for refs) via `pathutil.IsHFSDot`/`IsNTFSDot` with a "." needle, and `ValidTreePath` already rejects a disguised `.git`, so this applies the same per-component check to `..`.