### PR TITLE
plumbing: protocol/packp/sideband, Report only the bytes the muxer wrote

### DIFF
--- a/plumbing/protocol/packp/sideband/muxer.go
+++ b/plumbing/protocol/packp/sideband/muxer.go
@@ -61,6 +61,14 @@ func (m *Muxer) WriteChannel(t Channel, p []byte) (int, error) {
 func (m *Muxer) doWrite(ch Channel, p []byte) (int, error) {
 	sz := min(len(p), m.max)
 
-	_, err := pktline.Write(m.w, ch.WithPayload(p[:sz]))
-	return sz, err
+	n, err := pktline.Write(m.w, ch.WithPayload(p[:sz]))
+	if err != nil {
+		// n counts what reached w, which leads with the length prefix and the
+		// channel byte. Neither comes from p, so discount both: a write that
+		// failed the length check or died on the prefix consumed nothing at
+		// all, and claiming otherwise reports bytes the caller still owns.
+		return max(0, n-pktline.LenSize-chLen), err
+	}
+
+	return sz, nil
 }

--- a/plumbing/protocol/packp/sideband/muxer_test.go
+++ b/plumbing/protocol/packp/sideband/muxer_test.go
@@ -2,6 +2,9 @@ package sideband
 
 import (
 	"bytes"
+	"io"
+
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 )
 
 func (s *SidebandSuite) TestMuxerWrite() {
@@ -34,4 +37,57 @@ func (s *SidebandSuite) TestMuxerWriteChannelMultipleChannels() {
 
 	s.Equal(27, buf.Len())
 	s.Equal("0009\x01DDDD0009\x02PPPP0009\x01DDDD", buf.String())
+}
+
+// budgetWriter accepts at most budget bytes in total and then fails, reporting
+// how much of the final write it took as the io.Writer contract requires.
+type budgetWriter struct {
+	budget int
+}
+
+func (w *budgetWriter) Write(p []byte) (int, error) {
+	if w.budget <= 0 {
+		return 0, io.ErrShortWrite
+	}
+	if len(p) > w.budget {
+		n := w.budget
+		w.budget = 0
+		return n, io.ErrShortWrite
+	}
+	w.budget -= len(p)
+	return len(p), nil
+}
+
+// TestMuxerWriteFailureReportsBytesWritten checks that a failed write reports
+// only the bytes of p that reached the underlying writer. Every pkt-line leads
+// with a 4-byte length prefix and a channel byte, neither of which comes from
+// p, so a write that dies on the prefix has consumed nothing.
+func (s *SidebandSuite) TestMuxerWriteFailureReportsBytesWritten() {
+	const payloadPerPacket = MaxPackedSize - pktline.LenSize - chLen
+
+	for _, tc := range []struct {
+		name   string
+		budget int
+		want   int
+	}{
+		{"nothing accepted", 0, 0},
+		{"dies mid prefix", 2, 0},
+		{"prefix only", pktline.LenSize, 0},
+		{"prefix and channel byte", pktline.LenSize + chLen, 0},
+		{"ten payload bytes", pktline.LenSize + chLen + 10, 10},
+		{
+			// A full first packet, then a second that dies ten payload bytes in.
+			"across a chunk boundary",
+			MaxPackedSize + pktline.LenSize + chLen + 10,
+			payloadPerPacket + 10,
+		},
+	} {
+		s.Run(tc.name, func() {
+			w := &budgetWriter{budget: tc.budget}
+
+			n, err := NewMuxer(Sideband, w).Write(bytes.Repeat([]byte{'F'}, payloadPerPacket*2))
+			s.ErrorIs(err, io.ErrShortWrite)
+			s.Equal(tc.want, n)
+		})
+	}
 }


### PR DESCRIPTION
Noticed while reviewing #2329.

`Muxer.doWrite` discarded `pktline.Write`'s count and returned the chunk size it had *intended* to write:

```go
sz := min(len(p), m.max)

_, err := pktline.Write(m.w, ch.WithPayload(p[:sz]))
return sz, err
```

`WriteChannel` adds that count to its running total and hands it back, so `Muxer.Write` could report 995 bytes written to a writer that accepted nothing.

This is what made the chunk size bug in #2329 surface as `payload is too long (n=65519)` — `pktline.Write` rejected the oversized payload before touching the writer, and the muxer reported all of it as written.

The fix returns what actually reached `w`. `pktline.Write`'s count leads with the 4-byte length prefix and the channel byte, neither of which comes from `p`, so both are discounted and the result floored at zero. The success path is unchanged.

On the reasoning for a partial count rather than zero: after a failed chunk the stream is unusable, since the packet on the wire is truncated, so this is not a count a caller can resume from. It is the `io.Writer` contract — `n` is the bytes of `p` that were written — and over-reporting lets a caller conclude data was sent that never left the process.

The test drives a writer with a fixed byte budget across the interesting boundaries. Against the old `doWrite` every case reports `995`:

```
nothing accepted          expected: 0     actual: 995
dies mid prefix           expected: 0     actual: 995
prefix only               expected: 0     actual: 995
prefix and channel byte   expected: 0     actual: 995
ten payload bytes         expected: 10    actual: 995
across a chunk boundary   expected: 1005  actual: 995
```

Verified with the full suite under Go 1.27 (only the unrelated `TestConformanceSuite` failure, which needs git ≥ 2.52 locally) and `golangci-lint run ./plumbing/...` clean. Merges cleanly with #2331 in either order.

## AI assistance

Claude Opus 5 assisted with the fix, the test, and verifying the failure modes above. Commit carries `Assisted-by:` per AI_POLICY.md.