### PR TITLE
git: Record partial clones so git accepts a filtered fetch

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -167,6 +167,7 @@ compatibility status with go-git.
 | multi-pack-index     | [v1](https://github.com/git/git/blob/master/Documentation/gitformat-pack.txt)   | ❌     |       |
 | pack-\*.rev files    | [v1](https://github.com/git/git/blob/master/Documentation/gitformat-pack.txt)   | ✅     |       |
 | pack-\*.mtimes files | [v1](https://github.com/git/git/blob/master/Documentation/gitformat-pack.txt)   | ❌     |       |
+| pack-\*.promisor files | [v1](https://github.com/git/git/blob/master/Documentation/gitformat-pack.txt) | ✅     | Written for packs received by a filtered fetch, and preserved across repack. |
 | cruft packs          |                                                                                 | ❌     |       |
 
 ## Capabilities
@@ -198,7 +199,7 @@ compatibility status with go-git.
 | `allow-tip-sha1-in-want`       | ✅           |       |
 | `allow-reachable-sha1-in-want` | ❌           |       |
 | `push-cert=<nonce>`            | ❌           |       |
-| `filter`                       | ❌           |       |
+| `filter`                       | ⚠️ (partial) | Fetching with a filter is supported and records the partial clone (promisor-marked packs, `remote.<name>.promisor` and `partialclonefilter`), so git accepts the result. go-git cannot fetch the withheld objects back on demand, so reading one fails rather than backfilling it. Not offered when serving. |
 | `session-id=<session id>`      | ❌           |       |
 
 ## Transport Schemes

--- a/config/config.go
+++ b/config/config.go
@@ -474,6 +474,8 @@ const (
 	objectFormatKey            = "objectformat"
 	worktreeConfigKey          = "worktreeConfig"
 	mirrorKey                  = "mirror"
+	promisorKey                = "promisor"
+	partialCloneFilterKey      = "partialclonefilter"
 	versionKey                 = "version"
 	autoCRLFKey                = "autocrlf"
 	fileModeKey                = "filemode"
@@ -1050,6 +1052,21 @@ type RemoteConfig struct {
 	// Fetch the default set of "refspec" for fetch operation
 	Fetch []RefSpec
 
+	// Promisor indicates that the remote is a promisor remote: objects it
+	// filtered out of a partial clone are expected to be absent locally and
+	// can be fetched from it on demand. It is what tells git that a missing
+	// object is promised rather than a sign of a corrupt repository, so it
+	// must be set whenever a fetch from this remote used a Filter, alongside
+	// the .promisor marker on each pack received from it.
+	Promisor bool
+
+	// PartialCloneFilter is the object filter last used to fetch from this
+	// remote, in the wire format git records (e.g. "blob:none"). Git reapplies
+	// it to subsequent fetches, so leaving it unset while Promisor is true
+	// makes later fetches ask for objects the local repository is missing the
+	// delta bases for.
+	PartialCloneFilter string
+
 	// raw representation of the subsection, filled by marshal or unmarshal are
 	// called
 	raw *format.Subsection
@@ -1096,6 +1113,8 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 	c.URLs = append(c.URLs, c.raw.Options.GetAll(pushurlKey)...)
 	c.Fetch = fetch
 	c.Mirror = c.raw.Options.Get(mirrorKey) == "true"
+	c.Promisor = c.raw.Options.Get(promisorKey) == "true"
+	c.PartialCloneFilter = c.raw.Options.Get(partialCloneFilterKey)
 
 	return nil
 }
@@ -1130,6 +1149,22 @@ func (c *RemoteConfig) marshal() *format.Subsection {
 
 	if c.Mirror {
 		c.raw.SetOption(mirrorKey, strconv.FormatBool(c.Mirror))
+	}
+
+	// Both keys are removed when unset rather than left behind: a stale
+	// promisor = true without a matching partialclonefilter makes git fetch
+	// unfiltered into a repository that is missing objects, which fails while
+	// resolving deltas against bases it never received.
+	if c.Promisor {
+		c.raw.SetOption(promisorKey, strconv.FormatBool(c.Promisor))
+	} else {
+		c.raw.RemoveOption(promisorKey)
+	}
+
+	if c.PartialCloneFilter != "" {
+		c.raw.SetOption(partialCloneFilterKey, c.PartialCloneFilter)
+	} else {
+		c.raw.RemoveOption(partialCloneFilterKey)
 	}
 
 	return c.raw

--- a/config/config.go
+++ b/config/config.go
@@ -1060,11 +1060,13 @@ type RemoteConfig struct {
 	// the .promisor marker on each pack received from it.
 	Promisor bool
 
-	// PartialCloneFilter is the object filter last used to fetch from this
-	// remote, in the wire format git records (e.g. "blob:none"). Git reapplies
-	// it to subsequent fetches, so leaving it unset while Promisor is true
-	// makes later fetches ask for objects the local repository is missing the
-	// delta bases for.
+	// PartialCloneFilter is the object filter git reapplies to fetches from this
+	// remote, in the wire format git records (e.g. "blob:none").
+	//
+	// It is the filter the partial clone was first established with, not the one
+	// most recently used: git records it once and treats it as the default from
+	// then on. Leaving it unset while Promisor is true makes later fetches ask
+	// for objects the local repository is missing the delta bases for.
 	PartialCloneFilter string
 
 	// raw representation of the subsection, filled by marshal or unmarshal are

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -604,6 +604,110 @@ func (s *ConfigSuite) TestUnmarshalRemotesNamedFirst() {
 	s.Equal([]RefSpec{"+refs/heads/*:refs/remotes/origin/*"}, unnamedRemote.Fetch)
 }
 
+// TestUnmarshalRemotePartialClone reads back the partial-clone keys exactly as
+// the git binary writes them for a `clone --filter=blob:none`.
+func TestUnmarshalRemotePartialClone(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`[core]
+	repositoryformatversion = 1
+[remote "origin"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	promisor = true
+	partialclonefilter = blob:none
+`)
+
+	cfg := NewConfig()
+	require.NoError(t, cfg.Unmarshal(input))
+
+	origin := cfg.Remotes["origin"]
+	require.NotNil(t, origin)
+	assert.True(t, origin.Promisor)
+	assert.Equal(t, "blob:none", origin.PartialCloneFilter)
+}
+
+func TestMarshalRemotePartialClone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		promisor bool
+		filter   string
+		want     []string
+		notWant  []string
+	}{
+		{
+			name:     "promisor with filter",
+			promisor: true,
+			filter:   "blob:none",
+			want:     []string{"promisor = true", "partialclonefilter = blob:none"},
+		},
+		{
+			name:     "tree filter",
+			promisor: true,
+			filter:   "tree:0",
+			want:     []string{"promisor = true", "partialclonefilter = tree:0"},
+		},
+		{
+			name:    "neither set writes no partial-clone keys",
+			notWant: []string{"promisor", "partialclonefilter"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := NewConfig()
+			cfg.Remotes["origin"] = &RemoteConfig{
+				Name:               "origin",
+				URLs:               []string{"https://github.com/go-git/go-git.git"},
+				Promisor:           tc.promisor,
+				PartialCloneFilter: tc.filter,
+			}
+
+			b, err := cfg.Marshal()
+			require.NoError(t, err)
+
+			for _, want := range tc.want {
+				assert.Contains(t, string(b), want)
+			}
+			for _, notWant := range tc.notWant {
+				assert.NotContains(t, string(b), notWant)
+			}
+		})
+	}
+}
+
+// TestMarshalRemoteClearsPartialClone covers the state behind the fetch
+// failures this config exists to prevent: a promisor = true left behind without
+// a partialclonefilter makes git fetch unfiltered into a repository that is
+// missing objects, which then fails resolving deltas against absent bases.
+// Clearing either field must remove the key rather than leave it on disk.
+func TestMarshalRemoteClearsPartialClone(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`[remote "origin"]
+	url = https://github.com/go-git/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	promisor = true
+	partialclonefilter = blob:none
+`)
+
+	cfg := NewConfig()
+	require.NoError(t, cfg.Unmarshal(input))
+
+	cfg.Remotes["origin"].Promisor = false
+	cfg.Remotes["origin"].PartialCloneFilter = ""
+
+	b, err := cfg.Marshal()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(b), "promisor")
+	assert.NotContains(t, string(b), "partialclonefilter")
+}
+
 func TestUnmarshalPackReverseIndex(t *testing.T) {
 	t.Parallel()
 

--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -223,7 +223,7 @@ func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round Fe
 		}
 
 		if out.Packfile {
-			streamErr := streamPackfile(ctx, st, packReader, req.Progress)
+			streamErr := streamPackfile(ctx, st, packReader, req.Progress, req.Filter)
 			// Skip draining/closing on cancellation: streamPackfile wraps
 			// packReader in a NewContextReader, whose background goroutine
 			// can still be blocked in the underlying Read after the
@@ -266,11 +266,21 @@ func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round Fe
 }
 
 // streamPackfile demultiplexes the sideband-64k packfile stream into st.
-func streamPackfile(ctx context.Context, st storage.Storer, packReader io.Reader, progress sideband.Progress) error {
+//
+// A non-empty filter means the server withheld the objects it matched, so the
+// pack is recorded as coming from a promisor remote. Git reads unmarked
+// absences as corruption: fsck reports broken links to them and gc fails.
+func streamPackfile(ctx context.Context, st storage.Storer, packReader io.Reader, progress sideband.Progress, filter packp.Filter) error {
 	reader := ioutil.NewContextReader(ctx, packReader)
 	demuxer := sideband.NewDemuxer(sideband.Sideband64k, reader)
 	if progress != nil {
 		demuxer.Progress = progress
+	}
+	if filter != "" {
+		// The marker is left empty. Git fills it with the refs it sought on
+		// this path and leaves it empty when repacking, and accepts either,
+		// because only the file's presence is ever consulted.
+		return packfile.UpdatePromisorObjectStorage(st, demuxer, "")
 	}
 	return packfile.UpdateObjectStorage(st, demuxer)
 }

--- a/object_walker.go
+++ b/object_walker.go
@@ -1,11 +1,13 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 )
 
@@ -18,10 +20,53 @@ type objectWalker struct {
 	// shallows is the set of shallow roots, loaded lazily
 	// on the first commit walked.
 	shallows map[plumbing.Hash]struct{}
+	// promisor records that the repository is a partial clone, so an object
+	// a promisor remote withheld is expected to be absent rather than a sign
+	// of corruption. It makes the walk tolerate those absences, at the cost
+	// of having to confirm that referenced blobs are present.
+	promisor bool
+	// missing is the set of objects that are referenced but absent. It is only
+	// populated for a partial clone, where absences are expected; elsewhere a
+	// missing object fails the walk. Callers that write objects out have to
+	// exclude these, since there is nothing local to write.
+	missing map[plumbing.Hash]struct{}
 }
 
 func newObjectWalker(s storage.Storer) *objectWalker {
-	return &objectWalker{Storer: s, seen: map[plumbing.Hash]struct{}{}}
+	return &objectWalker{
+		Storer:   s,
+		seen:     map[plumbing.Hash]struct{}{},
+		promisor: isPartialClone(s),
+		missing:  map[plumbing.Hash]struct{}{},
+	}
+}
+
+// isPartialClone reports whether the repository holds packs fetched from a
+// promisor remote, which is what makes referenced-but-absent objects expected.
+//
+// Errors are treated as "not a partial clone": that keeps the stricter walk,
+// which fails loudly on a missing object rather than quietly tolerating it.
+func isPartialClone(s storage.Storer) bool {
+	pos, ok := s.(storer.PromisorObjectStorer)
+	if !ok {
+		return false
+	}
+
+	packs, err := pos.PromisorObjectPacks()
+	return err == nil && len(packs) > 0
+}
+
+// present returns the seen objects that are actually stored locally, which is
+// what can be written back out to a new pack.
+func (p *objectWalker) present() []plumbing.Hash {
+	objs := make([]plumbing.Hash, 0, len(p.seen)-len(p.missing))
+	for h := range p.seen {
+		if _, absent := p.missing[h]; absent {
+			continue
+		}
+		objs = append(objs, h)
+	}
+	return objs
 }
 
 // isShallow reports whether hash is a shallow root, meaning its
@@ -80,6 +125,13 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 	// Fetch the object.
 	obj, err := object.GetObject(p.Storer, hash)
 	if err != nil {
+		// In a partial clone the promisor remote withheld objects on
+		// purpose, so an absent one is expected. Record it and stop
+		// descending: there is nothing local to walk into.
+		if p.promisor && errors.Is(err, plumbing.ErrObjectNotFound) {
+			p.missing[hash] = struct{}{}
+			return nil
+		}
 		return fmt.Errorf("getting object %s failed: %w", hash, err)
 	}
 	// Walk all children depending on object type.
@@ -114,7 +166,22 @@ func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
 			// Other non-tree objects are somewhat rare, so they
 			// are not special-cased.
 			if obj.Entries[i].Mode|0o755 == filemode.Executable {
-				p.add(obj.Entries[i].Hash)
+				h := obj.Entries[i].Hash
+				p.add(h)
+				// The shortcut takes a tree entry's word for it that
+				// the blob exists, which a partial clone cannot afford:
+				// blob:none withholds exactly these, and treating them
+				// as present makes a later encode fail on an object
+				// that was never fetched. Only the filtered case pays
+				// for the lookup.
+				if p.promisor {
+					if _, err := p.Storer.EncodedObjectSize(h); err != nil {
+						if !errors.Is(err, plumbing.ErrObjectNotFound) {
+							return err
+						}
+						p.missing[h] = struct{}{}
+					}
+				}
 				continue
 			}
 			// Normal walk for sub-trees (and symlinks etc).

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -52,6 +52,36 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
 	return err
 }
 
+// UpdatePromisorObjectStorage is UpdateObjectStorage for a packfile received
+// from a promisor remote, as a filtered (partial clone) fetch returns. The pack
+// is recorded as a promisor pack so that the objects the filter excluded are
+// understood to be promised by that remote rather than missing.
+//
+// Storage that cannot record promisor packs falls back to an unmarked write.
+// That is only safe where git never sees the result, such as in-memory storage;
+// on disk it leaves a repository whose fsck reports broken links and whose gc
+// fails.
+func UpdatePromisorObjectStorage(s storer.Storer, packfile io.Reader, marker string) error {
+	if trace.Performance.Enabled() {
+		start := time.Now()
+		defer func() {
+			trace.Performance.Printf("performance: %.9f s: update_promisor_obj_storage", time.Since(start).Seconds())
+		}()
+	}
+
+	pw, ok := s.(storer.PromisorPackfileWriter)
+	if !ok {
+		return UpdateObjectStorage(s, packfile)
+	}
+
+	w, err := pw.PromisorPackfileWriter(marker)
+	if err != nil {
+		return err
+	}
+
+	return copyPackfile(w, packfile)
+}
+
 // WritePackfileToObjectStorage writes all the packfile objects into the given
 // object storage.
 func WritePackfileToObjectStorage(
@@ -63,6 +93,10 @@ func WritePackfileToObjectStorage(
 		return err
 	}
 
+	return copyPackfile(w, packfile)
+}
+
+func copyPackfile(w io.WriteCloser, packfile io.Reader) (err error) {
 	defer ioutil.CheckClose(w, &err)
 
 	n, err := ioutil.CopyBufferPool(w, packfile)

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -52,15 +53,38 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader) error {
 	return err
 }
 
+// ErrPromisorPacksUnsupported is returned when a packfile from a promisor
+// remote would be stored by a storer that writes packfiles but cannot record
+// them as promisor packs. Writing it unmarked would leave a repository whose
+// fsck reports broken links and whose gc fails, so the write is refused.
+var ErrPromisorPacksUnsupported = errors.New("storage writes packfiles but cannot record them as promisor packs")
+
+// SupportsPromisorPacks reports whether a packfile from a promisor remote can be
+// stored without losing the fact that it came from one.
+//
+// Storage that records promisor packs qualifies. So does storage that does not
+// write packfiles at all: it stores objects individually, so there is no pack to
+// mark and nothing to lose — in-memory storage works this way. What does not
+// qualify is storage that writes a packfile but cannot mark it, which is exactly
+// how an unmarked pack of deliberately absent objects reaches disk.
+func SupportsPromisorPacks(s storer.Storer) bool {
+	if _, ok := s.(storer.PromisorPackfileWriter); ok {
+		return true
+	}
+
+	_, writesPacks := s.(storer.PackfileWriter)
+	return !writesPacks
+}
+
 // UpdatePromisorObjectStorage is UpdateObjectStorage for a packfile received
 // from a promisor remote, as a filtered (partial clone) fetch returns. The pack
 // is recorded as a promisor pack so that the objects the filter excluded are
 // understood to be promised by that remote rather than missing.
 //
-// Storage that cannot record promisor packs falls back to an unmarked write.
-// That is only safe where git never sees the result, such as in-memory storage;
-// on disk it leaves a repository whose fsck reports broken links and whose gc
-// fails.
+// Storage that writes packfiles without being able to mark them is refused with
+// ErrPromisorPacksUnsupported rather than silently producing the corruption this
+// marking exists to prevent. Storage that writes no packfiles at all stores the
+// objects individually, where there is no marking to lose.
 func UpdatePromisorObjectStorage(s storer.Storer, packfile io.Reader, marker string) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()
@@ -71,6 +95,9 @@ func UpdatePromisorObjectStorage(s storer.Storer, packfile io.Reader, marker str
 
 	pw, ok := s.(storer.PromisorPackfileWriter)
 	if !ok {
+		if !SupportsPromisorPacks(s) {
+			return ErrPromisorPacksUnsupported
+		}
 		return UpdateObjectStorage(s, packfile)
 	}
 

--- a/plumbing/format/packfile/promisor_test.go
+++ b/plumbing/format/packfile/promisor_test.go
@@ -1,0 +1,76 @@
+package packfile
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// packWriterOnly writes packfiles but cannot record them as promisor packs —
+// the shape that must be refused, since it is how an unmarked pack of
+// deliberately absent objects reaches disk.
+type packWriterOnly struct {
+	*memory.Storage
+}
+
+func (packWriterOnly) PackfileWriter() (io.WriteCloser, error) {
+	return nil, assert.AnError
+}
+
+// promisorCapable records promisor packs, so it is safe for a filtered fetch.
+type promisorCapable struct {
+	packWriterOnly
+}
+
+func (promisorCapable) PromisorPackfileWriter(string) (io.WriteCloser, error) {
+	return nil, assert.AnError
+}
+
+func TestSupportsPromisorPacks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		st   storer.Storer
+		want bool
+	}{
+		{
+			name: "records promisor packs",
+			st:   promisorCapable{packWriterOnly{memory.NewStorage()}},
+			want: true,
+		},
+		{
+			name: "writes no packfiles, so nothing to mark",
+			st:   memory.NewStorage(),
+			want: true,
+		},
+		{
+			name: "writes packfiles it cannot mark",
+			st:   packWriterOnly{memory.NewStorage()},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, SupportsPromisorPacks(tc.st))
+		})
+	}
+}
+
+// TestUpdatePromisorObjectStorageRefusesUnmarkablePack pins the fail-closed
+// behaviour: rather than silently writing an unmarked pack, the write is refused.
+func TestUpdatePromisorObjectStorageRefusesUnmarkablePack(t *testing.T) {
+	t.Parallel()
+
+	err := UpdatePromisorObjectStorage(packWriterOnly{memory.NewStorage()},
+		bytes.NewReader(nil), "")
+	require.ErrorIs(t, err, ErrPromisorPacksUnsupported)
+}

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -110,9 +110,10 @@ type PackfileWriter interface {
 // and refuses to gc the repository.
 type PromisorPackfileWriter interface {
 	// PromisorPackfileWriter returns a writer for a packfile received from a
-	// promisor remote. marker is stored verbatim alongside the pack; git
-	// writes the fetched ref list there, and an empty marker for the pack of
-	// an initial clone.
+	// promisor remote. marker is stored verbatim alongside the pack; git writes
+	// the refs it sought there when the pack came from a fetch, and nothing at
+	// all when repacking. Only the file's presence is ever consulted, so the
+	// contents are free-form.
 	PromisorPackfileWriter(marker string) (io.WriteCloser, error)
 }
 

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -99,6 +99,35 @@ type PackfileWriter interface {
 	PackfileWriter() (io.WriteCloser, error)
 }
 
+// PromisorPackfileWriter is an optional interface for ObjectStorer
+// implementations that can record a packfile as having come from a promisor
+// remote, which a filtered (partial clone) fetch requires.
+//
+// A pack fetched with a filter is missing the objects the filter excluded, and
+// git only treats those absences as legitimate when the pack is marked. An
+// implementation that cannot record the mark should not be used for filtered
+// fetches that land on disk: git reports the excluded objects as broken links
+// and refuses to gc the repository.
+type PromisorPackfileWriter interface {
+	// PromisorPackfileWriter returns a writer for a packfile received from a
+	// promisor remote. marker is stored verbatim alongside the pack; git
+	// writes the fetched ref list there, and an empty marker for the pack of
+	// an initial clone.
+	PromisorPackfileWriter(marker string) (io.WriteCloser, error)
+}
+
+// PromisorObjectStorer is an optional interface for ObjectStorer
+// implementations that track which packs came from a promisor remote.
+//
+// It lets callers tell a repository that is a partial clone, and whose missing
+// objects are therefore expected, from one that is simply incomplete.
+type PromisorObjectStorer interface {
+	// PromisorObjectPacks returns the hashes of the packs received from a
+	// promisor remote. An empty result means the repository is not a partial
+	// clone, so any missing object is genuinely missing.
+	PromisorObjectPacks() ([]plumbing.Hash, error)
+}
+
 // EncodedObjectIter is a generic closable interface for iterating over objects.
 type EncodedObjectIter interface {
 	Next() (plumbing.EncodedObject, error)

--- a/plumbing/transport/fetch.go
+++ b/plumbing/transport/fetch.go
@@ -36,7 +36,21 @@ func FetchPack(
 		reader = demuxer
 	}
 
-	if err := packfile.UpdateObjectStorage(st, reader); err != nil {
+	// A filtered fetch deliberately leaves out objects, so the pack has to be
+	// recorded as coming from a promisor remote. Git otherwise reads those
+	// absences as corruption: fsck reports broken links to them and gc fails
+	// with "unable to read".
+	//
+	// The marker is left empty. Git fills it with the refs it sought on this
+	// path (fetch-pack.c create_promisor_file) and leaves it empty when
+	// repacking (repack-promisor.c), and accepts either, because only the
+	// file's presence is ever consulted — packfile.c tests it with access(2)
+	// and never opens it.
+	if req.Filter != "" {
+		if err := packfile.UpdatePromisorObjectStorage(st, reader, ""); err != nil {
+			return err
+		}
+	} else if err := packfile.UpdateObjectStorage(st, reader); err != nil {
 		return err
 	}
 

--- a/plumbing/transport/fetch_promisor_test.go
+++ b/plumbing/transport/fetch_promisor_test.go
@@ -1,0 +1,107 @@
+package transport
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/osfs"
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+)
+
+// emptyRepoStorage returns filesystem-backed storage for a fresh repository,
+// along with its pack directory. Filesystem storage is required here rather than
+// memory storage: the promisor marker is a file next to the pack, so only an
+// on-disk storer can record it.
+func emptyRepoStorage(t *testing.T) (*filesystem.Storage, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	st := filesystem.NewStorage(osfs.New(dir), cache.NewObjectLRUDefault())
+	t.Cleanup(func() { _ = st.Close() })
+
+	return st, filepath.Join(dir, "objects", "pack")
+}
+
+func promisorMarkersIn(t *testing.T, packDir string) []string {
+	t.Helper()
+	m, err := filepath.Glob(filepath.Join(packDir, "*.promisor"))
+	require.NoError(t, err)
+	return m
+}
+
+// TestFetchPackMarksFilteredPack pins the behaviour behind the reported bug: a
+// fetch that carried a filter must leave the pack marked as coming from a
+// promisor remote. The objects the filter excluded are absent from the result,
+// and git only accepts that when the pack is marked — unmarked, it reports them
+// as broken links and refuses to gc the repository.
+func TestFetchPackMarksFilteredPack(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		filter     packp.Filter
+		wantMarker bool
+	}{
+		{
+			name:       "blob:none marks the pack",
+			filter:     packp.FilterBlobNone(),
+			wantMarker: true,
+		},
+		{
+			name:       "tree:0 marks the pack",
+			filter:     packp.FilterTreeDepth(0),
+			wantMarker: true,
+		},
+		{
+			name:       "an unfiltered fetch leaves the pack unmarked",
+			filter:     "",
+			wantMarker: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			st, packDir := emptyRepoStorage(t)
+
+			pf, err := fixtures.Basic().One().Packfile()
+			require.NoError(t, err)
+
+			err = FetchPack(context.Background(), st, capability.List{},
+				io.NopCloser(pf), nil, &FetchRequest{Filter: tc.filter})
+			require.NoError(t, err)
+
+			markers := promisorMarkersIn(t, packDir)
+			if tc.wantMarker {
+				require.Len(t, markers, 1,
+					"a filtered fetch must mark its pack, or the excluded objects read as corruption")
+
+				// go-git leaves the marker empty. Git fills it with the refs
+				// it sought on this path and leaves it empty when repacking,
+				// and accepts either, because only presence is consulted.
+				fi, err := os.Stat(markers[0])
+				require.NoError(t, err)
+				assert.Zero(t, fi.Size())
+
+				// The marker has to name the pack it belongs to, otherwise it
+				// vouches for nothing.
+				pack := markers[0][:len(markers[0])-len(".promisor")] + ".pack"
+				_, err = os.Stat(pack)
+				assert.NoError(t, err, "marker does not sit beside a pack")
+			} else {
+				assert.Empty(t, markers)
+			}
+		})
+	}
+}

