### PR TITLE
plumbing: format/gitignore, Explain oracle disagreements Git 2.52 fixed

### DIFF
--- a/plumbing/format/gitignore/conformance_test.go
+++ b/plumbing/format/gitignore/conformance_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -186,8 +187,8 @@ func (s *ConformanceSuite) testMatch(pattern, text string, expected bool, desc s
 
 	if gitGot, ok := s.gitOracle([]string{pattern}, text, isDir); ok {
 		s.Equal(expected, gitGot,
-			"oracle disagrees with expectation: pattern=%q text=%q expected=%v git=%v (%s)",
-			pattern, text, expected, gitGot, desc)
+			"oracle disagrees with expectation: pattern=%q text=%q expected=%v git=%v (%s)%s",
+			pattern, text, expected, gitGot, desc, oracleVersionHint([]string{pattern}))
 	}
 }
 
@@ -217,8 +218,8 @@ func (s *ConformanceSuite) assertIgnore(m Matcher, patterns []string, path strin
 
 	if gitGot, ok := s.gitOracle(patterns, path, isDir); ok {
 		s.Equal(expected, gitGot,
-			"oracle disagrees: patterns=%v path=%q isDir=%v expected=%v git=%v (%s)",
-			patterns, path, isDir, expected, gitGot, desc)
+			"oracle disagrees: patterns=%v path=%q isDir=%v expected=%v git=%v (%s)%s",
+			patterns, path, isDir, expected, gitGot, desc, oracleVersionHint(patterns))
 	}
 }
 
@@ -999,9 +1000,34 @@ func skipOnLegacyGit(patterns []string) bool {
 	return false
 }
 
+// oracleVersionHint returns a note to append when the oracle disagrees about
+// patterns that a Git older than 2.52.0 is known to get wrong, so the reader is
+// pointed at their binary instead of reading the failure as a go-git bug.
+//
+// match_pathname pre-computed a pattern's leading non-wildcard characters and
+// handed only the remainder to fnmatch, which read that remainder as the start
+// of the path: with "foo" cut away, `foo**/bar` compared `**/bar` against
+// `bar`, and `**/` matches zero directories, so `foobar` wrongly matched. Fixed
+// by git 1940a02dc1 ("match_pathname(): give fnmatch one char of prefix
+// context"), released in 2.52.0.
+//
+// Only the message changes. The comparison still runs and still fails, because
+// a disagreement is worth seeing either way: the same shape is separately
+// mishandled by Git 2.11.0, and silencing it would hide a real regression in
+// go-git's own matcher just as effectively.
+func oracleVersionHint(patterns []string) string {
+	if !slices.ContainsFunc(patterns, hasNonSlashAdjacentDoubleStar) {
+		return ""
+	}
+	return "\nnote: `**` beside a non-slash character was mishandled by Git before" +
+		" 2.52.0 (fixed by 1940a02dc1) and is mishandled differently by 2.11.0." +
+		" Check the Git this ran against, which `make test` prints; -short" +
+		" disables the oracle."
+}
+
 // hasNonSlashAdjacentDoubleStar reports whether p contains a `**` whose
 // neighbour on either side is a non-slash character. The form Git 2.11.0
