### PR TITLE
plumbing: transport/http, Compare origins when following redirects

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -218,6 +218,11 @@ func credentialsMayFollow(from, to *url.URL) bool {
 		effectivePort(from) == "80" && effectivePort(to) == "443"
 }
 
+// safeHeaders lists the headers go-git sets itself, none of which can carry a
+// caller credential. It has two consumers: trace.HTTP logs only these, and
+// stripCredentials keeps only these when a redirect leaves the credential's
+// origin. Adding a name here makes it both loggable and forwardable across an
+// origin boundary — do not add anything a caller can put a secret in.
 var safeHeaders = map[string]struct{}{
 	"User-Agent":        {},
 	"Host":              {},

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strings"
 
@@ -139,16 +140,29 @@ func schemeUpgrade(from, to string) bool {
 	return strings.EqualFold(from, "http") && strings.EqualFold(to, "https")
 }
 
-// canonicalHost returns u's hostname in the form origins are compared in:
-// ASCII-lowercased. That fold is the only liberty taken; every other
-// difference in spelling is a different origin.
+// canonicalHost returns u's hostname in the form origins are compared in.
 //
-// A trailing root dot is one such difference and is kept. curl and the WHATWG
-// URL Standard both hold "example.com." and "example.com" to be distinct
-// hosts, and although crypto/tls and crypto/x509 fold the dot when they
-// authenticate the peer, net/http sends the name as written in Host, so a
-// server can route the two spellings to different virtual hosts. Reaching the
-// same peer is not reaching the same authority.
+// An address literal is normalised by netip, so the many spellings of one
+// address are one origin. Two literals are the same origin exactly when netip
+// parses them to the same Addr, which is also how the WHATWG URL Standard
+// compares hosts. An IPv4-mapped literal is deliberately not unmapped onto
+// the IPv4 it dials: reaching the same endpoint is not the same authority,
+// since net/http sends the literal as written in Host and a server may route
+// the two spellings to different virtual hosts.
+//
+// netip also keeps a scope zone verbatim, which is what origin comparison
+// needs: net resolves a zone to an interface by exact name, so folding %eth0
+// onto %ETH0 would call two hosts the same origin that net dials down
+// different interfaces.
+//
+// A registered name is ASCII-lowercased. That fold is the only liberty taken;
+// every other difference in spelling is a different origin.
+//
+// A trailing root dot is one such difference and is kept, for the same reason
+// as the IPv4-mapped literal: curl and the WHATWG URL Standard both hold
+// "example.com." and "example.com" to be distinct hosts, and although
+// crypto/tls and crypto/x509 fold the dot when they authenticate the peer,
+// net/http sends the name as written in Host.
 //
 // The fold is deliberately ASCII-only. strings.ToLower and strings.EqualFold
 // apply Unicode case mapping, which folds U+03C2 onto U+03C3 and so would
@@ -167,7 +181,11 @@ func schemeUpgrade(from, to string) bool {
 // the failure this comparison exists to prevent, and comparing bytes has no
 // such mode.
 func canonicalHost(u *url.URL) string {
-	b := []byte(u.Hostname())
+	host := u.Hostname()
+	if addr, err := netip.ParseAddr(host); err == nil {
+		return addr.String()
+	}
+	b := []byte(host)
 	for i := range b {
 		if b[i] >= 'A' && b[i] <= 'Z' {
 			b[i] += 'a' - 'A'

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -222,7 +222,11 @@ func credentialsMayFollow(from, to *url.URL) bool {
 // caller credential. It has two consumers: trace.HTTP logs only these, and
 // stripCredentials keeps only these when a redirect leaves the credential's
 // origin. Adding a name here makes it both loggable and forwardable across an
-// origin boundary — do not add anything a caller can put a secret in.
+// origin boundary — do not add anything a caller can put a secret in. This
+// narrows rather than eliminates the exposure: an Authorizer that writes a
+// credential into one of these names directly — for example
+// Header.Set("User-Agent", "token "+secret) — still survives a cross-origin
+// redirect and still gets logged.
 var safeHeaders = map[string]struct{}{
 	"User-Agent":        {},
 	"Host":              {},

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -106,8 +106,7 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 	if final.Scheme != "http" && final.Scheme != "https" {
 		return nil, fmt.Errorf("http transport: redirect to unsupported scheme %q", final.Scheme)
 	}
-	if final.Scheme != baseURL.Scheme &&
-		(baseURL.Scheme != "http" || final.Scheme != "https") {
+	if final.Scheme != baseURL.Scheme && !schemeUpgrade(baseURL.Scheme, final.Scheme) {
 		return nil, fmt.Errorf(
 			"http transport: redirect changes scheme from %q to %q",
 			baseURL.Scheme, final.Scheme,
@@ -119,6 +118,104 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 	redirected.Scheme = final.Scheme
 	redirected.Path = final.Path[:len(final.Path)-len(infoRefsPath)]
 	return &redirected, nil
+}
+
+// schemeUpgrade reports whether the scheme transition from one URL to
+// another is the one cross-scheme change go-git permits: a plain-http
+// origin upgrading to https. It strictly improves confidentiality and is
+// how servers steer clients off cleartext.
+//
+// Permitting it at all is a deliberate deviation: curl, git and the Fetch
+// standard all count scheme as part of host identity and drop credentials on
+// the upgrade. Auth is sent pre-emptively here, so an http origin has already
+// spent its credential in cleartext on the first request and refusing the
+// upgrade would break the clone without unspending it. The host is unchanged,
+// where an on-path attacker needs a valid certificate to receive anything.
+//
+// applyRedirect ("may this become the new base URL?") and
+// credentialsMayFollow ("may credentials travel here?") are both built on it,
+// so the two cannot drift apart.
+func schemeUpgrade(from, to string) bool {
+	return strings.EqualFold(from, "http") && strings.EqualFold(to, "https")
+}
+
+// canonicalHost returns u's hostname in the form origins are compared in:
+// ASCII-lowercased. That fold is the only liberty taken; every other
+// difference in spelling is a different origin.
+//
+// A trailing root dot is one such difference and is kept. curl and the WHATWG
+// URL Standard both hold "example.com." and "example.com" to be distinct
+// hosts, and although crypto/tls and crypto/x509 fold the dot when they
+// authenticate the peer, net/http sends the name as written in Host, so a
+// server can route the two spellings to different virtual hosts. Reaching the
+// same peer is not reaching the same authority.
+//
+// The fold is deliberately ASCII-only. strings.ToLower and strings.EqualFold
+// apply Unicode case mapping, which folds U+03C2 onto U+03C3 and so would
+// call two hosts the same origin when they resolve to different servers. An
+// ASCII-only fold cannot merge two names DNS keeps apart.
+//
+// No IDNA mapping is applied either, so a unicode hostname is a different
+// origin from the punycode encoding of it, and from another Unicode case of
+// itself, even though all three reach the same server. Mapping through
+// golang.org/x/net/idna would join them, but it can only widen this equality,
+// never narrow it, so leaving it out can cost a credential across such a
+// redirect and cannot forward one. Against that cost, go-git pins x/net while
+// net/http uses the copy vendored into the toolchain: the two are versioned
+// separately, so a release that moves the Unicode tables under one and not
+// the other would have this merge origins net/http still dials apart. That is
+// the failure this comparison exists to prevent, and comparing bytes has no
+// such mode.
+func canonicalHost(u *url.URL) string {
+	b := []byte(u.Hostname())
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}
+
+// effectivePort returns u's port as the connection will use it: the scheme's
+// well-known port when the URL does not spell one out, and without leading
+// zeroes, so "https://x", "https://x:443" and "https://x:0443" all agree.
+func effectivePort(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		switch strings.ToLower(u.Scheme) {
+		case "http":
+			return "80"
+		case "https":
+			return "443"
+		default:
+			return ""
+		}
+	}
+	if trimmed := strings.TrimLeft(port, "0"); trimmed != "" {
+		return trimmed
+	}
+	return "0"
+}
+
+// credentialsMayFollow reports whether credentials issued for one URL may be
+// sent to another.
+//
+// The relation is deliberately asymmetric: scheme, host and effective port
+// must all match, except that a plain http origin may upgrade to https on
+// the same host (see schemeUpgrade), mirroring applyRedirect.
+//
+// Host matching is exact. Unlike Go's http.Client, which forwards credentials
+// from a host to any subdomain of it, a subdomain is a different origin here —
+// matching canonical git and libcurl.
+func credentialsMayFollow(from, to *url.URL) bool {
+	if canonicalHost(from) != canonicalHost(to) {
+		return false
+	}
+	if strings.EqualFold(from.Scheme, to.Scheme) {
+		return effectivePort(from) == effectivePort(to)
+	}
+	return schemeUpgrade(from.Scheme, to.Scheme) &&
+		effectivePort(from) == "80" && effectivePort(to) == "443"
 }
 
 var safeHeaders = map[string]struct{}{

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -237,7 +237,21 @@ func TestCredentialsMayFollow(t *testing.T) {
 		{"http to https upgrade", "http://example.test/a", "https://example.test/a", true},
 		{"ipv4 literal", "http://127.0.0.1:8080/a", "http://127.0.0.1:8080/a", true},
 		{"ipv6 literal", "http://[::1]:8080/a", "http://[::1]:8080/a", true},
+		{"ipv6 zone, same spelling", "http://[fe80::1%25eth0]:8080/a", "http://[fe80::1%25eth0]:8080/a", true},
+		{"ipv6 zone, address case differs", "http://[FE80::1%25eth0]:8080/a", "http://[fe80::1%25eth0]:8080/a", true},
 		{"host with underscore", "http://build_host:8080/a", "http://build_host:8080/a", true},
+
+		// One address has many spellings. netip.ParseAddr is the same call
+		// net's resolver gates on (lookup.go), so these all name the endpoint
+		// the dialer would connect to and are one origin.
+		{"ipv6 compressed against expanded", "http://[::1]:8080/a", "http://[0:0:0:0:0:0:0:1]:8080/a", true},
+		{"ipv6 leading zeroes in a field", "http://[::1]:8080/a", "http://[::0001]:8080/a", true},
+		{"ipv6 hex against dotted-quad tail", "http://[::ffff:7f00:1]/a", "http://[::ffff:127.0.0.1]/a", true},
+
+		// A percent in a registered name is not a scope zone. %25 is the only
+		// escape net/url leaves in a host, so Hostname() really can return
+		// one, and the whole name folds.
+		{"percent in a registered name", "https://foo%25bar.test/a", "https://FOO%25BAR.test/a", true},
 
 		{"https to http downgrade", "https://example.test/a", "http://example.test/a", false},
 		{"subdomain", "https://example.test/a", "https://sub.example.test/a", false},
@@ -249,10 +263,26 @@ func TestCredentialsMayFollow(t *testing.T) {
 		// A trailing root dot reaches the same peer, but net/http sends the
 		// name as written in Host, so the two spellings can be routed to
 		// different virtual hosts. curl and the WHATWG URL Standard keep them
-		// distinct too.
+		// distinct too. A dotted IP literal is kept apart for the same reason,
+		// though it stops parsing as a literal and is compared as a name.
 		{"trailing root dot", "https://example.test/a", "https://example.test./a", false},
 		{"trailing root dot on the left", "https://example.test./a", "https://example.test/a", false},
+		{"ipv4 with a trailing root dot", "http://127.0.0.1/a", "http://127.0.0.1./a", false},
 		{"upgrade to a non-default https port", "http://example.test/a", "https://example.test:8443/a", false},
+
+		// An IPv6 scope zone names an interface, and net resolves it by exact
+		// name: %eth0 and %ETH0 can be two interfaces carrying the same
+		// link-local address. Folding the zone would let a credential issued
+		// for one cross to the other.
+		{"ipv6 zone case differs", "http://[fe80::1%25eth0]:8080/a", "http://[fe80::1%25ETH0]:8080/a", false},
+		{"ipv6 zone differs", "http://[fe80::1%25eth0]:8080/a", "http://[fe80::1%25eth1]:8080/a", false},
+		{"ipv6 zone against none", "http://[fe80::1%25eth0]:8080/a", "http://[fe80::1]:8080/a", false},
+
+		// An IPv4-mapped literal dials the same endpoint as the IPv4 it wraps,
+		// but net/http sends the literal as written in Host, so the two can
+		// reach different virtual hosts on that endpoint. Same endpoint is not
+		// the same authority, and netip keeps the two Addrs apart.
+		{"ipv4-mapped against the ipv4", "http://[::ffff:127.0.0.1]/a", "http://127.0.0.1/a", false},
 
 		// Hostnames are compared as bytes, so a unicode host is a different
 		// origin from the punycode that encodes it and from another Unicode

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -216,3 +216,96 @@ func TestApplyRedirect(t *testing.T) {
 		})
 	}
 }
+
+func TestCredentialsMayFollow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		from string
+		to   string
+		want bool
+	}{
+		{"identical", "https://example.test/a", "https://example.test/a", true},
+		{"path differs only", "https://example.test/a", "https://example.test/b", true},
+		{"explicit default port on the right", "https://example.test/a", "https://example.test:443/a", true},
+		{"explicit default port on the left", "http://example.test:80/a", "http://example.test/a", true},
+		{"leading zero port", "https://example.test/a", "https://example.test:0443/a", true},
+		{"uppercase host", "https://EXAMPLE.test/a", "https://example.test/a", true},
+		{"unicode host, same spelling", "https://ẞexample.test/a", "https://ẞexample.test/a", true},
+		{"unicode host, ASCII case differs", "https://ΣXAMPLE.test/a", "https://Σxample.test/a", true},
+		{"http to https upgrade", "http://example.test/a", "https://example.test/a", true},
+		{"ipv4 literal", "http://127.0.0.1:8080/a", "http://127.0.0.1:8080/a", true},
+		{"ipv6 literal", "http://[::1]:8080/a", "http://[::1]:8080/a", true},
+		{"host with underscore", "http://build_host:8080/a", "http://build_host:8080/a", true},
+
+		{"https to http downgrade", "https://example.test/a", "http://example.test/a", false},
+		{"subdomain", "https://example.test/a", "https://sub.example.test/a", false},
+		{"parent domain", "https://sub.example.test/a", "https://example.test/a", false},
+		{"different port", "https://example.test/a", "https://example.test:8443/a", false},
+		{"unrelated host", "https://example.test/a", "https://evil.test/a", false},
+		{"suffix but not subdomain", "https://example.test/a", "https://notexample.test/a", false},
+
+		// A trailing root dot reaches the same peer, but net/http sends the
+		// name as written in Host, so the two spellings can be routed to
+		// different virtual hosts. curl and the WHATWG URL Standard keep them
+		// distinct too.
+		{"trailing root dot", "https://example.test/a", "https://example.test./a", false},
+		{"trailing root dot on the left", "https://example.test./a", "https://example.test/a", false},
+		{"upgrade to a non-default https port", "http://example.test/a", "https://example.test:8443/a", false},
+
+		// Hostnames are compared as bytes, so a unicode host is a different
+		// origin from the punycode that encodes it and from another Unicode
+		// case of itself, even though each pair reaches the same server.
+		// These lose a credential across such a redirect rather than
+		// granting one, and they hold whatever Unicode tables the build uses.
+		{"unicode host against its punycode", "https://ςxample.test/a", "https://xn--xample-20e.test/a", false},
+		{"punycode host against its unicode", "https://xn--xample-20e.test/a", "https://ςxample.test/a", false},
+		{"unicode host, unicode case differs", "https://ПРИМЕР.РФ/a", "https://пример.рф/a", false},
+
+		// strings.EqualFold treats these pairs as equal, but each side
+		// resolves to a different server. Comparing with EqualFold would call
+		// them the same origin; the ASCII-only fold keeps them apart.
+		{"greek final sigma fold pair", "https://ςxample.test/a", "https://σxample.test/a", false},
+		{"sharp s fold pair", "https://ẞexample.test/a", "https://ßexample.test/a", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			from, err := url.Parse(tt.from)
+			require.NoError(t, err)
+			to, err := url.Parse(tt.to)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, credentialsMayFollow(from, to))
+		})
+	}
+}
+
+func TestEffectivePort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		rawURL string
+		want   string
+	}{
+		{"http://example.test/a", "80"},
+		{"https://example.test/a", "443"},
+		{"http://example.test:8080/a", "8080"},
+		{"https://example.test:0443/a", "443"},
+		{"https://example.test:080/a", "80"},
+		{"ftp://example.test/a", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.rawURL, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tt.rawURL)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, effectivePort(u))
+		})
+	}
+}

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -99,6 +99,16 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 	// and the session that follows it agree on what an origin is. In canonical
 	// git, credential_from_url() re-derives credentials from the new URL,
 	// effectively wiping the old ones.
