### PR TITLE
worktree: Collapse untracked directories in Status. Fixes #181

### DIFF
--- a/utils/merkletrie/change.go
+++ b/utils/merkletrie/change.go
@@ -136,6 +136,13 @@ func (l *Changes) addRecursive(root noder.Path, ctor noderToChangeFn) error {
 		return nil
 	}
 
+	if c, ok := root.Last().(noder.Collapser); ok && c.Collapse() {
+		if !root.Skip() {
+			l.Add(ctor(root))
+		}
+		return nil
+	}
+
 	i, err := NewIterFromPath(root)
 	if err != nil {
 		return err

--- a/utils/merkletrie/change_test.go
+++ b/utils/merkletrie/change_test.go
@@ -92,3 +92,58 @@ func (s *ChangeSuite) TestMalformedChange() {
 	change := merkletrie.Change{}
 	s.PanicsWithError("malformed change: nil from and to", func() { _ = change.String() })
 }
+
+// collapsibleNoder wraps a noder and implements noder.Collapser, so tests
+// can control whether a directory collapses into a single change.
+type collapsibleNoder struct {
+	noder.Noder
+	collapse bool
+}
+
+func (n collapsibleNoder) Collapse() bool { return n.collapse }
+
+func wrapLast(p noder.Path, collapse bool) noder.Path {
+	wrapped := make(noder.Path, len(p))
+	copy(wrapped, p)
+	wrapped[len(wrapped)-1] = collapsibleNoder{Noder: p.Last(), collapse: collapse}
+	return wrapped
+}
+
+func (s *ChangeSuite) TestAddRecursiveInsertCollapsedDir() {
+	tree, err := fsnoder.New("(a(b(z<>)))")
+	s.NoError(err)
+	p := wrapLast(find(s.T(), tree, "b"), true)
+
+	ret := merkletrie.NewChanges()
+	err = ret.AddRecursiveInsert(p)
+	s.NoError(err)
+
+	s.Len(ret, 1)
+	s.Equal("<Insert a/b>", ret[0].String())
+}
+
+func (s *ChangeSuite) TestAddRecursiveDeleteCollapsedDir() {
+	tree, err := fsnoder.New("(a(b(z<>)))")
+	s.NoError(err)
+	p := wrapLast(find(s.T(), tree, "b"), true)
+
+	ret := merkletrie.NewChanges()
+	err = ret.AddRecursiveDelete(p)
+	s.NoError(err)
+
+	s.Len(ret, 1)
+	s.Equal("<Delete a/b>", ret[0].String())
+}
+
+func (s *ChangeSuite) TestAddRecursiveInsertNonCollapsedDir() {
+	tree, err := fsnoder.New("(a(b(z<>)))")
+	s.NoError(err)
+	p := wrapLast(find(s.T(), tree, "b"), false)
+
+	ret := merkletrie.NewChanges()
+	err = ret.AddRecursiveInsert(p)
+	s.NoError(err)
+
+	s.Len(ret, 1)
+	s.Equal("<Insert a/b/z>", ret[0].String())
+}

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -43,6 +43,16 @@ type Options struct {
 	// reported. Requires Index to be set: without an index there is no way
 	// to identify tracked entries, so the matcher is treated as a no-op.
 	IgnoreMatcher gitignore.Matcher
+
+	// CollapseUntrackedDirs, when true, makes directories that contain no
+	// tracked entries and at least one visible (non-ignored) file report
+	// as a single change for the directory itself instead of being walked,
+	// matching the default behavior of "git status". Directories without
+	// any visible content produce no change at all, matching git not
+	// listing empty untracked directories. Requires Index to be set:
+	// without an index there is no way to identify tracked entries, so
+	// the option is treated as a no-op.
+	CollapseUntrackedDirs bool
 }
 
 // The node represents a file or a directory in a billy.Filesystem. It
@@ -112,7 +122,7 @@ func NewRootNodeWithOptions(
 			idxMap[entry.Name] = entry
 		}
 
-		if options.IgnoreMatcher != nil {
+		if options.IgnoreMatcher != nil || options.CollapseUntrackedDirs {
 			trackedDirs = make(map[string]struct{})
 			for _, entry := range options.Index.Entries {
 				for parent := path.Dir(entry.Name); parent != "." && parent != "/"; parent = path.Dir(parent) {
@@ -231,6 +241,13 @@ func (n *node) calculateChildren() error {
 // AND has no entry in the index. Tracked entries are never skipped so
 // modifications to them are still reported.
 func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
+	return n.isIgnoredUntracked(path.Join(n.path, name), isDir)
+}
+
+// isIgnoredUntracked reports whether the entry at childPath should be
+// skipped because it matches the configured ignore matcher AND has no
+// entry in the index.
+func (n *node) isIgnoredUntracked(childPath string, isDir bool) bool {
 	if n.options == nil || n.options.IgnoreMatcher == nil {
 		return false
 	}
@@ -240,7 +257,6 @@ func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
 	if n.idxMap == nil {
 		return false
 	}
-	childPath := path.Join(n.path, name)
 	if !n.options.IgnoreMatcher.Match(strings.Split(childPath, "/"), isDir) {
 		return false
 	}
@@ -256,6 +272,62 @@ func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
 		return !hasTrackedDescendant
 	}
 	return true
+}
+
+// Collapse implements noder.Collapser. It reports true when the node is a
+// directory that has no tracked descendants but contains at least one
+// visible (non-ignored) file, so the whole subtree can be represented by
+// a single change for the directory itself. Directories without any
+// visible content are not collapsed: they must produce no change at all,
+// matching git which does not list empty untracked directories.
+func (n *node) Collapse() bool {
+	if n.options == nil || !n.options.CollapseUntrackedDirs || !n.isDir {
+		return false
+	}
+	if n.idxMap == nil {
+		return false
+	}
+	if _, tracked := n.trackedDirs[n.path]; tracked {
+		return false
+	}
+	return n.containsVisibleEntry()
+}
+
+// containsVisibleEntry reports whether the subtree rooted at n contains at
+// least one entry that would surface in a walk: a non-ignored file,
+// symlink included. The scan short-circuits on the first visible entry,
+// so fully untracked directories are usually validated with a single
+// ReadDir per nesting level instead of a full enumeration.
+func (n *node) containsVisibleEntry() bool {
+	dirs := []string{n.path}
+	for len(dirs) > 0 {
+		dir := dirs[len(dirs)-1]
+		dirs = dirs[:len(dirs)-1]
+
+		files, err := n.fs.ReadDir(dir)
+		if err != nil {
+			// Refuse to collapse so the full walk surfaces the error.
+			return false
+		}
+
+		for _, file := range files {
+			if _, ok := ignore[file.Name()]; ok {
+				continue
+			}
+			if file.Type()&os.ModeSocket != 0 {
+				continue
+			}
+			isDir := file.IsDir()
+			if n.isIgnoredUntracked(path.Join(dir, file.Name()), isDir) {
+				continue
+			}
+			if !isDir {
+				return true
+			}
+			dirs = append(dirs, path.Join(dir, file.Name()))
+		}
+	}
+	return false
 }
 
 func (n *node) newChildNode(file os.FileInfo) (*node, error) {

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -52,6 +52,16 @@ type Options struct {
 	// Requires Index to be set: without an index there is no way to identify
 	// tracked entries, so the scope is treated as a no-op.
 	IgnoreScope *gitignore.Scope
+
+	// CollapseUntrackedDirs, when true, makes directories that contain no
+	// tracked entries and at least one visible (non-ignored) file report
+	// as a single change for the directory itself instead of being walked,
+	// matching the default behavior of "git status". Directories without
+	// any visible content produce no change at all, matching git not
+	// listing empty untracked directories. Requires Index to be set:
+	// without an index there is no way to identify tracked entries, so
+	// the option is treated as a no-op.
+	CollapseUntrackedDirs bool
 }
 
 // The node represents a file or a directory in a billy.Filesystem. It
@@ -65,9 +75,9 @@ type node struct {
 	idx        *index.Index
 	idxMap     map[string]*index.Entry
 	// trackedDirs holds every directory path that has at least one entry
-	// in the index. It is populated only when IgnoreScope is set so the
-	// walker can keep tracked entries even if their parent directory
-	// matches an ignore rule.
+	// in the index. It is populated only when IgnoreScope or
+	// CollapseUntrackedDirs is set so the walker can keep tracked entries
+	// even if their parent directory matches an ignore rule.
 	trackedDirs map[string]struct{}
 
 	options *Options
@@ -129,7 +139,7 @@ func NewRootNodeWithOptions(
 			idxMap[entry.Name] = entry
 		}
 
-		if options.IgnoreScope != nil {
+		if options.IgnoreScope != nil || options.CollapseUntrackedDirs {
 			trackedDirs = make(map[string]struct{})
 			for _, entry := range options.Index.Entries {
 				for parent := path.Dir(entry.Name); parent != "." && parent != "/"; parent = path.Dir(parent) {
@@ -262,35 +272,47 @@ func (n *node) resolveScope(files []iofs.DirEntry) error {
 	}
 	n.scopeResolved = true
 
-	if n.scope == nil {
-		return nil
+	scope, err := descendScope(n.fs, n.scope, n.path, files)
+	if err != nil {
+		return err
+	}
+	if scope != nil {
+		n.scope = scope
+	}
+
+	return nil
+}
+
+// descendScope derives the scope governing the entries of the directory at
+// dirPath from its parent's scope and the listing just taken for it,
+// reading the directory's own .gitignore only when the listing shows one.
+// A nil parent scope means no ignore filtering is in effect and yields a
+// nil scope. It mirrors resolveScope for directories the collapse scan
+// visits without creating nodes.
+func descendScope(fs billy.Filesystem, parent *gitignore.Scope, dirPath string, files []iofs.DirEntry) (*gitignore.Scope, error) {
+	if parent == nil {
+		return nil, nil
 	}
 
 	var readOwn func() ([]gitignore.Pattern, error)
 	for _, f := range files {
 		if f.Name() == gitignore.IgnoreFile && !f.IsDir() {
-			dir := n.pathComponents()
+			dir := pathComponents(dirPath)
 			readOwn = func() ([]gitignore.Pattern, error) {
-				return gitignore.DirPatterns(n.fs, dir)
+				return gitignore.DirPatterns(fs, dir)
 			}
 			break
 		}
 	}
 
-	scope, err := n.scope.Descend(n.pathComponents(), readOwn)
-	if err != nil {
-		return err
-	}
-	n.scope = scope
-
-	return nil
+	return parent.Descend(pathComponents(dirPath), readOwn)
 }
 
-func (n *node) pathComponents() []string {
-	if n.path == "" {
+func pathComponents(p string) []string {
+	if p == "" {
 		return nil
 	}
-	return strings.Split(n.path, "/")
+	return strings.Split(p, "/")
 }
 
 // shouldSkipIgnored reports whether the child entry of n with the given
@@ -298,7 +320,15 @@ func (n *node) pathComponents() []string {
 // AND has no entry in the index. Tracked entries are never skipped so
 // modifications to them are still reported.
 func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
-	if n.options == nil || n.options.IgnoreScope == nil {
+	return n.isIgnoredUntracked(n.scope, path.Join(n.path, name), isDir)
+}
+
+// isIgnoredUntracked reports whether the entry at childPath should be
+// skipped because scope matches it AND it has no entry in the index.
+// scope must be the one governing the entries of childPath's parent
+// directory; a nil scope means no ignore filtering is in effect.
+func (n *node) isIgnoredUntracked(scope *gitignore.Scope, childPath string, isDir bool) bool {
+	if scope == nil {
 		return false
 	}
 	// Without an index we cannot prove that a subtree contains no tracked
@@ -307,8 +337,7 @@ func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
 	if n.idxMap == nil {
 		return false
 	}
-	childPath := path.Join(n.path, name)
-	if !n.scope.Match(strings.Split(childPath, "/"), isDir) {
+	if !scope.Match(strings.Split(childPath, "/"), isDir) {
 		return false
 	}
 	// An entry whose own path is in the index is tracked, regardless of
@@ -323,6 +352,76 @@ func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
 		return !hasTrackedDescendant
 	}
 	return true
+}
+
+// Collapse implements noder.Collapser. It reports true when the node is a
+// directory that has no tracked descendants but contains at least one
+// visible (non-ignored) file, so the whole subtree can be represented by
+// a single change for the directory itself. Directories without any
+// visible content are not collapsed: they must produce no change at all,
+// matching git which does not list empty untracked directories.
+func (n *node) Collapse() bool {
+	if n.options == nil || !n.options.CollapseUntrackedDirs || !n.isDir {
+		return false
+	}
+	if n.idxMap == nil {
+		return false
+	}
+	if _, tracked := n.trackedDirs[n.path]; tracked {
+		return false
+	}
+	return n.containsVisibleEntry()
+}
+
+// containsVisibleEntry reports whether the subtree rooted at n contains at
+// least one entry that would surface in a walk: a non-ignored file,
+// symlink included. The scan short-circuits on the first visible entry,
+// so fully untracked directories are usually validated with a single
+// ReadDir per nesting level instead of a full enumeration.
+func (n *node) containsVisibleEntry() bool {
+	// pending directories carry the scope inherited from their parent and
+	// derive their own from the listing taken for them here, as walked
+	// nodes do in resolveScope, so a .gitignore below n is honored.
+	type pending struct {
+		path  string
+		scope *gitignore.Scope
+	}
+
+	dirs := []pending{{n.path, n.scope}}
+	for len(dirs) > 0 {
+		d := dirs[len(dirs)-1]
+		dirs = dirs[:len(dirs)-1]
+
+		files, err := n.fs.ReadDir(d.path)
+		if err != nil {
+			// Refuse to collapse so the full walk surfaces the error.
+			return false
+		}
+
+		scope, err := descendScope(n.fs, d.scope, d.path, files)
+		if err != nil {
+			return false
+		}
+
+		for _, file := range files {
+			if _, ok := ignore[file.Name()]; ok {
+				continue
+			}
+			if file.Type()&os.ModeSocket != 0 {
+				continue
+			}
+			isDir := file.IsDir()
+			childPath := path.Join(d.path, file.Name())
+			if n.isIgnoredUntracked(scope, childPath, isDir) {
+				continue
+			}
+			if !isDir {
+				return true
+			}
+			dirs = append(dirs, pending{childPath, scope})
+		}
+	}
+	return false
 }
 
 func (n *node) newChildNode(file os.FileInfo) (*node, error) {

--- a/utils/merkletrie/filesystem/node_collapse_test.go
+++ b/utils/merkletrie/filesystem/node_collapse_test.go
@@ -1,0 +1,233 @@
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/format/index"
+	"github.com/go-git/go-git/v6/utils/merkletrie"
+	mindex "github.com/go-git/go-git/v6/utils/merkletrie/index"
+)
+
+// changePaths returns a "action path" string per change for assertion.
+func changePaths(t *testing.T, changes merkletrie.Changes) []string {
+	t.Helper()
+	paths := make([]string, 0, len(changes))
+	for _, c := range changes {
+		paths = append(paths, c.String())
+	}
+	return paths
+}
+
+// TestUntrackedDirIsCollapsed verifies that a directory with no tracked
+// entries and at least one untracked file produces a single Insert change
+// for the directory itself, instead of one change per file, when
+// CollapseUntrackedDirs is set. This matches "git status" default output.
+func TestUntrackedDirIsCollapsed(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "src/keep.go", []byte("package main\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/img1.png", []byte("img1\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/deep/img2.png", []byte("img2\n"), 0o644))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "src/keep.go", Hash: blobHash(t, []byte("package main\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.Equal(t, []string{"<Insert assets>"}, changePaths(t, changes))
+}
+
+// TestEmptyUntrackedDirIsNotReported verifies that a directory without any
+// tracked entry and no untracked file inside (fully empty, or with only
+// empty nested directories) produces no change at all, matching git which
+// does not list empty untracked directories.
+func TestEmptyUntrackedDirIsNotReported(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "src/keep.go", []byte("package main\n"), 0o644))
+	require.NoError(t, fs.MkdirAll("assets/deep/deeper", 0o755))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "src/keep.go", Hash: blobHash(t, []byte("package main\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.Empty(t, changes)
+}
+
+// TestDirWithTrackedDescendantIsNotCollapsed verifies that a directory
+// containing tracked entries is walked normally: modifications surface
+// per file and untracked siblings are listed individually.
+func TestDirWithTrackedDescendantIsNotCollapsed(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "assets/keep.go", []byte("modified\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/new.go", []byte("new\n"), 0o644))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "assets/keep.go", Hash: blobHash(t, []byte("original\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.ElementsMatch(t,
+		[]string{"<Modify assets/keep.go>", "<Insert assets/new.go>"},
+		changePaths(t, changes))
+}
+
+// TestCollapseWithoutIndexIsNoop verifies that CollapseUntrackedDirs does
+// not take effect when Index is nil, mirroring the IgnoreScope contract:
+// without an index there is no way to prove a subtree has no tracked
+// entries, so every file is listed.
+func TestCollapseWithoutIndexIsNoop(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "assets/img1.png", []byte("img1\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/img2.png", []byte("img2\n"), 0o644))
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(NewRootNode(memfs.New(), nil), to, IsEquals)
+	require.NoError(t, err)
+	require.Len(t, changes, 2, "every untracked file must be listed when no index is provided")
+}
+
+// TestCollapseDisabledByDefault verifies the walk lists every untracked
+// file when CollapseUntrackedDirs is not set, preserving the historical
+// behavior.
+func TestCollapseDisabledByDefault(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "assets/img1.png", []byte("img1\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/img2.png", []byte("img2\n"), 0o644))
+
+	idx := &index.Index{}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{Index: idx})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.Len(t, changes, 2)
+}
+
+// TestCollapsedDirWithIgnoredContents verifies that ignore rules are
+// honored while deciding whether a directory collapses: a directory whose
+// contents are all ignored produces no change, while a single visible
+// file is enough to report the directory.
+func TestCollapsedDirWithIgnoredContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all contents ignored", func(t *testing.T) {
+		t.Parallel()
+		fs := memfs.New()
+		require.NoError(t, WriteFile(fs, "assets/a.tmp", []byte("tmp\n"), 0o644))
+
+		to := NewRootNodeWithOptions(fs, nil, Options{
+			Index:                 &index.Index{},
+			CollapseUntrackedDirs: true,
+			IgnoreScope:           scope("*.tmp"),
+		})
+
+		changes, err := merkletrie.DiffTree(NewRootNode(memfs.New(), nil), to, IsEquals)
+		require.NoError(t, err)
+		require.Empty(t, changes)
+	})
+
+	t.Run("one visible file", func(t *testing.T) {
+		t.Parallel()
+		fs := memfs.New()
+		require.NoError(t, WriteFile(fs, "assets/a.tmp", []byte("tmp\n"), 0o644))
+		require.NoError(t, WriteFile(fs, "assets/b.bin", []byte("bin\n"), 0o644))
+
+		to := NewRootNodeWithOptions(fs, nil, Options{
+			Index:                 &index.Index{},
+			CollapseUntrackedDirs: true,
+			IgnoreScope:           scope("*.tmp"),
+		})
+
+		changes, err := merkletrie.DiffTree(NewRootNode(memfs.New(), nil), to, IsEquals)
+		require.NoError(t, err)
+		require.Equal(t, []string{"<Insert assets>"}, changePaths(t, changes))
+	})
+}
+
+// TestTrackedFileReplacedByUntrackedDir verifies that when a tracked file
+// is replaced on disk by a directory, the diff reports the file deletion
+// and a single collapsed insertion of the new directory.
+func TestTrackedFileReplacedByUntrackedDir(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "config/app.conf", []byte("conf\n"), 0o644))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "config", Hash: blobHash(t, []byte("old\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.ElementsMatch(t,
+		[]string{"<Delete config>", "<Insert config>"},
+		changePaths(t, changes))
+}
+
+// TestCollapsedDirContainingSymlinkIsReported verifies that a symlink
+// inside an untracked directory counts as content, since git reports
+// symlinks as untracked files.
+func TestCollapsedDirContainingSymlinkIsReported(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "target.txt", []byte("x\n"), 0o644))
+	require.NoError(t, fs.MkdirAll("assets", 0o755))
+	require.NoError(t, fs.Symlink("../target.txt", "assets/link.txt"))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "target.txt", Hash: blobHash(t, []byte("x\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.Equal(t, []string{"<Insert assets>"}, changePaths(t, changes))
+}

--- a/utils/merkletrie/filesystem/node_collapse_test.go
+++ b/utils/merkletrie/filesystem/node_collapse_test.go
@@ -1,0 +1,233 @@
+package filesystem
+
+import (
+	"testing"
+
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/format/index"
+	"github.com/go-git/go-git/v6/utils/merkletrie"
+	mindex "github.com/go-git/go-git/v6/utils/merkletrie/index"
+)
+
+// changePaths returns a "action path" string per change for assertion.
+func changePaths(t *testing.T, changes merkletrie.Changes) []string {
+	t.Helper()
+	paths := make([]string, 0, len(changes))
+	for _, c := range changes {
+		paths = append(paths, c.String())
+	}
+	return paths
+}
+
+// TestUntrackedDirIsCollapsed verifies that a directory with no tracked
+// entries and at least one untracked file produces a single Insert change
+// for the directory itself, instead of one change per file, when
+// CollapseUntrackedDirs is set. This matches "git status" default output.
+func TestUntrackedDirIsCollapsed(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "src/keep.go", []byte("package main\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/img1.png", []byte("img1\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/deep/img2.png", []byte("img2\n"), 0o644))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "src/keep.go", Hash: blobHash(t, []byte("package main\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.Equal(t, []string{"<Insert assets>"}, changePaths(t, changes))
+}
+
+// TestEmptyUntrackedDirIsNotReported verifies that a directory without any
+// tracked entry and no untracked file inside (fully empty, or with only
+// empty nested directories) produces no change at all, matching git which
+// does not list empty untracked directories.
+func TestEmptyUntrackedDirIsNotReported(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "src/keep.go", []byte("package main\n"), 0o644))
+	require.NoError(t, fs.MkdirAll("assets/deep/deeper", 0o755))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "src/keep.go", Hash: blobHash(t, []byte("package main\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.Empty(t, changes)
+}
+
+// TestDirWithTrackedDescendantIsNotCollapsed verifies that a directory
+// containing tracked entries is walked normally: modifications surface
+// per file and untracked siblings are listed individually.
+func TestDirWithTrackedDescendantIsNotCollapsed(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "assets/keep.go", []byte("modified\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/new.go", []byte("new\n"), 0o644))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "assets/keep.go", Hash: blobHash(t, []byte("original\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.ElementsMatch(t,
+		[]string{"<Modify assets/keep.go>", "<Insert assets/new.go>"},
+		changePaths(t, changes))
+}
+
+// TestCollapseWithoutIndexIsNoop verifies that CollapseUntrackedDirs does
+// not take effect when Index is nil, mirroring the IgnoreMatcher contract:
+// without an index there is no way to prove a subtree has no tracked
+// entries, so every file is listed.
+func TestCollapseWithoutIndexIsNoop(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "assets/img1.png", []byte("img1\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/img2.png", []byte("img2\n"), 0o644))
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(NewRootNode(memfs.New(), nil), to, IsEquals)
+	require.NoError(t, err)
+	require.Len(t, changes, 2, "every untracked file must be listed when no index is provided")
+}
+
+// TestCollapseDisabledByDefault verifies the walk lists every untracked
+// file when CollapseUntrackedDirs is not set, preserving the historical
+// behavior.
+func TestCollapseDisabledByDefault(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "assets/img1.png", []byte("img1\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "assets/img2.png", []byte("img2\n"), 0o644))
+
+	idx := &index.Index{}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{Index: idx})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.Len(t, changes, 2)
+}
+
+// TestCollapsedDirWithIgnoredContents verifies that ignore rules are
+// honored while deciding whether a directory collapses: a directory whose
+// contents are all ignored produces no change, while a single visible
+// file is enough to report the directory.
+func TestCollapsedDirWithIgnoredContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("all contents ignored", func(t *testing.T) {
+		t.Parallel()
+		fs := memfs.New()
+		require.NoError(t, WriteFile(fs, "assets/a.tmp", []byte("tmp\n"), 0o644))
+
+		to := NewRootNodeWithOptions(fs, nil, Options{
+			Index:                 &index.Index{},
+			CollapseUntrackedDirs: true,
+			IgnoreMatcher:         matcher("*.tmp"),
+		})
+
+		changes, err := merkletrie.DiffTree(NewRootNode(memfs.New(), nil), to, IsEquals)
+		require.NoError(t, err)
+		require.Empty(t, changes)
+	})
+
+	t.Run("one visible file", func(t *testing.T) {
+		t.Parallel()
+		fs := memfs.New()
+		require.NoError(t, WriteFile(fs, "assets/a.tmp", []byte("tmp\n"), 0o644))
+		require.NoError(t, WriteFile(fs, "assets/b.bin", []byte("bin\n"), 0o644))
+
+		to := NewRootNodeWithOptions(fs, nil, Options{
+			Index:                 &index.Index{},
+			CollapseUntrackedDirs: true,
+			IgnoreMatcher:         matcher("*.tmp"),
+		})
+
+		changes, err := merkletrie.DiffTree(NewRootNode(memfs.New(), nil), to, IsEquals)
+		require.NoError(t, err)
+		require.Equal(t, []string{"<Insert assets>"}, changePaths(t, changes))
+	})
+}
+
+// TestTrackedFileReplacedByUntrackedDir verifies that when a tracked file
+// is replaced on disk by a directory, the diff reports the file deletion
+// and a single collapsed insertion of the new directory.
+func TestTrackedFileReplacedByUntrackedDir(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "config/app.conf", []byte("conf\n"), 0o644))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "config", Hash: blobHash(t, []byte("old\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.ElementsMatch(t,
+		[]string{"<Delete config>", "<Insert config>"},
+		changePaths(t, changes))
+}
+
+// TestCollapsedDirContainingSymlinkIsReported verifies that a symlink
+// inside an untracked directory counts as content, since git reports
+// symlinks as untracked files.
+func TestCollapsedDirContainingSymlinkIsReported(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "target.txt", []byte("x\n"), 0o644))
+	require.NoError(t, fs.MkdirAll("assets", 0o755))
+	require.NoError(t, fs.Symlink("../target.txt", "assets/link.txt"))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "target.txt", Hash: blobHash(t, []byte("x\n")), Mode: filemode.Regular},
+		},
+	}
+
+	to := NewRootNodeWithOptions(fs, nil, Options{
+		Index:                 idx,
+		CollapseUntrackedDirs: true,
+	})
+
+	changes, err := merkletrie.DiffTree(mindex.NewRootNode(idx), to, IsEquals)
+	require.NoError(t, err)
+	require.Equal(t, []string{"<Insert assets>"}, changePaths(t, changes))
+}

--- a/utils/merkletrie/noder/noder.go
+++ b/utils/merkletrie/noder/noder.go
@@ -56,5 +56,18 @@ type Noder interface {
 	Skip() bool
 }
 
+// Collapser may be implemented by directory-like noders to signal that
+// their whole subtree can be represented by a single change. When
+// Collapse reports true for a directory, Changes.AddRecursiveInsert and
+// Changes.AddRecursiveDelete emit one change for the directory itself
+// instead of descending into it. This mirrors how "git status" reports
+// untracked directories as a single entry by default.
+type Collapser interface {
+	// Collapse reports whether the directory subtree rooted at this
+	// noder can be represented by a single change. It must return false
+	// for file-like noders.
+	Collapse() bool
+}
+
 // NoChildren represents the children of a noder without children.
 var NoChildren = []Noder{}

--- a/worktree.go
+++ b/worktree.go
@@ -621,7 +621,11 @@ func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparse
 	}
 
 	// Check worktree status for local modifications on touched paths.
-	status, err := w.Status()
+	// UntrackedFilesAll: the checks below match exact file paths.
+	status, err := w.StatusWithOptions(StatusOptions{
+		Strategy:       defaultStatusStrategy,
+		UntrackedFiles: UntrackedFilesAll,
+	})
 	if err != nil {
 		return err
 	}
@@ -702,7 +706,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 	// Delete actions. The observable result is unchanged because Delete
 	// actions are skipped by the loop below; the matcher only avoids the
 	// pointless lstat of every file under directories like node_modules.
-	worktreeChanges, err := w.diffStagingWithWorktree(cfg, true, true)
+	worktreeChanges, err := w.diffStagingWithWorktree(cfg, true, true, UntrackedFilesAll)
 	if err != nil {
 		return err
 	}
@@ -772,7 +776,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 // noder's IgnoreMatcher would prune it from the walk and the Delete
 // action needed to remove it from disk would never be emitted.
 func (w *Worktree) resetWorktree(cfg *config.Config, t *object.Tree, files []string) error {
-	changes, err := w.diffStagingWithWorktree(cfg, true, false)
+	changes, err := w.diffStagingWithWorktree(cfg, true, false, UntrackedFilesAll)
 	if err != nil {
 		return err
 	}
@@ -854,7 +858,7 @@ func (w *Worktree) checkoutChange(cfg *config.Config, ch merkletrie.Change, t *o
 }
 
 func (w *Worktree) containsUnstagedChanges(cfg *config.Config) (bool, error) {
-	ch, err := w.diffStagingWithWorktree(cfg, false, true)
+	ch, err := w.diffStagingWithWorktree(cfg, false, true, UntrackedFilesAll)
 	if err != nil {
 		return false, err
 	}
@@ -1241,7 +1245,11 @@ func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
 // Clean the worktree by removing untracked files.
 // An empty dir could be removed - this is what  `git clean -f -d .` does.
 func (w *Worktree) Clean(opts *CleanOptions) error {
-	s, err := w.Status()
+	// UntrackedFilesAll: doClean checks IsUntracked per file path.
+	s, err := w.StatusWithOptions(StatusOptions{
+		Strategy:       defaultStatusStrategy,
+		UntrackedFiles: UntrackedFilesAll,
+	})
 	if err != nil {
 		return err
 	}

--- a/worktree.go
+++ b/worktree.go
@@ -666,7 +666,11 @@ func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparse
 	}
 
 	// Check worktree status for local modifications on touched paths.
-	status, err := w.Status()
+	// UntrackedFilesAll: the checks below match exact file paths.
+	status, err := w.StatusWithOptions(StatusOptions{
+		Strategy:       defaultStatusStrategy,
+		UntrackedFiles: UntrackedFilesAll,
+	})
 	if err != nil {
 		return err
 	}
@@ -750,7 +754,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 	// Delete actions. The observable result is unchanged because Delete
 	// actions are skipped by the loop below; the matcher only avoids the
 	// pointless lstat of every file under directories like node_modules.
-	worktreeChanges, err := w.diffStagingWithWorktree(cfg, true, true)
+	worktreeChanges, err := w.diffStagingWithWorktree(cfg, true, true, UntrackedFilesAll)
 	if err != nil {
 		return err
 	}
@@ -820,7 +824,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 // noder's IgnoreScope would prune it from the walk and the Delete
 // action needed to remove it from disk would never be emitted.
 func (w *Worktree) resetWorktree(cfg *config.Config, t *object.Tree, files []string) error {
-	changes, err := w.diffStagingWithWorktree(cfg, true, false)
+	changes, err := w.diffStagingWithWorktree(cfg, true, false, UntrackedFilesAll)
 	if err != nil {
 		return err
 	}
@@ -905,7 +909,7 @@ func (w *Worktree) checkoutChange(cfg *config.Config, fs *worktreeFilesystem, ch
 }
 
 func (w *Worktree) containsUnstagedChanges(cfg *config.Config) (bool, error) {
-	ch, err := w.diffStagingWithWorktree(cfg, false, true)
+	ch, err := w.diffStagingWithWorktree(cfg, false, true, UntrackedFilesAll)
 	if err != nil {
 		return false, err
 	}
@@ -1347,7 +1351,11 @@ func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
 // Clean the worktree by removing untracked files.
 // An empty dir could be removed - this is what  `git clean -f -d .` does.
 func (w *Worktree) Clean(opts *CleanOptions) error {
-	s, err := w.Status()
+	// UntrackedFilesAll: doClean checks IsUntracked per file path.
+	s, err := w.StatusWithOptions(StatusOptions{
+		Strategy:       defaultStatusStrategy,
+		UntrackedFiles: UntrackedFilesAll,
+	})
 	if err != nil {
 		return err
 	}

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -42,13 +42,41 @@ var (
 )
 
 // Status returns the working tree status.
+//
+// Untracked directories are reported as a single entry, without listing
+// their contents, matching the default behavior of "git status". Use
+// StatusWithOptions with UntrackedFilesAll to list every untracked file
+// individually.
 func (w *Worktree) Status() (Status, error) {
 	return w.StatusWithOptions(StatusOptions{Strategy: defaultStatusStrategy})
 }
 
+// UntrackedFilesMode defines how Status reports untracked files, mirroring
+// the values of git's status.showUntrackedFiles configuration.
+type UntrackedFilesMode int
+
+const (
+	// UntrackedFilesNormal reports untracked directories as a single
+	// entry, without descending into them. This matches the default
+	// behavior of "git status" (status.showUntrackedFiles=normal) and is
+	// significantly faster on worktrees with many untracked files.
+	UntrackedFilesNormal UntrackedFilesMode = iota
+	// UntrackedFilesAll reports every untracked file individually,
+	// matching "git status --untracked-files=all". This is go-git's
+	// historical behavior.
+	UntrackedFilesAll
+	// UntrackedFilesNo omits untracked entries from the status, matching
+	// "git status --untracked-files=no". Tracked changes are still
+	// reported.
+	UntrackedFilesNo
+)
+
 // StatusOptions defines the options for Worktree.StatusWithOptions().
 type StatusOptions struct {
 	Strategy StatusStrategy
+	// UntrackedFiles controls how untracked files are reported. The zero
+	// value is UntrackedFilesNormal.
+	UntrackedFiles UntrackedFilesMode
 }
 
 // StatusWithOptions returns the working tree status.
@@ -69,11 +97,11 @@ func (w *Worktree) StatusWithOptions(o StatusOptions) (Status, error) {
 		return nil, err
 	}
 
-	return w.status(cfg, o.Strategy, hash)
+	return w.status(cfg, o, hash)
 }
 
-func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing.Hash) (Status, error) {
-	s, err := ss.new(w)
+func (w *Worktree) status(cfg *config.Config, o StatusOptions, commit plumbing.Hash) (Status, error) {
+	s, err := o.Strategy.new(w)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +130,7 @@ func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing
 		}
 	}
 
-	right, err := w.diffStagingWithWorktree(cfg, false, true)
+	right, err := w.diffStagingWithWorktree(cfg, false, true, o.UntrackedFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +139,10 @@ func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing
 		a, err := ch.Action()
 		if err != nil {
 			return nil, err
+		}
+
+		if a == merkletrie.Insert && o.UntrackedFiles == UntrackedFilesNo {
+			continue
 		}
 
 		fs := s.File(nameFromAction(&ch))
@@ -141,7 +173,7 @@ func nameFromAction(ch *merkletrie.Change) string {
 	return name
 }
 
-func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeIgnoredChanges bool) (merkletrie.Changes, error) {
+func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeIgnoredChanges bool, untracked UntrackedFilesMode) (merkletrie.Changes, error) {
 	idx, err := w.r.Storer.Index()
 	if err != nil {
 		return nil, err
@@ -156,8 +188,9 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 	}
 
 	fsOpts := filesystem.Options{
-		AutoCRLF: cfg.Core.AutoCRLF == "true" || cfg.Core.AutoCRLF == "input",
-		Index:    idx,
+		AutoCRLF:              cfg.Core.AutoCRLF == "true" || cfg.Core.AutoCRLF == "input",
+		Index:                 idx,
+		CollapseUntrackedDirs: untracked != UntrackedFilesAll,
 	}
 
 	// When ignored changes are to be filtered out, hand the noder the ignore
@@ -394,11 +427,14 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 
 	fi, err := w.filesystem.Lstat(path)
 
-	// status is required for doAddDirectory
+	// status is required for doAddDirectory, which enumerates untracked files.
 	var s Status
 	var err2 error
 	if !skipStatus || fi == nil || fi.IsDir() {
-		s, err2 = w.Status()
+		s, err2 = w.StatusWithOptions(StatusOptions{
+			Strategy:       defaultStatusStrategy,
+			UntrackedFiles: UntrackedFilesAll,
+		})
 		if err2 != nil {
 			return plumbing.ZeroHash, err2
 		}
@@ -461,7 +497,11 @@ func (w *Worktree) AddGlob(pattern string) error {
 		return err
 	}
 
-	s, err := w.Status()
+	// UntrackedFilesAll: glob matches are added file by file.
+	s, err := w.StatusWithOptions(StatusOptions{
+		Strategy:       defaultStatusStrategy,
+		UntrackedFiles: UntrackedFilesAll,
+	})
 	if err != nil {
 		return err
 	}

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -42,13 +42,41 @@ var (
 )
 
 // Status returns the working tree status.
+//
+// Untracked directories are reported as a single entry, without listing
+// their contents, matching the default behavior of "git status". Use
+// StatusWithOptions with UntrackedFilesAll to list every untracked file
+// individually.
 func (w *Worktree) Status() (Status, error) {
 	return w.StatusWithOptions(StatusOptions{Strategy: defaultStatusStrategy})
 }
 
+// UntrackedFilesMode defines how Status reports untracked files, mirroring
+// the values of git's status.showUntrackedFiles configuration.
+type UntrackedFilesMode int
+
+const (
+	// UntrackedFilesNormal reports untracked directories as a single
+	// entry, without descending into them. This matches the default
+	// behavior of "git status" (status.showUntrackedFiles=normal) and is
+	// significantly faster on worktrees with many untracked files.
+	UntrackedFilesNormal UntrackedFilesMode = iota
+	// UntrackedFilesAll reports every untracked file individually,
+	// matching "git status --untracked-files=all". This is go-git's
+	// historical behavior.
+	UntrackedFilesAll
+	// UntrackedFilesNo omits untracked entries from the status, matching
+	// "git status --untracked-files=no". Tracked changes are still
+	// reported.
+	UntrackedFilesNo
+)
+
 // StatusOptions defines the options for Worktree.StatusWithOptions().
 type StatusOptions struct {
 	Strategy StatusStrategy
+	// UntrackedFiles controls how untracked files are reported. The zero
+	// value is UntrackedFilesNormal.
+	UntrackedFiles UntrackedFilesMode
 }
 
 // StatusWithOptions returns the working tree status.
@@ -69,11 +97,11 @@ func (w *Worktree) StatusWithOptions(o StatusOptions) (Status, error) {
 		return nil, err
 	}
 
-	return w.status(cfg, o.Strategy, hash)
+	return w.status(cfg, o, hash)
 }
 
-func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing.Hash) (Status, error) {
-	s, err := ss.new(w)
+func (w *Worktree) status(cfg *config.Config, o StatusOptions, commit plumbing.Hash) (Status, error) {
+	s, err := o.Strategy.new(w)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +130,7 @@ func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing
 		}
 	}
 
-	right, err := w.diffStagingWithWorktree(cfg, false, true)
+	right, err := w.diffStagingWithWorktree(cfg, false, true, o.UntrackedFiles)
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +139,10 @@ func (w *Worktree) status(cfg *config.Config, ss StatusStrategy, commit plumbing
 		a, err := ch.Action()
 		if err != nil {
 			return nil, err
+		}
+
+		if a == merkletrie.Insert && o.UntrackedFiles == UntrackedFilesNo {
+			continue
 		}
 
 		fs := s.File(nameFromAction(&ch))
@@ -141,7 +173,7 @@ func nameFromAction(ch *merkletrie.Change) string {
 	return name
 }
 
-func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeIgnoredChanges bool) (merkletrie.Changes, error) {
+func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeIgnoredChanges bool, untracked UntrackedFilesMode) (merkletrie.Changes, error) {
 	idx, err := w.r.Storer.Index()
 	if err != nil {
 		return nil, err
@@ -156,8 +188,9 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 	}
 
 	fsOpts := filesystem.Options{
-		AutoCRLF: cfg.Core.AutoCRLF == "true" || cfg.Core.AutoCRLF == "input",
-		Index:    idx,
+		AutoCRLF:              cfg.Core.AutoCRLF == "true" || cfg.Core.AutoCRLF == "input",
+		Index:                 idx,
+		CollapseUntrackedDirs: untracked != UntrackedFilesAll,
 	}
 
 	// When ignored changes are to be filtered out, gather the gitignore
@@ -376,11 +409,14 @@ func (w *Worktree) doAdd(path string, ignorePattern []gitignore.Pattern, skipSta
 
 	fi, err := w.filesystem.Lstat(path)
 
-	// status is required for doAddDirectory
+	// status is required for doAddDirectory, which enumerates untracked files.
 	var s Status
 	var err2 error
 	if !skipStatus || fi == nil || fi.IsDir() {
-		s, err2 = w.Status()
+		s, err2 = w.StatusWithOptions(StatusOptions{
+			Strategy:       defaultStatusStrategy,
+			UntrackedFiles: UntrackedFilesAll,
+		})
 		if err2 != nil {
 			return plumbing.ZeroHash, err2
 		}
@@ -442,7 +478,11 @@ func (w *Worktree) AddGlob(pattern string) error {
 		return err
 	}
 
-	s, err := w.Status()
+	// UntrackedFilesAll: glob matches are added file by file.
+	s, err := w.StatusWithOptions(StatusOptions{
+		Strategy:       defaultStatusStrategy,
+		UntrackedFiles: UntrackedFilesAll,
+	})
 	if err != nil {
 		return err
 	}

--- a/worktree_status_bench_test.go
+++ b/worktree_status_bench_test.go
@@ -409,3 +409,106 @@ func BenchmarkStatusIgnoredDir(b *testing.B) {
 		})
 	}
 }
+
+// setupUntrackedDirRepo builds a repo with `tracked` committed files and
+// `untracked` files dropped into a directory that is NOT gitignored. This
+// mirrors dotfiles-style repositories opened over a large worktree (e.g. a
+// home directory), where almost everything is untracked, from
+// https://github.com/go-git/go-git/issues/181.
+func setupUntrackedDirRepo(b *testing.B, tracked, untracked int) *Worktree {
+	b.Helper()
+
+	const untrackedDir = "untracked_dir"
+
+	tmpDir := b.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = repo.Close() })
+
+	wt, err := repo.Worktree()
+	require.NoError(b, err)
+
+	for i := range tracked {
+		path := filepath.Join("src", fmt.Sprintf("dir%02d", i%10), fmt.Sprintf("file%04d.go", i))
+		require.NoError(b, wt.Filesystem().MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(b, util.WriteFile(wt.Filesystem(), path, []byte("package main\n"), 0o644))
+	}
+
+	require.NoError(b, wt.AddGlob("src/*"))
+
+	sig := &object.Signature{
+		Name:  "Bench",
+		Email: "bench@test.com",
+		When:  time.Now().Add(-time.Hour), // older than index modtime so the metadata fast-path engages
+	}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(b, err)
+
+	for top := range untracked / 100 {
+		for sub := range 10 {
+			dir := filepath.Join(untrackedDir, fmt.Sprintf("top%03d", top), fmt.Sprintf("sub%02d", sub))
+			require.NoError(b, wt.Filesystem().MkdirAll(dir, 0o755))
+			for f := range 10 {
+				path := filepath.Join(dir, fmt.Sprintf("file%02d.txt", f))
+				require.NoError(b, util.WriteFile(wt.Filesystem(), path, []byte("untracked\n"), 0o644))
+			}
+		}
+	}
+
+	return wt
+}
+
+// BenchmarkStatusUntrackedDir measures the cost of running Status() over a
+// tree that contains a large untracked, non-ignored directory, comparing
+// the untracked files modes:
+//
+//   - Normal collapses the directory into a single entry, like "git status"
+//     does by default, so cost stays roughly flat as the tree grows.
+//   - All lists every untracked file (go-git's historical behavior), so
+//     cost grows linearly with the number of untracked files.
+func BenchmarkStatusUntrackedDir(b *testing.B) {
+	const tracked = 100
+
+	cases := []struct {
+		name      string
+		untracked int
+	}{
+		{"UntrackedFiles_1k", 1000},
+		{"UntrackedFiles_5k", 5000},
+		{"UntrackedFiles_20k", 20000},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.Run("Normal", func(b *testing.B) {
+				wt := setupUntrackedDirRepo(b, tracked, tc.untracked)
+				b.ResetTimer()
+				for b.Loop() {
+					s, err := wt.Status()
+					if err != nil {
+						b.Fatalf("status: %v", err)
+					}
+					if len(s) != 1 {
+						b.Fatalf("expected 1 collapsed entry, got %d", len(s))
+					}
+				}
+			})
+
+			b.Run("All", func(b *testing.B) {
+				wt := setupUntrackedDirRepo(b, tracked, tc.untracked)
+				b.ResetTimer()
+				for b.Loop() {
+					s, err := wt.StatusWithOptions(StatusOptions{UntrackedFiles: UntrackedFilesAll})
+					if err != nil {
+						b.Fatalf("status: %v", err)
+					}
+					if len(s) != tc.untracked {
+						b.Fatalf("expected %d entries, got %d", tc.untracked, len(s))
+					}
+				}
+			})
+		})
+	}
+}

--- a/worktree_status_bench_test.go
+++ b/worktree_status_bench_test.go
@@ -254,3 +254,106 @@ func BenchmarkStatusIgnoredDir(b *testing.B) {
 		})
 	}
 }
