### PR TITLE
config: read boolean values the way git does

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/go-git/go-billy/v6/osfs"
 
@@ -567,23 +566,17 @@ func (c *Config) unmarshalCore() {
 func (c *Config) unmarshalExtensions() {
 	s := c.Raw.Section(extensionsSection)
 	c.Extensions.ObjectFormat = format.ObjectFormat(s.Options.Get(objectFormatKey))
-	c.Extensions.WorktreeConfig = strings.EqualFold(s.Options.Get(worktreeConfigKey), "true")
+	c.Extensions.WorktreeConfig = parseConfigBool(s.Options.Get(worktreeConfigKey)).IsTrue()
 }
 
 func (c *Config) unmarshalTag() {
 	s := c.Raw.Section(tagSection)
-	v, err := strconv.ParseBool(s.Options.Get(gpgSignKey))
-	if err == nil {
-		c.Tag.GpgSign = NewOptBool(v)
-	}
+	c.Tag.GpgSign = parseConfigBool(s.Options.Get(gpgSignKey))
 }
 
 func (c *Config) unmarshalCommit() {
 	s := c.Raw.Section(commitSection)
-	v, err := strconv.ParseBool(s.Options.Get(gpgSignKey))
-	if err == nil {
-		c.Commit.GpgSign = NewOptBool(v)
-	}
+	c.Commit.GpgSign = parseConfigBool(s.Options.Get(gpgSignKey))
 }
 
 func (c *Config) unmarshalUser() {
@@ -730,10 +723,7 @@ func (c *Config) unmarshalProtocol() error {
 
 func (c *Config) unmarshalIndex() {
 	s := c.Raw.Section(indexSection)
-	v, err := strconv.ParseBool(s.Options.Get(skipHashKey))
-	if err == nil {
-		c.Index.SkipHash = NewOptBool(v)
-	}
+	c.Index.SkipHash = parseConfigBool(s.Options.Get(skipHashKey))
 }
 
 func (c *Config) unmarshalInit() {
@@ -743,10 +733,7 @@ func (c *Config) unmarshalInit() {
 
 func (c *Config) unmarshalUploadArchive() {
 	s := c.Raw.Section(uploadArchiveSection)
-	v, err := strconv.ParseBool(s.Options.Get(allowUnreachableKey))
-	if err == nil {
-		c.UploadArchive.AllowUnreachable = NewOptBool(v)
-	}
+	c.UploadArchive.AllowUnreachable = parseConfigBool(s.Options.Get(allowUnreachableKey))
 }
 
 // Marshal returns Config encoded as a git-config file.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1370,3 +1370,47 @@ func TestGPGConfig(t *testing.T) {
 		assert.Equal(t, OptBoolFalse, merged.Commit.GpgSign)
 	})
 }
+
+// Git accepts yes/no/on/off and any integer for a boolean, not just the set
+// strconv.ParseBool understands. Expectations are the output of
+// `git config -f <file> --type=bool --get <key>` under git 2.50.1.
+func (s *ConfigSuite) TestUnmarshalBoolValues() {
+	for _, tc := range []struct {
+		value string
+		want  OptBool
+	}{
+		{value: "true", want: OptBoolTrue},
+		{value: "TRUE", want: OptBoolTrue},
+		{value: "yes", want: OptBoolTrue},
+		{value: "Yes", want: OptBoolTrue},
+		{value: "on", want: OptBoolTrue},
+		{value: "On", want: OptBoolTrue},
+		{value: "1", want: OptBoolTrue},
+		{value: "2", want: OptBoolTrue},
+		{value: "-1", want: OptBoolTrue},
+		{value: "false", want: OptBoolFalse},
+		{value: "no", want: OptBoolFalse},
+		{value: "off", want: OptBoolFalse},
+		{value: "0", want: OptBoolFalse},
+		// git errors on a value it cannot read; go-git leaves the key unset so
+		// the caller's default applies.
+		{value: "garbage", want: OptBoolUnset},
+	} {
+		input := []byte("[commit]\n\tgpgsign = " + tc.value +
+			"\n[tag]\n\tgpgsign = " + tc.value +
+			"\n[index]\n\tskipHash = " + tc.value +
+			"\n[uploadarchive]\n\tallowUnreachable = " + tc.value +
+			"\n[extensions]\n\tworktreeConfig = " + tc.value + "\n")
+
+		cfg := NewConfig()
+		s.Require().NoError(cfg.Unmarshal(input), tc.value)
+
+		s.Equal(tc.want, cfg.Commit.GpgSign, "commit.gpgsign = %s", tc.value)
+		s.Equal(tc.want, cfg.Tag.GpgSign, "tag.gpgsign = %s", tc.value)
+		s.Equal(tc.want, cfg.Index.SkipHash, "index.skipHash = %s", tc.value)
+		s.Equal(tc.want, cfg.UploadArchive.AllowUnreachable,
+			"uploadarchive.allowUnreachable = %s", tc.value)
+		s.Equal(tc.want.IsTrue(), cfg.Extensions.WorktreeConfig,
+			"extensions.worktreeConfig = %s", tc.value)
+	}
+}


### PR DESCRIPTION
Git accepts `yes`/`no`/`on`/`off` and any integer for a boolean. This repository already implements that in `parseConfigBool`, citing `git_parse_maybe_bool_text` — but five keys did not use it.

Measured against `git config -f <file> --type=bool --get`, git 2.50.1:

| value | git | `commit.gpgsign` before | `core.protectNTFS` (already correct) |
| --- | --- | --- | --- |
| `yes` / `Yes` / `on` / `On` | true | **unset** | true |
| `no` / `off` | false | **unset** | false |
| `2` / `-1` | true | **unset** | true |
| `true` / `1` / `false` / `0` | as written | correct | correct |

- `commit.gpgsign` and `tag.gpgsign` used `strconv.ParseBool`, which rejects those spellings; the error was swallowed and the option left unset. Since unset means "use the default", a repository configured with `commit.gpgsign = yes` got **no signing at all**, with nothing reported.
- `index.skipHash` and `uploadarchive.allowUnreachable` had the same treatment.
- `extensions.worktreeConfig` compared against the literal `"true"`, so `1`, `yes` and `on` read as false.

All five now go through `parseConfigBool`. `core.protectNTFS`/`protectHFS` already did, which is what the new test contrasts against — same file, same value, two different answers before this change.

Behaviour worth calling out explicitly: an unreadable value (`garbage`) still leaves the key **unset** rather than erroring, exactly as before. Git errors there; go-git's contract is that the caller's default applies, and `parseConfigBool`'s own doc comment says an empty value means unset. I did not change that, since it is a separate decision from which spellings parse.

Verification:

- `TestUnmarshalBoolValues` expectations are that `git config --type=bool` output, not my reading of `parse.c`.
- Reverting only `config/config.go` fails the new test on the first `yes` case.
- `go test -short ./...` — 68 packages pass, no failures.

Note on the one pre-existing failure you may see locally: `plumbing/format/gitignore`'s `TestConformanceSuite` fails on any git older than 2.52.0, exactly as your own `oracleVersionHint` note predicts (mine is 2.50.1). Unrelated to this change, and I left it alone — the comment says the visible disagreement is deliberate.

This is a behaviour change rather than a pure refactor, so if you would rather it went through an issue or RFC first per `AI_POLICY.md`, say so and I will move the write-up there.

AI disclosure per `AI_POLICY.md`: found and written with Claude Code (Claude Opus 5), recorded in the commit's `Assisted-by:` trailer. @rawsun007 authorised the DCO sign-off and reviewed the change.
