### PR TITLE
internal: test, Isolate git from ambient config

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -59,8 +59,6 @@ jobs:
           echo "Git exec path mismatch: expected ${{ github.workspace }}/.git-dist/${{ matrix.git[0] }}, got $exec_path"
           exit 1
         fi
-        git config --global user.email "gha@example.com"
-        git config --global user.name "GitHub Actions"
 
     - name: Test
       run: make test-coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,6 @@ jobs:
         mkdir -p  ~/.ssh
         ssh-keyscan -H github.com > ~/.ssh/known_hosts
 
-    - name: Set Git config
-      run: |
-        git config --global user.email "gha@example.com"
-        git config --global user.name "GitHub Actions"
-
     - name: Validate
       run: make validate
 

--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 )
 
 var examplesTest = flag.Bool("examples", false, "run the examples tests")
@@ -96,7 +98,7 @@ func tempFolder() string {
 }
 
 func cloneRepository(url, folder string) string {
-	cmd := exec.Command("git", "clone", url, folder)
+	cmd := gitenv.Command("git", "clone", url, folder)
 	err := cmd.Run()
 	CheckIfError(err)
 
@@ -110,9 +112,9 @@ func createBareRepository(dir string) string {
 func createRepository(dir string, isBare bool) string {
 	var cmd *exec.Cmd
 	if isBare {
-		cmd = exec.Command("git", "init", "--bare", dir)
+		cmd = gitenv.Command("git", "init", "--bare", dir)
 	} else {
-		cmd = exec.Command("git", "init", dir)
+		cmd = gitenv.Command("git", "init", dir)
 	}
 	err := cmd.Run()
 	CheckIfError(err)
@@ -133,14 +135,14 @@ func setEmptyRemote(dir string) string {
 }
 
 func setRemote(local, remote string) {
-	cmd := exec.Command("git", "remote", "set-url", "origin", remote)
+	cmd := gitenv.Command("git", "remote", "set-url", "origin", remote)
 	cmd.Dir = local
 	err := cmd.Run()
 	CheckIfError(err)
 }
 
 func addRemote(local, remote string) {
-	cmd := exec.Command("git", "remote", "add", "origin", remote)
+	cmd := gitenv.Command("git", "remote", "add", "origin", remote)
 	cmd.Dir = local
 	err := cmd.Run()
 	CheckIfError(err)

--- a/internal/test/gitenv/gitenv.go
+++ b/internal/test/gitenv/gitenv.go
@@ -7,45 +7,168 @@
 // template directories, excludes files and default branch names all differ
 // from one machine to the next, CI supplies settings a developer machine does
 // not, and a config file git cannot parse fails every command it is given,
-// `git --version` included.
+// `git --version` included. Some variables are worse than a setting: GIT_DIR
+// and its relatives point git at a repository other than the one the test
+// built, so a stray value redirects the command rather than colouring it.
 //
-// Command returns a command with that configuration excluded and an identity
-// supplied. Env returns the environment on its own, for a caller that builds
-// the command itself. Neither replaces a variable the caller has already set,
-// so a test or a CI job can still pin what it needs:
+// Command returns a command with all of that removed and an identity supplied.
+// Env returns the environment on its own, for a caller that builds the command
+// itself. Every variable this package names is set unconditionally, whatever
+// the machine had: a value inherited from the environment is the thing being
+// isolated, so honouring it would defeat the purpose. A caller who needs
+// something different appends it, since the last entry for a variable is the
+// one the child sees:
 //
 //	cmd := gitenv.Command("git", "commit", "-m", "example")
 //	cmd.Dir = dir
+//	cmd.Env = append(cmd.Env, "GIT_AUTHOR_NAME=someone else")
 //	out, err := cmd.CombinedOutput()
 package gitenv
 
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 )
 
-// defaults are the settings a test run should not inherit from the machine.
+// stripped are variables no value of ours can correct, because their problem
+// is that they are set at all: they name a repository, or a part of one, or
+// inject configuration directly.
 //
-// An empty GIT_CONFIG_GLOBAL or GIT_CONFIG_SYSTEM disables that file rather
-// than naming one, which is portable in a way that a path such as /dev/null is
-// not: the tests run on Windows too.
-var defaults = []string{
+// The repository half is git's own local_repo_env (environment.c), which git
+// clears in sanitize_repo_env() before running against a repository other
+// than the one it was invoked in — which is gitenv's situation exactly. A test
+// run inherits these whenever `go test` is reached from a pre-commit or
+// pre-push hook (githooks(5): "Environment variables, such as GIT_DIR,
+// GIT_WORK_TREE, etc., are exported"), from `git bisect run`, or from
+// `git rebase --exec`.
+//
+// GIT_CONFIG_PARAMETERS and the GIT_CONFIG_COUNT family go too, which git
+// itself keeps deliberately: to git they carry the -c options of the parent
+// git and are worth propagating, but to a test they are one more ambient
+// setting, and settings below needs the count to itself.
+//
+// GIT_EXEC_PATH is deliberately absent: the compatibility matrix points it at
+// the git build under test.
+var stripped = []string{
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+	"GIT_COMMON_DIR",
+	"GIT_CONFIG",
+	"GIT_CONFIG_COUNT",
+	"GIT_CONFIG_PARAMETERS",
+	"GIT_DIR",
+	"GIT_GRAFT_FILE",
+	"GIT_IMPLICIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_NO_REPLACE_OBJECTS",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_PREFIX",
+	"GIT_REPLACE_REF_BASE",
+	"GIT_SHALLOW_FILE",
+	"GIT_WORK_TREE",
+
+	// Not repository locations, and not in local_repo_env: an inherited
+	// askpass helper is asked for credentials at a point where the test
+	// wanted a failure, and it is a program of the machine's choosing.
+	"GIT_ASKPASS",
+	"SSH_ASKPASS",
+}
+
+// strippedPrefixes are stripped by prefix because the number of them is not
+// fixed: GIT_CONFIG_KEY_0 upwards, as many as GIT_CONFIG_COUNT claimed.
+var strippedPrefixes = []string{"GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_"}
+
+// replaced are the variables given a value of this package's own, whatever the
+// environment held.
+var replaced = []string{
+	// GIT_CONFIG_NOSYSTEM is what actually suppresses system config:
+	// GIT_CONFIG_SYSTEM only redirects the ETC_GITCONFIG path, and a git that
+	// reads a gitconfig from elsewhere — Apple's does — ignores it.
+	"GIT_CONFIG_NOSYSTEM=1",
+	// An empty GIT_CONFIG_GLOBAL or GIT_CONFIG_SYSTEM names the empty path
+	// rather than disabling the file; git reads nothing because access()
+	// reports ENOENT and git tolerates that errno. /dev/null, which
+	// git-config(1) recommends and git for Windows special-cases, would do the
+	// same thing by the same mechanism.
 	"GIT_CONFIG_GLOBAL=",
 	"GIT_CONFIG_SYSTEM=",
-	"GIT_CONFIG_NOSYSTEM=1",
 	"GIT_AUTHOR_NAME=tester",
 	"GIT_AUTHOR_EMAIL=tester@test",
 	"GIT_COMMITTER_NAME=tester",
 	"GIT_COMMITTER_EMAIL=tester@test",
+	// Prompting is on by default and the prompt opens /dev/tty itself, so
+	// redirected stdio does not prevent it. With no home directory there is no
+	// credential helper either, which would turn an authentication failure a
+	// test asserts on into a hang.
+	"GIT_TERMINAL_PROMPT=0",
 }
+
+// homeVars are how git reaches ~/.gitconfig and $XDG_CONFIG_HOME/git/config.
+//
+// GIT_CONFIG_GLOBAL arrived in git 2.32 and older releases ignore it silently
+// — the compatibility matrix builds v2.11.0 — so redirecting the home
+// directory is what isolates those. It is the load-bearing half of the two.
+var homeVars = []string{"HOME", "USERPROFILE", "XDG_CONFIG_HOME"}
+
+// settings are configuration a test run should not take from the machine and
+// which no variable of its own can express.
+//
+// init.defaultBranch is the one that matters: with global config gone, `git
+// init` falls back to the built-in default, which is master today, is
+// documented to become main in git 3.0, and prints a twelve-line hint until it
+// is set. Pinning master keeps the name a call site sees the same on every
+// machine and every git, and matches what v2.11.0 does unprompted.
+//
+// GIT_CONFIG_COUNT arrived in git 2.31 and earlier releases ignore it, which
+// costs nothing here: v2.11.0 defaults to master already and has no
+// defaultBranchName advice to print.
+var settings = [][2]string{
+	{"init.defaultBranch", "master"},
+}
+
+// isolatedHome is the path git is given as a home directory. It does not
+// exist, and nothing here creates it.
+//
+// A home directory git reads no config from is a path that holds no config
+// file, and a path that holds nothing at all satisfies that: opening
+// ~/.gitconfig under it gives ENOENT, exactly as it does for a user who has
+// never written one. Creating a directory instead would mean either leaving it
+// behind, since a test binary has no moment at which it knows no further
+// command will be built and so cannot remove one, or removing the name at once
+// and handing git a path any other local user is then free to create — with a
+// .gitconfig in it that git will read, applying no ownership check of its own,
+// since the CVE-2022-24765 checks cover repositories rather than the config
+// files in a home directory.
+//
+// The path goes beside the test binary, in the directory the go tool builds it
+// in, which answers all of that without creating anything: the tool makes that
+// tree 0700, so no other user can put a directory there; it is unique to this
+// binary, so test binaries running side by side do not share a path; and the
+// tool removes the tree when the run ends, so nothing is left behind.
+//
+// A path elsewhere would still isolate git, since what does that is the path
+// holding nothing, but it would give up the rest: a name in the temporary
+// directory is one another user can predict and create. There is no reason to
+// reach for one — os.Executable answers on every platform the tests run on —
+// so a failure here says so rather than quietly settling for less.
+var isolatedHome = sync.OnceValue(func() string {
+	exe, err := os.Executable()
+	if err != nil {
+		panic("gitenv: cannot locate the test binary, so git has nowhere private to be pointed at: " + err.Error())
+	}
+
+	return filepath.Join(filepath.Dir(exe), "go-git-gitenv-home")
+})
 
 // Command returns an exec.Cmd for the named program, with Env already applied.
 //
 // This is the way to reach for git from a test. A command built here cannot
-// read the machine's configuration, where one built with exec.Command has to
-// remember not to. The caller sets Dir, and may append to Env for anything it
-// needs on top: later entries win.
+// read the machine's configuration or be pointed at another repository, where
+// one built with exec.Command has to remember not to. The caller sets Dir, and
+// may append to Env for anything it needs on top: later entries win.
 func Command(name string, args ...string) *exec.Cmd {
 	cmd := exec.Command(name, args...)
 	cmd.Env = Env()
@@ -53,22 +176,62 @@ func Command(name string, args ...string) *exec.Cmd {
 	return cmd
 }
 
-// Env returns the process environment with the defaults above applied, plus any
-// extra "KEY=value" entries the caller needs.
+// Env returns the environment to run git in: the process environment with the
+// machine's configuration taken out and this package's own put in.
 //
-// A default is applied only where the variable is not already set, so a caller
-// that means to control one of these — CI pinning an identity, or pointing
-// GIT_CONFIG_GLOBAL at a fixture — keeps it. Setting a variable to the empty
-// string counts as setting it. Entries in extra are appended last and so
-// override everything, including an inherited value.
-func Env(extra ...string) []string {
-	env := os.Environ()
-	for _, kv := range defaults {
+// The variables in replaced, the home directory and the settings above take
+// the value chosen here whatever the environment held, and the variables in
+// stripped are removed outright. A caller that means to control one of them
+// appends its own entry after this one, which is what the child will see.
+func Env() []string {
+	added := isolation(isolatedHome())
+
+	drop := make(map[string]bool, len(stripped)+len(added))
+	for _, key := range stripped {
+		drop[key] = true
+	}
+	for _, kv := range added {
 		key, _, _ := strings.Cut(kv, "=")
-		if _, ok := os.LookupEnv(key); !ok {
-			env = append(env, kv)
+		drop[key] = true
+	}
+
+	environ := os.Environ()
+	env := make([]string, 0, len(environ)+len(added))
+	for _, kv := range environ {
+		key, _, _ := strings.Cut(kv, "=")
+		if drop[key] || hasStrippedPrefix(key) {
+			continue
+		}
+		env = append(env, kv)
+	}
+
+	return append(env, added...)
+}
+
+// isolation is what Env adds, for the home directory it was given.
+func isolation(home string) []string {
+	env := make([]string, 0, len(replaced)+len(homeVars)+1+2*len(settings))
+	env = append(env, replaced...)
+
+	for _, key := range homeVars {
+		env = append(env, key+"="+home)
+	}
+
+	env = append(env, "GIT_CONFIG_COUNT="+strconv.Itoa(len(settings)))
+	for i, setting := range settings {
+		n := strconv.Itoa(i)
+		env = append(env, "GIT_CONFIG_KEY_"+n+"="+setting[0], "GIT_CONFIG_VALUE_"+n+"="+setting[1])
+	}
+
+	return env
+}
+
+func hasStrippedPrefix(key string) bool {
+	for _, prefix := range strippedPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
 		}
 	}
 
-	return append(env, extra...)
+	return false
 }

--- a/internal/test/gitenv/gitenv.go
+++ b/internal/test/gitenv/gitenv.go
@@ -1,0 +1,74 @@
+// Package gitenv runs the git binary from tests without the machine's own
+// configuration.
+//
+// A test that shells out to git inherits the process environment, and git
+// reads the user's and the system's configuration through it. What the test
+// observes then depends on who is running it: signing, identity, aliases,
+// template directories, excludes files and default branch names all differ
+// from one machine to the next, CI supplies settings a developer machine does
+// not, and a config file git cannot parse fails every command it is given,
+// `git --version` included.
+//
+// Command returns a command with that configuration excluded and an identity
+// supplied. Env returns the environment on its own, for a caller that builds
+// the command itself. Neither replaces a variable the caller has already set,
+// so a test or a CI job can still pin what it needs:
+//
+//	cmd := gitenv.Command("git", "commit", "-m", "example")
+//	cmd.Dir = dir
+//	out, err := cmd.CombinedOutput()
+package gitenv
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// defaults are the settings a test run should not inherit from the machine.
+//
+// An empty GIT_CONFIG_GLOBAL or GIT_CONFIG_SYSTEM disables that file rather
+// than naming one, which is portable in a way that a path such as /dev/null is
+// not: the tests run on Windows too.
+var defaults = []string{
+	"GIT_CONFIG_GLOBAL=",
+	"GIT_CONFIG_SYSTEM=",
+	"GIT_CONFIG_NOSYSTEM=1",
+	"GIT_AUTHOR_NAME=tester",
+	"GIT_AUTHOR_EMAIL=tester@test",
+	"GIT_COMMITTER_NAME=tester",
+	"GIT_COMMITTER_EMAIL=tester@test",
+}
+
+// Command returns an exec.Cmd for the named program, with Env already applied.
+//
+// This is the way to reach for git from a test. A command built here cannot
+// read the machine's configuration, where one built with exec.Command has to
+// remember not to. The caller sets Dir, and may append to Env for anything it
+// needs on top: later entries win.
+func Command(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	cmd.Env = Env()
+
+	return cmd
+}
+
+// Env returns the process environment with the defaults above applied, plus any
+// extra "KEY=value" entries the caller needs.
+//
+// A default is applied only where the variable is not already set, so a caller
+// that means to control one of these — CI pinning an identity, or pointing
+// GIT_CONFIG_GLOBAL at a fixture — keeps it. Setting a variable to the empty
+// string counts as setting it. Entries in extra are appended last and so
+// override everything, including an inherited value.
+func Env(extra ...string) []string {
+	env := os.Environ()
+	for _, kv := range defaults {
+		key, _, _ := strings.Cut(kv, "=")
+		if _, ok := os.LookupEnv(key); !ok {
+			env = append(env, kv)
+		}
+	}
+
+	return append(env, extra...)
+}

--- a/internal/test/gitenv/gitenv_test.go
+++ b/internal/test/gitenv/gitenv_test.go
@@ -1,0 +1,144 @@
+package gitenv_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
+)
+
+// gitIn runs a git command through Env and fails the test on error.
+func gitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := gitenv.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v in %s: %s", args, dir, out)
+
+	return strings.TrimSpace(string(out))
+}
+
+// unparseableConfig makes git refuse every command it is given, so a command
+// that reads it fails outright rather than quietly picking up a setting.
+const unparseableConfig = "[core\nthis is not a config file\n"
+
+// poisonHome points HOME at a directory holding the given .gitconfig. This is
+// how a real machine breaks a test run: not through an environment variable,
+// but through the file the contributor has had in their home directory for
+// years.
+func poisonHome(t *testing.T, config string) {
+	t.Helper()
+
+	home := t.TempDir()
+	path := filepath.Join(home, ".gitconfig")
+	require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
+	t.Setenv("HOME", home)
+	// git for Windows derives HOME from USERPROFILE when HOME is unset; set
+	// both so the poison lands on every platform the tests run on.
+	t.Setenv("USERPROFILE", home)
+}
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git CLI not found in PATH")
+	}
+}
+
+// TestEnvIgnoresTheMachinesOwnConfig is the property the package exists for: a
+// git subprocess started through Env does not read the user's configuration.
+//
+// Each case is a shape a real ~/.gitconfig takes, and each would break a test
+// run in its own way if it were read.
+//
+//nolint:paralleltest // every case calls t.Setenv, which forbids parallel
+func TestEnvIgnoresTheMachinesOwnConfig(t *testing.T) {
+	// Not parallel: t.Setenv, and the environment is process-wide.
+	for _, tc := range []struct { //nolint:paralleltest // t.Setenv in each subtest
+		name   string
+		config string
+	}{
+		{
+			// What a contributor who signs their commits has. gpg.program
+			// cannot be executed here, standing in for a signing key that is
+			// absent, locked, or on a token nobody is present to touch.
+			name: "signing turned on",
+			config: "[user]\n\tname = poison\n\temail = poison@example.invalid\n" +
+				"[commit]\n\tgpgsign = true\n" +
+				"[tag]\n\tgpgsign = true\n" +
+				"[gpg]\n\tprogram = go-git-nonexistent-signing-program\n",
+		},
+		{
+			// The other direction: a machine with no identity at all, which
+			// is what a test that never sets one has been borrowing.
+			name:   "no identity to borrow",
+			config: "[core]\n\tquotePath = false\n",
+		},
+		{
+			// git refuses to run at all, so this case is what a read-only
+			// command has to survive: isolating those matters too, and
+			// nothing else here would notice if it were dropped.
+			name:   "config that does not parse",
+			config: unparseableConfig,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requireGit(t)
+			poisonHome(t, tc.config)
+
+			dir := t.TempDir()
+			gitIn(t, dir, "init")
+			f := filepath.Join(dir, "f.txt")
+			require.NoError(t, os.WriteFile(f, []byte("x\n"), 0o644))
+			gitIn(t, dir, "add", "f.txt")
+			gitIn(t, dir, "commit", "-m", "hermetic")
+
+			require.Equal(t, "hermetic", gitIn(t, dir, "log", "-1", "--format=%s"))
+			require.Empty(t, gitIn(t, dir, "log", "-1", "--format=%GK"),
+				"the commit must not be signed with a key the machine happens to hold")
+		})
+	}
+}
+
+// TestEnvKeepsAnExplicitIdentity checks the override half: a caller that sets
+// one of these deliberately — CI pinning the author it wants to see — keeps it.
+func TestEnvKeepsAnExplicitIdentity(t *testing.T) {
+	requireGit(t)
+	poisonHome(t, unparseableConfig)
+	t.Setenv("GIT_AUTHOR_NAME", "CI Runner")
+	t.Setenv("GIT_AUTHOR_EMAIL", "ci@example.com")
+
+	dir := t.TempDir()
+	gitIn(t, dir, "init")
+	gitIn(t, dir, "commit", "--allow-empty", "-m", "authored by ci")
+
+	require.Equal(t, "CI Runner", gitIn(t, dir, "log", "-1", "--format=%an"))
+	require.Equal(t, "ci@example.com", gitIn(t, dir, "log", "-1", "--format=%ae"))
+}
+
+// TestEnvKeepsAnExplicitConfigFile is the same override, for the setting that
+// disables config reading rather than one that supplies a value: a caller who
+// points GIT_CONFIG_GLOBAL at a fixture gets that fixture, not the empty
+// default this package would otherwise apply.
+func TestEnvKeepsAnExplicitConfigFile(t *testing.T) {
+	requireGit(t)
+	poisonHome(t, unparseableConfig)
+
+	fixture := filepath.Join(t.TempDir(), "gitconfig")
+	contents := []byte("[user]\n\tname = From The Fixture\n")
+	require.NoError(t, os.WriteFile(fixture, contents, 0o600))
+	t.Setenv("GIT_CONFIG_GLOBAL", fixture)
+
+	dir := t.TempDir()
+	gitIn(t, dir, "init")
+
+	// Read back through config rather than through a commit: the identity
+	// defaults are environment variables, and those outrank config on an
+	// author line, which would hide whether the file was read at all.
+	require.Equal(t, "From The Fixture", gitIn(t, dir, "config", "--get", "user.name"))
+}

--- a/internal/test/gitenv/gitenv_test.go
+++ b/internal/test/gitenv/gitenv_test.go
@@ -12,35 +12,95 @@ import (
 	"github.com/go-git/go-git/v6/internal/test/gitenv"
 )
 
-// gitIn runs a git command through Env and fails the test on error.
+// gitIn runs a git command through Command and fails the test on error.
 func gitIn(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := gitenv.Command("git", args...)
 	cmd.Dir = dir
+
+	return runGit(t, cmd, dir, args)
+}
+
+// gitInEnv is gitIn with the environment chosen by the caller, so a test can
+// run git as a machine that reads only part of that environment would.
+func gitInEnv(t *testing.T, dir string, env []string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+
+	return runGit(t, cmd, dir, args)
+}
+
+func runGit(t *testing.T, cmd *exec.Cmd, dir string, args []string) string {
+	t.Helper()
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v in %s: %s", args, dir, out)
 
 	return strings.TrimSpace(string(out))
 }
 
+// commitIn makes a commit in dir with the given environment, initialising the
+// repository first: the sequence every isolation case here has to survive.
+func commitIn(t *testing.T, dir string, env []string, subject string) {
+	t.Helper()
+
+	gitInEnv(t, dir, env, "init")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x\n"), 0o644))
+	gitInEnv(t, dir, env, "add", "f.txt")
+	gitInEnv(t, dir, env, "commit", "-m", subject)
+}
+
 // unparseableConfig makes git refuse every command it is given, so a command
 // that reads it fails outright rather than quietly picking up a setting.
 const unparseableConfig = "[core\nthis is not a config file\n"
 
-// poisonHome points HOME at a directory holding the given .gitconfig. This is
-// how a real machine breaks a test run: not through an environment variable,
-// but through the file the contributor has had in their home directory for
-// years.
+// poisonHome points the home directory at one holding the given config, at
+// both paths git looks for it. This is how a real machine breaks a test run:
+// not through an environment variable, but through the file the contributor
+// has had in their home directory for years.
 func poisonHome(t *testing.T, config string) {
 	t.Helper()
 
 	home := t.TempDir()
-	path := filepath.Join(home, ".gitconfig")
-	require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".gitconfig"), []byte(config), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(home, "git"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(home, "git", "config"), []byte(config), 0o600))
+
 	t.Setenv("HOME", home)
 	// git for Windows derives HOME from USERPROFILE when HOME is unset; set
 	// both so the poison lands on every platform the tests run on.
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", home)
+}
+
+// withoutConfigEnv drops GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM, leaving the
+// environment as a git before 2.32 reads it — the matrix builds v2.11.0 — so
+// isolation has to hold here as well.
+func withoutConfigEnv(env []string) []string {
+	kept := make([]string, 0, len(env))
+	for _, kv := range env {
+		switch key, _, _ := strings.Cut(kv, "="); key {
+		case "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM":
+			continue
+		default:
+			kept = append(kept, kv)
+		}
+	}
+
+	return kept
+}
+
+// envVariants are the environments the isolation property must hold in.
+var envVariants = []struct {
+	name string
+	env  func() []string
+}{
+	{name: "as built", env: gitenv.Env},
+	{
+		name: "as a git without GIT_CONFIG_GLOBAL reads it",
+		env:  func() []string { return withoutConfigEnv(gitenv.Env()) },
+	},
 }
 
 func requireGit(t *testing.T) {
@@ -87,58 +147,255 @@ func TestEnvIgnoresTheMachinesOwnConfig(t *testing.T) {
 			config: unparseableConfig,
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			requireGit(t)
-			poisonHome(t, tc.config)
+		for _, variant := range envVariants {
+			t.Run(tc.name+", "+variant.name, func(t *testing.T) {
+				requireGit(t)
+				poisonHome(t, tc.config)
+				env := variant.env()
 
-			dir := t.TempDir()
-			gitIn(t, dir, "init")
-			f := filepath.Join(dir, "f.txt")
-			require.NoError(t, os.WriteFile(f, []byte("x\n"), 0o644))
-			gitIn(t, dir, "add", "f.txt")
-			gitIn(t, dir, "commit", "-m", "hermetic")
+				dir := t.TempDir()
+				commitIn(t, dir, env, "hermetic")
 
-			require.Equal(t, "hermetic", gitIn(t, dir, "log", "-1", "--format=%s"))
-			require.Empty(t, gitIn(t, dir, "log", "-1", "--format=%GK"),
-				"the commit must not be signed with a key the machine happens to hold")
-		})
+				require.Equal(t, "hermetic", gitInEnv(t, dir, env, "log", "-1", "--format=%s"))
+				require.Empty(t, gitInEnv(t, dir, env, "log", "-1", "--format=%GK"),
+					"the commit must not be signed with a key the machine happens to hold")
+			})
+		}
 	}
 }
 
