### PR TITLE
git: worktree, make the filesystem wrapper a symlink-safe boundary

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -954,6 +954,10 @@ func (w *Worktree) checkoutChangeSubmodule(fs *worktreeFilesystem,
 			return err
 		}
 
+		if err := w.clearBlockingSymlinks(fs, name); err != nil {
+			return err
+		}
+
 		if err := fs.MkdirAll(name, mode); err != nil {
 			return err
 		}
@@ -999,7 +1003,56 @@ func (w *Worktree) checkoutChangeRegularFile(cfg *config.Config,
 	return nil
 }
 
+// clearBlockingSymlinks removes a symlink that is in the way of
+// materialising name, so the checkout writes a real entry in its place
+// instead of following the link out of the worktree. Two cases:
+//
+//   - a leading directory component that is a symlink (e.g. "s" while
+//     writing "s/config", where "s" links to ".git"): OpenFile/MkdirAll
+//     would traverse it, so the write would land under the link's target.
+//   - the final component itself being a symlink (e.g. writing "s" while
+//     "s" links to ".git/config"): OpenFile with O_TRUNC, or Symlink,
+//     would follow/replace through it and clobber the target.
+//
+// A symlink can never be a legitimate parent of, or the destination for,
+// a tracked entry, so removing it is always correct. This mirrors upstream
+// Git's forced checkout, which unlinks a blocking symlink in the leading
+// path (create_directories) and unlinks an existing entry before
+// write_entry.
+// https://github.com/git/git/blob/v2.54.0/entry.c#L50
+func (w *Worktree) clearBlockingSymlinks(fs *worktreeFilesystem, name string) error {
+	var dirs []string
+	for dir := filepath.Dir(name); dir != "." && dir != "" && dir != string(filepath.Separator); dir = filepath.Dir(dir) {
+		dirs = append(dirs, dir)
+	}
+	// Leading components, shallowest-first: removing the shallowest symlink
+	// invalidates every component beneath it, so a single removal is enough.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		fi, err := fs.Lstat(dirs[i])
+		if err != nil {
+			continue
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fs.Remove(dirs[i])
+		}
+	}
+	// Final component: an existing symlink here would be followed by the
+	// subsequent OpenFile/Symlink/MkdirAll, so replace it.
+	if fi, err := fs.Lstat(name); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fs.Remove(name)
+	}
+	return nil
+}
+
 func (w *Worktree) checkoutFile(cfg *config.Config, fs *worktreeFilesystem, f *object.File) (err error) {
+	// checkoutFile is the materialisation boundary for tracked entries.
+	// Remove any blocking symlink first so the subsequent OpenFile or
+	// Symlink call writes the entry itself instead of following a planted
+	// final-component link in the underlying filesystem.
+	if err := w.clearBlockingSymlinks(fs, f.Name); err != nil {
+		return err
+	}
+
 	mode, err := f.Mode.ToOSFileMode()
 	if err != nil {
 		return err

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -116,6 +116,18 @@ func (w *Worktree) CherryPick(commitOpts *CommitOptions, ortStrategyOption OrtMe
 		return ErrCannotCherryPickWithoutCommitOptions
 	}
 
+	cfg, err := w.r.Config()
+	if err != nil {
+		return err
+	}
+
+	// Materialise changes through the same validating filesystem and
+	// checkout path as reset/checkout, so cherry-pick shares their
+	// leading-symlink handling, mode awareness (symlinks, exec bits,
+	// CRLF) and root reuse instead of writing raw bytes via Create.
+	fs, closeFS := w.reusableRootFS()
+	defer closeFS()
+
 	for _, commit := range commits {
 		var changes object.Changes
 		headRef, err := w.r.Head()
@@ -165,20 +177,14 @@ func (w *Worktree) CherryPick(commitOpts *CommitOptions, ortStrategyOption OrtMe
 				if to == nil {
 					continue
 				}
-				content, err := to.Contents()
-				if err != nil {
+				// change.Files names the *File after the tree leaf. The
+				// worktree write needs the full path so it lands at the
+				// right location and is validated by the wrapper.
+				to.Name = change.To.Name
+				if err := w.checkoutFile(cfg, fs, to); err != nil {
 					return err
 				}
-				name := change.To.Name
-				dstFile, err := w.filesystem.Create(name)
-				if err != nil {
-					return err
-				}
-				_, err = dstFile.Write([]byte(content))
-				if err != nil {
-					return err
-				}
-				if _, err := w.Add(name); err != nil {
+				if _, err := w.Add(to.Name); err != nil {
 					return err
 				}
 			}

--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -36,10 +36,25 @@ func defaultProtectNTFS() bool {
 	return true
 }
 
-// worktreeFilesystem wraps a billy.Filesystem and validates every path passed
-// to a mutating operation. This prevents writing to, or deleting from,
-// dangerous locations (e.g. .git/*, ../) regardless of which worktree
-// code path triggers the operation.
+// worktreeFilesystem wraps a billy.Filesystem and validates every path it
+// is handed, so worktree operations cannot use dangerous paths at the
+// boundary. Two layers apply:
+//
+//   - validPath rejects dangerous path *strings*: .git and its HFS+/NTFS
+//     variants, "..", control characters, volume names.
+//   - validNoLeadingSymlink rejects paths whose leading directories
+//     already exist on disk as symlinks, so a write or delete cannot
+//     follow a planted link out of the tree.
+//
+// Both layers run on every mutating operation (validWritePath) and every
+// read (validReadPath). Chroot additionally refuses a symlink as the final
+// component, so a sub-filesystem such as a submodule worktree cannot be
+// scoped to a redirected target.
+//
+// The wrapper intentionally stops at leading-component traversal. Callers
+// that need final-component no-follow semantics for materialisation
+// (checkoutFile) enforce that directly by removing the blocking symlink
+// before opening the destination path.
 type worktreeFilesystem struct {
 	billy.Filesystem
 	protectNTFS bool
@@ -51,7 +66,7 @@ func newWorktreeFilesystem(fs billy.Filesystem, protectNTFS, protectHFS bool) *w
 }
 
 func (sfs *worktreeFilesystem) Create(filename string) (billy.File, error) {
-	if err := sfs.validPath(filename); err != nil {
+	if err := sfs.validWritePath(filename); err != nil {
 		return nil, fmt.Errorf("create: %w", err)
 	}
 	return sfs.Filesystem.Create(filename)
@@ -65,7 +80,7 @@ func (sfs *worktreeFilesystem) Open(filename string) (billy.File, error) {
 }
 
 func (sfs *worktreeFilesystem) OpenFile(filename string, flag int, perm fs.FileMode) (billy.File, error) {
-	if err := sfs.validPath(filename); err != nil {
+	if err := sfs.validWritePath(filename); err != nil {
 		return nil, fmt.Errorf("openfile: %w", err)
 	}
 	return sfs.Filesystem.OpenFile(filename, flag, perm)
@@ -79,14 +94,14 @@ func (sfs *worktreeFilesystem) Stat(filename string) (os.FileInfo, error) {
 }
 
 func (sfs *worktreeFilesystem) Remove(filename string) error {
-	if err := sfs.validPath(filename); err != nil {
+	if err := sfs.validWritePath(filename); err != nil {
 		return fmt.Errorf("remove: %w", err)
 	}
 	return sfs.Filesystem.Remove(filename)
 }
 
 func (sfs *worktreeFilesystem) Rename(from, to string) error {
-	if err := sfs.validPath(from, to); err != nil {
+	if err := sfs.validWritePath(from, to); err != nil {
 		return fmt.Errorf("rename: %w", err)
 	}
 	return sfs.Filesystem.Rename(from, to)
@@ -107,7 +122,7 @@ func (sfs *worktreeFilesystem) Lstat(filename string) (os.FileInfo, error) {
 }
 
 func (sfs *worktreeFilesystem) Symlink(target, link string) error {
-	if err := sfs.validPath(link); err != nil {
+	if err := sfs.validWritePath(link); err != nil {
 		return fmt.Errorf("symlink: %w", err)
 	}
 	if err := sfs.validSymlinkName(link); err != nil {
@@ -132,7 +147,7 @@ func (sfs *worktreeFilesystem) MkdirAll(path string, perm fs.FileMode) error {
 	if path == "" || path == "." || path == "/" {
 		return nil
 	}
-	if err := sfs.validPath(path); err != nil {
+	if err := sfs.validWritePath(path); err != nil {
 		return fmt.Errorf("mkdirall: %w", err)
 	}
 	return sfs.Filesystem.MkdirAll(path, perm)
@@ -142,20 +157,33 @@ func (sfs *worktreeFilesystem) TempFile(_, _ string) (billy.File, error) {
 	return nil, fmt.Errorf("tempfile: %w", errUnsupportedOperation)
 }
 
-// validReadPath is like validPath but treats the empty string and "." as
-// valid references to the worktree root. Read-side operations on the root
-// (e.g. ReadDir(""), Lstat(".")) are legitimate; mutating the root itself
-// is not, so write-side operations continue to use validPath directly.
+// validReadPath is like validWritePath but treats the empty string and "."
+// as valid references to the worktree root. Read-side operations on the
+// root (e.g. ReadDir(""), Lstat(".")) are legitimate. Mutating the root
+// itself is not, so write-side operations reject it via validPath. Reads
+// are still refused through a leading symlink, so the wrapper never
+// follows a planted link even on the read surface.
 func (sfs *worktreeFilesystem) validReadPath(p string) error {
 	if p == "" || p == "." || p == "/" {
 		return nil
 	}
-	return sfs.validPath(p)
+	if err := sfs.validPath(p); err != nil {
+		return err
+	}
+	return sfs.validNoLeadingSymlink(p)
 }
 
 func (sfs *worktreeFilesystem) Chroot(path string) (billy.Filesystem, error) {
 	if err := sfs.validReadPath(path); err != nil {
 		return nil, fmt.Errorf("chroot: %w", err)
+	}
+	// Chroot scopes a sub-filesystem to path, so the final component must
+	// be a real directory too: a symlink there would silently redirect the
+	// scope (e.g. a submodule worktree) to a target outside the tree. This
+	// is the "valid path, wrong target" case that validNoLeadingSymlink,
+	// which only inspects leading components, does not cover.
+	if fi, err := sfs.Filesystem.Lstat(path); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("chroot: invalid path %q: is a symlink", path)
 	}
 	return sfs.Filesystem.Chroot(path)
 }
@@ -226,6 +254,50 @@ func (sfs *worktreeFilesystem) validPath(paths ...string) error {
 
 			if sfs.protectNTFS && !pathutil.WindowsValidPath(part) {
 				return fmt.Errorf("invalid path: %q", p)
+			}
+		}
+	}
+	return nil
+}
+
+// validWritePath validates paths for mutating operations. It layers the
+// filesystem-state check validNoLeadingSymlink on top of the string-only
+// checks in validPath, so a write can neither name a dangerous path nor
+// reach one by traversing an existing symlink. Every mutating method on
+// the wrapper funnels through here, so the leading-symlink invariant holds
+// for all worktree writers without each call site having to remember it.
+func (sfs *worktreeFilesystem) validWritePath(paths ...string) error {
+	if err := sfs.validPath(paths...); err != nil {
+		return err
+	}
+	return sfs.validNoLeadingSymlink(paths...)
+}
+
+// validNoLeadingSymlink rejects paths whose leading directory components
+// resolve through a symlink that already exists on the underlying
+// filesystem. validPath guards the path string. This guards the on-disk
+// state, so a write or delete cannot reach outside the worktree by
+// traversing a symlink that a tree or an earlier step left in place.
+//
+// This is the fail-closed backstop for the whole class. Callers that want
+// upstream's replace-and-continue behaviour (checkout) remove the blocking
+// symlink first via clearBlockingSymlinks, so no symlink remains when the
+// write reaches the wrapper. Callers that do not get a safe error,
+// matching upstream Git refusing rather than following the link. See
+// has_symlink_leading_path (symlinks.c) and the check_leading_path guard
+// in unlink_entry (entry.c).
+func (sfs *worktreeFilesystem) validNoLeadingSymlink(paths ...string) error {
+	for _, p := range paths {
+		for dir := filepath.Dir(p); dir != "." && dir != "" && dir != string(filepath.Separator); dir = filepath.Dir(dir) {
+			fi, err := sfs.Filesystem.Lstat(dir)
+			if err != nil {
+				// A missing ancestor is materialised as a real directory.
+				// Any other Lstat error is left for the operation itself
+				// to surface.
+				continue
+			}
+			if fi.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("invalid path %q: leading component %q is a symlink", p, dir)
 			}
 		}
 	}

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 	"testing"
 
+	billy "github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -356,6 +358,100 @@ func TestWorktreeFilesystemRejectsOpsOnPreExistingDotGitSymlink(t *testing.T) {
 	assertOpsRejected(t, fs, ".git/config")
 }
 
+// TestWorktreeFilesystemRejectsSymlinkTraversal pins the leading-path
+// symlink invariant at the wrapper boundary. Every operation on "s/<name>"
+// must be refused while "s" is an existing symlink, so no worktree code
+// path, read or write, can follow the link out of the worktree. The path
+// string is innocent, so validPath alone would allow it. validNoLeadingSymlink
+// is what catches it. Chroot is additionally refused when the final
+// component is itself a symlink, the "valid path, wrong target" case that
+// Submodule.Repository relies on.
+//
+// It runs against both memfs and osfs so real on-disk symlink semantics
+// are exercised alongside the pure abstraction.
+func TestWorktreeFilesystemRejectsSymlinkTraversal(t *testing.T) {
+	t.Parallel()
+
+	const wantSubstr = "is a symlink"
+
+	backends := []struct {
+		name   string
+		makeFS func(t *testing.T) billy.Filesystem
+	}{
+		{"memfs", func(*testing.T) billy.Filesystem { return memfs.New() }},
+		{"osfs", func(t *testing.T) billy.Filesystem { return osfs.New(t.TempDir()) }},
+	}
+
+	// symlinkFS wraps a fresh backend filesystem with "s" and "a/b/s"
+	// planted as symlinks. Each subtest gets its own, so the parallel
+	// subtests never share filesystem state.
+	symlinkFS := func(t *testing.T, makeFS func(*testing.T) billy.Filesystem) *worktreeFilesystem {
+		t.Helper()
+		base := makeFS(t)
+		require.NoError(t, base.MkdirAll("elsewhere", 0o755))
+		require.NoError(t, base.MkdirAll("a/b", 0o755))
+		if err := base.Symlink("elsewhere", "s"); err != nil {
+			if isSymlinkWindowsNonAdmin(err) {
+				t.Skipf("symlink creation requires elevated privileges: %v", err)
+			}
+			require.NoError(t, err)
+		}
+		require.NoError(t, base.Symlink("elsewhere", "a/b/s"))
+		return newWorktreeFilesystem(base, false, false)
+	}
+
+	for _, bk := range backends {
+		t.Run(bk.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, p := range []string{"s/file", "s/deeper/file", "a/b/s/file"} {
+				t.Run(p, func(t *testing.T) {
+					t.Parallel()
+					fs := symlinkFS(t, bk.makeFS)
+
+					_, err := fs.Create(p)
+					assert.ErrorContains(t, err, wantSubstr, "Create should reject %q", p)
+
+					_, err = fs.OpenFile(p, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+					assert.ErrorContains(t, err, wantSubstr, "OpenFile should reject %q", p)
+
+					_, err = fs.Open(p)
+					assert.ErrorContains(t, err, wantSubstr, "Open should reject read through symlink %q", p)
+
+					err = fs.MkdirAll(p, 0o755)
+					assert.ErrorContains(t, err, wantSubstr, "MkdirAll should reject %q", p)
+
+					err = fs.Symlink("target", p)
+					assert.ErrorContains(t, err, wantSubstr, "Symlink should reject %q", p)
+
+					err = fs.Rename("readme.md", p)
+					assert.ErrorContains(t, err, wantSubstr, "Rename should reject destination %q", p)
+
+					err = fs.Remove(p)
+					assert.ErrorContains(t, err, wantSubstr, "Remove should reject %q", p)
+				})
+			}
+
+			t.Run("Chroot through leading symlink", func(t *testing.T) {
+				t.Parallel()
+				fs := symlinkFS(t, bk.makeFS)
+				_, err := fs.Chroot("s/sub")
+				assert.ErrorContains(t, err, wantSubstr, "Chroot should reject a leading symlink")
+			})
+
+			// The submodule-scoping case: Submodule.Repository chroots into
+			// the tree-controlled submodule path. A symlink as the final
+			// component must not redirect the scope out of the worktree.
+			t.Run("Chroot onto symlink target", func(t *testing.T) {
+				t.Parallel()
+				fs := symlinkFS(t, bk.makeFS)
+				_, err := fs.Chroot("s")
+				assert.ErrorContains(t, err, wantSubstr, "Chroot should reject a symlink as the final component")
+			})
+		})
+	}
+}
+
 // assertOpsAllowed verifies the round-trip read/write surface for a path
 // the wrapper should accept: write a payload, read it back, and Lstat it.
 func assertOpsAllowed(t *testing.T, fs *worktreeFilesystem, p string) {
@@ -562,48 +658,260 @@ func TestCherryPickPathValidationMatchesGit(t *testing.T) {
 	}
 }
 
+func TestCherryPickDoesNotWriteThroughLeadingSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	r, err := PlainInit(dir, false)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	w, err := r.Worktree()
+	require.NoError(t, err)
+
+	require.NoError(t, util.WriteFile(w.Filesystem(), "README", []byte("init"), 0o644))
+	_, err = w.Add("README")
+	require.NoError(t, err)
+
+	initHash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	initCommit, err := r.CommitObject(initHash)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(dir, ".git", "config")
+	originalConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	attack := buildCommitWithEntry(t, r.Storer, initCommit, initHash, "s/config", filemode.Regular)
+
+	err = w.Filesystem().Symlink(".git", "s")
+	if err != nil && isSymlinkWindowsNonAdmin(err) {
+		t.Skipf("symlink creation requires elevated privileges on this platform: %v", err)
+	}
+	require.NoError(t, err)
+
+	err = w.CherryPick(
+		&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true},
+		TheirsMergeStrategy, attack,
+	)
+	require.NoError(t, err)
+
+	gotConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Equal(t, originalConfig, gotConfig, "CherryPick must not write s/config through symlink s -> .git")
+
+	got, err := os.ReadFile(filepath.Join(dir, "s", "config"))
+	require.NoError(t, err)
+	require.Equal(t, "exploit", string(got))
+}
+
+func TestCherryPickDoesNotWriteThroughFinalSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	r, err := PlainInit(dir, false)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	w, err := r.Worktree()
+	require.NoError(t, err)
+
+	require.NoError(t, util.WriteFile(w.Filesystem(), "README", []byte("init"), 0o644))
+	_, err = w.Add("README")
+	require.NoError(t, err)
+
+	initHash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	initCommit, err := r.CommitObject(initHash)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(dir, ".git", "config")
+	originalConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	attack := buildCommitWithEntry(t, r.Storer, initCommit, initHash, "s", filemode.Regular)
+
+	err = w.Filesystem().Symlink(".git/config", "s")
+	if err != nil && isSymlinkWindowsNonAdmin(err) {
+		t.Skipf("symlink creation requires elevated privileges on this platform: %v", err)
+	}
+	require.NoError(t, err)
+
+	err = w.CherryPick(
+		&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true},
+		TheirsMergeStrategy, attack,
+	)
+
+	gotConfig, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+	require.Equal(t, originalConfig, gotConfig, "CherryPick must not write s through symlink s -> .git/config")
+
+	if err == nil {
+		fi, statErr := os.Lstat(filepath.Join(dir, "s"))
+		require.NoError(t, statErr)
+		require.Zero(t, fi.Mode()&os.ModeSymlink, "successful CherryPick must replace the symlink with a regular file")
+
+		got, readErr := os.ReadFile(filepath.Join(dir, "s"))
+		require.NoError(t, readErr)
+		require.Equal(t, "exploit", string(got))
+	}
+}
+
+func TestCherryPickModifyTrackedSymlinkToRegularFileDoesNotWriteThroughSymlink(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	r, err := PlainInit(dir, false)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	w, err := r.Worktree()
+	require.NoError(t, err)
+
+	require.NoError(t, util.WriteFile(w.Filesystem(), "README", []byte("init"), 0o644))
+	_, err = w.Add("README")
+	require.NoError(t, err)
+
+	_, err = w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	err = w.Filesystem().Symlink(".git/config", "s")
+	if err != nil && isSymlinkWindowsNonAdmin(err) {
+		t.Skipf("symlink creation requires elevated privileges on this platform: %v", err)
+	}
+	require.NoError(t, err)
+
+	_, err = w.Add("s")
+	require.NoError(t, err)
+	linkHash, err := w.Commit("add symlink\n", &CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	linkCommit, err := r.CommitObject(linkHash)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(dir, ".git", "config")
+	originalConfig, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	attack := buildCommitReplacingRootEntry(t, r.Storer, linkCommit, linkHash, object.TreeEntry{
+		Name: "s",
+		Mode: filemode.Regular,
+		Hash: writeBlob(t, r.Storer, []byte("exploit")),
+	})
+
+	err = w.CherryPick(
+		&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true},
+		TheirsMergeStrategy, attack,
+	)
+
+	gotConfig, readErr := os.ReadFile(configPath)
+	require.NoError(t, readErr)
+	require.Equal(t, originalConfig, gotConfig, "CherryPick must not write tracked symlink s through to .git/config")
+	require.NoError(t, err)
+
+	fi, err := os.Lstat(filepath.Join(dir, "s"))
+	require.NoError(t, err)
+	require.Zero(t, fi.Mode()&os.ModeSymlink, "CherryPick should replace the tracked symlink with a regular file")
+
+	got, err := os.ReadFile(filepath.Join(dir, "s"))
+	require.NoError(t, err)
+	require.Equal(t, "exploit", string(got))
+}
+
 func buildCommitWithEntry(t *testing.T, s storer.Storer, parent *object.Commit, parentHash plumbing.Hash, filePath string, leafMode filemode.FileMode) *object.Commit {
 	t.Helper()
 
-	content := []byte("exploit")
-	blobObj := s.NewEncodedObject()
-	blobObj.SetType(plumbing.BlobObject)
-	blobObj.SetSize(int64(len(content)))
-	bw, err := blobObj.Writer()
-	require.NoError(t, err)
-	_, err = bw.Write(content)
-	require.NoError(t, err)
-	require.NoError(t, bw.Close())
-	blobHash, err := s.SetEncodedObject(blobObj)
-	require.NoError(t, err)
+	leafHash := writeBlob(t, s, []byte("exploit"))
 
 	// Build nested tree structure from leaf to root.
 	parts := strings.Split(filePath, "/")
-	leafHash := blobHash
-
 	for i := len(parts) - 1; i >= 1; i-- {
 		entry := object.TreeEntry{Name: parts[i], Mode: leafMode, Hash: leafHash}
 		leafHash = storeRawTree(t, s, []object.TreeEntry{entry})
 		leafMode = filemode.Dir
 	}
 
+	return buildCommitWithEntries(t, s, parent, parentHash,
+		[]object.TreeEntry{{Name: parts[0], Mode: leafMode, Hash: leafHash}},
+		"bad path: "+filePath+"\n")
+}
+
+func buildCommitReplacingRootEntry(t *testing.T, s storer.Storer, parent *object.Commit, parentHash plumbing.Hash, replacement object.TreeEntry) *object.Commit {
+	t.Helper()
+
 	parentTree, err := parent.Tree()
 	require.NoError(t, err)
 
-	entries := make([]object.TreeEntry, len(parentTree.Entries), len(parentTree.Entries)+1)
-	copy(entries, parentTree.Entries)
-	entries = append(entries, object.TreeEntry{
-		Name: parts[0],
-		Mode: leafMode,
-		Hash: leafHash,
-	})
+	entries := make([]object.TreeEntry, 0, len(parentTree.Entries)+1)
+	for _, e := range parentTree.Entries {
+		if e.Name == replacement.Name {
+			continue
+		}
+		entries = append(entries, e)
+	}
+	entries = append(entries, replacement)
 	sort.Sort(object.TreeEntrySorter(entries))
 	rootHash := storeRawTree(t, s, entries)
 
 	commit := &object.Commit{
 		Author:       *defaultSignature(),
 		Committer:    *defaultSignature(),
-		Message:      "bad path: " + filePath + "\n",
+		Message:      "replace " + replacement.Name + "\n",
+		TreeHash:     rootHash,
+		ParentHashes: []plumbing.Hash{parentHash},
+	}
+	commitObj := s.NewEncodedObject()
+	require.NoError(t, commit.Encode(commitObj))
+	commitHash, err := s.SetEncodedObject(commitObj)
+	require.NoError(t, err)
+
+	result, err := object.GetCommit(s, commitHash)
+	require.NoError(t, err)
+	return result
+}
+
+// writeBlob stores content as a blob object and returns its hash.
+func writeBlob(t *testing.T, s storer.Storer, content []byte) plumbing.Hash {
+	t.Helper()
+
+	obj := s.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	obj.SetSize(int64(len(content)))
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	hash, err := s.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
+}
+
+// buildCommitWithEntries builds a commit on top of parent whose tree is
+// the parent tree plus extra. Unlike buildCommitWithEntry it takes
+// fully-formed entries, so callers can plant symlinks and subtrees.
+func buildCommitWithEntries(t *testing.T, s storer.Storer, parent *object.Commit, parentHash plumbing.Hash, extra []object.TreeEntry, message string) *object.Commit {
+	t.Helper()
+
+	parentTree, err := parent.Tree()
+	require.NoError(t, err)
+
+	entries := make([]object.TreeEntry, len(parentTree.Entries), len(parentTree.Entries)+len(extra))
+	copy(entries, parentTree.Entries)
+	entries = append(entries, extra...)
+	sort.Sort(object.TreeEntrySorter(entries))
+	rootHash := storeRawTree(t, s, entries)
+
+	commit := &object.Commit{
+		Author:       *defaultSignature(),
+		Committer:    *defaultSignature(),
+		Message:      message,
 		TreeHash:     rootHash,
 		ParentHashes: []plumbing.Hash{parentHash},
 	}
@@ -749,6 +1057,221 @@ func TestResetAcceptsLegitPaths(t *testing.T) {
 
 			_, err = os.Stat(filepath.Join(dir, filepath.FromSlash(tc.path)))
 			require.NoError(t, err, "path %q should exist after Reset", tc.path)
+		})
+	}
+}
+
+// TestForceCheckoutRejectsDangerousPaths pins that a Force checkout
+// (Checkout{Force:true}) and its underlying HardReset refuse to
+// materialise attacker-shaped tree entries into the worktree.
+//
+// TestCherryPickPathValidationMatchesGit covers the merge/non-force
+// flow; this test closes the gap for the Force path. Force resolves to
+// a HardReset, which drives resetIndex and resetWorktreeToTree. Both
+// funnel every tree-derived path through Tree.FindEntry, so the strict
+// pathutil.ValidTreePath gate rejects a dangerous entry before anything
+// is written to disk. Each case asserts the operation errors and that
+// the exploit blob never lands anywhere under the repository directory.
+func TestForceCheckoutRejectsDangerousPaths(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping force checkout path validation test in short mode")
+	}
+	t.Parallel()
+
+	// The blob content buildCommitWithEntry writes into the crafted
+	// tree entry; used to detect any partial materialisation on disk.
+	const exploit = "exploit"
+
+	paths := []struct {
+		name string
+		path string
+	}{
+		{".git at root", ".git/config"},
+		{".git in subdirectory", "subdir/.git/config"},
+		{"final-component .git", "submodule/.git"},
+		{"git~1 8.3 short name", "git~1/config"},
+		{"dot-dot traversal", "a/../../etc/passwd"},
+		{"single dot component", "a/./b"},
+		{"NTFS trailing space on .git", ".git /config"},
+		{"NTFS trailing dot on .git", ".git./config"},
+		{"NTFS alternate data stream", ".git::$INDEX_ALLOCATION/config"},
+		{"HFS+ zero-width in .git", ".g\u200cit/config"},
+		{"control character", "a\x01b/config"},
+	}
+
+	modes := []struct {
+		name string
+		run  func(w *Worktree, h plumbing.Hash) error
+	}{
+		{"checkout-force", func(w *Worktree, h plumbing.Hash) error {
+			return w.Checkout(&CheckoutOptions{Hash: h, Force: true})
+		}},
+		{"reset-hard", func(w *Worktree, h plumbing.Hash) error {
+			return w.Reset(&ResetOptions{Commit: h, Mode: HardReset})
+		}},
+	}
+
+	for _, tc := range paths {
+		for _, m := range modes {
+			t.Run(tc.name+"/"+m.name, func(t *testing.T) {
+				t.Parallel()
+
+				dir := t.TempDir()
+
+				r, err := PlainInit(dir, false)
+				require.NoError(t, err)
+				defer func() { _ = r.Close() }()
+
+				w, err := r.Worktree()
+				require.NoError(t, err)
+
+				require.NoError(t, util.WriteFile(w.Filesystem(), "README", []byte("init"), 0o644))
+				_, err = w.Add("README")
+				require.NoError(t, err)
+
+				initHash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+				require.NoError(t, err)
+
+				initCommit, err := r.CommitObject(initHash)
+				require.NoError(t, err)
+
+				bad := buildCommitWithEntry(t, r.Storer, initCommit, initHash, tc.path, filemode.Regular)
+
+				err = m.run(w, bad.Hash)
+				require.Error(t, err, "%s should reject dangerous path %q", m.name, tc.path)
+
+				assertNotMaterialised(t, dir, exploit)
+			})
+		}
+	}
+}
+
+// assertNotMaterialised fails if any regular file under root holds the
+// given content, catching a dangerous tree entry that was written to
+// disk before validation aborted the operation.
+func assertNotMaterialised(t *testing.T, root, content string) {
+	t.Helper()
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		b, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		if string(b) == content {
+			t.Errorf("dangerous entry materialised at %s", path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestForceCheckoutReplacesLeadingSymlink covers the symlink-mask bypass
+// (CVE-2021-21300 class). A symlink "s" pointing at a dangerous directory
+// is present in the worktree, planted by an attacker or left by an earlier
+// checkout step, and the commit being force-checked-out writes a file at
+// "s/<leaf>". That path string is innocent (no ".git" or ".." component),
+// so string validation alone lets it through. Following the symlink would
+// let the write escape the worktree.
+//
+// Matching upstream Git's create_directories, a force checkout must
+// remove the blocking symlink and materialise a real directory, writing
+// the file safely inside the worktree. Each case asserts the checkout
+// succeeds, the dangerous target is untouched, and the file lands in the
+// worktree instead.
+func TestForceCheckoutReplacesLeadingSymlink(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping symlink-mask path validation test in short mode")
+	}
+	t.Parallel()
+
+	const exploit = "exploit"
+
+	cases := []struct {
+		name string
+		// setup returns the symlink target (the on-disk contents of the
+		// planted symlink "s"), the tree path the attack commit writes,
+		// and the on-disk location that path resolves to if "s" is
+		// followed.
+		setup func(t *testing.T, repoDir string) (linkTarget, entryPath, escapePath string)
+	}{
+		{
+			name: "masks .git config",
+			setup: func(_ *testing.T, repoDir string) (string, string, string) {
+				return ".git", "s/config", filepath.Join(repoDir, ".git", "config")
+			},
+		},
+		{
+			name: "masks .git hook",
+			setup: func(_ *testing.T, repoDir string) (string, string, string) {
+				return ".git", "s/hooks/pre-commit", filepath.Join(repoDir, ".git", "hooks", "pre-commit")
+			},
+		},
+		{
+			name: "masks parent dir",
+			setup: func(_ *testing.T, repoDir string) (string, string, string) {
+				return "..", "s/escape", filepath.Join(filepath.Dir(repoDir), "escape")
+			},
+		},
+		{
+			name: "masks absolute external dir",
+			setup: func(t *testing.T, _ string) (string, string, string) {
+				escape := t.TempDir()
+				return escape, "s/escape", filepath.Join(escape, "escape")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			r, err := PlainInit(dir, false)
+			require.NoError(t, err)
+			defer func() { _ = r.Close() }()
+
+			w, err := r.Worktree()
+			require.NoError(t, err)
+
+			require.NoError(t, util.WriteFile(w.Filesystem(), "README", []byte("init"), 0o644))
+			_, err = w.Add("README")
+			require.NoError(t, err)
+
+			initHash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+			require.NoError(t, err)
+			initCommit, err := r.CommitObject(initHash)
+			require.NoError(t, err)
+
+			linkTarget, entryPath, escapePath := tc.setup(t, dir)
+
+			attack := buildCommitWithEntry(t, r.Storer, initCommit, initHash, entryPath, filemode.Regular)
+
+			// Plant the masking symlink on disk via the bare filesystem.
+			// This models the pre-existing symlink an attacker relies on.
+			require.NoError(t, w.Filesystem().Symlink(linkTarget, "s"))
+
+			// Upstream git checkout -f succeeds here by replacing "s".
+			require.NoError(t, w.Checkout(&CheckoutOptions{Hash: attack.Hash, Force: true}),
+				"force checkout should replace symlink %q -> %q, not fail", entryPath, linkTarget)
+
+			// The dangerous target must not have been followed.
+			if data, readErr := os.ReadFile(escapePath); readErr == nil {
+				require.NotEqual(t, exploit, string(data),
+					"force checkout wrote through symlink %q -> %q to %s", entryPath, linkTarget, escapePath)
+			}
+
+			// The blocking symlink is gone and the file lands safely in the
+			// worktree instead.
+			fi, err := os.Lstat(filepath.Join(dir, "s"))
+			require.NoError(t, err)
+			require.Zero(t, fi.Mode()&os.ModeSymlink, "leading symlink %q must be replaced by a real directory", "s")
+
+			data, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(entryPath)))
+			require.NoError(t, err, "checked-out file must exist inside the worktree")
+			require.Equal(t, exploit, string(data))
 		})
 	}
 }

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -556,6 +556,64 @@ func (s *WorktreeSuite) TestCheckoutSymlink() {
 	s.NoError(err)
 }
 
+func (s *WorktreeSuite) TestCheckoutReplacesBlockingFinalSymlink() {
+	run := func(t *testing.T, fs billy.Filesystem) {
+		t.Helper()
+
+		w := &Worktree{
+			r:          s.Repository,
+			filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
+		}
+
+		require.NoError(t, util.WriteFile(fs, "target.txt", []byte("keep"), 0o644))
+		require.NoError(t, fs.Symlink("target.txt", "tracked.txt"))
+
+		blobObj := &plumbing.MemoryObject{}
+		blobObj.SetType(plumbing.BlobObject)
+		_, err := blobObj.Write([]byte("replacement"))
+		require.NoError(t, err)
+
+		blob, err := object.DecodeBlob(blobObj)
+		require.NoError(t, err)
+
+		err = w.checkoutFile(&config.Config{}, w.filesystem, object.NewFile("tracked.txt", filemode.Regular, blob))
+		require.NoError(t, err)
+
+		got, err := fs.Open("tracked.txt")
+		require.NoError(t, err)
+		defer func() { _ = got.Close() }()
+
+		content, err := io.ReadAll(got)
+		require.NoError(t, err)
+		assert.Equal(t, "replacement", string(content))
+
+		target, err := fs.Open("target.txt")
+		require.NoError(t, err)
+		defer func() { _ = target.Close() }()
+
+		targetContent, err := io.ReadAll(target)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", string(targetContent))
+
+		fi, err := fs.Lstat("tracked.txt")
+		require.NoError(t, err)
+		assert.Zero(t, fi.Mode()&os.ModeSymlink)
+	}
+
+	s.Run("memfs", func() {
+		run(s.T(), memfs.New())
+	})
+
+	s.Run("osfs", func() {
+		if runtime.GOOS == "windows" {
+			s.T().Skip("git doesn't support symlinks by default in windows")
+		}
+
+		dir := s.T().TempDir()
+		run(s.T(), osfs.New(dir))
+	})
+}
+
 func TestCheckoutSymlinkArbitraryTarget(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("git doesn't support symlinks by default in windows")


### PR DESCRIPTION
`worktreeFilesystem` validated path strings but did not account for symlinks already present on disk. As a result a worktree operation on an otherwise valid path could resolve through a symlinked component and act outside the worktree.

Enforce the invariant at the boundary. `validNoLeadingSymlink` rejects paths whose leading directories resolve through an existing symlink, and it runs on every operation. Mutating operations go through `validWritePath` (Create, OpenFile, MkdirAll, Symlink, Rename, Remove) and reads through `validReadPath` (Open, Stat, ReadDir, Lstat, Readlink, Chroot). This also covers `Worktree.Remove`, `RemoveGlob` and `rmFileAndDirsIfEmpty`, which delete through the wrapper. Chroot additionally refuses a symlink as the final component so a sub-filesystem such as a submodule worktree cannot be scoped to a redirected target.

The wrapper stops at leading-component traversal. Final-component no-follow during materialisation is enforced at the call site. `checkoutFile` removes a blocking symlink, whether in a leading component or at the final path, before writing. A forced checkout therefore replaces it with a real entry and succeeds, matching upstream create_directories and its unlink-before-write behaviour. Callers that do not remove it first get a safe error at the boundary.

CherryPick materialised changes with a raw Create and Write. It bypassed the symlink handling, ignored file mode such as symlinks, exec bits and CRLF, and named the file by the tree leaf rather than the full path. It now goes through the shared checkoutFile and reusableRootFS path, which fixes the path handling and inherits the symlink safety.

Mirrors upstream Git's `has_symlink_leading_path` in `symlinks.c` and the `check_leading_path` and `unlink-before-write` guards in `entry.c`.