### PR TITLE
plumbing: transport/ssh, add SSH agent connection cleanup

### DIFF
--- a/_examples/clone/auth/ssh/ssh_agent/main.go
+++ b/_examples/clone/auth/ssh/ssh_agent/main.go
@@ -14,8 +14,9 @@ func main() {
 	CheckArgs("<url>", "<directory>")
 	url, directory := os.Args[1], os.Args[2]
 
-	authMethod, err := ssh.NewSSHAgentAuth("git")
+	authMethod, closer, err := ssh.NewSSHAgentAuthWithCloser("git")
 	CheckIfError(err)
+	defer func() { _ = closer.Close() }()
 
 	Info("git clone %s ", url)
 

--- a/plumbing/transport/ssh/auth.go
+++ b/plumbing/transport/ssh/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/user"
@@ -142,27 +143,52 @@ type PublicKeysCallback struct {
 	HostKeyCallbackHelper
 }
 
+type sshAgentCloser struct {
+	closer io.Closer
+}
+
 // NewSSHAgentAuth returns a PublicKeysCallback based on an SSH agent. It opens
 // a pipe with the SSH agent and uses the pipe as the implementer of the public
-// key callback function.
+// key callback function. Callers that need to close the pipe should use
+// [NewSSHAgentAuthWithCloser].
 func NewSSHAgentAuth(u string) (*PublicKeysCallback, error) {
+	auth, _, err := NewSSHAgentAuthWithCloser(u)
+	return auth, err
+}
+
+// NewSSHAgentAuthWithCloser returns a PublicKeysCallback and a closer for the
+// pipe opened to the SSH agent. The closer is safe to call more than once.
+func NewSSHAgentAuthWithCloser(u string) (*PublicKeysCallback, io.Closer, error) {
 	var err error
 	if u == "" {
 		u, err = username()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	a, _, err := sshagent.New()
+	a, c, err := sshagent.New()
 	if err != nil {
-		return nil, fmt.Errorf("error creating SSH agent: %w", err)
+		return nil, nil, fmt.Errorf("error creating SSH agent: %w", err)
 	}
 
 	return &PublicKeysCallback{
 		User:     u,
 		Callback: a.Signers,
-	}, nil
+	}, &sshAgentCloser{closer: c}, nil
+}
+
+func (c *sshAgentCloser) Close() error {
+	if c == nil || c.closer == nil {
+		return nil
+	}
+	closer := c.closer
+	c.closer = nil
+	err := closer.Close()
+	if errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
 }
 
 // ClientConfig returns the ssh.ClientConfig for public key callback authentication.

--- a/plumbing/transport/ssh/auth_extended_test.go
+++ b/plumbing/transport/ssh/auth_extended_test.go
@@ -2,16 +2,20 @@ package ssh
 
 import (
 	"context"
+	"io"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/kevinburke/ssh_config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/crypto/ssh/testdata"
 
 	"github.com/go-git/go-git/v6/plumbing/transport"
@@ -60,6 +64,123 @@ func TestNewSSHAgentAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, auth)
 	assert.Equal(t, "foo", auth.User)
+}
+
+type errorCloser struct {
+	err error
+}
+
+func (c errorCloser) Close() error {
+	return c.err
+}
+
+func TestSSHAgentCloserCloseErrors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		closeErr error
+		wantErr  error
+	}{
+		{name: "already closed", closeErr: net.ErrClosed},
+		{name: "other error", closeErr: assert.AnError, wantErr: assert.AnError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			closer := &sshAgentCloser{closer: errorCloser{err: tc.closeErr}}
+			err := closer.Close()
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+			require.NoError(t, closer.Close())
+		})
+	}
+}
+
+func newSSHAgentListener(t *testing.T) net.Listener {
+	t.Helper()
+
+	f, err := os.CreateTemp("", "go-git-agent-")
+	require.NoError(t, err)
+	path := f.Name()
+	require.NoError(t, f.Close())
+	require.NoError(t, os.Remove(path))
+
+	listener, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(path)
+	})
+	return listener
+}
+
+func TestNewSSHAgentAuthWithCloserClose(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "js" {
+		t.Skip("Unix sockets are not available")
+	}
+
+	listener := newSSHAgentListener(t)
+	t.Setenv("SSH_AUTH_SOCK", listener.Addr().String())
+
+	auth, closer, err := NewSSHAgentAuthWithCloser("foo")
+	require.NoError(t, err)
+	require.NotNil(t, auth)
+
+	conn, err := listener.Accept()
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	require.NoError(t, closer.Close())
+	require.NoError(t, closer.Close())
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+	_, err = conn.Read(make([]byte, 1))
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestTransportConnectClosesDefaultSSHAgentAuth(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "js" {
+		t.Skip("Unix sockets are not available")
+	}
+
+	tempDir := t.TempDir()
+	listener := newSSHAgentListener(t)
+	t.Setenv("SSH_AUTH_SOCK", listener.Addr().String())
+
+	agentErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			agentErr <- err
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		agentErr <- agent.ServeAgent(agent.NewKeyring(), conn)
+	}()
+
+	knownHosts := filepath.Join(tempDir, "known_hosts")
+	require.NoError(t, os.WriteFile(knownHosts, nil, 0o600))
+	t.Setenv("SSH_KNOWN_HOSTS", knownHosts)
+
+	sshTransport := NewTransport(Options{
+		DialContext: func(context.Context, string, string) (net.Conn, error) {
+			return nil, assert.AnError
+		},
+	})
+	_, err := sshTransport.connect(t.Context(), &transport.Request{
+		URL: mustParseURL("ssh://git@example.com/repo.git"),
+	})
+	require.ErrorIs(t, err, assert.AnError)
+
+	select {
+	case err := <-agentErr:
+		require.ErrorIs(t, err, io.EOF)
+	case <-time.After(time.Second):
+		t.Fatal("SSH agent connection was not closed")
+	}
 }
 
 func TestNewSSHAgentAuthNoAgent(t *testing.T) {

--- a/plumbing/transport/ssh/ssh.go
+++ b/plumbing/transport/ssh/ssh.go
@@ -65,10 +65,17 @@ func (t *Transport) Connect(ctx context.Context, req *transport.Request) (transp
 }
 
 func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshConn, error) {
-	config, err := t.resolveConfig(ctx, req)
+	config, authCloser, err := t.resolveConfig(ctx, req)
 	if err != nil {
 		return nil, err
 	}
+	closeAuth := func() {
+		if authCloser != nil {
+			_ = authCloser.Close()
+			authCloser = nil
+		}
+	}
+	defer closeAuth()
 
 	hostWithPort, err := t.resolveHostWithPort(ctx, req)
 	if err != nil {
@@ -93,6 +100,7 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 	trace.SSH.Printf("ssh: host key algorithms %s", strings.Join(config.HostKeyAlgorithms, ", "))
 
 	client, err := t.dial(ctx, "tcp", hostWithPort, config)
+	closeAuth()
 	if err != nil {
 		return nil, err
 	}
@@ -152,9 +160,10 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (*sshCo
 	return conn, nil
 }
 
-func (t *Transport) resolveConfig(ctx context.Context, req *transport.Request) (*gossh.ClientConfig, error) {
+func (t *Transport) resolveConfig(ctx context.Context, req *transport.Request) (*gossh.ClientConfig, io.Closer, error) {
 	if t.opts.ClientConfig != nil {
-		return t.opts.ClientConfig(ctx, req)
+		config, err := t.opts.ClientConfig(ctx, req)
+		return config, nil, err
 	}
 
 	username := DefaultUsername
@@ -166,11 +175,16 @@ func (t *Transport) resolveConfig(ctx context.Context, req *transport.Request) (
 
 	trace.SSH.Printf("ssh: Using default auth builder (user: %s)", username)
 
-	auth, err := NewSSHAgentAuth(username)
+	auth, closer, err := NewSSHAgentAuthWithCloser(username)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return auth.ClientConfig(ctx, req)
+	config, err := auth.ClientConfig(ctx, req)
+	if err != nil {
+		_ = closer.Close()
+		return nil, nil, err
+	}
+	return config, closer, nil
 }
 
 func (t *Transport) dial(ctx context.Context, network, addr string, config *gossh.ClientConfig) (*gossh.Client, error) {

--- a/plumbing/transport/ssh/sshagent/sshagent_windows.go
+++ b/plumbing/transport/ssh/sshagent/sshagent_windows.go
@@ -67,7 +67,7 @@ func New() (agent.Agent, net.Conn, error) {
 			"SSH agent requested, but could not detect Pageant or Windows native SSH agent",
 		)
 	}
-	return agent.NewClient(conn), nil, nil
+	return agent.NewClient(conn), conn, nil
 }
 
 type conn struct {


### PR DESCRIPTION
NewSSHAgentAuth discards the io.Closer returned by sshagent.New(), leaking the underlying Unix socket.

Add NewSSHAgentAuthWithCloser so direct callers can close the separate SSH agent connection. Keep the existing NewSSHAgentAuth signature and PublicKeysCallback layout for backwards compatibility with direct callers. Use the closer in the default transport lifecycle and update the SSH agent example and regression coverage.

```go
auth, closer, err := ssh.NewSSHAgentAuthWithCloser("")
if err != nil {
   // handle error
}
defer closer.Close()
```
The change is non-breaking: NewSSHAgentAuthWithCloser is an additive API.

Callers that want explicit cleanup can opt into the new constructor.