### PR TITLE
plumbing: add radicle transport, read-only

### DIFF
--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -40,9 +40,9 @@ New filesystems (e.g. cloud based storage) could be created by implementing `go-
 
 ## Transport Schemes
 
-Git supports various transport schemes, including `http`, `https`, `ssh`, `git`, `file`. `go-git` defines the [transport.Transport interface](plumbing/transport/common.go#L48) to represent them.
+Git supports various transport schemes, including `http`, `https`, `ssh`, `git`, `file`. `go-git` defines the [transport.Transport interface](plumbing/transport/pack_session.go#L31) to represent them.
 
-The built-in implementations can be replaced by calling `transport.Register`.
+There is no global registry: transports are resolved per operation by a [`client.Client`](plumbing/client/client.go), built with `client.New(opts...)`. By default it resolves `file`, `git`, `ssh`, `http` and `https` to their built-in implementations. Built-in transports can be overridden, and new schemes added, with `client.WithTransport(scheme, tr)`, passed via `ClientOptions` on the operation (`CloneOptions`, `FetchOptions`, `PushOptions`, ...).
 
 An example of changing the built-in `https` implementation to skip TLS could look like this:
 
@@ -53,7 +53,23 @@ An example of changing the built-in `https` implementation to skip TLS could loo
 		},
 	}
 
-	transport.Register("https", githttp.NewTransport(&githttp.TransportOptions{Client: customClient}))
+	r, err := git.PlainClone(dir, &git.CloneOptions{
+		URL: "https://github.com/go-git/go-git",
+		ClientOptions: []client.Option{
+			client.WithTransport("https", githttp.NewTransport(githttp.Options{Client: customClient})),
+		},
+	})
+```
+
+The same mechanism registers an entirely new scheme. `plumbing/transport/rad` implements a read-only `rad://` transport for local [Radicle](https://radicle.xyz/) repository storage, by composing the built-in `file` transport with a custom `transport.Loader`. It is not one of the client's built-in schemes — Radicle-specific URL conventions don't belong in go-git core — so it is opted into the same way any external transport would be:
+
+```go
+	r, err := git.PlainClone(dir, &git.CloneOptions{
+		URL: "rad://z2cK19PnX6cAUgnZfMfwECBNppJ6z",
+		ClientOptions: []client.Option{
+			client.WithTransport("rad", rad.NewTransport(rad.Options{})),
+		},
+	})
 ```
 
 Some internal implementations enables code reuse amongst the different transport implementations. Some of these may be made public in the future (e.g. `plumbing/transport/internal/common`).

--- a/plumbing/transport/rad/doc.go
+++ b/plumbing/transport/rad/doc.go
@@ -1,0 +1,101 @@
+// Package rad implements a read-only rad:// transport for Radicle
+// (https://radicle.xyz/) repositories stored on the local machine.
+//
+// # URL form
+//
+// A rad URL is rad://<rid>[/<nid>]. It has a host and at most one path
+// segment, matching heartwood's Url::from_str:
+//
+//   - rid is the Radicle repository id in canonical form, for example
+//     "z2cK19PnX6cAUgnZfMfwECBNppJ6z". It selects the storage repository at
+//     $RAD_HOME/storage/<rid>.
+//   - nid, if present, is a Radicle node id, that is, a peer's public key.
+//     For example "z6Mkmywxg7Z7e63rkLTx7UJZeH69DLZ9KvhdQEPJ6N9nwVde". It
+//     selects that peer's namespaced refs (refs/namespaces/<nid>/*) instead
+//     of the repository's canonical refs.
+//
+// $RAD_HOME defaults to $HOME/.radicle, or $USERPROFILE/.radicle on
+// Windows. This matches radicle::profile::home(). Set Options.Home to point
+// at a different location, for example in tests.
+//
+// # What is served
+//
+// Without a namespace, the transport advertises the repository's canonical
+// references: HEAD, refs/heads/* and refs/tags/*. It hides refs/rad/*,
+// which holds Radicle's identity document and per-peer signed refs, and
+// refs/namespaces/*, which holds every peer's copy of their own refs.
+// Without this filter, cloning a repository with many peers would pull in
+// every namespaced ref alongside the canonical ones. Set Options.AllRefs to
+// turn the filter off and advertise everything, which is what raw
+// git-upload-pack does, and what Radicle's own libgit2 local transport
+// does. The view stays read-only either way.
+//
+// With a namespace (rad://<rid>/<nid>), the transport advertises only that
+// peer's refs. They are read from refs/namespaces/<nid>/* with the prefix
+// stripped, which is the equivalent of running git with GIT_NAMESPACE=<nid>
+// set. Radicle namespaces have no HEAD of their own, so this mode
+// advertises no HEAD. This matches git-remote-rad's list::for_fetch.
+//
+// The transport is read-only, and there is no option to change that.
+// git-receive-pack is rejected with transport.ErrCommandUnsupported, and
+// the storer passed to the pack protocol refuses reference writes on its
+// own. Pushing raw refs would leave Radicle storage inconsistent until
+// refs/rad/sigrefs is signed again with the device key, which this
+// transport does not do. Use rad or git-remote-rad to publish.
+// git-upload-archive is rejected too, because it needs a worktree-like view
+// that Radicle storage does not advertise.
+//
+// # Prerequisite: rad seed, not rad clone
+//
+// This transport only reads from local storage. It never talks to the
+// Radicle network. A repository is fetched from the network over the
+// Radicle wire protocol, which runs node to node over Noise. That is what
+// rad seed <rid> does: it updates the seeding policy and fetches the
+// repository into $RAD_HOME/storage. rad clone is rad seed followed by a
+// plain git clone of rad://, and this transport implements only that second
+// half:
+//
+//	rad seed <rid>              // policy + network fetch into local storage
+//	go-git clone rad://<rid>    // this transport, purely local
+//
+// If the repository is not in local storage yet, Load returns
+// transport.ErrRepositoryNotFound wrapped in a message naming the
+// rad seed <rid> command that fixes it.
+//
+// # Registration
+//
+// rad is not one of the client package's built-in schemes. It relies on
+// Radicle-specific conventions that do not belong in go-git core, and it
+// needs nothing beyond the standard library and go-git itself. Enable it
+// explicitly with client.WithTransport:
+//
+//	r, err := git.PlainClone(dir, &git.CloneOptions{
+//		URL: "rad://z2cK19PnX6cAUgnZfMfwECBNppJ6z",
+//		ClientOptions: []client.Option{
+//			client.WithTransport("rad", rad.NewTransport(rad.Options{})),
+//		},
+//	})
+//
+// # Known deviations from git-remote-rad
+//
+// These are follow-up work, not defects:
+//
+//   - HEAD comes from the storage repository's own HEAD file, usually
+//     "ref: refs/heads/main". It is not resolved from the identity
+//     document's default branch across delegate sigrefs. Raw
+//     git-upload-pack and Radicle's own libgit2 local transport behave the
+//     same way.
+//   - Patch refs (refs/heads/patches/<id>) are not advertised.
+//     git-remote-rad builds them from Radicle's collaborative objects
+//     (COBs).
+//   - There is no node interaction: no rad sync, no announce, no seeding,
+//     and no fetch on demand over the control socket. A fetch only sees
+//     what is already in local storage.
+//   - This is not a substitute for an HTTPS seed. Radicle seed nodes run
+//     radicle-httpd, which serves smart git over HTTP at
+//     https://<seed>/<rid>.git. go-git can already clone that with the
+//     plain http transport and no extra code, but without peer namespaces
+//     and without sigrefs verification. Pick whichever fits: this transport
+//     for local storage the Radicle node has already fetched, HTTPS for a
+//     seed you do not run yourself.
+package rad

--- a/plumbing/transport/rad/handshake.go
+++ b/plumbing/transport/rad/handshake.go
@@ -1,0 +1,23 @@
+package rad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+// Handshake performs a pack protocol handshake for req, delegating to the
+// embedded file transport. It returns transport.ErrCommandUnsupported for
+// git-receive-pack and git-upload-archive.
+func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (transport.Session, error) {
+	if unsupported(req.Command) {
+		return nil, fmt.Errorf("%w: %s", transport.ErrCommandUnsupported, req.Command)
+	}
+	return t.file.Handshake(ctx, req)
+}
+
+var (
+	_ transport.Transport = (*Transport)(nil)
+	_ transport.Connector = (*Transport)(nil)
+)

--- a/plumbing/transport/rad/integration_test.go
+++ b/plumbing/transport/rad/integration_test.go
@@ -1,0 +1,250 @@
+package rad
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/client"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// realRadicleHome returns the local Radicle home directory if it looks
+// populated (has a storage/ tree), or "" otherwise.
+func realRadicleHome(t *testing.T) string {
+	t.Helper()
+
+	home := os.Getenv("RAD_HOME")
+	if home == "" {
+		envVar := "HOME"
+		if runtime.GOOS == "windows" {
+			envVar = "USERPROFILE"
+		}
+		h := os.Getenv(envVar)
+		if h == "" {
+			return ""
+		}
+		home = filepath.Join(h, ".radicle")
+	}
+
+	if fi, err := os.Stat(filepath.Join(home, "storage")); err != nil || !fi.IsDir() {
+		return ""
+	}
+	return home
+}
+
+// anyStoredRID returns the id of any repository present in home's storage
+// tree, or "" if there is none. The fixtures here are whatever the machine
+// running the test happens to have seeded, so they are discovered rather
+// than hard-coded.
+func anyStoredRID(t *testing.T, home string) string {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join(home, "storage"))
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		if e.IsDir() {
+			return e.Name()
+		}
+	}
+	return ""
+}
+
+// namespaceWithBranches returns the node id of a peer whose namespace in rid
+// holds at least one branch, or "" if no peer does. Namespaces containing
+// only refs/rad/*, refs/cobs/* and patch refs are rejected: every one of
+// those is excluded from the ls-remote comparison, so a namespace without a
+// plain branch would compare empty against empty and assert nothing.
+func namespaceWithBranches(t *testing.T, home, rid string) string {
+	t.Helper()
+
+	out, err := exec.Command("git", "--git-dir="+filepath.Join(home, "storage", rid),
+		"for-each-ref", "--format=%(refname)", "refs/namespaces/").CombinedOutput()
+	require.NoErrorf(t, err, "git for-each-ref: %s", out)
+
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		rest, ok := strings.CutPrefix(name, "refs/namespaces/")
+		if !ok {
+			continue
+		}
+		nid, ref, ok := strings.Cut(rest, "/")
+		if !ok {
+			continue
+		}
+		branch, ok := strings.CutPrefix(ref, "refs/heads/")
+		if !ok || strings.HasPrefix(branch, "patches/") {
+			continue
+		}
+		return nid
+	}
+	return ""
+}
+
+// requireRadicleFixture skips the calling test unless this machine has a
+// populated Radicle home and the git-remote-rad helper both integration
+// tests shell out through.
+func requireRadicleFixture(t *testing.T) string {
+	t.Helper()
+
+	home := realRadicleHome(t)
+	if home == "" {
+		t.Skip("no local Radicle storage found ($RAD_HOME or $HOME/.radicle/storage); skipping integration test")
+	}
+	if _, err := exec.LookPath("git-remote-rad"); err != nil {
+		t.Skip("git-remote-rad not found in PATH; skipping integration test")
+	}
+	return home
+}
+
+// lsRemoteRefs runs `git ls-remote <url>` via the real git-remote-rad helper
+// and returns the advertised references matching refs/heads/* or
+// refs/tags/*, name -> hash.
+func lsRemoteRefs(t *testing.T, url string) map[string]string {
+	t.Helper()
+
+	out, err := exec.Command("git", "ls-remote", url).CombinedOutput()
+	require.NoErrorf(t, err, "git ls-remote %s: %s", url, out)
+
+	refs := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		require.Len(t, fields, 2, "unexpected ls-remote line: %q", line)
+		hash, name := fields[0], fields[1]
+		// refs/heads/patches/<id> is synthesized by git-remote-rad from
+		// Radicle's collaborative objects (COBs); this transport does not
+		// advertise it — see the package doc's "known deviations" section.
+		if strings.HasPrefix(name, "refs/heads/patches/") {
+			continue
+		}
+		if strings.HasPrefix(name, "refs/heads/") || strings.HasPrefix(name, "refs/tags/") {
+			refs[name] = hash
+		}
+	}
+	return refs
+}
+
+// transportRefs returns the refs/heads/* and refs/tags/* references
+// advertised by this package's transport for u, name -> hash.
+func transportRefs(t *testing.T, tr transport.Transport, u string) map[string]string {
+	t.Helper()
+
+	radURLValue := radURL(t, u)
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     radURLValue,
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	rr, err := sess.GetRemoteRefs(context.Background(), nil)
+	require.NoError(t, err)
+
+	refs := map[string]string{}
+	for _, ref := range rr.References {
+		name := ref.Name().String()
+		// See lsRemoteRefs: refs/heads/patches/<id> is excluded from this
+		// comparison since it is git-remote-rad-synthesized rather than
+		// raw storage, so it is not expected to match a raw view either
+		// way.
+		if strings.HasPrefix(name, "refs/heads/patches/") {
+			continue
+		}
+		if strings.HasPrefix(name, "refs/heads/") || strings.HasPrefix(name, "refs/tags/") {
+			refs[name] = ref.Hash().String()
+		}
+	}
+	return refs
+}
+
+// TestIntegration_MatchesGitRemoteRad ls-remotes a repository from the local
+// Radicle storage through this package's transport and through the real
+// git-remote-rad helper, and checks that refs/heads/* and refs/tags/* agree.
+// It is skipped unless a populated Radicle home ($RAD_HOME or $HOME/.radicle)
+// is present, and requires the `git` and `git-remote-rad` binaries in PATH.
+func TestIntegration_MatchesGitRemoteRad(t *testing.T) {
+	home := requireRadicleFixture(t)
+	rid := anyStoredRID(t, home)
+	if rid == "" {
+		t.Skip("local Radicle storage holds no repositories; skipping integration test")
+	}
+
+	tr := NewTransport(Options{Home: home})
+
+	t.Run("canonical", func(t *testing.T) {
+		want := lsRemoteRefs(t, "rad://"+rid)
+		require.NotEmpty(t, want, "fixture %s advertises no branches or tags, so this would assert nothing", rid)
+
+		assert.Equal(t, want, transportRefs(t, tr, "rad://"+rid))
+	})
+
+	t.Run("namespaced", func(t *testing.T) {
+		nid := namespaceWithBranches(t, home, rid)
+		if nid == "" {
+			t.Skipf("no peer namespace in %s holds a branch; skipping", rid)
+		}
+
+		want := lsRemoteRefs(t, "rad://"+rid+"/"+nid)
+		require.NotEmpty(t, want, "namespace %s advertises no branches, so this would assert nothing", nid)
+
+		assert.Equal(t, want, transportRefs(t, tr, "rad://"+rid+"/"+nid))
+	})
+}
+
+// TestIntegration_Clone clones a real local Radicle repository through
+// git.Clone using this package's transport, and checks that the cloned
+// reference points at the commit the real helper advertises for it. Skipped
+// under the same conditions as TestIntegration_MatchesGitRemoteRad.
+func TestIntegration_Clone(t *testing.T) {
+	home := requireRadicleFixture(t)
+	rid := anyStoredRID(t, home)
+	if rid == "" {
+		t.Skip("local Radicle storage holds no repositories; skipping integration test")
+	}
+
+	want := lsRemoteRefs(t, "rad://"+rid)
+
+	var branches []string
+	for name := range want {
+		if strings.HasPrefix(name, "refs/heads/") {
+			branches = append(branches, name)
+		}
+	}
+	if len(branches) == 0 {
+		t.Skipf("fixture %s has no refs/heads/* to clone", rid)
+	}
+	sort.Strings(branches)
+	target := "refs/heads/main"
+	if _, ok := want[target]; !ok {
+		target = branches[0]
+	}
+
+	repo, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
+		URL:           "rad://" + rid,
+		ReferenceName: plumbing.ReferenceName(target),
+		SingleBranch:  true,
+		ClientOptions: []client.Option{
+			client.WithTransport("rad", NewTransport(Options{Home: home})),
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	ref, err := repo.Reference(plumbing.ReferenceName(target), true)
+	require.NoError(t, err)
+	assert.Equal(t, want[target], ref.Hash().String())
+}

--- a/plumbing/transport/rad/loader.go
+++ b/plumbing/transport/rad/loader.go
@@ -1,0 +1,111 @@
+package rad
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/go-git/go-billy/v6/osfs"
+
+	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/filesystem"
+)
+
+// loader implements transport.Loader for rad:// URLs, resolving them
+// against a Radicle home directory.
+type loader struct {
+	home    string // resolved Radicle home directory
+	allRefs bool
+	err     error // set when the Radicle home could not be resolved
+}
+
+// newLoader builds a loader rooted at the Radicle home directory
+// identified by opts. Home resolution errors are deferred to the first
+// call to Load, so NewTransport itself never fails.
+func newLoader(opts Options) *loader {
+	home, err := radicleHome(opts)
+	if err != nil {
+		return &loader{err: err}
+	}
+	return &loader{home: home, allRefs: opts.AllRefs}
+}
+
+// radicleHome resolves the Radicle home directory: opts.Home if set, else
+// $RAD_HOME, else $HOME/.radicle ($USERPROFILE/.radicle on Windows) —
+// matching radicle::profile::home().
+func radicleHome(opts Options) (string, error) {
+	if opts.Home != "" {
+		return opts.Home, nil
+	}
+	if home := os.Getenv("RAD_HOME"); home != "" {
+		return home, nil
+	}
+
+	envVar := "HOME"
+	if runtime.GOOS == "windows" {
+		envVar = "USERPROFILE"
+	}
+	home := os.Getenv(envVar)
+	if home == "" {
+		return "", fmt.Errorf("rad: cannot resolve Radicle home: $RAD_HOME and $%s are both unset", envVar)
+	}
+	return filepath.Join(home, ".radicle"), nil
+}
+
+// Load resolves a rad:// URL to a reference-filtered view of the
+// repository's storage at <home>/storage/<rid>.
+func (l *loader) Load(u *url.URL) (storage.Storer, error) {
+	if l.err != nil {
+		return nil, l.err
+	}
+
+	ru, err := parseURL(u)
+	if err != nil {
+		return nil, err
+	}
+
+	st, err := l.loadRepo(ru.RID)
+	if err != nil {
+		if errors.Is(err, transport.ErrRepositoryNotFound) {
+			return nil, fmt.Errorf("%w: %s not found in local Radicle storage; fetch it first with `rad seed %s`", transport.ErrRepositoryNotFound, ru.RID, ru.RID)
+		}
+		return nil, err
+	}
+
+	if ru.NID != "" {
+		return newNamespaced(st, ru.NID), nil
+	}
+	if l.allRefs {
+		return newReadOnly(st), nil
+	}
+	return newCanonical(st), nil
+}
+
+// loadRepo resolves rid to a storage.Storer over <home>/storage/<rid>,
+// applying the same strict bare-repository check as
+// transport.NewFilesystemLoader(..., strict: true): a missing or malformed
+// "config" file surfaces as transport.ErrRepositoryNotFound.
+func (l *loader) loadRepo(rid string) (storage.Storer, error) {
+	repoPath := filepath.Join(l.home, "storage", rid)
+
+	// The filesystem is rooted directly at repoPath, rather than obtained
+	// by chrooting there from a wider root (which is how
+	// transport.NewFilesystemLoader would normally be used): billy's
+	// os.Root-backed Chroot loses the leading separator when chrooting
+	// onto an absolute path, yielding a relative root whose every lookup
+	// then resolves against the working directory. Rooting the filesystem
+	// at the final path up front sidesteps that entirely.
+	fs := osfs.New(repoPath)
+	fi, err := fs.Lstat("config")
+	if err != nil || fi.IsDir() {
+		return nil, transport.ErrRepositoryNotFound
+	}
+	return filesystem.NewStorageWithOptions(fs, cache.NewObjectLRUDefault(), filesystem.Options{}), nil
+}
+
+var _ transport.Loader = (*loader)(nil)

