### PR TITLE
[v5] plumbing: transport/http, Contain credentials across redirects

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -73,7 +75,7 @@ func advertisedReferences(ctx context.Context, s *session, serviceName string) (
 		s.endpoint.String(), infoRefsPath, serviceName,
 	)
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := newRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -455,14 +457,73 @@ func wrapCheckRedirect(policy RedirectPolicy, next func(*http.Request, []*http.R
 	}
 }
 
+// redactedURL returns the string form of u with the userinfo password
+// replaced, for use in error messages. (*url.URL).String() renders the
+// password verbatim, and request URLs are built from the endpoint, which
+// carries whatever credentials the caller put in the clone URL.
+func redactedURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	if u.User == nil {
+		return u.String()
+	}
+	if _, hasPassword := u.User.Password(); !hasPassword {
+		return u.String()
+	}
+	redacted := *u
+	redacted.User = url.UserPassword(u.User.Username(), "REDACTED")
+	return redacted.String()
+}
+
+// redactedRawURL is redactedURL for a string that may not parse. Request URLs
+// are assembled from Endpoint.String(), which re-emits Endpoint.Path raw, so a
+// path holding a stray percent produces a string url.Parse rejects. url.Parse
+// reports the input verbatim and applies no redaction of its own; only
+// http.Client strips a password, and only from errors it raises itself.
+func redactedRawURL(raw string) string {
+	i := strings.Index(raw, "://")
+	if i < 0 {
+		return raw
+	}
+	authority := raw[i+3:]
+	if end := strings.IndexByte(authority, '/'); end >= 0 {
+		authority = authority[:end]
+	}
+	at := strings.LastIndexByte(authority, '@')
+	if at < 0 {
+		return raw
+	}
+	colon := strings.IndexByte(authority[:at], ':')
+	if colon < 0 {
+		// Username only, left alone, as redactedURL leaves it.
+		return raw
+	}
+	return raw[:i+3+colon+1] + "REDACTED" + raw[i+3+at:]
+}
+
+// newRequest wraps http.NewRequest so that a URL it cannot parse does not
+// reach the caller with the endpoint's credentials still in it.
+func newRequest(method, rawURL string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, rawURL, body)
+	if err != nil {
+		var uerr *url.Error
+		if errors.As(err, &uerr) {
+			uerr.URL = redactedRawURL(uerr.URL)
+		}
+		return nil, err
+	}
+	return req, nil
+}
+
 func checkRedirect(req *http.Request, via []*http.Request, policy RedirectPolicy) error {
 	switch policy {
 	case FollowRedirects:
 	case NoFollowRedirects:
-		return fmt.Errorf("http redirect: redirects disabled to %s", req.URL)
+		return fmt.Errorf("http redirect: redirects disabled to %s", redactedURL(req.URL))
 	case "", FollowInitialRedirects:
 		if !isInitialRequest(req) {
-			return fmt.Errorf("http redirect: redirect on non-initial request to %s", req.URL)
+			return fmt.Errorf("http redirect: redirect on non-initial request to %s", redactedURL(req.URL))
 		}
 	default:
 		return fmt.Errorf("http redirect: invalid redirect policy %q", policy)
@@ -598,6 +659,6 @@ func (e *Err) StatusCode() int {
 
 func (e *Err) Error() string {
 	return fmt.Sprintf("unexpected requesting %q status code: %d",
-		e.Response.Request.URL, e.Response.StatusCode,
+		redactedURL(e.Response.Request.URL), e.Response.StatusCode,
 	)
 }

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -9,7 +9,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -372,11 +374,20 @@ func (s *session) ModifyEndpointIfRedirect(res *http.Response) error {
 	if !strings.HasSuffix(r.URL.Path, infoRefsPath) {
 		return fmt.Errorf("http redirect: target %q does not end with %s", r.URL.Path, infoRefsPath)
 	}
-	if r.URL.Scheme != "http" && r.URL.Scheme != "https" {
+	// A scheme is case-insensitive per RFC 3986, and checkRedirect folds case
+	// when it reads the same hop, so fold here too rather than reject a
+	// spelling that check let through. url.Parse and transport.NewEndpoint
+	// both lowercase what they parse, so only a hand-built URL or Endpoint
+	// arrives uppercased. The folded form is what gets stored below, so every
+	// later request built from the endpoint carries the canonical spelling.
+	scheme := strings.ToLower(r.URL.Scheme)
+	if scheme != "http" && scheme != "https" {
 		return fmt.Errorf("http redirect: unsupported scheme %q", r.URL.Scheme)
 	}
-	if r.URL.Scheme != s.endpoint.Protocol &&
-		!(s.endpoint.Protocol == "http" && r.URL.Scheme == "https") {
+	// schemeUpgrade rather than an inline comparison, so the one cross-scheme
+	// change go-git permits has a single definition shared with
+	// credentialsMayFollow.
+	if !strings.EqualFold(scheme, s.endpoint.Protocol) && !schemeUpgrade(s.endpoint.Protocol, scheme) {
 		return fmt.Errorf("http redirect: changes scheme from %q to %q", s.endpoint.Protocol, r.URL.Scheme)
 	}
 
@@ -386,7 +397,20 @@ func (s *session) ModifyEndpointIfRedirect(res *http.Response) error {
 		return err
 	}
 
-	if host != s.endpoint.Host || effectivePort(r.URL.Scheme, port) != effectivePort(s.endpoint.Protocol, s.endpoint.Port) {
+	// The session stores the endpoint and re-applies its credentials on every
+	// later request, so clear them once the redirect has left the origin they
+	// were issued for. This uses the same predicate as stripCredentials, so
+	// both halves share one definition of an origin.
+	//
+	// The two are deliberately asymmetric in one respect: stripCredentials is
+	// sticky over the whole chain, so an origin -> evil -> origin redirect
+	// leaves the discovery GET's later hops unauthenticated even though the
+	// chain returned home. This compares the endpoint only against the final
+	// URL, so the same round trip leaves the session authenticated. That is
+	// not a leak - the final URL's origin is the original one - but it means
+	// such a chain can make the discovery GET anonymous while the session's
+	// POSTs are authenticated, which can surface as a confusing 401.
+	if !credentialsMayFollow(endpointURL(s.endpoint), r.URL) {
 		s.endpoint.User = ""
 		s.endpoint.Password = ""
 		s.auth = nil
@@ -395,7 +419,7 @@ func (s *session) ModifyEndpointIfRedirect(res *http.Response) error {
 	s.endpoint.Host = host
 	s.endpoint.Port = port
 
-	s.endpoint.Protocol = r.URL.Scheme
+	s.endpoint.Protocol = scheme
 	s.endpoint.Path = r.URL.Path[:len(r.URL.Path)-len(infoRefsPath)]
 	return nil
 }
@@ -421,19 +445,132 @@ func endpointPort(port string) (int, error) {
 	return parsed, nil
 }
 
-func effectivePort(scheme string, port int) int {
-	if port != 0 {
-		return port
-	}
+// schemeUpgrade reports whether the scheme transition from one URL to another
+// is the one cross-scheme change go-git permits: a plain-http origin upgrading
+// to https. It strictly improves confidentiality and is how servers steer
+// clients off cleartext.
+//
+// Permitting it at all is a deliberate deviation: curl, git and the Fetch
+// standard all count scheme as part of host identity and drop credentials on
+// the upgrade. Auth is sent pre-emptively here, so an http origin has already
+// spent its credential in cleartext on the first request and refusing the
+// upgrade would break the clone without unspending it. The host is unchanged,
+// where an on-path attacker needs a valid certificate to receive anything.
+func schemeUpgrade(from, to string) bool {
+	return strings.EqualFold(from, "http") && strings.EqualFold(to, "https")
+}
 
-	switch strings.ToLower(scheme) {
-	case "http":
-		return 80
-	case "https":
-		return 443
-	default:
-		return 0
+// canonicalHost returns u's hostname in the form origins are compared in.
+//
+// An address literal is normalised by netip, so the many spellings of one
+// address are one origin. Two literals are the same origin exactly when netip
+// parses them to the same Addr, which is also how the WHATWG URL Standard
+// compares hosts. An IPv4-mapped literal is deliberately not unmapped onto
+// the IPv4 it dials: reaching the same endpoint is not the same authority,
+// since net/http sends the literal as written in Host and a server may route
+// the two spellings to different virtual hosts.
+//
+// netip also keeps a scope zone verbatim, which is what origin comparison
+// needs: net resolves a zone to an interface by exact name, so folding %eth0
+// onto %ETH0 would call two hosts the same origin that net dials down
+// different interfaces.
+//
+// A registered name is ASCII-lowercased. That fold is the only liberty taken;
+// every other difference in spelling is a different origin.
+//
+// A trailing root dot is one such difference and is kept, for the same reason
+// as the IPv4-mapped literal: curl and the WHATWG URL Standard both hold
+// "example.com." and "example.com" to be distinct hosts, and although
+// crypto/tls and crypto/x509 fold the dot when they authenticate the peer,
+// net/http sends the name as written in Host.
+//
+// The fold is deliberately ASCII-only. strings.ToLower and strings.EqualFold
+// apply Unicode case mapping, which folds U+03C2 onto U+03C3 and so would
+// call two hosts the same origin when they resolve to different servers. An
+// ASCII-only fold cannot merge two names DNS keeps apart.
+//
+// No IDNA mapping is applied either, so a unicode hostname is a different
+// origin from the punycode encoding of it, and from another Unicode case of
+// itself, even though all three reach the same server. Mapping through
+// golang.org/x/net/idna would join them, but it can only widen this equality,
+// never narrow it, so leaving it out can cost a credential across such a
+// redirect and cannot forward one. Against that cost, go-git pins x/net while
+// net/http uses the copy vendored into the toolchain: the two are versioned
+// separately, so a release that moves the Unicode tables under one and not
+// the other would have this merge origins net/http still dials apart. That is
+// the failure this comparison exists to prevent, and comparing bytes has no
+// such mode.
+func canonicalHost(u *url.URL) string {
+	host := u.Hostname()
+	if addr, err := netip.ParseAddr(host); err == nil {
+		return addr.String()
 	}
+	b := []byte(host)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 'a' - 'A'
+		}
+	}
+	return string(b)
+}
+
+// effectivePort returns u's port as the connection will use it: the scheme's
+// well-known port when the URL does not spell one out, and without leading
+// zeroes, so "https://x", "https://x:443" and "https://x:0443" all agree.
+func effectivePort(u *url.URL) string {
+	port := u.Port()
+	if port == "" {
+		switch strings.ToLower(u.Scheme) {
+		case "http":
+			return "80"
+		case "https":
+			return "443"
+		default:
+			return ""
+		}
+	}
+	if trimmed := strings.TrimLeft(port, "0"); trimmed != "" {
+		return trimmed
+	}
+	return "0"
+}
+
+// credentialsMayFollow reports whether credentials issued for one URL may be
+// sent to another.
+//
+// The relation is deliberately asymmetric: scheme, host and effective port
+// must all match, except that a plain http origin may upgrade to https on the
+// same host (see schemeUpgrade). That exception is confined to the two
+// default ports: 80 to 443 is the upgrade servers actually steer clients
+// through, whereas a non-default port carries no such convention, so
+// http://host:8080 to https://host:8443 is a move to another origin like any
+// other port change.
+//
+// Host matching is exact. Unlike Go's http.Client, which forwards credentials
+// from a host to any subdomain of it, a subdomain is a different origin here —
+// matching canonical git and libcurl.
+func credentialsMayFollow(from, to *url.URL) bool {
+	if canonicalHost(from) != canonicalHost(to) {
+		return false
+	}
+	if strings.EqualFold(from.Scheme, to.Scheme) {
+		return effectivePort(from) == effectivePort(to)
+	}
+	return schemeUpgrade(from.Scheme, to.Scheme) &&
+		effectivePort(from) == "80" && effectivePort(to) == "443"
+}
+
+// endpointURL renders an Endpoint's origin as a URL, so that the session's
+// credential clearing and the per-hop stripping share one definition of an
+// origin and cannot drift apart.
+func endpointURL(ep *transport.Endpoint) *url.URL {
+	host := strings.Trim(ep.Host, "[]")
+	if ep.Port != 0 {
+		host = net.JoinHostPort(host, strconv.Itoa(ep.Port))
+	} else if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	return &url.URL{Scheme: ep.Protocol, Host: host}
 }
 
 func (c *client) cloneHTTPClient(transport http.RoundTripper) *http.Client {

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -181,6 +181,24 @@ func NewClient(c *http.Client) transport.Transport {
 // and other custom options specific to the client.
 // If the net/http client is nil or empty, it will use a net/http client configured
 // with http.DefaultTransport.
+//
+// Credentials this client adds where the transport cannot see them are not
+// subject to the redirect stripping described on AuthMethod: a RoundTripper
+// injects after the hop is decided, and Client.Jar is consulted after
+// CheckRedirect, so a domain cookie still follows a redirect to a subdomain
+// the transport counts as another origin. Apply them in an AuthMethod instead
+// if that is not wanted. A CheckRedirect hook set on this client runs
+// alongside the transport's own, but any header it adds when a redirect
+// leaves the repository's origin is discarded the same way.
+//
+// A RoundTripper is therefore also how to authenticate to a new origin a
+// redirect has moved the repository to: match on the request URL and inject
+// the credential only for that origin, so it is not sent anywhere else. The
+// transport keeps its own CheckRedirect on the copy it makes of this client,
+// so the policy and the origin checks still apply.
+//
+// None of this applies to a RoundTripper that follows redirects itself:
+// CheckRedirect is not consulted then, so no stripping happens at all.
 func NewClientWithOptions(c *http.Client, opts *ClientOptions) transport.Transport {
 	if c == nil {
 		c = &http.Client{
@@ -587,11 +605,107 @@ func wrapCheckRedirect(policy RedirectPolicy, next func(*http.Request, []*http.R
 		if err := checkRedirect(req, via, policy); err != nil {
 			return err
 		}
+		// Strip before the caller's hook so it observes what will actually
+		// be sent, and again afterwards so a hook of the common "preserve
+		// my headers across redirects" shape - which copies from via[0],
+		// the original unsanitized request - cannot reinstate them.
+		// Carrying credentials across an origin boundary is deliberately
+		// unsupported.
+		stripCredentials(req, via)
 		if next != nil {
-			return next(req, via)
+			if err := next(req, via); err != nil {
+				return err
+			}
 		}
+		stripCredentials(req, via)
 		return nil
 	}
+}
+
+// safeHeaders lists the headers go-git sets itself, none of which can carry a
+// caller credential. stripCredentials keeps only these when a redirect leaves
+// the credential's origin. Adding a name here makes it forwardable across an
+// origin boundary - do not add anything a caller can put a secret in.
+//
+// This narrows rather than eliminates the exposure: an AuthMethod that writes
+// a credential into one of these names directly - for example
+// Header.Set("User-Agent", "token "+secret) - still survives a cross-origin
+// redirect. Such a value is also sent to the origin and to any proxy in path,
+// so it should not be placed there whether or not a redirect follows.
+var safeHeaders = map[string]struct{}{
+	"User-Agent":     {},
+	"Host":           {},
+	"Accept":         {},
+	"Content-Type":   {},
+	"Content-Length": {},
+}
+
+func filterHeaders(h http.Header) http.Header {
+	filtered := make(http.Header)
+	for key, values := range h {
+		if _, ok := safeHeaders[http.CanonicalHeaderKey(key)]; ok {
+			filtered[key] = values
+		}
+	}
+	return filtered
+}
+
+// stripCredentials removes credentials from req once the redirect chain has
+// left the origin of the original, credential-bearing request.
+//
+// CheckRedirect is the only hook that runs while a redirected request's
+// headers are still mutable: http.Client.Do performs the entire chain
+// internally, so anything the transport does after Do returns - including
+// ModifyEndpointIfRedirect - is too late for the hops themselves.
+//
+// Two subtleties:
+//
+//   - net/http rebuilds every redirect request from the original request's
+//     headers before calling this, so a header removed at one hop reappears
+//     at the next. The decision is therefore recomputed per hop.
+//   - The decision is sticky: once the chain has left the origin, credentials
+//     stay gone even if a later hop returns to it. Stickiness is derived from
+//     via rather than stored, because this closure is shared across a
+//     session's requests.
+//
+// Stripping keeps only the headers go-git sets itself (safeHeaders). An
+// allowlist is used rather than a list of credential header names because
+// caller credentials arrive under names that cannot be enumerated -
+// PRIVATE-TOKEN, X-Api-Key, gateway headers - which is exactly what
+// net/http's fixed list of sensitive header names gets wrong. It is also
+// immune to header-name canonicalisation: an AuthMethod that writes a raw map
+// key is still removed.
+func stripCredentials(req *http.Request, via []*http.Request) {
+	if len(via) == 0 {
+		return
+	}
+	// net/http sets a URL on every request it builds, and req.URL is non-nil
+	// by construction: checkRedirect dereferences req.URL.Scheme on each path
+	// that returns nil, so it runs first or not at all. This nil check and
+	// the two in crossedOrigin are defensive, against a synthetic caller.
+	// Each treats a URL it cannot read as an origin crossing; removing one
+	// panics in canonicalHost rather than leaking.
+	if origin := via[0].URL; origin != nil && !crossedOrigin(origin, req, via) {
+		return
+	}
+	req.Header = filterHeaders(req.Header)
+	if req.URL != nil {
+		req.URL.User = nil
+	}
+}
+
+// crossedOrigin reports whether any hop so far, including the pending one, has
+// left origin.
+func crossedOrigin(origin *url.URL, req *http.Request, via []*http.Request) bool {
+	if req.URL == nil || !credentialsMayFollow(origin, req.URL) {
+		return true
+	}
+	for _, prev := range via[1:] {
+		if prev.URL == nil || !credentialsMayFollow(origin, prev.URL) {
+			return true
+		}
+	}
+	return false
 }
 
 // redactedURL returns the string form of u with the userinfo password
@@ -713,6 +827,17 @@ func (*session) Close() error {
 }
 
 // AuthMethod is concrete implementation of common.AuthMethod for HTTP services
+//
+// Headers SetAuth adds are dropped when a redirect leaves the repository's
+// origin: only the headers the transport sets itself survive that boundary.
+// This applies to non-credential headers too, so an implementation that adds a
+// trace or tenant header loses it on such a hop.
+//
+// That filter matches header names, not values. An implementation that writes
+// a credential into a name the transport also uses - User-Agent, Host, Accept,
+// Content-Type, Content-Length - has that value carried across the boundary
+// with the name. Such a credential is also sent to the origin and to any proxy
+// in path, so it should not be placed there whether or not a redirect follows.
 type AuthMethod interface {
 	transport.AuthMethod
 	SetAuth(r *http.Request)

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -517,6 +517,37 @@ func newRequest(method, rawURL string, body io.Reader) (*http.Request, error) {
 }
 
 func checkRedirect(req *http.Request, via []*http.Request, policy RedirectPolicy) error {
+	// CheckRedirect is the only hook that runs before the next hop leaves
+	// the client. ModifyEndpointIfRedirect inspects the chain after
+	// client.Do has followed all of it, so a hop rejected there has already
+	// carried the request headers to its server.
+	//
+	// The wording matches the message ModifyEndpointIfRedirect produces for
+	// the same hop, which this check reaches first.
+	if len(via) != 0 {
+		// A hop whose scheme cannot be read cannot be shown not to have been
+		// https, so it is assumed to have been, and a cleartext target is
+		// rejected. Skipping the comparison instead would let an
+		// undeterminable hop turn the check off, which is the wrong default
+		// for a credential control; crossedOrigin fails closed the same way.
+		// An empty scheme is as unreadable as a nil URL, so both take the
+		// assumed-https default.
+		//
+		// The comparisons fold case because a scheme is case-insensitive per
+		// RFC 3986. net/url lowercases what it parses, so only a hand-built
+		// URL reaches here uppercased - the same synthetic caller the nil
+		// checks guard against - and for that caller "HTTPS" to "http" is
+		// still a downgrade.
+		prevScheme := "https"
+		if prev := via[len(via)-1]; prev.URL != nil && prev.URL.Scheme != "" {
+			prevScheme = prev.URL.Scheme
+		}
+		if strings.EqualFold(prevScheme, "https") && strings.EqualFold(req.URL.Scheme, "http") {
+			return fmt.Errorf("http redirect: changes scheme from %q to %q: %s",
+				prevScheme, req.URL.Scheme, redactedURL(req.URL))
+		}
+	}
+
 	switch policy {
 	case FollowRedirects:
 	case NoFollowRedirects:
@@ -528,7 +559,10 @@ func checkRedirect(req *http.Request, via []*http.Request, policy RedirectPolicy
 	default:
 		return fmt.Errorf("http redirect: invalid redirect policy %q", policy)
 	}
-	if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+	// Folded for the same reason as the guard above: a scheme is
+	// case-insensitive per RFC 3986, so a spelling the downgrade check read
+	// as https must not be rejected here as a scheme go-git cannot speak.
+	if !strings.EqualFold(req.URL.Scheme, "http") && !strings.EqualFold(req.URL.Scheme, "https") {
 		return fmt.Errorf("http redirect: unsupported scheme %q", req.URL.Scheme)
 	}
 	if len(via) >= 10 {

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -184,7 +185,10 @@ func (s *ClientSuite) Test_newSessionWrapsCustomClientRedirectPolicy(c *C) {
 	c.Assert(session.client, Not(Equals), customClient)
 	c.Assert(session.client.Transport, Equals, customTransport)
 
-	target, err := url.Parse("http://example.com/repo.git")
+	// https: the via entry below has no URL, and the scheme guard treats an
+	// unreadable hop as possibly-https, so a cleartext target would be
+	// rejected before the wrapped policy ran.
+	target, err := url.Parse("https://example.com/repo.git")
 	c.Assert(err, IsNil)
 
 	req := (&http.Request{URL: target, Header: http.Header{}}).WithContext(withInitialRequest(context.Background()))
@@ -421,7 +425,15 @@ func (s *ClientSuite) TestCheckRedirectPolicy(c *C) {
 		targetURL     string
 		initial       bool
 		redirectCount int
-		err           string
+		via           []string
+		// viaURLs holds hop URLs built by hand, for shapes url.Parse cannot
+		// produce: it lowercases the scheme it parses, so an uppercased hop
+		// only reaches checkRedirect from a caller that assembles the URL
+		// itself. Takes precedence over via.
+		viaURLs []*url.URL
+		// targetURLValue is targetURL built by hand, for the same reason.
+		targetURLValue *url.URL
+		err            string
 	}{
 		{
 			name:      "initial blocks non-initial request",
@@ -455,12 +467,89 @@ func (s *ClientSuite) TestCheckRedirectPolicy(c *C) {
 			err:       ".*unsupported scheme.*",
 		},
 		{
+			// https, so the scheme guard does not reject the chain before
+			// the count is reached: these via entries have no URL, which
+			// the guard treats as possibly-https.
 			name:          "blocks too many redirects",
 			policy:        FollowRedirects,
-			targetURL:     "http://example.com/repo.git",
+			targetURL:     "https://example.com/repo.git",
 			initial:       true,
 			redirectCount: 10,
 			err:           ".*too many redirects.*",
+		},
+		{
+			name:          "blocks a cleartext target after an unreadable hop",
+			policy:        FollowRedirects,
+			targetURL:     "http://example.com/repo.git",
+			initial:       true,
+			redirectCount: 1,
+			err:           ".*changes scheme from \"https\" to \"http\".*",
+		},
+		{
+			name:      "blocks https to http downgrade",
+			policy:    FollowRedirects,
+			targetURL: "http://example.com/repo.git",
+			initial:   true,
+			via:       []string{"https://example.com/repo.git"},
+			err:       ".*changes scheme from \"https\" to \"http\".*",
+		},
+		{
+			// A hop carrying a URL with no scheme is as unreadable as one
+			// carrying no URL, so it takes the same assumed-https default
+			// rather than turning the guard off.
+			name:      "blocks a cleartext target after a schemeless hop",
+			policy:    FollowRedirects,
+			targetURL: "http://example.com/repo.git",
+			initial:   true,
+			via:       []string{"//example.com/repo.git"},
+			err:       ".*changes scheme from \"https\" to \"http\".*",
+		},
+		{
+			// Schemes are case-insensitive, so an uppercased previous hop is
+			// still https and the downgrade is still a downgrade.
+			name:      "blocks a downgrade from an uppercased hop scheme",
+			policy:    FollowRedirects,
+			targetURL: "http://example.com/repo.git",
+			initial:   true,
+			viaURLs:   []*url.URL{{Scheme: "HTTPS", Host: "example.com", Path: "/repo.git"}},
+			err:       ".*changes scheme from \"HTTPS\" to \"http\".*",
+		},
+		{
+			// The mirror case: the target's spelling is folded too, so an
+			// uppercased cleartext target is still a downgrade.
+			name:           "blocks a downgrade to an uppercased target scheme",
+			policy:         FollowRedirects,
+			targetURLValue: &url.URL{Scheme: "HTTP", Host: "example.com", Path: "/repo.git"},
+			initial:        true,
+			via:            []string{"https://example.com/repo.git"},
+			err:            ".*changes scheme from \"https\" to \"HTTP\".*",
+		},
+		{
+			// The unsupported-scheme check folds on the same footing as the
+			// downgrade guard, so a scheme go-git does speak is not rejected
+			// for the case it is spelled in.
+			name:           "allows an uppercased target scheme",
+			policy:         FollowRedirects,
+			targetURLValue: &url.URL{Scheme: "HTTPS", Host: "example.com", Path: "/repo.git"},
+			initial:        true,
+			via:            []string{"https://example.com/repo.git"},
+		},
+		{
+			name:      "allows http to https upgrade",
+			policy:    FollowRedirects,
+			targetURL: "https://example.com/repo.git",
+			initial:   true,
+			via:       []string{"http://example.com/repo.git"},
+		},
+		{
+			// The target of a downgrade is attacker-supplied and can carry
+			// its own userinfo, so this message needs redacting too.
+			name:      "redacts credentials in the downgrade error",
+			policy:    FollowRedirects,
+			targetURL: "http://user:pass@example.com/repo.git",
+			initial:   true,
+			via:       []string{"https://example.com/repo.git"},
+			err:       ".*user:REDACTED@example.com.*",
 		},
 		{
 			name:      "redacts credentials in redirect errors",
@@ -485,8 +574,12 @@ func (s *ClientSuite) TestCheckRedirectPolicy(c *C) {
 	}
 
 	for _, tt := range tests {
-		target, err := url.Parse(tt.targetURL)
-		c.Assert(err, IsNil)
+		target := tt.targetURLValue
+		if target == nil {
+			parsed, err := url.Parse(tt.targetURL)
+			c.Assert(err, IsNil)
+			target = parsed
+		}
 
 		req := &http.Request{URL: target, Header: http.Header{}}
 		if tt.initial {
@@ -499,14 +592,169 @@ func (s *ClientSuite) TestCheckRedirectPolicy(c *C) {
 		for i := range via {
 			via[i] = &http.Request{}
 		}
+		switch {
+		case len(tt.viaURLs) != 0:
+			via = make([]*http.Request, 0, len(tt.viaURLs))
+			for _, u := range tt.viaURLs {
+				via = append(via, &http.Request{URL: u})
+			}
+		case len(tt.via) != 0:
+			via = make([]*http.Request, 0, len(tt.via))
+			for _, rawURL := range tt.via {
+				u, err := url.Parse(rawURL)
+				c.Assert(err, IsNil)
+				via = append(via, &http.Request{URL: u})
+			}
+		}
 
-		err = checkRedirect(req, via, tt.policy)
+		err := checkRedirect(req, via, tt.policy)
 		if tt.err != "" {
 			c.Assert(err, ErrorMatches, tt.err, Commentf(tt.name))
 			continue
 		}
 		c.Assert(err, IsNil, Commentf(tt.name))
 	}
+}
+
+// schemeProbe maps virtual host:port pairs onto real test listeners. Plaintext
+// dials and TLS dials go through separate functions, so a request that reaches
+// a server through DialContext demonstrably travelled unencrypted; that is the
+// property under test, and it cannot be read off a URL string.
+type schemeProbe struct {
+	mu        sync.Mutex
+	listeners map[string]string
+	dialed    []string
+	plainAuth []string
+	servers   []*httptest.Server
+}
+
+// close shuts the probe's listeners down. gocheck has no t.Cleanup, so every
+// test using a probe must defer this or leak an accept goroutine per server.
+func (p *schemeProbe) close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, srv := range p.servers {
+		srv.Close()
+	}
+	p.servers = nil
+}
+
+func newSchemeProbe() *schemeProbe {
+	return &schemeProbe{listeners: make(map[string]string)}
+}
+
+func (p *schemeProbe) dial(ctx context.Context, network, addr string) (net.Conn, error) {
+	p.mu.Lock()
+	target, ok := p.listeners[addr]
+	p.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("no listener mapped for %q", addr)
+	}
+
+	var d net.Dialer
+	return d.DialContext(ctx, network, target)
+}
+
+func (p *schemeProbe) client() *http.Client {
+	return &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			p.mu.Lock()
+			p.dialed = append(p.dialed, addr)
+			p.mu.Unlock()
+			return p.dial(ctx, network, addr)
+		},
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := p.dial(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				return nil, err
+			}
+			return tlsConn, nil
+		},
+	}}
+}
+
+// serve starts a listener and publishes it as host on the scheme's default
+// port, returning the base URL to address it by.
+func (p *schemeProbe) serve(c *C, host string, secure bool, h http.HandlerFunc) string {
+	var srv *httptest.Server
+	scheme, port := "http", "80"
+	if secure {
+		srv = httptest.NewTLSServer(h)
+		scheme, port = "https", "443"
+	} else {
+		srv = httptest.NewServer(h)
+	}
+	c.Assert(srv, NotNil)
+
+	u, err := url.Parse(srv.URL)
+	c.Assert(err, IsNil)
+
+	p.mu.Lock()
+	p.listeners[net.JoinHostPort(host, port)] = u.Host
+	p.servers = append(p.servers, srv)
+	p.mu.Unlock()
+
+	return scheme + "://" + host
+}
+
+// uploadPackAdvertisement is a decodable advertisement, so a redirect chain
+// that is not blocked completes and returns no error at all.
+func uploadPackAdvertisement() string {
+	pkt := func(s string) string { return fmt.Sprintf("%04x%s", len(s)+4, s) }
+	return pkt("# service=git-upload-pack\n") + "0000" +
+		pkt("6ecf0ef2c2dffb796033e5a02219af86ec6584e5 HEAD\x00multi_ack\n") +
+		pkt("6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/master\n") +
+		"0000"
+}
+
+func (s *ClientSuite) TestCheckRedirectBlocksDowngradeBeforeTheHop(c *C) {
+	probe := newSchemeProbe()
+	defer probe.close()
+
+	// Both servers are published on the same virtual host, so the base URLs
+	// are known before either starts and the plaintext handler does not race
+	// the assignment it closes over.
+	const secureBase = "https://example.test"
+	plainBase := probe.serve(c, "example.test", false, func(w http.ResponseWriter, req *http.Request) {
+		probe.mu.Lock()
+		probe.plainAuth = append(probe.plainAuth, req.Header.Get("Authorization"))
+		probe.mu.Unlock()
+
+		// Bounce back to https. ModifyEndpointIfRedirect only compares the
+		// final URL against the endpoint, so it accepts this chain.
+		http.Redirect(w, req, secureBase+"/other.git/info/refs?service=git-upload-pack", http.StatusFound)
+	})
+	c.Assert(probe.serve(c, "example.test", true, func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/repo.git/info/refs" {
+			http.Redirect(w, req, plainBase+"/repo.git/info/refs?service=git-upload-pack", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		_, _ = w.Write([]byte(uploadPackAdvertisement()))
+	}), Equals, secureBase)
+
+	ep, err := transport.NewEndpoint(secureBase + "/repo.git")
+	c.Assert(err, IsNil)
+
+	cl := NewClientWithOptions(probe.client(), &ClientOptions{})
+	sess, err := cl.NewUploadPackSession(ep, &BasicAuth{Username: "user", Password: "pass"})
+	c.Assert(err, IsNil)
+	defer sess.Close() //nolint:errcheck
+
+	_, err = sess.AdvertisedReferencesContext(context.Background())
+
+	// c.Check, not c.Assert: a regression in the guard must still report
+	// whether the credential reached the wire, which is what this harness
+	// exists to observe. c.Assert would abort before those two lines.
+	probe.mu.Lock()
+	defer probe.mu.Unlock()
+	c.Check(err, ErrorMatches, ".*changes scheme from \"https\" to \"http\".*")
+	c.Check(probe.dialed, HasLen, 0)
+	c.Check(probe.plainAuth, HasLen, 0)
 }
 
 func (s *ClientSuite) TestRedactedURL(c *C) {

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/cgi"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"os/exec"
@@ -17,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 
 	fixtures "github.com/go-git/go-git-fixtures/v4"
@@ -461,6 +463,19 @@ func (s *ClientSuite) TestCheckRedirectPolicy(c *C) {
 			err:           ".*too many redirects.*",
 		},
 		{
+			name:      "redacts credentials in redirect errors",
+			policy:    NoFollowRedirects,
+			targetURL: "https://user:pass@example.com/repo.git",
+			initial:   true,
+			err:       ".*https://user:REDACTED@example.com/repo.git.*",
+		},
+		{
+			name:      "redacts credentials on non-initial request",
+			policy:    FollowInitialRedirects,
+			targetURL: "https://user:pass@example.com/repo.git",
+			err:       ".*https://user:REDACTED@example.com/repo.git.*",
+		},
+		{
 			name:      "rejects invalid policy",
 			policy:    RedirectPolicy("bogus"),
 			targetURL: "http://example.com/repo.git",
@@ -492,6 +507,173 @@ func (s *ClientSuite) TestCheckRedirectPolicy(c *C) {
 		}
 		c.Assert(err, IsNil, Commentf(tt.name))
 	}
+}
+
+func (s *ClientSuite) TestRedactedURL(c *C) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   string
+	}{
+		{
+			name:   "redacts the password",
+			rawURL: "https://user:pass@example.com/repo.git",
+			want:   "https://user:REDACTED@example.com/repo.git",
+		},
+		{
+			name:   "redacts an empty password",
+			rawURL: "https://user:@example.com/repo.git",
+			want:   "https://user:REDACTED@example.com/repo.git",
+		},
+		{
+			name:   "leaves a username-only URL alone",
+			rawURL: "https://user@example.com/repo.git",
+			want:   "https://user@example.com/repo.git",
+		},
+		{
+			name:   "leaves a URL without userinfo alone",
+			rawURL: "https://example.com/repo.git",
+			want:   "https://example.com/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		u, err := url.Parse(tt.rawURL)
+		c.Assert(err, IsNil)
+		c.Assert(redactedURL(u), Equals, tt.want, Commentf(tt.name))
+	}
+
+	c.Assert(redactedURL(nil), Equals, "")
+}
+
+func (s *ClientSuite) TestRedactedRawURL(c *C) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "redacts the password",
+			raw:  "https://user:pass@example.com/repo.git",
+			want: "https://user:REDACTED@example.com/repo.git",
+		},
+		{
+			name: "redacts a password the URL parser rejects",
+			raw:  "https://user:pass@example.com/repo%zz.git/info/refs?service=git-upload-pack",
+			want: "https://user:REDACTED@example.com/repo%zz.git/info/refs?service=git-upload-pack",
+		},
+		{
+			name: "leaves a username-only URL alone",
+			raw:  "https://token@example.com/repo.git",
+			want: "https://token@example.com/repo.git",
+		},
+		{
+			name: "leaves a URL without userinfo alone",
+			raw:  "https://example.com/repo.git",
+			want: "https://example.com/repo.git",
+		},
+		{
+			name: "ignores an at sign in the path",
+			raw:  "https://example.com/repo@v2.git",
+			want: "https://example.com/repo@v2.git",
+		},
+		{
+			name: "leaves a string with no scheme alone",
+			raw:  "not a url",
+			want: "not a url",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Check(redactedRawURL(tt.raw), Equals, tt.want, Commentf(tt.name))
+	}
+}
+
+// Endpoint.String() re-emits Endpoint.Path raw, so a path holding a stray
+// percent yields a URL url.Parse rejects - reporting the string, credentials
+// and all. Reachable from a redirect Location, and from the clone URL.
+func (s *ClientSuite) TestNewRequestRedactsUnparseableURL(c *C) {
+	ep, err := transport.NewEndpoint("https://user:pass@example.com/repo.git")
+	c.Assert(err, IsNil)
+	ep.Path = "/repo%zz.git"
+
+	for _, suffix := range []string{
+		infoRefsPath + "?service=git-upload-pack",
+		"/git-upload-pack",
+		"/git-receive-pack",
+	} {
+		_, err := newRequest(http.MethodGet, ep.String()+suffix, nil)
+		c.Assert(err, NotNil, Commentf(suffix))
+		c.Check(err.Error(), Not(Matches), ".*:pass@.*", Commentf(suffix))
+		c.Check(err.Error(), Matches, ".*user:REDACTED@.*", Commentf(suffix))
+	}
+}
+
+// The same three URLs, reached through the calls that build them, so that a
+// call site reverting to http.NewRequest is caught as well as the helper.
+// The URL never parses, so no server is involved.
+func (s *ClientSuite) TestRequestBuildErrorsRedactCredentials(c *C) {
+	newSess := func() *transport.Endpoint {
+		ep, err := transport.NewEndpoint("https://user:pass@example.com/repo.git")
+		c.Assert(err, IsNil)
+		ep.Path = "/repo%zz.git"
+		return ep
+	}
+	check := func(what string, err error) {
+		c.Assert(err, NotNil, Commentf(what))
+		c.Check(err.Error(), Not(Matches), ".*:pass@.*", Commentf(what))
+		c.Check(err.Error(), Matches, ".*user:REDACTED@.*", Commentf(what))
+	}
+
+	up, err := DefaultClient.NewUploadPackSession(newSess(), nil)
+	c.Assert(err, IsNil)
+	defer up.Close() //nolint:errcheck
+
+	_, err = up.AdvertisedReferencesContext(context.Background())
+	check("advertised references", err)
+
+	upr := packp.NewUploadPackRequest()
+	upr.Wants = append(upr.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+	_, err = up.UploadPack(context.Background(), upr)
+	check("upload-pack", err)
+
+	rp, err := DefaultClient.NewReceivePackSession(newSess(), nil)
+	c.Assert(err, IsNil)
+	defer rp.Close() //nolint:errcheck
+
+	rpr := packp.NewReferenceUpdateRequest()
+	rpr.Commands = append(rpr.Commands, &packp.Command{
+		Name: "refs/heads/master",
+		Old:  plumbing.ZeroHash,
+		New:  plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+	})
+	_, err = rp.ReceivePack(context.Background(), rpr)
+	check("receive-pack", err)
+}
+
+func (s *ClientSuite) TestErrErrorRedactsCredentials(c *C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	c.Assert(err, IsNil)
+
+	ep, err := transport.NewEndpoint("http://user:pass@" + u.Host + "/repo.git")
+	c.Assert(err, IsNil)
+
+	sess, err := NewClient(nil).NewUploadPackSession(ep, nil)
+	c.Assert(err, IsNil)
+	defer sess.Close() //nolint:errcheck
+
+	// No redirect is involved: any non-2xx that NewErr does not map to a
+	// sentinel error formats the request URL, which is built from the
+	// endpoint and so carries the caller's credentials.
+	_, err = sess.AdvertisedReferencesContext(context.Background())
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Not(Matches), ".*pass@.*")
+	c.Assert(err.Error(), Matches, ".*user:REDACTED@.*status code: 500.*")
 }
 
 type BaseSuite struct {

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -276,6 +276,70 @@ func (s *ClientSuite) TestModifyEndpointIfRedirect(c *C) {
 	}
 }
 
+// url.Parse lowercases the scheme it parses and transport.NewEndpoint takes
+// Protocol from one, so an uppercased scheme only reaches here from a caller
+// that assembles the URL or the Endpoint itself. A scheme is case-insensitive
+// per RFC 3986, so such a spelling is read for what it means rather than
+// rejected as one go-git cannot speak, and the endpoint keeps the folded form
+// so every later request built from it is spelled canonically.
+func (s *ClientSuite) TestModifyEndpointIfRedirectFoldsSchemeCase(c *C) {
+	tests := []struct {
+		name             string
+		endpoint         *transport.Endpoint
+		redirect         *url.URL
+		expectedProtocol string
+		err              string
+	}{
+		{
+			name:             "uppercased redirect scheme",
+			endpoint:         &transport.Endpoint{Protocol: "https", Host: "example.com"},
+			redirect:         &url.URL{Scheme: "HTTPS", Host: "example.com", Path: "/foo.git" + infoRefsPath},
+			expectedProtocol: "https",
+		},
+		{
+			name:             "uppercased endpoint protocol",
+			endpoint:         &transport.Endpoint{Protocol: "HTTPS", Host: "example.com"},
+			redirect:         &url.URL{Scheme: "https", Host: "example.com", Path: "/foo.git" + infoRefsPath},
+			expectedProtocol: "https",
+		},
+		{
+			name:             "uppercased upgrade from http",
+			endpoint:         &transport.Endpoint{Protocol: "HTTP", Host: "example.com"},
+			redirect:         &url.URL{Scheme: "HTTPS", Host: "example.com", Path: "/foo.git" + infoRefsPath},
+			expectedProtocol: "https",
+		},
+		{
+			name:             "uppercased downgrade to http",
+			endpoint:         &transport.Endpoint{Protocol: "https", Host: "example.com"},
+			redirect:         &url.URL{Scheme: "HTTP", Host: "example.com", Path: "/foo.git" + infoRefsPath},
+			expectedProtocol: "https",
+			err:              ".*changes scheme from \"https\" to \"HTTP\".*",
+		},
+		{
+			// Folding decides how a scheme is spelled, not which ones are
+			// accepted.
+			name:             "uppercased unsupported scheme",
+			endpoint:         &transport.Endpoint{Protocol: "https", Host: "example.com"},
+			redirect:         &url.URL{Scheme: "FILE", Host: "example.com", Path: "/foo.git" + infoRefsPath},
+			expectedProtocol: "https",
+			err:              ".*unsupported scheme \"FILE\".*",
+		},
+	}
+
+	for _, tt := range tests {
+		sess := &session{endpoint: tt.endpoint}
+		err := sess.ModifyEndpointIfRedirect(&http.Response{
+			Request: &http.Request{URL: tt.redirect},
+		})
+		if tt.err != "" {
+			c.Check(err, ErrorMatches, tt.err, Commentf(tt.name))
+		} else {
+			c.Check(err, IsNil, Commentf(tt.name))
+		}
+		c.Check(tt.endpoint.Protocol, Equals, tt.expectedProtocol, Commentf(tt.name))
+	}
+}
+
 func (s *ClientSuite) TestModifyEndpointIfRedirectClearsCredentialsOnCrossHost(c *C) {
 	sess := &session{
 		auth: &BasicAuth{Username: "user", Password: "pass"},
@@ -373,6 +437,21 @@ func (s *ClientSuite) TestModifyEndpointIfRedirectPreservesCredentialsOnEquivale
 			expectedString: "https://user:pass@[2001:db8::1]/new.git",
 		},
 		{
+			name: "http upgraded to https on the same host",
+			endpoint: &transport.Endpoint{
+				Protocol: "http",
+				User:     "user",
+				Password: "pass",
+				Host:     "example.com",
+				Path:     "/old.git",
+			},
+			redirectURL:    "https://example.com/new.git/info/refs",
+			expectedHost:   "example.com",
+			expectedPort:   0,
+			expectedPath:   "/new.git",
+			expectedString: "https://user:pass@example.com/new.git",
+		},
+		{
 			name: "ipv6 mapped address non-default port",
 			endpoint: &transport.Endpoint{
 				Protocol: "https",
@@ -411,6 +490,88 @@ func (s *ClientSuite) TestModifyEndpointIfRedirectPreservesCredentialsOnEquivale
 		c.Assert(sess.endpoint.Path, Equals, tt.expectedPath, Commentf(tt.name))
 		c.Assert(sess.endpoint.String(), Equals, tt.expectedString, Commentf(tt.name))
 	}
+}
+
+func (s *ClientSuite) TestCredentialsMayFollow(c *C) {
+	tests := []struct {
+		name string
+		from string
+		to   string
+		want bool
+	}{
+		{"identical", "https://example.com", "https://example.com", true},
+		{"path differs", "https://example.com/a", "https://example.com/b", true},
+		{"host case folds", "https://Example.COM", "https://example.com", true},
+		{"explicit default port", "https://example.com", "https://example.com:443", true},
+		{"leading zeroes in port", "https://example.com:443", "https://example.com:0443", true},
+		{"http upgrades to https", "http://example.com", "https://example.com", true},
+
+		{"subdomain is a different origin", "https://example.com", "https://sub.example.com", false},
+		{"parent domain is a different origin", "https://sub.example.com", "https://example.com", false},
+		{"different port", "https://example.com", "https://example.com:8443", false},
+		{"https does not downgrade", "https://example.com", "http://example.com", false},
+		{"upgrade from a non-default port", "http://example.com:8080", "https://example.com", false},
+		{"upgrade to a non-default port", "http://example.com", "https://example.com:8443", false},
+		{"unrelated host", "https://example.com", "https://evil.com", false},
+		{"prefix of the host", "https://example.com", "https://example.com.evil.com", false},
+
+		// A trailing root dot reaches the same peer, but net/http sends the
+		// name as written in Host, so the two spellings can be routed to
+		// different virtual hosts. curl and the WHATWG URL Standard keep them
+		// distinct too. A dotted IP literal is kept apart for the same reason,
+		// though it stops parsing as a literal and is compared as a name.
+		{"trailing root dot", "https://example.com", "https://example.com.", false},
+		{"trailing root dot on the left", "https://example.com.", "https://example.com", false},
+		{"ipv4 with a trailing root dot", "http://127.0.0.1/a", "http://127.0.0.1./a", false},
+
+		// An IPv4-mapped literal dials the same endpoint as the IPv4 it wraps,
+		// but net/http sends the literal as written in Host, so the two can
+		// reach different virtual hosts on that endpoint. Same endpoint is not
+		// the same authority, and netip keeps the two Addrs apart.
+		{"ipv4-mapped against the ipv4", "http://[::ffff:127.0.0.1]/a", "http://127.0.0.1/a", false},
+
+		{"ipv6 hex case folds", "https://[2001:DB8::1]", "https://[2001:db8::1]", true},
+		{"ipv6 zone matches itself", "https://[fe80::1%25eth0]", "https://[fe80::1%25eth0]", true},
+
+		// One address has many spellings. netip.ParseAddr is the same call
+		// net's resolver gates on, so these all name the endpoint the dialer
+		// would connect to and are one origin.
+		{"ipv6 compressed against expanded", "http://[::1]:8080/a", "http://[0:0:0:0:0:0:0:1]:8080/a", true},
+		{"ipv6 leading zeroes in a field", "http://[::1]:8080/a", "http://[::0001]:8080/a", true},
+		{"ipv6 hex against dotted-quad tail", "http://[::ffff:7f00:1]/a", "http://[::ffff:127.0.0.1]/a", true},
+
+		// A percent in a registered name is not a scope zone. %25 is the only
+		// escape net/url leaves in a host, so Hostname() really can return
+		// one, and the whole name folds.
+		{"percent in a registered name", "https://foo%25bar.test/a", "https://FOO%25BAR.test/a", true},
+
+		// An IPv6 scope zone names an interface, and net resolves it by exact
+		// name: %eth0 and %ETH0 can be two interfaces carrying the same
+		// link-local address. Folding the zone would let a credential issued
+		// for one cross to the other.
+		{"ipv6 zone case differs", "http://[fe80::1%25eth0]:8080/a", "http://[fe80::1%25ETH0]:8080/a", false},
+		{"ipv6 zone differs", "https://[fe80::1%25eth0]", "https://[fe80::1%25eth1]", false},
+		{"ipv6 zone against none", "http://[fe80::1%25eth0]:8080/a", "http://[fe80::1]:8080/a", false},
+	}
+
+	for _, tt := range tests {
+		from, err := url.Parse(tt.from)
+		c.Assert(err, IsNil, Commentf(tt.name))
+		to, err := url.Parse(tt.to)
+		c.Assert(err, IsNil, Commentf(tt.name))
+		c.Check(credentialsMayFollow(from, to), Equals, tt.want, Commentf(tt.name))
+	}
+
+	// endpointURL takes Endpoint.Protocol verbatim, and nothing lowercases it
+	// on the way in, so the scheme comparison has to fold case itself. Every
+	// URL above comes from url.Parse, which already lowercases the scheme.
+	to, err := url.Parse("https://example.com")
+	c.Assert(err, IsNil)
+	from := endpointURL(&transport.Endpoint{Protocol: "HTTP", Host: "example.com"})
+	c.Check(credentialsMayFollow(from, to), Equals, true)
+
+	// The same on the destination side, which only a hand-built URL reaches.
+	c.Check(credentialsMayFollow(from, &url.URL{Scheme: "HTTPS", Host: "example.com"}), Equals, true)
 }
 
 func cloneEndpoint(ep *transport.Endpoint) *transport.Endpoint {

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -574,6 +574,419 @@ func (s *ClientSuite) TestCredentialsMayFollow(c *C) {
 	c.Check(credentialsMayFollow(from, &url.URL{Scheme: "HTTPS", Host: "example.com"}), Equals, true)
 }
 
+// customHeaderAuth is a third-party AuthMethod that carries its credential in
+// a header name net/http does not treat as sensitive.
+type customHeaderAuth struct {
+	name  string
+	value string
+}
+
+func (a *customHeaderAuth) Name() string   { return "custom-header-auth" }
+func (a *customHeaderAuth) String() string { return "custom-header-auth" }
+
+func (a *customHeaderAuth) SetAuth(r *http.Request) { r.Header.Set(a.name, a.value) }
+
+func (s *ClientSuite) TestStripCredentials(c *C) {
+	const origin = "https://user:pass@example.com/repo.git/info/refs"
+
+	tests := []struct {
+		name string
+		// hops lists the redirect targets in order; the last is the
+		// pending request, the ones before it are hops already taken.
+		hops []string
+		keep bool
+	}{
+		{
+			name: "same origin",
+			hops: []string{"https://example.com/other.git/info/refs"},
+			keep: true,
+		},
+		{
+			name: "same origin with the default port spelled out",
+			hops: []string{"https://example.com:443/other.git/info/refs"},
+			keep: true,
+		},
+		{
+			name: "same origin after another same-origin hop",
+			hops: []string{"https://example.com/a", "https://example.com/b"},
+			keep: true,
+		},
+		{
+			name: "subdomain",
+			hops: []string{"https://sub.example.com/repo.git/info/refs"},
+		},
+		{
+			name: "different port",
+			hops: []string{"https://example.com:8443/repo.git/info/refs"},
+		},
+		{
+			name: "unrelated host",
+			hops: []string{"https://evil.com/repo.git/info/refs"},
+		},
+		{
+			name: "left the origin and came back",
+			hops: []string{"https://evil.com/a", "https://example.com/b"},
+		},
+	}
+
+	for _, tt := range tests {
+		originURL, err := url.Parse(origin)
+		c.Assert(err, IsNil, Commentf(tt.name))
+
+		via := []*http.Request{{URL: originURL}}
+		for _, raw := range tt.hops[:len(tt.hops)-1] {
+			u, err := url.Parse(raw)
+			c.Assert(err, IsNil, Commentf(tt.name))
+			via = append(via, &http.Request{URL: u})
+		}
+
+		target, err := url.Parse(tt.hops[len(tt.hops)-1])
+		c.Assert(err, IsNil, Commentf(tt.name))
+		target.User = url.UserPassword("user", "pass")
+
+		req := &http.Request{URL: target, Header: http.Header{
+			"Authorization": {"Basic dXNlcjpwYXNz"},
+			// A raw, non-canonical map key, as a caller writing
+			// straight into the map would leave it.
+			"PRIVATE-TOKEN": {"glpat-secret"},
+			"User-Agent":    {"go-git/5.x"},
+		}}
+
+		stripCredentials(req, via)
+
+		// go-git's own headers survive either way.
+		c.Assert(req.Header.Get("User-Agent"), Equals, "go-git/5.x", Commentf(tt.name))
+
+		if tt.keep {
+			c.Assert(req.Header.Get("Authorization"), Equals, "Basic dXNlcjpwYXNz", Commentf(tt.name))
+			c.Assert(req.Header["PRIVATE-TOKEN"], HasLen, 1, Commentf(tt.name))
+			c.Assert(req.URL.User, NotNil, Commentf(tt.name))
+			continue
+		}
+
+		c.Assert(req.Header.Get("Authorization"), Equals, "", Commentf(tt.name))
+		c.Assert(req.Header["PRIVATE-TOKEN"], IsNil, Commentf(tt.name))
+		c.Assert(req.URL.User, IsNil, Commentf(tt.name))
+	}
+}
+
+// safeHeaders is the origin boundary: a name added here becomes forwardable
+// to another origin. Pinning the whole map means widening it has to be
+// deliberate rather than a side effect of adding a header elsewhere.
+func (s *ClientSuite) TestSafeHeadersMembership(c *C) {
+	c.Assert(safeHeaders, DeepEquals, map[string]struct{}{
+		"User-Agent":     {},
+		"Host":           {},
+		"Accept":         {},
+		"Content-Type":   {},
+		"Content-Length": {},
+	})
+}
+
+// The allowlist is matched on the canonical form of the name, so a caller
+// writing a raw map key is filtered on the same footing as one using
+// Header.Set. Keys are returned as they were given, which is why this asserts
+// on the map rather than through Header.Get.
+func (s *ClientSuite) TestFilterHeadersMatchesNonCanonicalKeys(c *C) {
+	filtered := filterHeaders(http.Header{
+		"user-agent":    {"go-git/5.x"},
+		"PRIVATE-TOKEN": {"glpat-secret"},
+		"authorization": {"Basic dXNlcjpwYXNz"},
+	})
+	c.Check(filtered["user-agent"], DeepEquals, []string{"go-git/5.x"})
+	c.Check(filtered["PRIVATE-TOKEN"], IsNil)
+	c.Check(filtered["authorization"], IsNil)
+}
+
+// stripCredentials treats a URL it cannot read as an origin crossing, so an
+// undeterminable hop strips rather than panicking or passing.
+func (s *ClientSuite) TestStripCredentialsFailsClosed(c *C) {
+	origin, err := url.Parse("https://example.com/repo.git/info/refs")
+	c.Assert(err, IsNil)
+	target, err := url.Parse("https://example.com/other.git/info/refs")
+	c.Assert(err, IsNil)
+
+	tests := []struct {
+		name string
+		via  []*http.Request
+		req  *http.Request
+	}{
+		{
+			name: "no hops yet",
+			via:  nil,
+			req:  &http.Request{URL: target},
+		},
+		{
+			name: "origin URL unreadable",
+			via:  []*http.Request{{}},
+			req:  &http.Request{URL: target},
+		},
+		{
+			name: "target URL unreadable",
+			via:  []*http.Request{{URL: origin}},
+			req:  &http.Request{},
+		},
+		{
+			name: "intermediate hop unreadable",
+			via:  []*http.Request{{URL: origin}, {}},
+			req:  &http.Request{URL: target},
+		},
+	}
+
+	for _, tt := range tests {
+		req := tt.req
+		req.Header = http.Header{
+			"Authorization": {"Basic dXNlcjpwYXNz"},
+			"User-Agent":    {"go-git/5.x"},
+		}
+
+		// Must not panic.
+		stripCredentials(req, tt.via)
+
+		if len(tt.via) == 0 {
+			// Nothing has been redirected yet, so nothing is stripped.
+			c.Check(req.Header.Get("Authorization"), Equals, "Basic dXNlcjpwYXNz", Commentf(tt.name))
+			continue
+		}
+		c.Check(req.Header.Get("Authorization"), Equals, "", Commentf(tt.name))
+		c.Check(req.Header.Get("User-Agent"), Equals, "go-git/5.x", Commentf(tt.name))
+	}
+}
+
+// A caller's own CheckRedirect hook runs between the two strips, so the common
+// "copy my headers from the original request" shape cannot put them back.
+func (s *ClientSuite) TestStripCredentialsSurvivesCustomRedirectHook(c *C) {
+	originURL, err := url.Parse("https://example.com/repo.git/info/refs")
+	c.Assert(err, IsNil)
+	target, err := url.Parse("https://evil.com/repo.git/info/refs")
+	c.Assert(err, IsNil)
+
+	via := []*http.Request{{
+		URL: originURL,
+		Header: http.Header{
+			"Authorization": {"Basic dXNlcjpwYXNz"},
+			"User-Agent":    {"go-git/5.x"},
+		},
+	}}
+	req := (&http.Request{URL: target, Header: http.Header{
+		"Authorization": {"Basic dXNlcjpwYXNz"},
+		"User-Agent":    {"go-git/5.x"},
+	}}).WithContext(withInitialRequest(context.Background()))
+
+	called := false
+	// observed is what the hook was handed: the strip runs before it, so a
+	// hook that logs or forwards headers rather than replacing them sees the
+	// sanitised set too.
+	observed := "unset"
+	next := func(req *http.Request, via []*http.Request) error {
+		called = true
+		observed = req.Header.Get("Authorization")
+		req.Header = via[0].Header.Clone()
+		return nil
+	}
+
+	err = wrapCheckRedirect(FollowRedirects, next)(req, via)
+	c.Assert(err, IsNil)
+	c.Assert(called, Equals, true)
+	c.Check(observed, Equals, "")
+	c.Check(req.Header.Get("Authorization"), Equals, "")
+	c.Check(req.Header.Get("User-Agent"), Equals, "go-git/5.x")
+}
+
+func (s *ClientSuite) TestCrossOriginRedirectDropsCallerHeaders(c *C) {
+	for _, tt := range []struct {
+		name     string
+		destHost string
+		keep     bool
+	}{
+		{name: "same origin", destHost: "example.test", keep: true},
+		{name: "subdomain", destHost: "sub.example.test"},
+		{name: "unrelated host", destHost: "evil.test"},
+	} {
+		// A function body per case, so each case's listeners are shut down
+		// when it ends rather than accumulating until the test returns.
+		func() {
+			probe := newSchemeProbe()
+			defer probe.close()
+
+			var mu sync.Mutex
+			var seen []http.Header
+			record := func(w http.ResponseWriter, req *http.Request) {
+				mu.Lock()
+				seen = append(seen, req.Header.Clone())
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+				_, _ = w.Write([]byte(uploadPackAdvertisement()))
+			}
+
+			// For the same-origin case the redirect stays on the origin and
+			// only changes path, so there is no second server.
+			sameOrigin := tt.destHost == "example.test"
+			var destBase string
+			if !sameOrigin {
+				destBase = probe.serve(c, tt.destHost, true, record)
+			}
+
+			originBase := probe.serve(c, "example.test", true, func(w http.ResponseWriter, req *http.Request) {
+				if req.URL.Path == "/repo.git/info/refs" {
+					http.Redirect(w, req,
+						destBase+"/other.git/info/refs?service=git-upload-pack",
+						http.StatusFound)
+					return
+				}
+				record(w, req)
+			})
+
+			ep, err := transport.NewEndpoint(originBase + "/repo.git")
+			c.Assert(err, IsNil, Commentf(tt.name))
+
+			cl := NewClientWithOptions(probe.client(), &ClientOptions{})
+			sess, err := cl.NewUploadPackSession(ep, &customHeaderAuth{name: "PRIVATE-TOKEN", value: "glpat-secret"})
+			c.Assert(err, IsNil, Commentf(tt.name))
+
+			_, err = sess.AdvertisedReferencesContext(context.Background())
+			c.Assert(err, IsNil, Commentf(tt.name))
+			c.Assert(sess.Close(), IsNil, Commentf(tt.name))
+
+			mu.Lock()
+			c.Assert(seen, Not(HasLen), 0, Commentf(tt.name))
+			got := seen[len(seen)-1].Get("PRIVATE-TOKEN")
+			mu.Unlock()
+
+			if tt.keep {
+				c.Assert(got, Equals, "glpat-secret", Commentf(tt.name))
+				return
+			}
+			c.Assert(got, Equals, "", Commentf(tt.name))
+		}()
+	}
+}
+
+// Under FollowRedirects a 307 on the upload-pack POST preserves the method and
+// the body, so a credential-bearing request with a body can be redirected too.
+// The same-origin subtest keeps the other honest: it is what shows the POST
+// carries the credential to begin with.
+func (s *ClientSuite) TestCrossOriginPostDropsCallerHeaders(c *C) {
+	for _, tt := range []struct {
+		name     string
+		destHost string
+		keep     bool
+	}{
+		{name: "same origin", destHost: "example.test", keep: true},
+		{name: "unrelated host", destHost: "evil.test"},
+	} {
+		// A function body per case, so each case's listeners are shut down
+		// when it ends rather than accumulating until the test returns.
+		func() {
+			probe := newSchemeProbe()
+			defer probe.close()
+
+			var mu sync.Mutex
+			var postAuth []string
+
+			recordPost := func(w http.ResponseWriter, req *http.Request) {
+				mu.Lock()
+				postAuth = append(postAuth, req.Header.Get("PRIVATE-TOKEN"))
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+				_, _ = w.Write([]byte("0008NAK\n"))
+			}
+
+			sameOrigin := tt.destHost == "example.test"
+			var destBase string
+			if !sameOrigin {
+				destBase = probe.serve(c, tt.destHost, true, recordPost)
+			}
+
+			originBase := probe.serve(c, "example.test", true, func(w http.ResponseWriter, req *http.Request) {
+				switch {
+				case req.URL.Path == "/repo.git/info/refs":
+					w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+					_, _ = w.Write([]byte(uploadPackAdvertisement()))
+				case req.URL.Path == "/repo.git/git-upload-pack":
+					// 307 keeps the method and the body.
+					http.Redirect(w, req, destBase+"/other.git/git-upload-pack", http.StatusTemporaryRedirect)
+				default:
+					recordPost(w, req)
+				}
+			})
+
+			ep, err := transport.NewEndpoint(originBase + "/repo.git")
+			c.Assert(err, IsNil, Commentf(tt.name))
+
+			cl := NewClientWithOptions(probe.client(), &ClientOptions{RedirectPolicy: FollowRedirects})
+			sess, err := cl.NewUploadPackSession(ep, &customHeaderAuth{name: "PRIVATE-TOKEN", value: "glpat-secret"})
+			c.Assert(err, IsNil, Commentf(tt.name))
+
+			_, err = sess.AdvertisedReferencesContext(context.Background())
+			c.Assert(err, IsNil, Commentf(tt.name))
+
+			upr := packp.NewUploadPackRequest()
+			upr.Wants = append(upr.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+			_, err = sess.UploadPack(context.Background(), upr)
+			c.Assert(err, IsNil, Commentf(tt.name))
+			c.Assert(sess.Close(), IsNil, Commentf(tt.name))
+
+			mu.Lock()
+			c.Assert(postAuth, Not(HasLen), 0, Commentf(tt.name))
+			got := postAuth[len(postAuth)-1]
+			mu.Unlock()
+
+			if tt.keep {
+				c.Check(got, Equals, "glpat-secret", Commentf(tt.name))
+				return
+			}
+			c.Check(got, Equals, "", Commentf(tt.name))
+		}()
+	}
+}
+
+// A Location can carry its own userinfo, and net/http's send() turns
+// req.URL.User into an Authorization header on the next hop, after
+// CheckRedirect has returned. Clearing the userinfo is what stops a hop the
+// transport decided must be unauthenticated from going out authenticated with
+// whatever the redirect chose. Nothing reaches req.URL.User by any other
+// route: for an absolute Location, ResolveReference takes the target's
+// userinfo, not the previous URL's.
+func (s *ClientSuite) TestCrossOriginRedirectDropsLocationUserinfo(c *C) {
+	probe := newSchemeProbe()
+	defer probe.close()
+
+	var mu sync.Mutex
+	var seen []string
+
+	destBase := probe.serve(c, "evil.test", true, func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		seen = append(seen, req.Header.Get("Authorization"))
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+		_, _ = w.Write([]byte(uploadPackAdvertisement()))
+	})
+
+	originBase := probe.serve(c, "example.test", true, func(w http.ResponseWriter, req *http.Request) {
+		http.Redirect(w, req,
+			"https://injected:secret@"+destBase[len("https://"):]+"/other.git/info/refs?service=git-upload-pack",
+			http.StatusFound)
+	})
+
+	// Credentials come from the clone URL, with no AuthMethod at all.
+	ep, err := transport.NewEndpoint(originBase[:len("https://")] + "user:pass@" + originBase[len("https://"):] + "/repo.git")
+	c.Assert(err, IsNil)
+
+	cl := NewClientWithOptions(probe.client(), &ClientOptions{})
+	sess, err := cl.NewUploadPackSession(ep, nil)
+	c.Assert(err, IsNil)
+	defer sess.Close() //nolint:errcheck
+
+	_, err = sess.AdvertisedReferencesContext(context.Background())
+	c.Assert(err, IsNil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	c.Assert(seen, HasLen, 1)
+	c.Check(seen[0], Equals, "")
+}
+
 func cloneEndpoint(ep *transport.Endpoint) *transport.Endpoint {
 	cloned := *ep
 	return &cloned
@@ -849,8 +1262,6 @@ func (p *schemeProbe) serve(c *C, host string, secure bool, h http.HandlerFunc) 
 	} else {
 		srv = httptest.NewServer(h)
 	}
-	c.Assert(srv, NotNil)
-
 	u, err := url.Parse(srv.URL)
 	c.Assert(err, IsNil)
 

--- a/plumbing/transport/http/receive_pack.go
+++ b/plumbing/transport/http/receive_pack.go
@@ -88,7 +88,7 @@ func (s *rpSession) doRequest(
 		body = content
 	}
 
-	req, err := http.NewRequest(method, url, body)
+	req, err := newRequest(method, url, body)
 	if err != nil {
 		return nil, plumbing.NewPermanentError(err)
 	}

--- a/plumbing/transport/http/upload_pack.go
+++ b/plumbing/transport/http/upload_pack.go
@@ -86,7 +86,7 @@ func (s *upSession) doRequest(
 		body = content
 	}
 
-	req, err := http.NewRequest(method, url, body)
+	req, err := newRequest(method, url, body)
 	if err != nil {
 		return nil, plumbing.NewPermanentError(err)
 	}


### PR DESCRIPTION
The v5 counterpart of #2355, plus two defects that are v5-only and are not visible in that diff.

---

`checkRedirect` had no scheme comparison. The only rejection lived in `ModifyEndpointIfRedirect`, which runs after `client.Do` has followed the whole chain, so an `https` to `http` hop had already carried the request headers to a plaintext server by the time the error was built. That check also compares only the final URL against the endpoint protocol, so `https -> http -> https` passed through it and returned no error at all. It is called only from `advertisedReferences`, never from the pack POST, so under `FollowRedirects` a downgraded `git-upload-pack` sent the credential *and the request body* in cleartext and also returned no error.

Separately, three error messages formatted a request URL raw, and `(*url.URL).String()` renders the userinfo password verbatim. One of them, `(*Err).Error()`, needs no redirect at all: it fires on any response `NewErr` does not map to a sentinel, and request URLs are built from the endpoint, which carries whatever credentials the clone URL did.

### How hosts compare

Registered names fold on ASCII case only. IP literals go through `netip.ParseAddr`, the same call `net`'s resolver uses to tell a literal from a name, so `[::1]` and `[0:0:0:0:0:0:0:1]` are one origin. Everything else is a different origin, including a trailing root dot and an IPv4-mapped literal against the IPv4 it dials. Both of those reach the same peer, but `net/http` sends the host as written in `Host`, so a server can route the two spellings to different virtual hosts. Same peer is not same authority.

No IDNA mapping is applied. It would only widen the equality, and go-git pins `x/net` in `go.mod` while `net/http` uses the copy vendored into the toolchain. The two are versioned separately, so a release that moved the Unicode tables under one and not the other would have the comparison merge origins `net/http` still dials apart.

`ModifyEndpointIfRedirect` now clears session credentials through the same predicate rather than its own host and port comparison, so the per-hop stripping and the session cannot drift apart on what an origin is. The two stay deliberately asymmetric in one respect, documented at the call site: the strip is sticky over the whole chain, while the session compares only the final URL, so an `origin -> elsewhere -> origin` chain can leave the discovery GET anonymous while the session's POSTs are authenticated.

### Behaviour change

When a redirect leaves the repository's origin, only the headers the transport sets itself are carried over. Headers added by an `AuthMethod` are not, including non-credential ones such as a trace or tenant header. There is deliberately no opt-out: a caller who needs to authenticate to the origin a redirect moved the repository to can inject the credential from a `RoundTripper` on the `*http.Client` passed to `NewClientWithOptions`, scoped to that origin. The transport keeps its own `CheckRedirect` on the client it copies, so the origin checks still apply. `NewClientWithOptions` now documents this, along with `Client.Jar`, which `net/http` consults after `CheckRedirect` and which is therefore outside the stripping too.

Redirect chains that pass through plaintext `http` now error where `https -> http -> https` and `http -> https -> http` previously completed silently. A cross-origin redirect to a private repository now fails at the discovery GET; on servers that hide private repositories this surfaces as `repository not found`, and the error does not mention the redirect.

Two things move the other way. Credentials now survive a same-host `http` to `https` upgrade, which previously dropped them because the endpoint's effective port moved from 80 to 443. Hosts differing only in ASCII case are no longer separate origins. Neither is a security fix; the credential was already spent on the first plaintext request in the upgrade case.

No exported identifier is added, removed, renamed or re-signatured, and `AuthMethod`'s method set is untouched, so this is patch-release safe.

### Deliberate deviations

Git does not carry `credential` authentication across a host, port or scheme change, and neither does this. But `http.extraHeader`, which is what an `AuthMethod`-supplied header amounts to, *is* forwarded by Git to arbitrary hosts across a redirect. go-git now drops it.

A unicode hostname and its punycode are different origins here, so a redirect that only respells the host loses the credential. Git and curl keep it, because they convert to punycode when parsing the URL rather than when comparing. Normalising at parse time is the better fix, but it changes `Endpoint.Host`, error text and what `remote.Config().URLs` round-trips, so it does not belong here.

Allowing credentials across an http to https upgrade goes the other way, and departs from curl, Git and Fetch, which all count scheme as part of host identity. Auth is sent pre-emptively, so an http origin has already spent its credential in cleartext before any redirect exists.

Where this branch differs from #2355, in each case deliberately:

- The downgrade guard reuses the wording `ModifyEndpointIfRedirect` already produced for the same hop, so the text a caller sees for a direct downgrade is unchanged. It gains the target URL, redacted. Because the error now comes from `CheckRedirect` it is wrapped by `net/http` in a `*url.Error`, so equality comparisons against the old string break while substring matches still work.
- The header allowlist has five entries rather than nine. This transport never sends `Git-Protocol`, `Cache-Control`, `Transfer-Encoding` or `Content-Encoding`.
- Error messages keep the existing `http redirect:` prefix.
- `ModifyEndpointIfRedirect` is kept. Its scheme branch is now unreachable through `CheckRedirect`, but it is the only thing that clears the *session* credential, and it still covers a caller-supplied `RoundTripper` that follows redirects itself — which bypasses `CheckRedirect`, and therefore all of the stripping.
- Redaction replaces the password and leaves a username-only URL alone, matching #2355.

Request URLs also reach an error before any of this, without being parsed: `Endpoint.String()` re-emits `Endpoint.Path` raw, so a path holding a stray percent builds a string `url.Parse` rejects and reports verbatim. Only `http.Client` redacts, and only errors it raises itself, so the three `http.NewRequest` calls go through a wrapper that redacts what `url.Parse` hands back. A redirect `Location` can install such a path on the session, and a clone URL can carry one directly.

### Tests

The origin comparison, including hosts where Unicode case-folding would merge two names that resolve to different servers; the redaction helpers and all six sites that reach them; redirects within and across an origin; multi-hop chains and the sticky decision; interaction with a caller-supplied `CheckRedirect`; the header allowlist pinned by membership so widening it has to be deliberate; and a redirected `git-upload-pack` POST on both sides of the origin boundary under `RedirectPolicy: "true"`, where a 307 preserves method and body.

The downgrade is covered end to end with split `DialContext` and `DialTLSContext`, so the assertion is that the plaintext listener was never dialled rather than that the URL looked wrong.
