### PR TITLE
config: index, honour index.version when creating a new index

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,14 @@ type Config struct {
 		// which skips the trailing SHA-1/SHA-256 computation for performance
 		// on large repositories.
 		SkipHash OptBool
+		// Version is the index format version to use when a new index file
+		// is written. This corresponds to git's index.version configuration.
+		// Zero means unset, in which case the writer picks its own default.
+		//
+		// The value is stored as configured, without range checking, mirroring
+		// git's repo-settings.c: it is the writer that decides which versions
+		// it can produce and falls back to its default otherwise.
+		Version uint32
 	}
 
 	Init struct {
@@ -507,7 +515,9 @@ func (c *Config) Unmarshal(b []byte) error {
 
 	c.unmarshalCore()
 	c.unmarshalExtensions()
-	c.unmarshalIndex()
+	if err := c.unmarshalIndex(); err != nil {
+		return err
+	}
 	c.unmarshalTag()
 	c.unmarshalCommit()
 	c.unmarshalUser()
@@ -726,12 +736,22 @@ func (c *Config) unmarshalProtocol() error {
 	return nil
 }
 
-func (c *Config) unmarshalIndex() {
+func (c *Config) unmarshalIndex() error {
 	s := c.Raw.Section(indexSection)
 	v, err := strconv.ParseBool(s.Options.Get(skipHashKey))
 	if err == nil {
 		c.Index.SkipHash = NewOptBool(v)
 	}
+
+	if version := s.Options.Get(versionKey); version != "" {
+		ver, err := strconv.ParseUint(version, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.Index.Version = uint32(ver)
+	}
+
+	return nil
 }
 
 func (c *Config) unmarshalInit() {
@@ -1015,6 +1035,10 @@ func (c *Config) marshalIndex() {
 	if c.Index.SkipHash.IsSet() {
 		s := c.Raw.Section(indexSection)
 		s.SetOption(skipHashKey, c.Index.SkipHash.FormatBool())
+	}
+	if c.Index.Version != 0 {
+		s := c.Raw.Section(indexSection)
+		s.SetOption(versionKey, strconv.FormatUint(uint64(c.Index.Version), 10))
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -813,6 +813,89 @@ func TestMarshalIndexSkipHash(t *testing.T) {
 	assert.Equal(t, OptBoolTrue, cfg2.Index.SkipHash)
 }
 
+func TestUnmarshalIndexVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    uint32
+		wantErr bool
+	}{
+		{
+			name:  "version 4",
+			input: "[index]\n\tversion = 4\n",
+			want:  4,
+		},
+		{
+			name:  "version 2",
+			input: "[index]\n\tversion = 2\n",
+			want:  2,
+		},
+		{
+			name:  "absent defaults to unset",
+			input: "[core]\n\tbare = false\n",
+			want:  0,
+		},
+		{
+			// git does not range check when reading the config either: an
+			// out of range value is only rejected when the index is written.
+			name:  "out of range is kept as configured",
+			input: "[index]\n\tversion = 7\n",
+			want:  7,
+		},
+		{
+			// git: "fatal: bad numeric config value 'abc' for 'index.version'".
+			name:    "non numeric value errors",
+			input:   "[index]\n\tversion = abc\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := NewConfig()
+			err := cfg.Unmarshal([]byte(tc.input))
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.want, cfg.Index.Version)
+		})
+	}
+}
+
+func TestMarshalIndexVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewConfig()
+	cfg.Index.Version = 4
+
+	b, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.Contains(t, string(b), "version = 4")
+
+	// Round-trip: unmarshal the marshaled output and verify.
+	cfg2 := NewConfig()
+	err = cfg2.Unmarshal(b)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(4), cfg2.Index.Version)
+}
+
+func TestMarshalIndexVersionUnsetIsOmitted(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewConfig()
+
+	b, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "[index]")
+}
+
 func TestMerge(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/plumbing/format/index/index.go
+++ b/plumbing/format/index/index.go
@@ -40,6 +40,11 @@ const (
 	TheirMode Stage = 3
 )
 
+// DefaultVersion is the index format version used when a new index is
+// created and no other version was requested. It matches git's
+// INDEX_FORMAT_DEFAULT.
+const DefaultVersion uint32 = 2
+
 // Index contains the information about which objects are currently checked out
 // in the worktree, having information about the working files. Changes in
 // worktree are detected using this Index. The Index is also used during merges

--- a/storage/filesystem/index.go
+++ b/storage/filesystem/index.go
@@ -19,6 +19,29 @@ type IndexStorage struct {
 	h        hash.Hash
 	cache    IndexCache
 	skipHash bool
+	// version holds index.version as configured, and is used when no index
+	// file exists yet. An existing index keeps the version recorded in its
+	// header, matching git, which only consults index.version when it has
+	// no version to preserve.
+	version uint32
+}
+
+// newIndex returns an empty index using the configured format version.
+func (s *IndexStorage) newIndex() *index.Index {
+	return &index.Index{Version: indexVersion(s.version)}
+}
+
+// indexVersion returns the index format version to write for the configured
+// index.version value, falling back to [index.DefaultVersion] when it is unset
+// or names a version that cannot be encoded. This mirrors git's
+// get_index_format_default, which warns and uses INDEX_FORMAT_DEFAULT rather
+// than failing when index.version is out of range.
+func indexVersion(v uint32) uint32 {
+	if v < index.DecodeVersionSupported.Min || v > index.EncodeVersionSupported {
+		return index.DefaultVersion
+	}
+
+	return v
 }
 
 // SetIndex writes the index to disk and updates the cache.
@@ -78,7 +101,7 @@ func (s *IndexStorage) Index() (i *index.Index, err error) {
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				s.cache.Clear()
-				return &index.Index{Version: 2}, nil
+				return s.newIndex(), nil
 			}
 			return nil, err
 		}
