### PR TITLE
plumbing: format/gitignore, Add Scope for per-directory ignore evaluation.

### DIFF
--- a/plumbing/format/gitignore/dir.go
+++ b/plumbing/format/gitignore/dir.go
@@ -14,12 +14,17 @@ import (
 	gioutil "github.com/go-git/go-git/v6/utils/ioutil"
 )
 
+// IgnoreFile is the name of the per-directory ignore file. A walk driven by a
+// Scope needs it to tell, from a directory listing it already holds, whether
+// that directory declares patterns of its own.
+const IgnoreFile = ".gitignore"
+
 const (
 	commentPrefix   = "#"
 	coreSection     = "core"
 	excludesfile    = "excludesfile"
 	gitDir          = ".git"
-	gitignoreFile   = ".gitignore"
+	gitignoreFile   = IgnoreFile
 	gitconfigFile   = ".gitconfig"
 	systemFile      = "/etc/gitconfig"
 	infoExcludeFile = gitDir + "/info/exclude"
@@ -55,6 +60,12 @@ func readIgnoreFile(fs billy.Filesystem, path []string, ignoreFile string) (ps [
 // matching reference git which reads $GIT_DIR/info/exclude of the
 // repository being walked. Ignore files are opened only when present in
 // the directory listing, so directories without them cost a single ReadDir.
+//
+// Deprecated: use Scope, which evaluates rules per directory as a walk
+// descends. The flat list returned here cannot express that a parent
+// directory is excluded, so a Matcher built from it may re-include a path
+// that git reports as ignored, and rules below an excluded directory are
+// collected even though reference git never reads them.
 func ReadPatterns(fs billy.Filesystem, path []string) (ps []Pattern, err error) {
 	fis, err := fs.ReadDir(fs.Join(path...))
 	if err != nil {

--- a/plumbing/format/gitignore/scope.go
+++ b/plumbing/format/gitignore/scope.go
@@ -1,0 +1,146 @@
+package gitignore
+
+import (
+	"os"
+	"slices"
+
+	"github.com/go-git/go-billy/v6"
+)
+
+// Scope is the set of ignore patterns in effect for the entries of a single
+// directory: those inherited from its ancestors, in ascending order of
+// priority, followed by those the directory declares itself.
+//
+// A Scope also records whether the directory it belongs to is excluded. That
+// is what a flat []Pattern cannot express. gitignore(5) states that a file
+// cannot be re-included once a parent directory of it is excluded, so once a
+// directory is excluded every entry below it is ignored whatever the patterns
+// there say. Reference git tracks the same state in its walk rather than
+// recomputing it per query: prep_exclude stops at the excluded directory and
+// last_matching_pattern returns its pattern directly (dir.c).
+//
+// A Scope is immutable and safe for concurrent use. Descend derives the Scope
+// for a subdirectory; the zero Scope matches nothing and is a valid root for a
+// walk with no patterns at all.
+type Scope struct {
+	// patterns is ancestors-then-own, in ascending order of priority.
+	patterns []Pattern
+	matcher  Matcher
+	// excluded reports whether this directory, or an ancestor of it, matched
+	// an exclude rule.
+	excluded bool
+}
+
+// NewScope returns the root Scope for a walk. base holds the patterns that
+// apply to the whole tree before any .gitignore is read: typically
+// .git/info/exclude, the core.excludesfile patterns, and any supplied by the
+// caller. They are ordered by ascending priority, as for NewMatcher.
+func NewScope(base []Pattern) *Scope {
+	// Cloned so the Scope really is immutable, as documented above: without it
+	// a caller mutating its own slice afterwards would change this Scope and
+	// every Scope derived from it, including concurrently. Descend already
+	// copies, so this is the only place the caller's memory could be shared.
+	base = slices.Clone(base)
+	return &Scope{patterns: base, matcher: NewMatcher(base)}
+}
+
+// Descend returns the Scope for the subdirectory of s at dir. dir is the full
+// path of the subdirectory from the root of the walk, so that patterns keep
+// matching against complete paths.
+//
+// readOwn supplies the patterns the subdirectory declares itself. It is called
+// only when the subdirectory is not excluded, because git does not read ignore
+// files below an excluded directory and nothing in one could change an
+// outcome. Passing it as a function rather than a slice keeps that decision
+// here, so callers cannot pay for a read that is then discarded. It may be nil
+// when the subdirectory has no ignore file, which callers already know from
+// the directory listing they hold.
+func (s *Scope) Descend(dir []string, readOwn func() ([]Pattern, error)) (*Scope, error) {
+	if s.excluded || s.matches(dir, true) {
+		// Nothing below an excluded directory can change an outcome, so the
+		// pattern set is frozen here and readOwn is never called.
+		return &Scope{patterns: s.patterns, matcher: s.matcher, excluded: true}, nil
+	}
+
+	if readOwn == nil {
+		return s, nil
+	}
+
+	own, err := readOwn()
+	if err != nil {
+		return nil, err
+	}
+	if len(own) == 0 {
+		return s, nil
+	}
+
+	patterns := slices.Concat(s.patterns, own)
+	return &Scope{patterns: patterns, matcher: NewMatcher(patterns)}, nil
+}
+
+// Excluded reports whether the directory this Scope belongs to, or an ancestor
+// of it, is excluded. Every entry below such a directory is ignored.
+func (s *Scope) Excluded() bool {
+	return s.excluded
+}
+
+// Match reports whether path is excluded by the patterns in effect. path is an
+// ordered sequence of the components of a complete path from the root of the
+// walk, and isDir reports whether its final component is a directory.
+//
+// Unlike a Matcher built from a flat pattern list, Match honours excluded
+// ancestors: below an excluded directory it reports true without consulting
+// any pattern, so a negation there cannot re-include the entry.
+func (s *Scope) Match(path []string, isDir bool) bool {
+	if s.excluded {
+		return true
+	}
+	return s.matches(path, isDir)
+}
+
+// Patterns returns the patterns in effect, ancestors first. The result must
+// not be modified.
+func (s *Scope) Patterns() []Pattern {
+	return s.patterns
+}
+
+func (s *Scope) matches(path []string, isDir bool) bool {
+	if s.matcher == nil {
+		return false
+	}
+	return s.matcher.Match(path, isDir)
+}
+
+// DirPatterns returns the patterns declared by the .gitignore of a single
+// directory, without recursing. A missing file is not an error and yields no
+// patterns. Use it to build the readOwn argument of Scope.Descend while walking
+// a tree; ReadPatterns is the eager whole-tree equivalent.
+func DirPatterns(fs billy.Filesystem, path []string) ([]Pattern, error) {
+	ps, err := readIgnoreFile(fs, path, gitignoreFile)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	return ps, nil
+}
+
+// RootPatterns returns the patterns that apply to a whole worktree before any
+// .gitignore is consulted: .git/info/exclude followed by the .gitignore at the
+// root, in ascending order of priority. Missing files are not an error.
+func RootPatterns(fs billy.Filesystem) ([]Pattern, error) {
+	// Both files are opened directly rather than confirmed against a listing of
+	// the root. Two opens cost less than enumerating a directory that may hold
+	// thousands of entries, and the walk lists the root for its own purposes
+	// anyway, so a listing here would be the second of two.
+	//
+	// Errors from the exclude file are dropped, as ReadPatterns drops them: it
+	// is optional, and a worktree filesystem may refuse to open a path inside
+	// .git outright rather than reporting it as missing.
+	ps, _ := readIgnoreFile(fs, nil, infoExcludeFile)
+
+	root, err := DirPatterns(fs, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(ps, root...), nil
+}

--- a/plumbing/format/gitignore/scope_test.go
+++ b/plumbing/format/gitignore/scope_test.go
@@ -1,0 +1,262 @@
+package gitignore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// walkScoped walks fs the way a consumer of Scope is meant to: read the root
+// patterns once, then derive a child Scope per directory, reading a
+// .gitignore only when the listing shows one and the directory is not
+// excluded. It returns the ignore verdict for every file it encounters, and
+// the set of directories it listed.
+func walkScoped(t *testing.T, fs billy.Filesystem) (verdicts, listed map[string]bool) {
+	t.Helper()
+
+	base, err := RootPatterns(fs)
+	require.NoError(t, err)
+
+	verdicts = map[string]bool{}
+	listed = map[string]bool{}
+
+	var walk func(dir []string, scope *Scope)
+	walk = func(dir []string, scope *Scope) {
+		joined := fs.Join(dir...)
+		listed[joined] = true
+
+		entries, err := fs.ReadDir(joined)
+		require.NoError(t, err)
+
+		for _, e := range entries {
+			if e.Name() == gitDir {
+				continue
+			}
+			child := append(append([]string{}, dir...), e.Name())
+			if !e.IsDir() {
+				verdicts[fs.Join(child...)] = scope.Match(child, false)
+				continue
+			}
+
+			// A real consumer knows from its own listing whether the child has
+			// an ignore file; here we probe cheaply for the test's purposes.
+			var readOwn func() ([]Pattern, error)
+			if sub, err := fs.ReadDir(fs.Join(child...)); err == nil {
+				for _, s := range sub {
+					if s.Name() == gitignoreFile {
+						readOwn = func() ([]Pattern, error) { return DirPatterns(fs, child) }
+					}
+				}
+			}
+
+			childScope, err := scope.Descend(child, readOwn)
+			require.NoError(t, err)
+			walk(child, childScope)
+		}
+	}
+
+	walk(nil, NewScope(base))
+	return verdicts, listed
+}
+
+// writeScopeFile creates the slash-separated path, and any parent
+// directories, holding content.
+func writeScopeFile(t *testing.T, fs billy.Filesystem, path, content string) {
+	t.Helper()
+	require.NoError(t, fs.MkdirAll(filepath.Dir(path), os.ModePerm))
+	require.NoError(t, util.WriteFile(fs, path, []byte(content), 0o644))
+}
+
+// TestScopeExcludedAncestorWins covers the three shapes a flat []Pattern
+// cannot get right at once. Reference git reports keep.txt as ignored in all
+// three, always attributing it to the rule that excluded the parent
+// directory. Verified with `git check-ignore -v`.
+func TestScopeExcludedAncestorWins(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name, root, nested string
+	}{
+		{
+			// A root negation cannot re-include below an excluded directory,
+			// even though a nested file re-excludes it. The flat API gets this
+			// right only by accident, by collecting the nested pattern.
+			name:   "root negation and nested re-exclude",
+			root:   "outer/ignored/\n!outer/ignored/keep.txt\n",
+			nested: "keep.txt\n",
+		},
+		{
+			// The same without the nested file. No version of the flat API has
+			// ever matched git here.
+			name: "root negation alone",
+			root: "outer/ignored/\n!outer/ignored/keep.txt\n",
+		},
+		{
+			// A negation inside the excluded directory: the common mistake.
+			name:   "nested negation",
+			root:   "outer/ignored/\n",
+			nested: "!keep.txt\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fs := memfs.New()
+			writeScopeFile(t, fs, ".gitignore", tc.root)
+			if tc.nested != "" {
+				writeScopeFile(t, fs, "outer/ignored/.gitignore", tc.nested)
+			}
+			writeScopeFile(t, fs, "outer/ignored/keep.txt", "x\n")
+
+			verdicts, listed := walkScoped(t, fs)
+
+			assert.True(t, verdicts[fs.Join("outer", "ignored", "keep.txt")],
+				"an excluded parent directory settles the verdict; git reports keep.txt as ignored")
+
+			// The walk still enters the excluded directory here because this
+			// test's walker has no index to tell it otherwise, but the ignore
+			// file below it must never influence the result.
+			assert.True(t, listed[fs.Join("outer", "ignored")])
+		})
+	}
+}
+
+// TestScopeDoesNotReadIgnoreFilesBelowExcluded verifies that Descend never
+// invokes readOwn for an excluded directory, which is what lets a walker skip
+// the open entirely.
+func TestScopeDoesNotReadIgnoreFilesBelowExcluded(t *testing.T) {
+	t.Parallel()
+
+	base := []Pattern{ParsePattern("outer/ignored/", nil)}
+	root := NewScope(base)
+
+	outer, err := root.Descend([]string{"outer"}, nil)
+	require.NoError(t, err)
+	require.False(t, outer.Excluded())
+
+	called := false
+	ignored, err := outer.Descend([]string{"outer", "ignored"}, func() ([]Pattern, error) {
+		called = true
+		return []Pattern{ParsePattern("!keep.txt", []string{"outer", "ignored"})}, nil
+	})
+	require.NoError(t, err)
+
+	assert.False(t, called, "readOwn must not be called for an excluded directory")
+	assert.True(t, ignored.Excluded())
+	assert.True(t, ignored.Match([]string{"outer", "ignored", "keep.txt"}, false))
+
+	// Exclusion is sticky: it survives further descent.
+	deeper, err := ignored.Descend([]string{"outer", "ignored", "deep"}, func() ([]Pattern, error) {
+		called = true
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.False(t, called)
+	assert.True(t, deeper.Excluded())
+	assert.True(t, deeper.Match([]string{"outer", "ignored", "deep", "any.txt"}, false))
+}
+
+// TestScopeDescendReusesParent checks the allocation-free path: a directory
+// that declares no patterns of its own shares its parent's Scope.
+func TestScopeDescendReusesParent(t *testing.T) {
+	t.Parallel()
+
+	root := NewScope([]Pattern{ParsePattern("*.log", nil)})
+
+	same, err := root.Descend([]string{"src"}, nil)
+	require.NoError(t, err)
+	assert.Same(t, root, same, "a directory with no ignore file reuses the parent Scope")
+
+	empty, err := root.Descend([]string{"src"}, func() ([]Pattern, error) { return nil, nil })
+	require.NoError(t, err)
+	assert.Same(t, root, empty, "an ignore file with no usable patterns reuses the parent Scope")
+}
+
+// TestScopeDeeperPatternWins checks ordering: a nested rule outranks an
+// ancestor one, which is why Descend appends rather than prepends.
+func TestScopeDeeperPatternWins(t *testing.T) {
+	t.Parallel()
+
+	root := NewScope([]Pattern{ParsePattern("*.log", nil)})
+	require.True(t, root.Match([]string{"src", "a.log"}, false))
+
+	src, err := root.Descend([]string{"src"}, func() ([]Pattern, error) {
+		return []Pattern{ParsePattern("!a.log", []string{"src"})}, nil
+	})
+	require.NoError(t, err)
+
+	assert.False(t, src.Match([]string{"src", "a.log"}, false),
+		"a negation in a deeper directory outranks an ancestor rule")
+	assert.True(t, root.Match([]string{"src", "a.log"}, false),
+		"the parent Scope is unchanged: Scope is immutable")
+}
+
+// TestScopeZeroValueAndEmptyBase checks the degenerate roots a walker may hit.
+func TestScopeZeroValueAndEmptyBase(t *testing.T) {
+	t.Parallel()
+
+	for name, s := range map[string]*Scope{
+		"zero value": {},
+		"nil base":   NewScope(nil),
+	} {
+		assert.False(t, s.Excluded(), name)
+		assert.False(t, s.Match([]string{"anything"}, false), name)
+		child, err := s.Descend([]string{"dir"}, nil)
+		require.NoError(t, err, name)
+		assert.False(t, child.Match([]string{"dir", "f"}, false), name)
+	}
+}
+
+func TestRootPatternsReadsExcludeThenGitignore(t *testing.T) {
+	t.Parallel()
+
+	fs := memfs.New()
+	require.NoError(t, fs.MkdirAll(".git/info", os.ModePerm))
+	writeScopeFile(t, fs, ".git/info/exclude", "from-exclude\n")
+	writeScopeFile(t, fs, ".gitignore", "!from-exclude\n")
+
+	ps, err := RootPatterns(fs)
+	require.NoError(t, err)
+	require.Len(t, ps, 2)
+
+	assert.False(t, NewScope(ps).Match([]string{"from-exclude"}, false),
+		".gitignore is read after .git/info/exclude, so it outranks it")
+}
+
+func TestDirPatternsMissingFile(t *testing.T) {
+	t.Parallel()
+
+	fs := memfs.New()
+	require.NoError(t, fs.MkdirAll("empty", os.ModePerm))
+
+	ps, err := DirPatterns(fs, []string{"empty"})
+	require.NoError(t, err, "a missing .gitignore is not an error")
+	assert.Empty(t, ps)
+}
+
+// TestNewScopeCopiesBase pins the immutability the type documents: a caller
+// mutating the slice it passed must not be able to change the Scope, or any
+// Scope derived from it, after construction.
+func TestNewScopeCopiesBase(t *testing.T) {
+	t.Parallel()
+
+	base := []Pattern{ParsePattern("build/", nil)}
+	root := NewScope(base)
+	child, err := root.Descend([]string{"src"}, nil)
+	require.NoError(t, err)
+
+	require.True(t, root.Match([]string{"build"}, true))
+
+	// Overwrite the caller's slice in place.
+	base[0] = ParsePattern("!build/", nil)
+
+	assert.True(t, root.Match([]string{"build"}, true),
+		"the Scope must not observe a later mutation of the caller's slice")
+	assert.True(t, child.Match([]string{"build"}, true),
+		"nor must a Scope derived from it")
+}

--- a/tests/gitcompare/status_bench_test.go
+++ b/tests/gitcompare/status_bench_test.go
@@ -1,0 +1,219 @@
+// Package gitcompare_test measures go-git against the reference git binary on
+// the same worktree.
+//
+// These are benchmarks rather than tests on purpose. There is no correct answer
+// to assert: any threshold would be a flaky test on a shared runner, and
+// nothing in CI passes -bench, so none of this runs there. Run it by hand when
+// a change is expected to move Status cost:
+//
+//	go test ./tests/gitcompare/ -run '^$' -bench BenchmarkStatus -benchtime 20x
+//
+// Read the numbers with Baseline/EmptyRepo in view. A git invocation is a
+// process, and process startup is a fixed cost go-git never pays: on macOS it
+// is over 10ms, on Linux a few. Subtract the baseline from each git figure
+// before concluding anything about the work either implementation does,
+// otherwise go-git appears to win cases where it is in fact slower.
+//
+// Set GOGIT_COMPARE_REPO to an existing checkout to measure it as well, which
+// is the quickest way to look at a worktree someone reports as slow:
+//
+//	GOGIT_COMPARE_REPO=~/src/some-repo go test ./tests/gitcompare/ \
+//	    -run '^$' -bench BenchmarkStatus/Env -benchtime 20x
+//
+// A repository supplied that way is left exactly as it was found: Worktree.Status
+// never writes the index, and git is invoked with --no-optional-locks so it does
+// not refresh one either. Fixtures are throwaway and so are measured without
+// that flag, which lets git cache stat data the way it normally would.
+package gitcompare_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	git "github.com/go-git/go-git/v6"
+)
+
+// compareRepoEnv names an existing checkout to measure alongside the fixtures.
+const compareRepoEnv = "GOGIT_COMPARE_REPO"
+
+func requireGit(b *testing.B) {
+	b.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		b.Skipf("git not found: %v", err)
+	}
+}
+
+// runGit executes a git command that is expected to succeed.
+func runGit(b *testing.B, dir string, args ...string) {
+	b.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	require.NoError(b, err, "git %v: %s", args, out)
+}
+
+func write(b *testing.B, dir, rel, content string) {
+	b.Helper()
+	abs := filepath.Join(dir, filepath.FromSlash(rel))
+	require.NoError(b, os.MkdirAll(filepath.Dir(abs), 0o755))
+	require.NoError(b, os.WriteFile(abs, []byte(content), 0o644))
+}
+
+// initRepo creates an empty repository. Fixtures are built with the git binary
+// rather than with go-git so that both implementations read an index written
+// the same way, and neither is measured against an index its own code produced.
+func initRepo(b *testing.B) string {
+	b.Helper()
+	dir := filepath.Join(b.TempDir(), "repo")
+	require.NoError(b, os.MkdirAll(dir, 0o755))
+	runGit(b, dir, "-c", "init.defaultBranch=main", "init", "-q")
+	runGit(b, dir, "config", "user.email", "bench@test.com")
+	runGit(b, dir, "config", "user.name", "Bench")
+	return dir
+}
+
+func commitAll(b *testing.B, dir string) {
+	b.Helper()
+	runGit(b, dir, "add", ".")
+	runGit(b, dir, "commit", "-q", "-m", "initial")
+}
+
+// benchGitStatus measures `git status --porcelain`, including the process
+// startup that Baseline/EmptyRepo exists to quantify.
+//
+// readOnly passes --no-optional-locks, which stops git refreshing the index it
+// would normally rewrite. That keeps a repository supplied by the caller
+// untouched, at the cost of understating git: it then repeats on every
+// invocation the stat work a refreshed index would have saved it. Fixtures are
+// throwaway, so they are measured without it and git gets its usual caching.
+func benchGitStatus(dir string, readOnly bool) func(*testing.B) {
+	args := []string{"-C", dir, "status", "--porcelain"}
+	if readOnly {
+		args = append([]string{"--no-optional-locks"}, args...)
+	}
+
+	return func(b *testing.B) {
+		// One untimed invocation first. On a fresh fixture it populates the
+		// index stat cache that steady-state use would already have, so the
+		// measurement is not dominated by a cost paid once.
+		if _, err := exec.Command("git", args...).Output(); err != nil {
+			b.Fatalf("git status: %v", err)
+		}
+
+		for b.Loop() {
+			if _, err := exec.Command("git", args...).Output(); err != nil {
+				b.Fatalf("git status: %v", err)
+			}
+		}
+	}
+}
+
+// benchGoGitStatus measures Worktree.Status on an already-open repository,
+// which is how a library caller uses it.
+func benchGoGitStatus(dir string) func(*testing.B) {
+	return func(b *testing.B) {
+		repo, err := git.PlainOpen(dir)
+		require.NoError(b, err)
+		b.Cleanup(func() { _ = repo.Close() })
+
+		wt, err := repo.Worktree()
+		require.NoError(b, err)
+
+		// Matched against the untimed git invocation above.
+		if _, err := wt.Status(); err != nil {
+			b.Fatalf("status: %v", err)
+		}
+
+		for b.Loop() {
+			if _, err := wt.Status(); err != nil {
+				b.Fatalf("status: %v", err)
+			}
+		}
+	}
+}
+
+// shape is a worktree layout to measure both implementations against.
+type shape struct {
+	name  string
+	build func(b *testing.B) string
+}
+
+func shapes() []shape {
+	return []shape{{
+		// A rule naming a directory below the one it is declared in. Collecting
+		// every pattern up front has to walk the ignored tree that the diff
+		// walk then skips, so cost here grows with the size of that tree.
+		name: "NestedIgnoredDir",
+		build: func(b *testing.B) string {
+			dir := initRepo(b)
+			write(b, dir, ".gitignore", "e2e/artifacts/\n")
+			for i := range 100 {
+				write(b, dir, fmt.Sprintf("src/dir%02d/file%04d.go", i%10, i), "package main\n")
+			}
+			commitAll(b, dir)
+			for i := range 2000 {
+				write(b, dir, fmt.Sprintf("e2e/artifacts/sub%05d/artifact.txt", i), "ignored\n")
+			}
+			return dir
+		},
+	}, {
+		// One .gitignore per directory and nothing excluded, the shape of a
+		// monorepo where each package carries its own rules. Nothing can be
+		// pruned, so what is left is the cost of the rules themselves.
+		name: "ManyIgnoreFiles",
+		build: func(b *testing.B) string {
+			dir := initRepo(b)
+			for i := range 500 {
+				var rules strings.Builder
+				for p := range 5 {
+					fmt.Fprintf(&rules, "*.generated%02d\n", p)
+				}
+				write(b, dir, fmt.Sprintf("pkg%04d/.gitignore", i), rules.String())
+				write(b, dir, fmt.Sprintf("pkg%04d/main.go", i), "package main\n")
+			}
+			commitAll(b, dir)
+			return dir
+		},
+	}, {
+		// No ignore rules at all: the floor for both implementations, dominated
+		// by stat and hash work rather than by anything ignore-related.
+		name: "LargeNoIgnoreFiles",
+		build: func(b *testing.B) string {
+			dir := initRepo(b)
+			for i := range 5000 {
+				write(b, dir, fmt.Sprintf("dir%d/file%04d.txt", i%20, i), "test content\n")
+			}
+			commitAll(b, dir)
+			return dir
+		},
+	}}
+}
+
+func BenchmarkStatus(b *testing.B) {
+	requireGit(b)
+
+	// Measured first and deliberately named so it is hard to miss: this is what
+	// a git invocation costs before it looks at a single file.
+	b.Run("Baseline/EmptyRepo/git", benchGitStatus(initRepo(b), false))
+
+	for _, s := range shapes() {
+		dir := s.build(b)
+		b.Run(s.name+"/git", benchGitStatus(dir, false))
+		b.Run(s.name+"/go-git", benchGoGitStatus(dir))
+	}
+
+	// An existing checkout, if one was named. Its status need not be clean;
+	// both sides simply report whatever is there. Measured read-only so the
+	// repository is left exactly as it was found.
+	if dir := os.Getenv(compareRepoEnv); dir != "" {
+		abs, err := filepath.Abs(dir)
+		require.NoError(b, err)
+		b.Logf("%s=%s", compareRepoEnv, abs)
+		b.Run("Env/git", benchGitStatus(abs, true))
+		b.Run("Env/go-git", benchGoGitStatus(abs))
+	}
+}

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -36,37 +36,21 @@ type Options struct {
 	// the function works without the optimization.
 	Index *index.Index
 
-	// IgnoreMatcher, if non-nil, is consulted while walking the tree.
-	// Untracked entries (files or directories) that match the matcher are
-	// excluded from the walk so callers do not have to descend into large
-	// gitignored directories like node_modules. Tracked entries are always
-	// walked even if they match, so modifications to them are still
-	// reported. Requires Index to be set: without an index there is no way
-	// to identify tracked entries, so the matcher is treated as a no-op.
+	// IgnoreScope, if non-nil, is consulted while walking the tree. Untracked
+	// entries (files or directories) that it reports as ignored are excluded
+	// from the walk, so callers do not have to descend into large gitignored
+	// directories like node_modules. Tracked entries are always walked even
+	// when ignored, so modifications to them are still reported.
 	//
-	// This skip is independent of the pruning gitignore.ReadPatterns already
-	// applies when collecting the patterns: that one drops excluded subtrees
-	// unconditionally, because a pattern declared inside an excluded directory
-	// cannot change any outcome. The skip here is an optimization constrained
-	// by tracking, so both are needed and neither subsumes the other.
+	// It is the scope in effect at the root of the walk, normally
+	// gitignore.NewScope of gitignore.RootPatterns plus any patterns the
+	// caller supplies. The walk derives each directory's scope from the
+	// listing it already takes, so a .gitignore is opened only in directories
+	// actually visited and never below an excluded one, and an excluded
+	// directory stays authoritative for everything under it.
 	//
-	// Deprecated: prefer IgnoreScope, which evaluates ignore rules per
-	// directory as the walk descends. A flat Matcher cannot express that a
-	// parent directory is excluded, so it disagrees with git when a negation
-	// targets a path below an excluded directory.
-	IgnoreMatcher gitignore.Matcher
-
-	// IgnoreScope, if non-nil, enables per-directory ignore evaluation and
-	// takes precedence over IgnoreMatcher. It is the scope in effect at the
-	// root of the walk, normally gitignore.NewScope of
-	// gitignore.RootPatterns plus any caller-supplied patterns.
-	//
-	// The walk derives each directory's scope from the listing it already
-	// takes, so a .gitignore is opened only in directories actually visited,
-	// and never below an excluded one. That matches git's prep_exclude and
-	// removes the need to read every ignore file in the worktree up front.
-	//
-	// Requires Index to be set, on the same terms as IgnoreMatcher.
+	// Requires Index to be set: without an index there is no way to identify
+	// tracked entries, so the scope is treated as a no-op.
 	IgnoreScope *gitignore.Scope
 }
 
@@ -81,7 +65,7 @@ type node struct {
 	idx        *index.Index
 	idxMap     map[string]*index.Entry
 	// trackedDirs holds every directory path that has at least one entry
-	// in the index. It is populated only when IgnoreMatcher is set so the
+	// in the index. It is populated only when IgnoreScope is set so the
 	// walker can keep tracked entries even if their parent directory
 	// matches an ignore rule.
 	trackedDirs map[string]struct{}
@@ -145,7 +129,7 @@ func NewRootNodeWithOptions(
 			idxMap[entry.Name] = entry
 		}
 
-		if options.IgnoreMatcher != nil || options.IgnoreScope != nil {
+		if options.IgnoreScope != nil {
 			trackedDirs = make(map[string]struct{})
 			for _, entry := range options.Index.Entries {
 				for parent := path.Dir(entry.Name); parent != "." && parent != "/"; parent = path.Dir(parent) {
@@ -309,34 +293,22 @@ func (n *node) pathComponents() []string {
 	return strings.Split(n.path, "/")
 }
 
-// matchIgnore consults the scope in effect for this directory's entries,
-// falling back to the flat matcher when no scope was supplied.
-func (n *node) matchIgnore(path []string, isDir bool) bool {
-	if n.scope != nil {
-		return n.scope.Match(path, isDir)
-	}
-	return n.options.IgnoreMatcher.Match(path, isDir)
-}
-
 // shouldSkipIgnored reports whether the child entry of n with the given
-// name should be skipped because it matches the ignore rules in effect
+// name should be skipped because it matches the ignore scope in effect
 // AND has no entry in the index. Tracked entries are never skipped so
 // modifications to them are still reported.
 func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
-	if n.options == nil {
-		return false
-	}
-	if n.options.IgnoreScope == nil && n.options.IgnoreMatcher == nil {
+	if n.options == nil || n.options.IgnoreScope == nil {
 		return false
 	}
 	// Without an index we cannot prove that a subtree contains no tracked
 	// entries, so refuse to skip. This matches the documented contract on
-	// Options.IgnoreMatcher.
+	// Options.IgnoreScope.
 	if n.idxMap == nil {
 		return false
 	}
 	childPath := path.Join(n.path, name)
-	if !n.matchIgnore(strings.Split(childPath, "/"), isDir) {
+	if !n.scope.Match(strings.Split(childPath, "/"), isDir) {
 		return false
 	}
 	// An entry whose own path is in the index is tracked, regardless of

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -3,6 +3,7 @@ package filesystem
 
 import (
 	"io"
+	iofs "io/fs"
 	"os"
 	"path"
 	"strings"
@@ -42,7 +43,31 @@ type Options struct {
 	// walked even if they match, so modifications to them are still
 	// reported. Requires Index to be set: without an index there is no way
 	// to identify tracked entries, so the matcher is treated as a no-op.
+	//
+	// This skip is independent of the pruning gitignore.ReadPatterns already
+	// applies when collecting the patterns: that one drops excluded subtrees
+	// unconditionally, because a pattern declared inside an excluded directory
+	// cannot change any outcome. The skip here is an optimization constrained
+	// by tracking, so both are needed and neither subsumes the other.
+	//
+	// Deprecated: prefer IgnoreScope, which evaluates ignore rules per
+	// directory as the walk descends. A flat Matcher cannot express that a
+	// parent directory is excluded, so it disagrees with git when a negation
+	// targets a path below an excluded directory.
 	IgnoreMatcher gitignore.Matcher
+
+	// IgnoreScope, if non-nil, enables per-directory ignore evaluation and
+	// takes precedence over IgnoreMatcher. It is the scope in effect at the
+	// root of the walk, normally gitignore.NewScope of
+	// gitignore.RootPatterns plus any caller-supplied patterns.
+	//
+	// The walk derives each directory's scope from the listing it already
+	// takes, so a .gitignore is opened only in directories actually visited,
+	// and never below an excluded one. That matches git's prep_exclude and
+	// removes the need to read every ignore file in the worktree up front.
+	//
+	// Requires Index to be set, on the same terms as IgnoreMatcher.
+	IgnoreScope *gitignore.Scope
 }
 
 // The node represents a file or a directory in a billy.Filesystem. It
@@ -62,6 +87,14 @@ type node struct {
 	trackedDirs map[string]struct{}
 
 	options *Options
+
+	// scope is the ignore scope governing this node's entries. On a child it
+	// starts as the parent's scope and is replaced by this directory's own on
+	// the first calculateChildren, which is when the listing that reveals
+	// whether a .gitignore is present becomes available. scopeResolved tracks
+	// that transition; the root node is created already resolved.
+	scope         *gitignore.Scope
+	scopeResolved bool
 
 	path     string
 	hash     []byte
@@ -112,7 +145,7 @@ func NewRootNodeWithOptions(
 			idxMap[entry.Name] = entry
 		}
 
-		if options.IgnoreMatcher != nil {
+		if options.IgnoreMatcher != nil || options.IgnoreScope != nil {
 			trackedDirs = make(map[string]struct{})
 			for _, entry := range options.Index.Entries {
 				for parent := path.Dir(entry.Name); parent != "." && parent != "/"; parent = path.Dir(parent) {
@@ -133,6 +166,10 @@ func NewRootNodeWithOptions(
 		trackedDirs: trackedDirs,
 		options:     &options,
 		isDir:       true,
+		// The root scope already accounts for the root's own ignore files, so
+		// it must not descend again.
+		scope:         options.IgnoreScope,
+		scopeResolved: true,
 	}
 }
 
@@ -198,6 +235,10 @@ func (n *node) calculateChildren() error {
 		return err
 	}
 
+	if err := n.resolveScope(files); err != nil {
+		return err
+	}
+
 	for _, file := range files {
 		if _, ok := ignore[file.Name()]; ok {
 			continue
@@ -226,12 +267,66 @@ func (n *node) calculateChildren() error {
 	return nil
 }
 
+// resolveScope derives this directory's ignore scope from the listing just
+// taken for it. Deferring to this point is the whole benefit of the scoped
+// walk: whether a .gitignore exists is read off a listing the walk needed
+// anyway, the file is opened only in directories actually visited, and
+// Scope.Descend declines to open it at all below an excluded directory.
+func (n *node) resolveScope(files []iofs.DirEntry) error {
+	if n.scopeResolved {
+		return nil
+	}
+	n.scopeResolved = true
+
+	if n.scope == nil {
+		return nil
+	}
+
+	var readOwn func() ([]gitignore.Pattern, error)
+	for _, f := range files {
+		if f.Name() == gitignore.IgnoreFile && !f.IsDir() {
+			dir := n.pathComponents()
+			readOwn = func() ([]gitignore.Pattern, error) {
+				return gitignore.DirPatterns(n.fs, dir)
+			}
+			break
+		}
+	}
+
+	scope, err := n.scope.Descend(n.pathComponents(), readOwn)
+	if err != nil {
+		return err
+	}
+	n.scope = scope
+
+	return nil
+}
+
+func (n *node) pathComponents() []string {
+	if n.path == "" {
+		return nil
+	}
+	return strings.Split(n.path, "/")
+}
+
+// matchIgnore consults the scope in effect for this directory's entries,
+// falling back to the flat matcher when no scope was supplied.
+func (n *node) matchIgnore(path []string, isDir bool) bool {
+	if n.scope != nil {
+		return n.scope.Match(path, isDir)
+	}
+	return n.options.IgnoreMatcher.Match(path, isDir)
+}
+
 // shouldSkipIgnored reports whether the child entry of n with the given
-// name should be skipped because it matches the configured ignore matcher
+// name should be skipped because it matches the ignore rules in effect
 // AND has no entry in the index. Tracked entries are never skipped so
 // modifications to them are still reported.
 func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
-	if n.options == nil || n.options.IgnoreMatcher == nil {
+	if n.options == nil {
+		return false
+	}
+	if n.options.IgnoreScope == nil && n.options.IgnoreMatcher == nil {
 		return false
 	}
 	// Without an index we cannot prove that a subtree contains no tracked
@@ -241,7 +336,7 @@ func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
 		return false
 	}
 	childPath := path.Join(n.path, name)
-	if !n.options.IgnoreMatcher.Match(strings.Split(childPath, "/"), isDir) {
+	if !n.matchIgnore(strings.Split(childPath, "/"), isDir) {
 		return false
 	}
 	// An entry whose own path is in the index is tracked, regardless of
@@ -268,6 +363,10 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 		idxMap:      n.idxMap,
 		trackedDirs: n.trackedDirs,
 		options:     n.options,
+
+		// The child inherits this directory's scope and resolves its own on
+		// its first listing.
+		scope: n.scope,
 
 		path:    path,
 		isDir:   file.IsDir(),

--- a/utils/merkletrie/filesystem/node_ignore_test.go
+++ b/utils/merkletrie/filesystem/node_ignore_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/utils/merkletrie"
 	mindex "github.com/go-git/go-git/v6/utils/merkletrie/index"
+	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
 )
 
 // blobHash returns the hash a Git blob would have for the given content.
@@ -27,9 +28,14 @@ func blobHash(t *testing.T, content []byte) plumbing.Hash {
 	return h.Sum()
 }
 
-// matcher builds a gitignore.Matcher with a single pattern.
-func matcher(pattern string) gitignore.Matcher {
-	return gitignore.NewMatcher([]gitignore.Pattern{gitignore.ParsePattern(pattern, nil)})
+// scope builds a root gitignore.Scope from patterns declared at the top of
+// the walk, as RootPatterns would return them.
+func scope(patterns ...string) *gitignore.Scope {
+	ps := make([]gitignore.Pattern, 0, len(patterns))
+	for _, p := range patterns {
+		ps = append(ps, gitignore.ParsePattern(p, nil))
+	}
+	return gitignore.NewScope(ps)
 }
 
 // TestIgnoredDirIsSkipped verifies that a directory matching the ignore
@@ -48,8 +54,8 @@ func TestIgnoredDirIsSkipped(t *testing.T) {
 	}
 
 	root := NewRootNodeWithOptions(fs, nil, Options{
-		Index:         idx,
-		IgnoreMatcher: matcher("vendor/"),
+		Index:       idx,
+		IgnoreScope: scope("vendor/"),
 	})
 
 	children, err := root.Children()
@@ -61,11 +67,11 @@ func TestIgnoredDirIsSkipped(t *testing.T) {
 	}
 
 	require.True(t, names["src"], "src/ should be walked")
-	require.False(t, names["vendor"], "vendor/ should be skipped — it matches the ignore matcher and contains no tracked entries")
+	require.False(t, names["vendor"], "vendor/ should be skipped — it matches the ignore scope and contains no tracked entries")
 }
 
 // TestTrackedFileInIgnoredDirReportsModify verifies that a tracked file
-// inside a directory matching the ignore matcher is still walked, and
+// inside a directory matching the ignore scope is still walked, and
 // modifications to it surface as a Modify change.
 func TestTrackedFileInIgnoredDirReportsModify(t *testing.T) {
 	t.Parallel()
@@ -83,8 +89,8 @@ func TestTrackedFileInIgnoredDirReportsModify(t *testing.T) {
 	}
 
 	to := NewRootNodeWithOptions(fs, nil, Options{
-		Index:         idx,
-		IgnoreMatcher: matcher("vendor/"),
+		Index:       idx,
+		IgnoreScope: scope("vendor/"),
 	})
 	from := mindex.NewRootNode(idx)
 
@@ -118,8 +124,8 @@ func TestUntrackedSiblingsInIgnoredDirAreSkipped(t *testing.T) {
 	}
 
 	to := NewRootNodeWithOptions(fs, nil, Options{
-		Index:         idx,
-		IgnoreMatcher: matcher("vendor/"),
+		Index:       idx,
+		IgnoreScope: scope("vendor/"),
 	})
 	from := mindex.NewRootNode(idx)
 
@@ -128,18 +134,18 @@ func TestUntrackedSiblingsInIgnoredDirAreSkipped(t *testing.T) {
 	require.Empty(t, changes, "vendor/extra.go is ignored+untracked and must not appear in the diff")
 }
 
-// TestIgnoreMatcherWithoutIndexIsNoop verifies that IgnoreMatcher does not
+// TestIgnoreScopeWithoutIndexIsNoop verifies that IgnoreScope does not
 // take effect when Index is nil. Without an index there is no way to prove
 // that an ignored subtree contains no tracked entries, so the documented
 // contract is that the matcher is ignored.
-func TestIgnoreMatcherWithoutIndexIsNoop(t *testing.T) {
+func TestIgnoreScopeWithoutIndexIsNoop(t *testing.T) {
 	t.Parallel()
 	fs := memfs.New()
 	require.NoError(t, WriteFile(fs, "src/keep.go", []byte("package main\n"), 0o644))
 	require.NoError(t, WriteFile(fs, "vendor/lib.go", []byte("package vendor\n"), 0o644))
 
 	root := NewRootNodeWithOptions(fs, nil, Options{
-		IgnoreMatcher: matcher("vendor/"),
+		IgnoreScope: scope("vendor/"),
 	})
 
 	children, err := root.Children()
@@ -174,8 +180,8 @@ func TestDeeplyNestedTrackedFileInIgnoredDir(t *testing.T) {
 	}
 
 	to := NewRootNodeWithOptions(fs, nil, Options{
-		Index:         idx,
-		IgnoreMatcher: matcher("vendor/"),
+		Index:       idx,
+		IgnoreScope: scope("vendor/"),
 	})
 	from := mindex.NewRootNode(idx)
 
@@ -185,7 +191,7 @@ func TestDeeplyNestedTrackedFileInIgnoredDir(t *testing.T) {
 }
 
 // TestSubmoduleInIgnoredDirIsWalked verifies that a tracked submodule
-// inside a directory matching the ignore matcher is still walked. A
+// inside a directory matching the ignore scope is still walked. A
 // submodule's own path is the index entry, so trackedDirs (which only
 // records *parents* of entries) does not list it; the dir branch of
 // shouldSkipIgnored must also consult idxMap to keep the submodule
@@ -206,8 +212,8 @@ func TestSubmoduleInIgnoredDirIsWalked(t *testing.T) {
 	}
 
 	root := NewRootNodeWithOptions(fs, submodules, Options{
-		Index:         idx,
-		IgnoreMatcher: matcher("vendor/"),
+		Index:       idx,
+		IgnoreScope: scope("vendor/"),
 	})
 
 	children, err := root.Children()
@@ -239,8 +245,8 @@ func TestFilePatternIgnoreSkipsUntrackedSiblings(t *testing.T) {
 	}
 
 	to := NewRootNodeWithOptions(fs, nil, Options{
-		Index:         idx,
-		IgnoreMatcher: matcher("*.log"),
+		Index:       idx,
+		IgnoreScope: scope("*.log"),
 	})
 	from := mindex.NewRootNode(idx)
 
@@ -265,8 +271,8 @@ func TestEmptyIgnoredDirIsSkipped(t *testing.T) {
 	}
 
 	root := NewRootNodeWithOptions(fs, nil, Options{
-		Index:         idx,
-		IgnoreMatcher: matcher("vendor/"),
+		Index:       idx,
+		IgnoreScope: scope("vendor/"),
 	})
 
 	children, err := root.Children()
@@ -278,4 +284,99 @@ func TestEmptyIgnoredDirIsSkipped(t *testing.T) {
 	}
 	require.True(t, names["src"], "src/ should be walked")
 	require.False(t, names["vendor"], "empty ignored vendor/ must be skipped")
+}
+
+// TestNestedIgnoreFileIsReadDuringWalk verifies that a .gitignore in a
+// subdirectory is picked up by the walk itself. The root scope knows nothing
+// about it, so this only works if each directory derives its own scope from
+// the listing taken for it.
+func TestNestedIgnoreFileIsReadDuringWalk(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "src/keep.go", []byte("package main\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "src/.gitignore", []byte("*.gen.go\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "src/api.gen.go", []byte("package main\n"), 0o644))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "src/keep.go", Hash: blobHash(t, []byte("package main\n")), Mode: filemode.Regular},
+		},
+	}
+
+	root := NewRootNodeWithOptions(fs, nil, Options{
+		Index: idx,
+		// Deliberately empty: the only rule lives in src/.gitignore.
+		IgnoreScope: scope(),
+	})
+
+	names := childNames(t, root, "src")
+	require.Contains(t, names, "keep.go")
+	require.Contains(t, names, ".gitignore")
+	require.NotContains(t, names, "api.gen.go",
+		"a rule declared in src/.gitignore must apply to src's entries")
+}
+
+// TestExcludedParentBeatsNestedNegation is the case a flat pattern list
+// cannot express. A tracked entry forces the walk into the excluded
+// directory, so its .gitignore is reachable; the negation there must still
+// not re-include keep.txt. Reference git reports outer/ignored/keep.txt as
+// ignored, attributing it to the outer/ignored/ rule, because a file cannot
+// be re-included once a parent directory of it is excluded.
+func TestExcludedParentBeatsNestedNegation(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "outer/ignored/tracked.go", []byte("package ignored\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "outer/ignored/.gitignore", []byte("!keep.txt\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "outer/ignored/keep.txt", []byte("x\n"), 0o644))
+
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{Name: "outer/ignored/tracked.go", Hash: blobHash(t, []byte("package ignored\n")), Mode: filemode.Regular},
+		},
+	}
+
+	root := NewRootNodeWithOptions(fs, nil, Options{
+		Index:       idx,
+		IgnoreScope: scope("outer/ignored/"),
+	})
+
+	names := childNames(t, root, "outer", "ignored")
+
+	require.Contains(t, names, "tracked.go",
+		"a tracked entry is walked even inside an excluded directory")
+	require.NotContains(t, names, "keep.txt",
+		"a negation below an excluded directory cannot re-include a file")
+	require.NotContains(t, names, ".gitignore",
+		"the ignore file itself is untracked and below an excluded directory")
+}
+
+// childNames returns the names of the children of the node reached by
+// following path from root.
+func childNames(t *testing.T, root noder.Noder, path ...string) []string {
+	t.Helper()
+
+	current := root
+	for _, want := range path {
+		children, err := current.Children()
+		require.NoError(t, err)
+
+		var next noder.Noder
+		for _, c := range children {
+			if c.Name() == want {
+				next = c
+				break
+			}
+		}
+		require.NotNil(t, next, "no child %q", want)
+		current = next
+	}
+
+	children, err := current.Children()
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(children))
+	for _, c := range children {
+		names = append(names, c.Name())
+	}
+	return names
 }

--- a/worktree.go
+++ b/worktree.go
@@ -725,7 +725,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 	// they are cleaned up in step 3 below.
 	//
 	// excludeIgnoredChanges=true engages the filesystem walker's
-	// IgnoreMatcher so untracked entries inside gitignored directories are
+	// IgnoreScope so untracked entries inside gitignored directories are
 	// pruned at enumeration time rather than walked and then dropped as
 	// Delete actions. The observable result is unchanged because Delete
 	// actions are skipped by the loop below; the matcher only avoids the
@@ -797,7 +797,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 // MergeReset, and files contains paths that were just removed from the
 // index by resetIndex. A tracked-but-gitignored path that was removed
 // from the index in this same Reset is no longer in idxMap, so the
-// noder's IgnoreMatcher would prune it from the walk and the Delete
+// noder's IgnoreScope would prune it from the walk and the Delete
 // action needed to remove it from disk would never be emitted.
 func (w *Worktree) resetWorktree(cfg *config.Config, t *object.Tree, files []string) error {
 	changes, err := w.diffStagingWithWorktree(cfg, true, false)

--- a/worktree_reset_bench_test.go
+++ b/worktree_reset_bench_test.go
@@ -8,9 +8,9 @@ import (
 // that contains a large gitignored directory (e.g. node_modules-like).
 //
 // resetWorktreeToTree walks the worktree to discover tracked files that are
-// missing or stale on disk. Without the IgnoreMatcher optimization, this walk
+// missing or stale on disk. Without the IgnoreScope optimization, this walk
 // descends into every gitignored subtree before the loop body discards the
-// resulting Delete actions. With the matcher engaged, the entire ignored
+// resulting Delete actions. With the scope engaged, the entire ignored
 // subtree is skipped at enumeration time, so cost stays roughly flat as the
 // number of ignored files grows.
 //

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -199,9 +199,10 @@ func (w *Worktree) ignoreScope() *gitignore.Scope {
 	}
 
 	patterns = append(patterns, w.Excludes...)
-	if len(patterns) == 0 {
-		return nil
-	}
+
+	// An empty root still yields a scope. Rules are read as the walk descends,
+	// so a worktree with no .gitignore at the root may well have one further
+	// down; returning nil here would mean never looking.
 
 	return gitignore.NewScope(patterns)
 }

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -160,17 +160,20 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 		Index:    idx,
 	}
 
-	// When ignored changes are to be filtered out, gather the gitignore
-	// patterns once, build a matcher, and let the filesystem noder skip
-	// ignored, untracked entries during the walk. This avoids descending
-	// into large gitignored directories like node_modules and makes a
-	// post-walk filter unnecessary: tracked entries are still walked even
-	// when their parent matches an ignore rule, so modifications to them
-	// are still reported.
+	// When ignored changes are to be filtered out, hand the noder the ignore
+	// scope in effect at the root and let it evaluate the rest per directory
+	// as it descends. This avoids descending into large gitignored
+	// directories like node_modules and makes a post-walk filter unnecessary:
+	// tracked entries are still walked even when their parent matches an
+	// ignore rule, so modifications to them are still reported.
+	//
+	// The scope is read lazily, so only directories the walk actually visits
+	// pay for their .gitignore, and none below an excluded directory is read
+	// at all. That both removes a second full traversal of the worktree and
+	// keeps an excluded parent authoritative, which a flat pattern list
+	// cannot express.
 	if excludeIgnoredChanges {
-		if patterns := w.collectIgnorePatterns(); len(patterns) > 0 {
-			fsOpts.IgnoreMatcher = gitignore.NewMatcher(patterns)
-		}
+		fsOpts.IgnoreScope = w.ignoreScope()
 	}
 
 	to := filesystem.NewRootNodeWithOptions(w.filesystem, submodules, fsOpts)
@@ -181,12 +184,26 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 	return merkletrie.DiffTree(from, to, diffTreeIsEquals)
 }
 
-func (w *Worktree) collectIgnorePatterns() []gitignore.Pattern {
-	patterns, err := gitignore.ReadPatterns(w.filesystem, nil)
+// ignoreScope builds the ignore scope in effect at the root of the worktree:
+// .git/info/exclude, the root .gitignore, then any patterns supplied by the
+// caller, in ascending order of priority. Ignore files in subdirectories are
+// read by the walk itself, only where it goes.
+func (w *Worktree) ignoreScope() *gitignore.Scope {
+	// A worktree whose root cannot be listed yields no patterns rather than an
+	// error, as collecting them did before: the walk itself already treats a
+	// missing root as an empty tree, and Status should not start failing for
+	// worktrees it used to report on.
+	patterns, err := gitignore.RootPatterns(w.filesystem)
 	if err != nil {
 		patterns = nil
 	}
-	return append(patterns, w.Excludes...)
+
+	patterns = append(patterns, w.Excludes...)
+	if len(patterns) == 0 {
+		return nil
+	}
+
+	return gitignore.NewScope(patterns)
 }
 
 func (w *Worktree) getSubmodulesStatus(cfg *config.Config) (map[string]plumbing.Hash, error) {

--- a/worktree_status_bench_test.go
+++ b/worktree_status_bench_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -216,6 +217,160 @@ func setupIgnoredDirRepo(b *testing.B, tracked, untracked int) *Worktree {
 	}
 
 	return wt
+}
+
+// setupNestedIgnoredDirRepo is setupIgnoredDirRepo with the ignored tree one
+// level deeper, so the root rule names a grandchild rather than a direct
+// child. The distinction is invisible to the diff walk, which prunes the
+// directory either way, but it decides whether collecting the ignore patterns
+// beforehand has to descend through the tree first.
+//
+// dirs, not files, is the parameter that matters: pattern collection costs one
+// ReadDir per directory, so a wide shallow tree of empty-ish directories is
+// what separates the approaches.
+func setupNestedIgnoredDirRepo(b *testing.B, tracked, dirs int) *Worktree {
+	b.Helper()
+
+	const ignoredDir = "e2e/artifacts"
+
+	tmpDir := b.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = repo.Close() })
+
+	wt, err := repo.Worktree()
+	require.NoError(b, err)
+
+	for i := range tracked {
+		path := filepath.Join("src", fmt.Sprintf("dir%02d", i%10), fmt.Sprintf("file%04d.go", i))
+		require.NoError(b, wt.Filesystem().MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(b, util.WriteFile(wt.Filesystem(), path, []byte("package main\n"), 0o644))
+	}
+
+	require.NoError(b, util.WriteFile(wt.Filesystem(), ".gitignore",
+		[]byte(ignoredDir+"/\n"), 0o644))
+
+	require.NoError(b, wt.AddGlob("src/*"))
+	_, err = wt.Add(".gitignore")
+	require.NoError(b, err)
+
+	sig := &object.Signature{
+		Name:  "Bench",
+		Email: "bench@test.com",
+		When:  time.Now().Add(-time.Hour), // older than index modtime so the metadata fast-path engages
+	}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(b, err)
+
+	// A wide gitignored tree. None of it affects status.
+	for i := range dirs {
+		path := filepath.Join(ignoredDir, fmt.Sprintf("sub%05d", i), "artifact.txt")
+		require.NoError(b, wt.Filesystem().MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(b, util.WriteFile(wt.Filesystem(), path, []byte("ignored\n"), 0o644))
+	}
+
+	return wt
+}
+
+// BenchmarkStatusNestedIgnoredDir measures Status over a worktree whose
+// ignored tree sits below the directory named by the rule. BenchmarkStatusIgnoredDir
+// cannot show this: its rule names a direct child of the root, which every
+// implementation prunes, and its ignored tree is only 21 directories wide.
+func BenchmarkStatusNestedIgnoredDir(b *testing.B) {
+	const tracked = 100
+
+	for _, dirs := range []int{200, 2000} {
+		b.Run(fmt.Sprintf("IgnoredDirs_%d", dirs), func(b *testing.B) {
+			wt := setupNestedIgnoredDirRepo(b, tracked, dirs)
+			for b.Loop() {
+				s, err := wt.Status()
+				if err != nil {
+					b.Fatalf("status: %v", err)
+				}
+				if !s.IsClean() {
+					b.Fatalf("expected clean status, got %v entries", len(s))
+				}
+			}
+		})
+	}
+}
+
+// setupManyIgnoreFilesRepo builds a worktree where every directory declares
+// its own .gitignore, the shape of a monorepo in which each package carries
+// its own rules. Everything is tracked and nothing is excluded wholesale, so
+// pruning excluded subtrees cannot help: both the pattern collection and the
+// diff walk have to visit every directory regardless.
+//
+// What is left is the cost the flat pattern list imposes. Collecting patterns
+// eagerly yields one list holding every rule in the repository, and each entry
+// the walk considers is tested against all of them. Evaluating per directory
+// instead tests an entry only against the rules on its own ancestor chain, so
+// the two diverge as the number of ignore files grows rather than as the size
+// of any one ignored tree grows.
+func setupManyIgnoreFilesRepo(b *testing.B, dirs, patternsPerDir int) *Worktree {
+	b.Helper()
+
+	tmpDir := b.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(b, err)
+	b.Cleanup(func() { _ = repo.Close() })
+
+	wt, err := repo.Worktree()
+	require.NoError(b, err)
+
+	for i := range dirs {
+		dir := fmt.Sprintf("pkg%04d", i)
+		require.NoError(b, wt.Filesystem().MkdirAll(dir, 0o755))
+
+		// Rules that match nothing present, so every entry is tested against
+		// every one of them without any short-circuiting on a hit.
+		var rules strings.Builder
+		for p := range patternsPerDir {
+			fmt.Fprintf(&rules, "*.generated%02d\n", p)
+		}
+		require.NoError(b, util.WriteFile(wt.Filesystem(),
+			filepath.Join(dir, ".gitignore"), []byte(rules.String()), 0o644))
+		require.NoError(b, util.WriteFile(wt.Filesystem(),
+			filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644))
+	}
+
+	require.NoError(b, wt.AddWithOptions(&AddOptions{All: true}))
+
+	sig := &object.Signature{
+		Name:  "Bench",
+		Email: "bench@test.com",
+		When:  time.Now().Add(-time.Hour), // older than index modtime so the metadata fast-path engages
+	}
+	_, err = wt.Commit("initial", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(b, err)
+
+	return wt
+}
+
+// BenchmarkStatusManyIgnoreFiles measures the case pruning cannot improve:
+// many ignore files, none of them excluding a subtree. It isolates the cost of
+// holding every rule in the repository in one list.
+func BenchmarkStatusManyIgnoreFiles(b *testing.B) {
+	const patternsPerDir = 5
+
+	for _, dirs := range []int{50, 500} {
+		b.Run(fmt.Sprintf("IgnoreFiles_%d", dirs), func(b *testing.B) {
+			wt := setupManyIgnoreFilesRepo(b, dirs, patternsPerDir)
+			for b.Loop() {
+				s, err := wt.Status()
+				if err != nil {
+					b.Fatalf("status: %v", err)
+				}
+				if !s.IsClean() {
+					b.Fatalf("expected clean status, got %v entries", len(s))
+				}
+			}
+		})
+	}
 }
 
 // BenchmarkStatusIgnoredDir measures the cost of running Status() over a tree

--- a/worktree_status_bench_test.go
+++ b/worktree_status_bench_test.go
@@ -171,7 +171,7 @@ func BenchmarkStatusLarge(b *testing.B) {
 // `ignoredDir`. The ignored directory is a stand-in for `node_modules`,
 // `vendor`, `.next`, etc. — directories that CLI `git status` skips at the
 // directory level and that go-git also skips via the filesystem walker's
-// IgnoreMatcher.
+// IgnoreScope.
 func setupIgnoredDirRepo(b *testing.B, tracked, untracked int) *Worktree {
 	b.Helper()
 
@@ -378,7 +378,7 @@ func BenchmarkStatusManyIgnoreFiles(b *testing.B) {
 //
 // Compared to BenchmarkStatus, the only difference is that the extra files
 // live in a directory listed in .gitignore. The filesystem walker's
-// IgnoreMatcher skips the directory at enumeration time, so cost should stay
+// IgnoreScope skips the directory at enumeration time, so cost should stay
 // roughly flat as the number of ignored files grows.
 func BenchmarkStatusIgnoredDir(b *testing.B) {
 	const tracked = 100

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -203,4 +204,119 @@ func TestAddSubdirectoryForwardSlash(t *testing.T) {
 	e, err := idx.Entry("dir/foo")
 	require.NoError(t, err)
 	assert.Equal(t, "dir/foo", e.Name)
+}
+
+// TestStatusMatchesReferenceGitForIgnoreLayouts compares the untracked set
+// Status reports against `git ls-files --others --exclude-standard` over
+// layouts that place ignore rules and negations at different depths. Ignore
+// evaluation happens during the walk, so the check belongs at this level and
+// not only against the gitignore package.
+//
+// Skipped under -short or without a git binary. Cases using a negation are
+// skipped against Git 2.11.0, which CI builds and which does not honour
+// re-include patterns in several positions.
+func TestStatusMatchesReferenceGitForIgnoreLayouts(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("oracle disabled: -short")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("oracle disabled: git not found: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		files map[string]string
+	}{{
+		name: "negation below an excluded directory, re-excluded by a nested rule",
+		files: map[string]string{
+			".gitignore":               "outer/ignored/\n!outer/ignored/keep.txt\n",
+			"outer/ignored/.gitignore": "keep.txt\n",
+			"outer/ignored/keep.txt":   "x\n",
+		},
+	}, {
+		name: "negation below an excluded directory",
+		files: map[string]string{
+			".gitignore":             "outer/ignored/\n!outer/ignored/keep.txt\n",
+			"outer/ignored/keep.txt": "x\n",
+		},
+	}, {
+		name: "negation inside an excluded directory",
+		files: map[string]string{
+			".gitignore":               "outer/ignored/\n",
+			"outer/ignored/.gitignore": "!keep.txt\n",
+			"outer/ignored/keep.txt":   "x\n",
+		},
+	}, {
+		name: "rule declared in a subdirectory",
+		files: map[string]string{
+			"outer/.gitignore":         "ignored/\n",
+			"outer/ignored/deep/f.txt": "x\n",
+			"outer/keep.txt":           "x\n",
+		},
+	}, {
+		name: "rule names a grandchild",
+		files: map[string]string{
+			".gitignore":               "outer/ignored/\n",
+			"outer/ignored/deep/f.txt": "x\n",
+			"outer/keep.txt":           "x\n",
+		},
+	}, {
+		name: "children excluded but one re-included",
+		files: map[string]string{
+			".gitignore":      "foo/*\n!foo/bar\n",
+			"foo/bar/baz.txt": "x\n",
+			"foo/other.txt":   "x\n",
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if os.Getenv("GIT_VERSION") == "v2.11.0" {
+				for _, content := range tc.files {
+					if strings.Contains(content, "!") {
+						t.Skip("oracle disabled: Git 2.11.0 does not honour re-include patterns")
+					}
+				}
+			}
+
+			dir := filepath.Join(t.TempDir(), "repo")
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			require.NoError(t, exec.Command("git", "-c", "init.defaultBranch=main", "-C", dir, "init", "-q").Run())
+
+			for p, content := range tc.files {
+				abs := filepath.Join(dir, filepath.FromSlash(p))
+				require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+				require.NoError(t, os.WriteFile(abs, []byte(content), 0o644))
+			}
+
+			out, err := exec.Command("git", "-C", dir, "ls-files", "--others", "--exclude-standard").Output()
+			require.NoError(t, err)
+			want := map[string]bool{}
+			for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+				if line != "" {
+					want[line] = true
+				}
+			}
+
+			repo, err := PlainOpen(dir)
+			require.NoError(t, err)
+			defer func() { _ = repo.Close() }()
+
+			wt, err := repo.Worktree()
+			require.NoError(t, err)
+
+			st, err := wt.Status()
+			require.NoError(t, err)
+
+			got := map[string]bool{}
+			for path, s := range st {
+				if s.Worktree == Untracked {
+					got[path] = true
+				}
+			}
+
+			assert.Equal(t, want, got, "untracked set must match reference git")
+		})
+	}
 }

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1937,7 +1937,7 @@ func (s *WorktreeSuite) TestResetHardWithGitIgnore() {
 	s.True(status.IsClean())
 }
 
-// TestResetHardTrackedFileInIgnoredDir covers the case the IgnoreMatcher
+// TestResetHardTrackedFileInIgnoredDir covers the case the IgnoreScope
 // optimization actually targets: a tracked file living inside a gitignored
 // directory. The walker must descend into the directory because trackedDirs
 // records it as containing tracked descendants, so the Delete-on-disk shows
@@ -2053,7 +2053,7 @@ func (s *WorktreeSuite) TestResetHardModifiedTrackedFileWithGitIgnore() {
 // the case Copilot flagged on this PR. resetIndex runs immediately before
 // resetWorktree and removes paths from the index, so a tracked path inside
 // a gitignored directory that is being removed by the reset would no
-// longer be in idxMap. If the noder's IgnoreMatcher were engaged here, it
+// longer be in idxMap. If the noder's IgnoreScope were engaged here, it
 // would prune the path during the walk and the Delete action needed to
 // remove the file from disk would never be emitted. resetWorktree must
 // keep excludeIgnoredChanges=false so MergeReset still cleans the file up.


### PR DESCRIPTION
> **Draft.** This adds and removes public API, which CONTRIBUTING lists under the [RFC process](https://github.com/go-git/go-git/tree/main/rfcs). Opening as a draft so the design and the measurements are reviewable; happy to write it up as an RFC instead if you would prefer that first.

Supersedes #2302, which fixed the same defect inside the existing flat-pattern design. Its own body argued for this approach once the numbers were in.

## API surface

| | |
| --- | --- |
| Added | `gitignore.Scope`, `NewScope`, `DirPatterns`, `RootPatterns`, `IgnoreFile`, `filesystem.Options.IgnoreScope` |
| Removed | `merkletrie/filesystem.Options.IgnoreMatcher` — present in `v6.0.0-alpha.5` but never in a stable release, so not a compatibility break ([#2048](https://github.com/go-git/go-git/pull/2048)) |
| Deprecated | `gitignore.ReadPatterns` (unchanged behaviour) |

## The problem

`Status` collected every ignore pattern in the worktree before diffing, then matched every entry against that one flat list. Two consequences.

**It cannot express an excluded parent.** gitignore(5): a file cannot be re-included once a parent directory of it is excluded. A flat list has nowhere to record that, so a negation anywhere in the repository can re-include a path git ignores:

```
.gitignore:  outer/ignored/
             !outer/ignored/keep.txt

$ git check-ignore -v outer/ignored/keep.txt
.gitignore:1:outer/ignored/	outer/ignored/keep.txt
```

git attributes the verdict to the rule that excluded the parent and ignores the negation. `main` reports `keep.txt` as not ignored.

**It walks the worktree twice** — once to gather patterns, once to diff — and the first walk descended into ignored trees the second one then skipped.

## The design

`gitignore.Scope` carries the patterns in effect for one directory *together with whether that directory is excluded*. `Descend` derives a subdirectory's scope; once excluded it stays excluded and `Match` answers without consulting a pattern, so a negation below cannot win.

`Descend` takes the subdirectory's own patterns as a function, not a slice, and does not call it when the subdirectory is excluded — the decision not to read an ignore file below an excluded directory lives in one place where a caller cannot get it wrong.

The noder resolves each directory's scope from the `ReadDir` listing it already takes, so `.gitignore` is opened only in directories actually visited and never below an excluded one, and the separate collection pass is gone.

This is git's structure. `prep_exclude` keeps a prefix-keyed `exclude_stack`, aborts before reading a directory's `.gitignore` when that directory already matched unless the match was a negation, and `last_matching_pattern` short-circuits on the excluded ancestor rather than recomputing it per query ([dir.c](https://github.com/git/git/blob/master/dir.c)).

## Numbers

`Status`, versus `main`:

| | `main` | this PR |
| --- | --- | --- |
| `StatusNestedIgnoredDir` 2000 ignored dirs | 252.1ms | **2.4ms** (-99.0%) |
| `StatusManyIgnoreFiles` 500 ignore files | 88.2ms | **52.5ms** (-40.4%) |
| `StatusLarge` 5000 files, no `.gitignore` | 23.1ms | **13.4ms** (-41.9%) |

`main` fails to scale on the first: ten times the directories cost it thirteen times the wall clock. The other two are shapes where pruning alone cannot help, since nothing is excluded wholesale — the saving there is the removed traversal and the smaller pattern set each entry is tested against.

Two of these benchmarks are new; the pre-existing `BenchmarkStatusIgnoredDir` could not show any of it, because its rule names a direct child of the root and its ignored tree is 21 directories wide.

`tests/gitcompare` measures the same shapes against the git binary. Read against its `Baseline/EmptyRepo` case, which is what a git *process* costs before it looks at a file (~11ms on macOS, a few on Linux):

| | git wall | git less baseline | go-git |
| --- | --- | --- | --- |
| `NestedIgnoredDir` | 12.1ms | ~1.2ms | 1.9ms |
| `ManyIgnoreFiles` | 33.1ms | ~22ms | 72.5ms |
| `LargeNoIgnoreFiles` | 18.8ms | ~8ms | 17.7ms |

## What this does not fix

`ManyIgnoreFiles` is still ~3x git's compute. Profiling says that is not the ignore machinery — reading the 500 `.gitignore` files is 22%, and git reads them too. The rest is elsewhere:

- **37% is `ObjectStorage.EncodedObject`**, one tree object per directory for the HEAD↔index diff. It scales with directory count, not file count: 1.4% at 20 directories, 37% at 500. go-git decodes the index's cache-tree extension into `idx.Cache` (`index/decoder.go:320`) but never reads it, so it redoes work git's cache-tree lets it skip.
- **95% of total time is syscalls**, `os.doInRoot` alone ~46%: every open goes through `BoundOS`/`os.Root`, which revalidates each path component. That is the deliberate symlink-safety boundary, but it means several syscalls where git pays one.

Both look worth their own issues; neither belongs here.

## Tests

- `gitignore`: `Scope` unit tests covering excluded-parent precedence, that `Descend` never reads an ignore file below an excluded directory, ordering, and the degenerate roots.
- `merkletrie/filesystem`: the nine existing ignore tests move to `IgnoreScope`, plus two the flat matcher could not express — a rule in a subdirectory's `.gitignore`, and a tracked entry forcing descent into an excluded directory where a negation must still not re-include a sibling. I checked the latter fails if excluded-parent precedence is removed.
- root: `Status` compared against `git ls-files --others --exclude-standard` over six layouts. **This found a real bug** — the root scope was omitted when the root declared no patterns, so a worktree whose only rules live below the root reported ignored files as untracked. Fixed in the same series.

Only pre-existing failure is `TestConformanceSuite/TestIgnoreDoubleStarPrefix`, which fails on `main` too (git 2.50.1). `golangci-lint` v2.11.4 reports 0 issues repo-wide, and every commit builds and tests independently.

## AI assistance disclosure

Per [AI_POLICY.md](https://github.com/go-git/go-git/blob/main/AI_POLICY.md), produced with AI assistance (Claude Opus 5), disclosed with an `Assisted-by:` trailer on each commit. Behaviour was verified against reference git two ways: oracle tests comparing `Status` and pattern verdicts against the git binary, and by reading `prep_exclude` in git's `dir.c` to confirm the design matches.
