### PR TITLE
build: Enforce the gofumpt extra rules the tree already follows

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,3 +65,5 @@ formatters:
     gofumpt:
       extra:
         group-params: true
+        clothe-returns: true
+        balance-calls: true


### PR DESCRIPTION
Follow-up to #2329.

That PR migrated the deprecated `gofumpt.extra-rules: true` to the granular `extra` block, but enabled only `group-params`. `group-params` is not the rule that did the work — `balance-calls` is:

> Multi-line function calls with the opening parenthesis at the end of a line should place the closing parenthesis at the start of a line.

That is the `…lines))` → `…lines,\n))` change applied to 22 of the 28 Go files in #2329.

Counting the files each rule alone asks to reformat, against the base of #2329 (`golangci-lint fmt --diff` with v2.13.1):

| `extra:` | files |
|---|---|
| `{}` | 7 |
| `group-params: true` | 7 |
| `clothe-returns: true` | 7 |
| **`balance-calls: true`** | **29** |

Applying the merged config to that same tree touches 6 Go files, not 28. So the tree currently carries a style nothing enforces: new code can go back to closing on the argument line, lint stays green, and the reformat drifts back a file at a time.

This enables the two remaining rules. Both are satisfied by `main` today, so it is config-only — no code diff:

- `golangci-lint fmt --diff` reports nothing outside the pre-existing `_examples/http-server/main.go` (which fails under v2.11.4 too, and which `golangci-lint run` never sees because `_examples` is skipped by package loading)
- `golangci-lint run` reports 0 issues

Worth landing before more PRs merge — while it is still a two-line config change rather than another tree-wide reformat.

## AI assistance

Claude Opus 5 assisted with the rule-by-rule measurement above and drafting. Commits carry `Assisted-by:` per AI_POLICY.md.