### PR TITLE
plumbing: format/gitignore, Inherit patterns through the ReadPatterns walk.

### DIFF
--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/go-git/go-billy/v6"
@@ -55,7 +56,22 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 // matching reference git which reads $GIT_DIR/info/exclude of the
 // repository being walked. Ignore files are opened only when present in
 // the directory listing, so directories without them cost a single ReadDir.
+//
+// Excluded directories are not descended into, at any depth below the ignore
+// file declaring the rule, so patterns declared inside an excluded directory
+// are not read and do not appear in the result. See the package documentation
+// for why gitignore(5) makes that equivalent to reading them.
 func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) {
+	return readPatterns(fs, path, nil)
+}
+
+// readPatterns collects the ignore patterns declared at path and below.
+//
+// inherited holds the patterns already in effect from ancestor directories in
+// ascending order of priority. They take part in the decision to descend into
+// a subdirectory, but are not returned, so each pattern reaches the caller
+// exactly once.
+func readPatterns(fs billy.Filesystem, path []string, inherited []Pattern) (ps []Pattern, err error) {
 	fis, err := fs.ReadDir(fs.Join(path...))
 	if err != nil {
 		return nil, err
@@ -80,25 +96,34 @@ func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) 
 		ps = append(ps, subps...)
 	}
 
+	// Ancestors first, so the deeper file wins. This deliberately excludes the
+	// patterns that the loop below collects from sibling subtrees: they cannot
+	// apply here, and including them would make the walk order-dependent.
+	inScope := inherited
+	if len(ps) > 0 {
+		inScope = slices.Concat(inherited, ps)
+	}
+	m := NewMatcher(inScope)
+
 	for _, fi := range fis {
-		if fi.IsDir() && fi.Name() != gitDir {
-			if NewMatcher(ps).Match(append(path, fi.Name()), true) {
-				continue
-			}
-
-			var subps []Pattern
-			subps, err = ReadPatterns(fs, append(path, fi.Name()))
-			if err != nil {
-				return ps, err
-			}
-
-			if len(subps) > 0 {
-				ps = append(ps, subps...)
-			}
+		if !fi.IsDir() || fi.Name() == gitDir {
+			continue
 		}
+
+		sub := slices.Concat(path, []string{fi.Name()})
+		if m.Match(sub, true) {
+			continue
+		}
+
+		subps, err := readPatterns(fs, sub, inScope)
+		if err != nil {
+			return ps, err
+		}
+
+		ps = append(ps, subps...)
 	}
 
-	return ps, err
+	return ps, nil
 }
 
 func loadPatterns(fs billy.Filesystem, path string) (ps []Pattern, err error) {

--- a/plumbing/format/gitignore/dir_bench_test.go
+++ b/plumbing/format/gitignore/dir_bench_test.go
@@ -17,14 +17,7 @@ func setupReadPatternsTree(b *testing.B, dirs int, withIgnoreFiles bool) string 
 	b.Helper()
 
 	root := b.TempDir()
-
-	for top := range dirs / 10 {
-		for sub := range 10 {
-			dir := filepath.Join(root, fmt.Sprintf("top%03d", top), fmt.Sprintf("sub%02d", sub))
-			require.NoError(b, os.MkdirAll(dir, 0o755))
-			require.NoError(b, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x\n"), 0o644))
-		}
-	}
+	populateTree(b, root, dirs)
 
 	if withIgnoreFiles {
 		require.NoError(b, os.MkdirAll(filepath.Join(root, ".git", "info"), 0o755))
@@ -33,6 +26,19 @@ func setupReadPatternsTree(b *testing.B, dirs int, withIgnoreFiles bool) string 
 	}
 
 	return root
+}
+
+// populateTree creates `dirs` directories under base, each holding one file.
+func populateTree(b *testing.B, base string, dirs int) {
+	b.Helper()
+
+	for top := range dirs / 10 {
+		for sub := range 10 {
+			dir := filepath.Join(base, fmt.Sprintf("top%03d", top), fmt.Sprintf("sub%02d", sub))
+			require.NoError(b, os.MkdirAll(dir, 0o755))
+			require.NoError(b, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x\n"), 0o644))
+		}
+	}
 }
 
 // BenchmarkReadPatterns measures the cost of collecting ignore patterns
@@ -69,4 +75,44 @@ func BenchmarkReadPatterns(b *testing.B) {
 			}
 		}
 	})