--- a/plumbing/transport/rad/rad.go
+++ b/plumbing/transport/rad/rad.go
@@ -1,0 +1,58 @@
+package rad
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/plumbing/transport/file"
+)
+
+// Options configures the rad transport.
+type Options struct {
+	// Home is the Radicle home directory containing the `storage/` tree.
+	// If empty, RAD_HOME is used, falling back to $HOME/.radicle
+	// ($USERPROFILE/.radicle on Windows).
+	Home string
+	// AllRefs advertises every reference in storage, including
+	// refs/rad/* and refs/namespaces/*, instead of the default
+	// canonical view (HEAD, refs/heads/*, refs/tags/*). It has no
+	// effect on namespaced URLs (rad://<rid>/<nid>), which always
+	// expose only that namespace's refs. The view stays read-only
+	// either way.
+	AllRefs bool
+}
+
+// Transport implements the rad:// protocol: read-only access to local
+// Radicle storage, by composing go-git's file transport with a Loader that
+// resolves rad://<rid>[/<nid>] to $RAD_HOME/storage/<rid> and applies a
+// reference view over it. See the package doc for URL forms and scope.
+type Transport struct {
+	file *file.Transport
+}
+
+// NewTransport creates a rad transport with the given options.
+func NewTransport(opts Options) *Transport {
+	return &Transport{
+		file: file.NewTransport(file.Options{Loader: newLoader(opts)}),
+	}
+}
+
+// unsupported reports whether cmd is rejected. git-receive-pack is refused
+// because writing raw refs into Radicle storage would leave it inconsistent
+// until refs/rad/sigrefs is re-signed with the device key, which this
+// transport does not do; git-upload-archive is refused because it needs a
+// worktree-ish view that Radicle storage does not advertise.
+func unsupported(cmd string) bool {
+	return cmd == transport.ReceivePackService || cmd == transport.UploadArchiveService
+}
+
+// Connect opens a raw connection for req, delegating to the embedded file
+// transport. It returns transport.ErrCommandUnsupported for
+// git-receive-pack and git-upload-archive.
+func (t *Transport) Connect(ctx context.Context, req *transport.Request) (transport.Conn, error) {
+	if unsupported(req.Command) {
+		return nil, fmt.Errorf("%w: %s", transport.ErrCommandUnsupported, req.Command)
+	}
+	return t.file.Connect(ctx, req)
+}