+
+// setupUntrackedDirRepo builds a repo with `tracked` committed files and
+// `untracked` files dropped into a directory that is NOT gitignored. This
+// mirrors dotfiles-style repositories opened over a large worktree (e.g. a
+// home directory), where almost everything is untracked, from
+// https://github.com/go-git/go-git/issues/181.
+func setupUntrackedDirRepo(b *testing.B, tracked, untracked int) *Worktree {
+	b.Helper()
+
+	const untrackedDir = "untracked_dir"
+
+	tmpDir := b.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = repo.Close() })
+
+	wt, err := repo.Worktree()
+	require.NoError(b, err)
+
+	for i := range tracked {
+		path := filepath.Join("src", fmt.Sprintf("dir%02d", i%10), fmt.Sprintf("file%04d.go", i))
+		require.NoError(b, wt.Filesystem().MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(b, util.WriteFile(wt.Filesystem(), path, []byte("package main\n"), 0o644))
+	}
+
+	require.NoError(b, wt.AddGlob("src/*"))
+
+	sig := &object.Signature{
+		Name:  "Bench",
+		Email: "bench@test.com",
+		When:  time.Now().Add(-time.Hour), // older than index modtime so the metadata fast-path engages
+	}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(b, err)
+
+	for top := range untracked / 100 {
+		for sub := range 10 {
+			dir := filepath.Join(untrackedDir, fmt.Sprintf("top%03d", top), fmt.Sprintf("sub%02d", sub))
+			require.NoError(b, wt.Filesystem().MkdirAll(dir, 0o755))
+			for f := range 10 {
+				path := filepath.Join(dir, fmt.Sprintf("file%02d.txt", f))
+				require.NoError(b, util.WriteFile(wt.Filesystem(), path, []byte("untracked\n"), 0o644))
+			}
+		}
+	}
+
+	return wt
+}
+
+// BenchmarkStatusUntrackedDir measures the cost of running Status() over a
+// tree that contains a large untracked, non-ignored directory, comparing
+// the untracked files modes:
+//
+//   - Normal collapses the directory into a single entry, like "git status"
+//     does by default, so cost stays roughly flat as the tree grows.
+//   - All lists every untracked file (go-git's historical behavior), so
+//     cost grows linearly with the number of untracked files.
+func BenchmarkStatusUntrackedDir(b *testing.B) {
+	const tracked = 100
+
+	cases := []struct {
+		name      string
+		untracked int
+	}{
+		{"UntrackedFiles_1k", 1000},
+		{"UntrackedFiles_5k", 5000},
+		{"UntrackedFiles_20k", 20000},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.Run("Normal", func(b *testing.B) {
+				wt := setupUntrackedDirRepo(b, tracked, tc.untracked)
+				b.ResetTimer()
+				for b.Loop() {
+					s, err := wt.Status()
+					if err != nil {
+						b.Fatalf("status: %v", err)
+					}
+					if len(s) != 1 {
+						b.Fatalf("expected 1 collapsed entry, got %d", len(s))
+					}
+				}
+			})
+
+			b.Run("All", func(b *testing.B) {
+				wt := setupUntrackedDirRepo(b, tracked, tc.untracked)
+				b.ResetTimer()
+				for b.Loop() {
+					s, err := wt.StatusWithOptions(StatusOptions{UntrackedFiles: UntrackedFilesAll})
+					if err != nil {
+						b.Fatalf("status: %v", err)
+					}
+					if len(s) != tc.untracked {
+						b.Fatalf("expected %d entries, got %d", tc.untracked, len(s))
+					}
+				}
+			})
+		})
+	}
+}

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -150,6 +150,131 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	assert.False(t, ok, "untracked file inside an ignored directory must not surface in Status")
 }
 
