### PR TITLE
[v5] git: repository, Ensure commondir is closed.

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -433,6 +433,7 @@ func dotGitCommonDirectory(fs billy.Filesystem) (commonDir billy.Filesystem, err
 	if err != nil {
 		return nil, err
 	}
+	defer ioutil.CheckClose(f, &err)
 
 	b, err := io.ReadAll(f)
 	if err != nil {


### PR DESCRIPTION
Anyone opening a linked worktree on the v5 line leaks a file handle, and on Windows that turns ordinary fixture cleanup into a test failure. The fix already exists on `main` and is one line; this backports it so v5 consumers stop hitting a problem that is already solved upstream.

## What

Cherry-pick of d6cff1c63d335c8798753f3abeb0cb5e3b2dccc5, "git: repository, Ensure commondir is closed."

```go
	if err != nil {
		return nil, err
	}
+	defer ioutil.CheckClose(f, &err)
 
 	b, err := io.ReadAll(f)
```

`dotGitCommonDirectory` opens `commondir` and never closes it. Its sibling `dotGitFileToOSFilesystem`, twenty lines above in the same file, already does `defer ioutil.CheckClose(f, &err)`. The `ioutil` import is present, so the diff is exactly the one line.

The function has a single caller, guarded by `PlainOpenOptions.EnableDotGitCommonDir`, so this only affects consumers that opt into linked-worktree support.

## Why it matters on Windows

The handle stays open until the `os.File` finalizer runs or the process exits. Unix does not mind unlinking an open file; Windows refuses the delete. A consumer that opens a linked worktree and then removes its fixture gets:

```
testing.go:1464: TempDir RemoveAll cleanup: unlinkat
C:\...\.git\worktrees\wt\commondir: The process cannot access the file
because it is being used by another process.
```

That is the same signature #1996 fixed on `main` for `TestAdd`, on the same file, and its analysis of the finalizer race applies here too: the failure is intermittent rather than certain.

I hit this downstream in Atmos (cloudposse/atmos#2824), where enabling `EnableDotGitCommonDir` to resolve commit timestamps inside linked worktrees made the Windows job fail during cleanup with every assertion passing.

## Cost of merge

One line, already proven on `main` since 2025-06. No behavior change for callers that do not set `EnableDotGitCommonDir`. `go build ./...` and the `TestWorktree` suite pass locally on `releases/v5.x`.

I kept this to the exact upstream change rather than adding a test, since a regression test for it is necessarily Windows-only and felt like scope you might not want in a backport. Happy to add one if you would prefer it.

## References

- Upstream commit: https://github.com/go-git/go-git/commit/d6cff1c63d335c8798753f3abeb0cb5e3b2dccc5
- Prior art, same signature and file: #1996
- Downstream report: https://github.com/cloudposse/atmos/pull/2824
