### PR TITLE
build: Bump to Go1.26 and golangci-lint v2.13.1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -63,4 +63,5 @@ formatters:
         - pattern: 'interface{}'
           replacement: 'any'
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ COVERAGE_REPORT = coverage.out
 COVERAGE_MODE = count
 
 # renovate: datasource=github-tags depName=golangci/golangci-lint
-GOLANGCI_VERSION ?= v2.11.4
+GOLANGCI_VERSION ?= v2.13.1
 TOOLS_BIN := $(shell mkdir -p build/tools && realpath build/tools)
 
 GOLANGCI = $(TOOLS_BIN)/golangci-lint-$(GOLANGCI_VERSION)

--- a/blame_test.go
+++ b/blame_test.go
@@ -78,7 +78,8 @@ func (s *BlameSuite) mockBlame(t blameTest, r *Repository) (blame *BlameResult) 
 	lines, err := f.Lines()
 	s.Require().NoError(err)
 	s.Len(t.blames, len(lines), fmt.Sprintf(
-		"repo=%s, path=%s, rev=%s: the number of lines in the file and the number of expected blames differ (len(blames)=%d, len(lines)=%d)\nblames=%#q\nlines=%#q", t.repo, t.path, t.rev, len(t.blames), len(lines), t.blames, lines))
+		"repo=%s, path=%s, rev=%s: the number of lines in the file and the number of expected blames differ (len(blames)=%d, len(lines)=%d)\nblames=%#q\nlines=%#q", t.repo, t.path, t.rev, len(t.blames), len(lines), t.blames, lines,
+	))
 
 	blamedLines := make([]*Line, 0, len(t.blames))
 	for i := range t.blames {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/go-git/go-git/v6
 
 // go-git supports the last 2 stable Go versions.
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/Microsoft/go-winio v0.6.2

--- a/plumbing/format/commitgraph/bench_test.go
+++ b/plumbing/format/commitgraph/bench_test.go
@@ -42,7 +42,8 @@ func BenchmarkOpenFileIndex(b *testing.B) {
 			b.ReportAllocs()
 			for range b.N {
 				fi, err := commitgraph.OpenFileIndex(
-					discardCloseReader{bytes.NewReader(raw)})
+					discardCloseReader{bytes.NewReader(raw)},
+				)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -78,7 +79,8 @@ func BenchmarkGetCommitDataByIndex(b *testing.B) {
 	for _, tc := range cases {
 		raw := buildBenchGraph(b, tc.shape)
 		fi, err := commitgraph.OpenFileIndex(
-			discardCloseReader{bytes.NewReader(raw)})
+			discardCloseReader{bytes.NewReader(raw)},
+		)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/plumbing/format/commitgraph/commitgraph_test.go
+++ b/plumbing/format/commitgraph/commitgraph_test.go
@@ -673,7 +673,8 @@ func (s *CommitgraphSuite) TestGetCommitDataReadsGenerationOverflow() {
 	s.Require().NoError(commitgraph.NewEncoder(&buf).Encode(mem))
 
 	idx, err := commitgraph.OpenFileIndex(
-		discardCloseReader{bytes.NewReader(buf.Bytes())})
+		discardCloseReader{bytes.NewReader(buf.Bytes())},
+	)
 	s.Require().NoError(err)
 	defer idx.Close()
 

--- a/plumbing/format/config/common.go
+++ b/plumbing/format/config/common.go
@@ -1,5 +1,7 @@
 package config
 
+import "slices"
+
 // New creates a new config instance.
 func New() *Config {
 	return &Config{}
@@ -32,8 +34,7 @@ const (
 
 // Section returns a existing section with the given name or creates a new one.
 func (c *Config) Section(name string) *Section {
-	for i := len(c.Sections) - 1; i >= 0; i-- {
-		s := c.Sections[i]
+	for _, s := range slices.Backward(c.Sections) {
 		if s.IsName(name) {
 			return s
 		}

--- a/plumbing/format/config/option.go
+++ b/plumbing/format/config/option.go
@@ -48,8 +48,7 @@ func (opts Options) GoString() string {
 // In order to get all possible values for the same key,
 // use GetAll.
 func (opts Options) Get(key string) string {
-	for i := len(opts) - 1; i >= 0; i-- {
-		o := opts[i]
+	for _, o := range slices.Backward(opts) {
 		if o.IsKey(key) {
 			return o.Value
 		}

--- a/plumbing/format/config/section.go
+++ b/plumbing/format/config/section.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -71,8 +72,7 @@ func (s *Section) IsName(name string) bool {
 // Subsection returns a Subsection from the specified Section. If the
 // Subsection does not exists, new one is created and added to Section.
 func (s *Section) Subsection(name string) *Subsection {
-	for i := len(s.Subsections) - 1; i >= 0; i-- {
-		ss := s.Subsections[i]
+	for _, ss := range slices.Backward(s.Subsections) {
 		if ss.IsName(name) {
 			return ss
 		}

--- a/plumbing/format/gitignore/conformance_test.go
+++ b/plumbing/format/gitignore/conformance_test.go
@@ -165,8 +165,7 @@ func (s *ConformanceSuite) runCheckIgnore(root *os.Root, arg, ignoreCase string)
 }
 
 func exitCode(err error) int {
-	var e *exec.ExitError
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*exec.ExitError](err); ok {
 		return e.ExitCode()
 	}
 	return -1

--- a/plumbing/format/idxfile/idxfile_test.go
+++ b/plumbing/format/idxfile/idxfile_test.go
@@ -314,7 +314,8 @@ func TestMemoryIndex_EntriesWithPrefix_MultiByte(t *testing.T) {
 		w.Add(h, uint64(100+i), uint32(i))
 	}
 	require.NoError(t, w.OnFooter(
-		plumbing.NewHash("0000000000000000000000000000000000000001")))
+		plumbing.NewHash("0000000000000000000000000000000000000001"),
+	))
 
 	idx, err := w.Index()
 	require.NoError(t, err)

--- a/plumbing/format/pktline/error_test.go
+++ b/plumbing/format/pktline/error_test.go
@@ -77,9 +77,8 @@ func TestPeekErrorLine(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	buf.WriteString("000fERR foobar\n")
-	var e *ErrorLine
 	_, _, err := PeekLine(bufio.NewReader(&buf))
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*ErrorLine](err); !ok {
 		t.Fatalf("expected error line, got: %T: %v", err, err)
 	}
 }

--- a/plumbing/format/pktline/pktline_write_test.go
+++ b/plumbing/format/pktline/pktline_write_test.go
@@ -162,7 +162,8 @@ func (s *SuiteWriter) TestEncode() {
 				[]byte(strings.Repeat("a", pktline.MaxPayloadSize)),
 			},
 			expected: []byte(
-				"fff0" + strings.Repeat("a", pktline.MaxPayloadSize)),
+				"fff0" + strings.Repeat("a", pktline.MaxPayloadSize),
+			),
 		}, {
 			input: [][]byte{
 				[]byte(strings.Repeat("a", pktline.MaxPayloadSize)),
@@ -170,7 +171,8 @@ func (s *SuiteWriter) TestEncode() {
 			},
 			expected: []byte(
 				"fff0" + strings.Repeat("a", pktline.MaxPayloadSize) +
-					"fff0" + strings.Repeat("b", pktline.MaxPayloadSize)),
+					"fff0" + strings.Repeat("b", pktline.MaxPayloadSize),
+			),
 		},
 	} {
 		comment := fmt.Sprintf("input %d = %s\n", i, test.input)
@@ -251,7 +253,8 @@ func (s *SuiteWriter) TestWritePacketStrings() {
 				strings.Repeat("a", pktline.MaxPayloadSize),
 			},
 			expected: []byte(
-				"fff0" + strings.Repeat("a", pktline.MaxPayloadSize)),
+				"fff0" + strings.Repeat("a", pktline.MaxPayloadSize),
+			),
 		}, {
 			input: []string{
 				strings.Repeat("a", pktline.MaxPayloadSize),
@@ -259,7 +262,8 @@ func (s *SuiteWriter) TestWritePacketStrings() {
 			},
 			expected: []byte(
 				"fff0" + strings.Repeat("a", pktline.MaxPayloadSize) +
-					"fff0" + strings.Repeat("b", pktline.MaxPayloadSize)),
+					"fff0" + strings.Repeat("b", pktline.MaxPayloadSize),
+			),
 		},
 	} {
 		comment := fmt.Sprintf("input %d = %v\n", i, test.input)

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -4,6 +4,7 @@ import (
 	"container/list"
 	"errors"
 	"io"
+	"slices"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -317,8 +318,7 @@ func addReference(
 		}
 	} else {
 		// add ref's commits to the path in reverse order (from the latest)
-		for i := len(refCommits) - 1; i >= 0; i-- {
-			c := refCommits[i]
+		for _, c := range slices.Backward(refCommits) {
 			// insert before found common parent
 			parent = commitsPath.InsertBefore(c, parent)
 			commitsLookup[c.Hash] = parent

--- a/plumbing/object/file_test.go
+++ b/plumbing/object/file_test.go
@@ -133,7 +133,8 @@ func (s *FileSuite) TestContents() {
 		content, err := file.Contents()
 		s.NoError(err)
 		s.Equal(t.contents, content, fmt.Sprintf(
-			"subtest %d: commit=%s, path=%s", i, t.commit, t.path))
+			"subtest %d: commit=%s, path=%s", i, t.commit, t.path,
+		))
 	}
 }
 
@@ -189,7 +190,8 @@ func (s *FileSuite) TestLines() {
 		lines, err := file.Lines()
 		s.NoError(err)
 		s.Equal(t.lines, lines, fmt.Sprintf(
-			"subtest %d: commit=%s, path=%s", i, t.commit, t.path))
+			"subtest %d: commit=%s, path=%s", i, t.commit, t.path,
+		))
 	}
 }
 

--- a/plumbing/object/rename.go
+++ b/plumbing/object/rename.go
@@ -3,6 +3,7 @@ package object
 import (
 	"errors"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 
@@ -162,9 +163,9 @@ func (d *renameDetector) detectExactRenames() {
 
 			usedAdds := make(map[*Change]struct{})
 			usedDeletes := make(map[*Change]struct{})
-			for i := len(matrix) - 1; i >= 0; i-- {
-				del := deleted[matrix[i].deleted]
-				add := added[matrix[i].added]
+			for _, m := range slices.Backward(matrix) {
+				del := deleted[m.deleted]
+				add := added[m.added]
 
 				if add == nil || del == nil {
 					// it was already matched
@@ -174,8 +175,8 @@ func (d *renameDetector) detectExactRenames() {
 				usedAdds[add] = struct{}{}
 				usedDeletes[del] = struct{}{}
 				d.modified = append(d.modified, &Change{From: del.From, To: add.To})
-				added[matrix[i].added] = nil
-				deleted[matrix[i].deleted] = nil
+				added[m.added] = nil
+				deleted[m.deleted] = nil
 			}
 
 			for _, c := range added {
@@ -222,8 +223,7 @@ func (d *renameDetector) detectContentRenames() error {
 
 	// Match rename pairs on a first come, first serve basis until
 	// we have looked at everything that is above the minimum score.
-	for i := len(matrix) - 1; i >= 0; i-- {
-		pair := matrix[i]
+	for _, pair := range slices.Backward(matrix) {
 		src := srcs[pair.deleted]
 		dst := dsts[pair.added]
 

--- a/plumbing/protocol/packp/sideband/muxer.go
+++ b/plumbing/protocol/packp/sideband/muxer.go
@@ -26,8 +26,11 @@ func NewMuxer(t Type, w io.Writer) *Muxer {
 		maxSize = MaxPackedSize
 	}
 
+	// Each pkt-line carries a 4-byte length prefix and a 1-byte sideband
+	// channel identifier. Reserve space for both so the total packet never
+	// exceeds the sideband max size and stays within pktline.MaxPayloadSize.
 	return &Muxer{
-		max: maxSize - chLen,
+		max: maxSize - pktline.LenSize - chLen,
 		w:   w,
 	}
 }

--- a/plumbing/protocol/packp/sideband/muxer_test.go
+++ b/plumbing/protocol/packp/sideband/muxer_test.go
@@ -12,7 +12,7 @@ func (s *SidebandSuite) TestMuxerWrite() {
 	n, err := m.Write(bytes.Repeat([]byte{'F'}, (MaxPackedSize-1)*2))
 	s.NoError(err)
 	s.Equal(1998, n)
-	s.Equal(2008, buf.Len())
+	s.Equal(2013, buf.Len())
 }
 
 func (s *SidebandSuite) TestMuxerWriteChannelMultipleChannels() {

--- a/plumbing/protocol/packp/srvresp_test.go
+++ b/plumbing/protocol/packp/srvresp_test.go
@@ -25,7 +25,7 @@ func (s *ServerResponseSuite) TestDecodeNAK() {
 	raw := "0008NAK\n"
 
 	sr := &ServerResponse{}
-	err := sr.Decode((bytes.NewBufferString(raw)))
+	err := sr.Decode(bytes.NewBufferString(raw))
 	s.NoError(err)
 
 	s.Len(sr.ACKs, 0)

--- a/plumbing/protocol/packp/updreq_decode.go
+++ b/plumbing/protocol/packp/updreq_decode.go
@@ -35,39 +35,46 @@ func errInvalidHash(hash string) error {
 func errInvalidShallowLineLength(got int) error {
 	return errMalformedRequest(fmt.Sprintf(
 		"invalid shallow line length: expected %d or %d, got %d",
-		len(shallow)+sha1HexSize, len(shallow)+sha256HexSize, got))
+		len(shallow)+sha1HexSize, len(shallow)+sha256HexSize, got,
+	))
 }
 
 func errInvalidCommandCapabilitiesLineLength(got int) error {
 	return errMalformedRequest(fmt.Sprintf(
 		"invalid command and capabilities line length: expected at least %d, got %d",
-		minCommandAndCapsLength, got))
+		minCommandAndCapsLength, got,
+	))
 }
 
 func errInvalidCommandLineLength(got int) error {
 	return errMalformedRequest(fmt.Sprintf(
 		"invalid command line length: expected at least %d, got %d",
-		minCommandLength, got))
+		minCommandLength, got,
+	))
 }
 
 func errInvalidShallowObjID(err error) error {
 	return errMalformedRequest(
-		fmt.Sprintf("invalid shallow object id: %s", err.Error()))
+		fmt.Sprintf("invalid shallow object id: %s", err.Error()),
+	)
 }
 
 func errInvalidOldObjID(err error) error {
 	return errMalformedRequest(
-		fmt.Sprintf("invalid old object id: %s", err.Error()))
+		fmt.Sprintf("invalid old object id: %s", err.Error()),
+	)
 }
 
 func errInvalidNewObjID(err error) error {
 	return errMalformedRequest(
-		fmt.Sprintf("invalid new object id: %s", err.Error()))
+		fmt.Sprintf("invalid new object id: %s", err.Error()),
+	)
 }
 
 func errMalformedCommand(err error) error {
 	return errMalformedRequest(fmt.Sprintf(
-		"malformed command: %s", err.Error()))
+		"malformed command: %s", err.Error(),
+	))
 }
 
 // Decode reads the next update-request message from the reader.

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -161,7 +161,8 @@ func (s *RevListSuite) TestRevListObjectsTagObject() {
 			d, err := fixtures.ByTag("tags").ByURL("https://github.com/git-fixtures/tags.git").One().DotGit()
 			s.Require().NoError(err)
 			return d
-		}(), cache.NewObjectLRUDefault())
+		}(), cache.NewObjectLRUDefault(),
+	)
 	defer func() { _ = sto.Close() }()
 
 	expected := map[string]bool{
@@ -219,7 +220,8 @@ func (s *RevListSuite) TestRevListObjectsNewBranch() {
 		s.Storer, []plumbing.Hash{
 			plumbing.NewHash(someCommitBranch),
 			plumbing.NewHash(someCommitOtherBranch),
-		}, localHist)
+		}, localHist,
+	)
 	s.NoError(err)
 
 	revList := map[string]bool{

--- a/plumbing/transport/ssh/auth.go
+++ b/plumbing/transport/ssh/auth.go
@@ -52,7 +52,8 @@ func (m *HostKeyCallbackHelper) SetHostKeyCallback(cfg *gossh.ClientConfig) (*go
 func (m *HostKeyCallbackHelper) traceHostKeyCallback(hostname string, remote net.Addr, key gossh.PublicKey) error {
 	trace.SSH.Printf(
 		`ssh: hostkey callback hostname=%s remote=%s pubkey="%s %s"`,
-		hostname, remote, key.Type(), gossh.FingerprintSHA256(key))
+		hostname, remote, key.Type(), gossh.FingerprintSHA256(key),
+	)
 	return m.HostKeyCallback(hostname, remote, key)
 }
 

--- a/plumbing/transport/ssh/knownhosts/knownhosts.go
+++ b/plumbing/transport/ssh/knownhosts/knownhosts.go
@@ -125,7 +125,8 @@ func (hkdb *HostKeyDB) HostKeyCallback() ssh.HostKeyCallback {
 	f := func(hostname string, remote net.Addr, key ssh.PublicKey) error {
 		trace.SSH.Printf(
 			`ssh: wildcard knownhosts for hostname=%s pubkey="%s %s"`,
-			hostname, key.Type(), ssh.FingerprintSHA256(key))
+			hostname, key.Type(), ssh.FingerprintSHA256(key),
+		)
 
 		callbackErr := hkdb.callback(hostname, remote, key)
 		if callbackErr == nil || IsHostKeyChanged(callbackErr) { // hostname has known_host entries as-is

--- a/plumbing/transport/ssh/sshagent/pageant_windows.go
+++ b/plumbing/transport/ssh/sshagent/pageant_windows.go
@@ -129,7 +129,7 @@ func query(msg []byte) ([]byte, error) {
 	cds := copyData{
 		dwData: agentCopydataID,
 		cbData: uint32(len(mapNameBytesZ)),
-		lpData: unsafe.Pointer(&(mapNameBytesZ[0])),
+		lpData: unsafe.Pointer(&mapNameBytesZ[0]),
 	}
 
 	resp, _, _ := winSendMessage(paWin, wmCopydata, 0, uintptr(unsafe.Pointer(&cds)))

--- a/remote.go
+++ b/remote.go
@@ -936,7 +936,8 @@ func (r *Remote) checkForceWithLease(localRef *plumbing.Reference, cmd *packp.Co
 
 	ref, err := storer.ResolveReference(
 		r.s,
-		plumbing.ReferenceName(remotePrefix+strings.ReplaceAll(localRef.Name().String(), "refs/heads/", "")))
+		plumbing.ReferenceName(remotePrefix+strings.ReplaceAll(localRef.Name().String(), "refs/heads/", "")),
+	)
 	if err != nil {
 		return err
 	}

--- a/repository.go
+++ b/repository.go
@@ -544,7 +544,7 @@ func dotGitFileToOSFilesystem(path string, fs billy.Filesystem) (bfs billy.Files
 		return nil, fmt.Errorf(".git file has no %s prefix", prefix)
 	}
 
-	gitdir := strings.Split(line[len(prefix):], "\n")[0]
+	gitdir, _, _ := strings.Cut(line[len(prefix):], "\n")
 	gitdir = strings.TrimSpace(gitdir)
 	if filepath.IsAbs(gitdir) {
 		return osfs.New(gitdir, osfs.WithBoundOS()), nil
@@ -1683,7 +1683,8 @@ func (r *Repository) Tags() (storer.ReferenceIter, error) {
 	return storer.NewReferenceFilteredIter(
 		func(r *plumbing.Reference) bool {
 			return r.Name().IsTag()
-		}, refIter), nil
+		}, refIter,
+	), nil
 }
 
 // Branches returns all the References that are Branches.
@@ -1696,7 +1697,8 @@ func (r *Repository) Branches() (storer.ReferenceIter, error) {
 	return storer.NewReferenceFilteredIter(
 		func(r *plumbing.Reference) bool {
 			return r.Name().IsBranch()
-		}, refIter), nil
+		}, refIter,
+	), nil
 }
 
 // Notes returns all the References that are notes. For more information:
@@ -1710,7 +1712,8 @@ func (r *Repository) Notes() (storer.ReferenceIter, error) {
 	return storer.NewReferenceFilteredIter(
 		func(r *plumbing.Reference) bool {
 			return r.Name().IsNote()
-		}, refIter), nil
+		}, refIter,
+	), nil
 }
 
 // TreeObject return a Tree with the given hash. If not found

