### PR TITLE
plumbing: protocol/packp/sideband, Test the muxer packet size limit

### DIFF
--- a/plumbing/protocol/packp/sideband/muxer_test.go
+++ b/plumbing/protocol/packp/sideband/muxer_test.go
@@ -2,7 +2,21 @@ package sideband
 
 import (
 	"bytes"
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
+
+// sidebandTypes pairs each sideband type with the maximum pkt-line size it
+// permits, counting the 4-byte length prefix.
+var sidebandTypes = []struct {
+	name string
+	t    Type
+	max  int
+}{
+	{"side-band", Sideband, MaxPackedSize},
+	{"side-band-64k", Sideband64k, MaxPackedSize64k},
+}
 
 func (s *SidebandSuite) TestMuxerWrite() {
 	buf := bytes.NewBuffer(nil)
@@ -13,6 +27,69 @@ func (s *SidebandSuite) TestMuxerWrite() {
 	s.NoError(err)
 	s.Equal(1998, n)
 	s.Equal(2013, buf.Len())
+}
+
+// TestMuxerChunksWithinPacketSizeLimit checks the invariant the Demuxer
+// enforces on the wire: no pkt-line the Muxer emits exceeds the maximum packet
+// size of its sideband type. Both the length prefix and the channel byte come
+// out of that budget, so a chunk may carry at most max-5 bytes of payload.
+//
+// Chunking used to leave room for the channel byte only. side-band therefore
+// emitted 1004-byte packets, which the Demuxer rejects with
+// ErrMaxPackedExceeded, and side-band-64k chunks crossed
+// pktline.MaxPayloadSize outright once a single Write reached 65516 bytes.
+func (s *SidebandSuite) TestMuxerChunksWithinPacketSizeLimit() {
+	for _, tc := range sidebandTypes {
+		s.Run(tc.name, func() {
+			// Two saturated chunks and a short remainder.
+			payload := bytes.Repeat([]byte{'F'}, tc.max*2+7)
+
+			var buf bytes.Buffer
+			n, err := NewMuxer(tc.t, &buf).Write(payload)
+			s.Require().NoError(err)
+			s.Equal(len(payload), n)
+
+			sc := pktline.NewScanner(bytes.NewReader(buf.Bytes()))
+			var pkts int
+			for sc.Scan() {
+				pkts++
+				s.Require().LessOrEqual(sc.Len(), tc.max,
+					"packet %d of %d exceeds the limit", pkts, tc.max)
+			}
+			s.Require().NoError(sc.Err())
+			s.Greater(pkts, 2, "expected the payload to be chunked")
+
+			// The Demuxer applies the same limit, so reading the stream back
+			// is the wire-level check.
+			got, err := io.ReadAll(NewDemuxer(tc.t, bytes.NewReader(buf.Bytes())))
+			s.Require().NoError(err)
+			s.Len(got, len(payload))
+			s.True(bytes.Equal(payload, got), "payload did not survive the round-trip")
+		})
+	}
+}
+
+// TestMuxerWriteFillsSinglePacket pins the boundary: the largest payload a
+// single packet can carry must not spill into a second one, and must fill the
+// packet exactly.
+func (s *SidebandSuite) TestMuxerWriteFillsSinglePacket() {
+	for _, tc := range sidebandTypes {
+		s.Run(tc.name, func() {
+			var buf bytes.Buffer
+			payload := bytes.Repeat([]byte{'F'}, tc.max-pktline.LenSize-chLen)
+
+			n, err := NewMuxer(tc.t, &buf).Write(payload)
+			s.Require().NoError(err)
+			s.Equal(len(payload), n)
+			s.Equal(tc.max, buf.Len())
+
+			sc := pktline.NewScanner(bytes.NewReader(buf.Bytes()))
+			s.Require().True(sc.Scan())
+			s.Equal(tc.max, sc.Len())
+			s.False(sc.Scan(), "payload spilled into a second packet")
+			s.Require().NoError(sc.Err())
+		})
+	}
 }
 
 func (s *SidebandSuite) TestMuxerWriteChannelMultipleChannels() {


### PR DESCRIPTION
Follow-up to #2329, which fixed `Muxer`'s chunk size but left no test that would catch a reintroduction.

The only test change there was `TestMuxerWrite`'s byte count, `2008` → `2013`. That number does not describe the constraint being violated, and the pre-fix code passed its *old* value while emitting packets no `Demuxer` accepts — so the assertion cannot distinguish correct chunking from broken chunking.

This asserts the invariant `Demuxer.nextPackData` already enforces on the wire: no pkt-line the `Muxer` emits exceeds the maximum packet size of its sideband type, counting the 4-byte length prefix. `pktline.Scanner.Len` reports exactly that, so the test walks the emitted stream and checks every packet, then reads the stream back through the `Demuxer`, which applies the same limit and so doubles as the wire-level check.

Against the pre-fix muxer both types fail, each on its own symptom:

```
--- FAIL: TestMuxerChunksWithinPacketSizeLimit/side-band
        Error:    "1004" is not less than or equal to "1000"
        Messages: packet 1 of 1000 exceeds the limit
--- FAIL: TestMuxerChunksWithinPacketSizeLimit/side-band-64k
        Error:    Received unexpected error: payload is too long
```

Those are the two distinct bugs #2329 fixed, and it is worth noting the first is not Go-version dependent: `side-band` (negotiated at `upload_pack.go:283` and `receive_pack.go:188`) emitted 1004-byte packets over git's 1000-byte `DEFAULT_PACKET_MAX`, which go-git's own `Demuxer` rejects with `ErrMaxPackedExceeded`.

`TestMuxerWriteFillsSinglePacket` guards the other direction, where too large a reservation would chunk a payload that fits: `max-5` bytes must fill exactly one packet and not spill into a second.

Test-only; no behaviour change. Merges cleanly with #2332 in either order.

## AI assistance

Claude Opus 5 assisted with writing the tests and verifying they fail against the pre-fix muxer. Commit carries `Assisted-by:` per AI_POLICY.md.