+
+	// The two cases above declare only file globs, so nothing is ever pruned
+	// and the whole tree is walked either way. These two isolate the pruning
+	// path: an identical tree is excluded by a rule naming a direct child in
+	// one case and a grandchild in the other. Depth1 prunes after listing the
+	// root alone; Nested must also list outer before it can prune
+	// outer/ignored, so each case costs one ReadDir per ancestor down to the
+	// pruned directory. Before patterns were inherited through the recursion
+	// only Depth1 pruned at all, and Nested walked every directory.
+	for _, tc := range []struct {
+		name, rule string
+	}{
+		{"PrunedPattern/Depth1", "outer/\n"},
+		{"PrunedPattern/Nested", "outer/ignored/\n"},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			fs := osfs.New(setupPrunedTree(b, dirs, tc.rule), osfs.WithBoundOS())
+			for b.Loop() {
+				ps, err := ReadPatterns(fs, nil)
+				if err != nil {
+					b.Fatalf("ReadPatterns: %v", err)
+				}
+				if len(ps) != 1 {
+					b.Fatalf("expected 1 pattern, got %d", len(ps))
+				}
+			}
+		})
+	}
+}
+
+// setupPrunedTree builds the same tree as setupReadPatternsTree but nested
+// under outer/ignored/, with rule as the sole root .gitignore entry.
+func setupPrunedTree(b *testing.B, dirs int, rule string) string {
+	b.Helper()
+
+	root := b.TempDir()
+	populateTree(b, filepath.Join(root, "outer", "ignored"), dirs)
+	require.NoError(b, os.WriteFile(filepath.Join(root, gitignoreFile), []byte(rule), 0o644))
+
+	return root
 }

