### PR TITLE
plumbing: format/gitignore, fix trailing ** matching unrelated paths

### DIFF
--- a/plumbing/format/gitignore/conformance_test.go
+++ b/plumbing/format/gitignore/conformance_test.go
@@ -311,6 +311,14 @@ func (s *ConformanceSuite) TestWildmatchSlashSemantics() {
 		{"**/bar/**", "deep/foo/bar/baz/", true, "double star with double star continuation"},
 		{"**/bar/*", "deep/foo/bar", false, "double star continuation needs path"},
 		{"**/bar/**", "deep/foo/bar/", true, "double star double star with directory"},
+		{"**/bar/**", "deep/", false, "double star suffix needs the named segment"},
+		{"**/bar/**", "deep/foo/", false, "double star suffix needs the named segment when nested"},
+		{"**/bar/**", "deep/foo/baz/", false, "double star suffix rejects a sibling directory"},
+		{"**/bar/**", "deep/foo/file.txt", false, "double star suffix rejects a file outside the named segment"},
+		{"a/**/*/**", "a/f.txt", false, "double star suffix needs something below the consumed path"},
+		{"a/**/*/**", "a/b/c/f.txt", true, "double star suffix with a path left to cover"},
+		{"a/**/*/**", "a/b/", true, "double star suffix with a directory left to cover"},
+		{"**/*.txt/**", "a/f.txt", false, "double star suffix does not match the segment it follows"},
 		{"**/bar**", "foo/bar/baz", true, "double star with adjacent stars"},
 		{"*/bar/**", "foo/bar/baz/x", true, "mixed single double star"},
 		{"*/bar/**", "deep/foo/bar/baz/x", false, "mixed stars wrong depth"},
@@ -840,6 +848,34 @@ func (s *ConformanceSuite) TestIgnoreRealWorld() {
 		{"backup~", false, true, "backup file"},
 		{"src/main.js", false, false, "normal source file"},
 		{"README.md", false, false, "normal doc file"},
+	}
+	for _, tt := range tests {
+		s.assertIgnore(m, patterns, tt.path, tt.isDir, tt.ignored, tt.desc)
+	}
+}
+
+// TestIgnoreDoubleStarSuffixRequiresSegment verifies that `**/<segment>/**`
+// excludes only paths that actually contain <segment>. Callers such as
+// Worktree.Status stop descending into a directory the matcher excludes, so a
+// directory wrongly reported as ignored hides every untracked file beneath it.
+func (s *ConformanceSuite) TestIgnoreDoubleStarSuffixRequiresSegment() {
+	patterns := []string{"**/node_modules/**"}
+	m := s.createMatcher(patterns)
+
+	tests := []struct {
+		path    string
+		isDir   bool
+		ignored bool
+		desc    string
+	}{
+		{"src", true, false, "sibling directory"},
+		{"src/pkg", true, false, "nested sibling directory"},
+		{"src/pkg/app.go", false, false, "file below a sibling directory"},
+		{"node_modules", true, true, "the named directory"},
+		{"node_modules/react", true, true, "directory below the named directory"},
+		{"node_modules/react/index.js", false, true, "file below the named directory"},
+		{"src/node_modules", true, true, "the named directory nested"},
+		{"src/node_modules/react/index.js", false, true, "file below a nested match"},
 	}
 	for _, tt := range tests {
 		s.assertIgnore(m, patterns, tt.path, tt.isDir, tt.ignored, tt.desc)

--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -502,11 +502,14 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 		}
 		if pattern == zeroToManyDirs {
 			if i == len(p.pattern)-1 {
-				// Trailing ** matches everything remaining (if there's something left or it's a dir)
-				if len(path) > 0 || isDir {
-					matched = true
-					trailingStar = true
-				}
+				// A trailing `**` matches the entries below whatever the
+				// earlier segments consumed, so it needs either a remaining
+				// component or a directory candidate standing in for them.
+				// Assigning matched rather than only raising it stops an
+				// exhausted path from inheriting the previous segment's
+				// result, which would make `a/**/*/**` match `a/f.txt`.
+				matched = len(path) > 0 || isDir
+				trailingStar = matched
 				break
 			}
 			canTraverse = true
@@ -525,9 +528,14 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 				if wildmatch(pattern, e) {
 					matched = true
 					break
-				} else if len(path) == 0 {
-					// if nothing left then fail
-					matched = false
+				}
+				if len(path) == 0 {
+					// A `**` that never finds the segment following it is a
+					// definitive non-match. Returning here rather than
+					// clearing matched keeps a trailing `**` from reviving
+					// the pattern once the path is exhausted, which would
+					// make `**/bar/**` match directories containing no bar.
+					return false
 				}
 			}
 		} else {


### PR DESCRIPTION
Fixes #2278

## Why

A `.gitignore` containing `**/node_modules/**` makes go-git report *every*
directory in the repository as ignored — including directories with no
`node_modules` component in their path, and even when no `node_modules` exists.

That hides files rather than just mislabelling them: `Worktree.Status` stops
descending into a directory the matcher excludes, so untracked work below the
repository root never shows up. `Status()` looks clean when it isn't.

The cause is in `globMatch`, which treats `matched` as a flag that only ever
moves to `true`. When the earlier segments of a pattern rule a path out, the
trailing `**` runs afterwards and flips it back on. A second symptom shares the
cause: a trailing `**` reached with the path already consumed inherits the
previous segment's answer, so `a/**/*/**` matches `a/f.txt`.

[gitignore(5)](https://git-scm.com/docs/gitignore) defines the trailing `/**`
form as matching everything *inside* the directory it follows — not paths that
never contained the preceding segment. Confirmed against `git check-ignore`
(git 2.47.3).

## What changed

Eight lines in `plumbing/format/gitignore/pattern.go`: a `**` that never finds
the segment following it now returns a definitive non-match, and the trailing
`**` assigns its own result instead of only raising the flag.

## Verification

- Regression tests added to `ConformanceSuite`, so every expectation is
  cross-checked against the real `git` binary. All fail on `main`, pass here.
- Randomised differential run against `git check-ignore` (296 patterns × 66
  paths): five over-matching pattern families on `main`, zero after the fix,
  no new divergence.
- `golangci-lint` (v2.11.4, `make validate-lint`): 0 issues. `go test ./...`
  shows the same failures before and after.
