### PR TITLE
internal: v2, skip closeReader on a cancelled context

### DIFF
--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -224,7 +224,26 @@ func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round Fe
 
 		if out.Packfile {
 			streamErr := streamPackfile(ctx, st, packReader, req.Progress)
-			closeReader(packReader)
+			// Skip draining/closing on cancellation: streamPackfile wraps
+			// packReader in a NewContextReader, whose background goroutine
+			// can still be blocked in the underlying Read after the
+			// <-ctx.Done() branch returns (see its doc comment). Closing
+			// here would race that goroutine's in-flight Read -- the same
+			// class of race fixed in plumbing/transport/http's Fetch/Push
+			// for the v0/v1 path. On a non-cancellation error or success,
+			// streamPackfile's last Read has already returned via the
+			// result channel and the goroutine is quiescent, so closing is
+			// safe and necessary. On cancellation, a packReader backed by
+			// a context-bound request (e.g. HTTP) gets torn down by that
+			// request's own context handling instead, so it is not leaked.
+			//
+			// Checked against streamErr itself, not ctx.Err(): ctx can be
+			// cancelled an instant after a successful/non-cancel return,
+			// and checking ctx.Err() at that point would skip the close
+			// for a read that was already fully quiescent.
+			if !errors.Is(streamErr, context.Canceled) && !errors.Is(streamErr, context.DeadlineExceeded) {
+				closeReader(packReader)
+			}
 			if streamErr != nil {
 				return streamErr
 			}

--- a/internal/transport/v2_closereader_cancel_test.go
+++ b/internal/transport/v2_closereader_cancel_test.go
@@ -1,0 +1,123 @@
+package transport
+
+import (
+	"context"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// countingBlockingReadCloser blocks on Read until its unblock channel is
+// closed, and counts Read/Close calls. Close itself does not unblock Read --
+// that mirrors NewContextReader for real: it has no way to interrupt an
+// in-flight underlying Read (see its doc comment), which is the whole reason
+// FetchV2's round loop must not touch packReader again on cancellation.
+// started is closed the first time Read is called, letting a test wait
+// deterministically for the read to be in flight. Used to verify FetchV2's
+// round loop skips draining/closing packReader on a cancelled context
+// instead of racing streamPackfile's NewContextReader goroutine, which can
+// still be blocked in the underlying Read after the <-ctx.Done() branch
+// returns -- the same class of race fixed in plumbing/transport/http's
+// Fetch/Push for the v0/v1 path (see FetchV2's round loop comment).
+type countingBlockingReadCloser struct {
+	unblock    chan struct{}
+	started    chan struct{}
+	startOnce  sync.Once
+	readCalls  atomic.Int32
+	closeCalls atomic.Int32
+}
+
+func newCountingBlockingReadCloser() *countingBlockingReadCloser {
+	return &countingBlockingReadCloser{
+		unblock: make(chan struct{}),
+		started: make(chan struct{}),
+	}
+}
+
+func (b *countingBlockingReadCloser) Read(_ []byte) (int, error) {
+	b.readCalls.Add(1)
+	b.startOnce.Do(func() { close(b.started) })
+	<-b.unblock
+	return 0, io.EOF
+}
+
+func (b *countingBlockingReadCloser) Close() error {
+	b.closeCalls.Add(1)
+	return nil
+}
+
+func TestFetchV2SkipsCloseReaderOnCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	r := newCountingBlockingReadCloser()
+
+	round := func(_ *packp.FetchArgs) (*packp.FetchOutput, io.Reader, error) {
+		return &packp.FetchOutput{Packfile: true}, r, nil
+	}
+
+	req := &FetchRequest{Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")}}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- FetchV2(ctx, memory.NewStorage(), req, round)
+	}()
+
+	// Wait for streamPackfile to actually start blocking on Read before
+	// cancelling, so this exercises a genuine mid-read cancel rather than a
+	// pre-cancelled context.
+	select {
+	case <-r.started:
+	case <-time.After(time.Second):
+		t.Fatal("streamPackfile did not start reading packReader")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected FetchV2 to return an error after cancel")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("FetchV2 did not return after cancel")
+	}
+
+	// Exactly the one in-flight Read (still blocked in the background) --
+	// closeReader's drain must not have run a second, concurrent Read.
+	if got := r.readCalls.Load(); got != 1 {
+		t.Errorf("expected exactly 1 Read call, got %d", got)
+	}
+	if got := r.closeCalls.Load(); got != 0 {
+		t.Errorf("expected Close not to be called on a cancelled fetch, got %d call(s)", got)
+	}
+}
+
+func TestFetchV2ClosesReaderOnNonCancelError(t *testing.T) {
+	t.Parallel()
+	// A non-cancellation streamPackfile error (e.g. a pack-parse failure) must
+	// still drain and close packReader: the read has already returned via
+	// the result channel and the goroutine is quiescent, so closing is safe
+	// and necessary -- otherwise the response body/connection leaks.
+	ctx := context.Background()
+	r := newCountingBlockingReadCloser()
+	close(r.unblock) // Read returns immediately with io.EOF, i.e. no packfile data
+
+	round := func(_ *packp.FetchArgs) (*packp.FetchOutput, io.Reader, error) {
+		return &packp.FetchOutput{Packfile: true}, r, nil
+	}
+
+	req := &FetchRequest{Wants: []plumbing.Hash{plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")}}
+
+	err := FetchV2(ctx, memory.NewStorage(), req, round)
+	if err == nil {
+		t.Fatal("expected an error from an empty (non-packfile) stream")
+	}
+	if got := r.closeCalls.Load(); got != 1 {
+		t.Errorf("expected packReader to be closed on a non-cancellation error, got %d call(s)", got)
+	}
+}

--- a/internal/transport/v2_closereader_cancel_test.go
+++ b/internal/transport/v2_closereader_cancel_test.go
@@ -56,6 +56,10 @@ func TestFetchV2SkipsCloseReaderOnCancel(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	r := newCountingBlockingReadCloser()
+	// The assertions below rely on the orphaned NewContextReader goroutine
+	// staying blocked in Read; release it once the test is done so it does
+	// not outlive the test as a leaked goroutine.
+	t.Cleanup(func() { close(r.unblock) })
 
 	round := func(_ *packp.FetchArgs) (*packp.FetchOutput, io.Reader, error) {
 		return &packp.FetchOutput{Packfile: true}, r, nil

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -324,16 +324,22 @@ func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *tr
 		}
 	}
 	err = transport.FetchPack(ctx, st, s.caps, io.NopCloser(neg), shallows, req)
-	// Close the response unless the context was cancelled. The race this guards
-	// against only exists on cancellation: a ctxReader goroutine inside
-	// FetchPack can still be blocked in the underlying Read after the
+	// Close the response unless the read itself was a cancellation. The race
+	// this guards against only exists on cancellation: a ctxReader goroutine
+	// inside FetchPack can still be blocked in the underlying Read after the
 	// <-ctx.Done() branch, so niling current.resp here would race it. On a
 	// non-cancellation error (or success) FetchPack's last Read returned via the
 	// result channel and its goroutine is quiescent, so closing is safe — and
 	// necessary, otherwise the response body/connection leaks. On the
 	// cancellation path the request context unblocks the in-flight read, so the
 	// body is not leaked.
-	if ctx.Err() == nil {
+	//
+	// Classified against err itself via errors.Is, not a fresh ctx.Err() check:
+	// ctx can turn Err() non-nil an instant after FetchPack already returned
+	// with its read fully quiescent, and re-checking ctx.Err() at that later,
+	// independent point would incorrectly skip the close and leak the response
+	// (mirrors FetchV2's round loop).
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		neg.closeResponse()
 	}
 	return err
@@ -387,10 +393,15 @@ func (s *smartPackSession) fetchV2(ctx context.Context, st storage.Storer, req *
 func (s *smartPackSession) Push(ctx context.Context, st storage.Storer, req *transport.PushRequest) error {
 	rwc := &httpRequester{session: s, ctx: ctx}
 	err := transport.SendPack(ctx, st, s.caps, rwc, io.NopCloser(rwc), req)
-	// Only close the response body on success. On error (especially context
-	// cancellation), context-wrapper goroutines inside SendPack may still
-	// be reading from it.
-	if err == nil && rwc.resp != nil {
+	// Close the response unless the read itself was a cancellation: a ctxReader
+	// goroutine inside SendPack can still be blocked in the underlying Read
+	// after the <-ctx.Done() branch, so closing the body here would race it —
+	// the request context tears the connection down instead. On a
+	// non-cancellation error (or success) SendPack's last Read returned via the
+	// result channel and its goroutine is quiescent, so closing is safe — and
+	// necessary, otherwise the response body/connection leaks (mirrors Fetch
+	// above and FetchV2's round loop).
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && rwc.resp != nil {
 		_ = rwc.resp.Body.Close()
 	}
 	return err

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,10 +26,13 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	filetransport "github.com/go-git/go-git/v6/plumbing/transport/file"
 	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
@@ -215,6 +219,162 @@ func TestFetchBodyReadRespectsCancellation(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("context-wrapped body read deadlocked after cancellation")
 	}
+}
+
+// bodyCloseRecorder wraps a response body and records whether the client code
+// closed it. The net/http transport tears down the connection below this
+// wrapper on context cancellation, so a recorded Close can only come from the
+// session's own close path.
+type bodyCloseRecorder struct {
+	io.ReadCloser
+	closed atomic.Bool
+}
+
+func (b *bodyCloseRecorder) Close() error {
+	b.closed.Store(true)
+	return b.ReadCloser.Close()
+}
+
+// bodyRecordingTransport wraps every response body in a bodyCloseRecorder.
+// respReceived is closed when the first response arrives, letting a test wait
+// until the client side actually holds a response before acting on it.
+type bodyRecordingTransport struct {
+	inner        http.RoundTripper
+	respReceived chan struct{}
+	respOnce     sync.Once
+	mu           sync.Mutex
+	bodies       []*bodyCloseRecorder
+}
+
+func (t *bodyRecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.inner.RoundTrip(req)
+	if resp != nil {
+		rec := &bodyCloseRecorder{ReadCloser: resp.Body}
+		resp.Body = rec
+		t.mu.Lock()
+		t.bodies = append(t.bodies, rec)
+		t.mu.Unlock()
+		t.respOnce.Do(func() { close(t.respReceived) })
+	}
+	return resp, err
+}
+
+func (t *bodyRecordingTransport) lastBody() *bodyCloseRecorder {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.bodies) == 0 {
+		return nil
+	}
+	return t.bodies[len(t.bodies)-1]
+}
+
+func newRecordingPushSession(t *testing.T, srv *httptest.Server) (*smartPackSession, *bodyRecordingTransport) {
+	t.Helper()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	rt := &bodyRecordingTransport{inner: srv.Client().Transport, respReceived: make(chan struct{})}
+	session := &smartPackSession{
+		client:  &http.Client{Transport: rt},
+		baseURL: u,
+		service: transport.ReceivePackService,
+	}
+	// report-status makes SendPack read the response body after sending the
+	// commands, which is the read path the close-vs-cancel guard protects.
+	session.caps.Set(capability.ReportStatus)
+	return session, rt
+}
+
+// deleteOnlyPushRequest builds a PushRequest whose single delete command needs
+// no packfile, keeping the exchange minimal.
+func deleteOnlyPushRequest() *transport.PushRequest {
+	return &transport.PushRequest{
+		Commands: []*packp.Command{{
+			Name: plumbing.ReferenceName("refs/heads/gone"),
+			Old:  plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+			New:  plumbing.ZeroHash,
+		}},
+	}
+}
+
+// TestPushClosesResponseOnNonCancelError verifies that Push closes the
+// response body when SendPack fails with a non-cancellation error (here a
+// report-status decode failure): the last Read already returned via the
+// ctxReader result channel, so closing is safe — and necessary, otherwise the
+// body and its connection leak.
+func TestPushClosesResponseOnNonCancelError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-git-receive-pack-result")
+		_, _ = w.Write([]byte("not a pkt-line report-status"))
+	}))
+	defer srv.Close()
+
+	session, rt := newRecordingPushSession(t, srv)
+
+	err := session.Push(context.Background(), memory.NewStorage(), deleteOnlyPushRequest())
+	require.Error(t, err)
+	require.NotErrorIs(t, err, context.Canceled)
+
+	body := rt.lastBody()
+	require.NotNil(t, body, "expected the push POST to have produced a response")
+	assert.True(t, body.closed.Load(), "expected Push to close the response body on a non-cancellation error")
+}
+
+// TestPushSkipsCloseResponseOnCancel verifies that Push does not close the
+// response body when SendPack fails with a cancellation: the ctxReader
+// goroutine inside SendPack can still be blocked in the underlying Read after
+// the <-ctx.Done() branch, so closing here would race it; the request context
+// tears the connection down instead.
+func TestPushSkipsCloseResponseOnCancel(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-git-receive-pack-result")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-release // hang with the body still open
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	session, rt := newRecordingPushSession(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- session.Push(ctx, memory.NewStorage(), deleteOnlyPushRequest())
+	}()
+
+	// Wait until the client holds the response (the server is now hanging mid
+	// report-status) before cancelling, so the cancel hits the body read
+	// rather than the POST itself.
+	select {
+	case <-rt.respReceived:
+	case <-time.After(5 * time.Second):
+		t.Fatal("push POST produced no response")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Push did not return after cancellation")
+	}
+
+	body := rt.lastBody()
+	require.NotNil(t, body, "expected the push POST to have produced a response")
+	assert.False(t, body.closed.Load(), "expected Push not to close the response body on cancellation")
 }
 
 type uploadPackRequests struct {


### PR DESCRIPTION
FetchV2's round loop called `closeReader(packReader)` unconditionally right after `streamPackfile` returned. `streamPackfile` wraps `packReader` in `ioutil.NewContextReader`, whose background goroutine can still be blocked in the underlying Read after the `<-ctx.Done()` branch returns (see its doc comment) -- closeReader's own drain-then-close then reads and closes that same packReader concurrently with the still-in-flight orphaned goroutine.
Caught by -race under context cancellation during a v2 fetch: DATA RACE between NewContextReader's orphaned background goroutine reading packReader and closeReader's own drain-then-close of that same packReader.

This is the same race class plumbing/transport/http's Fetch and Push guard against for the v0/v1 path (commits 37ef6522, e519c7a5): skip the close only when the read itself was a cancellation, since a non-cancellation error or
success means the last Read already returned via the result channel and the goroutine is quiescent, so closing is safe and necessary -- otherwise the response/connection leaks. On cancellation, a packReader backed by a
context-bound request (fetchV2's round callback builds its request with `http.NewRequestWithContext(ctx, ...)`, same as Fetch/Push) gets torn down by that request's own context handling instead, so nothing is leaked by
skipping the close here.

Classify against streamErr itself via errors.Is, not a fresh `ctx.Err()` check: ctx can turn Err() non-nil an instant after streamPackfile already returned with its read fully quiescent, and checking ctx.Err() again at that later, independent point would incorrectly skip the close and leak packReader.

Adds a test that FetchV2 skips draining/closing packReader on a cancelled context (verified failing against the prior unconditional close, which hangs trying to drain a reader that's blocked forever exactly like the hung-peer scenario this guards against) and still closes it on a non-cancellation error.

Assisted-by: Claude Sonnet 5
