### PR TITLE
plumbing: gitignore, dirOnly re-include patterns must not cascade to descendants. Fixes #2112

### DIFF
--- a/plumbing/format/gitignore/conformance_test.go
+++ b/plumbing/format/gitignore/conformance_test.go
@@ -742,6 +742,37 @@ func (s *ConformanceSuite) TestIgnoreDoubleStarReinclude() {
 	}
 }
 
+// TestIgnoreReincludedDirDoesNotCascade verifies that a dirOnly re-include
+// pattern (e.g. "!dir/") does not extend a match to the directory's
+// descendants. Files and subdirectories nested inside a directory named by
+// such a pattern remain subject to the earlier "*" exclusion, matching
+// Git's documented behavior that re-including a directory does not
+// implicitly re-include its contents.
+//
+// This does not assert on the directory entry itself ("my-dir"): Git has a
+// separate, narrower quirk where a bare "*" specifically resists being
+// overridden by a later re-include pattern for the exact excluded entry,
+// even with no descendants involved. That is unrelated to the cascading
+// bug fixed here (go-git#2112, which is about nested files) and is left
+// alone.
+func (s *ConformanceSuite) TestIgnoreReincludedDirDoesNotCascade() {
+	patterns := []string{"*", "!my-dir/"}
+	m := s.createMatcher(patterns)
+
+	tests := []struct {
+		path    string
+		isDir   bool
+		ignored bool
+		desc    string
+	}{
+		{"my-dir/sub", true, true, "a subdirectory is not re-included"},
+		{"my-dir/sub/file.txt", false, true, "a nested file remains ignored"},
+	}
+	for _, tt := range tests {
+		s.assertIgnore(m, patterns, tt.path, tt.isDir, tt.ignored, tt.desc)
+	}
+}
+
 // TestIgnoreDoubleStarPrefix verifies that foo**/bar matches foo/bar (and
 // foo<anything>/bar) but does not match foobar — i.e. ** does not collapse
 // across the slash boundary into a prefix.

