### PR TITLE
git: Accept pre-repositoryformatversion extensions (worktreeConfig, partialClone, preciousObjects)

### DIFF
--- a/repository_extensions.go
+++ b/repository_extensions.go
@@ -45,11 +45,13 @@ var (
 	// Some Git extensions were supported upstream before the introduction
 	// of repositoryformatversion. These are the only extensions that can be
 	// enabled while core.repositoryformatversion is unset or set to 0.
+	// Keys must be lowercase to match the output of extensions(), which
+	// normalises extension names with strings.ToLower.
 	extensionsValidForV0 = map[string]struct{}{
 		"noop":            {},
-		"partialClone":    {},
-		"preciousObjects": {},
-		"worktreeConfig":  {},
+		"partialclone":    {},
+		"preciousobjects": {},
+		"worktreeconfig":  {},
 	}
 )
 
@@ -106,6 +108,14 @@ func verifyExtensions(st storage.Storer, cfg *config.Config) error {
 		var missing []string
 		for _, ext := range needed {
 			if _, ok := builtinExtensions[ext.name]; ok {
+				continue
+			}
+
+			// Extensions that predate repositoryformatversion (e.g.
+			// worktreeConfig, partialClone, preciousObjects) are known to
+			// Git and safe to ignore; go-git does not need to implement
+			// them in order to open the repository.
+			if _, ok := extensionsValidForV0[ext.name]; ok {
 				continue
 			}
 

--- a/repository_extensions_test.go
+++ b/repository_extensions_test.go
@@ -42,6 +42,21 @@ func TestVerifyExtensions(t *testing.T) {
 			},
 		},
 		{
+			name: "repositoryformatversion=0: allows worktreeConfig regardless of case",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_0
+				cfg.Raw.Section("extensions").SetOption("worktreeConfig", "true")
+			},
+		},
+		{
+			name: "repositoryformatversion=0: allows partialClone and preciousObjects",
+			setup: func(t *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version_0
+				cfg.Raw.Section("extensions").SetOption("partialClone", "origin")
+				cfg.Raw.Section("extensions").SetOption("preciousObjects", "true")
+			},
+		},
+		{
 			name: "repositoryformatversion=1: rejects unknown extensions",
 			setup: func(t *testing.T, cfg *config.Config) {
 				cfg.Core.RepositoryFormatVersion = formatcfg.Version_1


### PR DESCRIPTION
### Problem

On `releases/v5.x`, opening a repository that enables a grandfathered extension such as `extensions.worktreeConfig` fails:

```
core.repositoryformatversion does not support extension: worktreeconfig
```

This happens for any repository with `core.repositoryformatversion = 0` (the default) that also sets `extensions.worktreeConfig` — e.g. every repository using linked worktrees with per-worktree config. Downstream tools are affected too; this was reported via `gitsign verify`, which embeds go-git/v5 and cannot verify commits in such repos.

### Root cause

There are actually **two** bugs on the v5 branch:

1. **Case mismatch (first check).** `extensions()` normalises every extension name with `strings.ToLower`, but `extensionsValidForV0` was keyed in camelCase (`worktreeConfig`, `partialClone`, `preciousObjects`). The lookup `extensionsValidForV0[ext.name]` therefore never matched, and the extension was reported as unsupported. This is the same issue fixed on `main` in 76c75bb ("git: Lowercase extension names"), which has not been backported here.

2. **`missing` loop (second check).** Even after fixing (1), the subsequent loop rejects these extensions as `unknown extension`, because on v5 an extension is only accepted if it is in `builtinExtensions`. The v6 `ExtensionChecker` storage mechanism — where the filesystem storage whitelists `worktreeconfig` via `SupportsExtension` — does not exist on v5, so there is nothing to accept it.

### Fix

- Lowercase the `extensionsValidForV0` keys (backport of 76c75bb).
- Treat the `extensionsValidForV0` entries as known in the `missing` loop as well. This is the v5 equivalent of the whitelist that the v6 filesystem storage applies via `SupportsExtension`, and reflects that these extensions predate `repositoryformatversion`, are known to Git, and are safe for go-git to ignore when opening a repository.

### Tests

Added two cases to `TestVerifyExtensions` covering `worktreeConfig` (mixed-case, exercising the case-insensitivity) and `partialClone`/`preciousObjects` at `repositoryformatversion=0`. Both fail on the current branch with the exact errors above and pass with this change.