--- a/plumbing/format/gitignore/dir_readpatterns_test.go
+++ b/plumbing/format/gitignore/dir_readpatterns_test.go
@@ -1,12 +1,17 @@
 package gitignore
 
 import (
+	iofs "io/fs"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
+	"github.com/go-git/go-billy/v6/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,6 +45,124 @@ type openCounterFS struct {
 func (fs *openCounterFS) Open(path string) (billy.File, error) {
 	fs.opens[path]++
 	return fs.Filesystem.Open(path)
+}
+
+// readDirCounterFS records the directories ReadPatterns listed, so a test can
+// assert on the shape of the walk instead of on wall-clock time.
+type readDirCounterFS struct {
+	billy.Filesystem
+	readDirs map[string]int
+}
+
+func (c *readDirCounterFS) ReadDir(path string) ([]iofs.DirEntry, error) {
+	c.readDirs[path]++
+	return c.Filesystem.ReadDir(path)
+}
+
+// writeFile creates the slash-separated path, and any parent directories,
+// holding content.
+func writeFile(t *testing.T, fs billy.Filesystem, path, content string) {
+	t.Helper()
+	require.NoError(t, fs.MkdirAll(filepath.Dir(path), os.ModePerm))
+	require.NoError(t, util.WriteFile(fs, path, []byte(content), 0o644))
+}
+
+// TestReadPatternsPrunesExcludedDirs verifies that patterns are inherited down
+// the walk, so an excluded directory is never descended into however deep below
+// the declaring .gitignore it sits. Before patterns were threaded through the
+// recursion, a rule could only prune a direct child of its own directory, and
+// everything below an ignored subtree was listed anyway.
+func TestReadPatternsPrunesExcludedDirs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		// ignoreFile is where the rule is declared, rule is its content.
+		ignoreFile, rule string
+		// pruned is the directory that must never be listed, and deep is a
+		// directory below it that must therefore never be listed either.
+		pruned, deep string
+	}{
+		{
+			name:       "direct child of declaring dir",
+			ignoreFile: ".gitignore",
+			rule:       "big/\n",
+			pruned:     "big",
+			deep:       "big/inner",
+		},
+		{
+			name:       "grandchild of declaring dir",
+			ignoreFile: ".gitignore",
+			rule:       "outer/ignored/\n",
+			pruned:     "outer/ignored",
+			deep:       "outer/ignored/deep",
+		},
+		{
+			name:       "unanchored rule matching at depth",
+			ignoreFile: ".gitignore",
+			rule:       "node_modules/\n",
+			pruned:     "a/b/node_modules",
+			deep:       "a/b/node_modules/pkg",
+		},
+		{
+			name:       "rule declared in a subdirectory",
+			ignoreFile: "outer/.gitignore",
+			rule:       "ignored/\n",
+			pruned:     "outer/ignored",
+			deep:       "outer/ignored/deep",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			base := memfs.New()
+			writeFile(t, base, tc.ignoreFile, tc.rule)
+			// A nested ignore file below the pruned directory. Collecting its
+			// pattern would prove the walk descended.
+			writeFile(t, base, tc.deep+"/.gitignore", "sentinel\n")
+
+			fs := &readDirCounterFS{Filesystem: base, readDirs: map[string]int{}}
+			ps, err := ReadPatterns(fs, nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, 1, fs.readDirs[""], "the root must be listed exactly once")
+			for _, dir := range []string{tc.pruned, tc.deep} {
+				assert.Zero(t, fs.readDirs[filepath.FromSlash(dir)],
+					"%s is excluded and must never be listed", dir)
+			}
+			assert.Len(t, ps, 1, "no pattern from below an excluded directory may be collected")
+
+			// And the rule itself still takes effect on the pruned path.
+			m := NewMatcher(ps)
+			assert.True(t, m.Match(strings.Split(tc.pruned, "/"), true), "%s must be reported as ignored", tc.pruned)
+		})
+	}
+}
+
+// TestReadPatternsExcludedDirCannotReinclude pins the semantics that make
+// pruning safe: gitignore(5) says a file cannot be re-included once a parent
+// directory of it is excluded, so a negation inside an excluded directory has
+// no effect and the directory need not be read.
+func TestReadPatternsExcludedDirCannotReinclude(t *testing.T) {
+	t.Parallel()
+	base := memfs.New()
+	writeFile(t, base, ".gitignore", "outer/ignored/\n")
+	writeFile(t, base, "outer/ignored/.gitignore", "!keep.txt\n")
+	writeFile(t, base, "outer/ignored/keep.txt", "x\n")
+
+	ps, err := ReadPatterns(base, nil)
+	require.NoError(t, err)
+
+	// The decision is what matters, so assert it first: reference git reports
+	// keep.txt as ignored. Collecting the nested "!keep.txt" gives it the
+	// highest priority in the returned set, which flips this to false.
+	m := NewMatcher(ps)
+	assert.True(t, m.Match([]string{"outer", "ignored"}, true),
+		"the excluded directory itself must be ignored")
+	assert.True(t, m.Match([]string{"outer", "ignored", "keep.txt"}, false),
+		"re-inclusion below an excluded directory is not possible, so keep.txt stays ignored")
+
+	// And the mechanism behind that decision: the negation was never read.
+	assert.Len(t, ps, 1, "the negation inside the excluded directory must not be collected")
 }
 
 func TestReadPatternsAvoidsBlindOpens(t *testing.T) {
@@ -87,4 +210,145 @@ func TestReadPatternsAvoidsBlindOpens(t *testing.T) {
 			assert.Equal(t, 1, fs.opens[p], "%s must be opened exactly once", p)
 		}
 	})
