### PR TITLE
storage: filesystem/dotgit, route symlink writes by link path.

### DIFF
--- a/storage/filesystem/dotgit/repository_filesystem.go
+++ b/storage/filesystem/dotgit/repository_filesystem.go
@@ -127,7 +127,7 @@ func (fs *RepositoryFilesystem) Lstat(filename string) (os.FileInfo, error) {
 
 // Symlink creates a symlink in the appropriate filesystem.
 func (fs *RepositoryFilesystem) Symlink(target, link string) error {
-	return fs.mapToRepositoryFsByPath(target).Symlink(target, link)
+	return fs.mapToRepositoryFsByPath(link).Symlink(target, link)
 }
 
 // Readlink reads the target of a symlink.

--- a/storage/filesystem/dotgit/repository_filesystem_test.go
+++ b/storage/filesystem/dotgit/repository_filesystem_test.go
@@ -63,6 +63,24 @@ func (s *SuiteDotGit) TestRepositoryFilesystem() {
 	s.Require().NoError(err)
 	s.Equal("newfile", link)
 
+	crossRootLinkTarget := repositoryFs.Join("refs", "heads", "main")
+	err = repositoryFs.Symlink(crossRootLinkTarget, "cross-root-link")
+	s.Require().NoError(err)
+
+	link, err = repositoryFs.Readlink("cross-root-link")
+	s.Require().NoError(err)
+	s.Equal(crossRootLinkTarget, link)
+
+	_, err = dotGitFs.Lstat("cross-root-link")
+	s.Require().NoError(err)
+
+	link, err = dotGitFs.Readlink("cross-root-link")
+	s.Require().NoError(err)
+	s.Equal(crossRootLinkTarget, link)
+
+	_, err = commonDotGitFs.Lstat("cross-root-link")
+	s.True(os.IsNotExist(err))
+
 	err = repositoryFs.Remove("somelink")
 	s.Require().NoError(err)
 


### PR DESCRIPTION
Fix RepositoryFilesystem.Symlink to choose the backing filesystem from the link path, not the symlink target. This keeps symlink creation routed to the correct dotgit root when target and link live under different trees.\n\nAdded a regression test that verifies symlink creation lands in the expected backing filesystem and does not touch the other root.\n\nVerification:\n- go test ./storage/filesystem/dotgit\n- go test ./storage/filesystem/... 