### PR TITLE
plumbing: transport/ssh, respect custom host key callbacks

### DIFF
--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -82,12 +82,6 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 		}
 		config.HostKeyCallback = db.HostKeyCallback()
 		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
-	} else if len(config.HostKeyAlgorithms) == 0 {
-		db, err := newKnownHostsDb()
-		if err != nil {
-			return nil, err
-		}
-		config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
 	}
 
 	trace.SSH.Printf("ssh: host key algorithms %s", strings.Join(config.HostKeyAlgorithms, ", "))

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -209,6 +209,32 @@ func TestSSHTransport_Connect(t *testing.T) {
 	}
 }
 
+func TestSSHTransport_CustomHostKeyCallbackWithoutKnownHosts(t *testing.T) {
+	t.Setenv("SSH_KNOWN_HOSTS", filepath.Join(t.TempDir(), "missing-known-hosts"))
+
+	addr := startSSHServer(t)
+	base := t.TempDir()
+	repoFS := test.PrepareRepository(t, fixtures.Basic().One(), base, "basic.git")
+	repoPath := filepath.ToSlash(repoFS.Root())
+
+	tr := NewTransport(sshClientOptions())
+	req := &transport.Request{
+		URL: &url.URL{
+			Scheme: "ssh",
+			User:   url.User("git"),
+			Host:   fmt.Sprintf("localhost:%d", addr.Port),
+			Path:   repoPath,
+		},
+		Command:  "git-upload-pack",
+		Protocol: protocol.V0,
+	}
+
+	sess, err := tr.Connect(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.NoError(t, sess.Close())
+}
+
 func TestSSHTransport_NoConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

When callers provide a custom SSH HostKeyCallback, the transport should not require a local known_hosts file just to populate host-key algorithms. This change lets callback-only configurations work on hosts without standard known_hosts files while preserving the existing known_hosts discovery path when no callback is supplied.

Adds an end-to-end regression test for a missing SSH_KNOWN_HOSTS path and a caller-provided callback.

Fixes #1234

## Validation

- go test ./plumbing/transport/ssh -count=1
- go vet ./plumbing/transport/ssh
- git diff --check
- The repository-wide suite currently has an unrelated existing failure in plumbing/format/gitignore/TestConformanceSuite/TestIgnoreDoubleStarPrefix.

## Disclosure

This contribution was prepared with Codex (GPT-5) assistance. I reviewed the implementation and regression test, and the commit includes the required Assisted-by trailer.