### PR TITLE
plumbing: format/gitignore, Avoid blind ignore-file opens in ReadPatterns

### DIFF
--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	gofs "io/fs"
 	"os"
 	"strings"
 
@@ -51,16 +50,34 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 // ReadPatterns reads the .git/info/exclude and then the gitignore patterns
 // recursively traversing through the directory structure. The result is in
 // the ascending order of priority (last higher).
+//
+// .git/info/exclude is only consulted at the root of the given filesystem,
+// matching reference git which reads $GIT_DIR/info/exclude of the
+// repository being walked. Ignore files are opened only when present in
+// the directory listing, so directories without them cost a single ReadDir.
 func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) {
-	ps, _ = readIgnoreFile(fs, path, infoExcludeFile)
-
-	subps, _ := readIgnoreFile(fs, path, gitignoreFile)
-	ps = append(ps, subps...)
-
-	var fis []gofs.DirEntry
-	fis, err = fs.ReadDir(fs.Join(path...))
+	fis, err := fs.ReadDir(fs.Join(path...))
 	if err != nil {
-		return ps, err
+		return nil, err
+	}
+
+	var hasGitDir, hasGitignore bool
+	for _, fi := range fis {
+		switch fi.Name() {
+		case gitDir:
+			hasGitDir = true
+		case gitignoreFile:
+			hasGitignore = true
+		}
+	}
+
+	if len(path) == 0 && hasGitDir {
+		ps, _ = readIgnoreFile(fs, path, infoExcludeFile)
+	}
+
+	if hasGitignore {
+		subps, _ := readIgnoreFile(fs, path, gitignoreFile)
+		ps = append(ps, subps...)
 	}
 
 	for _, fi := range fis {

--- a/plumbing/format/gitignore/dir_bench_test.go
+++ b/plumbing/format/gitignore/dir_bench_test.go
@@ -1,0 +1,72 @@
+package gitignore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/stretchr/testify/require"
+)
+
+// setupReadPatternsTree builds a directory tree with `dirs` nested
+// directories. With gitignore, a .gitignore is placed at the root and a
+// .git/info/exclude file is present, as in a regular repository worktree.
+func setupReadPatternsTree(b *testing.B, dirs int, withIgnoreFiles bool) string {
+	b.Helper()
+
+	root := b.TempDir()
+
+	for top := range dirs / 10 {
+		for sub := range 10 {
+			dir := filepath.Join(root, fmt.Sprintf("top%03d", top), fmt.Sprintf("sub%02d", sub))
+			require.NoError(b, os.MkdirAll(dir, 0o755))
+			require.NoError(b, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x\n"), 0o644))
+		}
+	}
+
+	if withIgnoreFiles {
+		require.NoError(b, os.MkdirAll(filepath.Join(root, ".git", "info"), 0o755))
+		require.NoError(b, os.WriteFile(filepath.Join(root, ".git", "info", "exclude"), []byte("*.log\n"), 0o644))
+		require.NoError(b, os.WriteFile(filepath.Join(root, gitignoreFile), []byte("*.tmp\n"), 0o644))
+	}
+
+	return root
+}
+
+// BenchmarkReadPatterns measures the cost of collecting ignore patterns
+// over a tree whose directories contain no ignore files - the common case
+// on worktrees like home directories, where blindly attempting to open
+// .gitignore and .git/info/exclude per directory dominated Status() CPU.
+func BenchmarkReadPatterns(b *testing.B) {
+	const dirs = 1100
+
+	b.Run("NoIgnoreFiles", func(b *testing.B) {
+		fs := osfs.New(setupReadPatternsTree(b, dirs, false), osfs.WithBoundOS())
+		b.ResetTimer()
+		for b.Loop() {
+			ps, err := ReadPatterns(fs, nil)
+			if err != nil {
+				b.Fatalf("ReadPatterns: %v", err)
+			}
+			if len(ps) != 0 {
+				b.Fatalf("expected no patterns, got %d", len(ps))
+			}
+		}
+	})
+
+	b.Run("RootIgnoreFiles", func(b *testing.B) {
+		fs := osfs.New(setupReadPatternsTree(b, dirs, true), osfs.WithBoundOS())
+		b.ResetTimer()
+		for b.Loop() {
+			ps, err := ReadPatterns(fs, nil)
+			if err != nil {
+				b.Fatalf("ReadPatterns: %v", err)
+			}
+			if len(ps) != 2 {
+				b.Fatalf("expected 2 patterns, got %d", len(ps))
+			}
+		}
+	})
+}

--- a/plumbing/format/gitignore/dir_readpatterns_test.go
+++ b/plumbing/format/gitignore/dir_readpatterns_test.go
@@ -1,0 +1,90 @@
+package gitignore
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadPatternsIgnoresNestedInfoExclude verifies that .git/info/exclude
+// is only read at the repository root. Reference git consults
+// $GIT_DIR/info/exclude of the repository being walked; a nested
+// <dir>/.git/info/exclude belongs to a different repository and must not
+// contribute patterns.
+func TestReadPatternsIgnoresNestedInfoExclude(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, fs.MkdirAll("sub/.git/info", os.ModePerm))
+	f, err := fs.Create("sub/.git/info/exclude")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("ignored.txt\n"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	ps, err := ReadPatterns(fs, nil)
+	require.NoError(t, err)
+	assert.Empty(t, ps, "nested .git/info/exclude must not be read")
+}
+
+// openCounterFS counts Open calls by path.
+type openCounterFS struct {
+	billy.Filesystem
+	opens map[string]int
+}
+
+func (fs *openCounterFS) Open(path string) (billy.File, error) {
+	fs.opens[path]++
+	return fs.Filesystem.Open(path)
+}
+
+func TestReadPatternsAvoidsBlindOpens(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no ignore files", func(t *testing.T) {
+		t.Parallel()
+		base := memfs.New()
+		require.NoError(t, base.MkdirAll("a/b/c", os.ModePerm))
+		f, err := base.Create("a/b/c/file.txt")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		fs := &openCounterFS{Filesystem: base, opens: map[string]int{}}
+		_, err = ReadPatterns(fs, nil)
+		require.NoError(t, err)
+
+		// billy joins with the OS separator; build expectations the same way.
+		excludeMarker := fs.Join(gitDir, "info", "exclude")
+		for path, n := range fs.opens {
+			isIgnoreFile := strings.HasSuffix(path, gitignoreFile) || strings.Contains(path, excludeMarker)
+			assert.False(t, isIgnoreFile, "%s was opened %d time(s) but does not exist in the listing", path, n)
+		}
+	})
+
+	t.Run("present ignore files are read once", func(t *testing.T) {
+		t.Parallel()
+		base := memfs.New()
+		require.NoError(t, base.MkdirAll(".git/info", os.ModePerm))
+		require.NoError(t, base.MkdirAll("sub", os.ModePerm))
+		for _, p := range []string{".git/info/exclude", ".gitignore", "sub/.gitignore"} {
+			f, err := base.Create(p)
+			require.NoError(t, err)
+			_, err = f.Write([]byte("*.log\n"))
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+		}
+
+		fs := &openCounterFS{Filesystem: base, opens: map[string]int{}}
+		ps, err := ReadPatterns(fs, nil)
+		require.NoError(t, err)
+		require.Len(t, ps, 3)
+
+		for _, p := range []string{fs.Join(gitDir, "info", "exclude"), fs.Join(gitignoreFile), fs.Join("sub", gitignoreFile)} {
+			assert.Equal(t, 1, fs.opens[p], "%s must be opened exactly once", p)
+		}
+	})
+}