--- a/plumbing/transport/rad/rad_test.go
+++ b/plumbing/transport/rad/rad_test.go
@@ -49,10 +49,14 @@ func buildFixtureHome(t *testing.T) (home string, mainCommit plumbing.Hash) {
 	home = t.TempDir()
 	storageDir := filepath.Join(home, "storage", fakeRID)
 	require.NoError(t, os.MkdirAll(filepath.Dir(storageDir), 0o755))
-	runGit(t, "", "init", "--bare", "-b", "main", storageDir)
+	runGit(t, "", "init", "-q", "--bare", storageDir)
+	// "git init -b" needs git >= 2.28; symbolic-ref sets the initial branch
+	// on any version.
+	runGit(t, "", "--git-dir="+storageDir, "symbolic-ref", "HEAD", "refs/heads/main")
 
 	work := t.TempDir()
-	runGit(t, work, "init", "-q", "-b", "main")
+	runGit(t, work, "init", "-q")
+	runGit(t, work, "symbolic-ref", "HEAD", "refs/heads/main")
 	runGit(t, work, "config", "user.email", "rad-test@example.com")
 	runGit(t, work, "config", "user.name", "rad-test")
 	require.NoError(t, os.WriteFile(filepath.Join(work, "README.md"), []byte("hello\n"), 0o644))

--- a/plumbing/transport/rad/rad_test.go
+++ b/plumbing/transport/rad/rad_test.go
@@ -1,0 +1,300 @@
+package rad
+
+import (
+	"context"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// fakeRID and fakeNID are used to build the synthetic RAD_HOME fixture.
+// They only need to satisfy validateID's charset, not be real base58.
+const (
+	fakeRID = "zFixtureRepoIdAAAAAAAAAAAAAAAAA"
+	fakeNID = "zFixtureNodeIdBBBBBBBBBBBBBBBBB"
+)
+
+// runGit runs git with args, optionally in dir, and fails the test on error.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s: %s", strings.Join(args, " "), out)
+	return string(out)
+}
+
+// buildFixtureHome builds a synthetic RAD_HOME under t.TempDir(): a bare
+// repository at storage/<fakeRID>/ with refs/heads/main, refs/tags/v1.0.0,
+// refs/rad/sigrefs and refs/namespaces/<fakeNID>/refs/heads/main, mirroring
+// the shape of real Radicle storage. Returns the home directory and the
+// commit hash of refs/heads/main.
+func buildFixtureHome(t *testing.T) (home string, mainCommit plumbing.Hash) {
+	t.Helper()
+
+	home = t.TempDir()
+	storageDir := filepath.Join(home, "storage", fakeRID)
+	require.NoError(t, os.MkdirAll(filepath.Dir(storageDir), 0o755))
+	runGit(t, "", "init", "--bare", "-b", "main", storageDir)
+
+	work := t.TempDir()
+	runGit(t, work, "init", "-q", "-b", "main")
+	runGit(t, work, "config", "user.email", "rad-test@example.com")
+	runGit(t, work, "config", "user.name", "rad-test")
+	require.NoError(t, os.WriteFile(filepath.Join(work, "README.md"), []byte("hello\n"), 0o644))
+	runGit(t, work, "add", "README.md")
+	runGit(t, work, "commit", "-q", "-m", "initial commit")
+	runGit(t, work, "tag", "v1.0.0")
+	runGit(t, work, "remote", "add", "origin", storageDir)
+	runGit(t, work, "push", "-q", "origin", "main", "v1.0.0")
+
+	out := runGit(t, work, "rev-parse", "HEAD")
+	mainCommit = plumbing.NewHash(strings.TrimSpace(out))
+	require.False(t, mainCommit.IsZero())
+
+	// refs/rad/sigrefs is Radicle's signed-refs metadata; a stand-in value
+	// is enough since this transport never reads it.
+	runGit(t, "", "--git-dir="+storageDir, "update-ref", "refs/rad/sigrefs", mainCommit.String())
+	// The peer's own namespaced copy of refs/heads/main.
+	runGit(t, "", "--git-dir="+storageDir, "update-ref",
+		"refs/namespaces/"+fakeNID+"/refs/heads/main", mainCommit.String())
+
+	return home, mainCommit
+}
+
+func radURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
+}
+
+func TestTransport_ReceivePackRejected(t *testing.T) {
+	t.Parallel()
+
+	home, _ := buildFixtureHome(t)
+	tr := NewTransport(Options{Home: home})
+
+	_, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     radURL(t, "rad://"+fakeRID),
+		Command: transport.ReceivePackService,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+
+	_, err = tr.Connect(context.Background(), &transport.Request{
+		URL:     radURL(t, "rad://"+fakeRID),
+		Command: transport.ReceivePackService,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+}
+
+func TestTransport_UploadArchiveRejected(t *testing.T) {
+	t.Parallel()
+
+	home, _ := buildFixtureHome(t)
+	tr := NewTransport(Options{Home: home})
+
+	_, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     radURL(t, "rad://"+fakeRID),
+		Command: transport.UploadArchiveService,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+}
+
+func TestTransport_UnknownRID_NamesRadSeed(t *testing.T) {
+	t.Parallel()
+
+	home, _ := buildFixtureHome(t)
+	tr := NewTransport(Options{Home: home})
+
+	const missing = "zMissingRepoIdCCCCCCCCCCCCCCCCC"
+	_, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     radURL(t, "rad://"+missing),
+		Command: transport.UploadPackService,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrRepositoryNotFound)
+	assert.Contains(t, err.Error(), "rad seed "+missing)
+}
+
+func TestTransport_CanonicalAdvertisement(t *testing.T) {
+	t.Parallel()
+
+	home, mainCommit := buildFixtureHome(t)
+	tr := NewTransport(Options{Home: home})
+
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:      radURL(t, "rad://"+fakeRID),
+		Command:  transport.UploadPackService,
+		Protocol: protocol.V2,
+	})
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	refs, err := sess.GetRemoteRefs(context.Background(), nil)
+	require.NoError(t, err)
+
+	var names []string
+	var head bool
+	var main plumbing.Hash
+	for _, ref := range refs.References {
+		names = append(names, ref.Name().String())
+		if ref.Name() == plumbing.HEAD {
+			head = true
+		}
+		if ref.Name() == "refs/heads/main" {
+			main = ref.Hash()
+		}
+	}
+
+	assert.True(t, head, "canonical view should advertise HEAD")
+	assert.Equal(t, mainCommit, main)
+	assert.ElementsMatch(t, []string{"HEAD", "refs/heads/main", "refs/tags/v1.0.0"}, names)
+}
+
+func TestTransport_AllRefsAdvertisement(t *testing.T) {
+	t.Parallel()
+
+	home, _ := buildFixtureHome(t)
+	tr := NewTransport(Options{Home: home, AllRefs: true})
+
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:      radURL(t, "rad://"+fakeRID),
+		Command:  transport.UploadPackService,
+		Protocol: protocol.V2,
+	})
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	refs, err := sess.GetRemoteRefs(context.Background(), nil)
+	require.NoError(t, err)
+
+	var names []string
+	for _, ref := range refs.References {
+		names = append(names, ref.Name().String())
+	}
+
+	assert.Contains(t, names, "refs/rad/sigrefs")
+	assert.Contains(t, names, "refs/namespaces/"+fakeNID+"/refs/heads/main")
+}
+
+func TestTransport_NamespacedAdvertisement(t *testing.T) {
+	t.Parallel()
+
+	home, mainCommit := buildFixtureHome(t)
+	tr := NewTransport(Options{Home: home})
+
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:      radURL(t, "rad://"+fakeRID+"/"+fakeNID),
+		Command:  transport.UploadPackService,
+		Protocol: protocol.V2,
+	})
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	refs, err := sess.GetRemoteRefs(context.Background(), nil)
+	require.NoError(t, err)
+
+	var names []string
+	var head bool
+	var main plumbing.Hash
+	for _, ref := range refs.References {
+		names = append(names, ref.Name().String())
+		if ref.Name() == plumbing.HEAD {
+			head = true
+		}
+		if ref.Name() == "refs/heads/main" {
+			main = ref.Hash()
+		}
+	}
+
+	assert.False(t, head, "namespaced view must not advertise HEAD")
+	assert.Equal(t, mainCommit, main)
+	assert.ElementsMatch(t, []string{"refs/heads/main"}, names)
+}
+
+func TestTransport_FullClone(t *testing.T) {
+	t.Parallel()
+
+	home, mainCommit := buildFixtureHome(t)
+	tr := NewTransport(Options{Home: home})
+
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:      radURL(t, "rad://"+fakeRID),
+		Command:  transport.UploadPackService,
+		Protocol: protocol.V2,
+	})
+	require.NoError(t, err)
+	defer func() { _ = sess.Close() }()
+
+	st := memory.NewStorage()
+	err = sess.Fetch(context.Background(), st, &transport.FetchRequest{
+		Wants: []plumbing.Hash{mainCommit},
+	})
+	require.NoError(t, err)
+
+	obj, err := st.EncodedObject(plumbing.CommitObject, mainCommit)
+	require.NoError(t, err)
+	assert.Equal(t, mainCommit, obj.Hash())
+}
+
+func TestTransport_HomeResolution(t *testing.T) {
+	// Subtests use t.Setenv, which cannot be combined with t.Parallel
+	// anywhere in the chain.
+	home, _ := buildFixtureHome(t)
+
+	t.Run("RAD_HOME env var", func(t *testing.T) {
+		t.Setenv("RAD_HOME", home)
+		tr := NewTransport(Options{})
+		sess, err := tr.Handshake(context.Background(), &transport.Request{
+			URL:     radURL(t, "rad://"+fakeRID),
+			Command: transport.UploadPackService,
+		})
+		require.NoError(t, err)
+		_ = sess.Close()
+	})
+
+	t.Run("Options.Home takes precedence", func(t *testing.T) {
+		t.Setenv("RAD_HOME", t.TempDir()) // deliberately wrong
+		tr := NewTransport(Options{Home: home})
+		sess, err := tr.Handshake(context.Background(), &transport.Request{
+			URL:     radURL(t, "rad://"+fakeRID),
+			Command: transport.UploadPackService,
+		})
+		require.NoError(t, err)
+		_ = sess.Close()
+	})
+}
+
+func TestLoader_AllRefsViewIsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	// AllRefs skips the canonical filter, but must not hand the pack
+	// protocol a writable storer: a push into Radicle storage leaves it
+	// inconsistent until refs/rad/sigrefs is re-signed.
+	home, _ := buildFixtureHome(t)
+
+	st, err := newLoader(Options{Home: home, AllRefs: true}).Load(radURL(t, "rad://"+fakeRID))
+	require.NoError(t, err)
+	defer func() { _ = st.(io.Closer).Close() }()
+
+	err = st.SetReference(plumbing.NewHashReference("refs/heads/pushed", plumbing.ZeroHash))
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+}

