### PR TITLE
build: re-enable go-billy renovate updates on `v5.x`

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -15,6 +15,10 @@
     },
     {
       "description": "Enable minor and patch updates for go-billy",
+      "matchBaseBranches": [
+        "main",
+        "releases/v5.x"
+      ],
       "matchPackageNames": [
         "github.com/go-git/go-billy",
       ],


### PR DESCRIPTION
Explicitly match the existing go-billy Renovate allow rule on releases/v5.x so minor and patch updates remain enabled there without broadening updates for other packages on the v5 release line.