### PR DESCRIPTION
## Why

`Worktree.Status()` collects ignore rules via `gitignore.ReadPatterns`, which blindly attempts to open `<dir>/.gitignore` **and** `<dir>/.git/info/exclude` at every directory it recurses into — even though the `ReadDir` listing it already holds answers whether those files exist. On `BoundOS` filesystems each failed open pays a full path-traversal cost; in the #181 investigation profile these failed opens dominated `ReadPatterns`, which itself accounted for ~28% of `Status()` CPU on a home-directory-style worktree.

Reference git reads a directory's `.gitignore` only when it exists, and consults `$GIT_DIR/info/exclude` only of the repository being walked ([`dir.c` `setup_standard_excludes()`](https://github.com/git/git/blob/master/dir.c)).

## What

- `ReadPatterns` now runs `ReadDir` first and opens `.gitignore` only when it appears in the listing. Directories without ignore files — the overwhelming common case — cost a single `ReadDir`, with zero open attempts.
- `.git/info/exclude` is read only at the root of the walked filesystem, and only when `.git` is present there. This also fixes a semantic divergence: a nested `<dir>/.git/info/exclude` (e.g. an embedded repository) previously contributed patterns to the outer walk; reference git never does that.
- Public API unchanged. One subtlety: on `ReadDir` error the function now returns `nil` patterns instead of partially-read ones; the sole caller (`collectIgnorePatterns`) discards patterns on error, so behavior is unchanged.

This is an independent follow-up to #2282 (stacks on `main`, not on that branch); the larger "lazy/incremental pattern walk" idea mentioned there remains future work.

## Benchmarks

New `BenchmarkReadPatterns` over 1,100 directories with no ignore files in subdirectories (home-directory-like worst case), `osfs` with `BoundOS` on an Apple M4 Pro. A/B of `main` vs this branch, 7 runs each (`-benchtime=3x`), via `benchstat`:

```
                              │ before (main) │  after (this PR)  │
                              │    sec/op     │  sec/op  vs base  │
ReadPatterns/NoIgnoreFiles-12    645.2m ± 79%  206.4m ± 8%  -68.01% (p=0.001 n=7)
ReadPatterns/RootIgnoreFiles-12  438.3m ± 19%  203.8m ± 10% -53.51% (p=0.001 n=7)
```

(The high variance on `main` reflects the syscall-bound failed-open cost; the after side is stable.)

## Test plan

- [x] New tests: nested `.git/info/exclude` is not read; zero blind opens when no ignore files exist; present ignore files are opened exactly once (open-counting billy filesystem wrapper)
- [x] Existing `plumbing/format/gitignore` suite: 105 passed
- [x] `go test .`: 754 passed, 0 failed
- [x] `go test -race ./...`: green; the 4 `plumbing/transport/http` backend E2E failures also occur on pristine `main` — they are caused by a local global git `pre-push` hook rejecting the tests' pushes to `main`, and pass with `core.hooksPath` disabled
- [x] `golangci-lint run` clean on changed packages

## AI disclosure

This contribution was produced with AI assistance (Kimi k3), including profiling analysis of #181, implementation and tests. Commits carry an `Assisted-by` trailer per AI_POLICY.md. The behavior was cross-checked against reference `git` semantics (`.git/info/exclude` scope).
