### PR TITLE
plumbing: format/packfile, Break cyclic delta chains instead of recursing. Fixes #2249

### DIFF
--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -147,8 +147,12 @@ func (dw *DeltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error 
 		m[otp.Hash()] = otp
 	}
 
+	// visiting holds the objects on the current resolution path, so that a
+	// delta chain looping back on itself can be detected and broken.
+	visiting := make(map[plumbing.Hash]bool)
+
 	for _, otp := range objectsToPack {
-		if err := dw.fixAndBreakChainsOne(m, otp); err != nil {
+		if err := dw.fixAndBreakChainsOne(m, otp, visiting); err != nil {
 			return err
 		}
 	}
@@ -156,7 +160,11 @@ func (dw *DeltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error 
 	return nil
 }
 
-func (dw *DeltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*ObjectToPack, otp *ObjectToPack) error {
+func (dw *DeltaSelector) fixAndBreakChainsOne(
+	objectsToPack map[plumbing.Hash]*ObjectToPack,
+	otp *ObjectToPack,
+	visiting map[plumbing.Hash]bool,
+) error {
 	if !otp.Object.Type().IsDelta() {
 		return nil
 	}
@@ -182,7 +190,21 @@ func (dw *DeltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*O
 		return dw.undeltify(otp)
 	}
 
-	if err := dw.fixAndBreakChainsOne(objectsToPack, base); err != nil {
+	// Mark this object as being resolved before looking at its base, so that
+	// a delta based on itself is caught by the check below.
+	h := otp.Hash()
+	visiting[h] = true
+	defer delete(visiting, h)
+
+	// A delta chain that loops back onto an object we are already resolving
+	// cannot be written: every delta needs its base written first. Break the
+	// chain here instead of following the cycle, which would recurse until
+	// the goroutine stack is exhausted.
+	if visiting[do.BaseHash()] {
+		return dw.undeltify(otp)
+	}
+
+	if err := dw.fixAndBreakChainsOne(objectsToPack, base, visiting); err != nil {
 		return err
 	}
 

--- a/plumbing/format/packfile/delta_selector_cycle_test.go
+++ b/plumbing/format/packfile/delta_selector_cycle_test.go
@@ -1,0 +1,179 @@
+package packfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// cyclicDelta is a delta object whose base hash is set by the test, allowing
+// delta chains that loop back on themselves to be built.
+type cyclicDelta struct {
+	plumbing.EncodedObject
+	self plumbing.Hash
+	base plumbing.Hash
+}
+
+func (d *cyclicDelta) Type() plumbing.ObjectType { return plumbing.OFSDeltaObject }
+func (d *cyclicDelta) BaseHash() plumbing.Hash   { return d.base }
+func (d *cyclicDelta) ActualHash() plumbing.Hash { return d.self }
+func (d *cyclicDelta) ActualSize() int64         { return d.Size() }
+
+type DeltaSelectorCycleSuite struct {
+	suite.Suite
+	store *memory.Storage
+	ds    *DeltaSelector
+}
+
+func TestDeltaSelectorCycleSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(DeltaSelectorCycleSuite))
+}
+
+func (s *DeltaSelectorCycleSuite) SetupTest() {
+	s.store = memory.NewStorage()
+	s.ds = NewDeltaSelector(s.store)
+}
+
+// addObject stores a non-delta object so that undeltify can restore it.
+func (s *DeltaSelectorCycleSuite) addObject(content string) plumbing.EncodedObject {
+	o := newObject(plumbing.BlobObject, []byte(content))
+	_, err := s.store.SetEncodedObject(o)
+	s.Require().NoError(err)
+	return o
+}
+
+// deltaOn returns an ObjectToPack for a delta of o based on base.
+func (s *DeltaSelectorCycleSuite) deltaOn(o plumbing.EncodedObject, base plumbing.Hash) *ObjectToPack {
+	return &ObjectToPack{
+		Object: &cyclicDelta{EncodedObject: o, self: o.Hash(), base: base},
+	}
+}
+
+// assertResolvable walks each object's Base pointers and fails if a cycle is
+// still reachable or the chain does not terminate at a non-delta object.
+func (s *DeltaSelectorCycleSuite) assertResolvable(objs []*ObjectToPack) {
+	for _, otp := range objs {
+		seen := make(map[plumbing.Hash]bool)
+		for cur := otp; cur != nil; cur = cur.Base {
+			h := cur.Hash()
+			s.Require().False(seen[h], "delta chain still contains a cycle at %s", h)
+			seen[h] = true
+		}
+		// A delta must have a base to be writable.
+		if otp.Object.Type().IsDelta() {
+			s.Require().NotNil(otp.Base, "delta %s left without a base", otp.Hash())
+		}
+	}
+}
+
+// A delta whose base is itself must not recurse forever.
+func (s *DeltaSelectorCycleSuite) TestSelfReferencingDelta() {
+	a := s.addObject("aaaaaaaa")
+	otpA := s.deltaOn(a, a.Hash())
+
+	objs := []*ObjectToPack{otpA}
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+
+	// The only way to break a self-cycle is to store the object whole.
+	s.False(otpA.Object.Type().IsDelta(), "self-referencing delta should be undeltified")
+	s.Nil(otpA.Base)
+	s.assertResolvable(objs)
+}
+
+// Two deltas based on each other must not recurse forever. This is the case
+// reported in issue #2249.
+func (s *DeltaSelectorCycleSuite) TestTwoObjectCycle() {
+	a := s.addObject("aaaaaaaa")
+	b := s.addObject("bbbbbbbb")
+
+	otpA := s.deltaOn(a, b.Hash())
+	otpB := s.deltaOn(b, a.Hash())
+
+	objs := []*ObjectToPack{otpA, otpB}
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+
+	s.assertResolvable(objs)
+
+	// Exactly one of the two must have been undeltified to break the cycle;
+	// the other stays a delta so pack size is not sacrificed needlessly.
+	deltas := 0
+	for _, otp := range objs {
+		if otp.Object.Type().IsDelta() {
+			deltas++
+		}
+	}
+	s.Equal(1, deltas, "exactly one object should be undeltified")
+}
+
+// A longer cycle (A -> B -> C -> A) must also terminate.
+func (s *DeltaSelectorCycleSuite) TestThreeObjectCycle() {
+	a := s.addObject("aaaaaaaa")
+	b := s.addObject("bbbbbbbb")
+	c := s.addObject("cccccccc")
+
+	otpA := s.deltaOn(a, b.Hash())
+	otpB := s.deltaOn(b, c.Hash())
+	otpC := s.deltaOn(c, a.Hash())
+
+	objs := []*ObjectToPack{otpA, otpB, otpC}
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+
+	s.assertResolvable(objs)
+
+	deltas := 0
+	for _, otp := range objs {
+		if otp.Object.Type().IsDelta() {
+			deltas++
+		}
+	}
+	s.Equal(2, deltas, "only one object should be undeltified to break the cycle")
+}
+
+// A valid, acyclic chain must keep every delta: the cycle check must not
+// produce false positives on diamonds or repeated bases.
+func (s *DeltaSelectorCycleSuite) TestAcyclicChainIsPreserved() {
+	base := s.addObject("basebasebase")
+	a := s.addObject("aaaaaaaa")
+	b := s.addObject("bbbbbbbb")
+
+	// base is a plain object; both a and b are deltas against it.
+	otpBase := newObjectToPack(base)
+	otpA := s.deltaOn(a, base.Hash())
+	otpB := s.deltaOn(b, base.Hash())
+
+	objs := []*ObjectToPack{otpBase, otpA, otpB}
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+
+	s.True(otpA.Object.Type().IsDelta(), "a should remain a delta")
+	s.True(otpB.Object.Type().IsDelta(), "b should remain a delta")
+	s.Equal(otpBase, otpA.Base)
+	s.Equal(otpBase, otpB.Base)
+	s.assertResolvable(objs)
+}
+
+// A deep chain shares bases across separate resolution paths; the visiting set
+// must be unwound correctly so no delta is dropped.
+func (s *DeltaSelectorCycleSuite) TestDeepChainIsPreserved() {
+	const n = 50
+
+	objs := make([]*ObjectToPack, 0, n)
+	prev := s.addObject("root")
+	objs = append(objs, newObjectToPack(prev))
+
+	for i := 1; i < n; i++ {
+		o := s.addObject(string(rune('a'+i%26)) + "-payload-" + string(rune('0'+i%10)))
+		objs = append(objs, s.deltaOn(o, prev.Hash()))
+		prev = o
+	}
+
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+	s.assertResolvable(objs)
+
+	for _, otp := range objs[1:] {
+		s.True(otp.Object.Type().IsDelta(), "delta %s was dropped", otp.Hash())
+	}
+}


### PR DESCRIPTION
Fixes #2249

## Problem

`DeltaSelector.fixAndBreakChainsOne` resolves a reused delta by recursing into its base first and assigning `ObjectToPack.Base` only *after* the recursive call returns:

```go
if otp.Base != nil {        // the only reentry guard
    return nil
}
...
if err := dw.fixAndBreakChainsOne(objectsToPack, base); err != nil {  // descend
    return err
}
otp.SetDelta(base, otp.Object)                                        // Base assigned here
```

Because `Base` is assigned after the descent, every object on the current resolution path still has `Base == nil` while the recursion is in flight, so the guard cannot distinguish an object being resolved from an unvisited one.

Given a delta chain that loops back on itself (`A → B → A`), the guard never fires and the function recurses until the goroutine stack is exhausted:

| depth | object | `otp.Base` | action |
|---|---|---|---|
| 1 | A | nil | base B found → descend |
| 2 | B | nil | base A found → descend |
| 3 | A | still nil | base B found → descend |
| … | | | until stack overflow |

This is an unrecoverable `fatal error: stack overflow` — not a returnable error — so callers cannot defend against it.

As noted in the issue thread, commit 2139126 (`storage: filesystem, MRU pack ordering`) changes which packfile is consulted first and so may mask a particular trigger, but it does not touch the recursion. The reporter's observation that there is "no recursive protection in `fixAndBreakChainsOne`" is the actual defect, and it is still present on `main`.

## Reproduction

Minimum working example (the delta objects are constructed directly so the cycle is deterministic; `newObject` is the existing test helper):

```go
// A delta object whose base hash we control.
type cyclicDelta struct {
	plumbing.EncodedObject
	self, base plumbing.Hash
}

func (d *cyclicDelta) Type() plumbing.ObjectType { return plumbing.OFSDeltaObject }
func (d *cyclicDelta) BaseHash() plumbing.Hash   { return d.base }
func (d *cyclicDelta) ActualHash() plumbing.Hash { return d.self }
func (d *cyclicDelta) ActualSize() int64         { return d.Size() }

a := newObject(plumbing.BlobObject, []byte("aaaaaaaa"))
b := newObject(plumbing.BlobObject, []byte("bbbbbbbb"))

// A's base is B, B's base is A.
otpA := &ObjectToPack{Object: &cyclicDelta{EncodedObject: a, self: a.Hash(), base: b.Hash()}}
otpB := &ObjectToPack{Object: &cyclicDelta{EncodedObject: b, self: b.Hash(), base: a.Hash()}}

NewDeltaSelector(store).fixAndBreakChains([]*ObjectToPack{otpA, otpB})
```

Before this change:

```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow

github.com/go-git/go-git/v6/plumbing/format/packfile.(*DeltaSelector).fixAndBreakChainsOne(...)
	plumbing/format/packfile/delta_selector.go:178
github.com/go-git/go-git/v6/plumbing/format/packfile.(*DeltaSelector).fixAndBreakChainsOne(...)
	plumbing/format/packfile/delta_selector.go:185
github.com/go-git/go-git/v6/plumbing/format/packfile.(*DeltaSelector).fixAndBreakChainsOne(...)
	plumbing/format/packfile/delta_selector.go:185      <- alternating between the two objects
```

This matches the frame pattern in the issue report (entry at `:178`, then `:185` repeating between two alternating object pointers).

## Fix

Track the objects on the current resolution path. Mark the current object *before* inspecting its base, and if the base is already on the path, break the chain by undeltifying instead of following the cycle.

Two details worth calling out:

- **The check is before the descent, not on entry.** Detecting the cycle on entry ("am I already being visited?") looks equivalent but is not: the inner frame undeltifies the object, then the outer frame — still holding its own `base` local — falls through to `SetDelta` and re-creates the loop. Testing whether the *base* is on the path means the cut is made by the frame that owns the offending edge.
- **The path set is unwound on return** (`defer delete`). This is required for correctness, not hygiene: without it, two deltas legitimately sharing one base would be treated as a cycle and the second would be needlessly undeltified.

Breaking the chain (rather than returning an error) matches what this function already does when a base is missing from the pack or is not a `DeltaObject`, and keeps a push working instead of failing it.

## Alignment with upstream git

git handles this in [`break_delta_chains()`](https://github.com/git/git/blob/master/builtin/pack-objects.c#L2490) using a three-state DFS, and does the same three things in the same order:

```c
cur->dfs_state = DFS_ACTIVE;                     /* mark self first */
if (DELTA(cur)->dfs_state == DFS_ACTIVE) {       /* is the BASE active? */
        drop_reused_delta(cur);                  /* undeltify this object */
        cur->dfs_state = DFS_DONE;
        break;
}
```

git's own comment confirms the ordering is deliberate — *"It's important to do this `_before_` we loop, because it impacts where we make the cut"* — and explains why cutting the **last** edge of the cycle is preferable: for `A → B → C → D → B`, cutting `D→B` keeps A's depth correct at 3, whereas cutting `B→C` would drop C and D from the chain. This change cuts the last edge for the same reason. `drop_reused_delta` is the direct counterpart of go-git's `undeltify` on the delta-reuse path.

## Tests

New `plumbing/format/packfile/delta_selector_cycle_test.go`:

| Test | Covers |
|---|---|
| `TestSelfReferencingDelta` | `A → A`; only escape is undeltifying |
| `TestTwoObjectCycle` | the reported case, `A → B → A`; asserts exactly one object undeltified |
| `TestThreeObjectCycle` | `A → B → C → A`; confirms the cut lands on the last edge (2 deltas kept) |
| `TestAcyclicChainIsPreserved` | shared base — guards against false positives |
| `TestDeepChainIsPreserved` | 50-long valid chain; every delta must survive |

A shared helper walks the resulting `Base` pointers and fails on a repeated hash or a delta left without a base, so the tests assert the output is a *writable* chain rather than merely that nothing crashed.

I verified the tests fail without the source change (the test binary dies with `fatal error: stack overflow`) and pass with it.

Also run locally: `make validate-lint` (golangci-lint v2.13.1) clean, `go test -race ./...`, `gofmt`, `go vet`.

## Notes for reviewers

- **On reachability:** the test constructs the cycle through the internal API rather than from a crafted packfile, so I would not claim a proven remote trigger. The issue reporter's stack trace is the field evidence; this change is defence-in-depth on the delta-*reuse* path, which is the same path upstream git guards (hence `drop_reused_delta`). Happy to be told this warrants a different framing.
- **Break vs. error:** I chose to break the chain for consistency with the function's existing behaviour, but if you would rather surface a cycle as an error (on the view that it indicates a corrupt local pack worth reporting), that is a small change.
- `fixAndBreakChainsOne` gains a parameter. It is unexported with a single caller, so there is no API impact — happy to thread the state differently if you prefer.
- **Backport:** targeting `main` per CONTRIBUTING. `releases/v5.x` looks to have the same shape; I can open a backport if useful rather than assume.

## AI assistance disclosure

Per [AI_POLICY.md](https://github.com/go-git/go-git/blob/main/AI_POLICY.md), this change was produced with AI assistance (Claude Opus 5), disclosed via an `Assisted-by:` trailer on the commit. I have reviewed and understand every line, verified the behaviour against reference git (2.55.0) and against git's own source, and confirmed the tests fail without the fix. I will respond to review feedback personally.