+// setupCollapseStatusRepo builds a repository with one tracked file at the
+// root and a mix of untracked content: a loose file at the root, a fully
+// untracked directory tree under assets/, and an untracked file next to a
+// tracked one under keep/.
+func setupCollapseStatusRepo(t *testing.T) *Worktree {
+	t.Helper()
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = repo.Close() })
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	write := func(name string) {
+		require.NoError(t, wt.Filesystem().MkdirAll(filepath.Dir(name), 0o755))
+		require.NoError(t, util.WriteFile(wt.Filesystem(), name, []byte(name+"\n"), 0o644))
+	}
+
+	write("tracked.txt")
+	write("keep/tracked.txt")
+	for _, p := range []string{"tracked.txt", "keep/tracked.txt"} {
+		_, err := wt.Add(p)
+		require.NoError(t, err)
+	}
+
+	sig := &object.Signature{Name: "test", Email: "test@test.com"}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(t, err)
+
+	write("loose.txt")
+	write("assets/img1.png")
+	write("assets/deep/img2.png")
+	write("keep/new.txt")
+
+	return wt
+}
+
+// TestStatusCollapsesUntrackedDirsByDefault verifies that Status() reports
+// a fully untracked directory as a single entry, like "git status" does by
+// default, while untracked files at the root or next to tracked entries
+// are still listed individually.
+func TestStatusCollapsesUntrackedDirsByDefault(t *testing.T) {
+	t.Parallel()
+	wt := setupCollapseStatusRepo(t)
+
+	st, err := wt.Status()
+	require.NoError(t, err)
+
+	assets, ok := st["assets"]
+	require.True(t, ok, "fully untracked directory must be reported as a single entry")
+	assert.Equal(t, Untracked, assets.Worktree)
+	assert.Equal(t, Untracked, assets.Staging)
+
+	_, ok = st["assets/img1.png"]
+	assert.False(t, ok, "files inside a collapsed directory must not be listed")
+	_, ok = st["assets/deep/img2.png"]
+	assert.False(t, ok, "files deep inside a collapsed directory must not be listed")
+
+	_, ok = st["loose.txt"]
+	assert.True(t, ok, "untracked file at the root must be listed")
+
+	_, ok = st["keep/new.txt"]
+	assert.True(t, ok, "untracked file next to a tracked entry must be listed")
+}
+
+// TestStatusUntrackedFilesAll verifies that StatusWithOptions with
+// UntrackedFilesAll restores the historical behavior of listing every
+// untracked file individually.
+func TestStatusUntrackedFilesAll(t *testing.T) {
+	t.Parallel()
+	wt := setupCollapseStatusRepo(t)
+
+	st, err := wt.StatusWithOptions(StatusOptions{UntrackedFiles: UntrackedFilesAll})
+	require.NoError(t, err)
+
+	for _, p := range []string{"loose.txt", "assets/img1.png", "assets/deep/img2.png", "keep/new.txt"} {
+		fs, ok := st[p]
+		assert.True(t, ok, "%s must be listed", p)
+		assert.Equal(t, Untracked, fs.Worktree)
+	}
+}
+
+// TestStatusUntrackedFilesNo verifies that StatusWithOptions with
+// UntrackedFilesNo omits untracked entries entirely, like "git status
+// -uno", while tracked modifications are still reported.
+func TestStatusUntrackedFilesNo(t *testing.T) {
+	t.Parallel()
+	wt := setupCollapseStatusRepo(t)
+
+	require.NoError(t, util.WriteFile(wt.Filesystem(), "tracked.txt", []byte("changed\n"), 0o644))
+
+	st, err := wt.StatusWithOptions(StatusOptions{UntrackedFiles: UntrackedFilesNo})
+	require.NoError(t, err)
+
+	for _, p := range []string{"loose.txt", "assets", "assets/img1.png", "keep/new.txt"} {
+		_, ok := st[p]
+		assert.False(t, ok, "%s must not be listed", p)
+	}
+
+	modified, ok := st["tracked.txt"]
+	require.True(t, ok, "modified tracked file must still be reported")
+	assert.Equal(t, Modified, modified.Worktree)
+}
+
+// TestAddDirectoryWithCollapsedStatus is a regression test: Add on a
+// directory must keep adding every untracked file inside it, even though
+// Status() now collapses untracked directories by default.
+func TestAddDirectoryWithCollapsedStatus(t *testing.T) {
+	t.Parallel()
+	wt := setupCollapseStatusRepo(t)
+
+	_, err := wt.Add("assets")
+	require.NoError(t, err)
+
+	idx, err := wt.r.Storer.Index()
+	require.NoError(t, err)
+
+	for _, p := range []string{"assets/img1.png", "assets/deep/img2.png"} {
+		_, err := idx.Entry(p)
+		assert.NoError(t, err, "%s must have been added to the index", p)
+	}
+}
+
 func BenchmarkWorktreeStatus(b *testing.B) {
 	b.StopTimer()
 

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -151,6 +151,131 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	assert.False(t, ok, "untracked file inside an ignored directory must not surface in Status")
 }
 
