### PR TITLE
plumbing: format/packfile, Break cyclic delta chains instead of recur…

### DIFF
--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -139,8 +139,12 @@ func (dw *deltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error 
 		m[otp.Hash()] = otp
 	}
 
+	// visiting holds the objects on the current resolution path, so that a
+	// delta chain looping back on itself can be detected and broken.
+	visiting := make(map[plumbing.Hash]bool)
+
 	for _, otp := range objectsToPack {
-		if err := dw.fixAndBreakChainsOne(m, otp); err != nil {
+		if err := dw.fixAndBreakChainsOne(m, otp, visiting); err != nil {
 			return err
 		}
 	}
@@ -148,7 +152,11 @@ func (dw *deltaSelector) fixAndBreakChains(objectsToPack []*ObjectToPack) error 
 	return nil
 }
 
-func (dw *deltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*ObjectToPack, otp *ObjectToPack) error {
+func (dw *deltaSelector) fixAndBreakChainsOne(
+	objectsToPack map[plumbing.Hash]*ObjectToPack,
+	otp *ObjectToPack,
+	visiting map[plumbing.Hash]bool,
+) error {
 	if !otp.Object.Type().IsDelta() {
 		return nil
 	}
@@ -174,7 +182,21 @@ func (dw *deltaSelector) fixAndBreakChainsOne(objectsToPack map[plumbing.Hash]*O
 		return dw.undeltify(otp)
 	}
 
-	if err := dw.fixAndBreakChainsOne(objectsToPack, base); err != nil {
+	// Mark this object as being resolved before looking at its base, so that
+	// a delta based on itself is caught by the check below.
+	h := otp.Hash()
+	visiting[h] = true
+	defer delete(visiting, h)
+
+	// A delta chain that loops back onto an object we are already resolving
+	// cannot be written: every delta needs its base written first. Break the
+	// chain here instead of following the cycle, which would recurse until
+	// the goroutine stack is exhausted.
+	if visiting[do.BaseHash()] {
+		return dw.undeltify(otp)
+	}
+
+	if err := dw.fixAndBreakChainsOne(objectsToPack, base, visiting); err != nil {
 		return err
 	}
 

--- a/plumbing/format/packfile/delta_selector_cycle_test.go
+++ b/plumbing/format/packfile/delta_selector_cycle_test.go
@@ -1,0 +1,179 @@
+package packfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+// cyclicDelta is a delta object whose base hash is set by the test, allowing
+// delta chains that loop back on themselves to be built.
+type cyclicDelta struct {
+	plumbing.EncodedObject
+	self plumbing.Hash
+	base plumbing.Hash
+}
+
+func (d *cyclicDelta) Type() plumbing.ObjectType { return plumbing.OFSDeltaObject }
+func (d *cyclicDelta) BaseHash() plumbing.Hash   { return d.base }
+func (d *cyclicDelta) ActualHash() plumbing.Hash { return d.self }
+func (d *cyclicDelta) ActualSize() int64         { return d.Size() }
+
+type DeltaSelectorCycleSuite struct {
+	suite.Suite
+	store *memory.Storage
+	ds    *deltaSelector
+}
+
+func TestDeltaSelectorCycleSuite(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(DeltaSelectorCycleSuite))
+}
+
+func (s *DeltaSelectorCycleSuite) SetupTest() {
+	s.store = memory.NewStorage()
+	s.ds = newDeltaSelector(s.store)
+}
+
+// addObject stores a non-delta object so that undeltify can restore it.
+func (s *DeltaSelectorCycleSuite) addObject(content string) plumbing.EncodedObject {
+	o := newObject(plumbing.BlobObject, []byte(content))
+	_, err := s.store.SetEncodedObject(o)
+	s.Require().NoError(err)
+	return o
+}
+
+// deltaOn returns an ObjectToPack for a delta of o based on base.
+func (s *DeltaSelectorCycleSuite) deltaOn(o plumbing.EncodedObject, base plumbing.Hash) *ObjectToPack {
+	return &ObjectToPack{
+		Object: &cyclicDelta{EncodedObject: o, self: o.Hash(), base: base},
+	}
+}
+
+// assertResolvable walks each object's Base pointers and fails if a cycle is
+// still reachable or the chain does not terminate at a non-delta object.
+func (s *DeltaSelectorCycleSuite) assertResolvable(objs []*ObjectToPack) {
+	for _, otp := range objs {
+		seen := make(map[plumbing.Hash]bool)
+		for cur := otp; cur != nil; cur = cur.Base {
+			h := cur.Hash()
+			s.Require().False(seen[h], "delta chain still contains a cycle at %s", h)
+			seen[h] = true
+		}
+		// A delta must have a base to be writable.
+		if otp.Object.Type().IsDelta() {
+			s.Require().NotNil(otp.Base, "delta %s left without a base", otp.Hash())
+		}
+	}
+}
+
+// A delta whose base is itself must not recurse forever.
+func (s *DeltaSelectorCycleSuite) TestSelfReferencingDelta() {
+	a := s.addObject("aaaaaaaa")
+	otpA := s.deltaOn(a, a.Hash())
+
+	objs := []*ObjectToPack{otpA}
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+
+	// The only way to break a self-cycle is to store the object whole.
+	s.False(otpA.Object.Type().IsDelta(), "self-referencing delta should be undeltified")
+	s.Nil(otpA.Base)
+	s.assertResolvable(objs)
+}
+
+// Two deltas based on each other must not recurse forever. This is the case
+// reported in issue #2249.
+func (s *DeltaSelectorCycleSuite) TestTwoObjectCycle() {
+	a := s.addObject("aaaaaaaa")
+	b := s.addObject("bbbbbbbb")
+
+	otpA := s.deltaOn(a, b.Hash())
+	otpB := s.deltaOn(b, a.Hash())
+
+	objs := []*ObjectToPack{otpA, otpB}
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+
+	s.assertResolvable(objs)
+
+	// Exactly one of the two must have been undeltified to break the cycle;
+	// the other stays a delta so pack size is not sacrificed needlessly.
+	deltas := 0
+	for _, otp := range objs {
+		if otp.Object.Type().IsDelta() {
+			deltas++
+		}
+	}
+	s.Equal(1, deltas, "exactly one object should be undeltified")
+}
+
+// A longer cycle (A -> B -> C -> A) must also terminate.
+func (s *DeltaSelectorCycleSuite) TestThreeObjectCycle() {
+	a := s.addObject("aaaaaaaa")
+	b := s.addObject("bbbbbbbb")
+	c := s.addObject("cccccccc")
+
+	otpA := s.deltaOn(a, b.Hash())
+	otpB := s.deltaOn(b, c.Hash())
+	otpC := s.deltaOn(c, a.Hash())
+
+	objs := []*ObjectToPack{otpA, otpB, otpC}
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+
+	s.assertResolvable(objs)
+
+	deltas := 0
+	for _, otp := range objs {
+		if otp.Object.Type().IsDelta() {
+			deltas++
+		}
+	}
+	s.Equal(2, deltas, "only one object should be undeltified to break the cycle")
+}
+
+// A valid, acyclic chain must keep every delta: the cycle check must not
+// produce false positives on diamonds or repeated bases.
+func (s *DeltaSelectorCycleSuite) TestAcyclicChainIsPreserved() {
+	base := s.addObject("basebasebase")
+	a := s.addObject("aaaaaaaa")
+	b := s.addObject("bbbbbbbb")
+
+	// base is a plain object; both a and b are deltas against it.
+	otpBase := newObjectToPack(base)
+	otpA := s.deltaOn(a, base.Hash())
+	otpB := s.deltaOn(b, base.Hash())
+
+	objs := []*ObjectToPack{otpBase, otpA, otpB}
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+
+	s.True(otpA.Object.Type().IsDelta(), "a should remain a delta")
+	s.True(otpB.Object.Type().IsDelta(), "b should remain a delta")
+	s.Equal(otpBase, otpA.Base)
+	s.Equal(otpBase, otpB.Base)
+	s.assertResolvable(objs)
+}
+
+// A deep chain shares bases across separate resolution paths; the visiting set
+// must be unwound correctly so no delta is dropped.
+func (s *DeltaSelectorCycleSuite) TestDeepChainIsPreserved() {
+	const n = 50
+
+	objs := make([]*ObjectToPack, 0, n)
+	prev := s.addObject("root")
+	objs = append(objs, newObjectToPack(prev))
+
+	for i := 1; i < n; i++ {
+		o := s.addObject(string(rune('a'+i%26)) + "-payload-" + string(rune('0'+i%10)))
+		objs = append(objs, s.deltaOn(o, prev.Hash()))
+		prev = o
+	}
+
+	s.Require().NoError(s.ds.fixAndBreakChains(objs))
+	s.assertResolvable(objs)
+
+	for _, otp := range objs[1:] {
+		s.True(otp.Object.Type().IsDelta(), "delta %s was dropped", otp.Hash())
+	}
+}


### PR DESCRIPTION
…sing. Fixes #2249

fixAndBreakChainsOne resolves a reused delta by recursing into its base and only assigns ObjectToPack.Base afterwards. While the recursion is in flight every object on the current path therefore still has a nil Base, so the existing reentry guard cannot fire. A delta chain that contains a cycle recursed until the goroutine stack was exhausted, aborting the process with a fatal stack overflow during push.

Track the objects on the current resolution path and, when a delta's base is already being resolved, break the chain by undeltifying that object instead of following the cycle. The path set is unwound on return so that objects legitimately sharing a base are not mistaken for a cycle.

This mirrors break_delta_chains() in git's builtin/pack-objects.c, which marks an entry DFS_ACTIVE before inspecting its base and calls drop_reused_delta() when the base is already active. Cutting the last edge of the cycle, as done here, is also what git documents as preferable because it preserves the depth of the objects already examined.


Assisted-by: Claude Opus 5 <noreply@anthropic.com>