### PR TITLE
plumbing: format/packfile, reset base position on backward delta copy

### DIFF
--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -182,6 +182,7 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 						return
 					}
 					baseBuf.Reset(baseRd)
+					basePos = 0
 					discard = offset
 				}
 				for discard > math.MaxInt32 {

--- a/plumbing/format/packfile/patch_delta_test.go
+++ b/plumbing/format/packfile/patch_delta_test.go
@@ -211,3 +211,46 @@ func TestPatchDeltaAcceptsEmptyTarget(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, out)
 }
+
+// TestReaderFromDeltaBackwardCopy asserts that the streaming applier
+// produces the same output as the slice-based PatchDelta when a delta
+// copies backward into the base (an earlier offset than a preceding
+// copy) and then forward again. Copy offsets are absolute into the base
+// and may appear in any order, so ReaderFromDelta rewinds the base
+// reader when it needs to go backward; it must also reset its position
+// cursor, otherwise a later forward copy reads the wrong region of the
+// base and the reconstructed object is silently corrupted.
+func TestReaderFromDeltaBackwardCopy(t *testing.T) {
+	t.Parallel()
+
+	src := make([]byte, 64)
+	for i := range src {
+		src[i] = byte(i)
+	}
+
+	// copy [40,50) -> advances the reader to 50
+	// copy [0,10)  -> backward, rewinds the reader to 0
+	// copy [60,64) -> forward again to an offset past the earlier one
+	delta := buildDelta(len(src), 24,
+		encodeCopyOperation(40, 10),
+		encodeCopyOperation(0, 10),
+		encodeCopyOperation(60, 4),
+	)
+
+	want, err := PatchDelta(src, delta)
+	require.NoError(t, err)
+
+	base := &plumbing.MemoryObject{}
+	_, err = base.Write(src)
+	require.NoError(t, err)
+
+	rc, err := ReaderFromDelta(base, io.NopCloser(bytes.NewReader(delta)))
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+
+	assert.Equal(t, want, got,
+		"ReaderFromDelta must match PatchDelta for a backward-then-forward copy")
+}


### PR DESCRIPTION
`ReaderFromDelta` streams a delta onto a base object and rewinds the base reader
when a copy-from-source op points backward (`basePos > offset`). It resets the
reader with `baseBuf.Reset(baseRd)` but leaves `basePos` at its old value, so the
position cursor no longer matches the reader. A later forward copy whose offset is
at or past the stale `basePos` then computes `discard = offset - basePos`, discards
too few bytes, and streams the wrong region of the base into the output. The
reconstructed object is silently corrupted and no error is returned.

The slice-based `PatchDelta` indexes the base absolutely and is not affected, so
the two appliers disagree on the same valid delta.

Copy offsets are absolute into the base and can appear in any order, and go-git's
own `DiffDelta` emits such deltas for reordered content. Over 2000 random trials of
`DiffDelta` on shuffled base chunks, 255 of the resulting deltas reconstruct
differently through `ReaderFromDelta` than through `PatchDelta` on current main;
with this change none do.

Fix: reset `basePos` to 0 in the rewind branch, since the reader is back at the
start. `TestReaderFromDeltaBackwardCopy` fails before and passes after.

The same code is on `releases/v5.x`.

Tested: `go test ./plumbing/format/packfile/...`.

AI-assisted (Claude Opus 4.8); the commit carries an `Assisted-by:` trailer per AI_POLICY.md.