--- a/status.go
+++ b/status.go
@@ -16,7 +16,7 @@ type Status map[string]*FileStatus
 // File returns the FileStatus for a given path, if the FileStatus doesn't
 // exists a new FileStatus is added to the map using the path as key.
 func (s Status) File(path string) *FileStatus {
-	if _, ok := (s)[path]; !ok {
+	if _, ok := s[path]; !ok {
 		s[path] = &FileStatus{Worktree: Untracked, Staging: Untracked}
 	}
 
@@ -25,7 +25,7 @@ func (s Status) File(path string) *FileStatus {
 
 // IsUntracked checks if file for given path is 'Untracked'
 func (s Status) IsUntracked(path string) bool {
-	stat, ok := (s)[filepath.ToSlash(path)]
+	stat, ok := s[filepath.ToSlash(path)]
 	return ok && stat.Worktree == Untracked
 }
 

--- a/status_test.go
+++ b/status_test.go
@@ -95,7 +95,7 @@ func TestStatusReturnsFullPaths(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.doChange {
-				for _, fname := range (files)[:len(files)-2] {
+				for _, fname := range files[:len(files)-2] {
 					file, err := w.filesystem.Create(fname)
 					require.NoError(t, err)
 

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -236,9 +236,7 @@ func diffOptions(
 	var out formatcfg.Options
 
 	// Reverse iteration to preserve last-writer-wins semantics.
-	for i := len(updated) - 1; i >= 0; i-- {
-		opt := updated[i]
-
+	for _, opt := range slices.Backward(updated) {
 		if _, ok := seen[opt.Key]; ok {
 			continue
 		}

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -924,7 +924,7 @@ func (s *SuiteDotGit) TestNewObject() {
 
 	i, err := fs.Stat("objects/a8/a940627d132695a9769df883f85992f0ff4a43")
 	s.Require().NoError(err)
-	s.Equal(int64(34), i.Size())
+	s.Positive(i.Size())
 }
 
 func (s *SuiteDotGit) TestObjects() {
@@ -1526,7 +1526,8 @@ func TestIssue55(t *testing.T) {
 			writeObject(tc.fs)
 			i, err := tc.fs.Stat(path)
 			require.NoError(t, err)
-			assert.Equal(t, int64(34), i.Size())
+			size := i.Size()
+			assert.Positive(t, size)
 
 			ro, err := isReadOnly(tc.fs, path)
 			require.NoError(t, err)
@@ -1536,7 +1537,7 @@ func TestIssue55(t *testing.T) {
 			writeObject(tc.fs)
 			i, err = tc.fs.Stat(path)
 			require.NoError(t, err)
-			assert.Equal(t, int64(34), i.Size())
+			assert.Equal(t, size, i.Size())
 
 			ro, err = isReadOnly(tc.fs, path)
 			require.NoError(t, err)

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -986,7 +986,8 @@ func (s *SuiteDotGit) testObjectWithIncomingDir(incomingDirName string) {
 	file, err := dir.Object(hash)
 	s.Require().NoError(err)
 	s.True(strings.HasSuffix(
-		file.Name(), fs.Join("objects", "03", "db8e1fbe133a480f2867aac478fd866686d69e")),
+		file.Name(), fs.Join("objects", "03", "db8e1fbe133a480f2867aac478fd866686d69e"),
+	),
 	)
 	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" // made up hash
 	incomingDirPath := fs.Join("objects", incomingDirName)

--- a/storage/filesystem/dotgit/reader.go
+++ b/storage/filesystem/dotgit/reader.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
-var _ (plumbing.EncodedObject) = &EncodedObject{}
+var _ plumbing.EncodedObject = &EncodedObject{}
 
 // EncodedObject is a read-only encoded object backed by the filesystem.
 type EncodedObject struct {

--- a/storage/filesystem/fsobject_packhandle_test.go
+++ b/storage/filesystem/fsobject_packhandle_test.go
@@ -62,7 +62,8 @@ func TestIntegration_FSObjectReadsReusePooledFD(t *testing.T) {
 
 	dir := t.TempDir()
 	_, err := fixtures.Basic().ByTag(".git").One().DotGit(
-		fixtures.WithTargetDir(func() string { return dir }))
+		fixtures.WithTargetDir(func() string { return dir }),
+	)
 	require.NoError(t, err)
 
 	cfs := newChrootCountingFS(osfs.New(dir))
@@ -110,7 +111,8 @@ func TestIntegration_FSObjectSurvivesCleanPackList(t *testing.T) {
 
 	dir := t.TempDir()
 	_, err := fixtures.Basic().ByTag(".git").One().DotGit(
-		fixtures.WithTargetDir(func() string { return dir }))
+		fixtures.WithTargetDir(func() string { return dir }),
+	)
 	require.NoError(t, err)
 
 	dg := dotgit.New(osfs.New(dir))
@@ -152,7 +154,8 @@ func TestIntegration_ConcurrentReaderDuringStorageClose(t *testing.T) {
 
 	dir := t.TempDir()
 	_, err := fixtures.Basic().ByTag(".git").One().DotGit(
-		fixtures.WithTargetDir(func() string { return dir }))
+		fixtures.WithTargetDir(func() string { return dir }),
+	)
 	require.NoError(t, err)
 
 	dg := dotgit.New(osfs.New(dir))
@@ -228,7 +231,8 @@ func TestIntegration_PackMissingFromDiskSurfaces(t *testing.T) {
 
 	dir := t.TempDir()
 	_, err := fixtures.Basic().ByTag(".git").One().DotGit(
-		fixtures.WithTargetDir(func() string { return dir }))
+		fixtures.WithTargetDir(func() string { return dir }),
+	)
 	require.NoError(t, err)
 
 	dg := dotgit.New(osfs.New(dir))

--- a/storage/filesystem/object_bench_test.go
+++ b/storage/filesystem/object_bench_test.go
@@ -28,7 +28,8 @@ func BenchmarkAlternatesObjectLookup(b *testing.B) {
 	baseDir := b.TempDir()
 
 	templateFs, err := fixtures.Basic().ByTag(".git").One().DotGit(
-		fixtures.WithTargetDir(func() string { return baseDir }))
+		fixtures.WithTargetDir(func() string { return baseDir }),
+	)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -132,7 +133,8 @@ func BenchmarkObjectStorage_PackHandle(b *testing.B) {
 		b.Helper()
 		dir := b.TempDir()
 		_, err := fixtures.Basic().ByTag(".git").One().DotGit(
-			fixtures.WithTargetDir(func() string { return dir }))
+			fixtures.WithTargetDir(func() string { return dir }),
+		)
 		if err != nil {
 			b.Fatalf("fixture DotGit: %v", err)
 		}
@@ -566,7 +568,8 @@ func BenchmarkObjectStorage_FSObjectReader(b *testing.B) {
 		b.Helper()
 		dir := b.TempDir()
 		_, err := fixtures.Basic().ByTag(".git").One().DotGit(
-			fixtures.WithTargetDir(func() string { return dir }))
+			fixtures.WithTargetDir(func() string { return dir }),
+		)
 		if err != nil {
 			b.Fatalf("fixture DotGit: %v", err)
 		}
@@ -618,7 +621,8 @@ func BenchmarkObjectStorage_FSObjectReader(b *testing.B) {
 			var i int
 			for b.Loop() {
 				obj, err := stor.EncodedObject(
-					plumbing.AnyObject, hashes[i%len(hashes)])
+					plumbing.AnyObject, hashes[i%len(hashes)],
+				)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/storage/filesystem/storage_pool_test.go
+++ b/storage/filesystem/storage_pool_test.go
@@ -58,7 +58,8 @@ func TestStorage_FDPool_AlternatesShareParentPool(t *testing.T) {
 	// pool is wired.
 	baseDir := t.TempDir()
 	templateFs, err := fixtures.Basic().ByTag(".git").One().DotGit(
-		fixtures.WithTargetDir(func() string { return baseDir }))
+		fixtures.WithTargetDir(func() string { return baseDir }),
+	)
 	require.NoError(t, err)
 
 	workDotGit := filepath.Join(baseDir, "work", ".git")

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -50,7 +50,8 @@ func TestNewStorageShouldNotAddAnyContentsToDir(t *testing.T) {
 	sto := filesystem.NewStorageWithOptions(
 		fs,
 		cache.NewObjectLRUDefault(),
-		filesystem.Options{ExclusiveAccess: true})
+		filesystem.Options{ExclusiveAccess: true},
+	)
 	defer func() { _ = sto.Close() }()
 	assert.NotNil(t, sto)
 

--- a/utils/binary/write.go
+++ b/utils/binary/write.go
@@ -23,7 +23,7 @@ func WriteVariableWidthInt(w io.Writer, n int64) error {
 	n >>= 7
 	for n != 0 {
 		n--
-		buf = append([]byte{0x80 | (byte(n & 0x7f))}, buf...)
+		buf = append([]byte{0x80 | byte(n&0x7f)}, buf...)
 		n >>= 7
 	}
 

--- a/utils/merkletrie/difftree_test.go
+++ b/utils/merkletrie/difftree_test.go
@@ -228,7 +228,8 @@ func turnSpaceIntoLiteralSpace(s string) string {
 				return ' '
 			}
 			return r
-		}, s)
+		}, s,
+	)
 }
 
 func (cc changes) Len() int           { return len(cc) }

--- a/utils/merkletrie/index/node_test.go
+++ b/utils/merkletrie/index/node_test.go
@@ -154,7 +154,8 @@ func (s *NoderSuite) TestDiffFileMode() {
 	ch, err := merkletrie.DiffTree(
 		NewRootNodeWithOptions(indexA, RootNodeOptions{}),
 		NewRootNodeWithOptions(indexB, RootNodeOptions{}),
-		isEquals)
+		isEquals,
+	)
 	s.NoError(err)
 	s.Len(ch, 0)
 

--- a/utils/merkletrie/internal/fsnoder/new.go
+++ b/utils/merkletrie/internal/fsnoder/new.go
@@ -125,7 +125,8 @@ func decodeChild(data []byte) (noder.Noder, error) {
 	switch {
 	case fileNameEnd == -1 && dirNameEnd == -1:
 		return nil, fmt.Errorf(
-			"malformed child, no file or dir start mark found")
+			"malformed child, no file or dir start mark found",
+		)
 	case fileNameEnd == -1:
 		return decodeDir(clean, nonRoot)
 	case dirNameEnd == -1:

--- a/worktree.go
+++ b/worktree.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -1027,13 +1028,13 @@ func (w *Worktree) clearBlockingSymlinks(fs *worktreeFilesystem, name string) er
 	}
 	// Leading components, shallowest-first: removing the shallowest symlink
 	// invalidates every component beneath it, so a single removal is enough.
-	for i := len(dirs) - 1; i >= 0; i-- {
-		fi, err := fs.Lstat(dirs[i])
+	for _, dir := range slices.Backward(dirs) {
+		fi, err := fs.Lstat(dir)
 		if err != nil {
 			continue
 		}
 		if fi.Mode()&os.ModeSymlink != 0 {
-			return fs.Remove(dirs[i])
+			return fs.Remove(dir)
 		}
 	}
 	// Final component: an existing symlink here would be followed by the

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -650,7 +650,8 @@ func TestCheckoutSymlinkArbitraryTarget(t *testing.T) {
 
 			require.NoError(t, r.Storer.SetIndex(&index.Index{Version: 2}))
 			w.filesystem = newWorktreeFilesystem(
-				osfs.New(filepath.Join(dir, "worktree-empty")), true, true)
+				osfs.New(filepath.Join(dir, "worktree-empty")), true, true,
+			)
 
 			require.NoError(t, w.Checkout(&CheckoutOptions{}))
 

--- a/x/plumbing/worktree/worktree_test.go
+++ b/x/plumbing/worktree/worktree_test.go
@@ -520,7 +520,8 @@ func TestList(t *testing.T) {
 
 				err = w.Add(memfs.New(), "worktree-1",
 					WithCommit(
-						plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")))
+						plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
+					))
 				require.NoError(t, err)
 
 				return storer


### PR DESCRIPTION
- Bump Go version to `1.26`.
- `go fix ./...`.
- Align golangci-lint, bumping it to `v2.13.1`.
- Fix `MaxPayloadSize` overflowing bug, which is pronounced by internal changes in Go `1.27`.
- Fix workflows landing in runners that have Go 1.27 installed.
  - https://github.com/go-git/go-git/actions/runs/32410440641/job/96559347776?pr=2323