+// setupCollapseStatusRepo builds a repository with one tracked file at the
+// root and a mix of untracked content: a loose file at the root, a fully
+// untracked directory tree under assets/, and an untracked file next to a
+// tracked one under keep/.
+func setupCollapseStatusRepo(t *testing.T) *Worktree {
+	t.Helper()
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = repo.Close() })
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	write := func(name string) {
+		require.NoError(t, wt.Filesystem().MkdirAll(filepath.Dir(name), 0o755))
+		require.NoError(t, util.WriteFile(wt.Filesystem(), name, []byte(name+"\n"), 0o644))
+	}
+
+	write("tracked.txt")
+	write("keep/tracked.txt")
+	for _, p := range []string{"tracked.txt", "keep/tracked.txt"} {
+		_, err := wt.Add(p)
+		require.NoError(t, err)
+	}
+
+	sig := &object.Signature{Name: "test", Email: "test@test.com"}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(t, err)
+
+	write("loose.txt")
+	write("assets/img1.png")
+	write("assets/deep/img2.png")
+	write("keep/new.txt")
+
+	return wt
+}
+
+// TestStatusCollapsesUntrackedDirsByDefault verifies that Status() reports
+// a fully untracked directory as a single entry, like "git status" does by
+// default, while untracked files at the root or next to tracked entries
+// are still listed individually.
+func TestStatusCollapsesUntrackedDirsByDefault(t *testing.T) {
+	t.Parallel()
+	wt := setupCollapseStatusRepo(t)
+
+	st, err := wt.Status()
+	require.NoError(t, err)
+
+	assets, ok := st["assets"]
+	require.True(t, ok, "fully untracked directory must be reported as a single entry")
+	assert.Equal(t, Untracked, assets.Worktree)
+	assert.Equal(t, Untracked, assets.Staging)
+
+	_, ok = st["assets/img1.png"]
+	assert.False(t, ok, "files inside a collapsed directory must not be listed")
+	_, ok = st["assets/deep/img2.png"]
+	assert.False(t, ok, "files deep inside a collapsed directory must not be listed")
+
+	_, ok = st["loose.txt"]
+	assert.True(t, ok, "untracked file at the root must be listed")
+
+	_, ok = st["keep/new.txt"]
+	assert.True(t, ok, "untracked file next to a tracked entry must be listed")
+}
+
+// TestStatusUntrackedFilesAll verifies that StatusWithOptions with
+// UntrackedFilesAll restores the historical behavior of listing every
+// untracked file individually.
+func TestStatusUntrackedFilesAll(t *testing.T) {
+	t.Parallel()
+	wt := setupCollapseStatusRepo(t)
+
+	st, err := wt.StatusWithOptions(StatusOptions{UntrackedFiles: UntrackedFilesAll})
+	require.NoError(t, err)
+
+	for _, p := range []string{"loose.txt", "assets/img1.png", "assets/deep/img2.png", "keep/new.txt"} {
+		fs, ok := st[p]
+		assert.True(t, ok, "%s must be listed", p)
+		assert.Equal(t, Untracked, fs.Worktree)
+	}
+}
+
+// TestStatusUntrackedFilesNo verifies that StatusWithOptions with
+// UntrackedFilesNo omits untracked entries entirely, like "git status
+// -uno", while tracked modifications are still reported.
+func TestStatusUntrackedFilesNo(t *testing.T) {
+	t.Parallel()
+	wt := setupCollapseStatusRepo(t)
+
+	require.NoError(t, util.WriteFile(wt.Filesystem(), "tracked.txt", []byte("changed\n"), 0o644))
+
+	st, err := wt.StatusWithOptions(StatusOptions{UntrackedFiles: UntrackedFilesNo})
+	require.NoError(t, err)
+
+	for _, p := range []string{"loose.txt", "assets", "assets/img1.png", "keep/new.txt"} {
+		_, ok := st[p]
+		assert.False(t, ok, "%s must not be listed", p)
+	}
+
+	modified, ok := st["tracked.txt"]
+	require.True(t, ok, "modified tracked file must still be reported")
+	assert.Equal(t, Modified, modified.Worktree)
+}
+
+// TestAddDirectoryWithCollapsedStatus is a regression test: Add on a
+// directory must keep adding every untracked file inside it, even though
+// Status() now collapses untracked directories by default.
+func TestAddDirectoryWithCollapsedStatus(t *testing.T) {
+	t.Parallel()
+	wt := setupCollapseStatusRepo(t)
+
+	_, err := wt.Add("assets")
+	require.NoError(t, err)
+
+	idx, err := wt.r.Storer.Index()
+	require.NoError(t, err)
+
+	for _, p := range []string{"assets/img1.png", "assets/deep/img2.png"} {
+		_, err := idx.Entry(p)
+		assert.NoError(t, err, "%s must have been added to the index", p)
+	}
+}
+
 func BenchmarkWorktreeStatus(b *testing.B) {
 	b.StopTimer()
 
@@ -210,7 +335,8 @@ func TestAddSubdirectoryForwardSlash(t *testing.T) {
 // Status reports against `git ls-files --others --exclude-standard` over
 // layouts that place ignore rules and negations at different depths. Ignore
 // evaluation happens during the walk, so the check belongs at this level and
-// not only against the gitignore package.
+// not only against the gitignore package. UntrackedFilesAll keeps the
+// comparison file-by-file, as ls-files does not collapse directories.
 //
 // Skipped under -short or without a git binary. Cases using a negation are
 // skipped against Git 2.11.0, which CI builds and which does not honour
@@ -306,7 +432,7 @@ func TestStatusMatchesReferenceGitForIgnoreLayouts(t *testing.T) {
 			wt, err := repo.Worktree()
 			require.NoError(t, err)
 
-			st, err := wt.Status()
+			st, err := wt.StatusWithOptions(StatusOptions{UntrackedFiles: UntrackedFilesAll})
 			require.NoError(t, err)
 
 			got := map[string]bool{}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2192,11 +2192,11 @@ func (s *WorktreeSuite) TestStatusIgnored() {
 
 	status, _ := w.Status()
 	s.Len(status, 3)
-	_, ok := status["another/file"]
+	_, ok := status["another"]
 	s.True(ok)
-	_, ok = status["vendor/github.com/file"]
+	_, ok = status["vendor/github.com"]
 	s.True(ok)
-	_, ok = status["vendor/gopkg.in/file"]
+	_, ok = status["vendor/gopkg.in"]
 	s.True(ok)
 
 	f, _ = fs.Create(".gitignore")
@@ -2210,11 +2210,11 @@ func (s *WorktreeSuite) TestStatusIgnored() {
 	s.Len(status, 4)
 	_, ok = status[".gitignore"]
 	s.True(ok)
-	_, ok = status["another/file"]
+	_, ok = status["another"]
 	s.True(ok)
 	_, ok = status["vendor/.gitignore"]
 	s.True(ok)
-	_, ok = status["vendor/github.com/file"]
+	_, ok = status["vendor/github.com"]
 	s.True(ok)
 }
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2346,11 +2346,11 @@ func (s *WorktreeSuite) TestStatusIgnored() {
 
 	status, _ := w.Status()
 	s.Len(status, 3)
-	_, ok := status["another/file"]
+	_, ok := status["another"]
 	s.True(ok)
-	_, ok = status["vendor/github.com/file"]
+	_, ok = status["vendor/github.com"]
 	s.True(ok)
-	_, ok = status["vendor/gopkg.in/file"]
+	_, ok = status["vendor/gopkg.in"]
 	s.True(ok)
 
 	f, _ = fs.Create(".gitignore")
@@ -2364,11 +2364,11 @@ func (s *WorktreeSuite) TestStatusIgnored() {
 	s.Len(status, 4)
 	_, ok = status[".gitignore"]
 	s.True(ok)
-	_, ok = status["another/file"]
+	_, ok = status["another"]
 	s.True(ok)
 	_, ok = status["vendor/.gitignore"]
 	s.True(ok)
-	_, ok = status["vendor/github.com/file"]
+	_, ok = status["vendor/github.com"]
 	s.True(ok)
 }
 


### PR DESCRIPTION
## Why

`Worktree.Status()` lists every untracked file individually, while reference `git status` reports a fully untracked directory as a single entry by default (`status.showUntrackedFiles=normal`, see [git-status docs](https://git-scm.com/docs/git-status) and [status.showUntrackedFiles](https://git-scm.com/docs/git-config#Documentation/git-config.txt-statusshowUntrackedFiles)).

On worktrees with many untracked, non-ignored files — e.g. dotfiles repositories opened over a home directory as reported in #181 — `Status()` enumerates, `lstat`s and allocates a merkletrie node, a `Change` and a `FileStatus` per untracked file. In a reproduction with a 30k-untracked-file worktree `Status()` takes ~2s where `git status` takes ~0.1s; the reporter measured 326s on their home directory.

## What

- New `StatusOptions.UntrackedFiles` mirroring git's `status.showUntrackedFiles`:
  - `UntrackedFilesNormal` (zero value, **new default**): untracked directories are reported as a single entry, like `git status` (`?? dir/`).
  - `UntrackedFilesAll`: every untracked file listed individually — go-git's historical behavior.
  - `UntrackedFilesNo`: untracked entries omitted, like `git status -uno`.
- The collapse is implemented in the diff machinery: a new `noder.Collapser` interface lets a directory noder declare its subtree representable by one change; `Changes.addRecursive` then emits a single change for the directory instead of descending.
- The filesystem noder gets a `CollapseUntrackedDirs` option (requires `Index`, same contract as `IgnoreMatcher`). A directory collapses only when it has **no tracked descendants** and contains **at least one visible (non-ignored) file**, validated with an early-exit scan — so fully untracked directories are usually validated with one `ReadDir` per nesting level instead of a full enumeration. Empty untracked directories produce no entry, matching git.
- Internal callers that enumerate untracked *files* (`Add`, `AddGlob`, `Clean`, and the KeepReset conflict check) are pinned to `UntrackedFilesAll` and behave exactly as before.

The design mirrors upstream git's traversal (`dir.c`): `UntrackedFilesNormal` maps to `DIR_SHOW_OTHER_DIRECTORIES | DIR_HIDE_EMPTY_DIRECTORIES`, the tracked-descendant check to `directory_exists_in_index()`, and the early-exit visibility scan to `read_directory_recursive()`'s `check_only` mode.

## Behavior change (v6)

`Status()` output for untracked files changes from per-file listing to collapsed directory entries (git parity). Consumers needing the old listing can opt into `StatusOptions{UntrackedFiles: UntrackedFilesAll}`. Verified against reference `git status --porcelain` on equivalent fixtures, including nested `.gitignore` un-ignore rules and tracked/untracked mixes.

## Benchmarks

A/B comparison of the `main`-branch binary vs this branch on an identical fixture (5,000 untracked files across 550 directories, 100 tracked files; Apple M4 Pro; 7 runs each, `-benchtime=5x`), via `benchstat`:

```
                  │  before (main)  │  after (this PR)  │
                  │     sec/op      │   sec/op  vs base │
StatusUntracked5k    309.3m ± 29%    185.4m ± 31%  -40.04% (p=0.001 n=7)
```

The included `BenchmarkStatusUntrackedDir` reproduces this on demand (20k files / 2,200 dirs: `All` 1476ms/op vs `Normal` 903ms/op) and the status map holds 1 entry instead of 20,000. Note: the remaining cost is dominated by the `gitignore.ReadPatterns` pre-walk, which still scans the whole worktree; making that walk lazy/incremental (as upstream's `prep_exclude` does) is a natural follow-up PR.

## Test plan

- [x] New unit tests: `utils/merkletrie` (collapse insert/delete/non-collapse), `utils/merkletrie/filesystem` (collapse truth table: empty dirs, tracked descendants, no-index no-op, ignored contents, file→dir replacement, symlinks)
- [x] New worktree tests: default collapse, `UntrackedFilesAll`, `UntrackedFilesNo`, and an `Add("dir")` regression test
- [x] Existing `TestStatusIgnored` updated to the git-parity output (verified against `git status --porcelain`)
- [x] `go test .`: 758 passed, 0 failed
- [x] `go test -race ./...`: 4659 passed; 4 failures in `plumbing/transport/http` backend E2E tests that also fail on pristine `main` (local git backend infrastructure limitation)
- [x] `golangci-lint run` clean on changed packages

## AI disclosure

This contribution was produced with AI assistance (Kimi k3), including profiling analysis of #181, implementation and tests. Commits carry an `Assisted-by` trailer per AI_POLICY.md. The behavior was cross-checked against reference `git` on equivalent fixtures.
