### PR TITLE
plumbing: transport/http, drop credentials on cross-host redirect

### DIFF
--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -130,11 +130,11 @@ func wrapCheckRedirect(policy RedirectPolicy, next func(*http.Request, []*http.R
 // default policy is "initial", where only the GET /info/refs discovery
 // request is allowed to follow redirects.
 //
-// Credential handling on redirect is left to Go's http.Client, which
-// already strips the Authorization header when a redirect crosses to a
-// different host (since Go 1.8) and preserves it for same-host
-// redirects — matching the expected behavior for scheme upgrades and
-// path-only redirects on the same server.
+// Credentials do not survive a redirect that leaves the host they were
+// issued for, matching libcurl's default (CURLOPT_UNRESTRICTED_AUTH
+// off), which is what canonical git relies on, and the host comparison
+// Handshake already applies to the session it builds from the redirect
+// target.
 func checkRedirect(req *http.Request, via []*http.Request, policy RedirectPolicy) error {
 	if len(via) != 0 {
 		prev := via[len(via)-1]
@@ -160,5 +160,38 @@ func checkRedirect(req *http.Request, via []*http.Request, policy RedirectPolicy
 	if len(via) >= 10 {
 		return fmt.Errorf("http transport: too many redirects")
 	}
+	stripCrossHostCredentials(req, via)
 	return nil
+}
+
+// stripCrossHostCredentials drops the credentials the transport put on
+// the original request once a redirect leaves the host they were issued
+// for. Go's http.Client only withholds Authorization when the target is
+// outside the initial host's registered domain, so it keeps sending it
+// to a sibling subdomain or to another port on the same name, and it
+// forwards every other header — including anything an Options.Authorizer
+// added — unconditionally.
+func stripCrossHostCredentials(req *http.Request, via []*http.Request) {
+	if len(via) == 0 || via[0].URL == nil || req.URL.Host == via[0].URL.Host {
+		return
+	}
+
+	for k := range req.Header {
+		if !crossHostSafeHeader(k) {
+			req.Header.Del(k)
+		}
+	}
+}
+
+// crossHostSafeHeader reports whether a header the transport sets is
+// free of credentials and can therefore follow a redirect to another
+// host. Anything not listed is dropped, so an Authorizer that
+// authenticates through a header other than Authorization is covered
+// too.
+func crossHostSafeHeader(key string) bool {
+	switch http.CanonicalHeaderKey(key) {
+	case "Accept", "Content-Type", "Git-Protocol", "User-Agent":
+		return true
+	}
+	return false
 }

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -7,7 +7,9 @@ import (
 	"maps"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"net/url"
+	"sync"
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	transport "github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
@@ -243,6 +246,93 @@ func TestRedirectStripsCredentials(t *testing.T) {
 	sps, ok := session.(*smartPackSession)
 	require.True(t, ok)
 	assert.Nil(t, sps.baseURL.User)
+}
+
+func TestRedirectDoesNotForwardCredentials(t *testing.T) {
+	t.Parallel()
+
+	base, backend := setupSmartServer(t)
+	prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
+
+	backendURL, err := url.Parse(fmt.Sprintf("http://localhost:%d", backend.Port))
+	require.NoError(t, err)
+
+	// The redirect target records what it was sent, then proxies to the
+	// real backend so the handshake still completes.
+	var mu sync.Mutex
+	var received http.Header
+
+	tl := test.ListenTCP(t)
+	taddr := tl.Addr().(*net.TCPAddr)
+	proxy := httputil.NewSingleHostReverseProxy(backendURL)
+	targetServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			received = r.Header.Clone()
+			mu.Unlock()
+			proxy.ServeHTTP(w, r)
+		}),
+	}
+
+	targetDone := make(chan struct{})
+	go func() {
+		defer close(targetDone)
+		require.ErrorIs(t, targetServer.Serve(tl), http.ErrServerClosed)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, targetServer.Close())
+		<-targetDone
+	})
+
+	rl := test.ListenTCP(t)
+	raddr := rl.Addr().(*net.TCPAddr)
+	targetURL := fmt.Sprintf("http://localhost:%d", taddr.Port)
+	redirectServer := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			target := targetURL + r.URL.Path
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusMovedPermanently)
+		}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		require.ErrorIs(t, redirectServer.Serve(rl), http.ErrServerClosed)
+	}()
+	t.Cleanup(func() {
+		require.NoError(t, redirectServer.Close())
+		<-done
+	})
+
+	tr := NewTransport(Options{
+		Authorizer: func(r *http.Request) error {
+			r.Header.Set("Private-Token", "super-secret")
+			return nil
+		},
+	})
+	endpoint := &url.URL{
+		Scheme: "http",
+		User:   url.UserPassword("testuser", "testpass"),
+		Host:   fmt.Sprintf("localhost:%d", raddr.Port),
+		Path:   "/basic.git",
+	}
+
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     endpoint,
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, received)
+	assert.Empty(t, received.Get("Authorization"))
+	assert.Empty(t, received.Get("Private-Token"))
+	assert.Equal(t, capability.DefaultAgent(), received.Get("User-Agent"))
 }
 
 func TestCheckRedirectPolicy(t *testing.T) {


### PR DESCRIPTION
With the endpoint carrying `testuser:testpass` and an `Options.Authorizer` setting `PRIVATE-TOKEN`, a 301 on the `/info/refs` GET puts both on the redirect target:

    redirect target received
      Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3M=
      Private-Token: super-secret

`checkRedirect` left this to `http.Client`, which only withholds `Authorization` when the target sits outside the initial host's registered domain, and that test ignores the port. Anything else, including whatever an `Authorizer` sets, crosses unconditionally. libcurl with `CURLOPT_UNRESTRICTED_AUTH` off, which is what git relies on, compares host, port and scheme exactly.

Nothing that worked before stops working: `Handshake` already drops `URL.User` and the `Authorizer` once the redirect lands on a different host, so every request after discovery was unauthenticated there anyway. I kept the allowlist to the headers the transport sets itself, since a header it did not add seems hard to assume safe for a host the credentials were not issued for.

`TestRedirectStripsCredentials` covers the session side of this and still passes; the new test checks what the target actually received.
