### PR TITLE
config, storage/filesystem: honor core.sharedRepository for object files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,10 @@ type Config struct {
 		// directional characters that HFS+ would normalize away).
 		// When unset, defaults to true on macOS.
 		ProtectHFS OptBool
+		// SharedRepository controls permissions applied to repository files.
+		// Valid values are "umask" (default), "group", "all" or an octal
+		// mode such as "0660". See git-config documentation for core.sharedRepository.
+		SharedRepository SharedRepository
 	}
 
 	User user
@@ -217,6 +221,18 @@ type Config struct {
 	// dropping unsupported fields.
 	Raw *format.Config
 }
+
+// SharedRepository represents the core.sharedRepository git config value.
+type SharedRepository string
+
+const (
+	// SharedRepositoryUmask uses the umask to determine file permissions.
+	SharedRepositoryUmask SharedRepository = "umask"
+	// SharedRepositoryGroup makes the repository shareable within a group.
+	SharedRepositoryGroup SharedRepository = "group"
+	// SharedRepositoryAll makes the repository readable by everyone.
+	SharedRepositoryAll SharedRepository = "all"
+)
 
 type user struct {
 	// Name is the personal name of the author and the committer of a commit.
@@ -479,6 +495,7 @@ const (
 	fileModeKey                = "filemode"
 	hooksPathKey               = "hooksPath"
 	protectNTFSKey             = "protectNTFS"
+	sharedRepositoryKey        = "sharedRepository"
 	protectHFSKey              = "protectHFS"
 	indexSection               = "index"
 	skipHashKey                = "skipHash"
@@ -556,6 +573,8 @@ func (c *Config) unmarshalCore() {
 	if fileMode := s.Options.Get(fileModeKey); fileMode == "false" {
 		c.Core.FileMode = false
 	}
+
+	c.Core.SharedRepository = SharedRepository(s.Options.Get(sharedRepositoryKey))
 
 	if s.Options.Get(repositoryFormatVersionKey) == string(format.Version1) {
 		c.Core.RepositoryFormatVersion = format.Version1
@@ -807,6 +826,13 @@ func (c *Config) marshalCore() {
 
 	if c.Core.ProtectHFS.IsSet() {
 		s.SetOption(protectHFSKey, c.Core.ProtectHFS.FormatBool())
+	}
+
+	switch c.Core.SharedRepository {
+	case "", SharedRepositoryUmask:
+		s.RemoveOption(sharedRepositoryKey)
+	default:
+		s.SetOption(sharedRepositoryKey, string(c.Core.SharedRepository))
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1266,3 +1266,47 @@ func TestGPGConfig(t *testing.T) {
 		assert.Equal(t, OptBoolFalse, merged.Commit.GpgSign)
 	})
 }
+
+func TestSharedRepositoryRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []SharedRepository{
+		SharedRepositoryGroup,
+		SharedRepositoryAll,
+		SharedRepository("custom"),
+	} {
+		t.Run(string(value), func(t *testing.T) {
+			t.Parallel()
+
+			cfg := NewConfig()
+			cfg.Core.SharedRepository = value
+
+			b, err := cfg.Marshal()
+			require.NoError(t, err)
+
+			if value == SharedRepositoryUmask {
+				assert.NotContains(t, string(b), sharedRepositoryKey)
+			} else {
+				assert.Contains(t, string(b), string(value))
+			}
+
+			loaded := NewConfig()
+			require.NoError(t, loaded.Unmarshal(b))
+			assert.Equal(t, value, loaded.Core.SharedRepository)
+		})
+	}
+}
+
+func TestSharedRepositoryUmaskDefault(t *testing.T) {
+	t.Parallel()
+
+	cfg := NewConfig()
+	require.NoError(t, cfg.Unmarshal([]byte(`[core]
+	sharedRepository = umask
+`)))
+	assert.Equal(t, SharedRepositoryUmask, cfg.Core.SharedRepository)
+
+	b, err := cfg.Marshal()
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), sharedRepositoryKey)
+}

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-git/go-billy/v6"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/internal/packhandle"
 	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -146,6 +147,13 @@ type Options struct {
 	AlternatesFS billy.Filesystem
 
 	ObjectFormat formatcfg.ObjectFormat
+
+	// SharedRepository controls the permission mode applied to new
+	// files and directories under .git. The default (empty or "umask")
+	// follows the process umask; "group" creates group-writable objects
+	// (0660 files and 2770 directories); "all" is equivalent to "group"
+	// in this implementation.
+	SharedRepository config.SharedRepository
 
 	// ReadReverseIndex controls whether .rev files are read from disk.
 	// When false, a reverse index is generated in memory on demand.
@@ -357,7 +365,7 @@ func (d *DotGit) DeleteReflog(name plumbing.ReferenceName) error {
 // disk and also generates and save the index for the given packfile.
 func (d *DotGit) NewObjectPack() (*PackWriter, error) {
 	cleanErr := d.cleanPackList()
-	pw, err := newPackWrite(d.fs, d.options.ObjectFormat, d.options.WriteReverseIndex)
+	pw, err := newPackWrite(d.fs, d.options.ObjectFormat, d.options.WriteReverseIndex, d.options.SharedRepository)
 	if err != nil {
 		return nil, errors.Join(cleanErr, err)
 	}
@@ -719,7 +727,7 @@ func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) er
 func (d *DotGit) NewObject() (*ObjectWriter, error) {
 	d.cleanObjectList()
 
-	return newObjectWriter(d.fs, d.options.ObjectFormat)
+	return newObjectWriter(d.fs, d.options.ObjectFormat, d.options.SharedRepository)
 }
 
 // ObjectsWithPrefix returns the hashes of objects that have the given prefix.

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"path/filepath"
 	"sync/atomic"
 
 	"github.com/go-git/go-billy/v6"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
@@ -27,18 +29,19 @@ import (
 type PackWriter struct {
 	Notify func(plumbing.Hash, *idxfile.Writer)
 
-	fs       billy.Filesystem
-	fr, fw   billy.File
-	synced   *syncedReader
-	checksum plumbing.Hash
-	parser   *packfile.Parser
-	writer   *idxfile.Writer
-	result   chan error
-	format   formatcfg.ObjectFormat
-	writeRev bool
+	fs               billy.Filesystem
+	fr, fw           billy.File
+	synced           *syncedReader
+	checksum         plumbing.Hash
+	parser           *packfile.Parser
+	writer           *idxfile.Writer
+	result           chan error
+	format           formatcfg.ObjectFormat
+	writeRev         bool
+	sharedRepository config.SharedRepository
 }
 
-func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev bool) (*PackWriter, error) {
+func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev bool, sharedRepository config.SharedRepository) (*PackWriter, error) {
 	fw, err := fs.TempFile(fs.Join(objectsPath, packPath), "tmp_pack_")
 	if err != nil {
 		return nil, err
@@ -50,13 +53,14 @@ func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev b
 	}
 
 	writer := &PackWriter{
-		fs:       fs,
-		fw:       fw,
-		fr:       fr,
-		synced:   newSyncedReader(fw, fr),
-		result:   make(chan error),
-		format:   format,
-		writeRev: writeRev,
+		fs:               fs,
+		fw:               fw,
+		fr:               fr,
+		synced:           newSyncedReader(fw, fr),
+		result:           make(chan error),
+		format:           format,
+		writeRev:         writeRev,
+		sharedRepository: sharedRepository,
 	}
 
 	writer.checksum.ResetBySize(format.Size())
@@ -166,7 +170,7 @@ func (w *PackWriter) save() error {
 		if err := idx.Close(); err != nil {
 			return err
 		}
-		fixPermissions(w.fs, idxPath)
+		fixPermissions(w.fs, idxPath, w.sharedRepository)
 	}
 
 	if w.writeRev {
@@ -189,7 +193,7 @@ func (w *PackWriter) save() error {
 			if err := rev.Close(); err != nil {
 				return err
 			}
-			fixPermissions(w.fs, revPath)
+			fixPermissions(w.fs, revPath, w.sharedRepository)
 		}
 	}
 
@@ -202,7 +206,7 @@ func (w *PackWriter) save() error {
 		if err := w.fs.Rename(w.fw.Name(), packPath); err != nil {
 			return err
 		}
-		fixPermissions(w.fs, packPath)
+		fixPermissions(w.fs, packPath, w.sharedRepository)
 	} else {
 		// Pack already exists, clean up the temp file.
 		return w.clean()
@@ -334,20 +338,22 @@ func (s *syncedReader) Close() error {
 // ObjectWriter writes a single git object to the filesystem.
 type ObjectWriter struct {
 	objfile.Writer
-	fs billy.Filesystem
-	f  billy.File
+	fs               billy.Filesystem
+	f                billy.File
+	sharedRepository config.SharedRepository
 }
 
-func newObjectWriter(fs billy.Filesystem, objectFormat formatcfg.ObjectFormat) (*ObjectWriter, error) {
+func newObjectWriter(fs billy.Filesystem, objectFormat formatcfg.ObjectFormat, sharedRepository config.SharedRepository) (*ObjectWriter, error) {
 	f, err := fs.TempFile(fs.Join(objectsPath, packPath), "tmp_obj_")
 	if err != nil {
 		return nil, err
 	}
 
 	return &ObjectWriter{
-		Writer: (*objfile.NewWriter(f, objectFormat)),
-		fs:     fs,
-		f:      f,
+		Writer:           (*objfile.NewWriter(f, objectFormat)),
+		fs:               fs,
+		f:                f,
+		sharedRepository: sharedRepository,
 	}, nil
 }
 
@@ -379,7 +385,8 @@ func (w *ObjectWriter) save() error {
 	if err := w.fs.Rename(w.f.Name(), file); err != nil {
 		return err
 	}
-	fixPermissions(w.fs, file)
+	fixPermissions(w.fs, file, w.sharedRepository)
+	fixDirectoryPermissions(w.fs, filepath.Dir(file), w.sharedRepository)
 
 	return nil
 }

--- a/storage/filesystem/dotgit/writers_test.go
+++ b/storage/filesystem/dotgit/writers_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -15,8 +16,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/format/config"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/idxfile"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 )
@@ -26,7 +28,7 @@ func BenchmarkNewObjectPack(b *testing.B) {
 	fs := osfs.New(b.TempDir())
 
 	for b.Loop() {
-		w, err := newPackWrite(fs, config.SHA1, false)
+		w, err := newPackWrite(fs, formatcfg.SHA1, false, config.SharedRepositoryUmask)
 
 		require.NoError(b, err)
 		pf, pfErr := f.Packfile()
@@ -159,7 +161,7 @@ func TestPackWriterUnusedNotify(t *testing.T) {
 	t.Parallel()
 	fs := osfs.New(t.TempDir())
 
-	w, err := newPackWrite(fs, config.SHA1, false)
+	w, err := newPackWrite(fs, formatcfg.SHA1, false, config.SharedRepositoryUmask)
 	require.NoError(t, err)
 
 	w.Notify = func(_ plumbing.Hash, _ *idxfile.Writer) {
@@ -357,6 +359,53 @@ func TestObjectWriterPermissions(t *testing.T) {
 			ro, err := isReadOnly(tc.fs, path)
 			require.NoError(t, err)
 			assert.True(t, ro, "file %q is not read-only", path)
+		})
+	}
+}
+
+func TestObjectWriterPermissionsSharedRepository(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name               string
+		sharedRepository   config.SharedRepository
+		expectedFileMode   os.FileMode
+		expectedDirMode    os.FileMode
+		expectedDirSetgid bool
+	}{
+		{"group", config.SharedRepositoryGroup, 0o660, 0o770, true},
+		{"all", config.SharedRepositoryAll, 0o664, 0o775, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := osfs.New(t.TempDir(), osfs.WithBoundOS())
+			dot := NewWithOptions(fs, Options{SharedRepository: tc.sharedRepository})
+			require.NoError(t, dot.Initialize())
+
+			w, err := dot.NewObject()
+			require.NoError(t, err)
+
+			err = w.WriteHeader(plumbing.BlobObject, 14)
+			require.NoError(t, err)
+
+			_, err = w.Write([]byte("this is a test"))
+			require.NoError(t, err)
+
+			require.NoError(t, w.Close())
+
+			filePath := filepath.Join("objects", "a8", "a940627d132695a9769df883f85992f0ff4a43")
+			fi, err := fs.Stat(filePath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedFileMode, fi.Mode().Perm(), "file %q permissions", filePath)
+
+			dirPath := filepath.Join("objects", "a8")
+			di, err := fs.Stat(dirPath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedDirMode, di.Mode().Perm(), "directory %q permissions", dirPath)
+			if runtime.GOOS != "darwin" {
+				assert.Equal(t, tc.expectedDirSetgid, di.Mode()&os.ModeSetgid != 0, "directory %q setgid bit", dirPath)
+			}
 		})
 	}
 }

--- a/storage/filesystem/dotgit/writers_unix.go
+++ b/storage/filesystem/dotgit/writers_unix.go
@@ -3,17 +3,52 @@
 package dotgit
 
 import (
+	"os"
+
 	"github.com/go-git/go-billy/v6"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/utils/trace"
 )
 
-const readOnly = 0o444
+const (
+	readOnly      os.FileMode = 0o444
+	groupWritable os.FileMode = 0o660
+	allWritable   os.FileMode = 0o664
+	groupDirMode  os.FileMode = 0o2770
+	allDirMode    os.FileMode = 0o2775
+)
 
-func fixPermissions(fs billy.Filesystem, path string) {
+func fixPermissions(fs billy.Filesystem, path string, sharedRepository config.SharedRepository) {
 	if chmodFS, ok := fs.(billy.Chmod); ok {
-		if err := chmodFS.Chmod(path, readOnly); err != nil {
+		mode := readOnly
+		switch sharedRepository {
+		case config.SharedRepositoryGroup:
+			mode = groupWritable
+		case config.SharedRepositoryAll:
+			mode = allWritable
+		}
+
+		if err := chmodFS.Chmod(path, mode); err != nil {
 			trace.General.Printf("failed to chmod %s: %v", path, err)
+		}
+	}
+}
+
+func fixDirectoryPermissions(fs billy.Filesystem, path string, sharedRepository config.SharedRepository) {
+	if chmodFS, ok := fs.(billy.Chmod); ok {
+		mode := os.FileMode(0)
+		switch sharedRepository {
+		case config.SharedRepositoryGroup:
+			mode = groupDirMode
+		case config.SharedRepositoryAll:
+			mode = allDirMode
+		}
+
+		if mode != 0 {
+			if err := chmodFS.Chmod(path, mode); err != nil {
+				trace.General.Printf("failed to chmod %s: %v", path, err)
+			}
 		}
 	}
 }

--- a/storage/filesystem/dotgit/writers_windows.go
+++ b/storage/filesystem/dotgit/writers_windows.go
@@ -9,10 +9,11 @@ import (
 	"github.com/go-git/go-billy/v6"
 	"golang.org/x/sys/windows"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/utils/trace"
 )
 
-func fixPermissions(fs billy.Filesystem, path string) {
+func fixPermissions(fs billy.Filesystem, path string, _ config.SharedRepository) {
 	fullpath := filepath.Join(fs.Root(), path)
 	p, err := windows.UTF16PtrFromString(fullpath)
 	if err != nil {
@@ -37,6 +38,8 @@ func fixPermissions(fs billy.Filesystem, path string) {
 		trace.General.Printf("failed to chmod %s: %v", fullpath, err)
 	}
 }
+
+func fixDirectoryPermissions(fs billy.Filesystem, path string, _ config.SharedRepository) {}
 
 func isReadOnly(fs billy.Filesystem, path string) (bool, error) {
 	fullpath := filepath.Join(fs.Root(), path)

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -72,6 +72,12 @@ type Options struct {
 	// ObjectFormat - even if implicitly (e.g. SHA1).
 	ObjectFormat formatcfg.ObjectFormat
 
+	// SharedRepository controls the permission mode applied to new files
+	// and directories under .git. See [config.SharedRepository] for the
+	// supported values. When left as the zero value, the process umask
+	// governs permissions.
+	SharedRepository config.SharedRepository
+
 	// UseInMemoryIdx loads .idx files fully into memory (MemoryIndex) instead
 	// of reading them on demand via ReadAt (LazyIndex). This uses more memory
 	// but avoids keeping file descriptors open. Defaults to false.
@@ -156,6 +162,7 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 		cfg, err := config.ReadConfig(f)
 		if err == nil {
 			ops.ObjectFormat = cfg.Extensions.ObjectFormat
+			ops.SharedRepository = cfg.Core.SharedRepository
 			readRevIdx = cfg.Pack.ReadReverseIndex
 			writeRevIdx = cfg.Pack.WriteReverseIndex
 			skipHash = cfg.Index.SkipHash.IsTrue()
@@ -175,12 +182,13 @@ func NewStorageWithOptions(fs billy.Filesystem, c cache.Object, ops Options) *St
 	}
 
 	dirOps := dotgit.Options{
-		ExclusiveAccess:   ops.ExclusiveAccess,
-		AlternatesFS:      ops.AlternatesFS,
-		ObjectFormat:      ops.ObjectFormat,
-		ReadReverseIndex:  readRevIdx,
-		WriteReverseIndex: writeRevIdx,
-		Pool:              pool,
+		ExclusiveAccess:    ops.ExclusiveAccess,
+		AlternatesFS:       ops.AlternatesFS,
+		ObjectFormat:       ops.ObjectFormat,
+		SharedRepository:   ops.SharedRepository,
+		ReadReverseIndex:   readRevIdx,
+		WriteReverseIndex:  writeRevIdx,
+		Pool:               pool,
 	}
 	dir := dotgit.NewWithOptions(fs, dirOps)
 


### PR DESCRIPTION
Parse `core.sharedRepository` in Config, propagate it through `dotgit.Options`, and apply group/all writable permissions to loose objects (and their parent directories) created by `ObjectWriter` and `PackWriter`.

- Adds `SharedRepository` type and constants to the config package.
- `ObjectWriter` now creates files as 0660 for `group` and 0664 for `all`.
- Parent directories are chmod'd to 2770 / 2775 on Unix so group ownership is inherited.
- The default (`umask` / unset) keeps the existing read-only object behavior.

Fixes #843.

AI disclosure: this PR was prepared with assistance from Claude.