### PR TITLE
build: Reject AI co-author trailers in PR validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -66,3 +66,64 @@ jobs:
             echo "See CONTRIBUTING.md for details."
             exit 1
           fi
+
+  check-ai-attribution:
+    name: Check AI Attribution
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Verify no commit credits an AI tool as co-author
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # AI tools are disclosed with Assisted-by:, never credited as authors.
+          # A tool cannot give the DCO certification that authorship implies, and
+          # several assistants add the trailer by default, so catch it before
+          # review. Human co-authors are unaffected. See AI_POLICY.md.
+          #
+          # Match a tool's own commit identity: a bot account, an agent mailbox,
+          # or a no-reply address at a vendor. Never a bare vendor domain and
+          # never a bare given name -- people who work at these companies
+          # contribute, someone@anthropic.com is a person, and Claude, Jules and
+          # Devin are names. A false positive accuses a contributor, which is
+          # worse than a miss, so keep every entry specific. Add identities as
+          # tools appear.
+          bots='\+copilot@users\.noreply\.github\.com|cursoragent@|devin-ai-integration|google-labs-jules|gemini-code-assist'
+          noreply='no-?reply@(anthropic|openai|cursor|codeium|windsurf)\.com'
+          models='claude (opus|sonnet|haiku|code)|chatgpt|gpt-[0-9]'
+          found=0
+          while IFS= read -r sha; do
+            credited=$(git log -1 --format="%B" "$sha" |
+              grep -iE "^Co-authored-by:.*($bots|$noreply|$models)" || true)
+            if [ -n "$credited" ]; then
+              echo "AI CO-AUTHOR: $sha $(git log -1 --format='%s' "$sha")"
+              printf '%s\n' "$credited" | sed 's/^/    /'
+              found=1
+            fi
+          done < <(git log --format="%H" "$BASE_SHA..$HEAD_SHA")
+          if [ "$found" -eq 1 ]; then
+            echo ""
+            echo "AI tools must not be credited as co-authors. Disclose them with an"
+            echo "Assisted-by: trailer instead, keeping a human Signed-off-by:"
+            echo ""
+            echo "  Assisted-by: Claude Opus 5"
+            echo "  Signed-off-by: Jane Smith <jane.smith@example.com>"
+            echo ""
+            echo "Drop the Co-Authored-By: lines shown above and force-push:"
+            echo "  git commit --amend              # last commit"
+            echo "  git rebase -i $BASE_SHA         # older commits"
+            echo ""
+            echo "If this flagged a person, say so on the pull request: the"
+            echo "identities are listed in .github/workflows/pr-validation.yml."
+            echo ""
+            echo "See AI_POLICY.md for details."
+            exit 1
+          fi

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -51,6 +51,16 @@ Assisted-by: Claude Sonnet 4.6
 Assisted-by: ChatGPT o3
 ```
 
+Do not credit an AI tool as a co-author. `Co-Authored-By:` states that the named
+party helped create the contribution, and the
+[DCO](CONTRIBUTING.md#developer-certificate-of-origin) asks the people who create
+a contribution to certify, with a `Signed-off-by:` line, that they have the right
+to submit it. A tool cannot make that certification, so naming one as a
+co-author claims authorship that no sign-off covers. Several assistants add the
+trailer by default, so check for it before opening a PR — `Assisted-by:` is the
+disclosure this project wants. Pull request validation rejects commits that name
+an AI tool as co-author; human co-authors are unaffected.
+
 Disclosure is not a penalty — it is trust infrastructure. It preserves
 transparency, helps reviewers calibrate their attention, and keeps provenance
 clear for the project's long-term health.


### PR DESCRIPTION
`AI_POLICY.md` asks for an `Assisted-by:` trailer, but says nothing about `Co-Authored-By:` — and several assistants add one by default. #2330 and #2331 both landed carrying `Co-Authored-By: Claude ...` with nothing in CI to catch it.

Co-authorship is the wrong claim to make for a tool: it asserts authorship, and authorship carries a DCO certification only a person can give. So `check-dco` passes happily on a commit whose stated authors cannot all sign off.

This adds a `check-ai-attribution` job next to it, and states the rule in `AI_POLICY.md` so the check enforces something written down rather than surprising contributors at CI time.

## What it matches

A tool-name list, applied to `Co-authored-by:` lines over the PR's commit range:

```
anthropic|claude|openai|chatgpt|gpt-[0-9]|codex|copilot|cursor|gemini|jules|devin|windsurf|codeium|aider|codewhisperer
```

Deliberately **not** a rule about `Co-authored-by:` in general. That trailer is well used by real contributors here — 32 commits for one maintainer alone — and none of those are affected. Bot trailers aren't matched either, so dependabot and renovate PRs are unaffected.

The list is a single shell variable with a comment saying to edit it. Naming tools is unavoidably incomplete; the goal is catching the default behaviour of the common ones, not exhaustiveness.

## Verified against real history

Run against actual ranges in this repository:

| case | result |
|---|---|
| the two commits from #2330 / #2331 | exit 1, both reported with the trailer quoted |
| the amended commit from #2332 | exit 0 |
| three human co-authored commits (Paulo, various) | exit 0 |
| `Co-authored-by: dependabot[bot] <...>` | not matched |
| this PR's own commit | exit 0 — it passes its own check |

Checked under the shell GitHub Actions uses (`bash --noprofile --norc -eo pipefail`), and `actionlint` reports no findings.

Failure output looks like:

```
AI CO-AUTHOR: 582b454f... plumbing: protocol/packp/sideband, Test the muxer packet size limit.
    Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

AI tools must not be credited as co-authors. Disclose them with an
Assisted-by: trailer instead, keeping a human Signed-off-by:

  Assisted-by: Claude Opus 5
  Signed-off-by: Jane Smith <jane.smith@example.com>
```

## Two calls for you

**Copilot and Cursor.** Of the 40 flagged commits reachable from `main`, 26 name Claude, 12 Copilot, 2 Cursor. The policy reasoning applies equally to all three, so the list covers them — but that changes what GitHub's Copilot coding agent can land as-is, and those commits were merged previously. Happy to narrow the list to Anthropic-only if you'd rather scope it that way for now.

**A stricter alternative I did not implement:** require every `Co-authored-by:` to be paired with a matching `Signed-off-by:`. That is the DCO-correct rule and needs no tool list at all, but it would reject most existing human co-authorship in this repo, where the committer signs off alone. That felt like a policy change for you to make rather than something to fold into this PR.

Added as a new job rather than folded into `check-dco`, so no existing required status check name changes.

## AI assistance

Claude Opus 5 assisted with the check, the measurements above, and drafting. Commit carries `Assisted-by:` per AI_POLICY.md — and no `Co-Authored-By:`, per the rule this PR adds.