+}
+
+// TestReadPatternsMatchesReferenceGit cross-checks the ignore decisions
+// produced by ReadPatterns + Matcher against `git ls-files`, over the same
+// rule expressed at different placements relative to its target. Pruning an
+// excluded directory means ignore files below it are no longer read, so the
+// placements have to be shown equivalent rather than merely fast.
+//
+// Skipped under -short or when no git binary is available, matching
+// ConformanceSuite's oracle.
+func TestReadPatternsMatchesReferenceGit(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("oracle disabled: -short")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("oracle disabled: git not found: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "rule names a direct child",
+			files: map[string]string{
+				".gitignore":      "big/\n",
+				"big/inner/f.txt": "x\n",
+				"keep.txt":        "x\n",
+			},
+		},
+		{
+			name: "rule names a grandchild",
+			files: map[string]string{
+				".gitignore":               "outer/ignored/\n",
+				"outer/ignored/deep/f.txt": "x\n",
+				"outer/keep.txt":           "x\n",
+			},
+		},
+		{
+			name: "rule declared in a subdirectory",
+			files: map[string]string{
+				"outer/.gitignore":         "ignored/\n",
+				"outer/ignored/deep/f.txt": "x\n",
+				"outer/keep.txt":           "x\n",
+			},
+		},
+		{
+			name: "unanchored rule matching at depth",
+			files: map[string]string{
+				".gitignore":                 "node_modules/\n",
+				"a/b/node_modules/pkg/f.txt": "x\n",
+				"a/b/keep.txt":               "x\n",
+			},
+		},
+		{
+			// Re-inclusion below an excluded directory is impossible per
+			// gitignore(5); the nested negation must have no effect.
+			name: "negation inside an excluded directory",
+			files: map[string]string{
+				".gitignore":               "outer/ignored/\n",
+				"outer/ignored/.gitignore": "!keep.txt\n",
+				"outer/ignored/keep.txt":   "x\n",
+			},
+		},
+		{
+			// The directory itself is not excluded here, only its children,
+			// so the walk must still descend into foo/bar.
+			name: "children excluded but one re-included",
+			files: map[string]string{
+				".gitignore":      "foo/*\n!foo/bar\n",
+				"foo/bar/baz.txt": "x\n",
+				"foo/other.txt":   "x\n",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// CI runs this suite against a locally built Git 2.11.0, which does
+			// not honour several re-include patterns. Reuse the conformance
+			// suite's exemption rather than maintaining a second list.
+			var rules []string
+			for p, content := range tc.files {
+				if filepath.Base(p) == gitignoreFile {
+					rules = append(rules, strings.Fields(content)...)
+				}
+			}
+			if skipOnLegacyGit(rules) {
+				t.Skipf("oracle disabled: %s does not support %v", os.Getenv("GIT_VERSION"), rules)
+			}
+
+			dir := t.TempDir()
+			require.NoError(t, exec.Command("git", "-c", "init.defaultBranch=main", "-C", dir, "init", "-q").Run())
+
+			for p, content := range tc.files {
+				abs := filepath.Join(dir, filepath.FromSlash(p))
+				require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+				require.NoError(t, os.WriteFile(abs, []byte(content), 0o644))
+			}
+
+			// Reference: every untracked file git reports as ignored. Nothing
+			// is committed, so every file in the tree is untracked.
+			out, err := exec.Command("git", "-C", dir, "ls-files", "--others", "--ignored", "--exclude-standard").Output()
+			require.NoError(t, err)
+			wantIgnored := map[string]bool{}
+			for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+				if line != "" {
+					wantIgnored[line] = true
+				}
+			}
+
+			ps, err := ReadPatterns(osfs.New(dir), nil)
+			require.NoError(t, err)
+			m := NewMatcher(ps)
+
+			// Walk the real tree and ask the matcher about every file.
+			require.NoError(t, filepath.WalkDir(dir, func(path string, d iofs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				rel, err := filepath.Rel(dir, path)
+				if err != nil {
+					return err
+				}
+				rel = filepath.ToSlash(rel)
+				if rel == "." {
+					return nil
+				}
+				if d.IsDir() {
+					if rel == gitDir {
+						return iofs.SkipDir
+					}
+					return nil
+				}
+				assert.Equal(t, wantIgnored[rel], m.Match(strings.Split(rel, "/"), false),
+					"%s: ignore decision must match reference git", rel)
+				return nil
+			}))
+		})
+	}
 }

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -42,6 +42,12 @@ type Options struct {
 	// walked even if they match, so modifications to them are still
 	// reported. Requires Index to be set: without an index there is no way
 	// to identify tracked entries, so the matcher is treated as a no-op.
+	//
+	// This skip is independent of the pruning gitignore.ReadPatterns already
+	// applies when collecting the patterns: that one drops excluded subtrees
+	// unconditionally, because a pattern declared inside an excluded directory
+	// cannot change any outcome. The skip here is an optimization constrained
+	// by tracking, so both are needed and neither subsumes the other.
 	IgnoreMatcher gitignore.Matcher
 }
 