@@ -88,9 +111,7 @@ func (s *IndexStorage) Index() (i *index.Index, err error) {
 		}
 	}
 
-	idx := &index.Index{
-		Version: 2,
-	}
+	idx := s.newIndex()
 
 	f, err := s.dir.Index()
 	if err != nil {

--- a/storage/filesystem/index_test.go
+++ b/storage/filesystem/index_test.go
@@ -1,12 +1,14 @@
 package filesystem_test
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -266,4 +268,103 @@ func newIndexStorageWithSpy(t *testing.T) (*filesystem.Storage, *spyIndexCache) 
 	require.NoError(t, sto.Init())
 
 	return sto, spy
+}
+
+func TestIndexVersionFromConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		config string
+		want   uint32
+	}{
+		{
+			name: "no config uses the default version",
+			want: 2,
+		},
+		{
+			name:   "version 4 enables path prefix compression",
+			config: "[index]\n\tversion = 4\n",
+			want:   4,
+		},
+		{
+			name:   "version 3",
+			config: "[index]\n\tversion = 3\n",
+			want:   3,
+		},
+		{
+			name:   "below the supported range falls back to the default",
+			config: "[index]\n\tversion = 1\n",
+			want:   2,
+		},
+		{
+			name:   "above the supported range falls back to the default",
+			config: "[index]\n\tversion = 7\n",
+			want:   2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := osfs.New(t.TempDir())
+			if tc.config != "" {
+				require.NoError(t, util.WriteFile(fs, "config", []byte(tc.config), 0o644))
+			}
+
+			sto := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{})
+			defer func() { _ = sto.Close() }()
+
+			idx, err := sto.Index()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, idx.Version)
+
+			// The version has to reach the encoder, not just the in-memory
+			// Index, so check the header that ends up on disk.
+			idx.Entries = []*index.Entry{
+				{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
+			}
+			require.NoError(t, sto.SetIndex(idx))
+
+			raw, err := util.ReadFile(fs, "index")
+			require.NoError(t, err)
+			require.Greater(t, len(raw), 8)
+			assert.Equal(t, tc.want, binary.BigEndian.Uint32(raw[4:8]))
+		})
+	}
+}
+
+func TestIndexVersionKeepsVersionOfExistingIndex(t *testing.T) {
+	t.Parallel()
+
+	fs := osfs.New(t.TempDir())
+	require.NoError(t, util.WriteFile(fs, "config", []byte("[index]\n\tversion = 4\n"), 0o644))
+
+	sto := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{})
+	require.NoError(t, sto.SetIndex(&index.Index{
+		Version: 2,
+		Entries: []*index.Entry{
+			{Hash: plumbing.NewHash("880cd14280f4b9b6ed3986d6671f907d7cc2a198"), Name: "foo.go"},
+		},
+	}))
+	require.NoError(t, sto.Close())
+
+	// A second Storage has no warm cache, so this goes through the decoder.
+	// An index already on disk carries its own version, which git preserves
+	// on rewrite rather than upgrading it to index.version.
+	sto2 := filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{})
+	defer func() { _ = sto2.Close() }()
+
+	idx, err := sto2.Index()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), idx.Version)
+
+	// And the version survives a rewrite, rather than being replaced by the
+	// configured one on the way back out.
+	require.NoError(t, sto2.SetIndex(idx))
+	raw, err := util.ReadFile(fs, "index")
+	require.NoError(t, err)
+	require.Greater(t, len(raw), 8)
+	assert.Equal(t, uint32(2), binary.BigEndian.Uint32(raw[4:8]))
 }

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -150,6 +150,7 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 	readRevIdx := true
 	writeRevIdx := true
 	skipHash := false
