### PR TITLE
plumbing: format/config, Reject unrepresentable subsection names when encoding

### DIFF
--- a/plumbing/format/config/encoder.go
+++ b/plumbing/format/config/encoder.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -15,6 +16,11 @@ var (
 	subsectionReplacer = strings.NewReplacer(`"`, `\"`, `\`, `\\`)
 	valueReplacer      = strings.NewReplacer(`"`, `\"`, `\`, `\\`, "\n", `\n`, "\t", `\t`, "\b", `\b`)
 )
+
+// ErrInvalidSubsectionName is returned when a subsection name cannot be
+// represented in a config file. Per git-config(1), subsection names "can
+// contain any characters except newline and the null byte".
+var ErrInvalidSubsectionName = errors.New("invalid subsection name")
 
 // NewEncoder returns a new encoder that writes to w.
 func NewEncoder(w io.Writer) *Encoder {
@@ -53,6 +59,14 @@ func (e *Encoder) encodeSection(s *Section) error {
 }
 
 func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
+	// Neither character is escapable inside the quoted name: git drops the
+	// backslash before any character other than `"` and `\`, so `\n` reads
+	// back as the letter "n". Writing them raw is the only faithful encoding,
+	// and that ends the header early and corrupts the file.
+	if strings.ContainsAny(s.Name, "\n\x00") {
+		return fmt.Errorf("%w: %q", ErrInvalidSubsectionName, s.Name)
+	}
+
 	if err := e.printf("[%s \"%s\"]\n", sectionName, subsectionReplacer.Replace(s.Name)); err != nil {
 		return err
 	}

--- a/plumbing/format/config/encoder_test.go
+++ b/plumbing/format/config/encoder_test.go
@@ -26,3 +26,29 @@ func (s *EncoderSuite) TestEncode() {
 		s.Equal(fixture.Text, buf.String(), fmt.Sprintf("bad result for fixture: %d", idx))
 	}
 }
+
+func (s *EncoderSuite) TestEncodeRejectsUnrepresentableSubsectionNames() {
+	for _, name := range []string{"a\nb", "a\x00b"} {
+		cfg := New()
+		cfg.Section("submodule").Subsection(name).SetOption("url", "https://example.com/x.git")
+
+		err := NewEncoder(&bytes.Buffer{}).Encode(cfg)
+
+		s.ErrorIs(err, ErrInvalidSubsectionName, "name %q", name)
+	}
+}
+
+// A newline in a subsection name terminates the header early, so the file the
+// encoder produced could not be read back by go-git or by git itself.
+func (s *EncoderSuite) TestEncodeNeverWritesUnreadableSubsectionHeader() {
+	cfg := New()
+	cfg.Section("submodule").Subsection("a\nb").SetOption("url", "https://example.com/x.git")
+
+	buf := &bytes.Buffer{}
+	if err := NewEncoder(buf).Encode(cfg); err != nil {
+		return
+	}
+
+	s.NoError(NewDecoder(bytes.NewReader(buf.Bytes())).Decode(New()),
+		"encoder wrote a config that the decoder cannot read: %q", buf.String())
+}


### PR DESCRIPTION
### Problem

`git-config(1)`: subsection names "can contain any characters except newline and the null byte."

The encoder escapes only `"` and `\`, so either of those two characters is written raw into the section header and the result cannot be read back — by go-git or by git:

```go
m := config.NewModules()
m.Unmarshal([]byte("[submodule \"a\\\nb\"]\n\tpath = p\n\turl = https://example.com/x.git\n"))

out, _ := m.Marshal()
// [submodule "a
// b"]
//     path = p
//     url = https://example.com/x.git

config.NewModules().Unmarshal(out) // 1:12: string not terminated
```

`git config --file … --list` on that same output: `fatal: bad config line 1`. With a NUL instead of the newline, go-git reports `illegal character NUL` and git silently truncates the name to `a`.

This is reachable from `.gitmodules`: submodule names come from the repository being operated on, and `config.Modules.Marshal` re-encodes them.

### Fix

Return an error instead of writing a file nothing can parse.

Escaping is not an option here. git drops a backslash before any character other than `"` and `\`, so `\n` reads back as the letter `n` and would quietly rename the subsection. git refuses to create such a key at all (`error: invalid key (newline)`), so the encoder does the same.

### Tests

Two regression tests in `encoder_test.go`. Withdrawing the fix while keeping them reproduces the failure on `main`:

```
--- FAIL: TestEncoderSuite/TestEncodeNeverWritesUnreadableSubsectionHeader
    Error:    Received unexpected error: 1:12: string not terminated
    Messages: encoder wrote a config that the decoder cannot read:
              "[submodule \"a\nb\"]\n\turl = https://example.com/x.git\n"
```

`go test ./...` matches the pre-change baseline exactly: 67 packages ok, with `plumbing/format/gitignore` `TestConformanceSuite/TestIgnoreDoubleStarPrefix` failing both before and after (pre-existing, tracked in #2317). `golangci-lint run ./plumbing/format/config/...` reports 0 issues. Behaviour checked against git 2.50.1.

### Scope

Section names and option keys have the same gap — they are written with no escaping or validation at all, so a space, tab, newline, `]`, `"` or `\` in either also yields an unreadable file. Those aren't reachable from repository data the way subsection names are, so I left them out to keep this a focused fix; happy to extend it if you'd prefer them covered here.

Found with a decode/encode/decode round-trip fuzz target, not included in this PR.

---

**AI disclosure** (per `AI_POLICY.md`): this change was produced with an AI agent, Claude Opus 5 via Claude Code, and the commit carries the `Assisted-by:` trailer. The reproduction, the git 2.50.1 comparisons, the baseline/after suite runs and the withdraw-the-fix check above were all actually executed, and the output quoted is real. Opened as a draft pending my own review before I ask for yours.
