### PR TITLE
config: allow branch merge to point to any refs/* path (v5.x backport)

### DIFF
--- a/config/branch.go
+++ b/config/branch.go
@@ -43,7 +43,7 @@ func (b *Branch) Validate() error {
 		return errBranchEmptyName
 	}
 
-	if b.Merge != "" && !b.Merge.IsBranch() {
+	if b.Merge != "" && !strings.HasPrefix(string(b.Merge), "refs/") {
 		return errBranchInvalidMerge
 	}
 

--- a/config/branch_test.go
+++ b/config/branch_test.go
@@ -79,3 +79,21 @@ func (b *BranchSuite) TestUnmarshal(c *C) {
 	c.Assert(branch.Merge, Equals, plumbing.ReferenceName("refs/heads/branch-tracking-on-clone"))
 	c.Assert(branch.Rebase, Equals, "interactive")
 }
+
+func (b *BranchSuite) TestValidateMergeWithPullRef(c *C) {
+	// Regression test for https://github.com/go-git/go-git/issues/1871
+	// branch.merge should allow refs/pull/<ID>/head (used by GitHub/GitLab PRs)
+	prBranch := Branch{
+		Name:   "contributor/fix-9999",
+		Remote: "upstream",
+		Merge:  "refs/pull/9999/head",
+	}
+	c.Assert(prBranch.Validate(), IsNil)
+
+	mrBranch := Branch{
+		Name:   "contributor/fix-42",
+		Remote: "origin",
+		Merge:  "refs/merge-requests/42/head",
+	}
+	c.Assert(mrBranch.Validate(), IsNil)
+}


### PR DESCRIPTION
## Summary
- Backports #1872 (`config: allow branch merge to point to any refs/* path`, merged onto `main`) onto `releases/v5.x`.
- `Branch.Validate()` currently requires `merge` to satisfy `IsBranch()` (i.e. `refs/heads/*`), which rejects a `branch.<name>.merge` pointing at `refs/pull/<ID>/head` or `refs/merge-requests/<ID>/head` — refs that real git accepts without complaint, and that `gh pr checkout` / GitLab tooling commonly write into `.git/config` when checking out a PR/MR ref into a local branch.
- The practical impact: any consumer that opens a repo via `git.PlainOpen`/`PlainOpenWithOptions` (this includes tools like `nektos/act`) fails outright with `branch config: invalid merge` the moment such a branch entry exists — even though the repo is otherwise perfectly valid and real git operates on it fine. See #1871 and the older duplicate #530.
- `main` is currently the unreleased v6 alpha line, so this fix isn't reachable by any consumer pinned to `go-git/go-git/v5` (the overwhelming majority) until it's backported here.

## Changes
- `config/branch.go`: same one-line fix as #1872 — `!b.Merge.IsBranch()` → `!strings.HasPrefix(string(b.Merge), "refs/")`.
- `config/branch_test.go`: same regression test as #1872, adapted from testify's suite style to this branch's `gopkg.in/check.v1` idiom (the production fix is byte-identical to the original).

## Test plan
- [x] `go build ./...`
- [x] `go test ./config/... -v -check.vv` — all 45 cases in the config suite pass, including the new `TestValidateMergeWithPullRef`.