### PR TITLE
plumbing: packp, accept flush-only upload requests. Fixes #554

### DIFF
--- a/plumbing/protocol/packp/ulreq_decode.go
+++ b/plumbing/protocol/packp/ulreq_decode.go
@@ -18,7 +18,8 @@ import (
 var ErrDeepenMutuallyExclusive = errors.New("deepen and deepen-since (or deepen-not) cannot be used together")
 
 // Decode reads the next upload-request from its input and
-// stores it in the UploadRequest.
+// stores it in the UploadRequest. A flush-pkt with no want lines is a
+// valid, empty upload-request, matching native git-upload-pack behavior.
 func (req *UploadRequest) Decode(r io.Reader) error {
 	var (
 		nLine         int
@@ -63,7 +64,7 @@ func (req *UploadRequest) Decode(r io.Reader) error {
 		return err
 	}
 	if !ok {
-		return fmt.Errorf("empty input")
+		return nil
 	}
 
 	if !bytes.HasPrefix(line, want) {

--- a/plumbing/protocol/packp/ulreq_decode.go
+++ b/plumbing/protocol/packp/ulreq_decode.go
@@ -18,9 +18,12 @@ import (
 var ErrDeepenMutuallyExclusive = errors.New("deepen and deepen-since (or deepen-not) cannot be used together")
 
 // Decode reads the next upload-request from its input and
-// stores it in the UploadRequest. A flush-pkt with no want lines is a
-// valid, empty upload-request, matching native git-upload-pack behavior.
+// stores it in the UploadRequest, discarding any prior contents. A
+// flush-pkt with no want lines is a valid, empty upload-request, matching
+// native git-upload-pack behavior.
 func (req *UploadRequest) Decode(r io.Reader) error {
+	*req = UploadRequest{}
+
 	var (
 		nLine         int
 		line          []byte

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -24,21 +24,52 @@ func TestUlReqDecodeSuite(t *testing.T) {
 	suite.Run(t, new(UlReqDecodeSuite))
 }
 
-func (s *UlReqDecodeSuite) TestEmpty() {
-	ur := &UploadRequest{}
-	var buf bytes.Buffer
-
-	err := ur.Decode(&buf)
-	s.ErrorContains(err, "pkt-line 1: EOF")
-}
-
-func (s *UlReqDecodeSuite) TestNoWant() {
-	payloads := []string{
-		"foobar",
-		"",
+func (s *UlReqDecodeSuite) TestDecodeMinimalInputs() {
+	tests := []struct {
+		name       string
+		payloads   []string
+		wantErrSub string
+	}{
+		{
+			name:       "empty reader",
+			wantErrSub: "pkt-line 1: EOF",
+		},
+		{
+			name:     "flush-only request",
+			payloads: []string{""},
+		},
+		{
+			name:       "first line missing want prefix",
+			payloads:   []string{"foobar", ""},
+			wantErrSub: "missing 'want '",
+		},
 	}
-	r := toPktLines(s.T(), payloads)
-	s.testDecoderErrorMatches(r, ".*missing 'want '.*")
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			var buf bytes.Buffer
+			for _, p := range tc.payloads {
+				if p == "" {
+					s.Require().NoError(pktline.WriteFlush(&buf))
+				} else {
+					_, err := pktline.WriteString(&buf, p)
+					s.Require().NoError(err)
+				}
+			}
+
+			ur := &UploadRequest{}
+			err := ur.Decode(&buf)
+
+			if tc.wantErrSub != "" {
+				s.ErrorContains(err, tc.wantErrSub)
+				return
+			}
+
+			s.Require().NoError(err)
+			s.Equal(&UploadRequest{}, ur)
+			s.Zero(buf.Len(), "flush-pkt should be fully consumed")
+		})
+	}
 }
 
 func (s *UlReqDecodeSuite) testDecoderErrorMatches(input io.Reader, pattern string) {

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -86,6 +86,7 @@ func (s *UlReqDecodeSuite) TestDecodeResetsReusedRequest() {
 		Wants:    []plumbing.Hash{plumbing.NewHash("1111111111111111111111111111111111111111")},
 		Shallows: []plumbing.Hash{plumbing.NewHash("2222222222222222222222222222222222222222")},
 		Depth:    DepthRequest{Deepen: 7},
+		Filter:   FilterBlobNone(),
 	}
 	ur.Capabilities.Add(capability.OFSDelta)
 

--- a/plumbing/protocol/packp/ulreq_decode_test.go
+++ b/plumbing/protocol/packp/ulreq_decode_test.go
@@ -78,6 +78,21 @@ func (s *UlReqDecodeSuite) testDecoderErrorMatches(input io.Reader, pattern stri
 	s.Regexp(regexp.MustCompile(pattern), err)
 }
 
+func (s *UlReqDecodeSuite) TestDecodeResetsReusedRequest() {
+	var buf bytes.Buffer
+	s.Require().NoError(pktline.WriteFlush(&buf))
+
+	ur := &UploadRequest{
+		Wants:    []plumbing.Hash{plumbing.NewHash("1111111111111111111111111111111111111111")},
+		Shallows: []plumbing.Hash{plumbing.NewHash("2222222222222222222222222222222222222222")},
+		Depth:    DepthRequest{Deepen: 7},
+	}
+	ur.Capabilities.Add(capability.OFSDelta)
+
+	s.Require().NoError(ur.Decode(&buf))
+	s.Equal(&UploadRequest{}, ur)
+}
+
 func (s *UlReqDecodeSuite) TestMalformedHash() {
 	payloads := []string{
 		"want 6ecf0ef2c2dffb796alberto2219af86ec6584e5\n",


### PR DESCRIPTION
## Summary

`UploadRequest.Decode` used to return `fmt.Errorf("empty input")` when the first pkt-line was a flush. That's a legal input: the reference `git-upload-pack` accepts it and exits cleanly whenever a client has nothing to fetch. This PR aligns `Decode`'s behavior with upstream Git and tightens the surrounding tests.

Fixes #554.

## Behavior change

`UploadRequest.Decode` now returns `nil` with a zero-value `UploadRequest` (empty `Wants`, `Shallows`, `Capabilities`, zero `Depth`, zero `Filter`) when the first pkt-line is a flush. Previously it returned an `"empty input"` error.

No exported API breaks: the previous error was a bare `fmt.Errorf`, not an exported sentinel. But downstream callers that string-matched `"empty input"` will now silently get a zero-value `UploadRequest` and `nil` error — worth noting for anyone maintaining forks.

`Decode` also now zeroes the receiver on entry, so every decode path fully overwrites it. Previously it populated fields in place, meaning a caller reusing a non-zero `UploadRequest` would retain stale `Wants`, `Shallows`, `Capabilities`, `Depth` and `Filter`. Callers that pre-populated a request before calling `Decode` — e.g. seeding `Capabilities` — will no longer see those values survive the call.

## Matches upstream Git

From [`Documentation/gitprotocol-pack.adoc`](https://github.com/git/git/blob/master/Documentation/gitprotocol-pack.adoc) in `git/git`, in the "Packfile Negotiation" section:

> After reference and capabilities discovery, the client can decide to terminate the connection by sending a flush-pkt, telling the server it can now gracefully terminate, and disconnect, when it does not need any pack data. This can happen with the ls-remote command, and also can happen when the client already is up to date.

The reference implementation in [`upload-pack.c`](https://github.com/git/git/blob/master/upload-pack.c) honors this: when the first pkt-line read is a flush, the server returns with no wants and exits without producing a packfile.

Wire format definitions per [`Documentation/gitprotocol-common.adoc`](https://github.com/git/git/blob/master/Documentation/gitprotocol-common.adoc) — flush-pkt (`0000`) is a distinct pkt-line type, valid wherever a terminator is expected.

## Reproduction

`git fetch` against an up-to-date remote produces exactly this shape on the wire. With `GIT_TRACE_PACKET=1`:

```
< …server ref advertisement…
< 0000
> 0000     ← client: "nothing to want, done"
```

Before this change, feeding that trailing `0000` to `packp.UploadRequest.Decode` errored. After this change, it returns `nil` with an empty `UploadRequest`.

## Tests

- Consolidated the three previous decode boundary tests (`TestEmpty`, `TestFlushOnly`, `TestNoWant`) into one table-driven `TestDecodeMinimalInputs` covering: empty reader (`pkt-line 1: EOF`), flush-only (success + zero-state + reader drained), and first-line-missing-`want` (error).
- The flush-only success case uses `s.Equal(&UploadRequest{}, ur)` — deep equality against the zero value — so any field added to `UploadRequest` later is automatically covered.
- Existing `FuzzUlReqDecode` already includes `"0000"` as a seed corpus entry, so fuzz coverage for the flush-only shape is preserved.
- `TestDecodeResetsReusedRequest` decodes a flush-only request into a pre-populated `UploadRequest` and asserts the result is zero-valued.

`TestDecodeMinimalInputs` fails on `main` before the fix and passes after.

## Verification

- `go test -race ./...`
- `golangci-lint run --timeout=5m --allow-parallel-runners --max-same-issues 0 --max-issues-per-linter 0 ./...`