--- a/worktree_status_bench_test.go
+++ b/worktree_status_bench_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -216,6 +217,160 @@ func setupIgnoredDirRepo(b *testing.B, tracked, untracked int) *Worktree {
 	}
 
 	return wt
+}
+
+// setupNestedIgnoredDirRepo is setupIgnoredDirRepo with the ignored tree one
+// level deeper, so the root rule names a grandchild rather than a direct
+// child. The distinction is invisible to the diff walk, which prunes the
+// directory either way, but it decides whether collecting the ignore patterns
+// beforehand has to descend through the tree first.
+//
+// dirs, not files, is the parameter that matters: pattern collection costs one
+// ReadDir per directory, so a wide shallow tree of empty-ish directories is
+// what separates the approaches.
+func setupNestedIgnoredDirRepo(b *testing.B, tracked, dirs int) *Worktree {
+	b.Helper()
+
+	const ignoredDir = "e2e/artifacts"
+
+	tmpDir := b.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = repo.Close() })
+
+	wt, err := repo.Worktree()
+	require.NoError(b, err)
+
+	for i := range tracked {
+		path := filepath.Join("src", fmt.Sprintf("dir%02d", i%10), fmt.Sprintf("file%04d.go", i))
+		require.NoError(b, wt.Filesystem().MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(b, util.WriteFile(wt.Filesystem(), path, []byte("package main\n"), 0o644))
+	}
+
+	require.NoError(b, util.WriteFile(wt.Filesystem(), ".gitignore",
+		[]byte(ignoredDir+"/\n"), 0o644))
+
+	require.NoError(b, wt.AddGlob("src/*"))
+	_, err = wt.Add(".gitignore")
+	require.NoError(b, err)
+
+	sig := &object.Signature{
+		Name:  "Bench",
+		Email: "bench@test.com",
+		When:  time.Now().Add(-time.Hour), // older than index modtime so the metadata fast-path engages
+	}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(b, err)
+
+	// A wide gitignored tree. None of it affects status.
+	for i := range dirs {
+		path := filepath.Join(ignoredDir, fmt.Sprintf("sub%05d", i), "artifact.txt")
+		require.NoError(b, wt.Filesystem().MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(b, util.WriteFile(wt.Filesystem(), path, []byte("ignored\n"), 0o644))
+	}
+
+	return wt
+}
+
+// BenchmarkStatusNestedIgnoredDir measures Status over a worktree whose
+// ignored tree sits below the directory named by the rule. BenchmarkStatusIgnoredDir
+// cannot show this: its rule names a direct child of the root, which every
+// implementation prunes, and its ignored tree is only 21 directories wide.
+func BenchmarkStatusNestedIgnoredDir(b *testing.B) {
+	const tracked = 100
+
+	for _, dirs := range []int{200, 2000} {
+		b.Run(fmt.Sprintf("IgnoredDirs_%d", dirs), func(b *testing.B) {
+			wt := setupNestedIgnoredDirRepo(b, tracked, dirs)
+			for b.Loop() {
+				s, err := wt.Status()
+				if err != nil {
+					b.Fatalf("status: %v", err)
+				}
+				if !s.IsClean() {
+					b.Fatalf("expected clean status, got %v entries", len(s))
+				}
+			}
+		})
+	}
+}
+
+// setupManyIgnoreFilesRepo builds a worktree where every directory declares
+// its own .gitignore, the shape of a monorepo in which each package carries
+// its own rules. Everything is tracked and nothing is excluded wholesale, so
+// pruning excluded subtrees cannot help: both the pattern collection and the
+// diff walk have to visit every directory regardless.
+//
+// What is left is the cost the flat pattern list imposes. Collecting patterns
+// eagerly yields one list holding every rule in the repository, and each entry
+// the walk considers is tested against all of them. Evaluating per directory
+// instead tests an entry only against the rules on its own ancestor chain, so
+// the two diverge as the number of ignore files grows rather than as the size
+// of any one ignored tree grows.
+func setupManyIgnoreFilesRepo(b *testing.B, dirs, patternsPerDir int) *Worktree {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = repo.Close() })
+
+	wt, err := repo.Worktree()
+	require.NoError(b, err)
+
+	for i := range dirs {
+		dir := fmt.Sprintf("pkg%04d", i)
+		require.NoError(b, wt.Filesystem().MkdirAll(dir, 0o755))
+
+		// Rules that match nothing present, so every entry is tested against
+		// every one of them without any short-circuiting on a hit.
+		var rules strings.Builder
+		for p := range patternsPerDir {
+			fmt.Fprintf(&rules, "*.generated%02d\n", p)
+		}
+		require.NoError(b, util.WriteFile(wt.Filesystem(),
+			filepath.Join(dir, ".gitignore"), []byte(rules.String()), 0o644))
+		require.NoError(b, util.WriteFile(wt.Filesystem(),
+			filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644))
+	}
+
+	require.NoError(b, wt.AddWithOptions(&AddOptions{All: true}))
+
+	sig := &object.Signature{
+		Name:  "Bench",
+		Email: "bench@test.com",
+		When:  time.Now().Add(-time.Hour), // older than index modtime so the metadata fast-path engages
+	}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(b, err)
+
+	return wt
+}
+
+// BenchmarkStatusManyIgnoreFiles measures the case pruning cannot improve:
+// many ignore files, none of them excluding a subtree. It isolates the cost of
+// holding every rule in the repository in one list.
+func BenchmarkStatusManyIgnoreFiles(b *testing.B) {
+	const patternsPerDir = 5
+
+	for _, dirs := range []int{50, 500} {
+		b.Run(fmt.Sprintf("IgnoreFiles_%d", dirs), func(b *testing.B) {
+			wt := setupManyIgnoreFilesRepo(b, dirs, patternsPerDir)
+			for b.Loop() {
+				s, err := wt.Status()
+				if err != nil {
+					b.Fatalf("status: %v", err)
+				}
+				if !s.IsClean() {
+					b.Fatalf("expected clean status, got %v entries", len(s))
+				}
+			}
+		})
+	}
 }
 
 // BenchmarkStatusIgnoredDir measures the cost of running Status() over a tree

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -150,6 +150,55 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	assert.False(t, ok, "untracked file inside an ignored directory must not surface in Status")
 }
 
