### PR TITLE
plumbing: transport, Walk the object graph once per upload-pack request. Refs #2350

### DIFF
--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -130,8 +130,9 @@ func UploadPack(
 				return fmt.Errorf("closing reader: %w", err)
 			}
 
-			// Find common commits/objects. Only membership is needed below,
-			// so walk the wants once as a set instead of once per want.
+			// Collect the objects reachable from the wants. Only membership
+			// is tested later, when a client have is checked against this
+			// set, so walk the wants once instead of once per want.
 			objs, err := revlist.Objects(st, wants, nil)
 			if err != nil {
 				return fmt.Errorf("getting objects: %w", err)

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -109,7 +109,7 @@ func UploadPack(
 	var done bool
 	var haves []plumbing.Hash
 	var upreq *packp.UploadRequest
-	var havesWithRef map[plumbing.Hash][]plumbing.Hash
+	var reachable map[plumbing.Hash]struct{}
 	var multiAck, multiAckDetailed bool
 	var caps capability.List
 	var wants []plumbing.Hash
@@ -130,10 +130,16 @@ func UploadPack(
 				return fmt.Errorf("closing reader: %w", err)
 			}
 
-			// Find common commits/objects
-			havesWithRef, err = revlist.ObjectsWithRef(st, wants, nil)
+			// Find common commits/objects. Only membership is needed below,
+			// so walk the wants once as a set instead of once per want.
+			objs, err := revlist.Objects(st, wants, nil)
 			if err != nil {
-				return fmt.Errorf("getting objects with ref: %w", err)
+				return fmt.Errorf("getting objects: %w", err)
+			}
+
+			reachable = make(map[plumbing.Hash]struct{}, len(objs))
+			for _, h := range objs {
+				reachable[h] = struct{}{}
 			}
 
 			// Encode objects to packfile and write to client
@@ -182,7 +188,7 @@ func UploadPack(
 
 		var acks []packp.ACK
 		for _, hu := range uphav.Haves {
-			_, ok := havesWithRef[hu]
+			_, ok := reachable[hu]
 
 			var status packp.ACKStatus
 			if multiAckDetailed {

--- a/plumbing/transport/upload_pack_bench_test.go
+++ b/plumbing/transport/upload_pack_bench_test.go
@@ -17,19 +17,20 @@ import (
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
-// benchRepo builds a linear history of n commits and points w refs at commits
-// spread across it, so that the wants share most of their history. This is the
-// shape of a server hosting a repository with many branches.
-func benchRepo(tb testing.TB, n, w int) (*memory.Storage, []plumbing.Hash) {
+// benchRepo builds a linear history of commits commits, then creates refs
+// references pointing at commits spread across that history, so that the
+// wants share most of their ancestry. This is the shape of a server hosting
+// a repository with many branches over a common history.
+func benchRepo(tb testing.TB, commits, refs int) (*memory.Storage, []plumbing.Hash) {
 	tb.Helper()
 
 	st := memory.NewStorage()
 	sig := object.Signature{Name: "bench", Email: "bench@example.com", When: time.Unix(0, 0).UTC()}
 
 	var parent plumbing.Hash
-	commits := make([]plumbing.Hash, 0, n)
+	history := make([]plumbing.Hash, 0, commits)
 
-	for i := range n {
+	for i := range commits {
 		blob := &plumbing.MemoryObject{}
 		blob.SetType(plumbing.BlobObject)
 		if _, err := fmt.Fprintf(blob, "content-%d", i); err != nil {
@@ -66,13 +67,13 @@ func benchRepo(tb testing.TB, n, w int) (*memory.Storage, []plumbing.Hash) {
 		}
 
 		parent = ch
-		commits = append(commits, ch)
+		history = append(history, ch)
 	}
 
-	wants := make([]plumbing.Hash, 0, w)
-	for i := range w {
-		idx := max(n-1-(i*n/(w*2)), 0)
-		h := commits[idx]
+	wants := make([]plumbing.Hash, 0, refs)
+	for i := range refs {
+		idx := max(commits-1-(i*commits/(refs*2)), 0)
+		h := history[idx]
 
 		name := plumbing.ReferenceName(fmt.Sprintf("refs/heads/branch-%d", i))
 		if err := st.SetReference(plumbing.NewHashReference(name, h)); err != nil {
@@ -81,7 +82,7 @@ func benchRepo(tb testing.TB, n, w int) (*memory.Storage, []plumbing.Hash) {
 		wants = append(wants, h)
 	}
 
-	if err := st.SetReference(plumbing.NewHashReference(plumbing.HEAD, commits[n-1])); err != nil {
+	if err := st.SetReference(plumbing.NewHashReference(plumbing.HEAD, history[commits-1])); err != nil {
 		tb.Fatal(err)
 	}
 
@@ -89,8 +90,10 @@ func benchRepo(tb testing.TB, n, w int) (*memory.Storage, []plumbing.Hash) {
 }
 
 // serveUploadPack runs a full upload-pack exchange for the given wants and
-// returns the bytes written to the client.
-func serveUploadPack(tb testing.TB, st *memory.Storage, wants []plumbing.Hash) string {
+// returns the number of bytes written to the client. The response is not
+// copied out of the buffer, so that the measurement stays on UploadPack
+// itself rather than on materialising the packfile a second time.
+func serveUploadPack(tb testing.TB, st *memory.Storage, wants []plumbing.Hash) int {
 	tb.Helper()
 
 	var upreq packp.UploadRequest
@@ -115,7 +118,7 @@ func serveUploadPack(tb testing.TB, st *memory.Storage, wants []plumbing.Hash) s
 		tb.Fatal(err)
 	}
 
-	return out.String()
+	return out.Len()
 }
 
 func benchmarkUploadPack(b *testing.B, commits, wants int) {
@@ -125,7 +128,7 @@ func benchmarkUploadPack(b *testing.B, commits, wants int) {
 	b.ResetTimer()
 
 	for b.Loop() {
-		if serveUploadPack(b, st, w) == "" {
+		if serveUploadPack(b, st, w) == 0 {
 			b.Fatal("no output produced")
 		}
 	}

--- a/plumbing/transport/upload_pack_bench_test.go
+++ b/plumbing/transport/upload_pack_bench_test.go
@@ -1,0 +1,139 @@
+package transport
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/storage/memory"
+	"github.com/go-git/go-git/v6/utils/ioutil"
+)
+
+// benchRepo builds a linear history of n commits and points w refs at commits
+// spread across it, so that the wants share most of their history. This is the
+// shape of a server hosting a repository with many branches.
+func benchRepo(tb testing.TB, n, w int) (*memory.Storage, []plumbing.Hash) {
+	tb.Helper()
+
+	st := memory.NewStorage()
+	sig := object.Signature{Name: "bench", Email: "bench@example.com", When: time.Unix(0, 0).UTC()}
+
+	var parent plumbing.Hash
+	commits := make([]plumbing.Hash, 0, n)
+
+	for i := range n {
+		blob := &plumbing.MemoryObject{}
+		blob.SetType(plumbing.BlobObject)
+		if _, err := fmt.Fprintf(blob, "content-%d", i); err != nil {
+			tb.Fatal(err)
+		}
+		bh, err := st.SetEncodedObject(blob)
+		if err != nil {
+			tb.Fatal(err)
+		}
+
+		tree := &object.Tree{Entries: []object.TreeEntry{
+			{Name: "file.txt", Mode: filemode.Regular, Hash: bh},
+		}}
+		to := &plumbing.MemoryObject{}
+		if err := tree.Encode(to); err != nil {
+			tb.Fatal(err)
+		}
+		th, err := st.SetEncodedObject(to)
+		if err != nil {
+			tb.Fatal(err)
+		}
+
+		c := &object.Commit{Author: sig, Committer: sig, Message: "commit", TreeHash: th}
+		if !parent.IsZero() {
+			c.ParentHashes = []plumbing.Hash{parent}
+		}
+		co := &plumbing.MemoryObject{}
+		if err := c.Encode(co); err != nil {
+			tb.Fatal(err)
+		}
+		ch, err := st.SetEncodedObject(co)
+		if err != nil {
+			tb.Fatal(err)
+		}
+
+		parent = ch
+		commits = append(commits, ch)
+	}
+
+	wants := make([]plumbing.Hash, 0, w)
+	for i := range w {
+		idx := max(n-1-(i*n/(w*2)), 0)
+		h := commits[idx]
+
+		name := plumbing.ReferenceName(fmt.Sprintf("refs/heads/branch-%d", i))
+		if err := st.SetReference(plumbing.NewHashReference(name, h)); err != nil {
+			tb.Fatal(err)
+		}
+		wants = append(wants, h)
+	}
+
+	if err := st.SetReference(plumbing.NewHashReference(plumbing.HEAD, commits[n-1])); err != nil {
+		tb.Fatal(err)
+	}
+
+	return st, wants
+}
+
+// serveUploadPack runs a full upload-pack exchange for the given wants and
+// returns the bytes written to the client.
+func serveUploadPack(tb testing.TB, st *memory.Storage, wants []plumbing.Hash) string {
+	tb.Helper()
+
+	var upreq packp.UploadRequest
+	upreq.Capabilities.Add(capability.NoProgress)
+	upreq.Wants = wants
+
+	var final packp.UploadHaves
+	final.Done = true
+
+	var req bytes.Buffer
+	if err := upreq.Encode(&req); err != nil {
+		tb.Fatal(err)
+	}
+	if err := final.Encode(&req); err != nil {
+		tb.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := UploadPack(context.Background(), st,
+		io.NopCloser(&req), ioutil.WriteNopCloser(&out),
+		&UploadPackRequest{GitProtocol: "version=1"}); err != nil {
+		tb.Fatal(err)
+	}
+
+	return out.String()
+}
+
+func benchmarkUploadPack(b *testing.B, commits, wants int) {
+	st, w := benchRepo(b, commits, wants)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		if serveUploadPack(b, st, w) == "" {
+			b.Fatal("no output produced")
+		}
+	}
+}
+
+// The cost of serving a fetch should depend on the size of the history, not on
+// how many refs the client asks for.
+func BenchmarkUploadPackWants1(b *testing.B)   { benchmarkUploadPack(b, 300, 1) }
+func BenchmarkUploadPackWants16(b *testing.B)  { benchmarkUploadPack(b, 300, 16) }
+func BenchmarkUploadPackWants64(b *testing.B)  { benchmarkUploadPack(b, 300, 64) }
+func BenchmarkUploadPackWants256(b *testing.B) { benchmarkUploadPack(b, 300, 256) }

--- a/plumbing/transport/upload_pack_test.go
+++ b/plumbing/transport/upload_pack_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
@@ -22,6 +23,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
@@ -193,6 +195,70 @@ func (s *UploadPackServeSuite) TestUploadPackStatefulMultiRoundSendsFinalACK() {
 	s.Require().NotEqual(-1, nakAt)
 	finalAt := strings.Index(response[continueAt+len(continueACK)+nakAt:], finalACK)
 	s.Require().NotEqual(-1, finalAt)
+}
+
+// A have that is reachable from any of the wants must be recognised as common,
+// not only one reachable from the first want.
+func (s *UploadPackServeSuite) TestUploadPackCommonAcrossMultipleWants() {
+	st := memory.NewStorage()
+	sig := object.Signature{Name: "t", Email: "t@example.com", When: time.Unix(0, 0).UTC()}
+
+	commit := func(content string, parents ...plumbing.Hash) plumbing.Hash {
+		blob := &plumbing.MemoryObject{}
+		blob.SetType(plumbing.BlobObject)
+		_, err := blob.Write([]byte(content))
+		s.Require().NoError(err)
+		bh, err := st.SetEncodedObject(blob)
+		s.Require().NoError(err)
+
+		tree := &object.Tree{Entries: []object.TreeEntry{
+			{Name: "f.txt", Mode: filemode.Regular, Hash: bh},
+		}}
+		to := &plumbing.MemoryObject{}
+		s.Require().NoError(tree.Encode(to))
+		th, err := st.SetEncodedObject(to)
+		s.Require().NoError(err)
+
+		c := &object.Commit{Author: sig, Committer: sig, Message: content, TreeHash: th, ParentHashes: parents}
+		co := &plumbing.MemoryObject{}
+		s.Require().NoError(c.Encode(co))
+		ch, err := st.SetEncodedObject(co)
+		s.Require().NoError(err)
+		return ch
+	}
+
+	// base --- tipA          (want #1)
+	//     \--- mid --- tipB  (want #2); mid is reachable only through tipB
+	base := commit("base")
+	tipA := commit("tipA", base)
+	mid := commit("mid", base)
+	tipB := commit("tipB", mid)
+
+	s.Require().NoError(st.SetReference(plumbing.NewHashReference(plumbing.HEAD, tipA)))
+
+	var upreq packp.UploadRequest
+	upreq.Capabilities.Add(capability.MultiACK)
+	upreq.Capabilities.Add(capability.NoProgress)
+	upreq.Wants = []plumbing.Hash{tipA, tipB}
+
+	var firstRound packp.UploadHaves
+	firstRound.Haves = []plumbing.Hash{mid}
+
+	var finalRound packp.UploadHaves
+	finalRound.Done = true
+
+	var req bytes.Buffer
+	s.Require().NoError(upreq.Encode(&req))
+	s.Require().NoError(firstRound.Encode(&req))
+	s.Require().NoError(finalRound.Encode(&req))
+
+	var out bytes.Buffer
+	s.Require().NoError(UploadPack(context.Background(), st,
+		io.NopCloser(&req), ioutil.WriteNopCloser(&out),
+		&UploadPackRequest{GitProtocol: "version=1"}))
+
+	s.Contains(out.String(), fmt.Sprintf("ACK %s continue\n", mid),
+		"a have reachable from the second want must be acknowledged as common")
 }
 
 type ReceivePackServeSuite struct {


### PR DESCRIPTION
Refs #2350

## Problem

`UploadPack` calls `revlist.ObjectsWithRef`, which runs a **complete object-graph walk for every want**:

```go
for _, want := range wants {
	hashes, err := Objects(s, []plumbing.Hash{want}, haves) // full walk, per want
	...
	all[h] = append(all[h], want)
}
```

The per-want attribution it builds is never used. There are exactly three references to the result in the tree:

```
upload_pack.go:112   var havesWithRef map[plumbing.Hash][]plumbing.Hash
upload_pack.go:134   havesWithRef, err = revlist.ObjectsWithRef(st, wants, nil)
upload_pack.go:185   _, ok := havesWithRef[hu]
```

Line 185 is the only consumer and it is a key-membership test — the `[]plumbing.Hash` values that the extra walks exist to produce are discarded. So the cost of serving a fetch scales with the number of refs requested, for information that is thrown away.

`ObjectsWithRef` has no other caller in the repository.

## Change

Walk the wants once and keep the result as a set:

```go
objs, err := revlist.Objects(st, wants, nil)
if err != nil {
	return fmt.Errorf("getting objects: %w", err)
}

reachable = make(map[plumbing.Hash]struct{}, len(objs))
for _, h := range objs {
	reachable[h] = struct{}{}
}
```

This preserves the negotiation semantics exactly, including which hashes are treated as common. Reachability from a set of roots is the union of reachability from each root, and the call site passes no haves. I verified the key sets are identical on a branching history — merge commits, nested trees, disjoint subgraphs, wants that are ancestors of other wants, and duplicate wants.

The equivalence relies on `haves == nil`, which is the case at this call site. I would not claim it for non-empty `haves`, where exclusion boundaries could interact, and this change does not depend on that.

## Numbers

`BenchmarkUploadPackWants*` (added in this PR), 300-commit history, refs spread across the shared history, `-benchtime 20x -count 3`, mean:

| wants | before | after | |
| ---: | --- | --- | --- |
| 1 | 19.03 ms · 7.39 MB | 16.55 ms · 6.94 MB | ~unchanged |
| 16 | 27.15 ms · 18.14 MB | 18.22 ms · 7.01 MB | 1.5× faster, 2.6× less memory |
| 64 | 55.35 ms · 50.64 MB | 17.77 ms · 7.08 MB | 3.1× faster, 7.2× less memory |
| 256 | 100.41 ms · 107.28 MB | 17.27 ms · 7.10 MB | **5.8× faster, 15.1× less memory** |

The point is the shape rather than the ratio: before, serving cost grows with the ref count; after, it is flat and tracks the size of the history instead.

Isolating just the changed call (no packfile encoding) shows where the time went — 256 wants: 124.7 ms / 166.4 MB / 1,578,725 allocs, versus 0.86 ms / 0.96 MB / 7,874 allocs for a single walk.

## Tests

`TestUploadPackCommonAcrossMultipleWants` covers the property this change depends on: a `have` reachable from the *second* want must still be acknowledged as common, not only one reachable from the first.

To be clear about what that test is and is not — this change is behaviour-preserving, so the test passes both before and after. It is a guard against a future regression in the union semantics, not a reproduction of a bug. The evidence that the change is correct is the equivalence check described above plus the existing transport suite.

Run locally: `make validate-lint` (golangci-lint v2.13.1) clean; `go test -race ./plumbing/transport/... ./plumbing/revlist/... .` green, including the root package's clone/fetch/push coverage.

## Notes

- **Scope.** This changes only the caller. `revlist.ObjectsWithRef` is exported and is left untouched, since removing it would be a breaking API change. It becomes unused in-tree — I raised the question of whether you would prefer it left, deprecated, or removed in #2350, and I am happy to follow up separately with whichever you choose. I used `Refs` rather than `Fixes` so that question is not auto-closed.
- **Relationship to previous work.** #1947 and #1973 optimised the inside of a single walk. This is orthogonal: it removes redundant *invocations* at the call boundary. It may be relevant to #1973's note that "after some of the changes to #1947, the performance gains weren't realised" — a caller that multiplies the walk by the ref count would mask a walk-level improvement on this path. #1947 did not introduce this; the pre-#1947 implementation was also per-want.
- **Possible relevance to #1691.** The structure built here grows with `objects × refs`, which is the shape of that OOM report. I have not reproduced #1691 against linux.git, so I am not claiming this is its root cause.
- **One measurement I could not explain.** In an earlier end-to-end run the 1-want case measured ~5% slower with the change, reproducibly, even though the isolated call is faster there and allocates less. Repeated runs since have shown it at or slightly better than parity (the table above), so I believe it was binary-layout/GC noise around the ~17 ms packfile encode rather than the change. Flagging it rather than presenting a spotless result.

## AI assistance disclosure

Per [AI_POLICY.md](https://github.com/go-git/go-git/blob/main/AI_POLICY.md), this change was produced with AI assistance (Claude Opus 5), disclosed via an `Assisted-by:` trailer on the commit. I have reviewed and understand every line, ran the benchmarks and equivalence checks locally, and will respond to review feedback personally.
