### PR TITLE
git: log, Add topological commit order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ profile.out
 .vscode
 build/tools/
 tests/testdata/
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ profile.out
 .vscode
 build/tools/
 tests/testdata/
+.DS_Store

--- a/options.go
+++ b/options.go
@@ -493,6 +493,8 @@ const (
 	LogOrderBSF
 	LogOrderCommitterTime
 	LogOrderDFSPostFirstParent
+	// LogOrderTopoOrder avoids showing commits on multiple lines of history intermixed.
+	LogOrderTopoOrder
 )
 
 // LogOptions describes how a log action should be performed.
@@ -509,6 +511,7 @@ type LogOptions struct {
 	// The default traversal algorithm is Depth-first search
 	// set Order=LogOrderCommitterTime for ordering by committer time (more compatible with `git log`)
 	// set Order=LogOrderBSF for Breadth-first search
+	// set Order=LogOrderTopoOrder for the equivalent of `git log --topo-order`
 	Order LogOrder
 
 	// Show only those commits in which the specified file was inserted/updated.

--- a/repository.go
+++ b/repository.go
@@ -27,6 +27,7 @@ import (
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/object/commitgraph"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/plumbing/transport"
@@ -1541,7 +1542,7 @@ func (r *Repository) ArchiveContext(ctx context.Context, o *ArchiveOptions) (io.
 
 // Log returns the commit history from the given LogOptions.
 func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
-	fn := commitIterFunc(o.Order)
+	fn := commitIterFunc(r.Storer, o.Order)
 	if fn == nil {
 		return nil, fmt.Errorf("invalid Order=%v", o.Order)
 	}
@@ -1620,7 +1621,7 @@ func (*Repository) logWithLimit(commitIter object.CommitIter, limitOptions objec
 	return object.NewCommitLimitIterFromIter(commitIter, limitOptions)
 }
 
-func commitIterFunc(order LogOrder) func(c *object.Commit) object.CommitIter {
+func commitIterFunc(s storer.EncodedObjectStorer, order LogOrder) func(c *object.Commit) object.CommitIter {
 	switch order {
 	case LogOrderDefault:
 		return func(c *object.Commit) object.CommitIter {
@@ -1646,8 +1647,69 @@ func commitIterFunc(order LogOrder) func(c *object.Commit) object.CommitIter {
 		return func(c *object.Commit) object.CommitIter {
 			return object.NewCommitPostorderIterFirstParent(c, nil)
 		}
+	case LogOrderTopoOrder:
+		return func(c *object.Commit) object.CommitIter {
+			return newCommitTopoOrderIter(s, c)
+		}
 	}
 	return nil
+}
+
+type commitNodeCommitIter struct {
+	commitgraph.CommitNodeIter
+	err error
+}
+
+func newCommitTopoOrderIter(s storer.EncodedObjectStorer, c *object.Commit) object.CommitIter {
+	node, err := commitgraph.NewObjectCommitNodeIndex(s).Get(c.Hash)
+	if err != nil {
+		return &commitNodeCommitIter{err: err}
+	}
+
+	return &commitNodeCommitIter{
+		CommitNodeIter: commitgraph.NewCommitNodeIterTopoOrder(node, nil, nil),
+	}
+}
+
+func (iter *commitNodeCommitIter) Next() (*object.Commit, error) {
+	if iter.err != nil {
+		err := iter.err
+		iter.err = nil
+		return nil, err
+	}
+	if iter.CommitNodeIter == nil {
+		return nil, io.EOF
+	}
+
+	node, err := iter.CommitNodeIter.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	return node.Commit()
+}
+
+func (iter *commitNodeCommitIter) ForEach(cb func(*object.Commit) error) error {
+	for {
+		commit, err := iter.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := cb(commit); errors.Is(err, storer.ErrStop) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+}
+
+func (iter *commitNodeCommitIter) Close() {
+	if iter.CommitNodeIter != nil {
+		iter.CommitNodeIter.Close()
+	}
 }
 
 // Tags returns all the tag References in a repository.

--- a/repository_test.go
+++ b/repository_test.go
@@ -2489,6 +2489,46 @@ func (s *RepositorySuite) TestLog() {
 	s.ErrorIs(err, io.EOF)
 }
 
+func (s *RepositorySuite) TestLogTopoOrder() {
+	r, _ := Init(memory.NewStorage())
+	defer func() { _ = r.Close() }()
+
+	storeCommit := func(message string, when time.Time, parents ...plumbing.Hash) plumbing.Hash {
+		signature := object.Signature{Name: "go-git", Email: "go-git@fake.local", When: when}
+		commit := &object.Commit{
+			Author:       signature,
+			Committer:    signature,
+			Message:      message,
+			ParentHashes: parents,
+			TreeHash:     plumbing.NewHash("4b825dc642cb6eb9a060e54bf8d69288fbee4904"),
+		}
+		encoded := r.Storer.NewEncodedObject()
+		s.Require().NoError(commit.Encode(encoded))
+		hash, err := r.Storer.SetEncodedObject(encoded)
+		s.Require().NoError(err)
+		return hash
+	}
+
+	start := time.Unix(0, 0)
+	initial := storeCommit("initial", start)
+	feature1 := storeCommit("feature 1", start.Add(time.Minute), initial)
+	feature2 := storeCommit("feature 2", start.Add(2*time.Minute), initial)
+	merge1 := storeCommit("merge 1", start.Add(3*time.Minute), initial, feature1)
+	merge2 := storeCommit("merge 2", start.Add(4*time.Minute), merge1, feature2)
+
+	iter, err := r.Log(&LogOptions{From: merge2, Order: LogOrderTopoOrder})
+	s.Require().NoError(err)
+	defer iter.Close()
+
+	var commits []plumbing.Hash
+	s.Require().NoError(iter.ForEach(func(commit *object.Commit) error {
+		commits = append(commits, commit.Hash)
+		return nil
+	}))
+
+	s.Equal([]plumbing.Hash{merge2, feature2, merge1, feature1, initial}, commits)
+}
+
 func (s *RepositorySuite) TestLogAll() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()


### PR DESCRIPTION
## What and why

`Repository.Log` cannot currently expose the existing commit-graph topological walker. That makes changelog-style traversals stop at an older merge before emitting a side-branch commit that `git log --topo-order` would show first.

This adds `LogOrderTopoOrder`, adapts `CommitNodeIter` to the public commit iterator used by `Repository.Log`, and verifies the exact order on the merge graph from the issue.

```go
iter, err := repo.Log(&git.LogOptions{
    From:  from,
    Order: git.LogOrderTopoOrder,
})
if err != nil {
    return err
}
defer iter.Close()
```

The reference behavior is documented by [`git log --topo-order`](https://git-scm.com/docs/git-log#Documentation/git-log.txt---topo-order): parents are not shown before their children, while commits from separate lines of history are kept from being intermixed.

Fixes #372

## Validation

- regression test before implementation: failed with `invalid Order=6`
- `go test ./ -run TestRepositorySuite/TestLogTopoOrder -count=1` — passed
- `go test ./ -count=1` — passed
- `go test ./plumbing/object/commitgraph -count=1` — passed
- `go test -race ./ -run TestRepositorySuite/TestLogTopoOrder -count=1` — passed
- `make validate-lint` — 0 issues
- reference Git comparison on the same five-commit merge graph — exact order matched: merge 2, feature 2, merge 1, feature 1, initial
- `go test ./...` — all non-daemon packages passed; the documented local `plumbing/transport/git` daemon tests hit the baseline `context canceled before the port is connectable` limitation

## AI assistance disclosure

Codex assisted with the implementation and regression test. The affected commit contains the required `Assisted-by: Codex <noreply@openai.com>` trailer and a DCO sign-off.

## Draft gate

GitHub has placed all five upstream workflows (`Test`, `Git Compatibility`, `CIFuzz`, `CodeQL`, and `PR Validation`) in `action_required` with no jobs. A maintainer must approve the workflow runs for this external-fork PR; after approval, every required machine check must complete successfully before this PR is marked ready for review.