-// TestEnvKeepsAnExplicitIdentity checks the override half: a caller that sets
-// one of these deliberately — CI pinning the author it wants to see — keeps it.
-func TestEnvKeepsAnExplicitIdentity(t *testing.T) {
+// TestEnvIgnoresAnIdentityInTheEnvironment is the same property for the
+// identity, which reaches git through variables rather than through a file: a
+// name exported from a shell profile or by direnv is ambient input too, and
+// this package replaces it rather than filling in around it.
+func TestEnvIgnoresAnIdentityInTheEnvironment(t *testing.T) {
 	requireGit(t)
-	poisonHome(t, unparseableConfig)
-	t.Setenv("GIT_AUTHOR_NAME", "CI Runner")
-	t.Setenv("GIT_AUTHOR_EMAIL", "ci@example.com")
+	t.Setenv("GIT_AUTHOR_NAME", "poison")
+	t.Setenv("GIT_AUTHOR_EMAIL", "poison@example.invalid")
+	t.Setenv("GIT_COMMITTER_NAME", "poison")
+	t.Setenv("GIT_COMMITTER_EMAIL", "poison@example.invalid")
 
 	dir := t.TempDir()
-	gitIn(t, dir, "init")
-	gitIn(t, dir, "commit", "--allow-empty", "-m", "authored by ci")
+	commitIn(t, dir, gitenv.Env(), "hermetic")
 
-	require.Equal(t, "CI Runner", gitIn(t, dir, "log", "-1", "--format=%an"))
-	require.Equal(t, "ci@example.com", gitIn(t, dir, "log", "-1", "--format=%ae"))
+	require.Equal(t, "tester tester", gitIn(t, dir, "log", "-1", "--format=%an %cn"))
 }
 
-// TestEnvKeepsAnExplicitConfigFile is the same override, for the setting that
-// disables config reading rather than one that supplies a value: a caller who
-// points GIT_CONFIG_GLOBAL at a fixture gets that fixture, not the empty
-// default this package would otherwise apply.
-func TestEnvKeepsAnExplicitConfigFile(t *testing.T) {
+// TestEnvIgnoresAmbientRepositoryLocations covers the variables that redirect
+// git rather than configure it. GIT_DIR and its relatives are exported by
+// every hook git runs (githooks(5)), by `git bisect run` and by
+// `git rebase --exec`, so `go test` reached from any of those inherits them —
+// and a redirected command is a worse failure than a stray setting.
+func TestEnvIgnoresAmbientRepositoryLocations(t *testing.T) {
 	requireGit(t)
-	poisonHome(t, unparseableConfig)
 
-	fixture := filepath.Join(t.TempDir(), "gitconfig")
-	contents := []byte("[user]\n\tname = From The Fixture\n")
-	require.NoError(t, os.WriteFile(fixture, contents, 0o600))
-	t.Setenv("GIT_CONFIG_GLOBAL", fixture)
+	// The repository the ambient variables point at, built before they are
+	// set so that it is reachable at all.
+	decoy := t.TempDir()
+	gitIn(t, decoy, "init")
+
+	decoyGit := filepath.Join(decoy, ".git")
+	t.Setenv("GIT_DIR", decoyGit)
+	t.Setenv("GIT_WORK_TREE", decoy)
+	t.Setenv("GIT_COMMON_DIR", decoyGit)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(decoyGit, "index"))
+	t.Setenv("GIT_OBJECT_DIRECTORY", filepath.Join(decoyGit, "objects"))
+
+	dir := t.TempDir()
+	commitIn(t, dir, gitenv.Env(), "hermetic")
+
+	require.Equal(t, "hermetic", gitIn(t, dir, "log", "-1", "--format=%s"),
+		"the commit must land in the repository the test built")
+	// for-each-ref rather than rev-list: it is the reference that would have
+	// been created here, and asking for one in a repository that has none is
+	// a usage error to git 2.11 rather than an answer of zero.
+	require.Empty(t, gitIn(t, decoy, "for-each-ref"),
+		"nothing must reach the repository the environment named")
+}
+
+// TestEnvIgnoresConfigInjectedThroughTheEnvironment covers the other way
+// configuration arrives without a file: the -c options of a parent git, which
+// git exports for its own children to inherit. git keeps these deliberately
+// when it runs against another repository; a test cannot.
+func TestEnvIgnoresConfigInjectedThroughTheEnvironment(t *testing.T) {
+	requireGit(t)
+	t.Setenv("GIT_CONFIG_PARAMETERS", "'user.name=poison' 'core.pager=poison'")
+	// Two of them, so that the count this package sets for itself is not the
+	// only thing standing between the second and git.
+	t.Setenv("GIT_CONFIG_COUNT", "2")
+	t.Setenv("GIT_CONFIG_KEY_0", "user.email")
+	t.Setenv("GIT_CONFIG_VALUE_0", "poison@example.invalid")
+	t.Setenv("GIT_CONFIG_KEY_1", "core.excludesFile")
+	t.Setenv("GIT_CONFIG_VALUE_1", "poison")
 
 	dir := t.TempDir()
 	gitIn(t, dir, "init")
 
-	// Read back through config rather than through a commit: the identity
-	// defaults are environment variables, and those outrank config on an
-	// author line, which would hide whether the file was read at all.
-	require.Equal(t, "From The Fixture", gitIn(t, dir, "config", "--get", "user.name"))
+	require.NotContains(t, gitIn(t, dir, "config", "--list"), "poison")
+}
+
+// TestEnvPinsTheInitialBranchName checks the setting that has no variable of
+// its own. Left to git the name is a property of the build — master today,
+// documented to become main in git 3.0 — which a call site that does not pass
+// -c init.defaultBranch would silently follow.
+func TestEnvPinsTheInitialBranchName(t *testing.T) { //nolint:paralleltest // t.Setenv
+	requireGit(t)
+	poisonHome(t, "[init]\n\tdefaultBranch = poison\n")
+
+	dir := t.TempDir()
+	out := gitIn(t, dir, "init")
+	require.Equal(t, "refs/heads/master", gitIn(t, dir, "symbolic-ref", "HEAD"))
+	require.NotContains(t, out, "hint:",
+		"a pinned name is also what suppresses the defaultBranchName advice")
+}
+
+// TestCommandTakesAnAppendedOverride is the escape hatch the package documents
+// in place of honouring the environment: a caller that needs a variable to
+// hold something else appends it, and the last entry is what the child sees.
+func TestCommandTakesAnAppendedOverride(t *testing.T) {
+	t.Parallel()
+	requireGit(t)
+
+	dir := t.TempDir()
+	gitIn(t, dir, "init")
+
+	cmd := gitenv.Command("git", "commit", "--allow-empty", "-m", "appended")
+	cmd.Dir = dir
+	cmd.Env = append(cmd.Env, "GIT_AUTHOR_NAME=Appended", "GIT_AUTHOR_EMAIL=appended@test")
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git commit: %s", out)
+
+	require.Equal(t, "Appended", gitIn(t, dir, "log", "-1", "--format=%an"))
+}
+
+// TestEnvSetsWhatItPromises is the environment read directly, for the entries
+// whose effect is a command that does not happen: a prompt that is not opened,
+// a helper that is not run.
+func TestEnvSetsWhatItPromises(t *testing.T) { //nolint:paralleltest // t.Setenv
+	// Set every variable to something recognisable, so that a value found
+	// below came from this package rather than from the machine.
+	for _, key := range []string{
+		"GIT_TERMINAL_PROMPT", "GIT_CONFIG_NOSYSTEM", "GIT_ASKPASS", "SSH_ASKPASS",
+	} {
+		t.Setenv(key, "poison")
+	}
+
+	env := gitenv.Env()
+	require.Equal(t, "0", valueOf(t, env, "GIT_TERMINAL_PROMPT"),
+		"the prompt opens /dev/tty itself, so redirected stdio does not prevent it")
+	require.Equal(t, "1", valueOf(t, env, "GIT_CONFIG_NOSYSTEM"),
+		"this, not GIT_CONFIG_SYSTEM, is what suppresses system config")
+
+	for _, key := range []string{"GIT_ASKPASS", "SSH_ASKPASS"} {
+		require.NotContains(t, keys(env), key,
+			"%s names a program of the machine's choosing, so it is removed rather than set", key)
+	}
+}
+
+// keys returns the variable names in env.
+func keys(env []string) []string {
+	names := make([]string, 0, len(env))
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		names = append(names, key)
+	}
+
+	return names
+}
+
+// valueOf returns the value the given environment carries for key, taking the
+// last entry as exec does when a variable appears more than once.
+func valueOf(t *testing.T, env []string, key string) string {
+	t.Helper()
+
+	value, found := "", false
+	for _, kv := range env {
+		if k, v, _ := strings.Cut(kv, "="); k == key {
+			value, found = v, true
+		}
+	}
+	require.True(t, found, "Env must set %s", key)
+
+	return value
+}
+
+// TestEnvRedirectsTheHomeDirectory checks what isolation rests on where
+// GIT_CONFIG_GLOBAL is not read: the home directory is replaced rather than
+// honoured, with a path holding no config file.
+func TestEnvRedirectsTheHomeDirectory(t *testing.T) { //nolint:paralleltest // poisonHome calls t.Setenv
+	poisonHome(t, unparseableConfig)
+	machine := os.Getenv("HOME")
+
+	env := gitenv.Env()
+	home := valueOf(t, env, "HOME")
+	require.NotEqual(t, machine, home, "the machine's home directory must not survive")
+	for _, key := range []string{"USERPROFILE", "XDG_CONFIG_HOME"} {
+		require.Equal(t, home, valueOf(t, env, key),
+			"%s must lead to the same place as HOME", key)
+	}
+
+	for _, path := range []string{
+		filepath.Join(home, ".gitconfig"),
+		filepath.Join(home, "git", "config"),
+	} {
+		_, err := os.Stat(path)
+		require.ErrorIs(t, err, os.ErrNotExist, "%s must not exist", path)
+	}
+}
+
+// TestEnvHomeDirectoryIsNotCreated is the other half of that: the path Env
+// hands git holds nothing because it does not exist, which is what lets a
+// package that cannot reach a *testing.T — `_examples` builds commands while
+// initialising a package-level variable, and the ssh server's handler runs on
+// a connection of its own — take part without leaving a directory behind.
+//
+// Running git against it is what the test checks, since a git that created a
+// home directory it was pointed at would defeat this quietly.
+func TestEnvHomeDirectoryIsNotCreated(t *testing.T) {
+	t.Parallel()
+	requireGit(t)
+
+	home := valueOf(t, gitenv.Env(), "HOME")
+
+	_, err := os.Lstat(home)
+	require.ErrorIs(t, err, os.ErrNotExist, "%s must not be created", home)
+
+	dir := t.TempDir()
+	commitIn(t, dir, gitenv.Env(), "hermetic")
+	gitIn(t, dir, "config", "--list")
+
+	_, err = os.Lstat(home)
+	require.ErrorIs(t, err, os.ErrNotExist, "%s must still not exist after git has run", home)
+}
+
+// TestEnvHomeDirectoryCannotBeSubstituted is why that path is the one beside
+// the test binary rather than a name of its own in the temporary directory. A
+// path that does not exist is a path someone else may create, and git reads a
+// config file in a home directory without checking who owns it — the
+// CVE-2022-24765 checks cover repositories. The go tool builds the binary
+// under a directory it makes private, so no other user can get there.
+func TestEnvHomeDirectoryCannotBeSubstituted(t *testing.T) {
+	t.Parallel()
+
+	home := valueOf(t, gitenv.Env(), "HOME")
+
+	exe, err := os.Executable()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Dir(exe), filepath.Dir(home),
+		"the home directory must sit beside the test binary, in the tree the go tool owns")
+
+	if os.PathSeparator != '/' {
+		return
+	}
+	for dir := filepath.Dir(home); ; dir = filepath.Dir(dir) {
+		info, err := os.Stat(dir)
+		require.NoError(t, err)
+		if info.Mode().Perm()&0o022 == 0 {
+			// Something on the way up denies everyone else the write it would
+			// take to create the home directory, which is all this needs.
+			return
+		}
+		require.NotEqual(t, dir, filepath.Dir(dir),
+			"no directory above %s keeps other users out", home)
+	}
 }

