### PR TITLE
storage: filesystem, Support relative worktrees. Fixes #2324

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -224,3 +224,4 @@ compatibility status with go-git.
 | `gitattributes` |                             | ✅     |                                                |          |
 | `git-worktree`  | `add`, `remove` and `list`  | ⚠️ (partial) | Not all flags nor subcommands are supported.   | - [worktrees](_examples/worktrees/main.go) |
 | `extensions`    | `worktreeConfig`            | ✅           | Per-worktree `config.worktree` files are read and overlaid on the common config when this extension is enabled. Supported only by `storage.filesystem`. |          |
+| `extensions`    | `relativeWorktrees`         | ✅           | Linked worktrees using relative paths can be opened with `storage.filesystem`. |          |

--- a/repository_extensions_test.go
+++ b/repository_extensions_test.go
@@ -50,6 +50,14 @@ func TestVerifyExtensions(t *testing.T) {
 			wantErr: "unknown extension: unknownext",
 		},
 		{
+			name: "repositoryformatversion=1: rejects filesystem extension in memory",
+			setup: func(_ *testing.T, cfg *config.Config) {
+				cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+				cfg.Raw.Section("extensions").SetOption("relativeWorktrees", "true")
+			},
+			wantErr: "unknown extension: relativeworktrees",
+		},
+		{
 			name: "repositoryformatversion=1: allows known extension",
 			setup: func(_ *testing.T, cfg *config.Config) {
 				cfg.Core.RepositoryFormatVersion = formatcfg.Version1

--- a/repository_test.go
+++ b/repository_test.go
@@ -190,6 +190,54 @@ func TestPlainInitAndPlainOpen(t *testing.T) {
 	})
 }
 
+func TestPlainOpenRelativeWorktree(t *testing.T) {
+	t.Parallel()
+
+	mainDir := filepath.Join(t.TempDir(), "main")
+	repo, err := PlainInit(mainDir, false)
+	require.NoError(t, err)
+	defer func() { _ = repo.Close() }()
+
+	cfg, err := repo.Config()
+	require.NoError(t, err)
+	cfg.Core.RepositoryFormatVersion = formatcfg.Version1
+	cfg.Raw.Section("extensions").SetOption("relativeWorktrees", "true")
+	require.NoError(t, repo.SetConfig(cfg))
+
+	linkedDir := filepath.Join(mainDir, "relative")
+	metadataDir := filepath.Join(mainDir, GitDirName, "worktrees", "relative")
+	require.NoError(t, os.MkdirAll(linkedDir, 0o755))
+	require.NoError(t, os.MkdirAll(metadataDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(linkedDir, GitDirName),
+		[]byte("gitdir: ../.git/worktrees/relative\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(metadataDir, "commondir"),
+		[]byte("../..\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(metadataDir, "gitdir"),
+		[]byte("../../../relative/.git\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(metadataDir, plumbing.HEAD.String()),
+		[]byte("ref: refs/heads/master\n"),
+		0o644,
+	))
+
+	linkedRepo, err := PlainOpen(linkedDir)
+	require.NoError(t, err)
+	defer func() { _ = linkedRepo.Close() }()
+
+	worktree, err := linkedRepo.Worktree()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Clean(linkedDir), filepath.Clean(worktree.Filesystem().Root()))
+}
+
 type RepositorySuite struct {
 	BaseSuite
 }

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -268,7 +268,7 @@ func (s *Storage) SupportsExtension(name, value string) bool {
 		case "sha1", "sha256", "":
 			return true
 		}
-	case "worktreeconfig":
+	case "worktreeconfig", "relativeworktrees":
 		switch value {
 		case "true", "false":
 			return true

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -335,6 +335,24 @@ func TestSupportsExtension(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "relativeworktrees enabled",
+			ext:   "relativeworktrees",
+			value: "true",
+			want:  true,
+		},
+		{
+			name:  "relativeworktrees disabled",
+			ext:   "relativeworktrees",
+			value: "false",
+			want:  true,
+		},
+		{
+			name:  "relativeworktrees with unsupported value",
+			ext:   "relativeworktrees",
+			value: "maybe",
+			want:  false,
+		},
+		{
 			name:  "unsupported extension name",
 			ext:   "noop",
 			value: "sha1",


### PR DESCRIPTION
Fixes #2324.

`git worktree add --relative-paths` upgrades the repository format, sets `extensions.relativeWorktrees=true`, and writes relative links between the common repository and the linked worktree. go-git already resolves that layout, but filesystem storage rejected the extension before the repository could be opened.

This change accepts canonical boolean values for `relativeWorktrees` in filesystem storage while keeping other storers fail-safe. The regression test models the `.git`, `commondir`, and reverse `gitdir` paths written by upstream Git and verifies that `PlainOpen` uses the linked worktree root.

Upstream behavior:
- [`extensions.relativeWorktrees` documentation](https://github.com/git/git/blob/1a3e64c6c4a623626ff0687008732a8e007e2a1c/Documentation/config/extensions.adoc)
- [`write_worktree_linking_files`](https://github.com/git/git/blob/1a3e64c6c4a623626ff0687008732a8e007e2a1c/worktree.c)

Minimal reproduction against a linked worktree created with `--relative-paths`:

```go
repo, err := git.PlainOpen(linkedWorktreePath)
if err != nil {
	return err
}
defer func() { _ = repo.Close() }()
```

Before this change, `PlainOpen` returns `unknown extension: relativeworktrees`.

Tests:
- `go test . -run '^(TestPlainOpenRelativeWorktree|TestVerifyExtensions)$' -count=1`
- `go test ./storage/filesystem/... -count=1`
- `go test ./plumbing/format/gitignore -count=1` (Git 2.55 oracle)
- `go test -v _examples/common_test.go _examples/common.go --examples`
- `go build ./...`
- `golangci-lint run`

I also ran `go test ./... -count=1`. The remaining failures were unrelated Windows environment checks requiring symlink privileges and two SSH environment tests. The Git-version and missing-`touch` failures passed when rerun with isolated MinGit 2.55 and its Unix tools.

AI assistance: OpenAI Codex was used for investigation, implementation, tests, and drafting.
