### PR TITLE
plumbing: object, Preserve decoded ident and header bytes

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -23,8 +23,6 @@ const (
 	headerpgp256   string = "gpgsig-sha256"
 	headerencoding string = "encoding"
 
-	encodingHeaderIndex = -1
-
 	defaultUtf8CommitMessageEncoding MessageEncoding = "UTF-8"
 )
 
@@ -73,9 +71,9 @@ type Commit struct {
 	// src holds the encoded object this Commit was decoded from, used by
 	// EncodeWithoutSignature to recover the canonical signed bytes.
 	src plumbing.EncodedObject
-	// headerOrder holds encodingHeaderIndex and ExtraHeaders indexes in their
-	// decoded order so struct encoding can retain their relative positions.
-	headerOrder []int
+	// encodingHeaderPosition is the one-based position of an explicit encoding
+	// header among ExtraHeaders. Zero means the source had no encoding header.
+	encodingHeaderPosition int
 }
 
 // ExtraHeader holds any non-standard header
@@ -390,34 +388,25 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
-	var headerOrder []int
-	if c.src != nil && len(c.headerOrder) > 0 {
-		fresh := &Commit{}
-		if decodeErr := fresh.Decode(c.src); decodeErr == nil &&
-			c.Encoding == fresh.Encoding &&
-			slices.Equal(c.ExtraHeaders, fresh.ExtraHeaders) {
-			headerOrder = c.headerOrder
-		}
-	}
-
-	if headerOrder == nil {
+	encodingPosition := c.encodingHeaderPosition - 1
+	if encodingPosition < 0 || encodingPosition > len(c.ExtraHeaders) || string(c.Encoding) == "" {
+		encodingPosition = -1
 		if string(c.Encoding) != "" && c.Encoding != defaultUtf8CommitMessageEncoding {
-			headerOrder = append(headerOrder, encodingHeaderIndex)
-		}
-		for i := range c.ExtraHeaders {
-			headerOrder = append(headerOrder, i)
+			encodingPosition = 0
 		}
 	}
 
-	for _, index := range headerOrder {
-		if index == encodingHeaderIndex {
+	for i := 0; i <= len(c.ExtraHeaders); i++ {
+		if i == encodingPosition {
 			if _, err = fmt.Fprintf(w, "\n%s %s", headerencoding, c.Encoding); err != nil {
 				return err
 			}
-			continue
+		}
+		if i == len(c.ExtraHeaders) {
+			break
 		}
 
-		header := c.ExtraHeaders[index]
+		header := c.ExtraHeaders[i]
 		if !isStandardHeader(header.Key) {
 			if _, err = fmt.Fprintf(w, "\n%s", header); err != nil {
 				return err

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -23,6 +23,8 @@ const (
 	headerpgp256   string = "gpgsig-sha256"
 	headerencoding string = "encoding"
 
+	encodingHeaderIndex = -1
+
 	defaultUtf8CommitMessageEncoding MessageEncoding = "UTF-8"
 )
 
@@ -71,6 +73,9 @@ type Commit struct {
 	// src holds the encoded object this Commit was decoded from, used by
 	// EncodeWithoutSignature to recover the canonical signed bytes.
 	src plumbing.EncodedObject
+	// headerOrder holds encodingHeaderIndex and ExtraHeaders indexes in their
+	// decoded order so struct encoding can retain their relative positions.
+	headerOrder []int
 }
 
 // ExtraHeader holds any non-standard header
@@ -385,18 +390,38 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
-	if string(c.Encoding) != "" && c.Encoding != defaultUtf8CommitMessageEncoding {
-		if _, err = fmt.Fprintf(w, "\n%s %s", headerencoding, c.Encoding); err != nil {
-			return err
+	var headerOrder []int
+	if c.src != nil && len(c.headerOrder) > 0 {
+		fresh := &Commit{}
+		if decodeErr := fresh.Decode(c.src); decodeErr == nil &&
+			c.Encoding == fresh.Encoding &&
+			slices.Equal(c.ExtraHeaders, fresh.ExtraHeaders) {
+			headerOrder = c.headerOrder
 		}
 	}
 
-	for _, header := range c.ExtraHeaders {
-		if isStandardHeader(header.Key) {
+	if headerOrder == nil {
+		if string(c.Encoding) != "" && c.Encoding != defaultUtf8CommitMessageEncoding {
+			headerOrder = append(headerOrder, encodingHeaderIndex)
+		}
+		for i := range c.ExtraHeaders {
+			headerOrder = append(headerOrder, i)
+		}
+	}
+
+	for _, index := range headerOrder {
+		if index == encodingHeaderIndex {
+			if _, err = fmt.Fprintf(w, "\n%s %s", headerencoding, c.Encoding); err != nil {
+				return err
+			}
 			continue
 		}
-		if _, err = fmt.Fprintf(w, "\n%s", header); err != nil {
-			return err
+
+		header := c.ExtraHeaders[index]
+		if !isStandardHeader(header.Key) {
+			if _, err = fmt.Fprintf(w, "\n%s", header); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -74,6 +74,8 @@ type Commit struct {
 	// encodingHeaderPosition is the one-based position of an explicit encoding
 	// header among ExtraHeaders. Zero means the source had no encoding header.
 	encodingHeaderPosition int
+	authorSource           identSource
+	committerSource        identSource
 }
 
 // ExtraHeader holds any non-standard header
@@ -337,13 +339,6 @@ func (c *Commit) matchesSource() bool {
 		slices.Equal(c.ExtraHeaders, fresh.ExtraHeaders)
 }
 
-func signatureEqual(a, b Signature) bool {
-	return a.Name == b.Name &&
-		a.Email == b.Email &&
-		a.When.Unix() == b.When.Unix() &&
-		a.When.Format("-0700") == b.When.Format("-0700")
-}
-
 func isStandardHeader(key string) bool {
 	switch key {
 	case "tree", "parent", "author", "committer",
@@ -376,7 +371,7 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
-	if err = c.Author.Encode(w); err != nil {
+	if err = c.authorSource.encode(w, c.Author); err != nil {
 		return err
 	}
 
@@ -384,7 +379,7 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
-	if err = c.Committer.Encode(w); err != nil {
+	if err = c.committerSource.encode(w, c.Committer); err != nil {
 		return err
 	}
 

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -38,10 +37,8 @@ type MessageEncoding string
 // commit, a pointer to the previous commit(s), etc.
 // http://shafiulazam.com/gitbook/1_the_git_object_model.html
 //
-// When a Commit is populated by Decode it retains a reference to the source
-// plumbing.EncodedObject so that EncodeWithoutSignature can reproduce the
-// exact bytes the signature was computed over. Refer to EncodeWithoutSignature
-// for more information.
+// When a Commit is populated by Decode it retains the original header layout
+// so that encoding changes only the fields that have been modified.
 type Commit struct {
 	// Hash of the commit object.
 	Hash plumbing.Hash
@@ -67,15 +64,10 @@ type Commit struct {
 	// List of extra headers of the commit
 	ExtraHeaders []ExtraHeader
 
-	s storer.EncodedObjectStorer
-	// src holds the encoded object this Commit was decoded from, used by
-	// EncodeWithoutSignature to recover the canonical signed bytes.
-	src plumbing.EncodedObject
-	// encodingHeaderPosition is the one-based position of an explicit encoding
-	// header among ExtraHeaders. Zero means the source had no encoding header.
-	encodingHeaderPosition int
-	authorSource           identSource
-	committerSource        identSource
+	s               storer.EncodedObjectStorer
+	layout          *commitLayout
+	authorSource    identSource
+	committerSource identSource
 }
 
 // ExtraHeader holds any non-standard header
@@ -192,8 +184,7 @@ func (c *Commit) NumParents() int {
 var ErrParentNotFound = errors.New("commit parent not found")
 
 // ErrMalformedCommit is returned when a commit object cannot be decoded
-// because its standard headers (tree, parent, author, committer) are missing,
-// duplicated, or out of order.
+// because its initial tree header or a hash in its parent block is invalid.
 var ErrMalformedCommit = errors.New("malformed commit")
 
 // Parent returns the ith parent of a commit.
@@ -258,7 +249,6 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 
 	c.reset()
 	c.Hash = o.Hash()
-	c.src = o
 
 	reader, err := o.Reader()
 	if err != nil {
@@ -269,6 +259,7 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	r := sync.GetBufioReader(reader)
 	defer sync.PutBufioReader(r)
 
+	c.layout = &commitLayout{}
 	s := &commitScanner{r: r, c: c}
 	for state := scanTree; state != nil; {
 		state, err = state(s)
@@ -280,6 +271,7 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 		return fmt.Errorf("%w: missing tree header", ErrMalformedCommit)
 	}
 	c.Message = s.msgbuf.String()
+	c.layout.remember(c)
 	return nil
 }
 
@@ -292,51 +284,13 @@ func (c *Commit) Encode(o plumbing.EncodedObject) error {
 // without any signature headers, producing the payload that PGP/GPG
 // signatures are computed over.
 //
-// Behaviour depends on how the Commit was created:
-//
-//   - For Commits populated by Decode whose exported fields still match the
-//     source object, the payload is streamed from the raw source bytes with
-//     gpgsig and gpgsig-sha256 headers (and their continuation lines)
-//     stripped verbatim. This preserves the exact bytes the signature was
-//     computed over, regardless of any normalization performed by Decode.
-//
-//   - For Commits constructed in memory, or for decoded Commits whose
-//     exported fields have been mutated, the payload is derived from the
-//     current struct fields. Mutation is detected by re-decoding the source
-//     object and comparing exported fields; if any differ, the in-memory
-//     representation prevails.
+// Decoded commits retain the original layout and bytes of unchanged headers.
+// Changing ParentHashes, for example, replaces only the contiguous parent
+// block after the tree header. Signature headers and their continuation lines
+// are omitted regardless of position. Commits constructed in memory use the
+// canonical header order.
 func (c *Commit) EncodeWithoutSignature(o plumbing.EncodedObject) error {
-	if c.matchesSource() {
-		return stripObjectSignatures(o, c.src, plumbing.CommitObject)
-	}
 	return c.encode(o, false)
-}
-
-// matchesSource reports whether c.src is set and re-decoding it produces a
-// Commit whose payload-affecting exported fields are identical to those of
-// c. It is the auto-detection used by EncodeWithoutSignature to decide
-// between the raw bytes and the struct-encoded payload.
-//
-// Signature and SignatureSHA256 are intentionally excluded from the
-// comparison: neither path emits them, so mutating them must not trigger a
-// switch to struct-encode (which would change the byte layout the caller is
-// trying to verify against).
-func (c *Commit) matchesSource() bool {
-	if c.src == nil {
-		return false
-	}
-	fresh := &Commit{}
-	if err := fresh.Decode(c.src); err != nil {
-		return false
-	}
-	return c.Hash == fresh.Hash &&
-		signatureEqual(c.Author, fresh.Author) &&
-		signatureEqual(c.Committer, fresh.Committer) &&
-		c.Message == fresh.Message &&
-		c.TreeHash == fresh.TreeHash &&
-		c.Encoding == fresh.Encoding &&
-		slices.Equal(c.ParentHashes, fresh.ParentHashes) &&
-		slices.Equal(c.ExtraHeaders, fresh.ExtraHeaders)
 }
 
 func isStandardHeader(key string) bool {
@@ -356,6 +310,9 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	}
 
 	defer ioutil.CheckClose(w, &err)
+	if c.layout != nil {
+		return c.encodeLayout(w, includeSig)
+	}
 
 	if _, err = fmt.Fprintf(w, "tree %s\n", c.TreeHash.String()); err != nil {
 		return err
@@ -383,12 +340,9 @@ func (c *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
-	encodingPosition := c.encodingHeaderPosition - 1
-	if encodingPosition < 0 || encodingPosition > len(c.ExtraHeaders) || string(c.Encoding) == "" {
-		encodingPosition = -1
-		if string(c.Encoding) != "" && c.Encoding != defaultUtf8CommitMessageEncoding {
-			encodingPosition = 0
-		}
+	encodingPosition := -1
+	if c.Encoding != "" && c.Encoding != defaultUtf8CommitMessageEncoding {
+		encodingPosition = 0
 	}
 
 	for i := 0; i <= len(c.ExtraHeaders); i++ {

--- a/plumbing/object/commit_layout.go
+++ b/plumbing/object/commit_layout.go
@@ -1,0 +1,169 @@
+package object
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/go-git/go-git/v6/plumbing"
+)
+
+// commitHeader connects a raw header (including continuation lines) to its
+// decoded field. An empty key denotes an ignored duplicate or misplaced
+// standard header, which is retained without changing the decoded fields.
+type commitHeader struct {
+	key   string
+	index int
+	raw   string
+}
+
+type commitLayout struct {
+	headers         []commitHeader
+	separator       bool
+	tree            plumbing.Hash
+	parents         []plumbing.Hash
+	encoding        MessageEncoding
+	extras          []ExtraHeader
+	signature       string
+	signatureSHA256 string
+}
+
+func (l *commitLayout) remember(c *Commit) {
+	l.tree = c.TreeHash
+	l.parents = slices.Clone(c.ParentHashes)
+	l.encoding = c.Encoding
+	l.extras = slices.Clone(c.ExtraHeaders)
+	l.signature = c.Signature
+	l.signatureSHA256 = c.SignatureSHA256
+}
+
+func (c *Commit) encodeLayout(w io.Writer, includeSig bool) error {
+	l := c.layout
+	parentsChanged := !slices.Equal(c.ParentHashes, l.parents)
+	seen := make(map[string]bool)
+	var headers bytes.Buffer
+	for _, h := range l.headers {
+		raw := h.raw
+		switch h.key {
+		case "tree":
+			if c.TreeHash != l.tree {
+				raw = fmt.Sprintf("tree %s\n", c.TreeHash)
+			}
+		case "parent":
+			if parentsChanged {
+				continue
+			}
+		case "author":
+			if !signatureEqual(c.Author, c.authorSource.signature) {
+				raw = commitIdentHeader(h.key, c.Author)
+			}
+		case "committer":
+			if !signatureEqual(c.Committer, c.committerSource.signature) {
+				raw = commitIdentHeader(h.key, c.Committer)
+			}
+		case headerencoding:
+			if c.Encoding != l.encoding {
+				raw = ""
+				if c.Encoding != "" {
+					raw = fmt.Sprintf("encoding %s\n", c.Encoding)
+				}
+			}
+		case headerpgp, headerpgp256:
+			// A header without the separating space is not a signature
+			// header according to Git's signature-stripping rules.
+			if !isSignatureHeader([]byte(raw)) {
+				break
+			}
+			if !includeSig {
+				continue
+			}
+			current, original := c.Signature, l.signature
+			if h.key == headerpgp256 {
+				current, original = c.SignatureSHA256, l.signatureSHA256
+			}
+			if current != original {
+				raw = ""
+				if !seen[h.key] && current != "" {
+					raw = commitSignatureHeader(h.key, current)
+				}
+			}
+		case "extra":
+			raw = ""
+			if h.index < len(c.ExtraHeaders) {
+				extra := c.ExtraHeaders[h.index]
+				if !isStandardHeader(extra.Key) {
+					if extra == l.extras[h.index] {
+						raw = h.raw
+					} else {
+						raw = fmt.Sprintf("%s\n", extra)
+					}
+				}
+			}
+		}
+		appendCommitHeader(&headers, raw)
+		seen[h.key] = true
+		if h.key == "tree" && parentsChanged {
+			for _, parent := range c.ParentHashes {
+				appendCommitHeader(&headers, fmt.Sprintf("parent %s\n", parent))
+			}
+		}
+	}
+
+	// New fields have no source position. Append them in canonical order;
+	// existing fields keep their original slots even when their values change.
+	if !seen["author"] && !signatureEqual(c.Author, Signature{}) {
+		appendCommitHeader(&headers, commitIdentHeader("author", c.Author))
+	}
+	if !seen["committer"] && !signatureEqual(c.Committer, Signature{}) {
+		appendCommitHeader(&headers, commitIdentHeader("committer", c.Committer))
+	}
+	if !seen[headerencoding] && c.Encoding != "" && c.Encoding != defaultUtf8CommitMessageEncoding {
+		appendCommitHeader(&headers, fmt.Sprintf("encoding %s\n", c.Encoding))
+	}
+	for i := len(l.extras); i < len(c.ExtraHeaders); i++ {
+		if extra := c.ExtraHeaders[i]; !isStandardHeader(extra.Key) {
+			appendCommitHeader(&headers, fmt.Sprintf("%s\n", extra))
+		}
+	}
+	if includeSig {
+		if !seen[headerpgp] && c.Signature != "" {
+			appendCommitHeader(&headers, commitSignatureHeader(headerpgp, c.Signature))
+		}
+		if !seen[headerpgp256] && c.SignatureSHA256 != "" {
+			appendCommitHeader(&headers, commitSignatureHeader(headerpgp256, c.SignatureSHA256))
+		}
+	}
+	if l.separator || c.Message != "" {
+		appendCommitHeader(&headers, "\n")
+	}
+	if _, err := w.Write(headers.Bytes()); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, c.Message)
+	return err
+}
+
+// appendCommitHeader separates newly added headers from an unterminated
+// source header while preserving a final missing newline on a round trip.
+func appendCommitHeader(dst *bytes.Buffer, raw string) {
+	if raw == "" {
+		return
+	}
+	if b := dst.Bytes(); len(b) > 0 && b[len(b)-1] != '\n' {
+		dst.WriteByte('\n')
+	}
+	dst.WriteString(raw)
+}
+
+func commitIdentHeader(key string, sig Signature) string {
+	var value bytes.Buffer
+	// bytes.Buffer.Write always succeeds.
+	_ = sig.Encode(&value)
+	return key + " " + value.String() + "\n"
+}
+
+func commitSignatureHeader(key, value string) string {
+	return key + " " + strings.ReplaceAll(strings.TrimSuffix(value, "\n"), "\n", "\n ") + "\n"
+}

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -147,7 +147,8 @@ func scanAuthor(s *commitScanner) (commitState, error) {
 
 	key, data := splitHeader(line)
 	if key == "author" {
-		s.c.Author.Decode(data)
+		s.c.authorSource = newIdentSource(data)
+		s.c.Author = s.c.authorSource.signature
 		s.sawAuthor = true
 		if err == io.EOF {
 			return nil, nil
@@ -175,7 +176,8 @@ func scanCommitter(s *commitScanner) (commitState, error) {
 
 	key, data := splitHeader(line)
 	if key == "committer" {
-		s.c.Committer.Decode(data)
+		s.c.committerSource = newIdentSource(data)
+		s.c.Committer = s.c.committerSource.signature
 		s.sawCommitter = true
 		if err == io.EOF {
 			return nil, nil

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -217,7 +217,7 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 	case headerencoding:
 		if !s.sawEncoding {
 			s.c.Encoding = MessageEncoding(data)
-			s.c.headerOrder = append(s.c.headerOrder, encodingHeaderIndex)
+			s.c.encodingHeaderPosition = len(s.c.ExtraHeaders) + 1
 			s.sawEncoding = true
 		}
 	case headerpgp:
@@ -233,7 +233,6 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 			next = scanExtraCont
 		} else {
 			s.c.ExtraHeaders = append(s.c.ExtraHeaders, h)
-			s.c.headerOrder = append(s.c.headerOrder, len(s.c.ExtraHeaders)-1)
 		}
 	}
 
@@ -303,7 +302,6 @@ func scanExtraCont(s *commitScanner) (commitState, error) {
 func (s *commitScanner) finaliseExtra() {
 	s.extra.Value = strings.TrimRight(s.extra.Value, "\n")
 	s.c.ExtraHeaders = append(s.c.ExtraHeaders, *s.extra)
-	s.c.headerOrder = append(s.c.headerOrder, len(s.c.ExtraHeaders)-1)
 	s.extra = nil
 }
 

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -217,6 +217,7 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 	case headerencoding:
 		if !s.sawEncoding {
 			s.c.Encoding = MessageEncoding(data)
+			s.c.headerOrder = append(s.c.headerOrder, encodingHeaderIndex)
 			s.sawEncoding = true
 		}
 	case headerpgp:
@@ -232,6 +233,7 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 			next = scanExtraCont
 		} else {
 			s.c.ExtraHeaders = append(s.c.ExtraHeaders, h)
+			s.c.headerOrder = append(s.c.headerOrder, len(s.c.ExtraHeaders)-1)
 		}
 	}
 
@@ -301,6 +303,7 @@ func scanExtraCont(s *commitScanner) (commitState, error) {
 func (s *commitScanner) finaliseExtra() {
 	s.extra.Value = strings.TrimRight(s.extra.Value, "\n")
 	s.c.ExtraHeaders = append(s.c.ExtraHeaders, *s.extra)
+	s.c.headerOrder = append(s.c.headerOrder, len(s.c.ExtraHeaders)-1)
 	s.extra = nil
 }
 

--- a/plumbing/object/commit_scanner.go
+++ b/plumbing/object/commit_scanner.go
@@ -26,7 +26,7 @@ type commitScanner struct {
 	pendingErr error
 
 	// First-occurrence tracking — once the corresponding field has been
-	// decoded, subsequent occurrences are silently dropped (matches
+	// decoded, subsequent occurrences do not overwrite decoded fields (matches
 	// upstream's find_commit_header / first-wins semantics).
 	//
 	// gpgsig/gpgsig-sha256 are NOT tracked here: upstream's
@@ -89,6 +89,7 @@ func scanTree(s *commitScanner) (commitState, error) {
 		return nil, herr
 	}
 	s.c.TreeHash = h
+	s.recordHeader("tree", 0, line)
 	s.sawTree = true
 	if err == io.EOF {
 		return nil, nil
@@ -97,10 +98,10 @@ func scanTree(s *commitScanner) (commitState, error) {
 }
 
 // scanParents consumes contiguous `parent HASH` lines. The first non-parent
-// line ends the parent block and is handed off to scanAuthor; any later
-// `parent` line is silently dropped (matches upstream's parse_commit_buffer
-// exiting its parent loop at the first non-parent line and
-// read_commit_extra_header_lines filtering `parent` out of extras).
+// line ends the parent block and is handed off to scanHeaders; any later
+// `parent` line is retained in the layout but excluded from ParentHashes,
+// matching upstream's parse_commit_buffer exiting its parent loop at the
+// first non-parent line.
 func scanParents(s *commitScanner) (commitState, error) {
 	line, err := s.readLine()
 	if err != nil && err != io.EOF {
@@ -110,6 +111,7 @@ func scanParents(s *commitScanner) (commitState, error) {
 		return nil, nil
 	}
 	if isBlankLine(line) {
+		s.c.layout.separator = true
 		return scanMessage, nil
 	}
 
@@ -119,70 +121,12 @@ func scanParents(s *commitScanner) (commitState, error) {
 		if herr != nil {
 			return nil, herr
 		}
+		s.recordHeader("parent", len(s.c.ParentHashes), line)
 		s.c.ParentHashes = append(s.c.ParentHashes, h)
 		if err == io.EOF {
 			return nil, nil
 		}
 		return scanParents, nil
-	}
-	s.pushBack(line, err)
-	return scanAuthor, nil
-}
-
-// scanAuthor accepts an `author` line at its canonical position immediately
-// after the parent block. Any other header here is pushed back for
-// scanCommitter; an out-of-place author is therefore silently dropped.
-// Mirrors upstream's parse_commit_date func.
-func scanAuthor(s *commitScanner) (commitState, error) {
-	line, err := s.readLine()
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-	if len(line) == 0 {
-		return nil, nil
-	}
-	if isBlankLine(line) {
-		return scanMessage, nil
-	}
-
-	key, data := splitHeader(line)
-	if key == "author" {
-		s.c.authorSource = newIdentSource(data)
-		s.c.Author = s.c.authorSource.signature
-		s.sawAuthor = true
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanCommitter, nil
-	}
-	s.pushBack(line, err)
-	return scanCommitter, nil
-}
-
-// scanCommitter accepts a `committer` line at its canonical position
-// immediately after the author. Any other header is pushed back for
-// scanHeaders. Same upstream rationale as scanAuthor.
-func scanCommitter(s *commitScanner) (commitState, error) {
-	line, err := s.readLine()
-	if err != nil && err != io.EOF {
-		return nil, err
-	}
-	if len(line) == 0 {
-		return nil, nil
-	}
-	if isBlankLine(line) {
-		return scanMessage, nil
-	}
-
-	key, data := splitHeader(line)
-	if key == "committer" {
-		s.c.committerSource = newIdentSource(data)
-		s.c.Committer = s.c.committerSource.signature
-		s.sawCommitter = true
-		if err == io.EOF {
-			return nil, nil
-		}
-		return scanHeaders, nil
 	}
 	s.pushBack(line, err)
 	return scanHeaders, nil
@@ -201,6 +145,7 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 		return nil, nil
 	}
 	if isBlankLine(line) {
+		s.c.layout.separator = true
 		return scanMessage, nil
 	}
 
@@ -209,26 +154,46 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 
 	var next commitState = scanHeaders
 	switch key {
-	case "tree", "parent", "author", "committer":
-		// Anything reaching scanHeaders with one of these keys is out of
-		// canonical position — duplicate tree, parent past the contiguous
-		// block, or author/committer not at their expected slot. Drop them
-		// the same way upstream's standard_header_field filter excludes
-		// them from the extras list (read_commit_extra_header_lines,
-		// commit.c:1520-1522).
+	case "tree", "parent":
+		// Duplicate trees and parents outside the contiguous parent block
+		// remain raw headers without changing the decoded graph.
+		s.recordHeader("", 0, line)
+	case "author":
+		if !s.sawAuthor {
+			s.c.authorSource = newIdentSource(data)
+			s.c.Author = s.c.authorSource.signature
+			s.sawAuthor = true
+			s.recordHeader(key, 0, line)
+		} else {
+			s.recordHeader("", 0, line)
+		}
+	case "committer":
+		if !s.sawCommitter {
+			s.c.committerSource = newIdentSource(data)
+			s.c.Committer = s.c.committerSource.signature
+			s.sawCommitter = true
+			s.recordHeader(key, 0, line)
+		} else {
+			s.recordHeader("", 0, line)
+		}
 	case headerencoding:
 		if !s.sawEncoding {
 			s.c.Encoding = MessageEncoding(data)
-			s.c.encodingHeaderPosition = len(s.c.ExtraHeaders) + 1
+			s.recordHeader(key, 0, line)
 			s.sawEncoding = true
+		} else {
+			s.recordHeader("", 0, line)
 		}
 	case headerpgp:
+		s.recordHeader(key, 0, line)
 		s.c.Signature += string(data) + "\n"
 		next = scanPgpCont
 	case headerpgp256:
+		s.recordHeader(key, 0, line)
 		s.c.SignatureSHA256 += string(data) + "\n"
 		next = scanPgp256Cont
 	default:
+		s.recordHeader("extra", len(s.c.ExtraHeaders), line)
 		h, multiline := parseExtraHeader(originalLine)
 		if multiline {
 			s.extra = &h
@@ -239,6 +204,9 @@ func scanHeaders(s *commitScanner) (commitState, error) {
 	}
 
 	if err == io.EOF {
+		if s.extra != nil {
+			s.finaliseExtra()
+		}
 		return nil, nil
 	}
 	return next, nil
@@ -266,6 +234,7 @@ func continuationCont(s *commitScanner, dst *string, self commitState) (commitSt
 		return nil, err
 	}
 	if len(line) > 0 && line[0] == ' ' {
+		s.c.layout.headers[len(s.c.layout.headers)-1].raw += string(line)
 		*dst += string(line[1:])
 		if err == io.EOF {
 			return nil, nil
@@ -287,6 +256,7 @@ func scanExtraCont(s *commitScanner) (commitState, error) {
 		return nil, err
 	}
 	if len(line) > 0 && line[0] == ' ' {
+		s.c.layout.headers[len(s.c.layout.headers)-1].raw += string(line)
 		s.extra.Value += string(line[1:])
 		if err == io.EOF {
 			s.finaliseExtra()
@@ -351,4 +321,8 @@ func parseObjectIDHex(data []byte, malformedErr error, header string) (plumbing.
 		return plumbing.ZeroHash, fmt.Errorf("%w: bad %s hash", malformedErr, header)
 	}
 	return h, nil
+}
+
+func (s *commitScanner) recordHeader(key string, index int, line []byte) {
+	s.c.layout.headers = append(s.c.layout.headers, commitHeader{key: key, index: index, raw: string(line)})
 }

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -65,11 +65,9 @@ func (s *SuiteCommit) TestDecodeClearsExistingState() {
 		ExtraHeaders: []ExtraHeader{
 			{Key: "x-stale", Value: "stale"},
 		},
-		s:   s.Storer,
-		src: staleSrc,
-		headerOrder: []int{
-			encodingHeaderIndex,
-		},
+		s:                      s.Storer,
+		src:                    staleSrc,
+		encodingHeaderPosition: 1,
 	}
 
 	obj := &plumbing.MemoryObject{}
@@ -90,7 +88,7 @@ func (s *SuiteCommit) TestDecodeClearsExistingState() {
 	s.Nil(commit.ExtraHeaders)
 	s.Equal(s.Storer, commit.s)
 	s.Equal(obj, commit.src)
-	s.Nil(commit.headerOrder)
+	s.Zero(commit.encodingHeaderPosition)
 }
 
 func (s *SuiteCommit) TestType() {
@@ -339,7 +337,7 @@ change
 		s.NoError(err)
 		commit.Hash = obj.Hash()
 		commit.src = obj
-		commit.headerOrder = newCommit.headerOrder
+		commit.encodingHeaderPosition = newCommit.encodingHeaderPosition
 		s.Equal(commit, newCommit)
 	}
 }

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -68,6 +68,8 @@ func (s *SuiteCommit) TestDecodeClearsExistingState() {
 		s:                      s.Storer,
 		src:                    staleSrc,
 		encodingHeaderPosition: 1,
+		authorSource:           newIdentSource([]byte("Stale Author <author@example.local> 1 +0000")),
+		committerSource:        newIdentSource([]byte("Stale Committer <committer@example.local> 2 +0000")),
 	}
 
 	obj := &plumbing.MemoryObject{}
@@ -89,6 +91,8 @@ func (s *SuiteCommit) TestDecodeClearsExistingState() {
 	s.Equal(s.Storer, commit.s)
 	s.Equal(obj, commit.src)
 	s.Zero(commit.encodingHeaderPosition)
+	s.Zero(commit.authorSource)
+	s.Zero(commit.committerSource)
 }
 
 func (s *SuiteCommit) TestType() {
@@ -338,6 +342,8 @@ change
 		commit.Hash = obj.Hash()
 		commit.src = obj
 		commit.encodingHeaderPosition = newCommit.encodingHeaderPosition
+		commit.authorSource = newCommit.authorSource
+		commit.committerSource = newCommit.committerSource
 		s.Equal(commit, newCommit)
 	}
 }
@@ -1142,6 +1148,78 @@ rewritten message
 			s.Equal(tc.expected, string(payload))
 		})
 	}
+}
+
+func (s *SuiteCommit) TestEncodeWithoutSignaturePreservesDecodedIdentBytes() {
+	tests := []struct {
+		name  string
+		ident string
+	}{
+		{name: "no space before date", ident: "A U Thor <author@example.test>1700000000 +0000"},
+		{name: "no space before email", ident: "A U Thor<author@example.test> 1700000000 +0000"},
+		{name: "no timezone", ident: "A U Thor <author@example.test> 1700000000"},
+		{name: "zero-padded timestamp", ident: "A U Thor <author@example.test> 01700000000 +0000"},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			const oldParent = "35e85108805c84807bc66a02d91535e1e24b38b9"
+			const newParent = "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"
+			raw := "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n" +
+				"parent " + oldParent + "\n" +
+				"author " + tc.ident + "\n" +
+				"committer " + tc.ident + "\n\nmessage\n"
+
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.CommitObject)
+			_, err := obj.Write([]byte(raw))
+			s.Require().NoError(err)
+
+			commit, err := DecodeCommit(s.Storer, obj)
+			s.Require().NoError(err)
+			commit.ParentHashes[0] = plumbing.NewHash(newParent)
+
+			encoded := &plumbing.MemoryObject{}
+			s.Require().NoError(commit.EncodeWithoutSignature(encoded))
+			r, err := encoded.Reader()
+			s.Require().NoError(err)
+			payload, err := io.ReadAll(r)
+			s.Require().NoError(err)
+			s.Equal(strings.Replace(raw, oldParent, newParent, 1), string(payload))
+		})
+	}
+}
+
+func (s *SuiteCommit) TestEncodeWithoutSignatureCanonicalizesChangedIdent() {
+	const raw = `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author A U Thor <author@example.test>1700000000 +0000
+committer C O Mitter <committer@example.test>1700000000 +0000
+
+message
+`
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.CommitObject)
+	_, err := obj.Write([]byte(raw))
+	s.Require().NoError(err)
+
+	commit, err := DecodeCommit(s.Storer, obj)
+	s.Require().NoError(err)
+	commit.Author.Name = "Changed Author"
+	commit.Message = "changed message\n"
+
+	encoded := &plumbing.MemoryObject{}
+	s.Require().NoError(commit.EncodeWithoutSignature(encoded))
+	r, err := encoded.Reader()
+	s.Require().NoError(err)
+	payload, err := io.ReadAll(r)
+	s.Require().NoError(err)
+	s.Equal(`tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+author Changed Author <author@example.test> 1700000000 +0000
+committer C O Mitter <committer@example.test>1700000000 +0000
+
+changed message
+`, string(payload))
 }
 
 func (s *SuiteCommit) TestEncodeExtraHeaders() {

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -67,6 +67,9 @@ func (s *SuiteCommit) TestDecodeClearsExistingState() {
 		},
 		s:   s.Storer,
 		src: staleSrc,
+		headerOrder: []int{
+			encodingHeaderIndex,
+		},
 	}
 
 	obj := &plumbing.MemoryObject{}
@@ -87,6 +90,7 @@ func (s *SuiteCommit) TestDecodeClearsExistingState() {
 	s.Nil(commit.ExtraHeaders)
 	s.Equal(s.Storer, commit.s)
 	s.Equal(obj, commit.src)
+	s.Nil(commit.headerOrder)
 }
 
 func (s *SuiteCommit) TestType() {
@@ -335,6 +339,7 @@ change
 		s.NoError(err)
 		commit.Hash = obj.Hash()
 		commit.src = obj
+		commit.headerOrder = newCommit.headerOrder
 		s.Equal(commit, newCommit)
 	}
 }
@@ -1026,6 +1031,54 @@ author John Doe <john.doe@example.com> 1755280730 -0700
 committer John Doe <john.doe@example.com> 1755280730 -0700
 
 rewritten message
+`,
+		},
+		{
+			name: "explicit UTF-8 encoding survives struct-encode",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+parent 35e85108805c84807bc66a02d91535e1e24b38b9
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+encoding UTF-8
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				c.ParentHashes[0] = plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69")
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+encoding UTF-8
+
+initial commit
+`,
+		},
+		{
+			name: "extra headers retain position relative to encoding",
+			commitRaw: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+parent 35e85108805c84807bc66a02d91535e1e24b38b9
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+x-before first
+encoding ISO-8859-1
+x-after second
+
+initial commit
+`,
+			mutate: func(c *Commit) {
+				c.ParentHashes[0] = plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69")
+			},
+			expected: `tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69
+author John Doe <john.doe@example.com> 1755280730 -0700
+committer John Doe <john.doe@example.com> 1755280730 -0700
+x-before first
+encoding ISO-8859-1
+x-after second
+
+initial commit
 `,
 		},
 		{

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -49,7 +49,6 @@ func (s *SuiteCommit) TestDecodeNonCommit() {
 func (s *SuiteCommit) TestDecodeClearsExistingState() {
 	const raw = "tree eba74343e2f15d62adedfd8c883ee0262b5c8021\n\nfresh message\n"
 
-	staleSrc := &plumbing.MemoryObject{}
 	commit := &Commit{
 		Hash:            plumbing.NewHash("1111111111111111111111111111111111111111"),
 		Author:          Signature{Name: "Stale Author", Email: "author@example.local", When: time.Unix(1, 0).UTC()},
@@ -65,11 +64,10 @@ func (s *SuiteCommit) TestDecodeClearsExistingState() {
 		ExtraHeaders: []ExtraHeader{
 			{Key: "x-stale", Value: "stale"},
 		},
-		s:                      s.Storer,
-		src:                    staleSrc,
-		encodingHeaderPosition: 1,
-		authorSource:           newIdentSource([]byte("Stale Author <author@example.local> 1 +0000")),
-		committerSource:        newIdentSource([]byte("Stale Committer <committer@example.local> 2 +0000")),
+		s:               s.Storer,
+		layout:          &commitLayout{separator: false, extras: []ExtraHeader{{Key: "stale"}}},
+		authorSource:    newIdentSource([]byte("Stale Author <author@example.local> 1 +0000")),
+		committerSource: newIdentSource([]byte("Stale Committer <committer@example.local> 2 +0000")),
 	}
 
 	obj := &plumbing.MemoryObject{}
@@ -89,8 +87,10 @@ func (s *SuiteCommit) TestDecodeClearsExistingState() {
 	s.Equal(defaultUtf8CommitMessageEncoding, commit.Encoding)
 	s.Nil(commit.ExtraHeaders)
 	s.Equal(s.Storer, commit.s)
-	s.Equal(obj, commit.src)
-	s.Zero(commit.encodingHeaderPosition)
+	s.Require().NotNil(commit.layout)
+	s.True(commit.layout.separator)
+	s.Empty(commit.layout.extras)
+	s.Len(commit.layout.headers, 1)
 	s.Zero(commit.authorSource)
 	s.Zero(commit.committerSource)
 }
@@ -340,8 +340,7 @@ change
 		err = newCommit.Decode(obj)
 		s.NoError(err)
 		commit.Hash = obj.Hash()
-		commit.src = obj
-		commit.encodingHeaderPosition = newCommit.encodingHeaderPosition
+		commit.layout = newCommit.layout
 		commit.authorSource = newCommit.authorSource
 		commit.committerSource = newCommit.committerSource
 		s.Equal(commit, newCommit)
@@ -740,27 +739,23 @@ func (s *SuiteCommit) TestDecodeFirstOccurrenceWins() {
 			},
 		},
 		{
-			name: "encoding between author and committer drops committer",
+			name: "encoding between identities preserves committer",
 			raw: "tree " + treeA + "\nauthor " + identAuthor +
 				"\nencoding latin-1\ncommitter " + identCommit + "\n\nmsg\n",
 			assert: func(c *Commit) {
 				s.Equal("Author Name", c.Author.Name)
 				s.Equal(MessageEncoding("latin-1"), c.Encoding)
-				// committer was not at its canonical position
-				// (immediately after author) so it is dropped, matching
-				// upstream's parse_commit_date returning 0 and the
-				// subsequent standard_header_field filter.
-				s.Empty(c.Committer.Name)
+				s.Equal("Commit Name", c.Committer.Name)
 			},
 		},
 		{
-			name: "author out of canonical position is dropped",
+			name: "identities after encoding are preserved",
 			raw: "tree " + treeA + "\nencoding latin-1\nauthor " + identAuthor +
 				"\ncommitter " + identCommit + "\n\nmsg\n",
 			assert: func(c *Commit) {
 				s.Equal(MessageEncoding("latin-1"), c.Encoding)
-				s.Empty(c.Author.Name)
-				s.Empty(c.Committer.Name)
+				s.Equal("Author Name", c.Author.Name)
+				s.Equal("Commit Name", c.Committer.Name)
 			},
 		},
 		{
@@ -1188,6 +1183,205 @@ func (s *SuiteCommit) TestEncodeWithoutSignaturePreservesDecodedIdentBytes() {
 			s.Equal(strings.Replace(raw, oldParent, newParent, 1), string(payload))
 		})
 	}
+}
+
+func (s *SuiteCommit) TestCommitHeaderLayout() {
+	const (
+		tree      = "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n"
+		oldParent = "parent 35e85108805c84807bc66a02d91535e1e24b38b9\n"
+		newParent = "parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69\n"
+		author    = "author A U Thor<author@example.test>01700000000 +0000\n"
+		committer = "committer C O Mitter <committer@example.test> 1700000000\n"
+		sig       = "gpgsig first\n \n  indented\n last\n"
+		sig256    = "gpgsig-sha256 first256\n last256\n"
+		mergetag  = "mergetag object 35e85108805c84807bc66a02d91535e1e24b38b9\n type commit\n tag test\n \n message\n \n"
+		message   = "\nmessage\n\ngpgsig in the body\n body continuation\n"
+	)
+	cases := []struct {
+		name, headers, unsigned string
+	}{
+		{"gpgsig before author", sig + author + committer, author + committer},
+		{"gpgsig between identities", author + sig + committer, author + committer},
+		{"mergetag before author", mergetag + author + committer, mergetag + author + committer},
+		{"extra before author", "custom value\n" + author + committer, "custom value\n" + author + committer},
+		{"encoding before author", "encoding UTF-8\n" + author + committer, "encoding UTF-8\n" + author + committer},
+		{"extra between identities", author + "custom value\n" + committer, author + "custom value\n" + committer},
+		{"committer before author", committer + author, committer + author},
+		{"empty extra separator", author + "custom \n" + committer, author + "custom \n" + committer},
+		{"valueless extra", author + "custom\n" + committer, author + "custom\n" + committer},
+		{"multiple signatures", sig256 + author + sig + committer + sig + sig256, author + committer},
+		{"encoding among extras", "x-first one\nencoding UTF-8\n" + author + "x-last two\n" + committer, "x-first one\nencoding UTF-8\n" + author + "x-last two\n" + committer},
+		{"duplicate fields", author + author + committer + "encoding UTF-8\nencoding latin-1\n", author + author + committer + "encoding UTF-8\nencoding latin-1\n"},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			for _, parents := range []string{"", oldParent, oldParent + newParent} {
+				for _, replacement := range []string{"", newParent, newParent + oldParent} {
+					raw := tree + parents + tc.headers + message
+					obj := &plumbing.MemoryObject{}
+					obj.SetType(plumbing.CommitObject)
+					_, err := obj.Write([]byte(raw))
+					s.Require().NoError(err)
+					commit, err := DecodeCommit(s.Storer, obj)
+					s.Require().NoError(err)
+					s.Equal("A U Thor", commit.Author.Name)
+					s.Equal("C O Mitter", commit.Committer.Name)
+
+					encoded := &plumbing.MemoryObject{}
+					s.Require().NoError(commit.Encode(encoded))
+					s.Equal(obj.Hash(), encoded.Hash(), "signed round trip")
+					commit.ParentHashes = nil
+					for line := range strings.FieldsSeq(replacement) {
+						if line != "parent" {
+							commit.ParentHashes = append(commit.ParentHashes, plumbing.NewHash(line))
+						}
+					}
+					for _, includeSig := range []bool{false, true} {
+						encoded = &plumbing.MemoryObject{}
+						want := tree + replacement + tc.unsigned + message
+						if includeSig {
+							s.Require().NoError(commit.Encode(encoded))
+							want = tree + replacement + tc.headers + message
+						} else {
+							s.Require().NoError(commit.EncodeWithoutSignature(encoded))
+						}
+						r, err := encoded.Reader()
+						s.Require().NoError(err)
+						payload, err := io.ReadAll(r)
+						s.Require().NoError(err)
+						s.Require().NoError(r.Close())
+						s.Equal(want, string(payload), "parents %q -> %q, signatures %v", parents, replacement, includeSig)
+					}
+				}
+			}
+		})
+	}
+}
+
+func (s *SuiteCommit) TestCommitHeaderLayoutMutations() {
+	const (
+		tree      = "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n"
+		author    = "author A U Thor<author@example.test>01700000000 +0000\n"
+		committer = "committer C O Mitter<committer@example.test>1700000000 +0000\n"
+		sig       = "gpgsig old\n continuation\n"
+		sig256    = "gpgsig-sha256 old256\n continuation256\n"
+		encoding  = "encoding UTF-8\n"
+		extra     = "custom \n"
+		message   = "\nmessage without final newline"
+		raw       = tree + sig + encoding + committer + extra + author + sig256 + message
+	)
+	cases := []struct {
+		name   string
+		mutate func(*Commit)
+		want   string
+	}{
+		{"tree", func(c *Commit) { c.TreeHash = plumbing.NewHash(strings.Repeat("1", 40)) }, strings.Replace(raw, tree, "tree "+strings.Repeat("1", 40)+"\n", 1)},
+		{"author", func(c *Commit) { c.Author.Name = "Changed Author" }, strings.Replace(raw, author, "author Changed Author <author@example.test> 1700000000 +0000\n", 1)},
+		{"committer", func(c *Commit) { c.Committer.Email = "changed@example.test" }, strings.Replace(raw, committer, "committer C O Mitter <changed@example.test> 1700000000 +0000\n", 1)},
+		{"timezone", func(c *Commit) { c.Author.When = c.Author.When.In(time.FixedZone("offset", 3600)) }, strings.Replace(raw, author, "author A U Thor <author@example.test> 1700000000 +0100\n", 1)},
+		{"message", func(c *Commit) { c.Message = "new message\n" }, strings.Replace(raw, message, "\nnew message\n", 1)},
+		{"encoding", func(c *Commit) { c.Encoding = "latin-1" }, strings.Replace(raw, encoding, "encoding latin-1\n", 1)},
+		{"remove encoding", func(c *Commit) { c.Encoding = "" }, strings.Replace(raw, encoding, "", 1)},
+		{"extra in place", func(c *Commit) { c.ExtraHeaders[0].Value = "changed\ncontinuation" }, strings.Replace(raw, extra, "custom changed\n continuation\n", 1)},
+		{"remove extra", func(c *Commit) { c.ExtraHeaders = nil }, strings.Replace(raw, extra, "", 1)},
+		{"append extra", func(c *Commit) { c.ExtraHeaders = append(c.ExtraHeaders, ExtraHeader{Key: "new", Value: "value"}) }, strings.Replace(raw, message, "new value\n"+message, 1)},
+		{"replace signature", func(c *Commit) { c.Signature = "new\nnew continuation\n" }, strings.Replace(raw, sig, "gpgsig new\n new continuation\n", 1)},
+		{"remove signature", func(c *Commit) { c.Signature = "" }, strings.Replace(raw, sig, "", 1)},
+		{"replace sha256 signature", func(c *Commit) { c.SignatureSHA256 = "new256\n" }, strings.Replace(raw, sig256, "gpgsig-sha256 new256\n", 1)},
+		{"remove sha256 signature", func(c *Commit) { c.SignatureSHA256 = "" }, strings.Replace(raw, sig256, "", 1)},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.CommitObject)
+			_, err := obj.Write([]byte(raw))
+			s.Require().NoError(err)
+			commit, err := DecodeCommit(s.Storer, obj)
+			s.Require().NoError(err)
+			tc.mutate(commit)
+			for _, includeSig := range []bool{false, true} {
+				want := tc.want
+				encoded := &plumbing.MemoryObject{}
+				if includeSig {
+					s.Require().NoError(commit.Encode(encoded))
+				} else {
+					s.Require().NoError(commit.EncodeWithoutSignature(encoded))
+					for _, signature := range []string{sig, sig256, "gpgsig new\n new continuation\n", "gpgsig-sha256 new256\n"} {
+						want = strings.ReplaceAll(want, signature, "")
+					}
+				}
+				r, err := encoded.Reader()
+				s.Require().NoError(err)
+				payload, err := io.ReadAll(r)
+				s.Require().NoError(err)
+				s.Require().NoError(r.Close())
+				s.Equal(want, string(payload))
+			}
+		})
+	}
+}
+
+func (s *SuiteCommit) TestCommitHeaderLayoutEndings() {
+	const tree = "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	for _, suffix := range []string{
+		"", "\n", "\n\n", "\n\nmessage", "\ncustom ", "\ncustom",
+		"\ncustom value", "\ncustom value\n continuation", "\ncustom value\n \n",
+		"\nencoding ", "\nauthor A U Thor <author@example.test> 1700000000 +0000",
+		"\ngpgsig", "\ngpgsig \n continuation", "\ngpgsig old\n continuation\n\nmessage",
+	} {
+		s.Run(fmt.Sprintf("suffix %q", suffix), func() {
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.CommitObject)
+			_, err := obj.Write([]byte(tree + suffix))
+			s.Require().NoError(err)
+			commit, err := DecodeCommit(s.Storer, obj)
+			s.Require().NoError(err)
+			encoded := &plumbing.MemoryObject{}
+			s.Require().NoError(commit.Encode(encoded))
+			s.Equal(obj.Hash(), encoded.Hash())
+
+			commit.ParentHashes = []plumbing.Hash{plumbing.NewHash(strings.Repeat("1", 40))}
+			encoded = &plumbing.MemoryObject{}
+			s.Require().NoError(commit.EncodeWithoutSignature(encoded))
+			var unsigned bytes.Buffer
+			s.Require().NoError(stripHeaderSignatures(&unsigned, strings.NewReader(tree+suffix)))
+			_, rest, _ := strings.Cut(unsigned.String(), "\n")
+			want := tree + "\nparent " + strings.Repeat("1", 40) + "\n" + rest
+			r, err := encoded.Reader()
+			s.Require().NoError(err)
+			payload, err := io.ReadAll(r)
+			s.Require().NoError(err)
+			s.Require().NoError(r.Close())
+			s.Equal(want, string(payload))
+		})
+	}
+}
+
+func (s *SuiteCommit) TestCommitHeaderLayoutAddsFields() {
+	const tree = "tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904\n"
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.CommitObject)
+	_, err := obj.Write([]byte(tree))
+	s.Require().NoError(err)
+	commit, err := DecodeCommit(s.Storer, obj)
+	s.Require().NoError(err)
+	commit.Author = Signature{Name: "Author", Email: "author@example.test", When: time.Unix(1700000000, 0).UTC()}
+	commit.Committer = commit.Author
+	commit.Encoding = "latin-1"
+	commit.ExtraHeaders = []ExtraHeader{{Key: "custom", Value: "value"}}
+	commit.Signature = "new\ncontinuation\n"
+	commit.SignatureSHA256 = "new256\n"
+	commit.Message = "new message\n"
+	encoded := &plumbing.MemoryObject{}
+	s.Require().NoError(commit.Encode(encoded))
+	r, err := encoded.Reader()
+	s.Require().NoError(err)
+	payload, err := io.ReadAll(r)
+	s.Require().NoError(err)
+	s.Require().NoError(r.Close())
+	s.Equal(tree+"author Author <author@example.test> 1700000000 +0000\n"+
+		"committer Author <author@example.test> 1700000000 +0000\nencoding latin-1\n"+
+		"custom value\ngpgsig new\n continuation\ngpgsig-sha256 new256\n\nnew message\n", string(payload))
 }
 
 func (s *SuiteCommit) TestEncodeWithoutSignatureCanonicalizesChangedIdent() {

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -102,9 +102,9 @@ func (s *Signature) Decode(b []byte) {
 	s.Name = string(bytes.Trim(b[:open], " "))
 	s.Email = string(b[open+1 : closeBracket])
 
-	hasTime := closeBracket+2 < len(b)
-	if hasTime {
-		s.decodeTimeAndTimeZone(b[closeBracket+2:])
+	timeAndTimeZone := bytes.TrimLeft(b[closeBracket+1:], " \t\n\v\f\r")
+	if len(timeAndTimeZone) > 0 {
+		s.decodeTimeAndTimeZone(timeAndTimeZone)
 	}
 }
 

--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -3,11 +3,11 @@
 package object
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v6/plumbing"
@@ -89,8 +89,12 @@ type Signature struct {
 
 // Decode decodes a byte slice into a signature
 func (s *Signature) Decode(b []byte) {
-	open := bytes.LastIndexByte(b, '<')
-	closeBracket := bytes.LastIndexByte(b, '>')
+	s.decode(string(b))
+}
+
+func (s *Signature) decode(raw string) {
+	open := strings.LastIndexByte(raw, '<')
+	closeBracket := strings.LastIndexByte(raw, '>')
 	if open == -1 || closeBracket == -1 {
 		return
 	}
@@ -99,10 +103,10 @@ func (s *Signature) Decode(b []byte) {
 		return
 	}
 
-	s.Name = string(bytes.Trim(b[:open], " "))
-	s.Email = string(b[open+1 : closeBracket])
+	s.Name = strings.Trim(raw[:open], " ")
+	s.Email = raw[open+1 : closeBracket]
 
-	timeAndTimeZone := bytes.TrimLeft(b[closeBracket+1:], " \t\n\v\f\r")
+	timeAndTimeZone := strings.TrimLeft(raw[closeBracket+1:], " \t\n\v\f\r")
 	if len(timeAndTimeZone) > 0 {
 		s.decodeTimeAndTimeZone(timeAndTimeZone)
 	}
@@ -119,26 +123,59 @@ func (s *Signature) Encode(w io.Writer) error {
 	return nil
 }
 
+// identSource keeps the exact header value and the signature decoded from it.
+// The raw value is reusable only while the public Signature is unchanged.
+type identSource struct {
+	raw       string
+	signature Signature
+	present   bool
+}
+
+func newIdentSource(raw []byte) identSource {
+	source := identSource{raw: string(raw), present: true}
+	source.signature.decode(source.raw)
+	return source
+}
+
+func (s identSource) matches(signature Signature) bool {
+	return s.present && signatureEqual(s.signature, signature)
+}
+
+func (s identSource) encode(w io.Writer, signature Signature) error {
+	if s.matches(signature) {
+		_, err := io.WriteString(w, s.raw)
+		return err
+	}
+	return signature.Encode(w)
+}
+
+func signatureEqual(a, b Signature) bool {
+	return a.Name == b.Name &&
+		a.Email == b.Email &&
+		a.When.Unix() == b.When.Unix() &&
+		a.When.Format("-0700") == b.When.Format("-0700")
+}
+
 var timeZoneLength = 5
 
-func (s *Signature) decodeTimeAndTimeZone(b []byte) {
-	space := bytes.IndexByte(b, ' ')
+func (s *Signature) decodeTimeAndTimeZone(raw string) {
+	space := strings.IndexByte(raw, ' ')
 	if space == -1 {
-		space = len(b)
+		space = len(raw)
 	}
 
-	ts, err := strconv.ParseInt(string(b[:space]), 10, 64)
+	ts, err := strconv.ParseInt(raw[:space], 10, 64)
 	if err != nil {
 		return
 	}
 
 	s.When = time.Unix(ts, 0).In(time.UTC)
 	tzStart := space + 1
-	if tzStart >= len(b) || tzStart+timeZoneLength > len(b) {
+	if tzStart >= len(raw) || tzStart+timeZoneLength > len(raw) {
 		return
 	}
 
-	timezone := string(b[tzStart : tzStart+timeZoneLength])
+	timezone := raw[tzStart : tzStart+timeZoneLength]
 	tzhours, err1 := strconv.ParseInt(timezone[0:3], 10, 64)
 	tzmins, err2 := strconv.ParseInt(timezone[3:], 10, 64)
 	if err1 != nil || err2 != nil {

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -138,6 +138,11 @@ func (s *ObjectsSuite) TestParseSignature() {
 			Email: "foo@bar.com",
 			When:  MustParseTime("2009-11-10 16:00:00 -0700"),
 		},
+		`Foo Bar <foo@bar.com>1257894000 +0100`: {
+			Name:  "Foo Bar",
+			Email: "foo@bar.com",
+			When:  MustParseTime("2009-11-11 00:00:00 +0100"),
+		},
 		`Foo Bar <> 1257894000 +0100`: {
 			Name:  "Foo Bar",
 			Email: "",

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -50,6 +50,8 @@ type Tag struct {
 	// src holds the encoded object this Tag was decoded from, used by
 	// EncodeWithoutSignature to recover the canonical signed bytes.
 	src plumbing.EncodedObject
+	// taggerSource retains the decoded tagger bytes for byte-exact re-encoding.
+	taggerSource identSource
 }
 
 // GetTag gets a tag from an object storer and decodes it.
@@ -197,12 +199,12 @@ func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 		return err
 	}
 
-	if !isZeroSignature(t.Tagger) {
+	if t.taggerSource.matches(t.Tagger) || !isZeroSignature(t.Tagger) {
 		if _, err = fmt.Fprint(w, "tagger "); err != nil {
 			return err
 		}
 
-		if err = t.Tagger.Encode(w); err != nil {
+		if err = t.taggerSource.encode(w, t.Tagger); err != nil {
 			return err
 		}
 

--- a/plumbing/object/tag_scanner.go
+++ b/plumbing/object/tag_scanner.go
@@ -154,7 +154,8 @@ func scanTagTagger(s *tagScanner) (tagState, error) {
 
 	key, data := splitHeader(line)
 	if key == "tagger" {
-		s.t.Tagger.Decode(data)
+		s.t.taggerSource = newIdentSource(data)
+		s.t.Tagger = s.t.taggerSource.signature
 		s.sawTagger = true
 		if err == io.EOF {
 			return nil, nil

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -243,6 +243,7 @@ func (s *TagSuite) TestTagEncodeDecodeIdempotent() {
 		s.NoError(err)
 		tag.Hash = obj.Hash()
 		tag.src = obj
+		tag.taggerSource = newTag.taggerSource
 		s.Equal(tag, newTag)
 	}
 }
@@ -295,6 +296,7 @@ func (s *TagSuite) TestTagDecodeClearsExistingState() {
 		Target:          plumbing.NewHash("2222222222222222222222222222222222222222"),
 		s:               store,
 		src:             staleSrc,
+		taggerSource:    newIdentSource([]byte("Stale <stale@example.local> 1 +0000")),
 	}
 
 	obj := &plumbing.MemoryObject{}
@@ -313,6 +315,7 @@ func (s *TagSuite) TestTagDecodeClearsExistingState() {
 	s.Equal("c029517f6300c2da0f4b651b8642506cd6aaf45e", tag.Target.String())
 	s.Equal(store, tag.s)
 	s.Equal(obj, tag.src)
+	s.Zero(tag.taggerSource)
 }
 
 func (s *TagSuite) TestTagDecodeRoundTrip() {
@@ -1059,6 +1062,25 @@ tagger Test Tagger <tagger@example.local> 1700000000 +0000
 tag message
 `,
 		},
+		{
+			name: "clearing tagger omits decoded tagger",
+			tagRaw: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger Test Tagger <tagger@example.local> 1700000000 +0000
+
+tag message
+`,
+			mutate: func(t *Tag) {
+				t.Tagger = Signature{}
+			},
+			expected: `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+
+tag message
+`,
+		},
 	}
 
 	for _, tc := range tests {
@@ -1088,4 +1110,76 @@ tag message
 			s.Equal(tc.expected, string(payload))
 		})
 	}
+}
+
+func (s *TagSuite) TestEncodeWithoutSignaturePreservesDecodedIdentBytes() {
+	tests := []struct {
+		name  string
+		ident string
+	}{
+		{name: "no space before date", ident: "A U Thor <author@example.test>1700000000 +0000"},
+		{name: "no space before email", ident: "A U Thor<author@example.test> 1700000000 +0000"},
+		{name: "no timezone", ident: "A U Thor <author@example.test> 1700000000"},
+		{name: "zero-padded timestamp", ident: "A U Thor <author@example.test> 01700000000 +0000"},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			raw := "object 1eca38290a3131d0c90709496a9b2207a872631e\n" +
+				"type commit\n" +
+				"tag v1\n" +
+				"tagger " + tc.ident + "\n\nmessage\n"
+
+			obj := &plumbing.MemoryObject{}
+			obj.SetType(plumbing.TagObject)
+			_, err := obj.Write([]byte(raw))
+			s.Require().NoError(err)
+
+			tag := &Tag{}
+			s.Require().NoError(tag.Decode(obj))
+			tag.Name = "v2"
+
+			encoded := &plumbing.MemoryObject{}
+			s.Require().NoError(tag.EncodeWithoutSignature(encoded))
+			r, err := encoded.Reader()
+			s.Require().NoError(err)
+			payload, err := io.ReadAll(r)
+			s.Require().NoError(err)
+			s.Equal(strings.Replace(raw, "tag v1", "tag v2", 1), string(payload))
+		})
+	}
+}
+
+func (s *TagSuite) TestEncodeWithoutSignatureCanonicalizesChangedIdent() {
+	const raw = `object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v1
+tagger A U Thor <author@example.test>1700000000 +0000
+
+message
+`
+
+	obj := &plumbing.MemoryObject{}
+	obj.SetType(plumbing.TagObject)
+	_, err := obj.Write([]byte(raw))
+	s.Require().NoError(err)
+
+	tag := &Tag{}
+	s.Require().NoError(tag.Decode(obj))
+	tag.Tagger.Name = "Changed Tagger"
+	tag.Name = "v2"
+
+	encoded := &plumbing.MemoryObject{}
+	s.Require().NoError(tag.EncodeWithoutSignature(encoded))
+	r, err := encoded.Reader()
+	s.Require().NoError(err)
+	payload, err := io.ReadAll(r)
+	s.Require().NoError(err)
+	s.Equal(`object 1eca38290a3131d0c90709496a9b2207a872631e
+type commit
+tag v2
+tagger Changed Tagger <author@example.test> 1700000000 +0000
+
+message
+`, string(payload))
 }


### PR DESCRIPTION
Changing `ParentHashes` on a decoded commit can change unrelated object bytes. Unusual ident formatting can be normalized, and headers before or between `author` and `committer` can cause identities to be discarded and re-encoded as `author  <> 0 +0000`. This PR preserves decoded identity bytes and commit header layout during unrelated mutations.

The decoder finds identities throughout the header block and retains raw headers, continuation lines, their positions, and snapshots of the decoded fields. `Encode` replays unchanged headers in place and substitutes changed fields. `EncodeWithoutSignature` uses the same layout while omitting `gpgsig` and `gpgsig-sha256` blocks wherever they occur. Parent rewrites replace only the contiguous parent block after `tree`. Explicit UTF-8 encoding, empty header separators, and message bytes remain intact. Commit encoding no longer re-decodes the source object to detect mutations.

The ident fixes also cover annotated tags. Commits and tags constructed in memory retain canonical encoding, and the public API is unchanged.

Regression coverage includes:

- `gpgsig`, `mergetag`, arbitrary headers, or `encoding` before `author`; headers between identities; and `committer` before `author`.
- Root, single-parent, and merge commits with parent replacement, addition, removal, and reordering; signed round trips and unsigned payloads are checked byte for byte.
- Empty extra-header separators, repeated signatures, mergetag continuation lines, duplicate headers, and missing final newlines.
- No space before the email or timestamp, missing timezones, zero-padded timestamps, explicit UTF-8, and extra-header ordering around encoding.
- Deliberate changes to identities, timezones, tree, encoding, extras, signatures, and message, plus adding previously absent fields and resetting reused decoders.

Git's [`split_ident_line`](https://github.com/git/git/blob/dea0ea3582e6980ddbc1173cc8e3e9f9db91cde0/ident.c#L268-L350) accepts zero or more spaces before the date. Its [`parse_commit_header`](https://github.com/git/git/blob/v2.54.0/pretty.c#L860-L882) scans the header block for identities regardless of position. Native Git read both identities correctly in all eight reported layout fixtures, and `git cat-file commit` returned the original bytes. Those unusual objects were imported with `git hash-object --literally`; strict object creation can reject their ordering.

Rebased onto upstream `main` at `fecc378865070c30b3e75f6f998948aca6edd32d`. `git range-diff` confirms that all four patches are unchanged, and all rewritten commits have valid GPG signatures. This upstream version requires Go 1.26.

Validation passed on the rebased head:

- Windows: `go test -race -p 2 ./plumbing/object -count=1`.
- Linux: `go test -race -p 2 ./plumbing/object ./tests/objectverify -count=1`, including native-Git/GPG verification.
- Repository-pinned `golangci-lint v2.13.1 run ./plumbing/object/...`: zero issues.

The new layout regression failed on the previous implementation before the fix. The full suite is not claimed passing: a broader Windows run before rebasing encountered system-resource exhaustion and a missing `touch` executable. Upstream CI results are separate from these local checks.

Fixes #2327

AI-assisted: GPT-5.6 Sol and OpenAI Codex were used for implementation and test authoring, with `Assisted-by:` trailers per the project's AI policy.