--- a/internal/transport/test/common.go
+++ b/internal/transport/test/common.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"net"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -12,6 +11,7 @@ import (
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 )
 
@@ -19,7 +19,7 @@ import (
 // (git >= 2.18). Transports backed by the reference git server use it to skip
 // the v2 suite run on older git, which would silently fall back to v0.
 func GitSupportsV2() bool {
-	out, err := exec.Command("git", "version").Output()
+	out, err := gitenv.Command("git", "version").Output()
 	if err != nil {
 		return false
 	}

--- a/object_walker_test.go
+++ b/object_walker_test.go
@@ -3,12 +3,11 @@ package git
 import (
 	"bytes"
 	"io"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/memory"
@@ -43,14 +42,13 @@ func (s *objectWalkerSuite) TestNormalClonedRepo() {
 	t := s.T()
 	local := t.TempDir()
 
-	cmd := exec.Command(
+	cmd := gitenv.Command(
 		"git",
 		"clone",
 		"--no-checkout",
 		"file://"+s.GetBasicLocalRepositoryURL(),
 		local,
 	)
-	cmd.Env = os.Environ()
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
 	cmd.Stdout = buf
@@ -73,7 +71,7 @@ func (s *objectWalkerSuite) TestShallowClonedRepo() {
 	t := s.T()
 	local := t.TempDir()
 
-	cmd := exec.Command(
+	cmd := gitenv.Command(
 		"git",
 		"clone",
 		"--no-checkout",
@@ -82,7 +80,6 @@ func (s *objectWalkerSuite) TestShallowClonedRepo() {
 		"file://"+s.GetBasicLocalRepositoryURL(),
 		local,
 	)
-	cmd.Env = os.Environ()
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
 	cmd.Stdout = buf

--- a/plumbing/format/gitignore/conformance_test.go
+++ b/plumbing/format/gitignore/conformance_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 )
 
 // ConformanceSuite verifies go-git's gitignore against upstream Git references:
@@ -56,7 +58,7 @@ func (s *ConformanceSuite) gitOracleRoot() *os.Root {
 			s.T().Logf("oracle disabled: tempdir: %v", err)
 			return
 		}
-		if err := exec.Command("git", "-c", "init.defaultBranch=main", "-C", dir, "init", "-q").Run(); err != nil {
+		if err := gitenv.Command("git", "-c", "init.defaultBranch=main", "-C", dir, "init", "-q").Run(); err != nil {
 			_ = os.RemoveAll(dir)
 			s.T().Logf("oracle disabled: git init: %v", err)
 			return
@@ -68,7 +70,7 @@ func (s *ConformanceSuite) gitOracleRoot() *os.Root {
 			return
 		}
 		s.oracleRoot = root
-		out, err := exec.Command("git", "-C", dir, "config", "--get", "core.ignorecase").Output()
+		out, err := gitenv.Command("git", "-C", dir, "config", "--get", "core.ignorecase").Output()
 		if err == nil {
 			s.platformIgnoresCase = strings.TrimSpace(string(out)) == "true"
 		}
@@ -153,7 +155,7 @@ func (s *ConformanceSuite) runCheckIgnore(root *os.Root, arg, ignoreCase string)
 		args = append(args, "-c", "core.ignorecase="+ignoreCase)
 	}
 	args = append(args, "check-ignore", "-q", "--", arg)
-	err := exec.Command("git", args...).Run()
+	err := gitenv.Command("git", args...).Run()
 	switch {
 	case err == nil:
 		return true, true

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -2,7 +2,6 @@ package revlist
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -591,7 +591,7 @@ func gitRevListObjects(t *testing.T, gitDir string, want, have plumbing.Hash) ma
 func tryGitRevListObjects(t *testing.T, gitDir string, want, have plumbing.Hash) (map[plumbing.Hash]bool, error) {
 	t.Helper()
 	args := []string{"--git-dir", gitDir, "rev-list", "--objects", want.String(), "^" + have.String()}
-	cmd := exec.Command("git", args...)
+	cmd := gitenv.Command("git", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("git rev-list failed: %s\n%s", err, string(out))

--- a/plumbing/transport/git/git_test.go
+++ b/plumbing/transport/git/git_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -20,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/transport"
@@ -34,13 +34,12 @@ func freePort(t *testing.T) int {
 
 func startDaemon(t *testing.T, base string, port int) {
 	t.Helper()
-	daemon := exec.Command("git", "daemon",
+	daemon := gitenv.Command("git", "daemon",
 		fmt.Sprintf("--base-path=%s", base),
 		"--export-all", "--enable=receive-pack", "--enable=upload-archive", "--reuseaddr",
 		fmt.Sprintf("--port=%d", port),
 		"--max-connections=1", "--listen=127.0.0.1",
 	)
-	daemon.Env = os.Environ()
 	require.NoError(t, daemon.Start())
 
 	t.Cleanup(func() {

--- a/plumbing/transport/http/backend_test.go
+++ b/plumbing/transport/http/backend_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	internalhttp "github.com/go-git/go-git/v6/internal/server/http"
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/transport"
@@ -25,7 +26,7 @@ import (
 // Output is captured for diagnostics.
 func run(t testing.TB, dir, name string, args ...string) {
 	t.Helper()
-	cmd := exec.Command(name, args...)
+	cmd := gitenv.Command(name, args...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s %v failed in %s: %s", name, args, dir, string(out))
@@ -37,9 +38,9 @@ func run(t testing.TB, dir, name string, args ...string) {
 // tests that had history and triggered haves+ready negotiation).
 func runV2(t testing.TB, dir, name string, args ...string) {
 	t.Helper()
-	cmd := exec.Command(name, args...)
+	cmd := gitenv.Command(name, args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "GIT_PROTOCOL=version=2")
+	cmd.Env = append(cmd.Env, "GIT_PROTOCOL=version=2")
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "%s %v failed in %s: %s", name, args, dir, string(out))
 }
@@ -249,7 +250,7 @@ func TestBackend_HTTP_E2E_ClonePullPush(t *testing.T) {
 // gitOut runs a git command and returns its trimmed combined output, failing on error.
 func gitOut(t testing.TB, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	cmd := gitenv.Command("git", args...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v in %s: %s", args, dir, out)
@@ -312,7 +313,10 @@ func TestBackend_HTTP_E2E_ShallowClone(t *testing.T) {
 	// Bounding: the parent commit's objects were never transferred (the pack is
 	// truncated to the boundary, not merely grafted).
 	parent := gitOut(t, work, "rev-parse", "HEAD~1")
-	catFile := exec.Command("git", "cat-file", "-e", parent)
+	// This one asserts a failure, so the isolation matters more here than
+	// elsewhere: a git that failed because it could not read the machine's
+	// config would satisfy the assertion while saying nothing about the object.
+	catFile := gitenv.Command("git", "cat-file", "-e", parent)
 	catFile.Dir = cloned
 	require.Error(t, catFile.Run(), "parent commit %s must be absent from a bounded --depth 1 clone", parent)
 }

--- a/plumbing/transport/http/http_test.go
+++ b/plumbing/transport/http/http_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -21,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	transport "github.com/go-git/go-git/v6/plumbing/transport"
 )
@@ -33,7 +33,7 @@ func setupSmartServer(t testing.TB) (base string, addr *net.TCPAddr) {
 	base = filepath.Join(t.TempDir(), fmt.Sprintf("go-git-http-%d", addr.Port))
 	require.NoError(t, os.MkdirAll(base, 0o755))
 
-	out, err := exec.Command("git", "--exec-path").CombinedOutput()
+	out, err := gitenv.Command("git", "--exec-path").CombinedOutput()
 	require.NoError(t, err)
 
 	server := &http.Server{

--- a/plumbing/transport/ssh/ssh_test.go
+++ b/plumbing/transport/ssh/ssh_test.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"net"
 	"net/url"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -21,6 +19,7 @@ import (
 	stdssh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/testdata"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/internal/transport/test"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/transport"
@@ -53,10 +52,10 @@ func handlerSSH(s ssh.Session) {
 		return
 	}
 
-	cmd := exec.Command(args[0], args[1:]...)
+	cmd := gitenv.Command(args[0], args[1:]...)
 	// Forward the SSH session environment (notably GIT_PROTOCOL, which the
 	// client sets via Setenv) so git speaks the requested wire version.
-	cmd.Env = append(os.Environ(), s.Environ()...)
+	cmd.Env = append(cmd.Env, s.Environ()...)
 	stdout, _ := cmd.StdoutPipe()
 	stdin, _ := cmd.StdinPipe()
 	stderr, _ := cmd.StderrPipe()

--- a/repository_promisor_test.go
+++ b/repository_promisor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
@@ -47,7 +48,8 @@ func requireGitPartialClone(t *testing.T) {
 	t.Helper()
 	requireGitBinary(t)
 
-	out, err := exec.Command("git", "version").Output()
+	versionCmd := gitenv.Command("git", "version")
+	out, err := versionCmd.Output()
 	if err != nil {
 		t.Skipf("cannot determine git version: %v", err)
 	}
@@ -97,7 +99,8 @@ func git(t *testing.T, dir string, args ...string) string {
 	// protocol.file.allow keeps file:// transport usable across git versions
 	// that restrict it by default.
 	full := append([]string{"-C", dir, "-c", "protocol.file.allow=always"}, args...)
-	out, err := exec.Command("git", full...).CombinedOutput()
+	cmd := gitenv.Command("git", full...)
+	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v: %s", args, out)
 	return string(out)
 }
@@ -107,7 +110,8 @@ func git(t *testing.T, dir string, args ...string) string {
 func gitAllowFail(t *testing.T, dir string, args ...string) (string, bool) {
 	t.Helper()
 	full := append([]string{"-C", dir, "-c", "protocol.file.allow=always"}, args...)
-	out, err := exec.Command("git", full...).CombinedOutput()
+	cmd := gitenv.Command("git", full...)
+	out, err := cmd.CombinedOutput()
 	return string(out), err == nil
 }
 
@@ -130,11 +134,13 @@ func newPartialClone(t *testing.T, filter string) string {
 	require.NoError(t, os.MkdirAll(src, 0o755))
 	require.NoError(t, os.MkdirAll(seed, 0o755))
 
-	out, err := exec.Command("git", "init", "-q", "--bare", src).CombinedOutput()
+	initBare := gitenv.Command("git", "init", "-q", "--bare", src)
+	out, err := initBare.CombinedOutput()
 	require.NoError(t, err, "git init --bare: %s", out)
 	git(t, src, "config", "uploadpack.allowFilter", "true")
 
-	out, err = exec.Command("git", "init", "-q", seed).CombinedOutput()
+	initSeed := gitenv.Command("git", "init", "-q", seed)
+	out, err = initSeed.CombinedOutput()
 	require.NoError(t, err, "git init: %s", out)
 	git(t, seed, "config", "user.email", "test@example.com")
 	git(t, seed, "config", "user.name", "test")
@@ -148,8 +154,9 @@ func newPartialClone(t *testing.T, filter string) string {
 	git(t, seed, "remote", "add", "origin", src)
 	git(t, seed, "push", "-q", "origin", "main")
 
-	out, err = exec.Command("git", "-c", "protocol.file.allow=always", "clone", "-q",
-		"--filter="+filter, "--no-checkout", "file://"+src, dst).CombinedOutput()
+	cloneCmd := gitenv.Command("git", "-c", "protocol.file.allow=always", "clone", "-q",
+		"--filter="+filter, "--no-checkout", "file://"+src, dst)
+	out, err = cloneCmd.CombinedOutput()
 	require.NoError(t, err, "git clone --filter=%s: %s", filter, out)
 
 	// Sanity-check the fixture really is a partial clone with absent objects,

--- a/repository_test.go
+++ b/repository_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"os/user"
 	"path"
 	"path/filepath"
@@ -32,6 +31,7 @@ import (
 	"github.com/go-git/go-git/v6/config"
 	archivePkg "github.com/go-git/go-git/v6/internal/archive"
 	"github.com/go-git/go-git/v6/internal/server"
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
@@ -3977,9 +3977,8 @@ func ExecuteOnPath(t *testing.T, path string, cmds ...string) error {
 
 func executeOnPath(path, cmd string) error {
 	args := strings.Split(cmd, " ")
-	c := exec.Command(args[0], args[1:]...)
+	c := gitenv.Command(args[0], args[1:]...)
 	c.Dir = path
-	c.Env = os.Environ()
 
 	buf := bytes.NewBuffer(nil)
 	c.Stderr = buf

--- a/tests/gitcompare/status_bench_test.go
+++ b/tests/gitcompare/status_bench_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	git "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 )
 
 // compareRepoEnv names an existing checkout to measure alongside the fixtures.
@@ -52,7 +53,8 @@ func requireGit(b *testing.B) {
 // runGit executes a git command that is expected to succeed.
 func runGit(b *testing.B, dir string, args ...string) {
 	b.Helper()
-	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	cmd := gitenv.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
 	require.NoError(b, err, "git %v: %s", args, out)
 }
 
@@ -100,12 +102,14 @@ func benchGitStatus(dir string, readOnly bool) func(*testing.B) {
 		// One untimed invocation first. On a fresh fixture it populates the
 		// index stat cache that steady-state use would already have, so the
 		// measurement is not dominated by a cost paid once.
-		if _, err := exec.Command("git", args...).Output(); err != nil {
+		warm := gitenv.Command("git", args...)
+		if _, err := warm.Output(); err != nil {
 			b.Fatalf("git status: %v", err)
 		}
 
 		for b.Loop() {
-			if _, err := exec.Command("git", args...).Output(); err != nil {
+			cmd := gitenv.Command("git", args...)
+			if _, err := cmd.Output(); err != nil {
 				b.Fatalf("git status: %v", err)
 			}
 		}

--- a/tests/objectverify/main_test.go
+++ b/tests/objectverify/main_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
@@ -164,14 +165,14 @@ func configureRepoSigning(t *testing.T, repo, keyID string) {
 		{"commit.gpgsign", "false"},
 		{"tag.gpgsign", "false"},
 	} {
-		out, err := exec.Command("git", "-C", repo, "config", "--local", kv[0], kv[1]).CombinedOutput()
+		out, err := gitenv.Command("git", "-C", repo, "config", "--local", kv[0], kv[1]).CombinedOutput()
 		require.NoErrorf(t, err, "git config %s: %s", kv[0], out)
 	}
 }
 
 func gitWriteEmptyTree(t *testing.T, repo string) plumbing.Hash {
 	t.Helper()
-	cmd := exec.Command("git", "-C", repo, "write-tree")
+	cmd := gitenv.Command("git", "-C", repo, "write-tree")
 	out, err := cmd.Output()
 	require.NoError(t, err, "git write-tree")
 	return plumbing.NewHash(strings.TrimSpace(string(out)))
@@ -179,8 +180,8 @@ func gitWriteEmptyTree(t *testing.T, repo string) plumbing.Hash {
 
 func gitCommitTreeSigned(t *testing.T, repo string, tree plumbing.Hash, msg string, envOverrides []string) plumbing.Hash {
 	t.Helper()
-	cmd := exec.Command("git", "-C", repo, "commit-tree", "-S", "-m", strings.TrimRight(msg, "\n"), tree.String())
-	cmd.Env = append(os.Environ(), envOverrides...)
+	cmd := gitenv.Command("git", "-C", repo, "commit-tree", "-S", "-m", strings.TrimRight(msg, "\n"), tree.String())
+	cmd.Env = append(cmd.Env, envOverrides...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
@@ -190,20 +191,20 @@ func gitCommitTreeSigned(t *testing.T, repo string, tree plumbing.Hash, msg stri
 
 func gitTagSigned(t *testing.T, repo, name string, target plumbing.Hash, msg string, envOverrides []string) plumbing.Hash {
 	t.Helper()
-	cmd := exec.Command("git", "-C", repo, "tag", "-s", "-m", strings.TrimRight(msg, "\n"), name, target.String())
-	cmd.Env = append(os.Environ(), envOverrides...)
+	cmd := gitenv.Command("git", "-C", repo, "tag", "-s", "-m", strings.TrimRight(msg, "\n"), name, target.String())
+	cmd.Env = append(cmd.Env, envOverrides...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	require.NoErrorf(t, cmd.Run(), "git tag -s: %s", stderr.String())
 
-	rev, err := exec.Command("git", "-C", repo, "rev-parse", name).Output()
+	rev, err := gitenv.Command("git", "-C", repo, "rev-parse", name).Output()
 	require.NoError(t, err)
 	return plumbing.NewHash(strings.TrimSpace(string(rev)))
 }
 
 func readObjectBytes(t *testing.T, repo, kind string, h plumbing.Hash) []byte {
 	t.Helper()
-	out, err := exec.Command("git", "-C", repo, "cat-file", kind, h.String()).Output()
+	out, err := gitenv.Command("git", "-C", repo, "cat-file", kind, h.String()).Output()
 	require.NoError(t, err, "git cat-file %s %s", kind, h.String())
 	return out
 }
@@ -313,14 +314,14 @@ func gpgSign(t *testing.T, payload []byte) string {
 func initRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	out, err := exec.Command("git", "-C", dir, "init", "--quiet").CombinedOutput()
+	out, err := gitenv.Command("git", "-C", dir, "init", "--quiet").CombinedOutput()
 	require.NoErrorf(t, err, "git init: %s", out)
 	return dir
 }
 
 func writeLooseObject(t *testing.T, repo, objType string, content []byte) plumbing.Hash {
 	t.Helper()
-	cmd := exec.Command("git", "-C", repo, "hash-object", "-w", "--literally", "-t", objType, "--stdin")
+	cmd := gitenv.Command("git", "-C", repo, "hash-object", "-w", "--literally", "-t", objType, "--stdin")
 	cmd.Stdin = bytes.NewReader(content)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -331,7 +332,7 @@ func writeLooseObject(t *testing.T, repo, objType string, content []byte) plumbi
 
 func gitVerifyCommit(t *testing.T, repo string, h plumbing.Hash) error {
 	t.Helper()
-	cmd := exec.Command("git", "-C", repo, "verify-commit", h.String())
+	cmd := gitenv.Command("git", "-C", repo, "verify-commit", h.String())
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -342,7 +343,7 @@ func gitVerifyCommit(t *testing.T, repo string, h plumbing.Hash) error {
 
 func gitVerifyTag(t *testing.T, repo string, h plumbing.Hash) error {
 	t.Helper()
-	cmd := exec.Command("git", "-C", repo, "verify-tag", h.String())
+	cmd := gitenv.Command("git", "-C", repo, "verify-tag", h.String())
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -24,6 +22,7 @@ import (
 	_ "unsafe"
 
 	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -943,9 +942,8 @@ func (s *WorktreeSuite) TestCommitTreeSort() {
 	err = r.Push(&PushOptions{})
 	s.Require().NoError(err)
 
-	cmd := exec.Command("git", "fsck")
+	cmd := gitenv.Command("git", "fsck")
 	cmd.Dir = fs.Root()
-	cmd.Env = os.Environ()
 	buf := &bytes.Buffer{}
 	cmd.Stderr = buf
 	cmd.Stdout = buf

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -19,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/internal/pathutil"
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
@@ -955,7 +955,7 @@ func storeRawTree(t *testing.T, s storer.Storer, entries []object.TreeEntry) plu
 
 func gitConfig(t *testing.T, dir, key, value string) {
 	t.Helper()
-	cmd := exec.Command("git", "config", key, value)
+	cmd := gitenv.Command("git", "config", key, value)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git config %s %s: %s", key, value, out)
@@ -968,7 +968,7 @@ func gitConfig(t *testing.T, dir, key, value string) {
 // NTFS Alternate Data Stream check (CVE-2019-1351).
 func gitAtLeast(t *testing.T, major, minor int) bool {
 	t.Helper()
-	out, err := exec.Command("git", "--version").Output()
+	out, err := gitenv.Command("git", "--version").Output()
 	if err != nil {
 		return false
 	}
@@ -984,9 +984,9 @@ func gitAtLeast(t *testing.T, major, minor int) bool {
 
 func gitCherryPick(t *testing.T, dir, hash string) error {
 	t.Helper()
-	cmd := exec.Command("git", "cherry-pick", hash)
+	cmd := gitenv.Command("git", "cherry-pick", hash)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(cmd.Env,
 		"GIT_AUTHOR_NAME=test",
 		"GIT_AUTHOR_EMAIL=test@test",
 		"GIT_COMMITTER_NAME=test",
@@ -994,7 +994,7 @@ func gitCherryPick(t *testing.T, dir, hash string) error {
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		abort := exec.Command("git", "cherry-pick", "--abort")
+		abort := gitenv.Command("git", "cherry-pick", "--abort")
 		abort.Dir = dir
 		_ = abort.Run()
 		return fmt.Errorf("git cherry-pick %s: %s: %w", hash, out, err)

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/storage/filesystem"
@@ -282,7 +283,7 @@ func TestStatusMatchesReferenceGitForIgnoreLayouts(t *testing.T) {
 
 			dir := filepath.Join(t.TempDir(), "repo")
 			require.NoError(t, os.MkdirAll(dir, 0o755))
-			require.NoError(t, exec.Command("git", "-c", "init.defaultBranch=main", "-C", dir, "init", "-q").Run())
+			require.NoError(t, gitenv.Command("git", "-c", "init.defaultBranch=main", "-C", dir, "init", "-q").Run())
 
 			for p, content := range tc.files {
 				abs := filepath.Join(dir, filepath.FromSlash(p))
@@ -290,7 +291,7 @@ func TestStatusMatchesReferenceGitForIgnoreLayouts(t *testing.T) {
 				require.NoError(t, os.WriteFile(abs, []byte(content), 0o644))
 			}
 
-			out, err := exec.Command("git", "-C", dir, "ls-files", "--others", "--exclude-standard").Output()
+			out, err := gitenv.Command("git", "-C", dir, "ls-files", "--others", "--exclude-standard").Output()
 			require.NoError(t, err)
 			want := map[string]bool{}
 			for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {


### PR DESCRIPTION
Break free of developer their machine configuration so tests always yield reliable results.