### PR TITLE
config: RefSpec, keep the force marker a spec prefix in Reverse.

### DIFF
--- a/config/refspec.go
+++ b/config/refspec.go
@@ -135,11 +135,18 @@ func (s RefSpec) Dst(n plumbing.ReferenceName) plumbing.ReferenceName {
 }
 
 // Reverse returns the RefSpec with source and destination swapped.
+// A force marker stays a prefix of the spec rather than swapping into the
+// destination side.
 func (s RefSpec) Reverse() RefSpec {
 	spec := string(s)
+	var force string
+	if strings.HasPrefix(spec, refSpecForce) {
+		force = refSpecForce
+		spec = spec[len(refSpecForce):]
+	}
 	before, after, _ := strings.Cut(spec, refSpecSeparator)
 
-	return RefSpec(after + refSpecSeparator + before)
+	return RefSpec(force + after + refSpecSeparator + before)
 }
 
 func (s RefSpec) String() string {

--- a/config/refspec_test.go
+++ b/config/refspec_test.go
@@ -188,6 +188,19 @@ func (s *RefSpecSuite) TestRefSpecReverse() {
 	s.Equal(RefSpec("refs/remotes/origin/*:refs/heads/*"), spec.Reverse())
 }
 
+func (s *RefSpecSuite) TestRefSpecReverseForce() {
+	spec := RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	rev := spec.Reverse()
+	s.Equal(RefSpec("+refs/remotes/origin/*:refs/heads/*"), rev)
+	s.True(rev.IsForceUpdate())
+	s.True(rev.Validate() == nil)
+	// The force marker must stay a spec prefix: it must not leak into the
+	// destination pattern, or Dst-mapped names grow a "+" prefix.
+	s.True(rev.Match(plumbing.ReferenceName("refs/remotes/origin/master")))
+	s.Equal("refs/heads/master",
+		rev.Dst(plumbing.ReferenceName("refs/remotes/origin/master")).String())
+}
+
 func (s *RefSpecSuite) TestMatchAny() {
 	specs := []RefSpec{
 		"refs/heads/bar:refs/remotes/origin/foo",

--- a/remote_test.go
+++ b/remote_test.go
@@ -1467,6 +1467,41 @@ func (s *RemoteSuite) TestPushPrune() {
 	s.ErrorIs(err, plumbing.ErrReferenceNotFound)
 }
 
+func (s *RemoteSuite) TestPushPruneForceRefSpec() {
+	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
+	s.Require().NoError(err)
+	defer func() { _ = server.Close() }()
+
+	r, err := PlainClone(s.T().TempDir(), &CloneOptions{
+		URL:  server.wt.Root(),
+		Bare: true,
+	})
+	s.Require().NoError(err)
+	defer func() { _ = r.Close() }()
+
+	remote, err := r.Remote(DefaultRemoteName)
+	s.NoError(err)
+
+	ref, err := r.Reference(plumbing.ReferenceName("refs/heads/master"), true)
+	s.NoError(err)
+
+	// Prune with a force refspec: refs that exist locally must survive on the
+	// remote. A buggy Reverse() moved the "+" into the destination pattern,
+	// making the prune-side local lookup miss every ref and delete the whole
+	// remote.
+	err = remote.Push(&PushOptions{
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("+refs/heads/*:refs/heads/*"),
+		},
+		Prune: true,
+	})
+	s.ErrorIs(err, NoErrAlreadyUpToDate)
+
+	AssertReferences(s.T(), server, map[string]string{
+		"refs/heads/master": ref.Hash().String(),
+	})
+}
+
 func (s *RemoteSuite) TestPushNewReference() {
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)


### PR DESCRIPTION
### Summary

`RefSpec.Reverse()` swaps source and destination by cutting the raw spec string
at the `:` separator, so the leading force marker travels with the source side
and ends up inside the destination pattern:

    "+refs/heads/*:refs/heads/*".Reverse()  ==  "refs/heads/*:+refs/heads/*"

`Dst()` on such a reversed spec then maps names to `+refs/heads/<name>`.

### Impact

The user-visible damage is in push with `Prune: true`: the prune path in
`deleteReferences` decides whether a remote ref still exists locally via
`refsDict[rs.Reverse().Dst(remoteRef)]`. With a force refspec the lookup key
grows a `+` prefix, never matches, and **prune deletes every matching ref on
the remote** — including refs the very same push just updated. Because
`PushOptions.Force` force-prefixes all refspecs before commands are built,
any `Force: true, Prune: true` push triggers this.

The fetch-side `pruneRemotes` shares the mis-mapping but is masked in
practice: `updateLocalReferenceStorage` immediately recreates the refs it
wrongly pruned.

### How this was found

I hit this building a Gitea-style push mirror (go-git v6 as both the push
client and the receiving smart-HTTP server): every sync after a force-push
emptied the mirror. Logging the decoded receive-pack commands server-side
showed the client sending, in one push:

    update refs/heads/master  b4dff471..c7342eeb   (correct)
    delete refs/heads/master  b4dff471..00000000   (?!)
    delete refs/heads/dev     b4dff471..00000000   (?!)

— prune deletes for refs that demonstrably existed locally, since the same
push had matched them via the refspec and packed their objects. Tracing the
command construction led to `Reverse()`.

### Fix

`Reverse()` now peels a leading `refSpecForce` marker, swaps the two sides,
and re-prefixes it, keeping the `+` an attribute of the spec rather than of
either side:

    "+refs/heads/*:refs/remotes/origin/*".Reverse()  ==  "+refs/remotes/origin/*:refs/heads/*"

### Alignment with git

- git's own parser ([refspec.c, `parse_refspec`](https://github.com/git/git/blob/master/refspec.c))
  strips `+` into the boolean `item->force` *before* src/dst are parsed — the
  marker is structurally separate from both sides, which is the invariant this
  patch restores.
- [git-push(1), `<refspec>`](https://git-scm.com/docs/git-push#Documentation/git-push.txt-ltrefspecgt82308203):
  "an optional plus `+`, followed by the source object `<src>`, followed by a
  colon `:`, followed by the destination ref `<dst>`" — the `+` belongs to
  neither side.
- [git-push(1), `--prune`](https://git-scm.com/docs/git-push#Documentation/git-push.txt---prune):
  "Remove remote branches that **don't have a local counterpart**." Prune
  selection is independent of forcedness; `git push --force --prune` never
  deletes remote refs whose local counterparts exist.

### Tests

- `TestRefSpecReverseForce` (unit): reversed force specs keep the marker as a
  prefix, still validate/match, and `Dst()` maps names without a `+`.
- `TestPushPruneForceRefSpec` (regression): same shape as the existing
  `TestPushPrune` but with `+refs/heads/*:refs/heads/*`; asserts the push is
  `NoErrAlreadyUpToDate` and locally-existing refs survive on the remote.

Both fail on `main` without the fix (`Dst` yields `+refs/heads/master`;
`refs/heads/master` is deleted from the server). Full `config` package and
`TestRemoteSuite` pass, `golangci-lint` (v2.13.1, the CI-pinned version)
reports 0 issues.

### AI disclosure

Per AI policy: this fix was produced with AI assistance
(Claude Fable 5 via Claude Code), which found the root cause while debugging
the mirror wipe and wrote the tests and fix; I reviewed and tested the
changes. The commit carries an `Assisted-by:` trailer.