-// mishandles.
+// mishandles, and the form Git mishandles differently before 2.52.0.
 func hasNonSlashAdjacentDoubleStar(p string) bool {
 	for i := 0; i+1 < len(p); i++ {
 		if p[i] != '*' || p[i+1] != '*' {
@@ -1014,4 +1040,25 @@ func hasNonSlashAdjacentDoubleStar(p string) bool {
 		}
 	}
 	return false
+}
+
+// TestOracleVersionHint pins the hint to the pattern shape affected by the Git
+// bugs, so an unrelated disagreement is not mislabelled as a Git version
+// problem and sent off in the wrong direction.
+func TestOracleVersionHint(t *testing.T) {
+	t.Parallel()
+
+	affected := []string{"foo**/bar", "**/bar**", "foo**bar", "**[!te]"}
+	unaffected := []string{"foo/bar", "*.txt", "**/bar", "foo/**", "a/**/b"}
+
+	for _, p := range affected {
+		if oracleVersionHint([]string{p}) == "" {
+			t.Errorf("oracleVersionHint(%q) is empty; the shape is affected and the reader needs the pointer", p)
+		}
+	}
+	for _, p := range unaffected {
+		if got := oracleVersionHint([]string{p}); got != "" {
+			t.Errorf("oracleVersionHint(%q) = %q; the shape is unaffected and must not blame the Git version", p, got)
+		}
+	}
 }


### PR DESCRIPTION
## Problem

Run the conformance suite with a git older than **2.52.0** and it fails like this, with nothing to suggest the binary is at fault:

```
--- FAIL: TestConformanceSuite/TestIgnoreDoubleStarPrefix
    oracle disagrees: patterns=[foo**/bar] path="foobar" isDir=false expected=false git=true
        (should not match foobar)
```

It reads as a go-git bug. It isn't — **go-git is right and the older oracle is wrong.** The suite's own expectation is `false`, with the note *"should not match foobar"*.

Reproducible with nothing but the binary:

```console
$ cat .gitignore
foo**/bar
$ git --version
git version 2.50.1
$ git check-ignore -v foobar
.gitignore:1:foo**/bar	foobar          # matches

$ git --version
git version 2.55.0
$ git check-ignore -v foobar
                                        # no match
```

`match_pathname()` pre-computed a pattern's leading non-wildcard characters and handed only the remainder to fnmatch, which read that remainder as the start of the path: with `foo` cut away it compared `**/bar` against `bar`, and `**/` matches zero directories, so it wrongly matched. Fixed upstream by [`1940a02dc1`](https://github.com/git/git/commit/1940a02dc1122d15706a7051ee47e73f329fb4f7) — *match_pathname(): give fnmatch one char of prefix context* (`jk/match-pathname-fix`, merged 2025-11-03), released in 2.52.0. That commit message uses this exact pattern and path as its example.

## Change

**Add the missing context to the failure message. Nothing else.**

```
oracle disagrees: patterns=[foo**/bar] path="foobar" isDir=false expected=false git=true
    (should not match foobar)
note: `**` beside a non-slash character was mishandled by Git before 2.52.0
    (fixed by 1940a02dc1) and is mishandled differently by 2.11.0. Check the Git
    this ran against, which `make test` prints; -short disables the oracle.
```

The note is attached only to the pattern shape the Git bugs affect, reusing the existing `hasNonSlashAdjacentDoubleStar` predicate, so an unrelated disagreement is never mislabelled as a version problem and sent off in the wrong direction.

### Why not skip the comparison

I first wrote this as a guard that skipped the affected comparisons — first version-gated, then probing the binary. Both were the wrong shape for this repo, and I've dropped them:

- The suite's contract is **explicit, pinned Git versions**. `git.yml` builds git at `master` and at `v2.11.0` and keys the existing legacy guard to that pin; `make test` prints `running against $(git version)`. Adapting behaviour to whatever unpinned binary happens to be installed cuts against that grain.
- **Both workflows are green on `main` today**, pinned and unpinned alike, so there is no failing CI to fix. The gap is a released version between the two matrix points — which is what contributors and distributions actually run — and it closes on its own as 2.52+ spreads.
- A skip is the more dangerous option. The same pattern shape is *separately* mishandled by 2.11.0, and these are the only cases exercising it, so silencing them locally would hide a genuine regression in go-git's own matcher exactly as well as it hides Git's.

So the comparison still runs and still fails. Only the explanation is new.

## Testing

`TestOracleVersionHint` pins the note to the affected shape (`foo**/bar`, `**/bar**`, `foo**bar`, `**[!te]`) and asserts it stays absent for unaffected patterns (`foo/bar`, `*.txt`, `**/bar`, `foo/**`, `a/**/b`), so it cannot start blaming the Git version for unrelated failures.

Verified by hand against three binaries, two of them built from source:

| git | behaviour |
| --- | --- |
| 2.55.0 (built from `master`) | agrees with go-git; suite `ok`, note never appears |
| 2.50.1 | disagrees; same failure as before, now carrying the note |
| 2.11.0 (built from source) + `GIT_VERSION=v2.11.0` | existing legacy guard skips the comparison; unchanged |

`golangci-lint` clean. Test-only change, one file, no library code and no change in which assertions run.

---

*AI-assisted: Claude Opus 5, disclosed per [AI_POLICY.md](https://github.com/go-git/go-git/blob/main/AI_POLICY.md) with an `Assisted-by:` trailer. Every claim above is backed by a reproduction against the git binary.*
