### PR TITLE
fix: add TreeEntryFileSkipValidation for entries from skipPathValidation walk

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -141,6 +141,18 @@ func (t *Tree) TreeEntryFile(e *TreeEntry) (*File, error) {
 		return nil, err
 	}
 
+	return t.treeEntryFile(e)
+}
+
+// TreeEntryFileSkipValidation returns the *File for a given *TreeEntry
+// without validating the entry's name. Use this when the entry was
+// obtained via a TreeWalker with skipPathValidation enabled, and the
+// caller has already verified the entry is safe to use.
+func (t *Tree) TreeEntryFileSkipValidation(e *TreeEntry) (*File, error) {
+	return t.treeEntryFile(e)
+}
+
+func (t *Tree) treeEntryFile(e *TreeEntry) (*File, error) {
 	blob, err := GetBlob(t.s, e.Hash)
 	if err != nil {
 		return nil, err

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -2465,3 +2465,33 @@ func TestTreeValidateReportsAllRules(t *testing.T) {
 	assert.ErrorIs(t, verr, pathutil.ErrInvalidPath)
 	assert.Contains(t, verr.Error(), "null hash")
 }
+
+// TestTreeEntryFileSkipValidationAllowsDangerousNames verifies that
+// TreeEntryFileSkipValidation does not reject dangerous entry names,
+// which is the whole point: callers that obtained the entry via a
+// skipPathValidation walk and have already validated it themselves
+// should be able to materialise the *File.
+func TestTreeEntryFileSkipValidationAllowsDangerousNames(t *testing.T) {
+	t.Parallel()
+
+	store := memory.NewStorage()
+	blob := &plumbing.MemoryObject{}
+	blob.SetType(plumbing.BlobObject)
+	bw, err := blob.Writer()
+	require.NoError(t, err)
+	_, err = bw.Write([]byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, bw.Close())
+	blobHash, err := store.SetEncodedObject(blob)
+	require.NoError(t, err)
+
+	tree := &Tree{s: store}
+	f, err := tree.TreeEntryFileSkipValidation(&TreeEntry{
+		Name: ".git",
+		Mode: filemode.Regular,
+		Hash: blobHash,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	require.Equal(t, ".git", f.Name)
+}


### PR DESCRIPTION
PR #2305 added SkipPathValidation to TreeWalker so inspection-only callers can enumerate entries with names upstream Git accepts but that are unsafe to materialise. However, TreeEntryFile still validates the path, blocking those callers from reading file contents.

Add TreeEntryFileSkipValidation as an opt-in alternative that skips the path check, mirroring the existing TreeWalker.SkipPathValidation pattern. The existing TreeEntryFile remains unchanged for safety.

Fixes go-git/go-git#2339