### PR TITLE
gitignore: dirOnly re-include patterns must not cascade to descendants

### DIFF
--- a/plumbing/format/gitignore/conformance_test.go
+++ b/plumbing/format/gitignore/conformance_test.go
@@ -742,6 +742,37 @@ func (s *ConformanceSuite) TestIgnoreDoubleStarReinclude() {
 	}
 }
 
+// TestIgnoreReincludedDirDoesNotCascade verifies that a dirOnly re-include
+// pattern (e.g. "!dir/") does not extend a match to the directory's
+// descendants. Files and subdirectories nested inside a directory named by
+// such a pattern remain subject to the earlier "*" exclusion, matching
+// Git's documented behavior that re-including a directory does not
+// implicitly re-include its contents.
+//
+// This does not assert on the directory entry itself ("my-dir"): Git has a
+// separate, narrower quirk where a bare "*" specifically resists being
+// overridden by a later re-include pattern for the exact excluded entry,
+// even with no descendants involved. That is unrelated to the cascading
+// bug fixed here (go-git#2112, which is about nested files) and is left
+// alone.
+func (s *ConformanceSuite) TestIgnoreReincludedDirDoesNotCascade() {
+	patterns := []string{"*", "!my-dir/"}
+	m := s.createMatcher(patterns)
+
+	tests := []struct {
+		path    string
+		isDir   bool
+		ignored bool
+		desc    string
+	}{
+		{"my-dir/sub", true, true, "a subdirectory is not re-included"},
+		{"my-dir/sub/file.txt", false, true, "a nested file remains ignored"},
+	}
+	for _, tt := range tests {
+		s.assertIgnore(m, patterns, tt.path, tt.isDir, tt.ignored, tt.desc)
+	}
+}
+
 // TestIgnoreDoubleStarPrefix verifies that foo**/bar matches foo/bar (and
 // foo<anything>/bar) but does not match foobar — i.e. ** does not collapse
 // across the slash boundary into a prefix.

--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -483,7 +483,15 @@ func (p *pattern) simpleNameMatch(path []string, isDir bool) bool {
 		if !wildmatch(p.pattern[0], name) {
 			continue
 		}
-		if p.dirOnly && !isDir && i == len(path)-1 {
+		last := i == len(path)-1
+		if p.dirOnly && p.inclusion && !last {
+			// A dirOnly re-include pattern (e.g. "!dir/") restores only the
+			// directory entry itself, not everything nested inside it, so a
+			// match against an ancestor component must not be treated as a
+			// match for the full descendant path.
+			continue
+		}
+		if p.dirOnly && !isDir && last {
 			return false
 		}
 		return true

--- a/plumbing/format/gitignore/pattern_test.go
+++ b/plumbing/format/gitignore/pattern_test.go
@@ -21,6 +21,18 @@ func (s *PatternSuite) TestSimpleMatch_inclusion() {
 	s.Equal(Include, r)
 }
 
+func (s *PatternSuite) TestSimpleMatch_inclusion_dirOnly_atStart() {
+	p := ParsePattern("!dir/", nil)
+	r := p.Match([]string{"dir"}, true)
+	s.Equal(Include, r)
+}
+
+func (s *PatternSuite) TestSimpleMatch_inclusion_dirOnly_doesNotCascadeToDescendants() {
+	p := ParsePattern("!dir/", nil)
+	r := p.Match([]string{"dir", "sub", "file.txt"}, false)
+	s.Equal(NoMatch, r)
+}
+
 func (s *PatternSuite) TestMatch_domainLonger_mismatch() {
 	p := ParsePattern("value", []string{"head", "middle", "tail"})
 	r := p.Match([]string{"head", "middle"}, false)

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -150,6 +150,36 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	assert.False(t, ok, "untracked file inside an ignored directory must not surface in Status")
 }
 
+// TestStatusReincludedDirDoesNotUnignoreContents reproduces go-git#2112: a
+// dirOnly re-include pattern ("!my-dir/") must only restore the named
+// directory entry itself. Files nested inside it are still subject to the
+// preceding "*" exclusion and must not surface as untracked in Status().
+func TestStatusReincludedDirDoesNotUnignoreContents(t *testing.T) {
+	t.Parallel()
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	write := func(name string, data []byte) {
+		require.NoError(t, wt.Filesystem().MkdirAll(filepath.Dir(name), 0o755))
+		require.NoError(t, util.WriteFile(wt.Filesystem(), name, data, 0o644))
+	}
+
+	write(".gitignore", []byte("*\n!my-dir/\n"))
+	write("my-dir/sub/file.txt", []byte("test\n"))
+
+	st, err := wt.Status()
+	require.NoError(t, err)
+
+	_, ok := st["my-dir/sub/file.txt"]
+	assert.False(t, ok, "file nested inside a re-included directory must remain ignored")
+}
+
 func BenchmarkWorktreeStatus(b *testing.B) {
 	b.StopTimer()
 


### PR DESCRIPTION
Fixes #2112

## Bug

A `.gitignore` re-include pattern like `!dir/` is meant to restore only the directory entry itself, not everything nested inside it. `simpleNameMatch` let a `dirOnly` inclusion pattern that matched an *ancestor* path component stand in as a match for the full descendant path, so:
```
*
!my-dir/
```
wrongly reported files under `my-dir/` (e.g. `my-dir/sub/file.txt`) as untracked in `Worktree.Status()` instead of ignored, even though real `git` keeps them ignored.

## Fix

In `plumbing/format/gitignore/pattern.go`, `simpleNameMatch` now skips (rather than matches) when a `dirOnly` inclusion pattern hits a non-final path component — it only applies at the exact matched entry, not its descendants. Exclusion patterns are unaffected.

## Testing
- New unit tests in `pattern_test.go` covering the pattern in isolation.
- New case in `conformance_test.go`, cross-checked against the real `git` binary via the existing oracle harness.
- New end-to-end regression test in `worktree_status_test.go` reproducing the original report via `Worktree.Status()`.
- `go test ./plumbing/format/gitignore/...` and `go test .` pass (aside from one pre-existing, unrelated oracle mismatch confirmed present on unmodified `main` too).