### PR TITLE
git: submodule, Avoid initializing uncloned modules during status. Fi…

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -85,6 +85,19 @@ func (s *Submodule) status(idx *index.Index) (*SubmoduleStatus, error) {
 		return status, nil
 	}
 
+	storer, err := s.w.r.Storer.Module(s.c.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = storer.Reference(plumbing.HEAD)
+	if errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return status, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
 	r, err := s.Repository()
 	if err != nil {
 		return nil, err

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -273,6 +273,35 @@ func TestSubmodulesStatus(t *testing.T) {
 	})
 }
 
+func TestSubmoduleStatusDoesNotInitializeUnclonedSubmodule(t *testing.T) {
+	t.Parallel()
+
+	fixtures.ByTag("submodule").Run(t, func(t *testing.T, f *fixtures.Fixture) {
+		t.Parallel()
+
+		r, wt := cloneFixture(t, f)
+		defer func() { _ = r.Close() }()
+
+		sm := namedSubmodule(t, wt, primaryFixtureSubmoduleName(f))
+		require.NoError(t, sm.Init())
+
+		status, err := sm.Status()
+		require.NoError(t, err)
+		require.Equal(t, sm.c.Path, status.Path)
+		require.Equal(t, submoduleHashFromIndex(t, r, sm.c.Name), status.Expected)
+		require.True(t, status.Current.IsZero())
+
+		_, err = wt.Status()
+		require.NoError(t, err)
+
+		_, err = os.Stat(filepath.Join(wt.Filesystem().Root(), sm.c.Path, ".git"))
+		require.ErrorIs(t, err, os.ErrNotExist)
+
+		_, err = os.Stat(filepath.Join(wt.Filesystem().Root(), ".git", "modules", sm.c.Name))
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
 func TestSubmodulesUpdateContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

  `Submodule.Status` now checks the registered module's `HEAD` before opening its repository. If the module has not been cloned, status returns the index gitlink as `Expected` with a zero `Current` instead of
  initializing a repository

  The regression test covers both SHA-1 and SHA-256 fixtures and verifies that neither the worktree `.git` file nor `.git/modules/<name>` is created

  ## Why

  Canonical Git treats submodule status as a read-only operation. go-git previously routed this state through `Submodule.Repository`, whose fallback `Init` created both artifacts.

  Git documents `status`, `init`, and `update --init` as separate operations:
  https://git-scm.com/docs/git-submodule

  ## Testing

  - Focused regression test
  - Focused race test
  - Related submodule status and initialization tests
  - Repository-wide package compilation with the regression filter
  - golangci-lint v2.11.4
  - Canonical Git behavior fixture

  Fixes #2297