### PR TITLE
plumbing: format/commitgraph, fix panic encoding a commit whose parent isn't in the index

### DIFF
--- a/plumbing/format/commitgraph/encoder.go
+++ b/plumbing/format/commitgraph/encoder.go
@@ -2,6 +2,7 @@ package commitgraph
 
 import (
 	"crypto"
+	"fmt"
 	"io"
 	"math"
 
@@ -30,7 +31,10 @@ func (e *Encoder) Encode(idx Index) error {
 	hashes := idx.Hashes()
 
 	// Sort the input and prepare helper structures we'll need for encoding
-	hashToIndex, fanout, extraEdgesCount, generationV2OverflowCount := e.prepare(idx, hashes)
+	hashToIndex, fanout, extraEdgesCount, generationV2OverflowCount, err := e.prepare(idx, hashes)
+	if err != nil {
+		return err
+	}
 
 	chunkSignatures := [][]byte{OIDFanoutChunk.Signature(), OIDLookupChunk.Signature(), CommitDataChunk.Signature()}
 	chunkSizes := []uint64{szUint32 * lenFanout, uint64(len(hashes) * e.hash.Size()), uint64(len(hashes) * (e.hash.Size() + szCommitData))}
@@ -80,7 +84,19 @@ func (e *Encoder) Encode(idx Index) error {
 	return e.encodeChecksum()
 }
 
-func (e *Encoder) prepare(idx Index, hashes []plumbing.Hash) (hashToIndex map[plumbing.Hash]uint32, fanout []uint32, extraEdgesCount, generationV2OverflowCount uint32) {
+// lookupParentIndex resolves a parent hash to its position in the file being
+// encoded. A bare map read yields index 0 for an absent hash, which would
+// silently record an arbitrary commit as the parent, so report it instead.
+func lookupParentIndex(hashToIndex map[plumbing.Hash]uint32, h plumbing.Hash) (uint32, error) {
+	i, ok := hashToIndex[h]
+	if !ok {
+		return 0, fmt.Errorf("%w: %s", ErrParentNotInIndex, h)
+	}
+
+	return i, nil
+}
+
+func (e *Encoder) prepare(idx Index, hashes []plumbing.Hash) (hashToIndex map[plumbing.Hash]uint32, fanout []uint32, extraEdgesCount, generationV2OverflowCount uint32, err error) {
 	// Sort the hashes and build our index
 	plumbing.HashesSort(hashes)
 	hashToIndex = make(map[plumbing.Hash]uint32)
@@ -97,9 +113,14 @@ func (e *Encoder) prepare(idx Index, hashes []plumbing.Hash) (hashToIndex map[pl
 
 	hasGenerationV2 := idx.HasGenerationV2()
 
-	// Find out if we will need extra edge table
+	// Find out if we will need extra edge table. An index that cannot satisfy
+	// the lookup returns a nil CommitData, so the error has to be checked
+	// before v is dereferenced.
 	for i := range len(hashes) {
-		v, _ := idx.GetCommitDataByIndex(uint32(i))
+		v, err := idx.GetCommitDataByIndex(uint32(i))
+		if err != nil {
+			return nil, nil, 0, 0, err
+		}
 		if len(v.ParentHashes) > 2 {
 			extraEdgesCount += uint32(len(v.ParentHashes) - 1)
 		}
@@ -108,7 +129,7 @@ func (e *Encoder) prepare(idx Index, hashes []plumbing.Hash) (hashToIndex map[pl
 		}
 	}
 
-	return hashToIndex, fanout, extraEdgesCount, generationV2OverflowCount
+	return hashToIndex, fanout, extraEdgesCount, generationV2OverflowCount, nil
 }
 
 func (e *Encoder) encodeFileHeader(chunkCount int) (err error) {
@@ -166,8 +187,16 @@ func (e *Encoder) encodeCommitData(hashes []plumbing.Hash, hashToIndex map[plumb
 		generationV2Data = make([]uint64, 0, len(hashes))
 	}
 	for _, hash := range hashes {
-		origIndex, _ := idx.GetIndexByHash(hash)
-		commitData, _ := idx.GetCommitDataByIndex(origIndex)
+		// Both lookups can fail, and commitData is nil when the second one
+		// does.
+		origIndex, err := idx.GetIndexByHash(hash)
+		if err != nil {
+			return extraEdges, generationV2Data, err
+		}
+		commitData, err := idx.GetCommitDataByIndex(origIndex)
+		if err != nil {
+			return extraEdges, generationV2Data, err
+		}
 		if _, err = e.Write(commitData.TreeHash.Bytes()); err != nil {
 			return extraEdges, generationV2Data, err
 		}
@@ -178,16 +207,28 @@ func (e *Encoder) encodeCommitData(hashes []plumbing.Hash, hashToIndex map[plumb
 			parent1 = parentNone
 			parent2 = parentNone
 		case 1:
-			parent1 = hashToIndex[commitData.ParentHashes[0]]
+			if parent1, err = lookupParentIndex(hashToIndex, commitData.ParentHashes[0]); err != nil {
+				return extraEdges, generationV2Data, err
+			}
 			parent2 = parentNone
 		case 2:
-			parent1 = hashToIndex[commitData.ParentHashes[0]]
-			parent2 = hashToIndex[commitData.ParentHashes[1]]
+			if parent1, err = lookupParentIndex(hashToIndex, commitData.ParentHashes[0]); err != nil {
+				return extraEdges, generationV2Data, err
+			}
+			if parent2, err = lookupParentIndex(hashToIndex, commitData.ParentHashes[1]); err != nil {
+				return extraEdges, generationV2Data, err
+			}
 		default:
-			parent1 = hashToIndex[commitData.ParentHashes[0]]
+			if parent1, err = lookupParentIndex(hashToIndex, commitData.ParentHashes[0]); err != nil {
+				return extraEdges, generationV2Data, err
+			}
 			parent2 = uint32(len(extraEdges)) | parentOctopusUsed
 			for _, parentHash := range commitData.ParentHashes[1:] {
-				extraEdges = append(extraEdges, hashToIndex[parentHash])
+				extraEdge, err := lookupParentIndex(hashToIndex, parentHash)
+				if err != nil {
+					return extraEdges, generationV2Data, err
+				}
+				extraEdges = append(extraEdges, extraEdge)
 			}
 			extraEdges[len(extraEdges)-1] |= parentLast
 		}

--- a/plumbing/format/commitgraph/encoder_test.go
+++ b/plumbing/format/commitgraph/encoder_test.go
@@ -3,8 +3,12 @@ package commitgraph
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/plumbing"
 )
 
 func TestEncodeFileHeaderRejectsTooManyChunks(t *testing.T) {
@@ -16,4 +20,100 @@ func TestEncodeFileHeaderRejectsTooManyChunks(t *testing.T) {
 
 	err := e.encodeFileHeader(256)
 	assert.ErrorIs(t, err, ErrTooManyChunks)
+}
+
+// A commit whose parent was never added to the index must be reported, not
+// dereferenced as a nil CommitData. This is the shape a shallow clone's
+// boundary commit has, since its ParentHashes still name the unfetched parent.
+func TestEncodeUnresolvableParentReturnsError(t *testing.T) {
+	t.Parallel()
+
+	mi := NewMemoryIndex()
+	mi.Add(plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"), &CommitData{
+		TreeHash:     plumbing.NewHash("cccccccccccccccccccccccccccccccccccccccc"),
+		ParentHashes: []plumbing.Hash{plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
+		When:         time.Unix(1700000000, 0),
+		Generation:   1,
+		GenerationV2: 1,
+	})
+
+	err := NewEncoder(&bytes.Buffer{}).Encode(mi)
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+}
+
+// A merge commit with one parent in the index and one outside it must be
+// reported too, rather than encoding only the resolvable edge.
+func TestEncodePartiallyResolvableParentsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	tree := plumbing.NewHash("cccccccccccccccccccccccccccccccccccccccc")
+	present := plumbing.NewHash("1111111111111111111111111111111111111111")
+
+	mi := NewMemoryIndex()
+	mi.Add(present, &CommitData{
+		TreeHash:     tree,
+		When:         time.Unix(1700000000, 0),
+		Generation:   1,
+		GenerationV2: 1,
+	})
+	mi.Add(plumbing.NewHash("3333333333333333333333333333333333333333"), &CommitData{
+		TreeHash: tree,
+		ParentHashes: []plumbing.Hash{
+			present,
+			plumbing.NewHash("2222222222222222222222222222222222222222"),
+		},
+		When:         time.Unix(1700000100, 0),
+		Generation:   2,
+		GenerationV2: 2,
+	})
+
+	err := NewEncoder(&bytes.Buffer{}).Encode(mi)
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+}
+
+// danglingEdgeIndex reports a parent that Hashes() does not include, so the
+// parent hash cannot be mapped to a position in the file being written. A
+// MemoryIndex rejects this earlier, so reaching the encoder's own lookup needs
+// a separate Index implementation.
+type danglingEdgeIndex struct {
+	hash   plumbing.Hash
+	parent plumbing.Hash
+}
+
+func (i danglingEdgeIndex) GetIndexByHash(h plumbing.Hash) (uint32, error) {
+	if h == i.hash {
+		return 0, nil
+	}
+
+	return 0, plumbing.ErrObjectNotFound
+}
+
+func (i danglingEdgeIndex) GetHashByIndex(uint32) (plumbing.Hash, error) { return i.hash, nil }
+
+func (i danglingEdgeIndex) GetCommitDataByIndex(uint32) (*CommitData, error) {
+	return &CommitData{
+		TreeHash:      plumbing.NewHash("cccccccccccccccccccccccccccccccccccccccc"),
+		ParentIndexes: []uint32{1},
+		ParentHashes:  []plumbing.Hash{i.parent},
+		When:          time.Unix(1700000000, 0),
+	}, nil
+}
+
+func (i danglingEdgeIndex) Hashes() []plumbing.Hash       { return []plumbing.Hash{i.hash} }
+func (i danglingEdgeIndex) HasGenerationV2() bool         { return false }
+func (i danglingEdgeIndex) MaximumNumberOfHashes() uint32 { return 1 }
+func (i danglingEdgeIndex) Close() error                  { return nil }
+
+// An unresolvable parent hash must not be written as index 0, which is a real
+// but arbitrary commit.
+func TestEncodeDanglingEdgeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	idx := danglingEdgeIndex{
+		hash:   plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		parent: plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	}
+
+	err := NewEncoder(&bytes.Buffer{}).Encode(idx)
+	require.ErrorIs(t, err, ErrParentNotInIndex)
 }

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -29,6 +29,10 @@ var (
 	// chunk-table configuration would not fit the uint8 the on-disk
 	// header stores at byte 6.
 	ErrTooManyChunks = errors.New("commitgraph: too many chunks")
+	// ErrParentNotInIndex is returned by Encoder.Encode when a commit names a
+	// parent that the index being written does not contain, so no edge can be
+	// recorded for it.
+	ErrParentNotInIndex = errors.New("commitgraph: parent is not part of the index being encoded")
 
 	commitFileSignature = []byte{'C', 'G', 'P', 'H'}
 


### PR DESCRIPTION
### Summary

`commitgraph.Encoder.Encode` panics with a nil-pointer dereference when the index contains a commit
whose recorded parent hash isn't part of that index. A shallow clone's boundary commit is the
natural way to reach it — its `ParentHashes` legitimately names a parent that was never fetched —
but any partially populated `MemoryIndex` does it.

### Root cause

Two discarded errors and an unchecked map read:

1. `prepare()` calls `idx.GetCommitDataByIndex`, discards the error, and dereferences the nil
   result on the next line. `encodeCommitData()` does the same, and also discards the error from
   `idx.GetIndexByHash`.
2. `encodeCommitData` resolves parent hashes with a bare `hashToIndex[hash]` read. An absent hash
   yields index `0`, so the encoder writes an arbitrary, wrong commit as the parent instead of
   failing. That corrupts the graph rather than crashing, and is reachable independently of the
   panic by any `Index` implementation whose `ParentHashes` names a commit outside `Hashes()`.

### Fix

- `prepare()` gains an error return; it and `encodeCommitData` propagate the lookup failures they
  were discarding, so a nil `CommitData` is never dereferenced. For a `MemoryIndex` this surfaces
  the `plumbing.ErrObjectNotFound` that `GetIndexByHash` was already producing and the encoder was
  throwing away.
- New `lookupParentIndex` helper returns `ErrParentNotInIndex` rather than encoding index `0`. This
  is the second defect and is independent of the first: it needs an `Index` whose `ParentIndexes`
  and `ParentHashes` agree but whose parent falls outside `Hashes()`, which `MemoryIndex` can't
  produce but a third-party implementation can.

No behaviour change for a well-formed index. Verified byte-identical: encoding an index containing a
root commit, two branches, a 2-parent merge and a 4-parent octopus — so the extra-edge and
generation-v2 paths are both exercised — produces the same 1692 bytes before and after
(`sha256=411537e7…`). The only new outcome is an error where there was previously a panic or a
silently wrong edge.


### Behaviour vs reference git

The panic has no git counterpart. Git's writer only encodes commits it has already collected, so it
can never be handed a parent it cannot resolve.

The second defect can be demonstrated, though it takes a purpose-built `Index` to reach it:
`MemoryIndex` fails earlier, so only an implementation that reports a parent outside its own
`Hashes()` gets that far. Given one, on a three-commit repository, go-git writes the file without
complaint and `git commit-graph verify` (git 2.55.0) exits 1 with:

```
commit-graph parent for 7bccae8d8abe3cd0d953622475a8a9ee5bb025c4 is 7bccae8d8abe3cd0d953622475a8a9ee5bb025c4 != 16dbf71e13ca56928da49c80a6b3e1236b0a9a8e
commit-graph generation for commit 7bccae8d8abe3cd0d953622475a8a9ee5bb025c4 is 3 < 4
```

Because the parent resolved to index `0` and the encoded hashes are sorted, the commit ends up
recorded as its own parent. With this change the same input is refused instead:

```
commitgraph: parent is not part of the index being encoded: 16dbf71e13ca56928da49c80a6b3e1236b0a9a8e
```

### Changes

- `encoder.go` — propagate the discarded lookup errors; checked parent-hash resolution via
  `lookupParentIndex`. (`prepare()` gained an error return; it's unexported with one call site.)
- `file.go` — new `ErrParentNotInIndex` sentinel, alongside the package's existing ones.
- `encoder_test.go` — three regression tests: an unresolvable single parent and a
  partially-resolvable merge both return an error instead of panicking, and a dangling edge from a
  custom `Index` returns `ErrParentNotInIndex` instead of silently encoding index `0`. All three
  were confirmed to fail against `main` — the first two panic, the third passes silently.

### AI assistance disclosure

Per [AI_POLICY.md](https://github.com/go-git/go-git/blob/main/AI_POLICY.md), this change was produced with AI assistance (Claude Opus 5), disclosed via an Assisted-by: trailer on the commit. I have reviewed and understand every line, verified the behaviour against reference git (2.55.0) and against git's own source, and confirmed the tests fail without the fix. I will respond to review feedback personally.