### PR TITLE
plumbing: format/gitignore, Backtrack non-trailing ** expansions. Fixes #2317

### DIFF
--- a/plumbing/format/gitignore/conformance_test.go
+++ b/plumbing/format/gitignore/conformance_test.go
@@ -765,6 +765,52 @@ func (s *ConformanceSuite) TestIgnoreDoubleStarPrefix() {
 	}
 }
 
+// TestIgnoreDoubleStarBacktracking verifies that a non-trailing ** retries
+// later expansions when the component first matching the next segment
+// dead-ends further down the pattern — **/a/b must match a/x/a/b even though
+// the leading a/x does not complete the match.
+func (s *ConformanceSuite) TestIgnoreDoubleStarBacktracking() {
+	patterns := []string{"**/a/b"}
+	m := s.createMatcher(patterns)
+
+	tests := []struct {
+		path    string
+		ignored bool
+		desc    string
+	}{
+		{"a/b", true, "zero directories before the segment"},
+		{"a/x/a/b", true, "retry after the leading a dead-ends"},
+		{"z/a/x/a/b", true, "retry below an unrelated prefix"},
+		{"a/x/b", false, "no expansion completes the pattern"},
+		{"a/x/a/c", false, "tail segment differs at every candidate"},
+	}
+	for _, tt := range tests {
+		s.assertIgnore(m, patterns, tt.path, false, tt.ignored, tt.desc)
+	}
+}
+
+// TestIgnoreDoubleStarMiddleBacktracking exercises the same retry for a **
+// between literal segments, where the segment after ** also names a component
+// that appears before the real match.
+func (s *ConformanceSuite) TestIgnoreDoubleStarMiddleBacktracking() {
+	patterns := []string{"a/**/b/c"}
+	m := s.createMatcher(patterns)
+
+	tests := []struct {
+		path    string
+		ignored bool
+		desc    string
+	}{
+		{"a/b/c", true, "zero directories consumed by **"},
+		{"a/b/x/b/c", true, "retry after the first b dead-ends"},
+		{"a/b/b/c", true, "adjacent duplicate segment"},
+		{"a/b/x/c", false, "no b directly above c"},
+	}
+	for _, tt := range tests {
+		s.assertIgnore(m, patterns, tt.path, false, tt.ignored, tt.desc)
+	}
+}
+
 // TestIgnoreTrailingWhitespace verifies t0008's rule that unescaped trailing
 // whitespace in a pattern is stripped.
 func (s *ConformanceSuite) TestIgnoreTrailingWhitespace() {

--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -87,7 +87,7 @@ func (p *pattern) Match(path []string, isDir bool) MatchResult {
 	}
 
 	path = path[len(p.domain):]
-	if p.isGlob && !p.globMatch(path, isDir) {
+	if p.isGlob && !p.globMatch(p.pattern, path, isDir) {
 		return NoMatch
 	} else if !p.isGlob && !p.simpleNameMatch(path, isDir) {
 		return NoMatch
@@ -491,17 +491,17 @@ func (p *pattern) simpleNameMatch(path []string, isDir bool) bool {
 	return false
 }
 
-func (p *pattern) globMatch(path []string, isDir bool) bool {
+func (p *pattern) globMatch(segs, path []string, isDir bool) bool {
 	matched := false
 	canTraverse := false
 	trailingStar := false
-	for i, pattern := range p.pattern {
+	for i, pattern := range segs {
 		if pattern == "" {
 			canTraverse = false
 			continue
 		}
 		if pattern == zeroToManyDirs {
-			if i == len(p.pattern)-1 {
+			if i == len(segs)-1 {
 				// A trailing `**` matches the entries below whatever the
 				// earlier segments consumed, so it needs either a remaining
 				// component or a directory candidate standing in for them.
@@ -521,33 +521,31 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 			return false
 		}
 		if canTraverse {
-			canTraverse = false
-			for len(path) > 0 {
-				e := path[0]
-				path = path[1:]
-				if wildmatch(pattern, e) {
-					matched = true
-					break
-				}
-				if len(path) == 0 {
-					// A `**` that never finds the segment following it is a
-					// definitive non-match. Returning here rather than
-					// clearing matched keeps a trailing `**` from reviving
-					// the pattern once the path is exhausted, which would
-					// make `**/bar/**` match directories containing no bar.
-					return false
+			// A non-trailing `**` matches zero or more components. Locking
+			// onto the first component that matches the next segment is not
+			// enough: with `**/a/b` against a/x/a/b the leading "a"
+			// dead-ends, and only retrying from the later "a" completes the
+			// match. Recurse for every candidate expansion instead.
+			for j := range path {
+				if p.globMatch(segs[i:], path[j:], isDir) {
+					return true
 				}
 			}
-		} else {
-			if !wildmatch(pattern, path[0]) {
-				return false
-			}
-			matched = true
-			path = path[1:]
-			// files matching dir globs, don't match
-			if len(path) == 0 && i < len(p.pattern)-1 {
-				matched = false
-			}
+			// A `**` that never finds the segment following it is a
+			// definitive non-match. Returning here rather than clearing
+			// matched keeps a trailing `**` from reviving the pattern once
+			// the path is exhausted, which would make `**/bar/**` match
+			// directories containing no bar.
+			return false
+		}
+		if !wildmatch(pattern, path[0]) {
+			return false
+		}
+		matched = true
+		path = path[1:]
+		// files matching dir globs, don't match
+		if len(path) == 0 && i < len(segs)-1 {
+			matched = false
 		}
 	}
 	// Check dirOnly: either we consumed all path (len(path) == 0) or we matched a trailing **


### PR DESCRIPTION
Fixes #2317

### What

In `plumbing/format/gitignore`, `globMatch` handled a non-trailing `**` by locking onto the **first** path component that matched the following segment. When a later segment then failed, the whole match was rejected without retrying the remaining candidates, so patterns like `**/a/b` did not match `a/x/a/b` (or `**/node_modules/lodash` vs `web/node_modules/x/node_modules/lodash`) even though `git check-ignore` ignores them.

This PR threads the segment slice through `globMatch` and, at a non-trailing `**`, recurses over every candidate expansion instead of committing to the first one. All other behaviour is preserved line-for-line: empty segments still reset traversal, a trailing `**` still requires a remaining component or a directory endpoint (#2278), the "files matching dir globs don't match" rule and the final `dirOnly` check are untouched.

### Why this shape

`**` is documented as matching *zero or more directories* (gitignore(5)), i.e. an existential choice — a correct matcher must be able to retry longer expansions when a shorter one dead-ends. Canonical git implements this with recursion in [`wildmatch.c`](https://github.com/git/git/blob/v2.54.0/wildmatch.c) (the `**` branch of `dowild` tries the remainder at every position). Recursing on the existing segment matcher is the minimal equivalent here and keeps the subtle semantics that previous fixes (#2278, #154) encoded in this function.

The new conformance cases run against the `git check-ignore` oracle like the rest of the suite. These patterns keep `**` in the documented positions, so they are unaffected by the pre-2.52 wildmatch corner case the suite already guards against.

### Verification against real git

```console
$ git init -q repro && cd repro
$ echo '**/a/b' > .gitignore
$ git check-ignore -v a/x/a/b
.gitignore:1:**/a/b	a/x/a/b        # ignored (git 2.48.1; same on 2.39.5)
```

go-git on `main` returns no match for the same input; with this fix it matches.

### Tests

Regression tests fail on `main` before the fix and pass with it:

```console
$ go test -run 'TestConformanceSuite/(TestIgnoreDoubleStarBacktracking|TestIgnoreDoubleStarMiddleBacktracking)' -v ./plumbing/format/gitignore/
--- PASS: TestConformanceSuite (0.45s)
    --- PASS: TestConformanceSuite/TestIgnoreDoubleStarBacktracking (0.27s)
    --- PASS: TestConformanceSuite/TestIgnoreDoubleStarMiddleBacktracking (0.17s)

# before the fix (pattern.go stashed):
    --- FAIL: TestConformanceSuite/TestIgnoreDoubleStarBacktracking
    --- FAIL: TestConformanceSuite/TestIgnoreDoubleStarMiddleBacktracking
```

Full run: `go test -short ./...` passes on darwin/arm64 with Go 1.26.5, except three tests that need network access to `github.com/git-fixtures` and hit a transient TLS timeout; all three passed on a re-run (`TestFetchByHashThenResolveRevision`, `TestWorktreeSuite/TestCheckoutRelativePathSubmoduleInitialized`, `TestRepositorySuite/TestCloneMirror`). Not run: `plumbing/transport/git` (requires a local `git daemon`, per AGENTS.md). `go vet` and `gofmt` are clean. The full (non-`-short`) gitignore conformance suite passes against the git 2.52+ oracle expectations; on this machine's older git the pre-existing `TestIgnoreDoubleStarPrefix` oracle note applies, unrelated to this change.

### Disclosure

This contribution was produced with AI assistance (Claude Fable 5, via Cursor); the commit carries an `Assisted-by:` trailer per AI_POLICY.md. I reproduced the bug locally, verified the behaviour against the reference git implementation, and reviewed every line.
