### PR TITLE
plumbing: send updates via StatusChan

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -15,6 +15,9 @@ type FetchRequest struct {
 	// Progress is the progress sideband.
 	Progress sideband.Progress
 
+	// StatusChan receives structured packfile progress updates.
+	StatusChan plumbing.StatusChan
+
 	// Wants is the list of object hashes the client wants to fetch.
 	// The caller selects which remote refs to fetch (refspec matching)
 	// and extracts their hashes.

--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -223,7 +223,7 @@ func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round Fe
 		}
 
 		if out.Packfile {
-			streamErr := streamPackfile(ctx, st, packReader, req.Progress)
+			streamErr := streamPackfile(ctx, st, packReader, req.Progress, req.StatusChan)
 			// Skip draining/closing on cancellation: streamPackfile wraps
 			// packReader in a NewContextReader, whose background goroutine
 			// can still be blocked in the underlying Read after the
@@ -266,13 +266,13 @@ func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round Fe
 }
 
 // streamPackfile demultiplexes the sideband-64k packfile stream into st.
-func streamPackfile(ctx context.Context, st storage.Storer, packReader io.Reader, progress sideband.Progress) error {
+func streamPackfile(ctx context.Context, st storage.Storer, packReader io.Reader, progress sideband.Progress, statusChan plumbing.StatusChan) error {
 	reader := ioutil.NewContextReader(ctx, packReader)
 	demuxer := sideband.NewDemuxer(sideband.Sideband64k, reader)
 	if progress != nil {
 		demuxer.Progress = progress
 	}
-	return packfile.UpdateObjectStorage(st, demuxer)
+	return packfile.UpdateObjectStorageWithStatus(st, demuxer, statusChan)
 }
 
 // closeReader drains and closes r when it owns a closable resource (such as an

--- a/options.go
+++ b/options.go
@@ -250,6 +250,9 @@ type FetchOptions struct {
 	// Filter requests that the server to send only a subset of the objects.
 	// See https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--filterltfilter-specgtcode
 	Filter packp.Filter
+	// StatusChan receives structured packfile progress updates during fetch.
+	// If nil, no updates are sent.
+	StatusChan plumbing.StatusChan
 }
 
 // Validate validates the fields and sets the default values.
@@ -312,6 +315,9 @@ type PushOptions struct {
 	// Quiet indicates whether the server should suppress human-readable
 	// output.
 	Quiet bool
+	// StatusChan receives structured packfile progress updates during push.
+	// If nil, no updates are sent.
+	StatusChan plumbing.StatusChan
 }
 
 // ForceWithLease sets fields on the lease

--- a/plumbing/format/idxfile/encoder.go
+++ b/plumbing/format/idxfile/encoder.go
@@ -5,6 +5,7 @@ import (
 	"hash"
 	"io"
 
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/utils/binary"
 )
 
@@ -14,15 +15,23 @@ type encoder struct {
 	writer  io.Writer
 	hashSum func() []byte
 	idx     *MemoryIndex
+	status  plumbing.StatusChan
 }
 
 // stateFnEncode defines each individual state within the state machine that
 // represents encoding an idxfile.
 type stateFnEncode func(*encoder) (stateFnEncode, error)
 
-// Encode encodes a MemoryIndex to the writer.
-// This function is safe to call concurrently with different parameters.
+// Encode encodes a MemoryIndex to the writer. This function is safe to call
+// concurrently with different parameters.
 func Encode(w io.Writer, h hash.Hash, idx *MemoryIndex) error {
+	return EncodeWithStatus(w, h, idx, nil)
+}
+
+// EncodeWithStatus encodes a MemoryIndex to the writer and reports progress to
+// statusChan. This function is safe to call concurrently with different
+// parameters.
+func EncodeWithStatus(w io.Writer, h hash.Hash, idx *MemoryIndex, statusChan plumbing.StatusChan) error {
 	if w == nil {
 		return fmt.Errorf("nil writer")
 	}
@@ -35,6 +44,7 @@ func Encode(w io.Writer, h hash.Hash, idx *MemoryIndex) error {
 		writer:  io.MultiWriter(w, h),
 		hashSum: func() []byte { return h.Sum(nil) },
 		idx:     idx,
+		status:  statusChan,
 	}
 
 	for state := writeHeader; state != nil; {
@@ -76,6 +86,9 @@ func writeFanout(e *encoder) (stateFnEncode, error) {
 }
 
 func writeHashes(e *encoder) (stateFnEncode, error) {
+	update := newIndexStatusUpdate(e.idx, plumbing.StatusIndexHash)
+	e.status.SendUpdate(update)
+
 	for k := range fanout {
 		pos := e.idx.FanoutMapping[k]
 		if pos == noMapping {
@@ -90,12 +103,17 @@ func writeHashes(e *encoder) (stateFnEncode, error) {
 		if err != nil {
 			return nil, err
 		}
+		update.ObjectsDone = int(e.idx.Fanout[k])
+		e.status.SendUpdateIfPossible(update)
 	}
 
 	return writeCRC32, nil
 }
 
 func writeCRC32(e *encoder) (stateFnEncode, error) {
+	update := newIndexStatusUpdate(e.idx, plumbing.StatusIndexCRC)
+	e.status.SendUpdate(update)
+
 	for k := range fanout {
 		pos := e.idx.FanoutMapping[k]
 		if pos == noMapping {
@@ -110,12 +128,17 @@ func writeCRC32(e *encoder) (stateFnEncode, error) {
 		if err != nil {
 			return nil, err
 		}
+		update.ObjectsDone = int(e.idx.Fanout[k])
+		e.status.SendUpdateIfPossible(update)
 	}
 
 	return writeOffsets, nil
 }
 
 func writeOffsets(e *encoder) (stateFnEncode, error) {
+	update := newIndexStatusUpdate(e.idx, plumbing.StatusIndexOffset)
+	e.status.SendUpdate(update)
+
 	for k := range fanout {
 		pos := e.idx.FanoutMapping[k]
 		if pos == noMapping {
@@ -130,6 +153,8 @@ func writeOffsets(e *encoder) (stateFnEncode, error) {
 		if err != nil {
 			return nil, err
 		}
+		update.ObjectsDone = int(e.idx.Fanout[k])
+		e.status.SendUpdateIfPossible(update)
 	}
 
 	if len(e.idx.Offset64) > 0 {
@@ -140,6 +165,14 @@ func writeOffsets(e *encoder) (stateFnEncode, error) {
 	}
 
 	return writeChecksums, nil
+}
+
+func newIndexStatusUpdate(idx *MemoryIndex, stage plumbing.StatusStage) plumbing.StatusUpdate {
+	count, _ := idx.Count()
+	return plumbing.StatusUpdate{
+		Stage:        stage,
+		ObjectsTotal: int(count),
+	}
 }
 
 func writeChecksums(e *encoder) (stateFnEncode, error) {

--- a/plumbing/format/idxfile/encoder_test.go
+++ b/plumbing/format/idxfile/encoder_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/plumbing"
 	. "github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/plumbing/hash"
 )
@@ -191,5 +192,45 @@ func TestDecodeEncode(t *testing.T) {
 
 		assert.Len(t, expected, result.Len())
 		assert.Equal(t, expected, result.Bytes())
+	}
+}
+
+func TestEncodeWithStatus(t *testing.T) {
+	t.Parallel()
+
+	fixture := fixtures.ByTag("packfile").One()
+	idxFile, err := fixture.Idx()
+	require.NoError(t, err)
+
+	idx := NewMemoryIndex(crypto.SHA1.Size())
+	require.NoError(t, NewDecoder(idxFile, hash.New(crypto.SHA1)).Decode(idx))
+	count, err := idx.Count()
+	require.NoError(t, err)
+	occupiedBuckets := 0
+	var previous uint32
+	for _, cumulative := range idx.Fanout {
+		if cumulative != previous {
+			occupiedBuckets++
+			previous = cumulative
+		}
+	}
+	assert.Greater(t, int(count), occupiedBuckets)
+
+	updates := make(chan plumbing.StatusUpdate, 1024)
+	require.NoError(t, EncodeWithStatus(io.Discard, hash.New(crypto.SHA1), idx, updates))
+	close(updates)
+
+	last := make(map[plumbing.StatusStage]plumbing.StatusUpdate)
+	for update := range updates {
+		last[update.Stage] = update
+	}
+	for _, stage := range []plumbing.StatusStage{
+		plumbing.StatusIndexHash,
+		plumbing.StatusIndexCRC,
+		plumbing.StatusIndexOffset,
+	} {
+		update, ok := last[stage]
+		require.True(t, ok)
+		assert.Equal(t, update.ObjectsTotal, update.ObjectsDone)
 	}
 }

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/utils/ioutil"
@@ -28,6 +29,12 @@ const (
 // UpdateObjectStorage updates the storer with the objects in the given
 // packfile.
 func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
+	return UpdateObjectStorageWithStatus(s, packfile, nil)
+}
+
+// UpdateObjectStorageWithStatus updates the storer with the objects in the
+// given packfile and reports progress to statusChan.
+func UpdateObjectStorageWithStatus(s storer.Storer, packfile io.Reader, statusChan plumbing.StatusChan) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -36,7 +43,7 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
 	}
 
 	if pw, ok := s.(storer.PackfileWriter); ok {
-		return WritePackfileToObjectStorage(pw, packfile)
+		return WritePackfileToObjectStorageWithStatus(pw, packfile, statusChan)
 	}
 
 	of := formatcfg.DefaultObjectFormat
@@ -47,7 +54,11 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
 		}
 	}
 
-	p := NewParser(packfile, WithStorage(s), WithObjectFormat(of))
+	opts := []ParserOption{WithStorage(s), WithObjectFormat(of)}
+	if statusChan != nil {
+		opts = append(opts, WithScannerObservers(NewStatusObserver(statusChan)))
+	}
+	p := NewParser(packfile, opts...)
 	_, err := p.Parse()
 	return err
 }
@@ -57,8 +68,23 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
 func WritePackfileToObjectStorage(
 	sw storer.PackfileWriter,
 	packfile io.Reader,
+) error {
+	return WritePackfileToObjectStorageWithStatus(sw, packfile, nil)
+}
+
+// WritePackfileToObjectStorageWithStatus writes all packfile objects to object
+// storage and reports progress to statusChan when the storage supports it.
+func WritePackfileToObjectStorageWithStatus(
+	sw storer.PackfileWriter,
+	packfile io.Reader,
+	statusChan plumbing.StatusChan,
 ) (err error) {
-	w, err := sw.PackfileWriter()
+	var w io.WriteCloser
+	if statusWriter, ok := sw.(storer.PackfileWriterWithStatus); ok {
+		w, err = statusWriter.PackfileWriterWithStatus(statusChan)
+	} else {
+		w, err = sw.PackfileWriter()
+	}
 	if err != nil {
 		return err
 	}

--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -48,7 +48,23 @@ func (dw *DeltaSelector) ObjectsToPack(
 	hashes []plumbing.Hash,
 	packWindow uint,
 ) ([]*ObjectToPack, error) {
-	otp, err := dw.objectsToPack(hashes, packWindow)
+	return dw.ObjectsToPackWithStatus(hashes, packWindow, nil)
+}
+
+// ObjectsToPackWithStatus creates a list of ObjectToPack values and reports
+// progress to statusChan.
+func (dw *DeltaSelector) ObjectsToPackWithStatus(
+	hashes []plumbing.Hash,
+	packWindow uint,
+	statusChan plumbing.StatusChan,
+) ([]*ObjectToPack, error) {
+	update := plumbing.StatusUpdate{
+		Stage:        plumbing.StatusRead,
+		ObjectsTotal: len(hashes),
+	}
+	statusChan.SendUpdate(update)
+
+	otp, err := dw.objectsToPack(hashes, packWindow, statusChan, update)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +73,17 @@ func (dw *DeltaSelector) ObjectsToPack(
 		return otp, nil
 	}
 
+	statusChan.SendUpdate(plumbing.StatusUpdate{
+		Stage:        plumbing.StatusSort,
+		ObjectsTotal: len(otp),
+	})
 	dw.sort(otp)
+
+	update = plumbing.StatusUpdate{
+		Stage:        plumbing.StatusDelta,
+		ObjectsTotal: len(otp),
+	}
+	statusChan.SendUpdate(update)
 
 	var objectGroups [][]*ObjectToPack
 	var prev *ObjectToPack
@@ -74,9 +100,10 @@ func (dw *DeltaSelector) ObjectsToPack(
 
 	var wg sync.WaitGroup
 	var once sync.Once
+	var updateMu sync.Mutex
 	for _, objs := range objectGroups {
 		wg.Go(func() {
-			if walkErr := dw.walk(objs, packWindow); walkErr != nil {
+			if walkErr := dw.walk(objs, packWindow, statusChan, &update, &updateMu); walkErr != nil {
 				once.Do(func() {
 					err = walkErr
 				})
@@ -95,6 +122,8 @@ func (dw *DeltaSelector) ObjectsToPack(
 func (dw *DeltaSelector) objectsToPack(
 	hashes []plumbing.Hash,
 	packWindow uint,
+	statusChan plumbing.StatusChan,
+	update plumbing.StatusUpdate,
 ) ([]*ObjectToPack, error) {
 	objectsToPack := make([]*ObjectToPack, 0, len(hashes))
 	for _, h := range hashes {
@@ -115,13 +144,15 @@ func (dw *DeltaSelector) objectsToPack(
 		}
 
 		objectsToPack = append(objectsToPack, otp)
+		update.ObjectsDone++
+		statusChan.SendUpdateIfPossible(update)
 	}
 
 	if packWindow == 0 {
 		return objectsToPack, nil
 	}
 
-	if err := dw.fixAndBreakChains(objectsToPack); err != nil {
+	if err := dw.fixAndBreakChains(objectsToPack, statusChan); err != nil {
 		return nil, err
 	}
 
@@ -141,7 +172,16 @@ func (dw *DeltaSelector) encodedObject(h plumbing.Hash) (plumbing.EncodedObject,
 	return dw.storer.EncodedObject(plumbing.AnyObject, h)
 }
 
-func (dw *DeltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error {
+func (dw *DeltaSelector) fixAndBreakChains(
+	objectsToPack []*ObjectToPack,
+	statusChan plumbing.StatusChan,
+) error {
+	update := plumbing.StatusUpdate{
+		Stage:        plumbing.StatusFixChains,
+		ObjectsTotal: len(objectsToPack),
+	}
+	statusChan.SendUpdate(update)
+
 	m := make(map[plumbing.Hash]*ObjectToPack, len(objectsToPack))
 	for _, otp := range objectsToPack {
 		m[otp.Hash()] = otp
@@ -151,6 +191,8 @@ func (dw *DeltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error 
 		if err := dw.fixAndBreakChainsOne(m, otp); err != nil {
 			return err
 		}
+		update.ObjectsDone++
+		statusChan.SendUpdateIfPossible(update)
 	}
 
 	return nil
@@ -228,8 +270,21 @@ func (dw *DeltaSelector) sort(objectsToPack []*ObjectToPack) {
 func (dw *DeltaSelector) walk(
 	objectsToPack []*ObjectToPack,
 	packWindow uint,
+	statusChan plumbing.StatusChan,
+	update *plumbing.StatusUpdate,
+	updateMu *sync.Mutex,
 ) error {
 	indexMap := make(map[plumbing.Hash]*deltaIndex)
+	sendUpdate := func() {
+		if statusChan == nil {
+			return
+		}
+		updateMu.Lock()
+		defer updateMu.Unlock()
+		update.ObjectsDone++
+		statusChan.SendUpdateIfPossible(*update)
+	}
+
 	for i := range len(objectsToPack) {
 		// Clean up the index map and reconstructed delta objects for anything
 		// outside our pack window, to save memory.
@@ -250,11 +305,13 @@ func (dw *DeltaSelector) walk(
 		// object. This happens when a delta is set to be reused from an existing
 		// packfile.
 		if target.IsDelta() {
+			sendUpdate()
 			continue
 		}
 
 		// We only want to create deltas from specific types.
 		if !applyDelta[target.Type()] {
+			sendUpdate()
 			continue
 		}
 
@@ -271,6 +328,7 @@ func (dw *DeltaSelector) walk(
 				return err
 			}
 		}
+		sendUpdate()
 	}
 
 	return nil

--- a/plumbing/format/packfile/delta_selector_test.go
+++ b/plumbing/format/packfile/delta_selector_test.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -215,9 +216,11 @@ func (s *DeltaSelectorSuite) TestObjectsToPack() {
 
 	// Don't sort so we can easily check the sliding window without
 	// creating a bunch of new objects.
-	otp, err = s.ds.objectsToPack(hashes, deltaWindowSize)
+	otp, err = s.ds.objectsToPack(hashes, deltaWindowSize, nil, plumbing.StatusUpdate{})
 	s.NoError(err)
-	err = s.ds.walk(otp, deltaWindowSize)
+	walkUpdate := plumbing.StatusUpdate{}
+	var walkMu sync.Mutex
+	err = s.ds.walk(otp, deltaWindowSize, nil, &walkUpdate, &walkMu)
 	s.NoError(err)
 	s.Len(otp, int(deltaWindowSize)+2)
 	targetIdx := len(otp) - 1
@@ -239,4 +242,22 @@ func (s *DeltaSelectorSuite) TestObjectsToPack() {
 func (s *DeltaSelectorSuite) TestMaxDepth() {
 	dsl := s.ds.deltaSizeLimit(0, 0, int(maxDepth), true)
 	s.Equal(int64(0), dsl)
+}
+
+func (s *DeltaSelectorSuite) TestObjectsToPackWithStatus() {
+	hashes := []plumbing.Hash{s.hashes["base"], s.hashes["target"]}
+	updates := make(chan plumbing.StatusUpdate, 50)
+
+	_, err := s.ds.ObjectsToPackWithStatus(hashes, 10, updates)
+	s.NoError(err)
+	close(updates)
+
+	stages := make(map[plumbing.StatusStage]bool)
+	for update := range updates {
+		stages[update.Stage] = true
+	}
+	s.True(stages[plumbing.StatusRead])
+	s.True(stages[plumbing.StatusFixChains])
+	s.True(stages[plumbing.StatusSort])
+	s.True(stages[plumbing.StatusDelta])
 }

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -23,6 +23,14 @@ type ObjectSelector interface {
 	ObjectsToPack(hashes []plumbing.Hash, packWindow uint) ([]*ObjectToPack, error)
 }
 
+type statusObjectSelector interface {
+	ObjectsToPackWithStatus(
+		hashes []plumbing.Hash,
+		packWindow uint,
+		statusChan plumbing.StatusChan,
+	) ([]*ObjectToPack, error)
+}
+
 // Encoder gets the data from the storage and write it into the writer in PACK
 // format.
 //
@@ -39,6 +47,7 @@ type Encoder struct {
 	hasher         hash.Hash
 
 	useRefDeltas bool
+	statusChan   plumbing.StatusChan
 }
 
 // EncoderOption configures an Encoder at construction time.
@@ -63,6 +72,14 @@ func WithObjectSelector(s ObjectSelector) EncoderOption {
 		if s != nil {
 			e.objectSelector = s
 		}
+	}
+}
+
+// WithStatusChan configures the encoder to report structured packfile
+// progress to statusChan.
+func WithStatusChan(statusChan plumbing.StatusChan) EncoderOption {
+	return func(e *Encoder) {
+		e.statusChan = statusChan
 	}
 }
 
@@ -120,7 +137,13 @@ func (e *Encoder) Encode(
 	hashes []plumbing.Hash,
 	packWindow uint,
 ) (plumbing.Hash, error) {
-	objects, err := e.objectSelector.ObjectsToPack(hashes, packWindow)
+	var objects []*ObjectToPack
+	var err error
+	if selector, ok := e.objectSelector.(statusObjectSelector); ok && e.statusChan != nil {
+		objects, err = selector.ObjectsToPackWithStatus(hashes, packWindow, e.statusChan)
+	} else {
+		objects, err = e.objectSelector.ObjectsToPack(hashes, packWindow)
+	}
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -129,6 +152,12 @@ func (e *Encoder) Encode(
 }
 
 func (e *Encoder) encode(objects []*ObjectToPack) (plumbing.Hash, error) {
+	update := plumbing.StatusUpdate{
+		Stage:        plumbing.StatusSend,
+		ObjectsTotal: len(objects),
+	}
+	e.statusChan.SendUpdate(update)
+
 	if err := e.head(len(objects)); err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -137,6 +166,8 @@ func (e *Encoder) encode(objects []*ObjectToPack) (plumbing.Hash, error) {
 		if err := e.entry(o); err != nil {
 			return plumbing.ZeroHash, err
 		}
+		update.ObjectsDone++
+		e.statusChan.SendUpdateIfPossible(update)
 	}
 
 	return e.footer()

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -95,6 +95,30 @@ func (s *EncoderSuite) TestHashNotFound() {
 	s.ErrorIs(err, plumbing.ErrObjectNotFound)
 }
 
+func (s *EncoderSuite) TestWithStatusChan() {
+	o := &plumbing.MemoryObject{}
+	o.SetType(plumbing.BlobObject)
+	o.SetSize(0)
+	_, err := s.store.SetEncodedObject(o)
+	s.NoError(err)
+
+	updates := make(chan plumbing.StatusUpdate, 50)
+	s.enc = NewEncoder(s.buf, s.store, false, WithStatusChan(updates))
+	_, err = s.enc.Encode([]plumbing.Hash{o.Hash()}, 10)
+	s.NoError(err)
+	close(updates)
+
+	var lastSend plumbing.StatusUpdate
+	for update := range updates {
+		if update.Stage == plumbing.StatusSend {
+			lastSend = update
+		}
+	}
+	s.Equal(plumbing.StatusSend, lastSend.Stage)
+	s.Equal(1, lastSend.ObjectsTotal)
+	s.Equal(1, lastSend.ObjectsDone)
+}
+
 func (s *EncoderSuite) TestDecodeEncodeWithDeltaDecodeREF() {
 	s.enc = NewEncoder(s.buf, s.store, true)
 	s.simpleDeltaTest()

--- a/plumbing/format/packfile/status_observer.go
+++ b/plumbing/format/packfile/status_observer.go
@@ -1,0 +1,44 @@
+package packfile
+
+import "github.com/go-git/go-git/v6/plumbing"
+
+// StatusObserver forwards packfile parsing progress to a StatusChan.
+type StatusObserver struct {
+	statusChan plumbing.StatusChan
+	update     plumbing.StatusUpdate
+}
+
+// NewStatusObserver returns an observer that sends packfile parsing progress
+// to statusChan. A nil statusChan makes the observer a no-op.
+func NewStatusObserver(statusChan plumbing.StatusChan) *StatusObserver {
+	return &StatusObserver{statusChan: statusChan}
+}
+
+// OnHeader reports the number of objects declared by the packfile header.
+func (o *StatusObserver) OnHeader(count uint32) error {
+	o.update = plumbing.StatusUpdate{
+		Stage:        plumbing.StatusFetch,
+		ObjectsTotal: int(count),
+	}
+	o.statusChan.SendUpdate(o.update)
+	return nil
+}
+
+// OnInflatedObjectHeader reports progress before advancing the completed
+// object count. The footer reports the sole completion update for the stage.
+func (o *StatusObserver) OnInflatedObjectHeader(plumbing.ObjectType, int64, int64) error {
+	o.statusChan.SendUpdate(o.update)
+	o.update.ObjectsDone++
+	return nil
+}
+
+// OnInflatedObjectContent is a no-op.
+func (*StatusObserver) OnInflatedObjectContent(plumbing.Hash, int64, uint32, []byte) error {
+	return nil
+}
+
+// OnFooter reports the final packfile parsing progress.
+func (o *StatusObserver) OnFooter(plumbing.Hash) error {
+	o.statusChan.SendUpdate(o.update)
+	return nil
+}

--- a/plumbing/revlist/object_walk.go
+++ b/plumbing/revlist/object_walk.go
@@ -21,21 +21,34 @@ type objectWalk struct {
 	havesSeen  map[plumbing.Hash]struct{}
 	seen       map[plumbing.Hash]struct{}
 	result     []plumbing.Hash
+	statusChan plumbing.StatusChan
+	update     plumbing.StatusUpdate
 }
 
-func newObjectWalk(s storer.EncodedObjectStorer) (*objectWalk, error) {
+func newObjectWalk(s storer.EncodedObjectStorer, statusChan plumbing.StatusChan) (*objectWalk, error) {
 	shallows, err := shallowSet(s)
 	if err != nil {
 		return nil, err
 	}
 
 	return &objectWalk{
-		s:         s,
-		shallows:  shallows,
-		wantsSeen: make(map[plumbing.Hash]struct{}),
-		havesSeen: make(map[plumbing.Hash]struct{}),
-		seen:      make(map[plumbing.Hash]struct{}),
+		s:          s,
+		shallows:   shallows,
+		wantsSeen:  make(map[plumbing.Hash]struct{}),
+		havesSeen:  make(map[plumbing.Hash]struct{}),
+		seen:       make(map[plumbing.Hash]struct{}),
+		statusChan: statusChan,
+		update:     plumbing.StatusUpdate{Stage: plumbing.StatusCount},
 	}, nil
+}
+
+func (w *objectWalk) addResult(hash plumbing.Hash) {
+	w.result = append(w.result, hash)
+	if w.statusChan == nil {
+		return
+	}
+	w.update.ObjectsTotal++
+	w.statusChan.SendUpdateIfPossible(w.update)
 }
 
 func shallowSet(s storer.EncodedObjectStorer) (map[plumbing.Hash]struct{}, error) {
@@ -88,19 +101,19 @@ func (w *objectWalk) seedWants(wants []plumbing.Hash) error {
 				return fmt.Errorf("decoding tag %s: %w", h, err)
 			}
 			w.seen[tag.Hash] = struct{}{}
-			w.result = append(w.result, tag.Hash)
+			w.addResult(tag.Hash)
 			wants = append(wants, tag.Target)
 		case plumbing.TreeObject:
 			t, err := object.GetTree(w.s, h)
 			if err != nil {
 				return fmt.Errorf("getting tree %s: %w", h, err)
 			}
-			if err := collectAllTreeObjects(w.s, t, w.seen, &w.result); err != nil {
+			if err := collectAllTreeObjects(w.s, t, w.seen, w.addResult); err != nil {
 				return err
 			}
 		case plumbing.BlobObject:
 			w.seen[h] = struct{}{}
-			w.result = append(w.result, h)
+			w.addResult(h)
 		default:
 			return fmt.Errorf("unsupported object type %s for %s", o.Type(), h)
 		}
@@ -309,14 +322,14 @@ func (w *objectWalk) walkFull() error {
 			continue
 		}
 		w.seen[lc.Hash] = struct{}{}
-		w.result = append(w.result, lc.Hash)
+		w.addResult(lc.Hash)
 
 		tree, err := lc.Tree()
 		if err != nil {
 			return fmt.Errorf("getting tree for %s: %w", lc.Hash, err)
 		}
 
-		if err := collectAllTreeObjects(w.s, tree, w.seen, &w.result); err != nil {
+		if err := collectAllTreeObjects(w.s, tree, w.seen, w.addResult); err != nil {
 			return fmt.Errorf("collecting tree objects for %s: %w", lc.Hash, err)
 		}
 
@@ -344,7 +357,7 @@ func (w *objectWalk) walkFull() error {
 func (w *objectWalk) processCommitTrees(lc *object.Commit) error {
 	if _, ok := w.seen[lc.Hash]; !ok {
 		w.seen[lc.Hash] = struct{}{}
-		w.result = append(w.result, lc.Hash)
+		w.addResult(lc.Hash)
 	}
 
 	newTree, err := lc.Tree()
@@ -368,7 +381,7 @@ func (w *objectWalk) processCommitTrees(lc *object.Commit) error {
 		oldTrees = append(oldTrees, pt)
 	}
 
-	if err := collectChangedTreeObjects(w.s, newTree, oldTrees, w.seen, &w.result); err != nil {
+	if err := collectChangedTreeObjects(w.s, newTree, oldTrees, w.seen, w.addResult); err != nil {
 		return fmt.Errorf("diffing trees for %s: %w", lc.Hash, err)
 	}
 
@@ -395,7 +408,7 @@ func collectChangedTreeObjects(
 	newTree *object.Tree,
 	oldTrees []*object.Tree,
 	seen map[plumbing.Hash]struct{},
-	result *[]plumbing.Hash,
+	addResult func(plumbing.Hash),
 ) error {
 	// If newTree matches any old tree exactly, nothing changed.
 	for _, ot := range oldTrees {
@@ -406,7 +419,7 @@ func collectChangedTreeObjects(
 
 	if _, ok := seen[newTree.Hash]; !ok {
 		seen[newTree.Hash] = struct{}{}
-		*result = append(*result, newTree.Hash)
+		addResult(newTree.Hash)
 	}
 
 	// Build per-parent entry indexes for O(1) lookup.
@@ -459,12 +472,12 @@ func collectChangedTreeObjects(
 					}
 				}
 			}
-			if err := collectChangedTreeObjects(s, newSub, oldSubs, seen, result); err != nil {
+			if err := collectChangedTreeObjects(s, newSub, oldSubs, seen, addResult); err != nil {
 				return err
 			}
 		} else {
 			seen[e.Hash] = struct{}{}
-			*result = append(*result, e.Hash)
+			addResult(e.Hash)
 		}
 	}
 
@@ -478,13 +491,13 @@ func collectAllTreeObjects(
 	s storer.EncodedObjectStorer,
 	t *object.Tree,
 	seen map[plumbing.Hash]struct{},
-	result *[]plumbing.Hash,
+	addResult func(plumbing.Hash),
 ) error {
 	if _, ok := seen[t.Hash]; ok {
 		return nil
 	}
 	seen[t.Hash] = struct{}{}
-	*result = append(*result, t.Hash)
+	addResult(t.Hash)
 
 	for _, e := range t.Entries {
 		if e.Mode == filemode.Submodule {
@@ -498,12 +511,12 @@ func collectAllTreeObjects(
 			if err != nil {
 				return fmt.Errorf("getting subtree %s: %w", e.Hash, err)
 			}
-			if err := collectAllTreeObjects(s, sub, seen, result); err != nil {
+			if err := collectAllTreeObjects(s, sub, seen, addResult); err != nil {
 				return err
 			}
 		} else {
 			seen[e.Hash] = struct{}{}
-			*result = append(*result, e.Hash)
+			addResult(e.Hash)
 		}
 	}
 	return nil

--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -24,11 +24,31 @@ func Objects(
 	wants,
 	haves []plumbing.Hash,
 ) ([]plumbing.Hash, error) {
+	return ObjectsWithStatus(s, wants, haves, nil)
+}
+
+// ObjectsWithStatus computes object hashes reachable from wants while
+// excluding commits reachable from haves and reports progress to statusChan.
+func ObjectsWithStatus(
+	s storer.EncodedObjectStorer,
+	wants,
+	haves []plumbing.Hash,
+	statusChan plumbing.StatusChan,
+) ([]plumbing.Hash, error) {
+	update := plumbing.StatusUpdate{Stage: plumbing.StatusCount}
+	statusChan.SendUpdate(update)
+
 	if walker, ok := s.(objectWalker); ok {
-		return walker.RevListObjects(wants, haves)
+		result, err := walker.RevListObjects(wants, haves)
+		if err != nil {
+			return nil, err
+		}
+		update.ObjectsTotal = len(result)
+		statusChan.SendUpdate(update)
+		return result, nil
 	}
 
-	w, err := newObjectWalk(s)
+	w, err := newObjectWalk(s, statusChan)
 	if err != nil {
 		return nil, err
 	}
@@ -41,6 +61,8 @@ func Objects(
 	if err := w.walk(); err != nil {
 		return nil, err
 	}
+	update.ObjectsTotal = len(w.result)
+	statusChan.SendUpdate(update)
 	return w.result, nil
 }
 

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -883,3 +883,21 @@ func BenchmarkObjects(b *testing.B) {
 		}
 	}
 }
+
+func (s *RevListSuite) TestObjectsWithStatus() {
+	updates := make(chan plumbing.StatusUpdate, 200)
+	result, err := ObjectsWithStatus(s.Storer,
+		[]plumbing.Hash{plumbing.NewHash(secondCommit)}, nil, updates)
+	s.Require().NoError(err)
+	s.NotEmpty(result)
+	close(updates)
+
+	var finalCount plumbing.StatusUpdate
+	for update := range updates {
+		if update.Stage == plumbing.StatusCount {
+			finalCount = update
+		}
+	}
+	s.Equal(plumbing.StatusCount, finalCount.Stage)
+	s.Len(result, finalCount.ObjectsTotal)
+}

--- a/plumbing/status.go
+++ b/plumbing/status.go
@@ -1,0 +1,70 @@
+package plumbing
+
+// StatusStage identifies a stage of packfile processing.
+type StatusStage int
+
+const (
+	// StatusCount counts objects selected by a revision walk.
+	StatusCount StatusStage = iota
+	// StatusRead reads objects from storage for pack generation.
+	StatusRead
+	// StatusFixChains fixes or breaks existing delta chains.
+	StatusFixChains
+	// StatusSort sorts objects before delta selection.
+	StatusSort
+	// StatusDelta selects delta bases for objects.
+	StatusDelta
+	// StatusSend writes objects to an outgoing packfile.
+	StatusSend
+	// StatusFetch reads objects from an incoming packfile.
+	StatusFetch
+	// StatusIndexHash writes object hashes to a pack index.
+	StatusIndexHash
+	// StatusIndexCRC writes object CRC values to a pack index.
+	StatusIndexCRC
+	// StatusIndexOffset writes object offsets to a pack index.
+	StatusIndexOffset
+	// StatusDone is reserved for an overall packfile completion update.
+	StatusDone
+
+	// StatusUnknown indicates an unknown packfile processing stage.
+	StatusUnknown StatusStage = -1
+)
+
+// StatusUpdate reports object-level progress for a packfile processing stage.
+type StatusUpdate struct {
+	Stage StatusStage
+
+	ObjectsTotal int
+	ObjectsDone  int
+}
+
+// StatusChan receives structured packfile progress updates. Callers must drain
+// a non-nil channel concurrently until the operation returns: stage-start and
+// stage-completion updates are delivered synchronously.
+type StatusChan chan<- StatusUpdate
+
+// SendUpdate sends update to sc. A nil StatusChan is a no-op.
+func (sc StatusChan) SendUpdate(update StatusUpdate) {
+	if sc == nil {
+		return
+	}
+	sc <- update
+}
+
+// SendUpdateIfPossible sends update without blocking, except that completion
+// updates are always delivered. A nil StatusChan is a no-op.
+func (sc StatusChan) SendUpdateIfPossible(update StatusUpdate) {
+	if sc == nil {
+		return
+	}
+	if update.ObjectsDone == update.ObjectsTotal {
+		sc <- update
+		return
+	}
+
+	select {
+	case sc <- update:
+	default:
+	}
+}

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -99,6 +99,13 @@ type PackfileWriter interface {
 	PackfileWriter() (io.WriteCloser, error)
 }
 
+// PackfileWriterWithStatus is an optional extension to PackfileWriter that
+// reports progress while writing a packfile.
+type PackfileWriterWithStatus interface {
+	PackfileWriter
+	PackfileWriterWithStatus(statusChan plumbing.StatusChan) (io.WriteCloser, error)
+}
+
 // EncodedObjectIter is a generic closable interface for iterating over objects.
 type EncodedObjectIter interface {
 	Next() (plumbing.EncodedObject, error)

--- a/plumbing/transport/fetch.go
+++ b/plumbing/transport/fetch.go
@@ -36,7 +36,7 @@ func FetchPack(
 		reader = demuxer
 	}
 
-	if err := packfile.UpdateObjectStorage(st, reader); err != nil {
+	if err := packfile.UpdateObjectStorageWithStatus(st, reader, req.StatusChan); err != nil {
 		return err
 	}
 

--- a/plumbing/transport/http/dumb.go
+++ b/plumbing/transport/http/dumb.go
@@ -42,7 +42,7 @@ func (s *dumbPackSession) fetchDumb(ctx context.Context, st storage.Storer, req 
 	}
 
 	repoFs := fsi.Filesystem()
-	r := newFetchWalker(ctx, s, st, repoFs)
+	r := newFetchWalker(ctx, s, st, repoFs, req.StatusChan)
 	if err := r.process(); err != nil {
 		return err
 	}
@@ -64,9 +64,10 @@ type fetchWalker struct {
 	fs         billy.Filesystem
 	queue      []plumbing.Hash
 	packIdx    map[plumbing.Hash]string
+	statusChan plumbing.StatusChan
 }
 
-func newFetchWalker(ctx context.Context, s *dumbPackSession, st storage.Storer, fs billy.Filesystem) *fetchWalker {
+func newFetchWalker(ctx context.Context, s *dumbPackSession, st storage.Storer, fs billy.Filesystem, statusChan plumbing.StatusChan) *fetchWalker {
 	return &fetchWalker{
 		ctx:        ctx,
 		client:     s.client,
@@ -77,6 +78,7 @@ func newFetchWalker(ctx context.Context, s *dumbPackSession, st storage.Storer, 
 		fs:         fs,
 		queue:      make([]plumbing.Hash, 0),
 		packIdx:    make(map[plumbing.Hash]string),
+		statusChan: statusChan,
 	}
 }
 
@@ -406,7 +408,7 @@ LOOP:
 			return err
 		}
 
-		if err := packfile.UpdateObjectStorage(r.st, f); err != nil {
+		if err := packfile.UpdateObjectStorageWithStatus(r.st, f, r.statusChan); err != nil {
 			_ = f.Close()
 			return err
 		}

--- a/remote.go
+++ b/remote.go
@@ -200,7 +200,7 @@ func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRef
 	var hashesToPush []plumbing.Hash
 	// Avoid the expensive revlist operation if we're only doing deletes.
 	if !allDelete {
-		hashesToPush, err = revlist.Objects(r.s, objects, haves)
+		hashesToPush, err = revlist.ObjectsWithStatus(r.s, objects, haves, o.StatusChan)
 		if err != nil {
 			return err
 		}
@@ -523,6 +523,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 			Haves:       haves,
 			Depth:       o.Depth,
 			Progress:    o.Progress,
+			StatusChan:  o.StatusChan,
 			IncludeTags: isWildcard && o.Tags == plumbing.TagFollowing,
 			Filter:      o.Filter,
 		}
@@ -1510,7 +1511,7 @@ func pushHashes(
 	if !allDelete {
 		req.Packfile = rd
 		go func() {
-			e := packfile.NewEncoder(wr, s, useRefDeltas)
+			e := packfile.NewEncoder(wr, s, useRefDeltas, packfile.WithStatusChan(o.StatusChan))
 			if _, err := e.Encode(hs, config.Pack.Window); err != nil {
 				done <- wr.CloseWithError(err)
 				return

--- a/remote_test.go
+++ b/remote_test.go
@@ -546,6 +546,11 @@ func (m *mockPackfileWriter) PackfileWriter() (io.WriteCloser, error) {
 	return m.Storer.(storer.PackfileWriter).PackfileWriter()
 }
 
+func (m *mockPackfileWriter) PackfileWriterWithStatus(statusChan plumbing.StatusChan) (io.WriteCloser, error) {
+	m.PackfileWriterCalled = true
+	return m.Storer.(storer.PackfileWriterWithStatus).PackfileWriterWithStatus(statusChan)
+}
+
 func (s *RemoteSuite) TestFetchWithPackfileWriter() {
 	fs := s.TemporalFilesystem()
 
@@ -557,8 +562,10 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter() {
 	r := NewRemote(mock, &config.RemoteConfig{Name: "foo", URLs: []string{url}})
 
 	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	updates := make(chan plumbing.StatusUpdate, 256)
 	err := r.Fetch(&FetchOptions{
-		RefSpecs: []config.RefSpec{refspec},
+		RefSpecs:   []config.RefSpec{refspec},
+		StatusChan: updates,
 	})
 
 	s.NoError(err)
@@ -574,6 +581,16 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter() {
 
 	s.Equal(31, count)
 	s.True(mock.PackfileWriterCalled)
+	close(updates)
+
+	var finalFetch plumbing.StatusUpdate
+	for update := range updates {
+		if update.Stage == plumbing.StatusFetch {
+			finalFetch = update
+		}
+	}
+	s.Equal(31, finalFetch.ObjectsTotal)
+	s.Equal(31, finalFetch.ObjectsDone)
 }
 
 func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDate() {
@@ -719,10 +736,20 @@ func (s *RemoteSuite) TestPushToEmptyRepository() {
 	})
 
 	rs := config.RefSpec("refs/heads/*:refs/heads/*")
+	updates := make(chan plumbing.StatusUpdate, 512)
 	err = r.Push(&PushOptions{
-		RefSpecs: []config.RefSpec{rs},
+		RefSpecs:   []config.RefSpec{rs},
+		StatusChan: updates,
 	})
 	s.NoError(err)
+	close(updates)
+
+	stages := make(map[plumbing.StatusStage]bool)
+	for update := range updates {
+		stages[update.Stage] = true
+	}
+	s.True(stages[plumbing.StatusCount])
+	s.True(stages[plumbing.StatusSend])
 
 	iter, err := r.s.IterReferences()
 	s.NoError(err)

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -356,8 +356,14 @@ func (d *DotGit) DeleteReflog(name plumbing.ReferenceName) error {
 // NewObjectPack return a writer for a new packfile, it saves the packfile to
 // disk and also generates and save the index for the given packfile.
 func (d *DotGit) NewObjectPack() (*PackWriter, error) {
+	return d.NewObjectPackWithStatus(nil)
+}
+
+// NewObjectPackWithStatus returns a writer for a new packfile and reports
+// progress to statusChan.
+func (d *DotGit) NewObjectPackWithStatus(statusChan plumbing.StatusChan) (*PackWriter, error) {
 	cleanErr := d.cleanPackList()
-	pw, err := newPackWrite(d.fs, d.options.ObjectFormat, d.options.WriteReverseIndex)
+	pw, err := newPackWrite(d.fs, d.options.ObjectFormat, d.options.WriteReverseIndex, statusChan)
 	if err != nil {
 		return nil, errors.Join(cleanErr, err)
 	}

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -36,9 +36,10 @@ type PackWriter struct {
 	result   chan error
 	format   formatcfg.ObjectFormat
 	writeRev bool
+	status   plumbing.StatusChan
 }
 
-func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev bool) (*PackWriter, error) {
+func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev bool, statusChan plumbing.StatusChan) (*PackWriter, error) {
 	fw, err := fs.TempFile(fs.Join(objectsPath, packPath), "tmp_pack_")
 	if err != nil {
 		return nil, err
@@ -57,6 +58,7 @@ func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev b
 		result:   make(chan error),
 		format:   format,
 		writeRev: writeRev,
+		status:   statusChan,
 	}
 
 	writer.checksum.ResetBySize(format.Size())
@@ -69,8 +71,12 @@ func (w *PackWriter) buildIndex() {
 	w.writer = new(idxfile.Writer)
 	var err error
 
+	observers := []packfile.Observer{w.writer}
+	if w.status != nil {
+		observers = append(observers, packfile.NewStatusObserver(w.status))
+	}
 	w.parser = packfile.NewParser(w.synced,
-		packfile.WithScannerObservers(w.writer),
+		packfile.WithScannerObservers(observers...),
 		packfile.WithObjectFormat(w.format))
 
 	h, err := w.parser.Parse()
@@ -232,7 +238,7 @@ func (w *PackWriter) encodeIdx(writer io.Writer, h hash.Hash) error {
 		return err
 	}
 
-	return idxfile.Encode(writer, h, idx)
+	return idxfile.EncodeWithStatus(writer, h, idx, w.status)
 }
 
 func (w *PackWriter) encodeRev(writer io.Writer, h hash.Hash) error {

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -26,7 +26,7 @@ func BenchmarkNewObjectPack(b *testing.B) {
 	fs := osfs.New(b.TempDir())
 
 	for b.Loop() {
-		w, err := newPackWrite(fs, config.SHA1, false)
+		w, err := newPackWrite(fs, config.SHA1, false, nil)
 
 		require.NoError(b, err)
 		pf, pfErr := f.Packfile()
@@ -159,7 +159,7 @@ func TestPackWriterUnusedNotify(t *testing.T) {
 	t.Parallel()
 	fs := osfs.New(t.TempDir())
 
-	w, err := newPackWrite(fs, config.SHA1, false)
+	w, err := newPackWrite(fs, config.SHA1, false, nil)
 	require.NoError(t, err)
 
 	w.Notify = func(_ plumbing.Hash, _ *idxfile.Writer) {

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -433,11 +433,17 @@ func (s *ObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 
 // PackfileWriter returns a writer for creating a new packfile.
 func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
+	return s.PackfileWriterWithStatus(nil)
+}
+
+// PackfileWriterWithStatus returns a writer for creating a new packfile and
+// reports progress to statusChan.
+func (s *ObjectStorage) PackfileWriterWithStatus(statusChan plumbing.StatusChan) (io.WriteCloser, error) {
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
 
-	w, err := s.dir.NewObjectPack()
+	w, err := s.dir.NewObjectPackWithStatus(statusChan)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/tests/storage_test.go
+++ b/storage/tests/storage_test.go
@@ -127,6 +127,48 @@ func TestPackfileWriter(t *testing.T) {
 	})
 }
 
+func TestPackfileWriterStatusChan(t *testing.T) {
+	t.Parallel()
+
+	forEachStorage(t, func(sto Storer, t *testing.T) {
+		pwr, ok := sto.(storer.PackfileWriterWithStatus)
+		if !ok {
+			t.Skip("not a PackfileWriter")
+		}
+
+		updates := make(chan plumbing.StatusUpdate, 32)
+		drainDone := make(chan struct{})
+		var lastFetch plumbing.StatusUpdate
+		fetchCompletions := 0
+		go func() {
+			defer close(drainDone)
+			for update := range updates {
+				if update.Stage == plumbing.StatusFetch {
+					lastFetch = update
+					if update.ObjectsDone == update.ObjectsTotal {
+						fetchCompletions++
+					}
+				}
+			}
+		}()
+
+		pw, err := pwr.PackfileWriterWithStatus(updates)
+		require.NoError(t, err)
+		pf, err := fixtures.Basic().One().Packfile()
+		require.NoError(t, err)
+		_, err = io.Copy(pw, pf)
+		require.NoError(t, err)
+		require.NoError(t, pw.Close())
+		close(updates)
+		<-drainDone
+
+		assert.Equal(t, plumbing.StatusFetch, lastFetch.Stage)
+		assert.Equal(t, 31, lastFetch.ObjectsTotal)
+		assert.Equal(t, 31, lastFetch.ObjectsDone)
+		assert.Equal(t, 1, fetchCompletions)
+	})
+}
+
 func TestDeltaObjectStorer(t *testing.T) {
 	t.Parallel()
 

--- a/storage/transactional/storage.go
+++ b/storage/transactional/storage.go
@@ -148,6 +148,14 @@ func (s *packageWriter) PackfileWriter() (io.WriteCloser, error) {
 	return s.pw.PackfileWriter()
 }
 
+// PackfileWriterWithStatus honors storer.PackfileWriterWithStatus.
+func (s *packageWriter) PackfileWriterWithStatus(statusChan plumbing.StatusChan) (io.WriteCloser, error) {
+	if pw, ok := s.pw.(storer.PackfileWriterWithStatus); ok {
+		return pw.PackfileWriterWithStatus(statusChan)
+	}
+	return s.pw.PackfileWriter()
+}
+
 func (s *reflogBasic) Reflog(name plumbing.ReferenceName) ([]*reflog.Entry, error) {
 	return s.reflog.Reflog(name)
 }
@@ -162,5 +170,13 @@ func (s *reflogBasic) DeleteReflog(name plumbing.ReferenceName) error {
 
 // PackfileWriter honors storer.PackfileWriter.
 func (s *reflogPackageWriter) PackfileWriter() (io.WriteCloser, error) {
+	return s.pw.PackfileWriter()
+}
+
+// PackfileWriterWithStatus honors storer.PackfileWriterWithStatus.
+func (s *reflogPackageWriter) PackfileWriterWithStatus(statusChan plumbing.StatusChan) (io.WriteCloser, error) {
+	if pw, ok := s.pw.(storer.PackfileWriterWithStatus); ok {
+		return pw.PackfileWriterWithStatus(statusChan)
+	}
 	return s.pw.PackfileWriter()
 }


### PR DESCRIPTION
Assisted-by: Codex gpt-5.6-sol

• Add structured packfile progress reporting through fetch, push, revision walking, delta selection, pack encoding, storage writes, and index generation, while preserving existing v6 APIs. Includes accurate idx progress counts, a single terminal fetch update, nil-channel handling, and regression coverage.

@pjbgf I'm happy to make architectural changes to align with the existing project.

Note that the original work came from the below, this  PR is a modernized adaptation to reduce forked behavior.

https://github.com/keybase/go-git/commit/e800f06a5841d52fe2d7243c3988250758549d96
https://github.com/keybase/go-git/commit/8a3371e49c338fd8854f4a9d555414041efd00a6
https://github.com/keybase/go-git/pull/3
https://github.com/keybase/go-git/pull/22