--- a/plumbing/transport/rad/rad_test.go
+++ b/plumbing/transport/rad/rad_test.go
@@ -46,12 +46,16 @@ func runGit(t *testing.T, dir string, args ...string) string {
 func buildFixtureHome(t *testing.T) (home string, mainCommit plumbing.Hash) {
 	t.Helper()
 
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git CLI not found in PATH; required to build the storage fixture")
+	}
+
 	home = t.TempDir()
 	storageDir := filepath.Join(home, "storage", fakeRID)
 	require.NoError(t, os.MkdirAll(filepath.Dir(storageDir), 0o755))
 	runGit(t, "", "init", "-q", "--bare", storageDir)
-	// "git init -b" needs git >= 2.28; symbolic-ref sets the initial branch
-	// on any version.
+	// symbolic-ref rather than "git init -b", which needs git >= 2.28.
+	// Nothing else here has a version floor worth pinning.
 	runGit(t, "", "--git-dir="+storageDir, "symbolic-ref", "HEAD", "refs/heads/main")
 
 	work := t.TempDir()

--- a/plumbing/transport/rad/refview.go
+++ b/plumbing/transport/rad/refview.go
@@ -1,0 +1,186 @@
+package rad
+
+import (
+	"io"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage"
+)
+
+// readOnlyRefs disables the reference-mutating methods of an embedded
+// storage.Storer, so that view types built on top of it stay read-only
+// regardless of what the underlying storer supports.
+type readOnlyRefs struct {
+	storage.Storer
+}
+
+// newReadOnly wraps base so that its references cannot be mutated, without
+// otherwise restricting which of them are visible.
+func newReadOnly(base storage.Storer) *readOnlyRefs {
+	return &readOnlyRefs{Storer: base}
+}
+
+// Close releases the wrapped storer. storage.Storer does not embed
+// io.Closer, so a view holding one as an interface field would not satisfy
+// an io.Closer type assertion by itself — and the file transport this
+// package composes releases its storer through exactly such an assertion
+// (see file.Transport.connect). Forwarding Close here keeps that cleanup
+// path working through the views; storers that are not closeable report
+// success.
+func (r *readOnlyRefs) Close() error {
+	if c, ok := r.Storer.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// SetReference always fails: the rad transport is read-only.
+func (r *readOnlyRefs) SetReference(*plumbing.Reference) error {
+	return transport.ErrCommandUnsupported
+}
+
+// CheckAndSetReference always fails: the rad transport is read-only.
+func (r *readOnlyRefs) CheckAndSetReference(new, old *plumbing.Reference) error {
+	return transport.ErrCommandUnsupported
+}
+
+// RemoveReference always fails: the rad transport is read-only.
+func (r *readOnlyRefs) RemoveReference(plumbing.ReferenceName) error {
+	return transport.ErrCommandUnsupported
+}
+
+// canonical is a storage.Storer view exposing only the canonical references
+// of a Radicle storage repository: HEAD, refs/heads/* and refs/tags/*. It
+// hides refs/rad/* (Radicle identity and signed-refs metadata) and
+// refs/namespaces/* (every peer's copy of their refs), which raw
+// git-upload-pack would otherwise advertise wholesale. Objects, config,
+// shallow and index storage pass straight through to the wrapped storer.
+type canonical struct {
+	readOnlyRefs
+}
+
+// newCanonical wraps base to expose only its canonical references.
+func newCanonical(base storage.Storer) *canonical {
+	return &canonical{readOnlyRefs{Storer: base}}
+}
+
+// isCanonical reports whether name is one this view advertises.
+func isCanonical(name plumbing.ReferenceName) bool {
+	return name == plumbing.HEAD ||
+		strings.HasPrefix(name.String(), "refs/heads/") ||
+		strings.HasPrefix(name.String(), "refs/tags/")
+}
+
+// Reference returns the canonical reference with the given name, or
+// plumbing.ErrReferenceNotFound if name is not HEAD, refs/heads/* or
+// refs/tags/*.
+func (c *canonical) Reference(name plumbing.ReferenceName) (*plumbing.Reference, error) {
+	if !isCanonical(name) {
+		return nil, plumbing.ErrReferenceNotFound
+	}
+	return c.Storer.Reference(name)
+}
+
+// IterReferences returns an iterator over HEAD, refs/heads/* and
+// refs/tags/*, hiding refs/rad/* and refs/namespaces/*.
+func (c *canonical) IterReferences() (storer.ReferenceIter, error) {
+	it, err := c.Storer.IterReferences()
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []*plumbing.Reference
+	err = it.ForEach(func(ref *plumbing.Reference) error {
+		if isCanonical(ref.Name()) {
+			refs = append(refs, ref)
+		}
+		return nil
+	})
+	it.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return storer.NewReferenceSliceIter(refs), nil
+}
+
+// namespaced is a storage.Storer view exposing a single peer's copy of
+// their refs — refs/namespaces/<ns>/* — with the namespace prefix
+// stripped, go-git's equivalent of running git with GIT_NAMESPACE=<ns>
+// set. Radicle namespaces contain no HEAD of their own, and the root HEAD
+// is not under the namespace prefix, so this view never advertises HEAD —
+// matching git-remote-rad's list::for_fetch namespaced branch. Objects,
+// config, shallow and index storage pass straight through to the wrapped
+// storer.
+type namespaced struct {
+	readOnlyRefs
+	prefix string
+}
+
+// newNamespaced wraps base to expose refs/namespaces/<ns>/* with the
+// prefix stripped.
+func newNamespaced(base storage.Storer, ns string) *namespaced {
+	return &namespaced{readOnlyRefs{Storer: base}, "refs/namespaces/" + ns + "/"}
+}
+
+// Reference returns the namespaced reference for name, which is given
+// without the namespace prefix (e.g. "refs/heads/main").
+func (n *namespaced) Reference(name plumbing.ReferenceName) (*plumbing.Reference, error) {
+	full, err := n.Storer.Reference(plumbing.ReferenceName(n.prefix + name.String()))
+	if err != nil {
+		return nil, err
+	}
+	return n.strip(full), nil
+}
+
+// IterReferences returns an iterator over refs/namespaces/<ns>/* with the
+// namespace prefix stripped from each reference name.
+func (n *namespaced) IterReferences() (storer.ReferenceIter, error) {
+	it, err := n.Storer.IterReferences()
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []*plumbing.Reference
+	err = it.ForEach(func(ref *plumbing.Reference) error {
+		if strings.HasPrefix(ref.Name().String(), n.prefix) {
+			refs = append(refs, n.strip(ref))
+		}
+		return nil
+	})
+	it.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return storer.NewReferenceSliceIter(refs), nil
+}
+
+// strip removes the namespace prefix from ref's name (and, for a symbolic
+// reference, from its target when the target is itself namespaced).
+func (n *namespaced) strip(ref *plumbing.Reference) *plumbing.Reference {
+	name := plumbing.ReferenceName(strings.TrimPrefix(ref.Name().String(), n.prefix))
+
+	if ref.Type() == plumbing.SymbolicReference {
+		target := ref.Target()
+		target = plumbing.ReferenceName(strings.TrimPrefix(target.String(), n.prefix))
+		return plumbing.NewSymbolicReference(name, target)
+	}
+
+	return plumbing.NewHashReference(name, ref.Hash())
+}
+
+var (
+	_ storage.Storer = (*readOnlyRefs)(nil)
+	_ storage.Storer = (*canonical)(nil)
+	_ storage.Storer = (*namespaced)(nil)
+
+	// The views must stay assertable as io.Closer: the composed file
+	// transport releases its storer through that assertion.
+	_ io.Closer = (*readOnlyRefs)(nil)
+	_ io.Closer = (*canonical)(nil)
+	_ io.Closer = (*namespaced)(nil)
+)

--- a/plumbing/transport/rad/refview_test.go
+++ b/plumbing/transport/rad/refview_test.go
@@ -1,0 +1,212 @@
+package rad
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+func fixtureStorer(t *testing.T) *memory.Storage {
+	t.Helper()
+
+	st := memory.NewStorage()
+	commit := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+
+	refs := []*plumbing.Reference{
+		plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main"),
+		plumbing.NewHashReference("refs/heads/main", commit),
+		plumbing.NewHashReference("refs/tags/v1.0.0", commit),
+		plumbing.NewHashReference("refs/rad/sigrefs", commit),
+		plumbing.NewHashReference("refs/rad/id", commit),
+		plumbing.NewHashReference("refs/namespaces/nid1/refs/heads/main", commit),
+		plumbing.NewHashReference("refs/namespaces/nid1/refs/tags/v1.0.0", commit),
+	}
+	for _, ref := range refs {
+		require.NoError(t, st.SetReference(ref))
+	}
+	return st
+}
+
+func TestCanonical_IterReferences(t *testing.T) {
+	t.Parallel()
+
+	base := fixtureStorer(t)
+	c := newCanonical(base)
+
+	it, err := c.IterReferences()
+	require.NoError(t, err)
+
+	var names []string
+	for {
+		ref, err := it.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, ref.Name().String())
+	}
+	it.Close()
+
+	assert.ElementsMatch(t, []string{"HEAD", "refs/heads/main", "refs/tags/v1.0.0"}, names)
+}
+
+func TestCanonical_Reference(t *testing.T) {
+	t.Parallel()
+
+	base := fixtureStorer(t)
+	c := newCanonical(base)
+
+	ref, err := c.Reference(plumbing.HEAD)
+	require.NoError(t, err)
+	assert.Equal(t, plumbing.ReferenceName("refs/heads/main"), ref.Target())
+
+	ref, err = c.Reference("refs/heads/main")
+	require.NoError(t, err)
+	assert.False(t, ref.Hash().IsZero())
+
+	_, err = c.Reference("refs/rad/sigrefs")
+	assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+
+	_, err = c.Reference("refs/namespaces/nid1/refs/heads/main")
+	assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+}
+
+func TestCanonical_ReadOnly(t *testing.T) {
+	t.Parallel()
+
+	c := newCanonical(fixtureStorer(t))
+
+	err := c.SetReference(plumbing.NewHashReference("refs/heads/other", plumbing.ZeroHash))
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+
+	err = c.CheckAndSetReference(plumbing.NewHashReference("refs/heads/other", plumbing.ZeroHash), nil)
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+
+	err = c.RemoveReference("refs/heads/main")
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+}
+
+func TestNamespaced_IterReferences(t *testing.T) {
+	t.Parallel()
+
+	base := fixtureStorer(t)
+	n := newNamespaced(base, "nid1")
+
+	it, err := n.IterReferences()
+	require.NoError(t, err)
+
+	var names []string
+	var sawHead bool
+	for {
+		ref, err := it.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if ref.Name() == plumbing.HEAD {
+			sawHead = true
+		}
+		names = append(names, ref.Name().String())
+	}
+	it.Close()
+
+	assert.False(t, sawHead, "namespaced view must not advertise HEAD")
+	assert.ElementsMatch(t, []string{"refs/heads/main", "refs/tags/v1.0.0"}, names)
+}
+
+func TestNamespaced_Reference(t *testing.T) {
+	t.Parallel()
+
+	base := fixtureStorer(t)
+	n := newNamespaced(base, "nid1")
+
+	ref, err := n.Reference("refs/heads/main")
+	require.NoError(t, err)
+	assert.False(t, ref.Hash().IsZero())
+	assert.Equal(t, plumbing.ReferenceName("refs/heads/main"), ref.Name())
+
+	_, err = n.Reference(plumbing.HEAD)
+	assert.Error(t, err)
+}
+
+func TestNamespaced_ReadOnly(t *testing.T) {
+	t.Parallel()
+
+	n := newNamespaced(fixtureStorer(t), "nid1")
+
+	err := n.SetReference(plumbing.NewHashReference("refs/heads/other", plumbing.ZeroHash))
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+
+	err = n.RemoveReference("refs/heads/main")
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported)
+}
+
+// closeCountingStorer records Close calls so a view can be checked to
+// forward them to the storer it wraps.
+type closeCountingStorer struct {
+	*memory.Storage
+	closed int
+}
+
+func (s *closeCountingStorer) Close() error {
+	s.closed++
+	return nil
+}
+
+func TestViewsForwardClose(t *testing.T) {
+	t.Parallel()
+
+	// The composed file transport releases its storer via an io.Closer type
+	// assertion, and storage.Storer does not embed io.Closer. A view that
+	// failed to satisfy the assertion would silently leak the underlying
+	// *filesystem.Storage on every connection.
+	for name, view := range map[string]func(storage.Storer) storage.Storer{
+		"readOnly":   func(s storage.Storer) storage.Storer { return newReadOnly(s) },
+		"canonical":  func(s storage.Storer) storage.Storer { return newCanonical(s) },
+		"namespaced": func(s storage.Storer) storage.Storer { return newNamespaced(s, "nid1") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			base := &closeCountingStorer{Storage: fixtureStorer(t)}
+
+			closer, ok := view(base).(io.Closer)
+			require.True(t, ok, "view must satisfy io.Closer")
+			require.NoError(t, closer.Close())
+
+			assert.Equal(t, 1, base.closed)
+		})
+	}
+}
+
+func TestViewClose_NonCloseableBaseSucceeds(t *testing.T) {
+	t.Parallel()
+
+	// memory.Storage has no Close of its own; the view still has to satisfy
+	// the assertion and report success rather than panicking on the
+	// type-assert-and-call.
+	closer, ok := any(newCanonical(memory.NewStorage())).(io.Closer)
+	require.True(t, ok, "view must satisfy io.Closer")
+
+	assert.NoError(t, closer.Close())
+}
+
+func TestReadOnly_RejectsWrites(t *testing.T) {
+	t.Parallel()
+
+	// The AllRefs view goes through newReadOnly rather than the filtering
+	// views, and must not become a writable path into Radicle storage.
+	ro := newReadOnly(fixtureStorer(t))
+	ref := plumbing.NewHashReference("refs/heads/pushed", plumbing.ZeroHash)
+
+	assert.ErrorIs(t, ro.SetReference(ref), transport.ErrCommandUnsupported)
+	assert.ErrorIs(t, ro.CheckAndSetReference(ref, nil), transport.ErrCommandUnsupported)
+	assert.ErrorIs(t, ro.RemoveReference("refs/heads/main"), transport.ErrCommandUnsupported)
+}

