### PR TITLE
[v5] plumbing: revlist, Skip path validation in the object walk

### DIFF
--- a/plumbing/object/difftree_pathvalidation_test.go
+++ b/plumbing/object/difftree_pathvalidation_test.go
@@ -1,0 +1,74 @@
+package object
+
+import (
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/storage/memory"
+
+	. "gopkg.in/check.v1"
+)
+
+type DiffTreePathValidationSuite struct{}
+
+var _ = Suite(&DiffTreePathValidationSuite{})
+
+func (s *DiffTreePathValidationSuite) storeBlob(c *C, sto *memory.Storage, content string) plumbing.Hash {
+	obj := sto.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+
+	w, err := obj.Writer()
+	c.Assert(err, IsNil)
+	_, err = w.Write([]byte(content))
+	c.Assert(err, IsNil)
+	c.Assert(w.Close(), IsNil)
+
+	h, err := sto.SetEncodedObject(obj)
+	c.Assert(err, IsNil)
+	return h
+}
+
+// storeTree writes a tree verbatim. Tree.Encode rejects only NUL, matching
+// upstream Git, which forbids just '/' and NUL inside a path component.
+func (s *DiffTreePathValidationSuite) storeTree(c *C, sto *memory.Storage, entries []TreeEntry) *Tree {
+	tree := &Tree{Entries: entries}
+
+	obj := sto.NewEncodedObject()
+	c.Assert(tree.Encode(obj), IsNil)
+
+	h, err := sto.SetEncodedObject(obj)
+	c.Assert(err, IsNil)
+
+	stored, err := GetTree(sto, h)
+	c.Assert(err, IsNil)
+	return stored
+}
+
+// TestDiffTree_ControlCharacterEntry checks that a tree entry name upstream
+// Git accepts does not abort a diff. DiffTree computes changes in memory and
+// never writes a name to disk, so the worktree-safety validation in
+// TreeWalker.Next does not apply to it.
+//
+// Before the fix this failed with:
+//
+//	from: invalid path "\x1b\x1b\x1b": contains control character
+func (s *DiffTreePathValidationSuite) TestDiffTree_ControlCharacterEntry(c *C) {
+	sto := memory.NewStorage()
+
+	before := s.storeBlob(c, sto, "one")
+	after := s.storeBlob(c, sto, "two")
+
+	from := s.storeTree(c, sto, []TreeEntry{
+		{Name: "\x1b\x1b\x1b", Mode: filemode.Regular, Hash: before},
+	})
+	to := s.storeTree(c, sto, []TreeEntry{
+		{Name: "\x1b\x1b\x1b", Mode: filemode.Regular, Hash: after},
+	})
+
+	changes, err := DiffTree(from, to)
+	c.Assert(err, IsNil)
+	c.Assert(changes, HasLen, 1)
+
+	action, err := changes[0].Action()
+	c.Assert(err, IsNil)
+	c.Assert(action.String(), Equals, "Modify")
+}

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -474,6 +474,14 @@ type TreeWalker struct {
 	recursive bool
 	seen      map[plumbing.Hash]bool
 
+	// skipPathValidation disables the pathutil.ValidTreePath check in Next.
+	// It is set by inspection-only callers (e.g. the revlist object walk)
+	// that never funnel entry names into the filesystem and must enumerate
+	// trees faithfully, including entries with names upstream Git accepts
+	// but that are unsafe to materialise (control characters, `.git`-shaped
+	// names).
+	skipPathValidation bool
+
 	s storer.EncodedObjectStorer
 	t *Tree
 }
@@ -496,9 +504,31 @@ func NewTreeWalker(t *Tree, recursive bool, seen map[plumbing.Hash]bool) *TreeWa
 	}
 }
 
+// SkipPathValidation disables the pathutil.ValidTreePath check performed by
+// Next, and must be called before the first Next.
+//
+// It is for inspection-only walks that never funnel an entry name into the
+// filesystem — enumerating which objects exist, rather than materialising
+// them — and that must therefore see the tree faithfully, including entries
+// whose names upstream Git accepts but that are unsafe to check out. Callers
+// that hand the returned name to filesystem or archive output must not use
+// it; path safety for those is enforced at the materialisation boundaries
+// (FindEntry, TreeEntryFile, archive, FileIter).
+func (w *TreeWalker) SkipPathValidation() {
+	w.skipPathValidation = true
+}
+
 // Next returns the next object from the tree. Objects are returned in order
 // and subtrees are included. After the last object has been returned further
 // calls to Next() will return io.EOF.