+	//
+	// The two are deliberately asymmetric in one respect: stripCredentials is
+	// sticky over the whole chain, so an origin -> evil -> origin redirect
+	// leaves the discovery GET's later hops unauthenticated even though the
+	// chain returned home. This check instead compares baseURL only against
+	// the final redirectedURL, so the same round trip leaves the session
+	// authenticated. That is not a leak — redirectedURL's origin is the
+	// original one — but it means such a chain can make the discovery GET
+	// anonymous while the session's POSTs are authenticated, which can surface
+	// as a confusing 401 rather than a credential exposure.
 	if !credentialsMayFollow(baseURL, redirectedURL) {
 		// Copy before clearing rather than writing through redirectedURL:
 		// applyRedirect returns baseURL itself when the redirect changed

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -90,18 +90,26 @@ func (t *Transport) Handshake(ctx context.Context, req *transport.Request) (tran
 	sessReq.URL = redirectedURL
 	authorizer := t.opts.Authorizer
 
-	// Clear credentials when the redirect landed on a different host.
-	// The session stores baseURL and re-applies its User field and the
-	// Authorizer callback on every subsequent POST — without this, the
-	// original host's credentials would be sent to the new host.
-	// Go's http.Client already strips the Authorization header on
-	// cross-host redirects during the initial GET, but User and
-	// Authorizer are carried in the session and applied explicitly by
-	// doPost/applyAuth. In canonical git, credential_from_url()
-	// re-derives credentials from the new URL, effectively wiping the
-	// old ones.
-	if redirectedURL.Host != baseURL.Host {
-		sessReq.URL.User = nil
+	// Clear credentials when the redirect left the origin they were issued
+	// for. The session stores baseURL and re-applies its User field and the
+	// Authorizer callback on every subsequent POST, so without this the
+	// original origin's credentials would be sent to the new one.
+	//
+	// This uses the same predicate as stripCredentials, so the discovery GET
+	// and the session that follows it agree on what an origin is. In canonical
+	// git, credential_from_url() re-derives credentials from the new URL,
+	// effectively wiping the old ones.
+	if !credentialsMayFollow(baseURL, redirectedURL) {
+		// Copy before clearing rather than writing through redirectedURL:
+		// applyRedirect returns baseURL itself when the redirect changed
+		// nothing, and baseURL belongs to the caller. That aliasing cannot
+		// currently reach this branch — an aliased URL is trivially the same
+		// origin as itself — so this keeps the two functions independent
+		// rather than fixing a live bug: neither can make the other unsafe
+		// by changing later.
+		cleared := *redirectedURL
+		cleared.User = nil
+		sessReq.URL = &cleared
 		authorizer = nil
 	}
 

--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -47,13 +47,15 @@ type Options struct {
 	// created. When Client is set, TLS and HTTPProxy are ignored —
 	// configure them on the provided Client directly.
 	//
-	// Credentials injected by a custom RoundTripper on this Client are
-	// invisible to the transport, so they are not subject to the redirect
-	// stripping described on Authorizer and will follow redirects across
-	// origins; apply those in Authorizer instead if that is not wanted. A
-	// CheckRedirect hook set on this Client runs alongside the transport's
-	// own, but any header it adds when a redirect leaves the repository's
-	// origin is discarded the same way.
+	// Credentials this Client adds where the transport cannot see them are
+	// not subject to the redirect stripping described on Authorizer: a
+	// RoundTripper injects after the hop is decided, and Client.Jar is
+	// consulted after CheckRedirect, so a domain cookie still follows a
+	// redirect to a subdomain the transport counts as another origin. Apply
+	// them in Authorizer instead if that is not wanted. A CheckRedirect hook
+	// set on this Client runs alongside the transport's own, but any header
+	// it adds when a redirect leaves the repository's origin is discarded
+	// the same way.
 	//
 	// A RoundTripper is therefore also how to authenticate to a new origin a
 	// redirect has moved the repository to: match on the request URL and

--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -47,11 +47,20 @@ type Options struct {
 	// created. When Client is set, TLS and HTTPProxy are ignored —
 	// configure them on the provided Client directly.
 	//
-	// When a redirect leaves the repository's origin, the transport keeps
-	// only the headers it sets itself and drops everything else, including
-	// any header an Authorizer added. Credentials injected by a custom
-	// RoundTripper on this Client are added after that point and will follow
-	// redirects; apply those in Authorizer instead.
+	// Credentials injected by a custom RoundTripper on this Client are
+	// invisible to the transport, so they are not subject to the redirect
+	// stripping described on Authorizer and will follow redirects across
+	// origins; apply those in Authorizer instead if that is not wanted. A
+	// CheckRedirect hook set on this Client runs alongside the transport's
+	// own, but any header it adds when a redirect leaves the repository's
+	// origin is discarded the same way.
+	//
+	// A RoundTripper is therefore also how to authenticate to a new origin a
+	// redirect has moved the repository to: match on the request URL and
+	// inject the credential only for that origin, so it is not sent
+	// anywhere else. The transport keeps its own CheckRedirect on the copy
+	// it makes of this Client, so the policy and the origin checks still
+	// apply.
 	Client *http.Client
 
 	// FollowRedirects controls redirect handling. The zero value defaults
@@ -59,6 +68,19 @@ type Options struct {
 	FollowRedirects RedirectPolicy
 
 	// Authorizer mutates outgoing HTTP requests to add authentication.
+	//
+	// Headers it adds are dropped when a redirect leaves the repository's
+	// origin: only the headers the transport sets itself survive that
+	// boundary. This applies to non-credential headers too, so an
+	// Authorizer that adds a trace or tenant header will lose it on such
+	// a hop.
+	//
+	// That filter matches header names, not values. An Authorizer that
+	// writes a credential into a name the transport also uses — User-Agent,
+	// Accept, Content-Type, Git-Protocol — has that value carried across the
+	// boundary with the name. Such a credential is also sent to the origin
+	// and to any proxy in path, and appears in trace.HTTP output, so it
+	// should not be placed there whether or not a redirect follows.
 	Authorizer func(*http.Request) error
 
 	// HTTPProxy returns the proxy URL for a given HTTP request.
@@ -150,9 +172,9 @@ func wrapCheckRedirect(policy RedirectPolicy, next func(*http.Request, []*http.R
 //
 // Two subtleties:
 //
-//   - Go rebuilds every redirect request from the original request's headers
-//     before calling this, so a header removed at one hop reappears at the
-//     next. The decision is therefore recomputed per hop.
+//   - net/http rebuilds every redirect request from the original request's
+//     headers before calling this, so a header removed at one hop reappears
+//     at the next. The decision is therefore recomputed per hop.
 //   - The decision is sticky: once the chain has left the origin, credentials
 //     stay gone even if a later hop returns to it. Stickiness is derived from
 //     via rather than stored, because this closure is shared across a
@@ -161,9 +183,10 @@ func wrapCheckRedirect(policy RedirectPolicy, next func(*http.Request, []*http.R
 // Stripping keeps only the headers go-git sets itself (safeHeaders). An
 // allowlist is used rather than a list of credential header names because
 // caller credentials arrive under names that cannot be enumerated —
-// PRIVATE-TOKEN, X-Api-Key, gateway headers — which is exactly what Go's fixed
-// list of sensitive names gets wrong. It is also immune to header-name
-// canonicalisation: an Authorizer that writes a raw map key is still removed.
+// PRIVATE-TOKEN, X-Api-Key, gateway headers — which is exactly what
+// net/http's fixed list of sensitive header names gets wrong. It is also
+// immune to header-name canonicalisation: an Authorizer that writes a raw
+// map key is still removed.
 func stripCredentials(req *http.Request, via []*http.Request) {
 	if len(via) == 0 {
 		return
@@ -203,8 +226,8 @@ func crossedOrigin(origin *url.URL, req *http.Request, via []*http.Request) bool
 //
 // This function decides only whether a hop may proceed. Credentials on a
 // permitted hop are handled by stripCredentials, which removes them when the
-// hop leaves the origin they were issued for. Go's http.Client applies its own
-// rule first, but that rule forwards credentials from a host to its
+// hop leaves the origin they were issued for. net/http's Client applies its
+// own rule first, but that rule forwards credentials from a host to its
 // subdomains, ignores the port and the scheme, and recognises only a fixed set
 // of header names, so it is not sufficient on its own.
 func checkRedirect(req *http.Request, via []*http.Request, policy RedirectPolicy) error {

--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -46,6 +46,12 @@ type Options struct {
 	// Client is the underlying HTTP client. If nil, a default client is
 	// created. When Client is set, TLS and HTTPProxy are ignored —
 	// configure them on the provided Client directly.
+	//
+	// When a redirect leaves the repository's origin, the transport keeps
+	// only the headers it sets itself and drops everything else, including
+	// any header an Authorizer added. Credentials injected by a custom
+	// RoundTripper on this Client are added after that point and will follow
+	// redirects; apply those in Authorizer instead.
 	Client *http.Client
 
 	// FollowRedirects controls redirect handling. The zero value defaults
@@ -119,22 +125,88 @@ func wrapCheckRedirect(policy RedirectPolicy, next func(*http.Request, []*http.R
 		if err := checkRedirect(req, via, policy); err != nil {
 			return err
 		}
+		// Strip before the caller's hook so it observes what will actually be
+		// sent, and again afterwards so a hook of the common "preserve my
+		// headers across redirects" shape — which copies from via[0], the
+		// original unsanitized request — cannot reinstate them. Carrying
+		// credentials across an origin boundary is deliberately unsupported.
+		stripCredentials(req, via)
 		if next != nil {
-			return next(req, via)
+			if err := next(req, via); err != nil {
+				return err
+			}
 		}
+		stripCredentials(req, via)
 		return nil
 	}
+}
+
+// stripCredentials removes credentials from req once the redirect chain has
+// left the origin of the original, credential-bearing request.
+//
+// CheckRedirect is the only hook that runs while a redirected request's
+// headers are still mutable: http.Client.Do performs the entire chain
+// internally, so anything the transport does after Do returns is too late.
+//
+// Two subtleties:
+//
+//   - Go rebuilds every redirect request from the original request's headers
+//     before calling this, so a header removed at one hop reappears at the
+//     next. The decision is therefore recomputed per hop.
+//   - The decision is sticky: once the chain has left the origin, credentials
+//     stay gone even if a later hop returns to it. Stickiness is derived from
+//     via rather than stored, because this closure is shared across a
+//     session's requests.
+//
+// Stripping keeps only the headers go-git sets itself (safeHeaders). An
+// allowlist is used rather than a list of credential header names because
+// caller credentials arrive under names that cannot be enumerated —
+// PRIVATE-TOKEN, X-Api-Key, gateway headers — which is exactly what Go's fixed
+// list of sensitive names gets wrong. It is also immune to header-name
+// canonicalisation: an Authorizer that writes a raw map key is still removed.
+func stripCredentials(req *http.Request, via []*http.Request) {
+	if len(via) == 0 {
+		return
+	}
+	// net/http sets a URL on every request it builds, and req.URL is non-nil
+	// by construction: checkRedirect dereferences req.URL.Scheme on each path
+	// that returns nil, so it runs first or not at all. This nil check and
+	// the two in crossedOrigin are defensive, against a synthetic caller.
+	// Each treats a URL it cannot read as an origin crossing; removing one
+	// panics in canonicalHost rather than leaking.
+	if origin := via[0].URL; origin != nil && !crossedOrigin(origin, req, via) {
+		return
+	}
+	req.Header = filterHeaders(req.Header)
+	if req.URL != nil {
+		req.URL.User = nil
+	}
+}
+
+// crossedOrigin reports whether any hop so far, including the pending one, has
+// left origin.
+func crossedOrigin(origin *url.URL, req *http.Request, via []*http.Request) bool {
+	if req.URL == nil || !credentialsMayFollow(origin, req.URL) {
+		return true
+	}
+	for _, prev := range via[1:] {
+		if prev.URL != nil && !credentialsMayFollow(origin, prev.URL) {
+			return true
+		}
+	}
+	return false
 }
 
 // checkRedirect implements Git's http.followRedirects policies. The
 // default policy is "initial", where only the GET /info/refs discovery
 // request is allowed to follow redirects.
 //
-// Credential handling on redirect is left to Go's http.Client, which
-// already strips the Authorization header when a redirect crosses to a
-// different host (since Go 1.8) and preserves it for same-host
-// redirects — matching the expected behavior for scheme upgrades and
-// path-only redirects on the same server.
+// This function decides only whether a hop may proceed. Credentials on a
+// permitted hop are handled by stripCredentials, which removes them when the
+// hop leaves the origin they were issued for. Go's http.Client applies its own
+// rule first, but that rule forwards credentials from a host to its
+// subdomains, ignores the port and the scheme, and recognises only a fixed set
+// of header names, so it is not sufficient on its own.
 func checkRedirect(req *http.Request, via []*http.Request, policy RedirectPolicy) error {
 	if len(via) != 0 {
 		prev := via[len(via)-1]

--- a/plumbing/transport/http/http.go
+++ b/plumbing/transport/http/http.go
@@ -213,7 +213,7 @@ func crossedOrigin(origin *url.URL, req *http.Request, via []*http.Request) bool
 		return true
 	}
 	for _, prev := range via[1:] {
-		if prev.URL != nil && !credentialsMayFollow(origin, prev.URL) {
+		if prev.URL == nil || !credentialsMayFollow(origin, prev.URL) {
 			return true
 		}
 	}

--- a/plumbing/transport/http/http_test.go
+++ b/plumbing/transport/http/http_test.go
@@ -123,11 +123,15 @@ func (h *vhostMap) client() *http.Client {
 // vhost is a server reachable under a virtual authority. It records every
 // request it receives and optionally redirects the discovery request.
 type vhost struct {
-	mu       sync.Mutex
-	received []http.Header
-	srv      *httptest.Server
-	base     string
-	redirect string
+	mu          sync.Mutex
+	received    []http.Header
+	receivedLen []int64
+	srv         *httptest.Server
+	base        string
+	redirect    string
+	// redirectPost answers the service request with a 307, which preserves
+	// the method and the body. Only reachable under FollowRedirects.
+	redirectPost string
 }
 
 // newTLSVhost starts an HTTPS server registered at hostname:port. Its base
@@ -152,9 +156,15 @@ func newVhostServer(t *testing.T, hm *vhostMap, hostname, port string, useTLS bo
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v.mu.Lock()
 		v.received = append(v.received, r.Header.Clone())
+		v.receivedLen = append(v.receivedLen, r.ContentLength)
 		redirect := v.redirect
+		redirectPost := v.redirectPost
 		v.mu.Unlock()
 
+		if redirectPost != "" && r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/repo.git/git-upload-pack") {
+			http.Redirect(w, r, redirectPost, http.StatusTemporaryRedirect)
+			return
+		}
 		if redirect != "" && strings.HasSuffix(r.URL.Path, "/repo.git/info/refs") {
 			http.Redirect(w, r, redirect, http.StatusFound)
 			return
@@ -200,6 +210,16 @@ func (v *vhost) lastRequest(t *testing.T) http.Header {
 	defer v.mu.Unlock()
 	require.NotEmpty(t, v.received, "the redirect target was never reached")
 	return v.received[len(v.received)-1]
+}
+
+// lastContentLength returns the body length of the most recent request this
+// vhost served.
+func (v *vhost) lastContentLength(t *testing.T) int64 {
+	t.Helper()
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	require.NotEmpty(t, v.receivedLen, "the redirect target was never reached")
+	return v.receivedLen[len(v.receivedLen)-1]
 }
 
 func refsPath(repo string) string {

--- a/plumbing/transport/http/http_test.go
+++ b/plumbing/transport/http/http_test.go
@@ -1,22 +1,28 @@
 package http
 
 import (
+	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/cgi"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
 	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/internal/transport/test"
+	transport "github.com/go-git/go-git/v6/plumbing/transport"
 )
 
 func setupSmartServer(t testing.TB) (base string, addr *net.TCPAddr) {
@@ -61,4 +67,173 @@ func httpEndpoint(addr *net.TCPAddr, name string) *url.URL {
 		Host:   fmt.Sprintf("localhost:%d", addr.Port),
 		Path:   "/" + name,
 	}
+}
+
+// v2Advertisement is a minimal protocol v2 capability advertisement: enough
+// for Handshake to succeed.
+const v2Advertisement = "001e# service=git-upload-pack\n0000000eversion 2\n0000"
+
+// vhostMap resolves arbitrary hostnames and ports to loopback listeners, so
+// tests can exercise subdomain, port and cross-host redirects without DNS.
+type vhostMap struct {
+	mu sync.Mutex
+	m  map[string]string // "name:port" -> "127.0.0.1:realport"
+}
+
+func newVhostMap() *vhostMap { return &vhostMap{m: map[string]string{}} }
+
+func (h *vhostMap) add(authority, backend string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.m[authority] = backend
+}
+
+func (h *vhostMap) dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	h.mu.Lock()
+	backend, ok := h.m[addr]
+	h.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("no vhost mapping for %q", addr)
+	}
+	var d net.Dialer
+	return d.DialContext(ctx, network, backend)
+}
+
+func (h *vhostMap) client() *http.Client {
+	return &http.Client{Transport: &http.Transport{
+		DialContext: h.dial,
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := h.dial(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			//nolint:gosec // httptest's TLS server uses a self-signed certificate.
+			tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				// Closing the tls.Conn closes conn with it; nothing else
+				// owns either once this returns an error.
+				_ = tlsConn.Close()
+				return nil, err
+			}
+			return tlsConn, nil
+		},
+	}}
+}
+
+// vhost is a server reachable under a virtual authority. It records every
+// request it receives and optionally redirects the discovery request.
+type vhost struct {
+	mu       sync.Mutex
+	received []http.Header
+	srv      *httptest.Server
+	base     string
+	redirect string
+}
+
+// newVhost starts a server registered at hostname:port. Its base URL omits the
+// port when that port is the scheme's default.
+func newVhost(t *testing.T, hm *vhostMap, hostname, port string, useTLS bool) *vhost {
+	t.Helper()
+
+	v := &vhost{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v.mu.Lock()
+		v.received = append(v.received, r.Header.Clone())
+		redirect := v.redirect
+		v.mu.Unlock()
+
+		if redirect != "" && strings.HasSuffix(r.URL.Path, "/repo.git/info/refs") {
+			http.Redirect(w, r, redirect, http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		_, _ = w.Write([]byte(v2Advertisement))
+	})
+
+	if useTLS {
+		v.srv = httptest.NewTLSServer(handler)
+	} else {
+		v.srv = httptest.NewServer(handler)
+	}
+	t.Cleanup(v.srv.Close)
+
+	backend, err := url.Parse(v.srv.URL)
+	require.NoError(t, err)
+
+	scheme, defaultPort := "http", "80"
+	if useTLS {
+		scheme, defaultPort = "https", "443"
+	}
+	hm.add(net.JoinHostPort(hostname, port), backend.Host)
+
+	v.base = scheme + "://" + hostname
+	if port != defaultPort {
+		v.base += ":" + port
+	}
+	return v
+}
+
+// redirectTo makes the vhost answer the discovery request with a redirect.
+func (v *vhost) redirectTo(target string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.redirect = target
+}
+
+// lastRequest returns the headers of the most recent request this vhost served.
+func (v *vhost) lastRequest(t *testing.T) http.Header {
+	t.Helper()
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	require.NotEmpty(t, v.received, "the redirect target was never reached")
+	return v.received[len(v.received)-1]
+}
+
+func refsPath(repo string) string {
+	return "/" + repo + "/info/refs?service=git-upload-pack"
+}
+
+// handshakeWithCredentials performs a discovery handshake carrying three
+// credentials: URL userinfo (becomes Authorization), a custom header set with
+// Header.Set, and a custom header written as a raw map key. The raw one guards
+// against a strip implemented with http.Header.Del, which canonicalises the
+// name and would leave that spelling in place.
+func handshakeWithCredentials(t *testing.T, hm *vhostMap, originBase string) (transport.Session, error) {
+	t.Helper()
+
+	tr := NewTransport(Options{
+		Client: hm.client(),
+		Authorizer: func(r *http.Request) error {
+			r.Header.Set("X-Private-Token", "custom-canary")
+			r.Header["X-Raw-Token"] = []string{"raw-canary"}
+			return nil
+		},
+	})
+
+	u, err := url.Parse(originBase + "/repo.git")
+	require.NoError(t, err)
+	u.User = url.UserPassword("testuser", "testpass")
+
+	sess, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     u,
+		Command: transport.UploadPackService,
+	})
+	if err == nil {
+		t.Cleanup(func() { _ = sess.Close() })
+	}
+	return sess, err
+}
+
+func assertCredentialsPresent(t *testing.T, h http.Header) {
+	t.Helper()
+	assert.NotEmpty(t, h.Get("Authorization"), "Authorization should have been preserved")
+	assert.Equal(t, "custom-canary", h.Get("X-Private-Token"), "custom credential should have been preserved")
+	assert.Equal(t, []string{"raw-canary"}, h["X-Raw-Token"], "raw-key credential should have been preserved")
+}
+
+func assertCredentialsAbsent(t *testing.T, h http.Header) {
+	t.Helper()
+	assert.Empty(t, h.Get("Authorization"), "Authorization must not cross an origin boundary")
+	assert.Empty(t, h.Get("X-Private-Token"), "custom credential must not cross an origin boundary")
+	assert.Empty(t, h["X-Raw-Token"], "raw-key credential must not cross an origin boundary")
 }

--- a/plumbing/transport/http/http_test.go
+++ b/plumbing/transport/http/http_test.go
@@ -130,9 +130,22 @@ type vhost struct {
 	redirect string
 }
 
-// newVhost starts a server registered at hostname:port. Its base URL omits the
-// port when that port is the scheme's default.
-func newVhost(t *testing.T, hm *vhostMap, hostname, port string, useTLS bool) *vhost {
+// newTLSVhost starts an HTTPS server registered at hostname:port. Its base
+// URL omits the port when that port is the scheme's default.
+func newTLSVhost(t *testing.T, hm *vhostMap, hostname, port string) *vhost {
+	t.Helper()
+	return newVhostServer(t, hm, hostname, port, true)
+}
+
+// newVhost starts a plain HTTP server registered at hostname:port. Its base
+// URL omits the port when that port is the scheme's default.
+func newVhost(t *testing.T, hm *vhostMap, hostname, port string) *vhost {
+	t.Helper()
+	return newVhostServer(t, hm, hostname, port, false)
+}
+
+// newVhostServer implements newTLSVhost and newVhost.
+func newVhostServer(t *testing.T, hm *vhostMap, hostname, port string, useTLS bool) *vhost {
 	t.Helper()
 
 	v := &vhost{}
@@ -195,20 +208,31 @@ func refsPath(repo string) string {
 
 // handshakeWithCredentials performs a discovery handshake carrying three
 // credentials: URL userinfo (becomes Authorization), a custom header set with
-// Header.Set, and a custom header written as a raw map key. The raw one guards
-// against a strip implemented with http.Header.Del, which canonicalises the
-// name and would leave that spelling in place.
-func handshakeWithCredentials(t *testing.T, hm *vhostMap, originBase string) (transport.Session, error) {
+// Header.Set, and a custom header written as a raw, non-canonical map key.
+// The raw one guards against a strip implemented with http.Header.Del: Del
+// canonicalises the name it is given and would remove the canonical spelling,
+// but a lowercase key stored directly in the map bypasses that and would
+// survive such a strip undetected. The allowlist in filterHeaders instead
+// canonicalises for lookup, so it catches this spelling too.
+//
+// opts, if given, are applied to the base Options after the defaults above
+// are set, so a caller can override Client or add settings like ForceDumb
+// without duplicating the credential setup.
+func handshakeWithCredentials(t *testing.T, hm *vhostMap, originBase string, opts ...func(*Options)) (transport.Session, error) {
 	t.Helper()
 
-	tr := NewTransport(Options{
+	options := Options{
 		Client: hm.client(),
 		Authorizer: func(r *http.Request) error {
 			r.Header.Set("X-Private-Token", "custom-canary")
-			r.Header["X-Raw-Token"] = []string{"raw-canary"}
+			r.Header["x-raw-token"] = []string{"raw-canary"}
 			return nil
 		},
-	})
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	tr := NewTransport(options)
 
 	u, err := url.Parse(originBase + "/repo.git")
 	require.NoError(t, err)

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -454,3 +454,171 @@ func fetchWithRedirectedPost(t *testing.T, opts Options) error {
 
 	return session.Fetch(context.Background(), st, req)
 }
+
+func TestRedirectKeepsCredentialsWithinOrigin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("path only", func(t *testing.T) {
+		t.Parallel()
+		hm := newVhostMap()
+		v := newVhost(t, hm, "example.test", "443", true)
+		v.redirectTo(v.base + refsPath("other.git"))
+
+		_, err := handshakeWithCredentials(t, hm, v.base)
+		require.NoError(t, err)
+		assertCredentialsPresent(t, v.lastRequest(t))
+	})
+
+	t.Run("explicit default port", func(t *testing.T) {
+		t.Parallel()
+		hm := newVhostMap()
+		v := newVhost(t, hm, "example.test", "443", true)
+		v.redirectTo("https://example.test:443" + refsPath("other.git"))
+
+		_, err := handshakeWithCredentials(t, hm, v.base)
+		require.NoError(t, err)
+		assertCredentialsPresent(t, v.lastRequest(t))
+	})
+
+	t.Run("http to https upgrade", func(t *testing.T) {
+		t.Parallel()
+		hm := newVhostMap()
+		secure := newVhost(t, hm, "example.test", "443", true)
+		plain := newVhost(t, hm, "example.test", "80", false)
+		plain.redirectTo(secure.base + refsPath("other.git"))
+
+		_, err := handshakeWithCredentials(t, hm, plain.base)
+		require.NoError(t, err)
+		assertCredentialsPresent(t, secure.lastRequest(t))
+	})
+}
+
+func TestRedirectDropsCredentialsAcrossOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		destHost string
+		destPort string
+	}{
+		{"subdomain", "sub.example.test", "443"},
+		{"different port", "example.test", "8443"},
+		{"unrelated host", "evil.test", "443"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hm := newVhostMap()
+			dest := newVhost(t, hm, tt.destHost, tt.destPort, true)
+			origin := newVhost(t, hm, "example.test", "443", true)
+			origin.redirectTo(dest.base + refsPath("repo.git"))
+
+			_, err := handshakeWithCredentials(t, hm, origin.base)
+			require.NoError(t, err)
+			assertCredentialsAbsent(t, dest.lastRequest(t))
+		})
+	}
+
+	// The dumb HTTP walker applies credentials through the same path, and
+	// sends /info/refs without the ?service= query.
+	t.Run("force dumb", func(t *testing.T) {
+		t.Parallel()
+
+		hm := newVhostMap()
+		dest := newVhost(t, hm, "evil.test", "443", true)
+		origin := newVhost(t, hm, "example.test", "443", true)
+		origin.redirectTo(dest.base + "/repo.git/info/refs")
+
+		tr := NewTransport(Options{
+			Client:    hm.client(),
+			ForceDumb: true,
+			Authorizer: func(r *http.Request) error {
+				r.Header.Set("X-Private-Token", "custom-canary")
+				r.Header["X-Raw-Token"] = []string{"raw-canary"}
+				return nil
+			},
+		})
+		u, err := url.Parse(origin.base + "/repo.git")
+		require.NoError(t, err)
+		u.User = url.UserPassword("testuser", "testpass")
+
+		sess, err := tr.Handshake(context.Background(), &transport.Request{
+			URL:     u,
+			Command: transport.UploadPackService,
+		})
+		if err == nil {
+			t.Cleanup(func() { _ = sess.Close() })
+		} else {
+			// The vhost serves a smart advertisement, so the dumb decoder may
+			// reject it. The assertion below is about the headers that reached
+			// dest, which that does not affect.
+			t.Logf("handshake: %v", err)
+		}
+		assertCredentialsAbsent(t, dest.lastRequest(t))
+	})
+}
+
+// Once the chain has left the origin, credentials stay gone even if a later
+// hop returns to it. Go restores non-sensitive headers on every hop, so
+// without the sticky check the custom credentials reappear on the final hop.
+func TestRedirectCredentialsStickyMultiHop(t *testing.T) {
+	t.Parallel()
+
+	hm := newVhostMap()
+	origin := newVhost(t, hm, "example.test", "443", true)
+	detour := newVhost(t, hm, "evil.test", "443", true)
+
+	detour.redirectTo(origin.base + refsPath("other.git"))
+	origin.redirectTo(detour.base + refsPath("repo.git"))
+
+	_, err := handshakeWithCredentials(t, hm, origin.base)
+	require.NoError(t, err)
+	// origin served the final /other.git request.
+	assertCredentialsAbsent(t, origin.lastRequest(t))
+}
+
+// A caller-supplied CheckRedirect must observe the sanitized request, and must
+// not be able to reinstate credentials by copying headers from via[0].
+func TestRedirectStripsAroundCallerHook(t *testing.T) {
+	t.Parallel()
+
+	hm := newVhostMap()
+	dest := newVhost(t, hm, "evil.test", "443", true)
+	origin := newVhost(t, hm, "example.test", "443", true)
+	origin.redirectTo(dest.base + refsPath("repo.git"))
+
+	var seen http.Header
+	client := hm.client()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		seen = req.Header.Clone()
+		// The "preserve my headers across redirects" shape: via[0] is the
+		// original, unsanitized request.
+		maps.Copy(req.Header, via[0].Header)
+		return nil
+	}
+
+	tr := NewTransport(Options{
+		Client: client,
+		Authorizer: func(r *http.Request) error {
+			r.Header.Set("X-Private-Token", "custom-canary")
+			r.Header["X-Raw-Token"] = []string{"raw-canary"}
+			return nil
+		},
+	})
+	u, err := url.Parse(origin.base + "/repo.git")
+	require.NoError(t, err)
+	u.User = url.UserPassword("testuser", "testpass")
+
+	_, err = tr.Handshake(context.Background(), &transport.Request{
+		URL:     u,
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, seen, "caller CheckRedirect was never invoked")
+	assert.Empty(t, seen.Get("Authorization"), "the caller hook should observe a sanitized request")
+	assert.Empty(t, seen.Get("X-Private-Token"), "the caller hook should observe a sanitized request")
+	assertCredentialsAbsent(t, dest.lastRequest(t))
+}

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -494,6 +494,62 @@ func TestRedirectDropsCredentialsAcrossOrigin(t *testing.T) {
 	})
 }
 
+// The strip applies to every request a session makes, not just discovery.
+// Under FollowRedirects a 307 on the upload-pack POST preserves the method
+// and the body, so a credential-bearing request with a body reaches the new
+// origin intact.
+func TestRedirectPostCredentials(t *testing.T) {
+	t.Parallel()
+
+	t.Run("drops credentials across an origin", func(t *testing.T) {
+		t.Parallel()
+
+		hm := newVhostMap()
+		dest := newTLSVhost(t, hm, "evil.test", "443")
+		origin := newTLSVhost(t, hm, "example.test", "443")
+		origin.redirectPost = dest.base + "/repo.git/git-upload-pack"
+
+		sess, err := handshakeWithCredentials(t, hm, origin.base, func(o *Options) {
+			o.FollowRedirects = FollowRedirects
+		})
+		require.NoError(t, err)
+
+		// Discovery stayed on the origin, so the session kept its credentials
+		// and the POST below is genuinely credential-bearing.
+		assertCredentialsPresent(t, origin.lastRequest(t))
+
+		// dest answers with the discovery advertisement, which is not a valid
+		// ls-refs response, so an error here is expected and irrelevant: the
+		// assertion is about what reached dest.
+		_, _ = sess.GetRemoteRefs(context.Background(), nil)
+
+		assertCredentialsPresent(t, origin.lastRequest(t)) // the POST as sent to the origin
+		assertCredentialsAbsent(t, dest.lastRequest(t))
+
+		// The 307 replayed the method and the body. Without this the test
+		// could pass trivially, on a redirected request carrying nothing.
+		wantLen := origin.lastContentLength(t)
+		assert.Positive(t, wantLen, "the POST to the origin had no body")
+		assert.Equal(t, wantLen, dest.lastContentLength(t), "the redirected POST body was not replayed intact")
+	})
+
+	t.Run("keeps credentials within the origin", func(t *testing.T) {
+		t.Parallel()
+
+		hm := newVhostMap()
+		origin := newTLSVhost(t, hm, "example.test", "443")
+		origin.redirectPost = origin.base + "/other.git/git-upload-pack"
+
+		sess, err := handshakeWithCredentials(t, hm, origin.base, func(o *Options) {
+			o.FollowRedirects = FollowRedirects
+		})
+		require.NoError(t, err)
+
+		_, _ = sess.GetRemoteRefs(context.Background(), nil)
+		assertCredentialsPresent(t, origin.lastRequest(t))
+	})
+}
+
 // Once the chain has left the origin, credentials stay gone even if a later
 // hop returns to it. net/http restores non-sensitive headers on every hop,
 // so without the sticky check the custom credentials reappear on the final

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -195,56 +195,6 @@ func TestRedirectPostAllowedWithFollowRedirects(t *testing.T) {
 	require.NoError(t, fetchWithRedirectedPost(t, Options{FollowRedirects: FollowRedirects}))
 }
 
-func TestRedirectStripsCredentials(t *testing.T) {
-	t.Parallel()
-
-	base, backend := setupSmartServer(t)
-	prepareRepo(t, fixtures.Basic().One(), base, "basic.git")
-
-	rl := test.ListenTCP(t)
-	raddr := rl.Addr().(*net.TCPAddr)
-
-	backendURL := fmt.Sprintf("http://localhost:%d", backend.Port)
-	redirectServer := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			target := backendURL + r.URL.Path
-			if r.URL.RawQuery != "" {
-				target += "?" + r.URL.RawQuery
-			}
-			http.Redirect(w, r, target, http.StatusMovedPermanently)
-		}),
-	}
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		require.ErrorIs(t, redirectServer.Serve(rl), http.ErrServerClosed)
-	}()
-	t.Cleanup(func() {
-		require.NoError(t, redirectServer.Close())
-		<-done
-	})
-
-	tr := NewTransport(Options{})
-	endpoint := &url.URL{
-		Scheme: "http",
-		User:   url.UserPassword("testuser", "testpass"),
-		Host:   fmt.Sprintf("localhost:%d", raddr.Port),
-		Path:   "/basic.git",
-	}
-
-	session, err := tr.Handshake(context.Background(), &transport.Request{
-		URL:     endpoint,
-		Command: transport.UploadPackService,
-	})
-	require.NoError(t, err)
-	defer session.Close()
-
-	sps, ok := session.(*smartPackSession)
-	require.True(t, ok)
-	assert.Nil(t, sps.baseURL.User)
-}
-
 func TestCheckRedirectPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -621,4 +571,66 @@ func TestRedirectStripsAroundCallerHook(t *testing.T) {
 	assert.Empty(t, seen.Get("Authorization"), "the caller hook should observe a sanitized request")
 	assert.Empty(t, seen.Get("X-Private-Token"), "the caller hook should observe a sanitized request")
 	assertCredentialsAbsent(t, dest.lastRequest(t))
+}
+
+func TestSessionCredentialsAfterRedirect(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retained when the redirect stays within the origin", func(t *testing.T) {
+		t.Parallel()
+		hm := newVhostMap()
+		v := newVhost(t, hm, "example.test", "443", true)
+		// Same origin, spelled with its default port.
+		v.redirectTo("https://example.test:443" + refsPath("other.git"))
+
+		sess, err := handshakeWithCredentials(t, hm, v.base)
+		require.NoError(t, err)
+
+		sps, ok := sess.(*smartPackSession)
+		require.True(t, ok)
+		assert.NotNil(t, sps.baseURL.User, "credentials should survive a same-origin redirect")
+		assert.NotNil(t, sps.authorizer, "the authorizer should survive a same-origin redirect")
+	})
+
+	t.Run("cleared when the redirect leaves the origin", func(t *testing.T) {
+		t.Parallel()
+		hm := newVhostMap()
+		dest := newVhost(t, hm, "sub.example.test", "443", true)
+		origin := newVhost(t, hm, "example.test", "443", true)
+		origin.redirectTo(dest.base + refsPath("repo.git"))
+
+		sess, err := handshakeWithCredentials(t, hm, origin.base)
+		require.NoError(t, err)
+
+		sps, ok := sess.(*smartPackSession)
+		require.True(t, ok)
+		assert.Nil(t, sps.baseURL.User, "credentials must not follow the session across origins")
+		assert.Nil(t, sps.authorizer, "the authorizer must not follow the session across origins")
+	})
+
+	// applyRedirect returns baseURL itself when the redirect changed nothing,
+	// and baseURL is the caller's URL. That aliasing cannot currently coincide
+	// with the clearing branch (an aliased URL is the same origin as itself),
+	// so this pins the invariant rather than catching an active regression.
+	t.Run("does not mutate the caller's URL", func(t *testing.T) {
+		t.Parallel()
+		hm := newVhostMap()
+		dest := newVhost(t, hm, "evil.test", "443", true)
+		origin := newVhost(t, hm, "example.test", "443", true)
+		origin.redirectTo(dest.base + refsPath("repo.git"))
+
+		tr := NewTransport(Options{Client: hm.client()})
+		u, err := url.Parse(origin.base + "/repo.git")
+		require.NoError(t, err)
+		u.User = url.UserPassword("testuser", "testpass")
+
+		sess, err := tr.Handshake(context.Background(), &transport.Request{
+			URL:     u,
+			Command: transport.UploadPackService,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = sess.Close() })
+
+		assert.NotNil(t, u.User, "the caller's URL must not have been modified")
+	})
 }

--- a/plumbing/transport/http/redirect_test.go
+++ b/plumbing/transport/http/redirect_test.go
@@ -411,7 +411,7 @@ func TestRedirectKeepsCredentialsWithinOrigin(t *testing.T) {
 	t.Run("path only", func(t *testing.T) {
 		t.Parallel()
 		hm := newVhostMap()
-		v := newVhost(t, hm, "example.test", "443", true)
+		v := newTLSVhost(t, hm, "example.test", "443")
 		v.redirectTo(v.base + refsPath("other.git"))
 
 		_, err := handshakeWithCredentials(t, hm, v.base)
@@ -422,7 +422,7 @@ func TestRedirectKeepsCredentialsWithinOrigin(t *testing.T) {
 	t.Run("explicit default port", func(t *testing.T) {
 		t.Parallel()
 		hm := newVhostMap()
-		v := newVhost(t, hm, "example.test", "443", true)
+		v := newTLSVhost(t, hm, "example.test", "443")
 		v.redirectTo("https://example.test:443" + refsPath("other.git"))
 
 		_, err := handshakeWithCredentials(t, hm, v.base)
@@ -433,8 +433,8 @@ func TestRedirectKeepsCredentialsWithinOrigin(t *testing.T) {
 	t.Run("http to https upgrade", func(t *testing.T) {
 		t.Parallel()
 		hm := newVhostMap()
-		secure := newVhost(t, hm, "example.test", "443", true)
-		plain := newVhost(t, hm, "example.test", "80", false)
+		secure := newTLSVhost(t, hm, "example.test", "443")
+		plain := newVhost(t, hm, "example.test", "80")
 		plain.redirectTo(secure.base + refsPath("other.git"))
 
 		_, err := handshakeWithCredentials(t, hm, plain.base)
@@ -461,8 +461,8 @@ func TestRedirectDropsCredentialsAcrossOrigin(t *testing.T) {
 			t.Parallel()
 
 			hm := newVhostMap()
-			dest := newVhost(t, hm, tt.destHost, tt.destPort, true)
-			origin := newVhost(t, hm, "example.test", "443", true)
+			dest := newTLSVhost(t, hm, tt.destHost, tt.destPort)
+			origin := newTLSVhost(t, hm, "example.test", "443")
 			origin.redirectTo(dest.base + refsPath("repo.git"))
 
 			_, err := handshakeWithCredentials(t, hm, origin.base)
@@ -477,30 +477,14 @@ func TestRedirectDropsCredentialsAcrossOrigin(t *testing.T) {
 		t.Parallel()
 
 		hm := newVhostMap()
-		dest := newVhost(t, hm, "evil.test", "443", true)
-		origin := newVhost(t, hm, "example.test", "443", true)
+		dest := newTLSVhost(t, hm, "evil.test", "443")
+		origin := newTLSVhost(t, hm, "example.test", "443")
 		origin.redirectTo(dest.base + "/repo.git/info/refs")
 
-		tr := NewTransport(Options{
-			Client:    hm.client(),
-			ForceDumb: true,
-			Authorizer: func(r *http.Request) error {
-				r.Header.Set("X-Private-Token", "custom-canary")
-				r.Header["X-Raw-Token"] = []string{"raw-canary"}
-				return nil
-			},
+		_, err := handshakeWithCredentials(t, hm, origin.base, func(o *Options) {
+			o.ForceDumb = true
 		})
-		u, err := url.Parse(origin.base + "/repo.git")
-		require.NoError(t, err)
-		u.User = url.UserPassword("testuser", "testpass")
-
-		sess, err := tr.Handshake(context.Background(), &transport.Request{
-			URL:     u,
-			Command: transport.UploadPackService,
-		})
-		if err == nil {
-			t.Cleanup(func() { _ = sess.Close() })
-		} else {
+		if err != nil {
 			// The vhost serves a smart advertisement, so the dumb decoder may
 			// reject it. The assertion below is about the headers that reached
 			// dest, which that does not affect.
@@ -511,14 +495,15 @@ func TestRedirectDropsCredentialsAcrossOrigin(t *testing.T) {
 }
 
 // Once the chain has left the origin, credentials stay gone even if a later
-// hop returns to it. Go restores non-sensitive headers on every hop, so
-// without the sticky check the custom credentials reappear on the final hop.
+// hop returns to it. net/http restores non-sensitive headers on every hop,
+// so without the sticky check the custom credentials reappear on the final
+// hop.
 func TestRedirectCredentialsStickyMultiHop(t *testing.T) {
 	t.Parallel()
 
 	hm := newVhostMap()
-	origin := newVhost(t, hm, "example.test", "443", true)
-	detour := newVhost(t, hm, "evil.test", "443", true)
+	origin := newTLSVhost(t, hm, "example.test", "443")
+	detour := newTLSVhost(t, hm, "evil.test", "443")
 
 	detour.redirectTo(origin.base + refsPath("other.git"))
 	origin.redirectTo(detour.base + refsPath("repo.git"))
@@ -535,8 +520,8 @@ func TestRedirectStripsAroundCallerHook(t *testing.T) {
 	t.Parallel()
 
 	hm := newVhostMap()
-	dest := newVhost(t, hm, "evil.test", "443", true)
-	origin := newVhost(t, hm, "example.test", "443", true)
+	dest := newTLSVhost(t, hm, "evil.test", "443")
+	origin := newTLSVhost(t, hm, "example.test", "443")
 	origin.redirectTo(dest.base + refsPath("repo.git"))
 
 	var seen http.Header
@@ -549,21 +534,8 @@ func TestRedirectStripsAroundCallerHook(t *testing.T) {
 		return nil
 	}
 
-	tr := NewTransport(Options{
-		Client: client,
-		Authorizer: func(r *http.Request) error {
-			r.Header.Set("X-Private-Token", "custom-canary")
-			r.Header["X-Raw-Token"] = []string{"raw-canary"}
-			return nil
-		},
-	})
-	u, err := url.Parse(origin.base + "/repo.git")
-	require.NoError(t, err)
-	u.User = url.UserPassword("testuser", "testpass")
-
-	_, err = tr.Handshake(context.Background(), &transport.Request{
-		URL:     u,
-		Command: transport.UploadPackService,
+	_, err := handshakeWithCredentials(t, hm, origin.base, func(o *Options) {
+		o.Client = client
 	})
 	require.NoError(t, err)
 
@@ -579,7 +551,7 @@ func TestSessionCredentialsAfterRedirect(t *testing.T) {
 	t.Run("retained when the redirect stays within the origin", func(t *testing.T) {
 		t.Parallel()
 		hm := newVhostMap()
-		v := newVhost(t, hm, "example.test", "443", true)
+		v := newTLSVhost(t, hm, "example.test", "443")
 		// Same origin, spelled with its default port.
 		v.redirectTo("https://example.test:443" + refsPath("other.git"))
 
@@ -595,8 +567,8 @@ func TestSessionCredentialsAfterRedirect(t *testing.T) {
 	t.Run("cleared when the redirect leaves the origin", func(t *testing.T) {
 		t.Parallel()
 		hm := newVhostMap()
-		dest := newVhost(t, hm, "sub.example.test", "443", true)
-		origin := newVhost(t, hm, "example.test", "443", true)
+		dest := newTLSVhost(t, hm, "sub.example.test", "443")
+		origin := newTLSVhost(t, hm, "example.test", "443")
 		origin.redirectTo(dest.base + refsPath("repo.git"))
 
 		sess, err := handshakeWithCredentials(t, hm, origin.base)
@@ -615,8 +587,8 @@ func TestSessionCredentialsAfterRedirect(t *testing.T) {
 	t.Run("does not mutate the caller's URL", func(t *testing.T) {
 		t.Parallel()
 		hm := newVhostMap()
-		dest := newVhost(t, hm, "evil.test", "443", true)
-		origin := newVhost(t, hm, "example.test", "443", true)
+		dest := newTLSVhost(t, hm, "evil.test", "443")
+		origin := newTLSVhost(t, hm, "example.test", "443")
 		origin.redirectTo(dest.base + refsPath("repo.git"))
 
 		tr := NewTransport(Options{Client: hm.client()})


### PR DESCRIPTION
`url.URL.Host` was compared verbatim to decide whether a redirect had changed origin. That is both too loose and too strict: it ignores the scheme, and it treats `example.com` and `example.com:443` as different origins, dropping credentials the session still needed.

This adds one origin comparison over scheme, host and effective port, and uses it in the two places that need one: which headers may travel to a redirect target, and whether the session keeps its credentials. An http to https upgrade on the same host is allowed.

### How hosts compare

Registered names fold on ASCII case only. IP literals go through `netip.ParseAddr`, the same call `net`'s resolver uses to tell a literal from a name, so `[::1]` and `[0:0:0:0:0:0:0:1]` are one origin. Everything else is a different origin, including a trailing root dot and an IPv4-mapped literal against the IPv4 it dials. Both of those reach the same peer, but `net/http` sends the host as written in `Host`, so a server can route the two spellings to different virtual hosts. Same peer is not same authority.

No IDNA mapping is applied. It would only widen the equality, and go-git pins `x/net` in `go.mod` while `net/http` uses the copy vendored into the toolchain. The two are versioned separately, so a release that moved the Unicode tables under one and not the other would have the comparison merge origins `net/http` still dials apart.

### Behaviour change

When a redirect leaves the repository's origin, only the headers the transport sets itself are carried over. Headers added by an `Authorizer` are not, including non-credential ones such as a trace or tenant header. There is deliberately no opt-out: a caller who needs to authenticate to the origin a redirect moved the repository to can inject the credential from a `RoundTripper` on `Options.Client`, scoped to that origin. The transport keeps its own `CheckRedirect` on the client it copies, so the origin checks still apply. `Options.Client` now documents this.

### Deliberate deviations

Git does not carry `credential` authentication across a host, port or scheme change, and neither does this. But `http.extraHeader`, which is what an `Authorizer`-supplied header amounts to, *is* forwarded by Git to arbitrary hosts across a redirect. go-git now drops it.

A unicode hostname and its punycode are different origins here, so a redirect that only respells the host loses the credential and surfaces as `ErrAuthenticationRequired`. Git and curl keep it, because they convert to punycode when parsing the URL rather than when comparing. Normalising at parse time is the better fix, but it changes `Endpoint.Host`, error text and what `remote.Config().URLs` round-trips, so it does not belong here.

Allowing credentials across an http to https upgrade goes the other way, and departs from curl, Git and Fetch, which all count scheme as part of host identity. Auth is sent pre-emptively, so an http origin has already spent its credential in cleartext before any redirect exists.

### Tests

The origin comparison, including hosts where Unicode case-folding would merge two names that resolve to different servers; redirects within and across an origin; multi-hop chains; interaction with a caller-supplied `CheckRedirect`; and a redirected `git-upload-pack` POST on both sides of the origin boundary under `FollowRedirects: "true"`, where a 307 preserves method and body.