--- a/plumbing/transport/rad/url.go
+++ b/plumbing/transport/rad/url.go
@@ -1,0 +1,70 @@
+package rad
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+// URL is the parsed form of a rad:// URL: rad://<rid>[/<nid>].
+type URL struct {
+	// RID is the Radicle repository id, e.g. "z2cK19PnX6cAUgnZfMfwECBNppJ6z".
+	RID string
+	// NID is the optional Radicle node id, selecting the namespaced
+	// reference view (refs/namespaces/<NID>/*), e.g.
+	// "z6Mkmywxg7Z7e63rkLTx7UJZeH69DLZ9KvhdQEPJ6N9nwVde". Empty selects the
+	// canonical (non-namespaced) view.
+	NID string
+}
+
+// parseURL parses u into a URL, accepting exactly the form rad://<rid>[/<nid>]
+// — a host and at most one optional path segment — matching heartwood's
+// Url::from_str. The host is used unmodified as the RID: base58 identifiers
+// are case-sensitive, and url.Parse preserves Host case, so no case
+// normalization happens here. Errors wrap transport.ErrInvalidRequest.
+func parseURL(u *url.URL) (URL, error) {
+	rid := u.Host
+	if err := validateID(rid); err != nil {
+		return URL{}, fmt.Errorf("%w: invalid rid %q: %s", transport.ErrInvalidRequest, rid, err)
+	}
+
+	nid := strings.Trim(u.Path, "/")
+	if nid == "" {
+		return URL{RID: rid}, nil
+	}
+
+	if strings.Contains(nid, "/") {
+		return URL{}, fmt.Errorf("%w: too many path segments in %q", transport.ErrInvalidRequest, u.Path)
+	}
+	if err := validateID(nid); err != nil {
+		return URL{}, fmt.Errorf("%w: invalid nid %q: %s", transport.ErrInvalidRequest, nid, err)
+	}
+
+	return URL{RID: rid, NID: nid}, nil
+}
+
+// validateID checks that id is safe to use as a single path segment: not
+// empty, not "." or "..", and restricted to a base58btc-ish alphanumeric
+// charset. This deliberately does not decode or verify base58 — its only
+// job is to make path traversal through the resolved storage path
+// impossible.
+func validateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("empty identifier")
+	}
+	if id == "." || id == ".." {
+		return fmt.Errorf("identifier must not be %q", id)
+	}
+	for _, r := range id {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		default:
+			return fmt.Errorf("identifier contains invalid character %q", r)
+		}
+	}
+	return nil
+}