--- a/remote.go
+++ b/remote.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/internal/repository"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/client"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
@@ -532,6 +533,12 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 			// this point, we have everything we're asking for.
 			return nil, err
 		}
+
+		if o.Filter != "" {
+			if err := r.recordPromisor(o.Filter); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	var updatedPrune bool
@@ -629,6 +636,56 @@ func (r *Remote) transportProtocol() protocol.Version {
 		return config.DefaultProtocolVersion
 	}
 	return cfg.Protocol.Version
+}
+
+// recordPromisor marks this remote as a promisor remote and stores the filter
+// that was used, mirroring what git records for a partial clone.
+//
+// Both keys matter. promisor is what lets git accept that the filtered-out
+// objects are absent on purpose, and partialclonefilter is what makes git
+// reapply the same filter on later fetches. Recording the first without the
+// second leaves the repository fetching unfiltered while missing objects, which
+// fails in index-pack resolving deltas against bases it never receives.
+//
+// Nothing is recorded for a fetch that did not come from a configured remote:
+// an anonymous URL fetch has no remote section to write to, and git leaves the
+// configured remotes alone in that case too.
+func (r *Remote) recordPromisor(filter packp.Filter) error {
+	if r.s == nil || r.c == nil || r.c.Name == "" {
+		return nil
+	}
+
+	cfg, err := r.s.Config()
+	if err != nil {
+		return err
+	}
+
+	remote, ok := cfg.Remotes[r.c.Name]
+	if !ok {
+		return nil
+	}
+
+	if remote.Promisor && remote.PartialCloneFilter == string(filter) {
+		return nil
+	}
+
+	remote.Promisor = true
+	remote.PartialCloneFilter = string(filter)
+
+	// Partial clone is a repository format extension, so the format version
+	// has to allow extensions to be present at all.
+	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+
+	if err := r.s.SetConfig(cfg); err != nil {
+		return err
+	}
+
+	// Keep the in-memory view consistent with what was just stored, so a
+	// caller holding this Remote sees the recorded filter.
+	r.c.Promisor = remote.Promisor
+	r.c.PartialCloneFilter = remote.PartialCloneFilter
+
+	return nil
 }
 
 func (r *Remote) pruneRemotes(specs []config.RefSpec, localRefs []*plumbing.Reference, remoteRefs storer.ReferenceStorer) (bool, error) {

--- a/remote.go
+++ b/remote.go
@@ -647,6 +647,10 @@ func (r *Remote) transportProtocol() protocol.Version {
 // second leaves the repository fetching unfiltered while missing objects, which
 // fails in index-pack resolving deltas against bases it never receives.
 //
+// The filter is recorded once and then left alone, which is git's behaviour: it
+// is the default reapplied to later fetches, not a record of the most recent
+// one.
+//
 // Nothing is recorded for a fetch that did not come from a configured remote:
 // an anonymous URL fetch has no remote section to write to, and git leaves the
 // configured remotes alone in that case too.
@@ -665,16 +669,26 @@ func (r *Remote) recordPromisor(filter packp.Filter) error {
 		return nil
 	}
 
-	if remote.Promisor && remote.PartialCloneFilter == string(filter) {
+	// A filter already recorded for this remote is left alone, even when this
+	// fetch used a different one. Git treats the first filter as the default to
+	// reapply to later fetches and does not rewrite it
+	// (list-objects-filter-options.c partial_clone_register returns early once
+	// the remote has a partialclonefilter), so overwriting it here would change
+	// what an unfiltered `git fetch` does afterwards.
+	if remote.Promisor && remote.PartialCloneFilter != "" {
 		return nil
 	}
 
-	remote.Promisor = true
-	remote.PartialCloneFilter = string(filter)
+	if !remote.Promisor {
+		remote.Promisor = true
 
-	// Partial clone is a repository format extension, so the format version
-	// has to allow extensions to be present at all.
-	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+		// Partial clone is a repository format extension, so the format
+		// version has to allow extensions to be present at all. Git raises it
+		// when first registering the remote, for the same reason.
+		cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+	}
+
+	remote.PartialCloneFilter = string(filter)
 
 	if err := r.s.SetConfig(cfg); err != nil {
 		return err

--- a/remote.go
+++ b/remote.go
@@ -431,6 +431,15 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (sto storer.Referen
 		return nil, err
 	}
 
+	// Fail before opening a connection rather than after the objects have
+	// landed. A filtered fetch stored as an ordinary pack leaves a repository
+	// git reports as corrupt and refuses to gc, so if this storage cannot record
+	// the pack as coming from a promisor remote, the fetch does not start.
+	if o.Filter != "" && !packfile.SupportsPromisorPacks(r.s) {
+		return nil, fmt.Errorf("%w: refusing to fetch with filter %q",
+			packfile.ErrPromisorPacksUnsupported, o.Filter)
+	}
+
 	if len(o.RefSpecs) == 0 {
 		o.RefSpecs = r.c.Fetch
 	}

--- a/remote_promisor_test.go
+++ b/remote_promisor_test.go
@@ -1,0 +1,92 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/config"
+	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// TestRecordPromisor covers the config a filtered fetch has to leave behind.
+//
+// Both keys have to land together. promisor alone is the state behind the
+// reported fetch failures: git accepts that objects are absent but, with no
+// partialclonefilter to reapply, fetches unfiltered, and index-pack then dies
+// resolving deltas against bases the pack assumed were local.
+func TestRecordPromisor(t *testing.T) {
+	t.Parallel()
+
+	newRepo := func(t *testing.T) *Repository {
+		t.Helper()
+		r, err := Init(memory.NewStorage())
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = r.Close() })
+		_, err = r.CreateRemote(&config.RemoteConfig{
+			Name: DefaultRemoteName,
+			URLs: []string{"https://github.com/go-git/go-git.git"},
+		})
+		require.NoError(t, err)
+		return r
+	}
+
+	t.Run("records both keys and the format version", func(t *testing.T) {
+		t.Parallel()
+
+		r := newRepo(t)
+		rem, err := r.Remote(DefaultRemoteName)
+		require.NoError(t, err)
+
+		require.NoError(t, rem.recordPromisor(packp.FilterBlobNone()))
+
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		assert.True(t, cfg.Remotes[DefaultRemoteName].Promisor)
+		assert.Equal(t, "blob:none", cfg.Remotes[DefaultRemoteName].PartialCloneFilter)
+		assert.EqualValues(t, formatcfg.Version1, cfg.Core.RepositoryFormatVersion,
+			"partial clone is a format extension, so extensions have to be permitted")
+
+		// The in-memory view has to agree with what was stored.
+		assert.True(t, rem.Config().Promisor)
+		assert.Equal(t, "blob:none", rem.Config().PartialCloneFilter)
+	})
+
+	t.Run("updates the filter when it changes", func(t *testing.T) {
+		t.Parallel()
+
+		r := newRepo(t)
+		rem, err := r.Remote(DefaultRemoteName)
+		require.NoError(t, err)
+
+		require.NoError(t, rem.recordPromisor(packp.FilterBlobNone()))
+		require.NoError(t, rem.recordPromisor(packp.FilterTreeDepth(0)))
+
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		assert.Equal(t, "tree:0", cfg.Remotes[DefaultRemoteName].PartialCloneFilter)
+	})
+
+	t.Run("records nothing for an unconfigured remote", func(t *testing.T) {
+		t.Parallel()
+
+		r, err := Init(memory.NewStorage())
+		require.NoError(t, err)
+		defer func() { _ = r.Close() }()
+
+		// An anonymous URL fetch has no remote section to write to, and git
+		// leaves the configured remotes alone in that case too.
+		rem := NewRemote(r.Storer, &config.RemoteConfig{
+			Name: "",
+			URLs: []string{"https://github.com/go-git/go-git.git"},
+		})
+		require.NoError(t, rem.recordPromisor(packp.FilterBlobNone()))
+
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		assert.Empty(t, cfg.Remotes)
+	})
+}

--- a/remote_promisor_test.go
+++ b/remote_promisor_test.go
@@ -55,7 +55,11 @@ func TestRecordPromisor(t *testing.T) {
 		assert.Equal(t, "blob:none", rem.Config().PartialCloneFilter)
 	})
 
-	t.Run("updates the filter when it changes", func(t *testing.T) {
+	// Git records the first filter as the default to reapply to later fetches
+	// and does not rewrite it, so a second fetch with a different filter leaves
+	// the recorded one alone. Overwriting it would change what a plain
+	// `git fetch` does from then on.
+	t.Run("keeps the first filter when a later fetch differs", func(t *testing.T) {
 		t.Parallel()
 
 		r := newRepo(t)
@@ -67,6 +71,28 @@ func TestRecordPromisor(t *testing.T) {
 
 		cfg, err := r.Config()
 		require.NoError(t, err)
+		assert.Equal(t, "blob:none", cfg.Remotes[DefaultRemoteName].PartialCloneFilter)
+		assert.Equal(t, "blob:none", rem.Config().PartialCloneFilter)
+	})
+
+	// A remote already flagged promisor but carrying no filter is not the
+	// sticky case: git falls through and records one, and so does this.
+	t.Run("records a filter onto a promisor remote that has none", func(t *testing.T) {
+		t.Parallel()
+
+		r := newRepo(t)
+		cfg, err := r.Config()
+		require.NoError(t, err)
+		cfg.Remotes[DefaultRemoteName].Promisor = true
+		require.NoError(t, r.Storer.SetConfig(cfg))
+
+		rem, err := r.Remote(DefaultRemoteName)
+		require.NoError(t, err)
+		require.NoError(t, rem.recordPromisor(packp.FilterTreeDepth(0)))
+
+		cfg, err = r.Config()
+		require.NoError(t, err)
+		assert.True(t, cfg.Remotes[DefaultRemoteName].Promisor)
 		assert.Equal(t, "tree:0", cfg.Remotes[DefaultRemoteName].PartialCloneFilter)
 	})
 

--- a/repository.go
+++ b/repository.go
@@ -2116,6 +2116,30 @@ func (r *Repository) Merge(ref plumbing.Reference, opts MergeOptions) error {
 	return r.Storer.SetReference(plumbing.NewHashReference(head.Name(), ref.Hash()))
 }
 
+// newPackWriter opens a writer for the pack a repack is about to produce.
+//
+// Repacking a partial clone folds objects out of promisor packs into the new
+// one, which therefore has to be marked promisor itself. Left unmarked, the
+// trees it carries would reference blobs the remote withheld with nothing to
+// record that the absence is intended, and git would report them as broken
+// links and refuse to gc the repository — the very state repacking is meant to
+// tidy up.
+func (r *Repository) newPackWriter(promisor bool) (io.WriteCloser, error) {
+	if promisor {
+		ppw, ok := r.Storer.(storer.PromisorPackfileWriter)
+		if !ok {
+			return nil, fmt.Errorf("repository storer cannot record promisor packs, refusing to repack a partial clone")
+		}
+		return ppw.PromisorPackfileWriter("")
+	}
+
+	pfw, ok := r.Storer.(storer.PackfileWriter)
+	if !ok {
+		return nil, fmt.Errorf("Repository storer is not a storer.PackfileWriter")
+	}
+	return pfw.PackfileWriter()
+}
+
 // createNewObjectPack is a helper for RepackObjects taking care
 // of creating a new pack. It is used so the PackfileWriter
 // deferred close has the right scope.
@@ -2125,15 +2149,12 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 	if err != nil {
 		return h, err
 	}
-	objs := make([]plumbing.Hash, 0, len(ow.seen))
-	for h := range ow.seen {
-		objs = append(objs, h)
-	}
-	pfw, ok := r.Storer.(storer.PackfileWriter)
-	if !ok {
-		return h, fmt.Errorf("Repository storer is not a storer.PackfileWriter")
-	}
-	wc, err := pfw.PackfileWriter()
+	// Only objects that are actually present can be written out. In a partial
+	// clone the walk reaches objects the promisor remote withheld, and asking
+	// the encoder for those fails with "object not found".
+	objs := ow.present()
+
+	wc, err := r.newPackWriter(ow.promisor)
 	if err != nil {
 		return h, err
 	}

--- a/repository_promisor_test.go
+++ b/repository_promisor_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -28,6 +29,66 @@ func requireGitBinary(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skipf("oracle disabled: git not found: %v", err)
 	}
+}
+
+// partialCloneMinGit is the first Git release whose clone accepts --filter.
+// Partial clone landed in 2.19.0, so on anything older the fixture cannot be
+// built at all: `git clone --filter=blob:none` fails with "unknown option".
+// The Git Compatibility workflow builds 2.11.0, which is exactly that case.
+//
+// A version comparison is the right test here, unlike for a behavioural bug a
+// vendor might backport: the option either exists in the CLI or it does not,
+// and no distribution adds partial clone to 2.11.0.
+var partialCloneMinGit = [2]int{2, 19}
+
+// requireGitPartialClone skips unless the git binary can build the fixture
+// these tests need.
+func requireGitPartialClone(t *testing.T) {
+	t.Helper()
+	requireGitBinary(t)
+
+	out, err := exec.Command("git", "version").Output()
+	if err != nil {
+		t.Skipf("cannot determine git version: %v", err)
+	}
+
+	major, minor, ok := parseGitMajorMinor(string(out))
+	if !ok {
+		t.Skipf("cannot parse git version from %q", strings.TrimSpace(string(out)))
+	}
+
+	wantMajor, wantMinor := partialCloneMinGit[0], partialCloneMinGit[1]
+	if major < wantMajor || (major == wantMajor && minor < wantMinor) {
+		t.Skipf("git %d.%d has no clone --filter, so a partial clone cannot be built (needs %d.%d+)",
+			major, minor, wantMajor, wantMinor)
+	}
+}
+
+// parseGitMajorMinor extracts the major and minor version from `git version`
+// output, which carries a variable number of trailing components and, on some
+// platforms, a vendor suffix. ok is false when the output cannot be read, which
+// callers treat as "unknown, skip" rather than assuming a modern Git.
+func parseGitMajorMinor(out string) (major, minor int, ok bool) {
+	fields := strings.Fields(out)
+	if len(fields) < 3 || fields[0] != "git" || fields[1] != "version" {
+		return 0, 0, false
+	}
+
+	parts := strings.Split(fields[2], ".")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+
+	return major, minor, true
 }
 
 // git runs a git command that is expected to succeed and returns its output.
@@ -163,7 +224,7 @@ var partialCloneFilters = []string{"blob:none", "tree:0"}
 // absences into corruption and cost the repository its ability to gc.
 func TestRepackObjectsOnPartialClone(t *testing.T) {
 	t.Parallel()
-	requireGitBinary(t)
+	requireGitPartialClone(t)
 
 	for _, filter := range partialCloneFilters {
 		t.Run(filter, func(t *testing.T) {
@@ -197,7 +258,7 @@ func TestRepackObjectsOnPartialClone(t *testing.T) {
 // that RepackObjects used to fail in.
 func TestPruneOnPartialClone(t *testing.T) {
 	t.Parallel()
-	requireGitBinary(t)
+	requireGitPartialClone(t)
 
 	for _, filter := range partialCloneFilters {
 		t.Run(filter, func(t *testing.T) {
@@ -223,7 +284,7 @@ func TestPruneOnPartialClone(t *testing.T) {
 // writing into a partial clone, which must leave the existing markers alone.
 func TestPartialCloneMarkersSurviveObjectWrites(t *testing.T) {
 	t.Parallel()
-	requireGitBinary(t)
+	requireGitPartialClone(t)
 
 	dir := newPartialClone(t, "blob:none")
 	before := promisorMarkers(t, dir)
@@ -244,4 +305,46 @@ func TestPartialCloneMarkersSurviveObjectWrites(t *testing.T) {
 
 	assert.ElementsMatch(t, before, promisorMarkers(t, dir))
 	requireFsckClean(t, dir)
+}
+
+// TestParseGitMajorMinor covers the shapes `git version` emits. Misreading it
+// would skip the partial-clone tests on a Git that supports them, or run them
+// on one that does not and fail building the fixture.
+func TestParseGitMajorMinor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		out   string
+		major int
+		minor int
+		ok    bool
+	}{
+		{name: "release", out: "git version 2.19.0\n", major: 2, minor: 19, ok: true},
+		{name: "patch release", out: "git version 2.50.1\n", major: 2, minor: 50, ok: true},
+		{name: "vendor suffix", out: "git version 2.50.1 (Apple Git-155)\n", major: 2, minor: 50, ok: true},
+		{name: "build from master", out: "git version 2.55.0.525.g2c78326f81\n", major: 2, minor: 55, ok: true},
+		{name: "windows suffix", out: "git version 2.51.0.windows.1\n", major: 2, minor: 51, ok: true},
+		{name: "legacy", out: "git version 2.11.0\n", major: 2, minor: 11, ok: true},
+		{name: "empty", out: ""},
+		{name: "truncated", out: "git version\n"},
+		{name: "unexpected prefix", out: "hg version 2.19.0\n"},
+		{name: "single component", out: "git version 2\n"},
+		{name: "non-numeric", out: "git version next.0\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			major, minor, ok := parseGitMajorMinor(tc.out)
+			if !tc.ok {
+				assert.False(t, ok, "parseGitMajorMinor(%q) should report failure", tc.out)
+				return
+			}
+			require.True(t, ok, "parseGitMajorMinor(%q) should succeed", tc.out)
+			assert.Equal(t, tc.major, major)
+			assert.Equal(t, tc.minor, minor)
+		})
+	}
 }

--- a/repository_promisor_test.go
+++ b/repository_promisor_test.go
@@ -1,0 +1,247 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// The partial-clone tests below use the git binary to build the fixture and to
+// judge the result. Both matter: only real git produces the on-disk shape of a
+// partial clone (promisor-marked packs plus genuinely absent objects), and only
+// real git decides whether an absence reads as promised or as corruption. A
+// pure go-git assertion would happily accept a repository that git refuses to
+// gc, which is exactly the bug these cover.
+
+func requireGitBinary(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("oracle disabled: -short")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("oracle disabled: git not found: %v", err)
+	}
+}
+
+// git runs a git command that is expected to succeed and returns its output.
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	// protocol.file.allow keeps file:// transport usable across git versions
+	// that restrict it by default.
+	full := append([]string{"-C", dir, "-c", "protocol.file.allow=always"}, args...)
+	out, err := exec.Command("git", full...).CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+	return string(out)
+}
+
+// gitAllowFail runs a git command and returns its output and whether it
+// succeeded, for the cases where the failure is the thing under test.
+func gitAllowFail(t *testing.T, dir string, args ...string) (string, bool) {
+	t.Helper()
+	full := append([]string{"-C", dir, "-c", "protocol.file.allow=always"}, args...)
+	out, err := exec.Command("git", full...).CombinedOutput()
+	return string(out), err == nil
+}
+
+// newPartialClone builds a real partial clone with the given filter and returns
+// its path. The source history rewrites the same file on every commit, so each
+// commit contributes a distinct blob and the clone is left genuinely missing
+// objects rather than trivially complete.
+//
+// The clone is made with --no-checkout so no lazy backfill happens: checking out
+// a worktree would fetch the objects it needs and quietly heal the very state
+// under test.
+func newPartialClone(t *testing.T, filter string) string {
+	t.Helper()
+
+	base := t.TempDir()
+	src := filepath.Join(base, "src.git")
+	seed := filepath.Join(base, "seed")
+	dst := filepath.Join(base, "clone")
+
+	require.NoError(t, os.MkdirAll(src, 0o755))
+	require.NoError(t, os.MkdirAll(seed, 0o755))
+
+	out, err := exec.Command("git", "init", "-q", "--bare", src).CombinedOutput()
+	require.NoError(t, err, "git init --bare: %s", out)
+	git(t, src, "config", "uploadpack.allowFilter", "true")
+
+	out, err = exec.Command("git", "init", "-q", seed).CombinedOutput()
+	require.NoError(t, err, "git init: %s", out)
+	git(t, seed, "config", "user.email", "test@example.com")
+	git(t, seed, "config", "user.name", "test")
+
+	for _, content := range []string{"one", "two", "three", "four"} {
+		require.NoError(t, os.WriteFile(filepath.Join(seed, "file.txt"), []byte(content+"\n"), 0o644))
+		git(t, seed, "add", ".")
+		git(t, seed, "commit", "-qm", content)
+	}
+	git(t, seed, "branch", "-M", "main")
+	git(t, seed, "remote", "add", "origin", src)
+	git(t, seed, "push", "-q", "origin", "main")
+
+	out, err = exec.Command("git", "-c", "protocol.file.allow=always", "clone", "-q",
+		"--filter="+filter, "--no-checkout", "file://"+src, dst).CombinedOutput()
+	require.NoError(t, err, "git clone --filter=%s: %s", filter, out)
+
+	// Sanity-check the fixture really is a partial clone with absent objects,
+	// so a later clean fsck means the markers did their job rather than that
+	// there was nothing to promise.
+	require.NotEmpty(t, promisorMarkers(t, dst), "fixture should have promisor-marked packs")
+	require.NotZero(t, missingObjects(t, dst), "fixture should be missing objects")
+	requireFsckClean(t, dst)
+
+	return dst
+}
+
+func packDir(dir string) string {
+	return filepath.Join(dir, ".git", "objects", "pack")
+}
+
+func promisorMarkers(t *testing.T, dir string) []string {
+	t.Helper()
+	m, err := filepath.Glob(filepath.Join(packDir(dir), "*.promisor"))
+	require.NoError(t, err)
+	return m
+}
+
+// missingObjects counts the objects git reaches from the refs but does not have.
+func missingObjects(t *testing.T, dir string) int {
+	t.Helper()
+	out := git(t, dir, "rev-list", "--objects", "--all", "--missing=print")
+	var n int
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.HasPrefix(line, "?") {
+			n++
+		}
+	}
+	return n
+}
+
+// requireFsckClean asserts git considers every absence promised. fsck reports
+// "broken link"/"missing blob" for an object that is absent without a promisor
+// pack vouching for it, and stays silent when one does.
+func requireFsckClean(t *testing.T, dir string) {
+	t.Helper()
+	out, ok := gitAllowFail(t, dir, "fsck")
+	assert.True(t, ok, "git fsck failed: %s", out)
+	assert.NotContains(t, out, "broken link", "git fsck: %s", out)
+	assert.NotContains(t, out, "missing blob", "git fsck: %s", out)
+}
+
+// requireNoOrphanMarkers asserts every .promisor still has the pack it belongs
+// to. An orphan claims a pack that is gone, so the objects it vouched for are no
+// longer understood as promised.
+func requireNoOrphanMarkers(t *testing.T, dir string) {
+	t.Helper()
+	for _, marker := range promisorMarkers(t, dir) {
+		pack := strings.TrimSuffix(marker, ".promisor") + ".pack"
+		_, err := os.Stat(pack)
+		assert.NoError(t, err, "orphaned marker %s has no pack", filepath.Base(marker))
+	}
+}
+
+// partialCloneFilters covers the two shapes that leave different object types
+// absent: blob:none withholds blobs, which the walk reaches through tree
+// entries, while tree:0 withholds the trees themselves, which it reaches by
+// loading them. Each exercises a different tolerance path.
+var partialCloneFilters = []string{"blob:none", "tree:0"}
+
+// TestRepackObjectsOnPartialClone covers repacking a partial clone. It used to
+// fail outright with "object not found", because the walk assumed every object
+// a tree names is present, which a filtered clone breaks.
+//
+// The pack it produces has to be promisor-marked in turn: it carries the objects
+// that reference the withheld ones, so leaving it unmarked would turn those
+// absences into corruption and cost the repository its ability to gc.
+func TestRepackObjectsOnPartialClone(t *testing.T) {
+	t.Parallel()
+	requireGitBinary(t)
+
+	for _, filter := range partialCloneFilters {
+		t.Run(filter, func(t *testing.T) {
+			t.Parallel()
+
+			dir := newPartialClone(t, filter)
+			before := missingObjects(t, dir)
+
+			r, err := PlainOpen(dir)
+			require.NoError(t, err)
+			defer func() { _ = r.Close() }()
+
+			require.NoError(t, r.RepackObjects(&RepackConfig{}))
+
+			assert.NotEmpty(t, promisorMarkers(t, dir),
+				"the repacked pack must stay promisor-marked, or the objects the remote withheld read as corruption")
+			requireNoOrphanMarkers(t, dir)
+			assert.Equal(t, before, missingObjects(t, dir), "repacking must not change which objects are absent")
+
+			// The judgement that matters: git still accepts the repository, and
+			// can still gc it. Before the fix gc died with "unable to read".
+			requireFsckClean(t, dir)
+			out, ok := gitAllowFail(t, dir, "gc", "--prune=now")
+			assert.True(t, ok, "git gc failed after repack: %s", out)
+			requireFsckClean(t, dir)
+		})
+	}
+}
+
+// TestPruneOnPartialClone covers pruning a partial clone, which shares the walk
+// that RepackObjects used to fail in.
+func TestPruneOnPartialClone(t *testing.T) {
+	t.Parallel()
+	requireGitBinary(t)
+
+	for _, filter := range partialCloneFilters {
+		t.Run(filter, func(t *testing.T) {
+			t.Parallel()
+
+			dir := newPartialClone(t, filter)
+			before := missingObjects(t, dir)
+
+			r, err := PlainOpen(dir)
+			require.NoError(t, err)
+			defer func() { _ = r.Close() }()
+
+			require.NoError(t, r.Prune(PruneOptions{Handler: r.DeleteObject}))
+
+			assert.Equal(t, before, missingObjects(t, dir), "pruning must not drop a promised object")
+			requireNoOrphanMarkers(t, dir)
+			requireFsckClean(t, dir)
+		})
+	}
+}
+
+// TestPartialCloneMarkersSurviveObjectWrites covers the ordinary case of go-git
+// writing into a partial clone, which must leave the existing markers alone.
+func TestPartialCloneMarkersSurviveObjectWrites(t *testing.T) {
+	t.Parallel()
+	requireGitBinary(t)
+
+	dir := newPartialClone(t, "blob:none")
+	before := promisorMarkers(t, dir)
+
+	r, err := PlainOpen(dir)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	obj := r.Storer.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = w.Write([]byte("written by go-git\n"))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	_, err = r.Storer.SetEncodedObject(obj)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, before, promisorMarkers(t, dir))
+	requireFsckClean(t, dir)
+}

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -735,6 +735,10 @@ func (a packHandleAdapter) PackHash() (plumbing.Hash, error) {
 // reverse index is optional and may have been generated only in memory — and
 // neither is a missing .promisor, which only packs fetched from a promisor
 // remote carry.
+//
+// The .promisor is the one sibling that is not independent: it is removed only
+// once the pack itself is gone, since a pack left on disk without it reads as
+// corrupt.
 func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) error {
 	var errs []error
 	if err := d.cleanPackList(); err != nil {
@@ -754,7 +758,26 @@ func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) er
 		}
 	}
 
-	for _, ext := range []string{`pack`, `idx`, `rev`, `promisor`} {
+	// The pack goes first, because the .promisor may only outlive it, never the
+	// other way round. A marker removed while its pack is still readable turns
+	// every object the promisor remote withheld into what git reports as a
+	// broken link, so on a removal that leaves the pack behind the marker stays
+	// too. An already-absent pack is a different matter: the marker is then an
+	// orphan vouching for nothing, and goes.
+	packGone := true
+	if err := d.fs.Remove(packPath); err != nil {
+		if !os.IsNotExist(err) {
+			packGone = false
+		}
+		errs = append(errs, err)
+	}
+
+	siblings := []string{`idx`, `rev`}
+	if packGone {
+		siblings = append(siblings, `promisor`)
+	}
+
+	for _, ext := range siblings {
 		if err := d.fs.Remove(d.objectPackPath(hash, ext)); err != nil {
 			if (ext == `rev` || ext == `promisor`) && os.IsNotExist(err) {
 				continue

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -58,6 +58,13 @@ const (
 
 	packPrefix = "pack-"
 	packExt    = ".pack"
+
+	// promisorExt marks a pack as having been received from a promisor
+	// remote, meaning objects it references but does not contain are
+	// promised by that remote rather than missing. Git refuses to treat
+	// such absences as legitimate without this marker: fsck reports them as
+	// broken links and gc fails outright.
+	promisorExt = ".promisor"
 )
 
 var (
@@ -365,6 +372,59 @@ func (d *DotGit) NewObjectPack() (*PackWriter, error) {
 		return nil, cleanErr
 	}
 	return pw, nil
+}
+
+// NewPromisorObjectPack is NewObjectPack for a packfile received from a
+// promisor remote, as a filtered (partial clone) fetch produces. Alongside the
+// pack it writes a .promisor sidecar containing marker, which is how git tells
+// objects the remote deliberately withheld from ones that are genuinely
+// missing. Without it git reports the withheld objects as broken links and
+// refuses to gc the repository.
+//
+// Git writes the fetched ref list as the marker, one "<hash> <ref>" line each,
+// and an empty marker for the pack of an initial clone.
+func (d *DotGit) NewPromisorObjectPack(marker string) (*PackWriter, error) {
+	pw, err := d.NewObjectPack()
+	if err != nil {
+		return nil, err
+	}
+
+	pw.promisor = &marker
+	return pw, nil
+}
+
+// PromisorObjectPacks returns the hashes of the packs that were received from a
+// promisor remote, that is those carrying a .promisor marker.
+func (d *DotGit) PromisorObjectPacks() ([]plumbing.Hash, error) {
+	packs, err := d.ObjectPacks()
+	if err != nil {
+		return nil, err
+	}
+
+	var promisors []plumbing.Hash
+	for _, h := range packs {
+		ok, err := d.hasPromisor(h)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			promisors = append(promisors, h)
+		}
+	}
+
+	return promisors, nil
+}
+
+// hasPromisor reports whether the pack carries a .promisor marker.
+func (d *DotGit) hasPromisor(hash plumbing.Hash) (bool, error) {
+	fi, err := d.fs.Lstat(d.objectPackPath(hash, promisorExt[1:]))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return fi.Mode().IsRegular(), nil
 }
 
 // ObjectPacks returns the list of availables packfiles

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -381,8 +381,9 @@ func (d *DotGit) NewObjectPack() (*PackWriter, error) {
 // missing. Without it git reports the withheld objects as broken links and
 // refuses to gc the repository.
 //
-// Git writes the fetched ref list as the marker, one "<hash> <ref>" line each,
-// and an empty marker for the pack of an initial clone.
+// Git writes the refs it sought as the marker, one "<hash> <ref>" line each,
+// when the pack came from a fetch, and an empty marker when repacking. Either
+// is accepted: only the file's presence is ever consulted, never its contents.
 func (d *DotGit) NewPromisorObjectPack(marker string) (*PackWriter, error) {
 	pw, err := d.NewObjectPack()
 	if err != nil {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -729,10 +729,12 @@ func (a packHandleAdapter) PackHash() (plumbing.Hash, error) {
 }
 
 // DeleteOldObjectPackAndIndex removes a pack and its index if older than t.
-// The .pack, .idx and .rev files are each attempted independently; any
-// failures are joined into the returned error so a partial failure cannot
+// The .pack, .idx, .rev and .promisor files are each attempted independently;
+// any failures are joined into the returned error so a partial failure cannot
 // leave orphaned siblings on disk. A missing .rev is not an error — the
-// reverse index is optional and may have been generated only in memory.
+// reverse index is optional and may have been generated only in memory — and
+// neither is a missing .promisor, which only packs fetched from a promisor
+// remote carry.
 func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) error {
 	var errs []error
 	if err := d.cleanPackList(); err != nil {
@@ -752,9 +754,9 @@ func (d *DotGit) DeleteOldObjectPackAndIndex(hash plumbing.Hash, t time.Time) er
 		}
 	}
 
-	for _, ext := range []string{`pack`, `idx`, `rev`} {
+	for _, ext := range []string{`pack`, `idx`, `rev`, `promisor`} {
 		if err := d.fs.Remove(d.objectPackPath(hash, ext)); err != nil {
-			if ext == `rev` && os.IsNotExist(err) {
+			if (ext == `rev` || ext == `promisor`) && os.IsNotExist(err) {
 				continue
 			}
 			errs = append(errs, err)

--- a/storage/filesystem/dotgit/promisor_test.go
+++ b/storage/filesystem/dotgit/promisor_test.go
@@ -2,7 +2,9 @@ package dotgit
 
 import (
 	"io"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/osfs"
@@ -93,4 +95,31 @@ func TestPromisorObjectPacks(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, promisors, "a repository with no promisor pack is not a partial clone, so every missing object is genuinely missing")
 	})
+}
+
+// TestDeleteOldObjectPackAndIndexRemovesMarker pins the sidecar to its pack. A
+// .promisor left behind after its pack is gone claims a pack that no longer
+// exists, and the objects it vouched for stop being understood as promised.
+func TestDeleteOldObjectPackAndIndexRemovesMarker(t *testing.T) {
+	t.Parallel()
+
+	dot, h, fs := createPromisorPack(t, "")
+
+	require.NoError(t, dot.DeleteOldObjectPackAndIndex(h, time.Time{}))
+
+	for _, ext := range []string{"pack", "idx", "promisor"} {
+		path := fs.Join("objects", "pack", "pack-"+h.String()+"."+ext)
+		_, err := fs.Lstat(path)
+		assert.ErrorIs(t, err, os.ErrNotExist, "%s should have been removed with its pack", ext)
+	}
+}
+
+// TestDeleteOldObjectPackAndIndexWithoutMarker guards the ordinary case: an
+// absent .promisor is normal, and must not be reported as a failure.
+func TestDeleteOldObjectPackAndIndexWithoutMarker(t *testing.T) {
+	t.Parallel()
+
+	dot, h, _ := createPackWithRev(t, Options{})
+
+	require.NoError(t, dot.DeleteOldObjectPackAndIndex(h, time.Time{}))
 }

--- a/storage/filesystem/dotgit/promisor_test.go
+++ b/storage/filesystem/dotgit/promisor_test.go
@@ -1,8 +1,10 @@
 package dotgit
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -122,4 +124,98 @@ func TestDeleteOldObjectPackAndIndexWithoutMarker(t *testing.T) {
 	dot, h, _ := createPackWithRev(t, Options{})
 
 	require.NoError(t, dot.DeleteOldObjectPackAndIndex(h, time.Time{}))
+}
+
+// TestPromisorMarkerNotAddedToExistingPack covers a duplicate arrival: a pack
+// already on disk unmarked, then the same pack again from a promisor remote.
+//
+// The existing pack must be left alone. Packs are content addressed, so an equal
+// hash means equal objects and nothing is newly absent, while marking it would
+// declare the repository a partial clone on the strength of a duplicate — which
+// makes the object walk tolerate missing objects and every later repack write a
+// promisor pack.
+func TestPromisorMarkerNotAddedToExistingPack(t *testing.T) {
+	t.Parallel()
+
+	f := fixtures.Basic().One()
+	fs := osfs.New(t.TempDir())
+	dot := New(fs)
+	require.NoError(t, dot.Initialize())
+
+	writePack := func(w *PackWriter) {
+		t.Helper()
+		pf, err := f.Packfile()
+		require.NoError(t, err)
+		_, err = io.Copy(w, pf)
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+	}
+
+	plain, err := dot.NewObjectPack()
+	require.NoError(t, err)
+	writePack(plain)
+
+	promisors, err := dot.PromisorObjectPacks()
+	require.NoError(t, err)
+	require.Empty(t, promisors, "an ordinary pack must start unmarked")
+
+	// The same pack again, this time from a promisor remote.
+	dup, err := dot.NewPromisorObjectPack("")
+	require.NoError(t, err)
+	writePack(dup)
+
+	promisors, err = dot.PromisorObjectPacks()
+	require.NoError(t, err)
+	assert.Empty(t, promisors,
+		"a pack already on disk must keep its marker state; marking it turns the repository into a partial clone because a duplicate arrived")
+}
+
+// removeFailFS fails Remove for paths with a given suffix, to exercise the case
+// where a pack cannot be deleted.
+type removeFailFS struct {
+	billy.Filesystem
+
+	failSuffix string
+}
+
+func (fs removeFailFS) Remove(path string) error {
+	if strings.HasSuffix(path, fs.failSuffix) {
+		return fmt.Errorf("simulated failure removing %s", path)
+	}
+	return fs.Filesystem.Remove(path)
+}
+
+// TestDeleteOldObjectPackKeepsMarkerWhenPackSurvives pins the ordering between
+// a pack and its marker. Removing the marker while the pack is still readable
+// leaves objects the promisor remote withheld looking like broken links, which
+// is the state the marker exists to prevent — so a failed pack removal has to
+// leave the marker in place.
+func TestDeleteOldObjectPackKeepsMarkerWhenPackSurvives(t *testing.T) {
+	t.Parallel()
+
+	f := fixtures.Basic().One()
+	fs := removeFailFS{Filesystem: osfs.New(t.TempDir()), failSuffix: ".pack"}
+	dot := New(fs)
+	require.NoError(t, dot.Initialize())
+
+	w, err := dot.NewPromisorObjectPack("")
+	require.NoError(t, err)
+	pf, err := f.Packfile()
+	require.NoError(t, err)
+	_, err = io.Copy(w, pf)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	h := plumbing.NewHash(f.PackfileHash)
+	base := fs.Join("objects", "pack", "pack-"+h.String())
+
+	// The pack cannot be removed, so the call reports failure.
+	require.Error(t, dot.DeleteOldObjectPackAndIndex(h, time.Time{}))
+
+	_, err = fs.Lstat(base + ".pack")
+	require.NoError(t, err, "precondition: the pack should have survived removal")
+
+	_, err = fs.Lstat(base + ".promisor")
+	assert.NoError(t, err,
+		"the marker must outlive a failed pack removal, or the surviving pack's withheld objects read as corruption")
 }

--- a/storage/filesystem/dotgit/promisor_test.go
+++ b/storage/filesystem/dotgit/promisor_test.go
@@ -55,9 +55,10 @@ func TestNewPromisorObjectPackWritesMarker(t *testing.T) {
 	assert.Contains(t, packs, h)
 }
 
-// TestNewPromisorObjectPackMarkerContents covers git's own convention: the
-// marker holds the fetched ref list, and is empty for the pack of an initial
-// partial clone.
+// TestNewPromisorObjectPackMarkerContents covers git's own convention for the
+// contents: the refs it sought when the pack came from a fetch, and nothing when
+// repacking. The writer stores whatever it is given, since git consults only the
+// file's presence.
 func TestNewPromisorObjectPackMarkerContents(t *testing.T) {
 	t.Parallel()
 

--- a/storage/filesystem/dotgit/promisor_test.go
+++ b/storage/filesystem/dotgit/promisor_test.go
@@ -1,0 +1,96 @@
+package dotgit
+
+import (
+	"io"
+	"testing"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/osfs"
+	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// createPromisorPack writes the basic fixture pack as a promisor pack carrying
+// the given marker, returning the DotGit, the pack hash and the filesystem.
+func createPromisorPack(t *testing.T, marker string) (*DotGit, plumbing.Hash, billy.Filesystem) {
+	t.Helper()
+
+	f := fixtures.Basic().One()
+	fs := osfs.New(t.TempDir())
+	dot := New(fs)
+	require.NoError(t, dot.Initialize())
+
+	w, err := dot.NewPromisorObjectPack(marker)
+	require.NoError(t, err)
+
+	pf, err := f.Packfile()
+	require.NoError(t, err)
+	_, err = io.Copy(w, pf)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	return dot, plumbing.NewHash(f.PackfileHash), fs
+}
+
+func TestNewPromisorObjectPackWritesMarker(t *testing.T) {
+	t.Parallel()
+
+	dot, h, fs := createPromisorPack(t, "")
+
+	marker := fs.Join("objects", "pack", "pack-"+h.String()+".promisor")
+	fi, err := fs.Lstat(marker)
+	require.NoError(t, err, "a filtered fetch must leave a .promisor marker: without it git reports the withheld objects as broken links and refuses to gc")
+	assert.True(t, fi.Mode().IsRegular())
+
+	// The pack itself has to be readable as an ordinary pack.
+	packs, err := dot.ObjectPacks()
+	require.NoError(t, err)
+	assert.Contains(t, packs, h)
+}
+
+// TestNewPromisorObjectPackMarkerContents covers git's own convention: the
+// marker holds the fetched ref list, and is empty for the pack of an initial
+// partial clone.
+func TestNewPromisorObjectPackMarkerContents(t *testing.T) {
+	t.Parallel()
+
+	const refs = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\n" +
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/master\n"
+
+	_, h, fs := createPromisorPack(t, refs)
+
+	f, err := fs.Open(fs.Join("objects", "pack", "pack-"+h.String()+".promisor"))
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	got, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, refs, string(got))
+}
+
+func TestPromisorObjectPacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reports a promisor pack", func(t *testing.T) {
+		t.Parallel()
+
+		dot, h, _ := createPromisorPack(t, "")
+
+		promisors, err := dot.PromisorObjectPacks()
+		require.NoError(t, err)
+		assert.Equal(t, []plumbing.Hash{h}, promisors)
+	})
+
+	t.Run("reports nothing for an ordinary pack", func(t *testing.T) {
+		t.Parallel()
+
+		dot, _, _ := createPackWithRev(t, Options{})
+
+		promisors, err := dot.PromisorObjectPacks()
+		require.NoError(t, err)
+		assert.Empty(t, promisors, "a repository with no promisor pack is not a partial clone, so every missing object is genuinely missing")
+	})
+}

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -196,18 +196,30 @@ func (w *PackWriter) save() error {
 		}
 	}
 
-	// The marker is written before the pack is moved into place. A pack that
-	// is visible without it looks like an ordinary pack, so anything the
-	// promisor remote filtered out would read as corruption until the marker
-	// landed; crashing in that window must not be able to produce a
-	// repository git refuses to gc.
-	if w.promisor != nil {
+	packPath := fmt.Sprintf("%s.pack", base)
+	exists, err = fileExists(w.fs, packPath)
+	if err != nil {
+		return err
+	}
+
+	// The marker is written before the pack is moved into place, and only for a
+	// pack this writer is placing. A pack visible without its marker looks
+	// ordinary, so whatever the promisor remote withheld would read as
+	// corruption until the marker landed; crashing in that window must not be
+	// able to produce a repository git refuses to gc.
+	//
+	// An identical pack already on disk is left exactly as it is, marked or
+	// not. Packs are content addressed, so the same hash means the same
+	// objects, and nothing is missing that was not missing before; marking it
+	// now would newly declare the repository a partial clone on the strength of
+	// a duplicate.
+	if w.promisor != nil && !exists {
 		promisorPath := fmt.Sprintf("%s%s", base, promisorExt)
-		exists, err := fileExists(w.fs, promisorPath)
+		promisorExists, err := fileExists(w.fs, promisorPath)
 		if err != nil {
 			return err
 		}
-		if !exists {
+		if !promisorExists {
 			f, err := w.fs.Create(promisorPath)
 			if err != nil {
 				return err
@@ -224,11 +236,6 @@ func (w *PackWriter) save() error {
 		}
 	}
 
-	packPath := fmt.Sprintf("%s.pack", base)
-	exists, err = fileExists(w.fs, packPath)
-	if err != nil {
-		return err
-	}
 	if !exists {
 		if err := w.fs.Rename(w.fw.Name(), packPath); err != nil {
 			return err

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -36,6 +36,9 @@ type PackWriter struct {
 	result   chan error
 	format   formatcfg.ObjectFormat
 	writeRev bool
+	// promisor, when non-nil, writes a .promisor sidecar next to the pack
+	// carrying these contents. A nil value leaves the pack unmarked.
+	promisor *string
 }
 
 func newPackWrite(fs billy.Filesystem, format formatcfg.ObjectFormat, writeRev bool) (*PackWriter, error) {
@@ -190,6 +193,34 @@ func (w *PackWriter) save() error {
 				return err
 			}
 			fixPermissions(w.fs, revPath)
+		}
+	}
+
+	// The marker is written before the pack is moved into place. A pack that
+	// is visible without it looks like an ordinary pack, so anything the
+	// promisor remote filtered out would read as corruption until the marker
+	// landed; crashing in that window must not be able to produce a
+	// repository git refuses to gc.
+	if w.promisor != nil {
+		promisorPath := fmt.Sprintf("%s%s", base, promisorExt)
+		exists, err := fileExists(w.fs, promisorPath)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			f, err := w.fs.Create(promisorPath)
+			if err != nil {
+				return err
+			}
+
+			if _, err := io.WriteString(f, *w.promisor); err != nil {
+				_ = f.Close()
+				return err
+			}
+
+			if err := f.Close(); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -433,11 +433,32 @@ func (s *ObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 
 // PackfileWriter returns a writer for creating a new packfile.
 func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
+	return s.packfileWriter(func() (*dotgit.PackWriter, error) {
+		return s.dir.NewObjectPack()
+	})
+}
+
+// PromisorPackfileWriter returns a writer for creating a new packfile received
+// from a promisor remote, marking it so that the objects the remote filtered
+// out are understood to be promised rather than missing.
+func (s *ObjectStorage) PromisorPackfileWriter(marker string) (io.WriteCloser, error) {
+	return s.packfileWriter(func() (*dotgit.PackWriter, error) {
+		return s.dir.NewPromisorObjectPack(marker)
+	})
+}
+
+// PromisorObjectPacks returns the hashes of the packs that came from a promisor
+// remote.
+func (s *ObjectStorage) PromisorObjectPacks() ([]plumbing.Hash, error) {
+	return s.dir.PromisorObjectPacks()
+}
+
+func (s *ObjectStorage) packfileWriter(newPack func() (*dotgit.PackWriter, error)) (io.WriteCloser, error) {
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
 
-	w, err := s.dir.NewObjectPack()
+	w, err := newPack()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

`FetchOptions.Filter` / `CloneOptions.Filter` perform a real partial fetch, but go-git writes none of the bookkeeping git uses to tell a *promised* object from a *lost* one. The resulting repository is one git considers corrupt, permanently.

Reproduced against git 2.50.1 and git 2.55.0: after a go-git filtered fetch into a filesystem-backed repository,

```
$ git fsck
broken link from    tree afda3ac0071f457223379cd81a3c42da5ffd311f
              to    blob ba674588414ea8386e3c37bade1adcbe8d6a7288
missing blob 9fa9c9d85f05a550465df168d72827f66bca3fd9
...

$ git gc
fatal: unable to read ba674588414ea8386e3c37bade1adcbe8d6a7288
fatal: failed to run repack
```

`gc` never succeeds again. For comparison, `git clone --filter=blob:none` of the same source writes `pack-<hash>.promisor` plus `remote.origin.promisor` / `partialclonefilter`, and both `fsck` and `gc` are clean.

Four further defects surfaced while tracing it, each confirmed by a test that fails without its fix:

- `RepackObjects` and `Prune` fail with `object not found` on *any* partial clone, including one made by the git binary. The object walk takes a tree entry's word that the blob it names is present, which is exactly what `blob:none` breaks.
- `dotgit.DeleteOldObjectPackAndIndex` removes `.pack`/`.idx`/`.rev` but leaves any `.promisor` behind, contrary to the promise in its own doc comment that a partial failure cannot leave orphaned siblings. An orphan vouches for a pack that no longer exists.
- The same function treated all siblings as independent and carried on past failures, so a pack whose removal *failed* kept its objects while losing its marker — reaching the exact corrupt state the marker prevents, via the cleanup path.
- The marker was written before checking whether the pack was already on disk, so an identical pack that arrived earlier unmarked got marked by a later filtered fetch. Content is unaffected (equal hash means equal objects), but a stray marker makes the object walk tolerate missing objects and every later repack emit a promisor pack — on the strength of a duplicate.

## Changes

Sixteen focused commits, each buildable on its own:

1. `config` — `RemoteConfig.Promisor` and `PartialCloneFilter`. Both keys are *removed* when unset, so clearing cannot leave a half-configured state.
2. `dotgit` — `NewPromisorObjectPack` writes the `.promisor` sidecar; `PromisorObjectPacks` reports which packs carry one. The marker lands **before** the pack is renamed into place, so crashing in that window cannot publish an unmarked pack full of absent objects.
3. `dotgit` — remove the `.promisor` along with its pack.
4. `plumbing/storer` — `PromisorPackfileWriter` and `PromisorObjectStorer`, optional interfaces following `PackfileWriter`.
5. `plumbing/format/packfile` — `UpdatePromisorObjectStorage`.
6. `plumbing/transport` — mark the pack whenever a filter was sent. Needed on **both** fetch paths: a filtered fetch negotiates over protocol v2 and never reaches `FetchPack`.
7. `git/remote` — record `remote.<name>.promisor` + `partialclonefilter` and raise the format version. Nothing is recorded for an anonymous URL fetch, matching git.
8. `git/repository` — tolerate promised absences in the walk and pack only what is present. The repacked pack is marked promisor in turn: it carries the objects referencing the withheld ones, so leaving it unmarked would recreate the corruption repacking is meant to clean up. Git keeps promisor objects in a separate promisor pack for the same reason.
9. `docs` — `COMPATIBILITY.md`.
10. `git/repository` — skip the partial-clone tests when the git binary has no `clone --filter`. Partial clone arrived in 2.19.0, so on the Git Compatibility job that builds v2.11.0 the fixture cannot be built at all.
11. `dotgit` — mark only a pack this writer is placing, leaving an identical pack already on disk exactly as it is.
12. `dotgit` — drop the `.promisor` only once its pack is gone, so a failed pack removal cannot leave a surviving pack unmarked.
13. `dotgit` — correct what the comments say git puts *in* a marker (review feedback, see below).
14. `git/remote` — keep the first `partialclonefilter` rather than overwriting it, matching `partial_clone_register` (review feedback, see below).
15. `config` — describe `PartialCloneFilter` as the sticky default rather than the filter "last used" (review feedback).
16. `plumbing/format/packfile` — refuse a promisor pack that cannot be marked, checked before the fetch starts (review feedback).

### Marker contents, and the sticky filter

Two points from review, both verified against the git source and both acted on:

- **What goes in the marker.** My comments said git leaves it empty for the pack of an initial partial clone. That is wrong: empty is the *repack* path (`repack-promisor.c` passes no refs), while a fetch — including the one a partial clone starts with — writes the refs it sought, one `<hash> <ref>` line each (`fetch-pack.c create_promisor_file` → `write_promisor_file`). An initial `clone --filter=blob:none --no-checkout` leaves a 103-byte marker, not an empty one. Commit 13 fixes every place that said otherwise. go-git still writes an empty marker, which is a shape git produces itself and accepts identically, since only the file's presence is ever consulted — `packfile.c` tests for it with `access(2)` and never opens it. Writing the sought ref list to match byte-for-byte would mean threading the fetched refs into `transport.FetchRequest`; happy to do that if you want the fidelity, but it buys nothing git reads.
- **The filter is sticky in git.** `partial_clone_register` returns early once the remote already has a `partialclonefilter`, and calls that value *"the initial filter-spec … as the default for subsequent fetches from this remote"*. So it is not a record of the latest fetch, and rewriting it changes what a plain `git fetch` does afterwards. Commit 14 records it once and leaves it; a remote flagged promisor but carrying no filter still gets one, and the format version is raised only on first registration, both matching git.

### Why `partialclonefilter` and not just `promisor`

`promisor` alone lets git accept that objects are absent, but with no filter recorded it fetches **unfiltered** into a repository that is missing objects, and `index-pack` then dies resolving deltas against bases the pack assumed were local:

```
fatal: pack has 4 unresolved deltas
fatal: fetch-pack: invalid index-pack output
```

Recording only one of the pair is its own broken state, hence both, and hence removing both when cleared.

## Testing

Every defect above has a regression test that I verified **fails without its fix**, by reverting the source and re-running: the repack tests fail with the original `object not found` on both `blob:none` and `tree:0`, the transport test fails on the missing marker, and the two marker-ordering tests fail on precisely the assertions naming the hazard.

The end-to-end tests use the git binary to *build* the fixture and to *judge* the result. Both matter: only real git produces the on-disk shape of a partial clone, and only real git decides whether an absence reads as promised or as corruption. A go-git-only assertion would happily accept a repository git refuses to gc. Fixtures use `--no-checkout` so no lazy backfill quietly heals the state under test, and cover `blob:none` and `tree:0`, which leave different object types absent and exercise different tolerance paths.

The failed-pack-removal case is simulated through a billy wrapper rather than filesystem permissions, so it behaves identically on all three CI platforms.

Validated against **git 2.50.1**, a build of **git 2.55.0** (`master`, `2c78326f81`) and a build of **git 2.11.0**, including the negative control: with the marking reverted, 2.55 reports the same broken links and `gc` failure, so the validation is meaningful rather than vacuous.

`golangci-lint`: 0 issues.

## Scope / known limitations

- go-git still cannot lazily fetch a withheld object back from the promisor remote. Reading one fails rather than backfilling it. That is a separate, much larger feature; this PR makes the on-disk result *honest* so the git binary and other tools can work with the repository. `COMPATIBILITY.md` records this.
- `filter` is still not offered when serving.
- A filtered fetch into storage that writes packfiles but cannot record promisor packs now fails with `ErrPromisorPacksUnsupported`, before the fetch opens a connection, rather than silently writing an unmarked pack. Storage that writes no packfiles is unaffected, so filtered fetches into in-memory storage keep working.
- `RepackObjects` consolidates into a single promisor-marked pack rather than splitting promisor and non-promisor objects into two packs the way `git repack` does. Marking the combined pack is the conservative direction — it is more permissive about absences, never less — but I am happy to split it if maintainers prefer to match git's layout exactly.
- A filtered fetch from a *configured* remote now persists `promisor` and `partialclonefilter` on it, which changes how the git binary fetches from that remote afterwards. That is what git itself does, and an anonymous URL fetch records nothing, but it is a behaviour change for anyone who used `Filter` expecting it to be one-shot.
- go-git writes an empty `.promisor` where git writes the refs it sought. Cosmetic — git never reads the contents — but it is a visible difference to anyone comparing repositories byte-for-byte.

Happy to split this into smaller PRs, or to open an issue/RFC first if the new `storer` interfaces warrant that discussion.

---

*AI-assisted: Claude Opus 5 was used for implementation and test authoring, disclosed per [AI_POLICY.md](https://github.com/go-git/go-git/blob/main/AI_POLICY.md) with `Assisted-by:` trailers on each commit. I have reviewed and can explain every change; the behavioural claims above are each backed by a reproduction against the git binary.*
