### PR TITLE
fix: accept flush-only upload requests

### DIFF
--- a/plumbing/protocol/packp/ulreq_decode.go
+++ b/plumbing/protocol/packp/ulreq_decode.go
@@ -63,7 +63,7 @@ func (req *UploadRequest) Decode(r io.Reader) error {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("empty input")
+		return nil
 	}
 
 	if !bytes.HasPrefix(line, want) {

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -32,6 +32,15 @@ func (s *UlReqDecodeSuite) TestEmpty() {
 	s.ErrorContains(err, "pkt-line 1: EOF")
 }
 
+func (s *UlReqDecodeSuite) TestFlushOnly() {
+	ur := &UploadRequest{}
+	var buf bytes.Buffer
+	s.NoError(pktline.WriteFlush(&buf))
+
+	s.NoError(ur.Decode(&buf))
+	s.Empty(ur.Wants)
+}
+
 func (s *UlReqDecodeSuite) TestNoWant() {
 	payloads := []string{
 		"foobar",


### PR DESCRIPTION
## Summary

Accept a protocol flush packet as an empty `UploadPackRequest`. A flush-only
request is a valid end-of-request marker and should not be reported as an
empty-input error; the request remains empty and ready for the caller.

Fixes #554.

## Validation

- native Git protocol reproduction
- focused package and protocol suites
- `git diff --check`

## AI assistance

AI assistance was used for investigation and drafting. I compared the behavior
with native Git, reviewed the pkt-line decoding contract, and independently ran
the focused suites.