+// TestStatusIgnoresReincludedFileInsideIgnoredDirectory verifies that Status
+// does not report an untracked file that a nested .gitignore tries to
+// re-include from inside a directory an ancestor .gitignore already excluded.
+// gitignore(5): "It is not possible to re-include a file if a parent directory
+// of that file is excluded", and `git status` reports nothing here.
+//
+// Two mechanisms independently produce that outcome, and this test asserts the
+// outcome rather than either mechanism: gitignore.ReadPatterns no longer
+// collects the nested negation, and the noder's shouldSkipIgnored would skip
+// keep.txt anyway. It therefore passes both before and after the ReadPatterns
+// fix, and is here to keep Status agreeing with git across that change — not to
+// demonstrate the fix, which plumbing/format/gitignore tests cover.
+func TestStatusIgnoresReincludedFileInsideIgnoredDirectory(t *testing.T) {
+	t.Parallel()
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	write := func(name string, data []byte) {
+		require.NoError(t, wt.Filesystem().MkdirAll(filepath.Dir(name), 0o755))
+		require.NoError(t, util.WriteFile(wt.Filesystem(), name, data, 0o644))
+	}
+
+	// The rule names a grandchild, so the excluded directory is not a direct
+	// child of the .gitignore declaring it.
+	write(".gitignore", []byte("outer/ignored/\n"))
+	_, err = wt.Add(".gitignore")
+	require.NoError(t, err)
+
+	sig := &object.Signature{Name: "test", Email: "test@test.com"}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(t, err)
+
+	// Untracked content inside the excluded directory, including a nested
+	// negation that must have no effect.
+	write("outer/ignored/.gitignore", []byte("!keep.txt\n"))
+	write("outer/ignored/keep.txt", []byte("x\n"))
+	write("outer/ignored/deep/other.txt", []byte("x\n"))
+
+	st, err := wt.Status()
+	require.NoError(t, err)
+	assert.True(t, st.IsClean(), "nothing inside an excluded directory may surface in Status, got: %v", st)
+}
+
 func BenchmarkWorktreeStatus(b *testing.B) {
 	b.StopTimer()
 


### PR DESCRIPTION
**Draft: seeking design input, not review.** The pruning below is correct and a large win, but it exposes that the exported `ReadPatterns` + `Matcher` pair cannot represent "a parent directory is excluded". I don't think that is fixable at acceptable cost in the current design — numbers below.

## The defect

`ReadPatterns` recursed without passing the patterns it had collected, so every directory rebuilt its set from its own ignore files. A rule could therefore only prune a *direct child* of the `.gitignore` declaring it. With root `outer/ignored/`: `Match(["outer"])` fails (correctly), the recursion into `outer/` starts with an empty set, and the subtree is walked in full.

`readPatterns` now threads the in-scope patterns down the recursion. Sibling-subtree patterns stay out of that scope — they cannot apply, and including them made the walk order-dependent.

This is what git does. `prep_exclude` keeps a prefix-keyed `exclude_stack` and aborts before reading a directory's `.gitignore` when that directory is already excluded, unless the matching pattern is a negation ([dir.c](https://github.com/git/git/blob/master/dir.c)).

## Numbers

`BenchmarkReadPatterns/PrunedPattern`, 1,100 directories under one excluded directory: rule naming a direct child 79.4µs → 44µs, rule naming a grandchild **56.5ms → 64µs**.

At `Status()` level, via a new `BenchmarkStatusNestedIgnoredDir` (the existing `BenchmarkStatusIgnoredDir` cannot show this — its rule names a direct child, which `main` already prunes, and its ignored tree is 21 directories wide):

| ignored dirs | `main` | this PR |
| --- | --- | --- |
| 200 | 19.6ms | 3.0ms (-84.7%) |
| 2000 | **252.1ms** | **4.0ms (-98.4%)** |

`main` does not merely lose here, it fails to scale: ten times the directories costs it thirteen times the wall clock, because pattern collection walks the whole ignored tree that the diff walk then skips.

### Where this PR does not help

Also added, `BenchmarkStatusManyIgnoreFiles` — every directory declares its own `.gitignore` and nothing is excluded, so there is nothing to prune:

| ignore files | `main` | this PR |
| --- | --- | --- |
| 50 | 8.36ms | 8.62ms (~, p=0.818) |
| 500 | 88.2ms | 94.2ms (+6.9%, p=0.015) |

No benefit, and possibly a small cost — though +6.9% sits inside that arm's own ±21% spread, so "no measurable change" is the fair reading. `BenchmarkStatusLarge` (5,000 files, no `.gitignore` at all) likewise shows nothing.

This is the honest shape of the change: a large win on one layout, nothing on the others. It is the same boundary the correctness problem sits on — both come from collecting every pattern in the repository up front.

## The problem

```
.gitignore:                 outer/ignored/
                            !outer/ignored/keep.txt
outer/ignored/.gitignore:   keep.txt
```

`git check-ignore -v outer/ignored/keep.txt` → ignored, via `.gitignore:1:outer/ignored/`.

| case | `main` | this PR | + ancestor-aware `Match` | git |
| --- | --- | --- | --- | --- |
| **A** root negation + nested re-exclude | true | **false** | true | true |
| **B** root negation, no nested file | false | false | true | true |
| **C** nested `!keep.txt` under an excluded dir | false | true | true | true |

Case A is a regression in this PR, caught in review. But B is the same layout without the nested file and is wrong before *and* after: `Matcher` is a flat pattern list with no notion of an excluded ancestor, so it has never matched git for this class. `main` only gets A right by accident — it descends into the excluded directory and collects `keep.txt`, which sorts last. C is the common user mistake, and `main` gets it wrong.

### Ancestor-aware matching is correct but too expensive

Checking each ancestor prefix before the normal scan fixes A, B and C, and keeps the conformance suite's ~900 `check-ignore` oracle assertions green. Cost:

```
Matcher.Match (n=6)                geomean 433n → 1.64µs   +277%
  patterns=100/depth=10                   3.22µs → 19.3µs
BenchmarkStatusLarge/Clean (n=5)          19.38m → 22.16m   +14.4% (p=0.016)
```

n=5 is below benchstat's threshold, so treat the end-to-end figure as directional.

In `Status()` that work is redundant: the noder already prunes excluded directories top-down, so no ancestor is ever excluded by the time it asks about a file, and the loop runs to completion returning false every time. Git avoids this by carrying the excluded ancestor in the walk (`dir->internal.pattern`) instead of deciding per query. The state belongs in the traversal, not the predicate.

## Options

1. Land as-is, documenting A as a known limitation of the flat API (B is pre-existing).
2. Land with ancestor-aware `Match` — correct everywhere, ~14% on `Status()`.
3. Park this and build the scoped walk #2284 deferred.

I would prefer 3, because it fixes correctness and cost together: re-inclusion under an excluded parent becomes impossible, per-entry matching drops from O(all patterns repo-wide) to O(ancestor chain), and `Status()` stops traversing the worktree twice — once in `ReadPatterns`, once in the merkletrie diff. `readPatterns` already computes the per-directory scope such a matcher needs and discards it.

I have a working prototype, measured on the same three benchmarks (all vs `main`):

| | this PR | scoped walk |
| --- | --- | --- |
| `StatusNestedIgnoredDir` 2000 dirs | -98.4% | **-99.0%** |
| `StatusManyIgnoreFiles` 500 files | ~0 / +6.9% | **-40.4%** |
| `StatusLarge` (no `.gitignore`) | ~0 | **-41.9%** |

It also passes cases A, B and C. Ratios are robust; absolute figures are not precise to three digits, since several arms ran at ±20% or worse.

The blocker is API shape: `Options.IgnoreMatcher` is the one-method `gitignore.Matcher`, so a push/pop scoped matcher needs a new exported type or a breaking change. That may warrant an RFC; happy to write one.

## Tests

`ReadDir`-counting assertions over four rule placements (*grandchild* and *unanchored-at-depth* fail without this change; *direct child* and *declared in a subdirectory* are controls), a hermetic memfs test for case C, and an oracle test cross-checking six placements against `git ls-files --others --ignored`, gated on `skipOnLegacyGit` for the git 2.11.0 CI leg. No test covers case A yet — which behaviour is correct depends on the option chosen.

`golangci-lint` v2.11.4 reports 0 issues. `TestConformanceSuite/TestIgnoreDoubleStarPrefix` fails on `main` too (git 2.50.1) and is unrelated.

Per [AI_POLICY.md](https://github.com/go-git/go-git/blob/main/AI_POLICY.md): produced with AI assistance (Claude Opus 5), disclosed with an `Assisted-by:` trailer on the commit.