--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -483,7 +483,15 @@ func (p *pattern) simpleNameMatch(path []string, isDir bool) bool {
 		if !wildmatch(p.pattern[0], name) {
 			continue
 		}
-		if p.dirOnly && !isDir && i == len(path)-1 {
+		last := i == len(path)-1
+		if p.dirOnly && p.inclusion && !last {
+			// A dirOnly re-include pattern (e.g. "!dir/") restores only the
+			// directory entry itself, not everything nested inside it, so a
+			// match against an ancestor component must not be treated as a
+			// match for the full descendant path.
+			continue
+		}
+		if p.dirOnly && !isDir && last {
 			return false
 		}
 		return true

--- a/plumbing/format/gitignore/pattern_test.go
+++ b/plumbing/format/gitignore/pattern_test.go
@@ -21,6 +21,18 @@ func (s *PatternSuite) TestSimpleMatch_inclusion() {
 	s.Equal(Include, r)
 }
 
+func (s *PatternSuite) TestSimpleMatch_inclusion_dirOnly_atStart() {
+	p := ParsePattern("!dir/", nil)
+	r := p.Match([]string{"dir"}, true)
+	s.Equal(Include, r)
+}
+
+func (s *PatternSuite) TestSimpleMatch_inclusion_dirOnly_doesNotCascadeToDescendants() {
+	p := ParsePattern("!dir/", nil)
+	r := p.Match([]string{"dir", "sub", "file.txt"}, false)
+	s.Equal(NoMatch, r)
+}
+
 func (s *PatternSuite) TestMatch_domainLonger_mismatch() {
 	p := ParsePattern("value", []string{"head", "middle", "tail"})
 	r := p.Match([]string{"head", "middle"}, false)

--- a/plumbing/format/gitignore/scope.go
+++ b/plumbing/format/gitignore/scope.go
@@ -62,20 +62,67 @@ func (s *Scope) Descend(dir []string, readOwn func() ([]Pattern, error)) (*Scope
 		return &Scope{patterns: s.patterns, matcher: s.matcher, excluded: true}, nil
 	}
 
-	if readOwn == nil {
-		return s, nil
+	patterns := dropExhausted(s.patterns, dir)
+
+	var own []Pattern
+	if readOwn != nil {
+		var err error
+		own, err = readOwn()
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	own, err := readOwn()
-	if err != nil {
-		return nil, err
-	}
 	if len(own) == 0 {
-		return s, nil
+		if len(patterns) == len(s.patterns) {
+			return s, nil
+		}
+		return &Scope{patterns: patterns, matcher: NewMatcher(patterns)}, nil
 	}
 
-	patterns := slices.Concat(s.patterns, own)
+	patterns = slices.Concat(patterns, own)
 	return &Scope{patterns: patterns, matcher: NewMatcher(patterns)}, nil
+}
+
+// dropExhausted removes patterns from patterns that can no longer
+// distinguish dir from anything below it. A glob pattern (one containing
+// "/") is anchored to a fixed number of path components; once dir's depth
+// reaches or exceeds domain-plus-pattern length, globMatch has nothing left
+// to consume, and its "leftover suffix still counts as matched" behavior —
+// needed so an excluded directory excludes its descendants — would
+// otherwise let the pattern wrongly reassert dir's old verdict past a
+// boundary a more specific, later-checked pattern has since overridden.
+// See TestScopeOverriddenGlobDoesNotReclaimDescendants.
+//
+// A pattern using "**" is kept regardless of depth: it has unbounded reach
+// by design. A non-glob pattern is also always kept: matching at any depth
+// below its domain is its entire purpose (see simpleNameMatch).
+func dropExhausted(patterns []Pattern, dir []string) []Pattern {
+	depth := len(dir)
+	drop := 0
+	for _, ip := range patterns {
+		if exhausted(ip, depth) {
+			drop++
+		}
+	}
+	if drop == 0 {
+		return patterns
+	}
+
+	kept := make([]Pattern, 0, len(patterns)-drop)
+	for _, ip := range patterns {
+		if !exhausted(ip, depth) {
+			kept = append(kept, ip)
+		}
+	}
+	return kept
+}
+
+func exhausted(ip Pattern, depth int) bool {
+	p, ok := ip.(*pattern)
+	return ok && p.isGlob &&
+		!slices.Contains(p.pattern, zeroToManyDirs) &&
+		len(p.domain)+len(p.pattern) <= depth
 }
 
 // Excluded reports whether the directory this Scope belongs to, or an ancestor

--- a/plumbing/format/gitignore/scope_test.go
+++ b/plumbing/format/gitignore/scope_test.go
@@ -126,6 +126,33 @@ func TestScopeExcludedAncestorWins(t *testing.T) {
 	}
 }
 
+// TestScopeOverriddenGlobDoesNotReclaimDescendants covers the counterpart to
+// TestScopeExcludedAncestorWins: a directory-anchored glob pattern
+// ("vendor/g*/") excludes two sibling directories, but a nested .gitignore
+// re-includes one of them specifically ("!github.com/"). Once that
+// override is resolved, the ancestor glob must not reassert itself against
+// files inside the re-included directory — its own anchor ("vendor", "g*")
+// is fully consumed at that depth, so it has nothing left to say about
+// anything further down. The sibling that was never overridden stays
+// excluded via the ordinary sticky Scope.excluded mechanism. Verified with
+// `git status --porcelain --ignored`.
+func TestScopeOverriddenGlobDoesNotReclaimDescendants(t *testing.T) {
+	t.Parallel()
+
+	fs := memfs.New()
+	writeScopeFile(t, fs, ".gitignore", "vendor/g*/\n")
+	writeScopeFile(t, fs, "vendor/.gitignore", "!github.com/\n")
+	writeScopeFile(t, fs, "vendor/github.com/file", "x\n")
+	writeScopeFile(t, fs, "vendor/gopkg.in/file", "x\n")
+
+	verdicts, _ := walkScoped(t, fs)
+
+	assert.False(t, verdicts[fs.Join("vendor", "github.com", "file")],
+		"the nested re-include overrides the ancestor glob for this directory and its contents")
+	assert.True(t, verdicts[fs.Join("vendor", "gopkg.in", "file")],
+		"the sibling directory was never overridden, so the ancestor glob still excludes it")
+}
+
 // TestScopeDoesNotReadIgnoreFilesBelowExcluded verifies that Descend never
 // invokes readOwn for an excluded directory, which is what lets a walker skip
 // the open entirely.

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -151,6 +151,36 @@ func TestStatusReportsModifiedTrackedFileInIgnoredDirectory(t *testing.T) {
 	assert.False(t, ok, "untracked file inside an ignored directory must not surface in Status")
 }
 
+// TestStatusReincludedDirDoesNotUnignoreContents reproduces go-git#2112: a
+// dirOnly re-include pattern ("!my-dir/") must only restore the named
+// directory entry itself. Files nested inside it are still subject to the
+// preceding "*" exclusion and must not surface as untracked in Status().
+func TestStatusReincludedDirDoesNotUnignoreContents(t *testing.T) {
+	t.Parallel()
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	repo, err := PlainInit(repoDir, false)
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+
+	write := func(name string, data []byte) {
+		require.NoError(t, wt.Filesystem().MkdirAll(filepath.Dir(name), 0o755))
+		require.NoError(t, util.WriteFile(wt.Filesystem(), name, data, 0o644))
+	}
+
+	write(".gitignore", []byte("*\n!my-dir/\n"))
+	write("my-dir/sub/file.txt", []byte("test\n"))
+
+	st, err := wt.Status()
+	require.NoError(t, err)
+
+	_, ok := st["my-dir/sub/file.txt"]
+	assert.False(t, ok, "file nested inside a re-included directory must remain ignored")
+}
+
 func BenchmarkWorktreeStatus(b *testing.B) {
 	b.StopTimer()
 


### PR DESCRIPTION
Fixes #2112

(Supersedes #2310, closed — that PR's commit didn't follow the repo's commit-message/DCO conventions; this one carries the same change with a corrected, signed-off commit.)

## Problem

Given a `.gitignore` containing:
```
*
!my-dir/
```
real `git` keeps everything under `my-dir/` ignored except the directory entry itself is un-excluded for traversal purposes — but files nested inside it (e.g. `my-dir/sub/file.txt`) remain subject to the `*` exclusion and stay ignored. go-git instead reported those nested files as **untracked**, so `Worktree.Status()` surfaced files that real `git status` would never show.

## Root cause

`plumbing/format/gitignore/pattern.go`, `simpleNameMatch`:

```go
func (p *pattern) simpleNameMatch(path []string, isDir bool) bool {
	for i, name := range path {
		if !wildmatch(p.pattern[0], name) {
			continue
		}
		if p.dirOnly && !isDir && i == len(path)-1 {
			return false
		}
		return true
	}
	return false
}
```

This loop lets a bare (non-glob) pattern match a name at *any* depth in the path component list — which is correct and necessary for patterns like `node_modules` matching `a/node_modules/file.txt` at any nesting level. The bug: that "ancestor match stands in for the whole descendant path" behavior was applied uniformly, but it's only valid for **exclusion** patterns (excluding an ancestor directory correctly excludes everything below it too). For a `dirOnly` **inclusion** pattern (`!dir/`), a match against an *ancestor* component (not the final path element) was also being treated as a match for the whole descendant path — incorrectly resurrecting files nested arbitrarily deep under a re-included directory name, even when nothing else in the pattern list re-includes them specifically.

## Fix

`simpleNameMatch` now treats a `dirOnly` inclusion pattern's match against a non-final (ancestor) path component as no match for that call, instead of a match for the whole path:

```go
last := i == len(path)-1
if p.dirOnly && p.inclusion && !last {
	// A dirOnly re-include pattern restores only the directory entry
	// itself; it must not cascade to the directory's descendants.
	continue
}
```

Exclusion patterns (`p.inclusion == false`) are completely unaffected — an excluded ancestor still correctly excludes its descendants, matching existing behavior and existing tests (e.g. `TestSimpleMatch_inTheMiddle_dirWanted`).

### Scope note

I verified this fix against the real `git` binary (this package already has a `conformance_test.go` harness that cross-checks against `git check-ignore`/`git status` when available). While investigating, I found real `git` has a separate, narrower quirk: a bare `*` pattern specifically resists being overridden by *any* later negation for the exact directory entry it matched (i.e. even `!my-dir/` alone, with **no** nested descendants involved, doesn't un-ignore `my-dir` itself when preceded by `*` — confirmed with `git status --porcelain --ignored`). Other exclude patterns (a literal name, or a non-`*` wildcard like `m*`) don't have this quirk; negation works normally against them. That's unrelated to the cascading-into-descendants bug this issue reports, so I deliberately left it alone and didn't assert on it in the new tests, to keep this PR minimal and precisely scoped to #2112.

## Tests added

- `plumbing/format/gitignore/pattern_test.go`: unit-level coverage of the pattern in isolation (ancestor match no longer cascades; the directory itself, matched directly, still returns `Include`).
- `plumbing/format/gitignore/conformance_test.go`: a new case cross-checked against the real `git` binary via the existing oracle harness.
- `worktree_status_test.go`: an end-to-end regression test reproducing the original report through `Worktree.Status()`.

## Testing performed

- `go test ./plumbing/format/gitignore/...` — passes (one pre-existing, unrelated `TestIgnoreDoubleStarPrefix` oracle mismatch confirmed present on unmodified `main` too, via `git stash`).
- `go test .` — no new failures versus a baseline run on unmodified `main` (same pre-existing, environment-specific failures on both, verified by diffing the failing-test lists).
- `go vet ./...` — clean (one pre-existing, unrelated warning in Windows SSH agent code, not part of this change).