### PR TITLE
transport: don't report an empty remote for prefix-narrowed ls-refs

### DIFF
--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -86,7 +86,7 @@ func lsRefsSupportsUnborn(server capability.List) bool {
 // branch, and requests unborn HEAD reporting when the server advertises it. The
 // returned references include a symbolic HEAD (and an unborn HEAD as a symref
 // whose target has no hash reference) so callers can detect an unborn branch.
-func LsRefs(ctx context.Context, cmd CommandFunc, server capability.List, refPrefixes []string) ([]*plumbing.Reference, error) {
+func LsRefs(ctx context.Context, cmd CommandFunc, server capability.List, refPrefixes []string) (*packp.LsRefsOutput, error) {
 	args := &packp.LsRefsArgs{
 		Peel:        true,
 		Symrefs:     true,
@@ -99,20 +99,7 @@ func LsRefs(ctx context.Context, cmd CommandFunc, server capability.List, refPre
 		return nil, err
 	}
 
-	return out.References, nil
-}
-
-// HasHashRef reports whether refs contains at least one hash (non-symbolic)
-// reference. A v2 ls-refs result with only a symbolic or unborn HEAD and no
-// hash references corresponds to an empty repository, so callers treat the
-// absence of hash references the same as the v0/v1 empty advertisement.
-func HasHashRef(refs []*plumbing.Reference) bool {
-	for _, r := range refs {
-		if r.Type() == plumbing.HashReference {
-			return true
-		}
-	}
-	return false
+	return out, nil
 }
 
 // wantsLocal reports whether every wanted object is already present in haves, so

--- a/plumbing/protocol/packp/fuzz_test.go
+++ b/plumbing/protocol/packp/fuzz_test.go
@@ -191,6 +191,6 @@ func FuzzParseLsRefsLine(f *testing.F) {
 	f.Add("")
 
 	f.Fuzz(func(_ *testing.T, line string) {
-		_, _ = parseLsRefsLine(line)
+		_, _, _ = parseLsRefsLine(line)
 	})
 }

--- a/plumbing/protocol/packp/lsrefs.go
+++ b/plumbing/protocol/packp/lsrefs.go
@@ -137,6 +137,11 @@ func (r *LsRefsArgs) Decode(rd io.Reader) error {
 // consumed by the transport layer and not seen by Decode.
 type LsRefsOutput struct {
 	References []*plumbing.Reference
+	// HasOid reports whether any ref line carried an object id. A line with
+	// "unborn" as the oid does not count. This lets callers distinguish an
+	// empty repository from a ref-prefix-narrowed advertisement that simply
+	// matched nothing except a symbolic HEAD.
+	HasOid bool
 }
 
 // Encode writes the ls-refs response lines as pkt-lines following the v2
@@ -205,26 +210,28 @@ func (r *LsRefsOutput) Decode(rd io.Reader) error {
 			continue
 		}
 
-		refs, err := parseLsRefsLine(line)
+		refs, hasOid, err := parseLsRefsLine(line)
 		if err != nil {
 			return err
 		}
 		r.References = append(r.References, refs...)
+		r.HasOid = r.HasOid || hasOid
 	}
 }
 
 // parseLsRefsLine parses a single ref line from ls-refs output.
 // Format: <oid-or-unborn> SP <refname> [SP <attr>...] LF
 // Returns one or two references (base + peeled if the peeled attribute is present).
-func parseLsRefsLine(line string) ([]*plumbing.Reference, error) {
+func parseLsRefsLine(line string) ([]*plumbing.Reference, bool, error) {
 	// Fields tolerates the SP-separated grammar without producing empty tokens
 	// on repeated spaces: [oid-or-unborn, refname, attr1, attr2, ...].
 	parts := strings.Fields(line)
 	if len(parts) < 2 {
-		return nil, fmt.Errorf("malformed ref line: %q", line)
+		return nil, false, fmt.Errorf("malformed ref line: %q", line)
 	}
 
 	oidStr := parts[0]
+	hasOid := oidStr != "unborn"
 	refName := plumbing.ReferenceName(parts[1])
 
 	var symrefTarget plumbing.ReferenceName
@@ -237,7 +244,7 @@ func parseLsRefsLine(line string) ([]*plumbing.Reference, error) {
 		} else if strings.HasPrefix(attr, "peeled:") {
 			h, ok := parseFullHash(attr[len("peeled:"):])
 			if !ok {
-				return nil, fmt.Errorf("malformed peeled hash: %q", attr)
+				return nil, false, fmt.Errorf("malformed peeled hash: %q", attr)
 			}
 			peeledHash = h
 			hasPeeled = true
@@ -249,16 +256,16 @@ func parseLsRefsLine(line string) ([]*plumbing.Reference, error) {
 	// Handle unborn refs
 	if oidStr == "unborn" {
 		if symrefTarget == "" {
-			return nil, fmt.Errorf("malformed unborn ref line, missing symref-target: %q", line)
+			return nil, false, fmt.Errorf("malformed unborn ref line, missing symref-target: %q", line)
 		}
 		refs = append(refs, plumbing.NewSymbolicReference(refName, symrefTarget))
-		return refs, nil
+		return refs, false, nil
 	}
 
 	// Regular hash ref
 	hash, ok := parseFullHash(oidStr)
 	if !ok {
-		return nil, fmt.Errorf("malformed object id: %q", oidStr)
+		return nil, false, fmt.Errorf("malformed object id: %q", oidStr)
 	}
 
 	if symrefTarget != "" {
@@ -275,7 +282,7 @@ func parseLsRefsLine(line string) ([]*plumbing.Reference, error) {
 		))
 	}
 
-	return refs, nil
+	return refs, hasOid, nil
 }
 
 // parseFullHash strictly parses a full-length SHA-1 or SHA-256 object id in hex

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -245,14 +245,14 @@ func (s *smartPackSession) GetRemoteRefs(ctx context.Context, opts *transport.Ge
 		if opts != nil {
 			prefixes = opts.RefPrefixes
 		}
-		refs, err := internal.LsRefs(ctx, s.Command, s.caps, prefixes)
+		out, err := internal.LsRefs(ctx, s.Command, s.caps, prefixes)
 		if err != nil {
 			return nil, err
 		}
-		if !forPush && !internal.HasHashRef(refs) {
+		if !forPush && !out.HasOid {
 			return nil, transport.ErrEmptyRemoteRepository
 		}
-		return transport.NewRemoteRefs(refs), nil
+		return transport.NewRemoteRefs(out.References), nil
 	}
 
 	if s.refs == nil {

--- a/plumbing/transport/pack_stream.go
+++ b/plumbing/transport/pack_stream.go
@@ -112,14 +112,14 @@ func (s *StreamSession) GetRemoteRefs(ctx context.Context, opts *GetRemoteRefsOp
 		if opts != nil {
 			prefixes = opts.RefPrefixes
 		}
-		refs, err := internal.LsRefs(ctx, s.Command, s.caps, prefixes)
+		out, err := internal.LsRefs(ctx, s.Command, s.caps, prefixes)
 		if err != nil {
 			return nil, err
 		}
-		if !forPush && !internal.HasHashRef(refs) {
+		if !forPush && !out.HasOid {
 			return nil, ErrEmptyRemoteRepository
 		}
-		return NewRemoteRefs(refs), nil
+		return NewRemoteRefs(out.References), nil
 	}
 
 	if s.refs == nil {

--- a/plumbing/transport/v2_lsrefs_test.go
+++ b/plumbing/transport/v2_lsrefs_test.go
@@ -181,3 +181,91 @@ func TestV2GetRemoteRefsUnbornOnlyIsEmpty(t *testing.T) {
 	_, err := s.GetRemoteRefs(context.TODO(), nil)
 	require.ErrorIs(t, err, ErrEmptyRemoteRepository)
 }
+
+func TestV2GetRemoteRefsPrefixedSymrefHeadOnlyIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	const headHash = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+
+	serve := func(serverConn net.Conn) (err error) {
+		defer func() { _ = serverConn.Close() }()
+
+		w := serverConn
+		for _, line := range []string{
+			"version 2\n",
+			"agent=test\n",
+			"ls-refs=unborn\n",
+			"object-format=sha1\n",
+		} {
+			if _, err := pktline.WriteString(w, line); err != nil {
+				return err
+			}
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return err
+		}
+
+		req := &packp.CommandRequest{Args: &packp.LsRefsArgs{}}
+		if err := req.Decode(bufio.NewReader(serverConn)); err != nil {
+			return err
+		}
+
+		// A populated repository whose branch is not among the requested
+		// ref-prefixes: only HEAD is returned, still carrying the resolved
+		// object id. This is not an empty repository.
+		if _, err := pktline.Writef(w, "%s HEAD symref-target:refs/heads/main\n", headHash); err != nil {
+			return err
+		}
+		return pktline.WriteFlush(w)
+	}
+
+	s := newV2Session(t, serve)
+	rr, err := s.GetRemoteRefs(context.TODO(), &GetRemoteRefsOptions{
+		RefPrefixes: []string{"refs/heads/no-such-branch", "HEAD"},
+	})
+	require.NoError(t, err)
+	require.Len(t, rr.References, 1)
+	require.Equal(t, plumbing.HEAD, rr.References[0].Name())
+	require.Equal(t, plumbing.SymbolicReference, rr.References[0].Type())
+}
+
+func TestV2GetRemoteRefsPrefixedUnbornHeadIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	serve := func(serverConn net.Conn) (err error) {
+		defer func() { _ = serverConn.Close() }()
+
+		w := serverConn
+		for _, line := range []string{
+			"version 2\n",
+			"agent=test\n",
+			"ls-refs=unborn\n",
+			"object-format=sha1\n",
+		} {
+			if _, err := pktline.WriteString(w, line); err != nil {
+				return err
+			}
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return err
+		}
+
+		req := &packp.CommandRequest{Args: &packp.LsRefsArgs{}}
+		if err := req.Decode(bufio.NewReader(serverConn)); err != nil {
+			return err
+		}
+
+		// A genuinely empty repository: even when filtered by ref-prefixes,
+		// only an unborn HEAD comes back.
+		if _, err := pktline.WriteString(w, "unborn HEAD symref-target:refs/heads/main\n"); err != nil {
+			return err
+		}
+		return pktline.WriteFlush(w)
+	}
+
+	s := newV2Session(t, serve)
+	_, err := s.GetRemoteRefs(context.TODO(), &GetRemoteRefsOptions{
+		RefPrefixes: []string{"refs/heads/no-such-branch", "HEAD"},
+	})
+	require.ErrorIs(t, err, ErrEmptyRemoteRepository)
+}

--- a/repository_test.go
+++ b/repository_test.go
@@ -648,6 +648,32 @@ func TestPlainCloneContext_EmptyRemoteReturnsError(t *testing.T) {
 	require.ErrorIs(t, err, transport.ErrEmptyRemoteRepository)
 }
 
+func TestPlainCloneContext_SingleBranchMissingRefIsNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	// A populated remote: one commit on the default branch.
+	src := t.TempDir()
+	repo, err := PlainInit(src, false)
+	require.NoError(t, err)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(src, "a.txt"), []byte("hi"), 0o600))
+	_, err = wt.Add("a.txt")
+	require.NoError(t, err)
+	sig := &object.Signature{Name: "t", Email: "t@example.com", When: time.Now()}
+	_, err = wt.Commit("init", &CommitOptions{Author: sig, Committer: sig})
+	require.NoError(t, err)
+
+	dest := t.TempDir()
+	_, err = PlainCloneContext(context.Background(), dest, &CloneOptions{
+		URL:           "file://" + src,
+		ReferenceName: plumbing.NewBranchReferenceName("no-such-branch"),
+		SingleBranch:  true,
+	})
+	require.ErrorIs(t, err, ErrRemoteRefNotFound)
+	require.NotErrorIs(t, err, transport.ErrEmptyRemoteRepository)
+}
+
 // TestPlainCloneContext_EmptyRemoteDoesNotCleanup verifies that cloning an
 // empty remote repository with AllowEmptyRepo does not remove the directory.
 func TestPlainCloneContext_EmptyRemoteDoesNotCleanup(t *testing.T) {


### PR DESCRIPTION
## What

Single-branch clones of a non-existent branch (`SingleBranch: true` + `ReferenceName` that does not exist on the remote) fail with `transport.ErrEmptyRemoteRepository` ("remote repository is empty") even when the remote has commits. Before v6.0.0-alpha.5 the same case returned `git.ErrRemoteRefNotFound`.

## Why

Since `config.DefaultProtocolVersion` is v2, ref discovery goes through `ls-refs`. `fetchRefPrefixes` narrows the request with `ref-prefix` values derived from the fetch refspecs (plus `HEAD`). For a single-branch clone of a missing branch, the only prefix that matches anything is `HEAD`, and the server returns a symbolic `HEAD` carrying the resolved object id. The decoder converts that line to a symbolic reference and discards the oid, so `HasHashRef` sees no hash references and `StreamSession.GetRemoteRefs` (and the HTTP `smartPackSession`) treat the result as an empty repository.

A v0/v1 empty advertisement has no references at all; with v2 that corresponds to a result containing only an **unborn** HEAD. A symbolic HEAD with an oid proves the repository has commits, so the "no hash refs ⇒ empty" heuristic only holds for an unfiltered advertisement.

## Changes

- `plumbing/protocol/packp/lsrefs.go`: `LsRefsOutput` gains a `HasOid` field, set by the decoder whenever a ref line carries an object id (`unborn` lines do not).
- `internal/transport/v2.go`: `LsRefs` returns the `LsRefsOutput` so callers can see `HasOid`; removes the now-misleading `HasHashRef` helper.
- `plumbing/transport/pack_stream.go` and `plumbing/transport/http/handshake.go`: use `!out.HasOid` as the empty-repository signal.
- Tests: session-level tests for the prefix-narrowed symref-HEAD case (not empty) and the unborn-HEAD case (still empty), plus an end-to-end `PlainCloneContext` test asserting a single-branch clone of a missing branch returns `ErrRemoteRefNotFound` and not `ErrEmptyRemoteRepository`.

## Verification

- `go test ./plumbing/transport/ ./plumbing/protocol/packp/ ./internal/transport/ . -run ...` (targeted regression tests pass)
- `go test ./plumbing/transport/ ./plumbing/protocol/packp/ ./internal/transport/`
- `golangci-lint run` on the changed packages: 0 issues

Behavior now matches `git clone --single-branch --branch no-such-branch`: the missing branch is reported instead of an empty repository.

Fixes #2314