+	idxVersion := uint32(0)
 
 	f, err := fs.Open("config")
 	if err == nil {
@@ -159,6 +160,7 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 			readRevIdx = cfg.Pack.ReadReverseIndex
 			writeRevIdx = cfg.Pack.WriteReverseIndex
 			skipHash = cfg.Index.SkipHash.IsTrue()
+			idxVersion = cfg.Index.Version
 		}
 
 		_ = f.Close()
@@ -199,7 +201,7 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 
 		ObjectStorage:    NewObjectStorageWithOptions(dir, c, ops),
 		ReferenceStorage: ReferenceStorage{dir: dir},
-		IndexStorage:     IndexStorage{dir: dir, h: hasher.Hash, cache: ops.IndexCache, skipHash: skipHash},
+		IndexStorage:     IndexStorage{dir: dir, h: hasher.Hash, cache: ops.IndexCache, skipHash: skipHash, version: idxVersion},
 		ShallowStorage:   ShallowStorage{dir: dir},
 		ConfigStorage:    ConfigStorage{dir: dir, objectFormat: ops.ObjectFormat},
 		ModuleStorage:    ModuleStorage{dir: dir, objectFormat: ops.ObjectFormat},


### PR DESCRIPTION
Refs #2198 (the `index.version=4` box)

## Why

git's `index.version` picks the on-disk index format a repository writes, and
`feature.manyFiles=true` sets it to 4 for the path-prefix compression that box
is about. go-git parses neither, so a repository configured for version 4 gets
a version 2 index back from go-git.

Against git 2.46.1:

```console
$ git init repo && cd repo && git config index.version 4
$ echo hi > a.txt && git add a.txt
$ python3 -c "import struct;print(struct.unpack('>I',open('.git/index','rb').read(8)[4:])[0])"
4
```

Same config, driven through `PlainInit` + `Worktree.Add`, before this change:

```
go-git wrote index sig=DIRC version=2 entries=1
```

Nothing in the format layer was missing — `DecodeVersionSupported` is `{2, 4}`
and `EncodeVersionSupported` is `4`, and `encodeEntryNameV4` already does the
prefix compression. The version simply never reached it: `config.Index` carried
only `SkipHash`, and `storage/filesystem/index.go` hardcoded

```go
idx := &index.Index{
	Version: 2,
}
```

so the encoder was always handed a 2.

## What changed

- `config`: `Config.Index.Version` holds `index.version` as configured.
  No range check there, mirroring `repo-settings.c`, which reads the value
  verbatim and leaves the decision to the writer. A non-numeric value is an
  error, matching git's `fatal: bad numeric config value`, and following the
  existing `unmarshalPack`/`pack.window` precedent.
