### PR TITLE
fix: order all commits by committer time across orphan refs

### DIFF
--- a/log_ctime.go
+++ b/log_ctime.go
@@ -1,0 +1,128 @@
+package git
+
+import (
+	"errors"
+	"io"
+
+	"github.com/emirpasic/gods/trees/binaryheap"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/storage"
+)
+
+type commitAllIteratorByCTime struct {
+	store storer.EncodedObjectStorer
+	seen  map[plumbing.Hash]bool
+	heap  *binaryheap.Heap
+}
+
+func newCommitAllIterCTime(repoStorer storage.Storer) (object.CommitIter, error) {
+	commits := make([]*object.Commit, 0)
+	seen := make(map[plumbing.Hash]bool)
+	addReference := func(ref *plumbing.Reference) {
+		if seen[ref.Hash()] {
+			return
+		}
+
+		commit, _ := object.GetCommit(repoStorer, ref.Hash())
+		if commit == nil {
+			return
+		}
+
+		seen[commit.Hash] = true
+		commits = append(commits, commit)
+	}
+
+	head, err := storer.ResolveReference(repoStorer, plumbing.HEAD)
+	if err == nil {
+		addReference(head)
+	}
+	if err != nil && err != plumbing.ErrReferenceNotFound {
+		return nil, err
+	}
+
+	refIter, err := repoStorer.IterReferences()
+	if err != nil {
+		return nil, err
+	}
+	defer refIter.Close()
+
+	for {
+		ref, err := refIter.Next()
+		if err == io.EOF {
+			break
+		}
+		if err == plumbing.ErrReferenceNotFound {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		addReference(ref)
+	}
+
+	heap := binaryheap.NewWith(func(a, b any) int {
+		if a.(*object.Commit).Committer.When.Before(b.(*object.Commit).Committer.When) {
+			return 1
+		}
+		return -1
+	})
+	for _, commit := range commits {
+		heap.Push(commit)
+	}
+
+	return &commitAllIteratorByCTime{
+		store: repoStorer,
+		seen:  make(map[plumbing.Hash]bool),
+		heap:  heap,
+	}, nil
+}
+
+func (w *commitAllIteratorByCTime) Next() (*object.Commit, error) {
+	for {
+		commit, ok := w.heap.Pop()
+		if !ok {
+			return nil, io.EOF
+		}
+		current := commit.(*object.Commit)
+		if w.seen[current.Hash] {
+			continue
+		}
+
+		w.seen[current.Hash] = true
+		for _, hash := range current.ParentHashes {
+			if w.seen[hash] {
+				continue
+			}
+			parent, err := object.GetCommit(w.store, hash)
+			if err != nil {
+				return nil, err
+			}
+			w.heap.Push(parent)
+		}
+
+		return current, nil
+	}
+}
+
+func (w *commitAllIteratorByCTime) ForEach(cb func(*object.Commit) error) error {
+	for {
+		commit, err := w.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := cb(commit); err != nil {
+			if errors.Is(err, storer.ErrStop) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+func (w *commitAllIteratorByCTime) Close() {}

--- a/repository.go
+++ b/repository.go
@@ -1551,7 +1551,11 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		err error
 	)
 	if o.All {
-		it, err = r.logAll(fn)
+		if o.Order == LogOrderCommitterTime {
+			it, err = newCommitAllIterCTime(r.Storer)
+		} else {
+			it, err = r.logAll(fn)
+		}
 	} else {
 		it, err = r.log(o.From, fn)
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -2625,6 +2625,51 @@ func (s *RepositorySuite) TestLogAllOrderByTime() {
 	cIter.Close()
 }
 
+func (s *RepositorySuite) TestLogAllOrderByTimeWithOrphanHistory() {
+	r, err := Init(memory.NewStorage())
+	s.NoError(err)
+	defer func() { _ = r.Close() }()
+
+	storeCommit := func(when time.Time, parents ...plumbing.Hash) plumbing.Hash {
+		signature := object.Signature{
+			Name:  "Test",
+			Email: "test@example.com",
+			When:  when,
+		}
+		commit := &object.Commit{
+			Author:       signature,
+			Committer:    signature,
+			Message:      "commit",
+			TreeHash:     plumbing.NewHash("4b825dc642cb6eb9a060e54bf8d69288fbee4904"),
+			ParentHashes: parents,
+		}
+		encoded := r.Storer.NewEncodedObject()
+		s.NoError(commit.Encode(encoded))
+		hash, err := r.Storer.SetEncodedObject(encoded)
+		s.NoError(err)
+		return hash
+	}
+
+	oldest := storeCommit(time.Unix(10, 0).UTC())
+	newest := storeCommit(time.Unix(30, 0).UTC(), oldest)
+	orphan := storeCommit(time.Unix(20, 0).UTC())
+
+	s.NoError(r.Storer.SetReference(plumbing.NewHashReference("refs/heads/main", newest)))
+	s.NoError(r.Storer.SetReference(plumbing.NewHashReference("refs/heads/orphan", orphan)))
+
+	iter, err := r.Log(&LogOptions{All: true, Order: LogOrderCommitterTime})
+	s.NoError(err)
+	defer iter.Close()
+
+	var commits []plumbing.Hash
+	err = iter.ForEach(func(commit *object.Commit) error {
+		commits = append(commits, commit.Hash)
+		return nil
+	})
+	s.NoError(err)
+	s.Equal([]plumbing.Hash{newest, orphan, oldest}, commits)
+}
+
 func (s *RepositorySuite) TestLogHead() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()


### PR DESCRIPTION
## Summary

Make `LogOptions{All: true, Order: LogOrderCommitterTime}` include commits from
orphan branch histories in the same committer-time ordering. The iterator now
starts from `HEAD` and every reference, deduplicates shared ancestry, and uses
a heap while traversing parents.

Fixes #417.

## Validation

- native Git orphan-order reproduction
- focused repository-suite regression test
- `gofmt` and `git diff --check`

The behavior is checked against Git's `--all` and committer-date ordering
semantics: https://git-scm.com/docs/git-log.

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the iterator
contract, compared it with native Git, and independently ran the regression
test and formatting checks.
