### PR TITLE
worktree: honor global ignore files in Status

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
 
 	"github.com/go-git/go-git/v6/config"
@@ -182,9 +183,27 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 }
 
 func (w *Worktree) collectIgnorePatterns() []gitignore.Pattern {
-	patterns, err := gitignore.ReadPatterns(w.filesystem, nil)
-	if err != nil {
-		patterns = nil
+	var patterns []gitignore.Pattern
+
+	// Global and system excludes are rooted at the operating system, not at
+	// the repository. Loading them through w.filesystem would turn an absolute
+	// path such as /Users/alice/.gitconfig into a path inside the worktree (and
+	// rejects Windows drive-letter paths entirely). Only OS-backed worktrees
+	// have a meaningful host-level ignore configuration; in-memory and custom
+	// filesystems retain their existing repository-local behavior.
+	if _, ok := w.filesystem.Filesystem.(*osfs.BoundOS); ok {
+		if system, err := gitignore.LoadSystemPatterns(osfs.Default); err == nil {
+			patterns = append(patterns, system...)
+		}
+		if global, err := gitignore.LoadGlobalPatterns(osfs.Default); err == nil {
+			patterns = append(patterns, global...)
+		}
+	}
+
+	// Repository rules have higher precedence than system/global excludes, and
+	// explicit Worktree.Excludes remain the final override as before.
+	if repository, err := gitignore.ReadPatterns(w.filesystem, nil); err == nil {
+		patterns = append(patterns, repository...)
 	}
 	return append(patterns, w.Excludes...)
 }

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -3,6 +3,8 @@ package git
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -148,6 +150,39 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 
 	_, ok = st["vendor/extra.go"]
 	assert.False(t, ok, "untracked file inside an ignored directory must not surface in Status")
+}
+
+// TestStatusHonoursGlobalIgnoreFile verifies that Status reads the global
+// excludes file configured in the user's gitconfig for an OS-backed worktree.
+func TestStatusHonoursGlobalIgnoreFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+
+	globalIgnore := filepath.Join(home, ".gitignore_global")
+	require.NoError(t, os.WriteFile(globalIgnore, []byte("*.globalignored\n"), 0o644))
+	gitconfig := filepath.Join(home, ".gitconfig")
+	require.NoError(t, os.WriteFile(gitconfig, []byte("[core]\n\texcludesfile = "+strconv.Quote(globalIgnore)+"\n"), 0o644))
+
+	repoDir := t.TempDir()
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "ignored.globalignored"), []byte("ignored\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "visible.txt"), []byte("visible\n"), 0o644))
+
+	status, err := wt.Status()
+	require.NoError(t, err)
+
+	_, ignored := status["ignored.globalignored"]
+	assert.False(t, ignored, "globally ignored untracked files must not appear in Status")
+	_, visible := status["visible.txt"]
+	assert.True(t, visible, "untracked files not covered by the global ignore file must appear in Status")
 }
 
 func BenchmarkWorktreeStatus(b *testing.B) {


### PR DESCRIPTION
Summary

This addresses #795 by making Worktree.Status load Git global ignore patterns before evaluating untracked and modified paths.

Changes

- Load global patterns from an OS-backed filesystem so absolute paths such as the configured core.excludesFile are readable.
- Keep repository patterns and explicit Worktree.Excludes behavior, with explicit worktree excludes taking precedence.
- Limit the global-file lookup to the native OS filesystem so in-memory and non-OS filesystems keep their existing behavior.

Validation

- git diff --check passed.
- Go tests were not run locally because the Go toolchain is unavailable in this environment; CI should exercise the go-git test suite.

AI assistance: ChatGPT assisted with code exploration and drafting. I reviewed the resulting patch and remain responsible for it.

Fixes #795