--- a/plumbing/transport/rad/url.go
+++ b/plumbing/transport/rad/url.go
@@ -19,24 +19,38 @@ type URL struct {
 	NID string
 }
 
-// parseURL parses u into a URL, accepting exactly the form rad://<rid>[/<nid>]
-// — a host and at most one optional path segment — matching heartwood's
-// Url::from_str. The host is used unmodified as the RID: base58 identifiers
-// are case-sensitive, and url.Parse preserves Host case, so no case
-// normalization happens here. Errors wrap transport.ErrInvalidRequest.
+// parseURL parses u into a URL, accepting only rad://<rid>[/<nid>]: a host,
+// plus either no path or a single non-empty path segment. Looser forms such
+// as userinfo, a query, a fragment or an empty path segment are rejected by
+// the real git-remote-rad helper too.
+//
+// The host is used unmodified as the RID: base58 identifiers are
+// case-sensitive and url.Parse preserves Host case. Errors wrap
+// transport.ErrInvalidRequest.
 func parseURL(u *url.URL) (URL, error) {
+	switch {
+	case u.User != nil:
+		return URL{}, fmt.Errorf("%w: rad URL must not carry userinfo: %q", transport.ErrInvalidRequest, u.Redacted())
+	case u.RawQuery != "":
+		return URL{}, fmt.Errorf("%w: rad URL must not carry a query: %q", transport.ErrInvalidRequest, u.String())
+	case u.Fragment != "":
+		return URL{}, fmt.Errorf("%w: rad URL must not carry a fragment: %q", transport.ErrInvalidRequest, u.String())
+	case u.Opaque != "":
+		return URL{}, fmt.Errorf("%w: rad URL must be rad://<rid>[/<nid>], got %q", transport.ErrInvalidRequest, u.String())
+	}
+
 	rid := u.Host
 	if err := validateID(rid); err != nil {
 		return URL{}, fmt.Errorf("%w: invalid rid %q: %s", transport.ErrInvalidRequest, rid, err)
 	}
 
-	nid := strings.Trim(u.Path, "/")
-	if nid == "" {
+	if u.Path == "" {
 		return URL{RID: rid}, nil
 	}
 
-	if strings.Contains(nid, "/") {
-		return URL{}, fmt.Errorf("%w: too many path segments in %q", transport.ErrInvalidRequest, u.Path)
+	nid, ok := strings.CutPrefix(u.Path, "/")
+	if !ok || nid == "" || strings.Contains(nid, "/") {
+		return URL{}, fmt.Errorf("%w: expected a single path segment naming a nid, got %q", transport.ErrInvalidRequest, u.Path)
 	}
 	if err := validateID(nid); err != nil {
 		return URL{}, fmt.Errorf("%w: invalid nid %q: %s", transport.ErrInvalidRequest, nid, err)

--- a/plumbing/transport/rad/url_test.go
+++ b/plumbing/transport/rad/url_test.go
@@ -105,3 +105,40 @@ func TestParseURL_RejectsInvalidCharset(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, transport.ErrInvalidRequest)
 }
+
+func TestParseURL_RejectsFormsRadicleRejects(t *testing.T) {
+	t.Parallel()
+
+	// Every form here is rejected by the real git-remote-rad helper, which
+	// splits everything after "rad://" on "/" and accepts only one or two
+	// non-empty components. Accepting them would let this transport resolve
+	// URLs that Radicle itself refuses.
+	const (
+		rid = "z2cK19PnX6cAUgnZfMfwECBNppJ6z"
+		nid = "z6MktoAvnp6XUueF169dr4quTKnFU4v8e8sz3FMLNnpt53Wg"
+	)
+
+	tests := map[string]string{
+		"userinfo":               "rad://user@" + rid,
+		"userinfo/:pass":         "rad://user:pass@" + rid,
+		"query":                  "rad://" + rid + "?x=1",
+		"fragment":               "rad://" + rid + "#f",
+		"trailing slash":         "rad://" + rid + "/",
+		"empty segment":          "rad://" + rid + "//" + nid,
+		"trailing empty segment": "rad://" + rid + "/" + nid + "/",
+		"opaque, no authority":   "rad:" + rid,
+	}
+
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(raw)
+			require.NoError(t, err)
+
+			_, err = parseURL(u)
+			require.Errorf(t, err, "%q should be rejected", raw)
+			assert.ErrorIs(t, err, transport.ErrInvalidRequest)
+		})
+	}
+}