+//
+// Each entry's name is validated against pathutil.ValidTreePath as it
+// surfaces, so callers that funnel the returned name into filesystem
+// or archive output can trust it is free of `.git`-shaped components,
+// HFS+/NTFS variants, Windows reserved names, and traversal sequences.
+// A malformed entry stops the walk with the validator's error;
+// inspection-only callers that need to enumerate raw, unvalidated
+// names can read Tree.Entries directly or call SkipPathValidation.
 //
 // In the current implementation any objects which cannot be found in the
 // underlying repository will be skipped automatically. It is possible that this
@@ -536,8 +566,10 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 			continue
 		}
 
-		if err := pathutil.ValidTreePath(entry.Name); err != nil {
-			return name, entry, err
+		if !w.skipPathValidation {
+			if err := pathutil.ValidTreePath(entry.Name); err != nil {
+				return name, entry, err
+			}
 		}
 
 		if entry.Mode == filemode.Dir {

--- a/plumbing/object/treenoder.go
+++ b/plumbing/object/treenoder.go
@@ -106,6 +106,12 @@ func transformChildren(t *Tree) ([]noder.Noder, error) {
 	ret := make([]noder.Noder, 0, len(t.Entries))
 
 	walker := NewTreeWalker(t, false, nil) // don't recurse
+	// The diff walk is read-only and never materialises entry names into the
+	// filesystem, so it must enumerate the tree faithfully — including entries
+	// with names that are unsafe to check out but valid per upstream Git (e.g.
+	// control characters). Path safety is enforced at materialisation
+	// boundaries (FindEntry, TreeEntryFile, archive, FileIter), not here.
+	walker.SkipPathValidation()
 	// don't defer walker.Close() for efficiency reasons.
 	for {
 		_, e, err = walker.Next()

--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -187,6 +187,13 @@ func iterateCommitTrees(
 	cb(tree.Hash)
 
 	treeWalker := object.NewTreeWalker(tree, true, seen)
+	// This walk only enumerates which objects are reachable, to decide what
+	// to send; it never materialises an entry name into the filesystem. It
+	// must therefore enumerate the tree faithfully, including entries with
+	// names that are unsafe to check out but valid per upstream Git (e.g.
+	// control characters). Path safety is enforced at materialisation
+	// boundaries (FindEntry, TreeEntryFile, archive, FileIter), not here.
+	treeWalker.SkipPathValidation()
 
 	for {
 		_, e, err := treeWalker.Next()

--- a/plumbing/revlist/revlist_pathvalidation_test.go
+++ b/plumbing/revlist/revlist_pathvalidation_test.go
@@ -1,0 +1,140 @@
+package revlist
+
+import (
+	"time"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
+
+	. "gopkg.in/check.v1"
+)
+
+// storeBlob writes a blob and returns its hash.
+func storeBlob(c *C, sto *memory.Storage, content string) plumbing.Hash {
+	obj := sto.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+
+	w, err := obj.Writer()
+	c.Assert(err, IsNil)
+	_, err = w.Write([]byte(content))
+	c.Assert(err, IsNil)
+	c.Assert(w.Close(), IsNil)
+
+	h, err := sto.SetEncodedObject(obj)
+	c.Assert(err, IsNil)
+	return h
+}
+
+// storeTree writes a tree verbatim, bypassing the higher-level helpers so
+// that entry names Git itself accepts can be stored. Tree.Encode only
+// rejects NUL, matching upstream Git, which forbids just '/' and NUL inside
+// a path component.
+func storeTree(c *C, sto *memory.Storage, entries []object.TreeEntry) plumbing.Hash {
+	tree := &object.Tree{Entries: entries}
+
+	obj := sto.NewEncodedObject()
+	c.Assert(tree.Encode(obj), IsNil)
+
+	h, err := sto.SetEncodedObject(obj)
+	c.Assert(err, IsNil)
+	return h
+}
+
+// storeCommit writes a commit pointing at treeHash with the given parents.
+func storeCommit(c *C, sto *memory.Storage, msg string, treeHash plumbing.Hash, parents ...plumbing.Hash) plumbing.Hash {
+	when := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sig := object.Signature{Name: "Test", Email: "test@example.com", When: when}
+
+	commit := &object.Commit{
+		Author:       sig,
+		Committer:    sig,
+		Message:      msg,
+		TreeHash:     treeHash,
+		ParentHashes: parents,
+	}
+
+	obj := sto.NewEncodedObject()
+	c.Assert(commit.Encode(obj), IsNil)
+
+	h, err := sto.SetEncodedObject(obj)
+	c.Assert(err, IsNil)
+	return h
+}
+
+// TestRevListObjects_ControlCharacterInHistory reproduces the push failure in
+// issue #2251.
+//
+// The object walk that Push uses to decide what to send enumerates every
+// reachable tree entry. It never materialises a name into a worktree, so the
+// worktree-safety validation in TreeWalker.Next does not apply to it — the
+// same reasoning PR #2222 established for the tree diff walk.
+//
+// Before the fix this fails with:
+//
+//	invalid path "\x1b\x1b\x1b": contains control character
+//
+// even though the entry exists only in history and is not part of the commit
+// being pushed.
+func (s *RevListSuite) TestRevListObjects_ControlCharacterInHistory(c *C) {
+	sto := memory.NewStorage()
+
+	// Distinct blobs matter. TreeWalker.Next checks its seen set *before*
+	// validating the name, so an entry whose blob is still reachable from a
+	// newer tree is skipped before the validator ever sees it. Content that
+	// was genuinely deleted has a blob nothing else references, which is
+	// what makes the historical entry reach the validator.
+	deletedBlob := storeBlob(c, sto, "deleted content")
+	liveBlob := storeBlob(c, sto, "live content")
+
+	// Upstream Git's verify_path permits this name: only '/' and NUL are
+	// forbidden inside a path component.
+	historical := storeTree(c, sto, []object.TreeEntry{
+		{Name: "\x1b\x1b\x1b", Mode: filemode.Regular, Hash: deletedBlob},
+	})
+	current := storeTree(c, sto, []object.TreeEntry{
+		{Name: "ok.txt", Mode: filemode.Regular, Hash: liveBlob},
+	})
+
+	// The offending entry lives only in history — the commit being pushed
+	// deleted it, exactly as reported.
+	old := storeCommit(c, sto, "adds an oddly named file", historical)
+	head := storeCommit(c, sto, "deletes it again", current, old)
+
+	objs, err := Objects(sto, []plumbing.Hash{head}, nil)
+	c.Assert(err, IsNil)
+
+	// Both commits, both trees and both blobs must be reported as reachable.
+	got := make(map[plumbing.Hash]bool, len(objs))
+	for _, h := range objs {
+		got[h] = true
+	}
+	for _, h := range []plumbing.Hash{head, old, current, historical, liveBlob, deletedBlob} {
+		c.Assert(got[h], Equals, true, Commentf("missing reachable object %s", h))
+	}
+}
+
+// TestRevListObjects_ControlCharacterInPushedCommit covers the same walk when
+// the offending entry is in the commit being pushed rather than only in its
+// history. Push still only enumerates hashes here, so this must not error.
+func (s *RevListSuite) TestRevListObjects_ControlCharacterInPushedCommit(c *C) {
+	sto := memory.NewStorage()
+
+	blob := storeBlob(c, sto, "content")
+	tree := storeTree(c, sto, []object.TreeEntry{
+		{Name: "\x1b\x1b\x1b", Mode: filemode.Regular, Hash: blob},
+	})
+	head := storeCommit(c, sto, "adds an oddly named file", tree)
+
+	objs, err := Objects(sto, []plumbing.Hash{head}, nil)
+	c.Assert(err, IsNil)
+
+	got := make(map[plumbing.Hash]bool, len(objs))
+	for _, h := range objs {
+		got[h] = true
+	}
+	for _, h := range []plumbing.Hash{head, tree, blob} {
+		c.Assert(got[h], Equals, true, Commentf("missing reachable object %s", h))
+	}
+}


### PR DESCRIPTION
# [v5] plumbing: revlist, Skip path validation in the object walk

Fixes #2251

Targets `releases/v5.x`. `main` is unaffected — the v6 object walk was rewritten
to read `Tree.Entries` directly and no longer goes through `TreeWalker`.

## Problem

`Push` computes the set of objects to send with `revlist.Objects`. If **any**
reachable tree in history contains an entry whose name holds a control
character, the whole push aborts before any network transfer:

```
invalid path "\x1b\x1b\x1b": contains control character
```

The offending entry does not have to be part of the commit being pushed. In the
reported case it was deleted years earlier and its objects were already on the
remote, so they would never have been sent. Upstream Git pushes such a
repository without complaint: `verify_path` forbids only `/` and NUL inside a
path component.

## Root cause

`iterateCommitTrees` enumerates entries through `TreeWalker.Next`, which since
#2105 validates every name:

```go
// plumbing/object/tree.go
if err := pathutil.ValidTreePath(entry.Name); err != nil {
    return name, entry, err
}
```

`ValidTreePath` exists so that callers **materialising** entries into a worktree
or archive stay safe. The revlist walk materialises nothing — it only collects
hashes to decide what to send — but a validator error propagates out of
`iterateCommitTrees` and fails the entire walk.

This is the same defect #2222 fixed for the tree diff walk, at a call site that
fix did not cover.

## Fix

`TreeWalker` gains an opt-out, and revlist takes it:

```go
treeWalker := object.NewTreeWalker(tree, true, seen)
treeWalker.SkipPathValidation()
```

Validation stays **on by default**; only this inspection-only walk opts out.
Path safety for callers that do materialise names is untouched and still
enforced at `FindEntry`, `TreeEntryFile`, `archive` and `FileIter`.

**Why an exported method rather than the unexported field #2222 used.** On
`main` the only opt-out caller is `treeNoder`, which lives in package `object`
and can set the field directly. `revlist` is a separate package, so v5 needs an
exported entry point. `SkipPathValidation()` is the smallest such surface I
could find — happy to reshape it into an exported field, a `NewTreeWalker`
variant, or an `internal/` accessor if you'd prefer not to grow the v5 API.

## A subtlety worth flagging

`Next` checks its `seen` set **before** validating, so an entry whose blob is
still reachable from a newer tree is skipped before the validator sees it. My
first attempt at a regression test reused one blob across both trees and
**passed against the unfixed branch**. Content that was genuinely deleted has a
blob nothing else references, which is exactly why the reported case involves
history. Both tests now use distinct blobs.

## What I deliberately left out

- **No change to `ValidTreePath` itself**, and no relaxation of any
  materialisation boundary. Only the walk that decides which objects to send.
- **No v6 change** — the bug does not exist there.
- **No backport of the `archive`/`FileIter` call sites.** Those do materialise
  names, so validation belongs there.

## The second commit

`plumbing: object, Skip path validation in tree diff walk` backports #2222,
which landed on `main` but never on `releases/v5.x`. I found it by checking the
sibling call site. On this branch `DiffTree` still fails:

```
from: invalid path "\x1b\x1b\x1b": contains control character
```

It is a separate commit precisely so you can drop it if you'd rather track the
v5 backport on its own — the first commit stands alone.

## Tests

Two new files, both failing on the unfixed branch with the reported error:

```
$ git stash                       # revert source, keep tests
$ go test ./plumbing/revlist/ -check.f ControlCharacter

FAIL: revlist_pathvalidation_test.go:80: RevListSuite.TestRevListObjects_ControlCharacterInHistory
... ("invalid path \"\\x1b\\x1b\\x1b\": contains control character")

FAIL: revlist_pathvalidation_test.go:121: RevListSuite.TestRevListObjects_ControlCharacterInPushedCommit
... ("invalid path \"\\x1b\\x1b\\x1b\": contains control character")

OOPS: 0 passed, 2 FAILED
```

```
$ git stash -- plumbing/object/treenoder.go
$ go test ./plumbing/object/ -check.f DiffTreePathValidation

FAIL: difftree_pathvalidation_test.go:54: DiffTreePathValidationSuite.TestDiffTree_ControlCharacterEntry
... ("from: invalid path \"\\x1b\\x1b\\x1b\": contains control character")

OOPS: 0 passed, 1 FAILED
```

With the fixes applied, all three pass.

The trees are written through `Tree.Encode`, which rejects only NUL — the same
constraint upstream Git applies — so the fixtures hold names Git itself would
accept, rather than anything synthetic.

## Verification

`go test -count=1 ./...` on macOS 26.1 arm64, Go 1.26.0:

| | ok | FAIL | no test files |
|---|---|---|---|
| baseline (`releases/v5.x` @ 42852fda) | 53 | 0 | 7 |
| with both commits | 53 | 0 | 7 |

Package-level results are byte-identical to the baseline. No pre-existing
failures on this branch in my environment, with one caveat worth naming: on the
very first cold run `plumbing/transport/git` failed 12 tests with
`dial tcp [::1]:PORT: connect: connection refused`. It passed on every
subsequent run including the recorded cold baseline, so I treated it as a
local port-binding flake in that suite's `git daemon` setup, not a real result.

`gofmt -l` is clean on all five changed files, and `go vet ./...` is clean.
(`gofmt -l .` reports 30 pre-existing files, e.g. `plumbing/format/commitgraph/*`,
none of them touched here.)

## Reshaping

Happy to split the two commits into separate PRs, drop the second, rename or
restructure `SkipPathValidation`, or move the regression tests into the existing
`revlist_test.go` / `difftree_test.go` if you'd rather not have new files.