- `storage/filesystem`: `IndexStorage` keeps the configured version and uses it
  for an index that does not exist yet. Out-of-range values fall back to
  `index.DefaultVersion` instead of failing, which is what
  [`get_index_format_default`](https://github.com/git/git/blob/master/read-cache.c)
  does — it warns and returns `INDEX_FORMAT_DEFAULT`.
- An index already on disk keeps the version in its header. git behaves the
  same way: `do_write_index` only calls `get_index_format_default` when
  `istate->version` is unset, so an existing v2 index stays v2 even after
  `index.version` is set to 4. Confirmed against the git binary.
- `plumbing/format/index`: `DefaultVersion` (2), named next to the existing
  version constants, replacing the two hardcoded 2s.

+49/-7 across four files, plus tests.

## Verification

Behaviour table, produced from git 2.46.1 and matched by the tests:

| `index.version` | git   | go-git after this change |
| --------------- | ----- | ------------------------ |
| unset           | 2     | 2                        |
| 2 / 3 / 4       | 2/2/4 | 2/3/4                    |
| 1, 5, 7         | 2 + warning | 2                  |
| `abc`           | fatal | error from `Unmarshal`   |

git writes 2 for `index.version=3` because `do_write_index` demotes 3 to 2 when
no entry needs extended flags; go-git has no equivalent demotion, so it writes
the 3 it was asked for. Both are valid and git reads either. Adding the
demotion is a write-path change, not a config one, so it is not in here.

Interop, checked by hand — a v4 index written by go-git for nested,
common-prefixed paths (so the prefix compression actually engages), then read
by the git binary:

```console
$ git ls-files -s
100644 eaa5fa8755fc20f08d0b3da347a5d1868404e462 0	a.txt
100644 52f632b028926333566d0653f8dd6c4d939816a3 0	src/pkg/alpha/one.go
100644 07c0d4fc10a96da197738c78f768af634eaae29f 0	src/pkg/alpha/two.go
100644 8c4104e25531077625c1416831226690da579e8a 0	src/pkg/alphabet/three.go
100644 917d5e59f915a22823d86ff1547f2312a9dfc601 0	src/pkg/beta/four.go
100644 071d25199295c8cf57586a64094bc334496552f4 0	src/pkg/beta/nested/deeper/five.go
100644 6637220c76f2dc36511895728d5d003988b15d9b 0	zzz.txt
```

`git status` and `git fsck` are clean on it.

Tests:

- `config`: `TestUnmarshalIndexVersion` (5 cases incl. the non-numeric error and
  an out-of-range value surviving unchanged), `TestMarshalIndexVersion`
  round-trip, `TestMarshalIndexVersionUnsetIsOmitted`.
- `storage/filesystem`: `TestIndexVersionFromConfig` asserts both the in-memory
  `Index.Version` and the header byte that lands on disk, so a version that
  stops short of the encoder fails. `TestIndexVersionKeepsVersionOfExistingIndex`
  pins the preservation rule via a second `Storage` (cold cache, so it goes
  through the decoder).
- The version-3 and version-4 rows of `TestIndexVersionFromConfig` fail on
  `main` (`expected 0x4, actual 0x2`); the config tests do not compile against
  `main`, since the field is new. `TestIndexVersionKeepsVersionOfExistingIndex`
  passes on `main` — `main` always writes 2 — but it does fail if the new code
  overwrites the decoded version with the configured one, which is the mistake
  it is there to catch.

`go test ./...`: same two results before and after — `plumbing/format/gitignore`
`TestConformanceSuite/TestIgnoreDoubleStarPrefix` fails on `main` too (its
oracle disagrees with git 2.46.1 on `foo**/bar`), everything else passes.
`golangci-lint run` on the touched packages reports 0 issues on the changed
lines (the 2 pre-existing `modernize` hits in `storage/filesystem/config.go` and
`dotgit/dotgit.go` are untouched).

## Not in scope

`feature.manyFiles` expansion. #2199 is already adding alias handling for
`index.skipHash` in `unmarshalIndex`, and once it lands the same helper can set
`index.version = 4` in a few lines. Doing it here would collide with that PR.
That leaves `core.untrackedCache` as the remaining box on #2198.

## Checklist

- [x] `go test ./...` run, compared against `main`
- [x] `golangci-lint run` on the touched packages
- [x] Tests added, and verified to fail without the change
- [x] Behaviour checked against the git binary (2.46.1, macOS/arm64)
- [x] Commit signed off (DCO)

Per [AI_POLICY.md](https://github.com/go-git/go-git/blob/main/AI_POLICY.md):
written with AI assistance (Claude Opus 5), disclosed with an `Assisted-by:`
trailer on the commit. The git-side behaviour in the table above was measured
against the real binary rather than taken from the model.