--- a/plumbing/transport/rad/url_test.go
+++ b/plumbing/transport/rad/url_test.go
@@ -1,0 +1,107 @@
+package rad
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+func TestParseURL_RIDOnly(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("rad://z2cK19PnX6cAUgnZfMfwECBNppJ6z")
+	require.NoError(t, err)
+
+	ru, err := parseURL(u)
+	require.NoError(t, err)
+	assert.Equal(t, "z2cK19PnX6cAUgnZfMfwECBNppJ6z", ru.RID)
+	assert.Empty(t, ru.NID)
+}
+
+func TestParseURL_RIDAndNID(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("rad://z2cK19PnX6cAUgnZfMfwECBNppJ6z/z6Mkmywxg7Z7e63rkLTx7UJZeH69DLZ9KvhdQEPJ6N9nwVde")
+	require.NoError(t, err)
+
+	ru, err := parseURL(u)
+	require.NoError(t, err)
+	assert.Equal(t, "z2cK19PnX6cAUgnZfMfwECBNppJ6z", ru.RID)
+	assert.Equal(t, "z6Mkmywxg7Z7e63rkLTx7UJZeH69DLZ9KvhdQEPJ6N9nwVde", ru.NID)
+}
+
+func TestParseURL_CasePreserved(t *testing.T) {
+	t.Parallel()
+
+	// Base58 identifiers are case-sensitive; a mixed-case RID must round-trip
+	// with its case intact so it maps to the right storage directory.
+	const mixed = "z2cK19PnX6cAUgnZfMfwECBNppJ6z"
+
+	u, err := url.Parse("rad://" + mixed)
+	require.NoError(t, err)
+	require.Equal(t, mixed, u.Host, "url.Parse should preserve Host case")
+
+	ru, err := parseURL(u)
+	require.NoError(t, err)
+	assert.Equal(t, mixed, ru.RID)
+}
+
+func TestParseURL_RejectsThirdSegment(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("rad://a/b/c")
+	require.NoError(t, err)
+
+	_, err = parseURL(u)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrInvalidRequest)
+}
+
+func TestParseURL_RejectsEmptyHost(t *testing.T) {
+	t.Parallel()
+
+	u, err := url.Parse("rad://")
+	require.NoError(t, err)
+
+	_, err = parseURL(u)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrInvalidRequest)
+}
+
+func TestParseURL_RejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		u    *url.URL
+	}{
+		{"traversal host", &url.URL{Host: "..", Path: ""}},
+		{"traversal nid", &url.URL{Host: "z2cK19PnX6cAUgnZfMfwECBNppJ6z", Path: "/.."}},
+		{"path separator in host-equivalent segment", &url.URL{Host: "z2cK19PnX6cAUgnZfMfwECBNppJ6z", Path: "/a/b"}},
+		{"slash-decoded traversal in nid", &url.URL{Host: "z2cK19PnX6cAUgnZfMfwECBNppJ6z", Path: "/../.."}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseURL(tt.u)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, transport.ErrInvalidRequest)
+		})
+	}
+}
+
+func TestParseURL_RejectsInvalidCharset(t *testing.T) {
+	t.Parallel()
+
+	u := &url.URL{Host: "not/a-valid_rid"}
+
+	_, err := parseURL(u)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrInvalidRequest)
+}


### PR DESCRIPTION
Adds `plumbing/transport/rad`, a read-only transport for rad:// URLs backed by local (Radicle)[https://radicle.xyz/] storage.

This follow a long due one as per #1713

rad is not registered as a built-in scheme, since Radicle-specific URL conventions do not belong in go-git core imo. It is opted into with `client.WithTransport("rad", ...)`. Like git-remote-rad itself, this only reads local storage. Fetching a repository from the network is `rad seed <rid>`, which is a separate step.

read only scope for now, as pushing raw refs would leave storage inconsistent until `refs/rad/sigrefs` is signed again with the device key, which this transport does not do.
 
_N.B. I took the liberty of updating `EXTENDING.md` file as it looked out of date but that might be an oversight of me._