### PR TITLE
plumbing: transport, reject want lines for unadvertised objects

### DIFF
--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -126,6 +126,10 @@ func UploadPack(
 			wants = upreq.Wants
 			caps = upreq.Capabilities
 
+			if err := checkWants(st, wants); err != nil {
+				return err
+			}
+
 			if err := r.Close(); err != nil {
 				return fmt.Errorf("closing reader: %w", err)
 			}
@@ -316,6 +320,73 @@ func UploadPack(
 
 func objectsToUpload(st storage.Storer, wants, haves []plumbing.Hash) ([]plumbing.Hash, error) {
 	return revlist.Objects(st, wants, haves)
+}
+
+// ErrNotOurRef is returned when a client asks for an object id the server did
+// not advertise.
+var ErrNotOurRef = errors.New("not our ref")
+
+// advertisedObjects returns the object ids the advertisement exposes: every
+// reference's value, plus each id along an annotated tag's chain, since a tag
+// is advertised together with its peeled value.
+func advertisedObjects(st storage.Storer) (map[plumbing.Hash]struct{}, error) {
+	iter, err := st.IterReferences()
+	if err != nil {
+		return nil, err
+	}
+	defer iter.Close()
+
+	adv := make(map[plumbing.Hash]struct{})
+	err = iter.ForEach(func(r *plumbing.Reference) error {
+		h := r.Hash()
+		if r.Type() == plumbing.SymbolicReference {
+			ref, rerr := storer.ResolveReference(st, r.Target())
+			if rerr != nil {
+				// A dangling symref advertises nothing.
+				return nil
+			}
+			h = ref.Hash()
+		}
+		for {
+			if _, ok := adv[h]; ok {
+				// Already recorded; also breaks a tag cycle in a malformed repo.
+				return nil
+			}
+			adv[h] = struct{}{}
+			tag, terr := object.GetTag(st, h)
+			if terr != nil {
+				return nil
+			}
+			h = tag.Target
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return adv, nil
+}
+
+// checkWants refuses want lines naming an object that was never advertised.
+// It mirrors upstream's check_non_tip (upload-pack.c) with
+// uploadpack.allowTipSHA1InWant, allowReachableSHA1InWant and
+// allowAnySHA1InWant left at their default of false: a client may only ask for
+// the ids it was shown.
+func checkWants(st storage.Storer, wants []plumbing.Hash) error {
+	if len(wants) == 0 {
+		return nil
+	}
+
+	adv, err := advertisedObjects(st)
+	if err != nil {
+		return err
+	}
+
+	for _, w := range wants {
+		if _, ok := adv[w]; !ok {
+			return fmt.Errorf("%w %s", ErrNotOurRef, w)
+		}
+	}
+	return nil
 }
 
 func getShallowCommits(st storage.Storer, heads []plumbing.Hash, depth int, upd *packp.ShallowUpdate) error {
@@ -644,6 +715,11 @@ func serveFetchV2(_ context.Context, st storage.Storer, w io.WriteCloser, args *
 	// nothing and just close the stream, no stray flush packet.
 	if len(wants) == 0 {
 		return true, w.Close()
+	}
+
+	if err := checkWants(st, wants); err != nil {
+		_ = w.Close()
+		return true, err
 	}
 
 	out := &packp.FetchOutput{}

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -78,6 +78,38 @@ func (s *UploadPackServeSuite) TestUploadPackAlwaysUseSidebandWhenAvailable() {
 	s.Equal(expected, buf.String()[:len(expected)])
 }
 
+func (s *UploadPackServeSuite) TestUploadPackRejectsUnadvertisedWant() {
+	dot, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+	s.Require().NoError(err)
+	st := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	defer func() { _ = st.Close() }()
+
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	s.Require().NoError(err)
+	c, err := object.GetCommit(st, head.Hash())
+	s.Require().NoError(err)
+	s.Require().NotEmpty(c.ParentHashes, "HEAD must have a parent for this test")
+
+	// An ancestor of an advertised tip is in the object store but was never
+	// advertised, so it is not a valid want.
+	upreq := &packp.UploadRequest{}
+	upreq.Wants = append(upreq.Wants, c.ParentHashes[0])
+
+	var uphav packp.UploadHaves
+	uphav.Done = true
+
+	var reqW bytes.Buffer
+	s.Require().NoError(upreq.Encode(&reqW))
+	s.Require().NoError(uphav.Encode(&reqW))
+
+	var out bytes.Buffer
+	err = UploadPack(context.TODO(), st, io.NopCloser(&reqW), ioutil.WriteNopCloser(&out),
+		&UploadPackRequest{GitProtocol: "version=1", StatelessRPC: true})
+
+	s.Require().ErrorIs(err, ErrNotOurRef)
+	s.NotContains(out.String(), "PACK")
+}
+
 func (s *UploadPackServeSuite) TestUploadPackSkipDeltaCompression() {
 	dot, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
 	s.Require().NoError(err)

--- a/plumbing/transport/upload_pack_v2_test.go
+++ b/plumbing/transport/upload_pack_v2_test.go
@@ -217,6 +217,10 @@ func TestUploadPackV2FetchCommonButNotReady(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
 	parent := c.ParentHashes[0]
+	// The ancestor needs a ref of its own: a want is only honoured when it was
+	// advertised.
+	require.NoError(t, st.SetReference(
+		plumbing.NewHashReference("refs/heads/ancestor", parent)))
 
 	// want an ancestor, have its descendant (HEAD). HEAD is a known object so it
 	// is ACK'd, but it is not an ancestor of the want, so no want is anchored:
@@ -231,6 +235,30 @@ func TestUploadPackV2FetchCommonButNotReady(t *testing.T) {
 	require.Contains(t, out, "ACK "+head.Hash().String())
 	require.NotContains(t, out, "ready")
 	require.NotContains(t, out, "packfile")
+}
+
+func TestUploadPackV2FetchRejectsUnadvertisedWant(t *testing.T) {
+	t.Parallel()
+	st := basicV2Storage(t)
+	head, err := storer.ResolveReference(st, plumbing.HEAD)
+	require.NoError(t, err)
+	c, err := object.GetCommit(st, head.Hash())
+	require.NoError(t, err)
+	require.NotEmpty(t, c.ParentHashes, "HEAD must have a parent for this test")
+
+	// An ancestor of an advertised tip is in the object store but was never
+	// advertised, so it is not a valid want.
+	var out bytes.Buffer
+	err = UploadPack(context.TODO(), st, v2Request(t, "fetch", nil, []string{
+		"want " + c.ParentHashes[0].String(),
+		"done",
+	}), ioutil.WriteNopCloser(&out), &UploadPackRequest{
+		GitProtocol:  "version=2",
+		StatelessRPC: true,
+	})
+
+	require.ErrorIs(t, err, ErrNotOurRef)
+	require.NotContains(t, out.String(), "packfile")
 }
 
 func TestUploadPackV2FetchNoWantsEmitsNothing(t *testing.T) {


### PR DESCRIPTION
The server advertises one tip; a client asks for a different object and gets it:

    advertised:
      7f80bcc93a8d1226ac4f7eac0299ca27ada0a95a HEAD
      7f80bcc93a8d1226ac4f7eac0299ca27ada0a95a refs/heads/master

    want cb94db795b1542f008a5868b24d42d2abcc57e8e   (no ref points at it)
    -> PACK  cb94db79 c51d7a8d 58e7f96b

`UploadPack` passes `upreq.Wants` straight to revlist, and `serveFetchV2` does the same with `args.Wants`, so anything still in the object store gets packed on request: commits orphaned by a force-push before gc runs, refs an operator kept out of the advertisement, and, where a fork network shares one object store, another repository's objects. Canonical git declines these in `check_non_tip` unless one of the `uploadpack.allow*SHA1InWant` knobs is set, and the upload-archive path here already takes the same line through `archive.ResolveTreeish(..., allowUnreachable=false)`.

The check sits in front of both server entry points, so the advertisement stays the only thing a client can ask for. Symrefs are resolved and annotated tag chains walked, since a tag is advertised alongside its peeled value.

One thing worth flagging for review: a want that is reachable but not itself advertised is now refused. That matches git's default, though it is a change for anyone who was relying on the old behavior, and it is why `TestUploadPackV2FetchCommonButNotReady` now gives its ancestor commit a ref of its own. I left the `allowTipSHA1InWant` / `allowReachableSHA1InWant` / `allowAnySHA1InWant` knobs out rather than guess at how you would want them configured, but happy to add them if you would rather have the escape hatch in the same change.
