### PR TITLE
plumbing: Harden reference names across storage and transport

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/transport"
+	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
 // Request describes a Git server-side operation.
@@ -93,6 +94,15 @@ func (b *Backend) Serve(ctx context.Context, r io.ReadCloser, w io.WriteCloser, 
 			_ = closer.Close()
 		}
 	}()
+
+	// Transport commands may close their streams when an exchange finishes.
+	// Serve leaves the underlying streams open for the caller.
+	if r != nil {
+		r = io.NopCloser(r)
+	}
+	if w != nil {
+		w = ioutil.WriteNopCloser(w)
+	}
 
 	switch req.Service {
 	case transport.UploadPackService:

--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"bytes"
 	"io"
 	"net/http/httptest"
 	"net/url"
@@ -9,12 +10,176 @@ import (
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/format/packfile"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/memory"
 )
+
+type callerStream struct {
+	bytes.Buffer
+	closed bool
+}
+
+func (s *callerStream) Close() error {
+	s.closed = true
+	return io.ErrClosedPipe
+}
+
+func (s *callerStream) Read(p []byte) (int, error) {
+	if s.closed {
+		return 0, io.ErrClosedPipe
+	}
+	return s.Buffer.Read(p)
+}
+
+func (s *callerStream) Write(p []byte) (int, error) {
+	if s.closed {
+		return 0, io.ErrClosedPipe
+	}
+	return s.Buffer.Write(p)
+}
+
+func TestServeKeepsCallerStreamsOpen(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		service   string
+		advertise bool
+		malformed bool
+		report    bool
+		sideband  bool
+	}{
+		{name: "receive without report", service: transport.ReceivePackService},
+		{name: "receive sideband without report", service: transport.ReceivePackService, sideband: true},
+		{name: "receive report", service: transport.ReceivePackService, report: true},
+		{name: "receive sideband report", service: transport.ReceivePackService, report: true, sideband: true},
+		{name: "receive advertisement", service: transport.ReceivePackService, advertise: true},
+		{name: "receive malformed", service: transport.ReceivePackService, malformed: true},
+		{name: "upload advertisement", service: transport.UploadPackService, advertise: true},
+		{name: "upload pack", service: transport.UploadPackService},
+		{name: "upload malformed", service: transport.UploadPackService, malformed: true},
+		{name: "archive formats", service: transport.UploadArchiveService},
+		{name: "archive malformed", service: transport.UploadArchiveService, malformed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			st := memory.NewStorage()
+			obj := st.NewEncodedObject()
+			obj.SetType(plumbing.BlobObject)
+			hash, err := st.SetEncodedObject(obj)
+			require.NoError(t, err)
+			ref := plumbing.NewHashReference("refs/heads/main", hash)
+			require.NoError(t, st.SetReference(ref))
+			r, w := &callerStream{}, &callerStream{}
+			switch {
+			case tc.malformed:
+				_, err := r.Write([]byte("bad!"))
+				require.NoError(t, err)
+			case tc.advertise:
+			case tc.service == transport.ReceivePackService:
+				req := &packp.UpdateRequests{Commands: []*packp.Command{{Name: ref.Name(), Old: ref.Hash()}}}
+				if tc.report {
+					req.Capabilities.Set(capability.ReportStatus)
+				}
+				if tc.sideband {
+					req.Capabilities.Set(capability.Sideband64k)
+				}
+				require.NoError(t, req.Encode(r))
+			case tc.service == transport.UploadPackService:
+				req := &packp.UploadRequest{Wants: []plumbing.Hash{hash}}
+				require.NoError(t, req.Encode(r))
+				_, err := pktline.WriteString(r, "done\n")
+				require.NoError(t, err)
+			case tc.service == transport.UploadArchiveService:
+				_, err := pktline.WriteString(r, "argument --list\n")
+				require.NoError(t, err)
+				require.NoError(t, pktline.WriteFlush(r))
+			}
+
+			b := New(transport.MapLoader{"/repo": st})
+			err = b.Serve(t.Context(), r, w, &Request{
+				URL:           &url.URL{Path: "/repo"},
+				Service:       tc.service,
+				AdvertiseRefs: tc.advertise,
+				StatelessRPC:  true,
+			})
+			if tc.malformed {
+				require.Error(t, err)
+				require.NotErrorIs(t, err, io.ErrClosedPipe)
+			} else {
+				require.NoError(t, err)
+			}
+			require.False(t, r.closed, "Serve closed the caller's reader")
+			require.False(t, w.closed, "Serve closed the caller's writer")
+
+			switch {
+			case tc.malformed:
+			case tc.advertise:
+				require.Contains(t, w.String(), ref.Name().String())
+				require.True(t, bytes.HasSuffix(w.Bytes(), []byte("0000")))
+			case tc.service == transport.ReceivePackService:
+				_, err := st.Reference(ref.Name())
+				require.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+				switch {
+				case tc.report:
+					var response io.Reader = bytes.NewReader(w.Bytes())
+					if tc.sideband {
+						require.True(t, bytes.HasSuffix(w.Bytes(), []byte("0000")), "missing outer sideband flush")
+						response = sideband.NewDemuxer(sideband.Sideband64k, response)
+					}
+					var report packp.ReportStatus
+					require.NoError(t, report.Decode(response))
+					require.NoError(t, report.Error())
+					require.Len(t, report.CommandStatuses, 1)
+					require.Equal(t, ref.Name(), report.CommandStatuses[0].ReferenceName)
+				case tc.sideband:
+					require.Equal(t, "0000", w.String())
+				default:
+					require.Empty(t, w.Bytes())
+				}
+			case tc.service == transport.UploadPackService:
+				require.True(t, bytes.HasPrefix(w.Bytes(), []byte("0008NAK\n")))
+				dst := memory.NewStorage()
+				require.NoError(t, packfile.UpdateObjectStorage(dst, bytes.NewReader(w.Bytes()[8:])))
+				require.NoError(t, dst.HasEncodedObject(hash))
+			case tc.service == transport.UploadArchiveService:
+				require.Contains(t, w.String(), "ACK\n")
+				require.Contains(t, w.String(), "tar\n")
+				require.True(t, bytes.HasSuffix(w.Bytes(), []byte("0000")))
+			}
+
+			r.Reset()
+			_, err = r.Write([]byte("next request"))
+			require.NoError(t, err)
+			remaining, err := io.ReadAll(r)
+			require.NoError(t, err)
+			require.Equal(t, "next request", string(remaining))
+			_, err = w.Write([]byte("caller response"))
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestServeNilReceiveStreams(t *testing.T) {
+	t.Parallel()
+	b := New(transport.MapLoader{"/repo": memory.NewStorage()})
+	req := &Request{URL: &url.URL{Path: "/repo"}, Service: transport.ReceivePackService, StatelessRPC: true}
+	require.EqualError(t, b.Serve(t.Context(), nil, nil, req), "nil writer")
+	w := &callerStream{}
+	require.EqualError(t, b.Serve(t.Context(), nil, w, req), "nil reader")
+	require.False(t, w.closed)
+	req.AdvertiseRefs = true
+	require.NoError(t, b.Serve(t.Context(), nil, w, req))
+	require.False(t, w.closed)
+}
 
 type fixturesLoader struct {
 	testing.TB

--- a/internal/pathutil/path_util.go
+++ b/internal/pathutil/path_util.go
@@ -30,3 +30,50 @@ func ReplaceTildeWithHome(path string) (string, error) {
 
 	return path, nil
 }
+
+// HasUnsafeComponent reports whether name, split on '/' and '\\', has a path
+// component that must not be stored verbatim as a filesystem path: one holding
+// a control character, or one that a case-insensitive, NTFS or HFS+ filesystem
+// would resolve back to "." or "..".
+//
+// A literal ".." is only the plainest spelling of an escape. IsHFSDot and
+// IsNTFSDot read their needle as the component's spelling after the leading
+// dot, so "." finds ".." and "" finds a bare "." — each with the disguises
+// those two already cover: the code points HFS+ drops during normalisation,
+// and the trailing dots or spaces NTFS trims and the Alternate Data Stream
+// suffix it truncates at. A component folding to ".." aliases the parent
+// directory, and one folding to "." aliases the directory it sits in, which
+// turns "refs/heads/<U+200C>./main" into "refs/heads/main".
+//
+// Three of the four needle combinations do work. IsNTFSDot with an empty
+// needle already matches every component NTFS trims down to a dot, and what it
+// matches strictly contains what the "." needle could add, so that fourth
+// call would never be the one to fire.
+//
+// A component holding no '.' can match none of them, so the control-character
+// scan records whether it saw a dot and the fold checks run only if it did.
+// The checks run regardless of the host OS, because a name can be authored on
+// one system and reach the filesystem on another.
+func HasUnsafeComponent(name string) bool {
+	for _, part := range strings.FieldsFunc(name, isPathSep) {
+		var dot bool
+		for i := 0; i < len(part); i++ {
+			c := part[i]
+			if c < 0x20 || c == 0x7f {
+				return true
+			}
+			dot = dot || c == '.'
+		}
+		if !dot {
+			continue
+		}
+
+		if IsHFSDot(part, "") || IsNTFSDot(part, "", "") || IsHFSDot(part, ".") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isPathSep(r rune) bool { return r == '/' || r == '\\' }

--- a/internal/pathutil/path_util_test.go
+++ b/internal/pathutil/path_util_test.go
@@ -1,0 +1,70 @@
+package pathutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasUnsafeComponent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"refs/heads/main", false},
+		{"refs/heads/feature/nested", false},
+		{"HEAD", false},
+		{"", false},
+		{"refs/heads/a.b", false},
+		{"refs/heads/.hidden", false},
+		{"refs/tags/v1.0.0", false},
+
+		{".", true},
+		{"..", true},
+		{"refs/../config", true},
+		{"refs/heads/../../config", true},
+		{"refs/./heads", true},
+		{"refs\\..\\config", true},
+
+		// NTFS strips trailing periods and spaces from a component and
+		// truncates it at the Alternate Data Stream colon, so each of these
+		// resolves to "..".
+		{"refs/...", true},
+		{"refs/.. /config", true},
+		{"refs/..:$DATA/config", true},
+
+		// HFS+ drops these code points during path normalisation, so the
+		// component reads as ".." to the filesystem while holding no literal
+		// "..": zero width non-joiner, the BOM, and the left-to-right mark.
+		{"refs/\u200c.\u200c./config", true},
+		{"refs/\ufeff.\ufeff.\ufeff/config", true},
+		{"refs/\u200e.\u200e./config", true},
+
+		// A component the filesystem reads as a single "." is an alias for the
+		// directory it sits in, so each of these names resolves to
+		// "refs/heads/main". Nothing after the dot spells the component, so
+		// the needle for these is the empty string.
+		{"refs/heads/\u200c./main", true},
+		{"refs/heads/.\u200c/main", true},
+		{"refs/heads/\u200c.\u200c/main", true},
+		{"refs/\ufeff./heads/main", true},
+		{"refs/\u200e./heads/main", true},
+		{"refs/heads/. /main", true},
+		{"refs/heads/.  /main", true},
+		{"refs/heads/.:$DATA/main", true},
+		{"refs/heads/. :$DATA/main", true},
+
+		{"refs/heads/ma\x00in", true},
+		{"refs/heads/ma\nin", true},
+		{"refs/heads/ma\x7fin", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, HasUnsafeComponent(tc.in))
+		})
+	}
+}

--- a/internal/reference/advertisement.go
+++ b/internal/reference/advertisement.go
@@ -1,0 +1,21 @@
+package reference
+
+import (
+	"errors"
+	"syscall"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/storer"
+)
+
+// IsUnresolvableForAdvertisement identifies broken symbolic referents that
+// advertisements omit individually. ELOOP also covers filesystem symlink
+// chains exceeding the operating system limit. Other storage errors remain
+// fatal. Maintenance reachability must not use this classification to omit
+// references on ELOOP or recursion-limit errors.
+func IsUnresolvableForAdvertisement(err error) bool {
+	return errors.Is(err, plumbing.ErrReferenceNotFound) ||
+		errors.Is(err, plumbing.ErrInvalidReferenceName) ||
+		errors.Is(err, storer.ErrMaxResolveRecursion) ||
+		errors.Is(err, syscall.ELOOP)
+}

--- a/internal/repository/refs.go
+++ b/internal/repository/refs.go
@@ -51,13 +51,18 @@ func WriteInfoRefs(w io.Writer, s storage.Storer) error {
 	reference.Sort(refs)
 	for _, ref := range refs {
 		name := ref.Name()
+		// Dumb HTTP lists refs/ names only. Keep malformed names visible to
+		// storage consumers, but never interpolate them into wire records.
+		if !name.IsUnderRefs() || name.Validate() != nil {
+			continue
+		}
 		hash := ref.Hash()
 		switch ref.Type() {
 		case plumbing.SymbolicReference:
-			if name == plumbing.HEAD {
+			ref, err := storer.ResolveReference(s, ref.Target())
+			if reference.IsUnresolvableForAdvertisement(err) {
 				continue
 			}
-			ref, err := s.Reference(ref.Target())
 			if err != nil {
 				return err
 			}

--- a/object_walker.go
+++ b/object_walker.go
@@ -86,7 +86,7 @@ func (p *objectWalker) isShallow(hash plumbing.Hash) (bool, error) {
 	return ok, nil
 }
 
-// walkAllRefs walks all (hash) references from the repo.
+// walkAllRefs walks the objects reachable through hash and symbolic references.
 func (p *objectWalker) walkAllRefs() error {
 	// Walk over all the references in the repo.
 	it, err := p.Storer.IterReferences()
@@ -95,7 +95,19 @@ func (p *objectWalker) walkAllRefs() error {
 	}
 	defer it.Close()
 	err = it.ForEach(func(ref *plumbing.Reference) error {
-		// Exit this iteration early for non-hash references.
+		if ref.Type() == plumbing.SymbolicReference {
+			resolved, err := storer.ResolveReference(p.Storer, ref.Target())
+			if errors.Is(err, plumbing.ErrReferenceNotFound) {
+				// Unborn HEAD and dangling symrefs do not name any objects.
+				return nil
+			}
+			if err != nil {
+				// Prune and repack must not discard objects when a failed
+				// lookup or an unresolved cycle makes reachability unknown.
+				return fmt.Errorf("resolving reference %q failed: %w", ref.Name(), err)
+			}
+			ref = resolved
+		}
 		if ref.Type() != plumbing.HashReference {
 			return nil
 		}

--- a/options.go
+++ b/options.go
@@ -37,6 +37,10 @@ const (
 var ErrMissingURL = errors.New("URL field is required")
 
 // CloneOptions describes how a clone should be performed.
+//
+// References with unusable names are skipped. To diagnose skipped references,
+// enable [github.com/go-git/go-git/v6/utils/trace.General] with
+// [github.com/go-git/go-git/v6/utils/trace.SetTarget].
 type CloneOptions struct {
 	// The (possibly remote) repository URL to clone from.
 	URL string
@@ -222,7 +226,11 @@ const (
 	NoTags = plumbing.NoTags
 )
 
-// FetchOptions describes how a fetch should be performed
+// FetchOptions describes how a fetch should be performed.
+//
+// References with unusable names are skipped. To diagnose skipped references,
+// enable [github.com/go-git/go-git/v6/utils/trace.General] with
+// [github.com/go-git/go-git/v6/utils/trace.SetTarget].
 type FetchOptions struct {
 	// Name of the remote to fetch from. Defaults to origin.
 	RemoteName string

--- a/plumbing/protocol/packp/updreq_decode.go
+++ b/plumbing/protocol/packp/updreq_decode.go
@@ -78,6 +78,9 @@ func errMalformedCommand(err error) error {
 }
 
 // Decode reads the next update-request message from the reader.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/builtin/receive-pack.c#L2562-L2566
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/pkt-line.c#L466-L493
 func (req *UpdateRequests) Decode(r io.Reader) error {
 	var (
 		payload []byte
@@ -168,7 +171,9 @@ func (req *UpdateRequests) Decode(r io.Reader) error {
 			break
 		}
 
-		cmd, err := parseCommand(payload)
+		// Match receive-pack's PACKET_READ_CHOMP_NEWLINE without stripping
+		// whitespace that belongs to the reference name.
+		cmd, err := parseCommand(bytes.TrimSuffix(payload, eol))
 		if err != nil {
 			return err
 		}
@@ -183,33 +188,42 @@ func (req *UpdateRequests) Decode(r io.Reader) error {
 	return validateUpdateRequests(req)
 }
 
+// parseCommand preserves the complete reference name after the two object IDs.
+// See https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/builtin/receive-pack.c#L2144-L2152.
 func parseCommand(b []byte) (*Command, error) {
 	if len(b) < minCommandLength {
 		return nil, errInvalidCommandLineLength(len(b))
 	}
 
-	var (
-		os, ns string
-		n      plumbing.ReferenceName
-	)
-	if _, err := fmt.Sscanf(string(b), "%s %s %s", &os, &ns, &n); err != nil {
-		return nil, errMalformedCommand(err)
+	oldHex, rest, ok := bytes.Cut(b, []byte{' '})
+	if !ok {
+		return nil, errMalformedCommand(io.EOF)
+	}
+	newHex, name, ok := bytes.Cut(rest, []byte{' '})
+	if !ok || len(name) == 0 {
+		return nil, errMalformedCommand(io.EOF)
 	}
 
-	oh, err := parseHash(os)
+	oh, err := parseHash(string(oldHex))
 	if err != nil {
 		return nil, errInvalidOldObjID(err)
 	}
 
-	nh, err := parseHash(ns)
+	nh, err := parseHash(string(newHex))
 	if err != nil {
 		return nil, errInvalidNewObjID(err)
 	}
 
-	return &Command{Old: oh, New: nh, Name: n}, nil
+	// Git's queue_command (builtin/receive-pack.c) keeps the entire remainder
+	// after the two object IDs. The receive-pack name gate must see whitespace
+	// in that remainder rather than update a different, truncated reference.
+	return &Command{Old: oh, New: nh, Name: plumbing.ReferenceName(name)}, nil
 }
 
 func parseHash(s string) (plumbing.Hash, error) {
+	if len(s) != sha1HexSize && len(s) != sha256HexSize {
+		return plumbing.ZeroHash, errInvalidHash(s)
+	}
 	h, ok := plumbing.FromHex(s)
 	if !ok {
 		return plumbing.ZeroHash, errInvalidHash(s)

--- a/plumbing/protocol/packp/updreq_decode_test.go
+++ b/plumbing/protocol/packp/updreq_decode_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -105,6 +106,83 @@ func (s *UpdReqDecodeSuite) TestMalformedCommand() {
 		"",
 	}
 	s.testDecoderErrorMatches(toPktLines(s.T(), payloads), "^malformed request: malformed command: EOF$")
+}
+
+func (s *UpdReqDecodeSuite) TestCommandPreservesReferenceName() {
+	old := plumbing.NewHash(strings.Repeat("1", sha1HexSize))
+	newHash := plumbing.NewHash(strings.Repeat("2", sha1HexSize))
+	for _, name := range []string{
+		"refs/heads/a b", "refs/heads/a\tb", "refs/heads/a\nb",
+		"refs/heads/a\rb", "refs/heads/a\vb", "refs/heads/a\fb",
+		"refs/heads/a ", " refs/heads/a", "refs/heads/a\u00a0b",
+	} {
+		s.Run(name, func() {
+			command := old.String() + " " + newHash.String() + " " + name
+			payloads := []string{command + "\x00report-status\n", command + "\n", ""}
+			req := &UpdateRequests{}
+			s.Require().NoError(req.Decode(toPktLines(s.T(), payloads)))
+			s.Require().Len(req.Commands, 2)
+			for _, cmd := range req.Commands {
+				s.Equal(plumbing.ReferenceName(name), cmd.Name)
+				s.Equal(old, cmd.Old)
+				s.Equal(newHash, cmd.New)
+			}
+		})
+	}
+}
+
+func (s *UpdReqDecodeSuite) TestCommandRequiresSpaceSeparators() {
+	oldHex, newHex := strings.Repeat("1", sha1HexSize), strings.Repeat("2", sha1HexSize)
+	for _, command := range []string{
+		oldHex + "\t" + newHex + " refs/heads/main",
+		oldHex + " " + newHex + "\trefs/heads/main",
+		oldHex + "  " + newHex + " refs/heads/main",
+		" " + oldHex + " " + newHex + " refs/heads/main",
+	} {
+		s.Run(command, func() {
+			req := &UpdateRequests{}
+			s.Error(req.Decode(toPktLines(s.T(), []string{command + "\x00", ""})))
+		})
+	}
+}
+
+func (s *UpdReqDecodeSuite) TestCommandTrailingNewline() {
+	oldHex, newHex := strings.Repeat("1", sha1HexSize), strings.Repeat("2", sha1HexSize)
+	command := oldHex + " " + newHex + " refs/heads/main"
+	req := &UpdateRequests{}
+	s.Require().NoError(req.Decode(toPktLines(s.T(), []string{
+		command + "\n\x00report-status\n", command + "\n\n", "",
+	})))
+	s.Require().Len(req.Commands, 2)
+	for _, cmd := range req.Commands {
+		s.Equal(plumbing.ReferenceName("refs/heads/main\n"), cmd.Name)
+	}
+}
+
+func (s *UpdReqDecodeSuite) TestCommandRequiresFullObjectIDs() {
+	for _, size := range []int{0, 38, 42, 62, 66} {
+		short := strings.Repeat("1", size)
+		full := strings.Repeat("2", sha1HexSize)
+		for _, command := range []string{
+			short + " " + full + " refs/heads/main",
+			full + " " + short + " refs/heads/main",
+		} {
+			req := &UpdateRequests{}
+			s.Error(req.Decode(toPktLines(s.T(), []string{command + "\x00", ""})), "command %q", command)
+		}
+	}
+}
+
+func (s *UpdReqDecodeSuite) TestSHA256Command() {
+	oldHex, newHex := strings.Repeat("1", sha256HexSize), strings.Repeat("2", sha256HexSize)
+	req := &UpdateRequests{}
+	s.Require().NoError(req.Decode(toPktLines(s.T(), []string{
+		oldHex + " " + newHex + " refs/heads/main\x00", "",
+	})))
+	s.Require().Len(req.Commands, 1)
+	s.Equal(oldHex, req.Commands[0].Old.String())
+	s.Equal(newHex, req.Commands[0].New.String())
+	s.Equal(plumbing.ReferenceName("refs/heads/main"), req.Commands[0].Name)
 }
 
 func (s *UpdReqDecodeSuite) TestInvalidCommandInvalidHash() {

--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -216,6 +216,13 @@ var ctrlSeqs = regexp.MustCompile(`[\000-\037\177]`)
 //  8. They cannot contain a sequence @{.
 //  9. They cannot be the single character @.
 //  10. They cannot contain a \.
+//
+// A leading "-" is not among them, and neither is a component spelled "@".
+// Git restricts a leading "-" when a branch or a tag is created, in
+// check_branch_ref and check_tag_ref rather than in check_refname_format; see
+// ValidateBranchName and ValidateTagName.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs.c#L191-L322
 func (r ReferenceName) Validate() error {
 	s := string(r)
 	if len(s) == 0 {
@@ -225,6 +232,20 @@ func (r ReferenceName) Validate() error {
 	// HEAD is a special case
 	if r == HEAD {
 		return nil
+	}
+
+	// rule 9. The rule is about the whole name, not about a component: Git
+	// tests it once, against the entire string, before it starts walking the
+	// components (check_or_sanitize_refname, refs.c). "@" is an ordinary
+	// character everywhere else, so "refs/heads/@" is a name git branch
+	// creates and git clone replicates.
+	//
+	// Rule 2 below already refuses every one-level name, so this changes no
+	// outcome today. It is spelled out because Git needs it — the rule earns
+	// its keep under REFNAME_ALLOW_ONELEVEL, which this function has no mode
+	// for — and so that adding such a mode does not quietly admit "@".
+	if s == "@" {
+		return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 	}
 
 	// rule 7
@@ -238,9 +259,7 @@ func (r ReferenceName) Validate() error {
 		return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 	}
 
-	isBranch := r.IsBranch()
-	isTag := r.IsTag()
-	for i, part := range parts {
+	for _, part := range parts {
 		// rule 6
 		if len(part) == 0 {
 			return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
@@ -251,18 +270,60 @@ func (r ReferenceName) Validate() error {
 			ctrlSeqs.MatchString(part) || // rule 4
 			strings.ContainsAny(part, "~^:?*[ \t\n") || // rule 4 & 5
 			strings.Contains(part, "@{") || // rule 8
-			part == "@" || // rule 9
 			strings.Contains(part, "\\") || // rule 10
 			strings.HasSuffix(part, ".lock") { // rule 1
-			return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
-		}
-
-		if (isBranch || isTag) && strings.HasPrefix(part, "-") && (i == 2) { // branches & tags can't start with -
 			return fmt.Errorf("%w: %q", ErrInvalidReferenceName, s)
 		}
 	}
 
 	return nil
+}
+
+// ValidateBranchName reports whether name, a literal branch shorthand, may be
+// used to create a branch. It applies the naming checks from Git's check_branch_ref
+// (refs.c): the shorthand must not begin with "-", the resulting reference must
+// not be refs/heads/HEAD, and the reference name must satisfy Validate.
+// It does not perform repository-dependent expansion of expressions such as
+// "@{-1}"; callers must resolve those before validating the resulting name.
+//
+// The leading "-" is not a check_refname_format rule and Git does not apply it
+// to a name arriving over the wire: refs/heads/-foo is a reference git fetch
+// and git clone store without complaint, and git update-ref creates on request.
+// This restriction applies at creation time. Existing leading-hyphen names can
+// still be read, written and deleted; for example, git branch -D -- -foo removes
+// an existing branch named -foo.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs.c#L761-L781
+func ValidateBranchName(name string) error {
+	// Every error names the spliced reference rather than the shorthand, so a
+	// caller holding a ReferenceName is told about the name it passed.
+	r := NewBranchReferenceName(name)
+
+	// Git compares the shorthand for the "-" rule and the spliced name for the
+	// HEAD one; keep that, since the two disagree for a shorthand such as
+	// "refs/heads/HEAD", which Git accepts.
+	if strings.HasPrefix(name, "-") || r == refHeadPrefix+"HEAD" {
+		return fmt.Errorf("%w: %q", ErrInvalidReferenceName, string(r))
+	}
+
+	return r.Validate()
+}
+
+// ValidateTagName reports whether name, the shorthand of a tag as a user spells
+// it, may be used to create a tag. It mirrors Git's check_tag_ref (refs.c): the
+// shorthand must not begin with "-" nor be "HEAD", and the reference name must
+// satisfy Validate. See ValidateBranchName for why the "-" rule belongs here
+// rather than in Validate.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs.c#L783-L792
+func ValidateTagName(name string) error {
+	r := NewTagReferenceName(name)
+
+	if strings.HasPrefix(name, "-") || name == "HEAD" {
+		return fmt.Errorf("%w: %q", ErrInvalidReferenceName, string(r))
+	}
+
+	return r.Validate()
 }
 
 const (

--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -8,11 +8,16 @@ import (
 )
 
 const (
-	refPrefix       = "refs/"
-	refHeadPrefix   = refPrefix + "heads/"
-	refTagPrefix    = refPrefix + "tags/"
-	refRemotePrefix = refPrefix + "remotes/"
-	refNotePrefix   = refPrefix + "notes/"
+	// RefPrefix is the sub-tree every ordinary reference lives under. The
+	// reference store, the receive-pack gate and both ends of the transport
+	// all draw a line at it, so they draw it at the same string.
+	RefPrefix = "refs/"
+	// RefHeadPrefix is the sub-tree branches live under.
+	RefHeadPrefix = RefPrefix + "heads/"
+
+	refTagPrefix    = RefPrefix + "tags/"
+	refRemotePrefix = RefPrefix + "remotes/"
+	refNotePrefix   = RefPrefix + "notes/"
 	symrefPrefix    = "ref: "
 )
 
@@ -67,7 +72,7 @@ type ReferenceName string
 // NewBranchReferenceName returns a reference name describing a branch based on
 // his short name.
 func NewBranchReferenceName(name string) ReferenceName {
-	return ReferenceName(refHeadPrefix + name)
+	return ReferenceName(RefHeadPrefix + name)
 }
 
 // NewNoteReferenceName returns a reference name describing a note based on his
@@ -96,7 +101,7 @@ func NewTagReferenceName(name string) ReferenceName {
 
 // IsBranch check if a reference is a branch
 func (r ReferenceName) IsBranch() bool {
-	return strings.HasPrefix(string(r), refHeadPrefix)
+	return strings.HasPrefix(string(r), RefHeadPrefix)
 }
 
 // IsNote check if a reference is a note
@@ -120,28 +125,51 @@ func (r ReferenceName) IsPeeled() bool {
 	return strings.HasSuffix(string(r), "^{}")
 }
 
+// IsUnderRefs reports whether the name lives in the refs/ sub-tree, where
+// every ordinary reference lives.
+//
+// Four gates draw a line here and each drew it with its own copy of the
+// string: the storer deciding what it will write, the receive-pack gate
+// deciding what a push may name, and the two ends of the transport deciding
+// what may be advertised and what an advertisement may carry. What each does
+// with the answer differs — the transport keeps HEAD, the storer also takes a
+// root ref, and a push takes neither — so this reports the fact and leaves
+// the policy to them.
+func (r ReferenceName) IsUnderRefs() bool {
+	return strings.HasPrefix(string(r), RefPrefix)
+}
+
 // IsSafe reports whether the reference name can be safely turned into a path
-// under the .git directory, mirroring Git's refname_is_safe (refs.c). A name
+// under the .git directory. It follows Git's refname_is_safe, but rejects
+// backslashes on every platform; Git rejects them only on Windows. A name
 // is safe when it is either:
 //
 //   - under "refs/", non-empty after the prefix, containing no backslash and
 //     no empty, "." or ".." path component (so it cannot escape the refs/
 //     sub-tree, or alias another name, once turned into a path); or
-//   - a one-level pseudo-ref whose spelling is restricted to [A-Z_]
+//   - a one-level name whose spelling is restricted to [A-Z_]
 //     (e.g. HEAD, ORIG_HEAD, FETCH_HEAD).
 //
 // Everything else — a lowercase or mixed one-level name such as "config" or
 // "index", an absolute or drive-prefixed name, or a refs/ name that escapes —
-// is unsafe, because it could resolve onto unrelated repository metadata.
-// This is a storage-safety check, not full check_refname_format validation;
-// see Validate for the latter.
+// is unsafe.
+//
+// IsSafe is not an allowlist of legitimate names, and does not on its own keep
+// a name off unrelated repository metadata: its one-level arm admits any [A-Z_]
+// spelling, "CONFIG" and "SHALLOW" included. A caller that creates or updates a
+// reference must also require the name to be under refs/ or to satisfy IsRoot.
+// This is a storage-safety check, not full check_refname_format validation; see
+// Validate for the latter.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs.c#L382-L412
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs/refs-internal.h#L57-L69
 func (r ReferenceName) IsSafe() bool {
 	s := string(r)
 	if s == "" {
 		return false
 	}
 
-	if rest, ok := strings.CutPrefix(s, refPrefix); ok {
+	if rest, ok := strings.CutPrefix(s, RefPrefix); ok {
 		// '\' is a path separator on Windows, so a refs/ name containing one
 		// could escape the sub-tree or alias another name once turned into a
 		// path; reject it outright (check_refname_format forbids '\' too).
@@ -156,12 +184,68 @@ func (r ReferenceName) IsSafe() bool {
 		return true
 	}
 
+	// Git's refname_is_safe admits any [A-Z_] one-level spelling.
+	// "CONFIG" and "SHALLOW" fold onto .git/config and .git/shallow on a
+	// case-insensitive filesystem; IsRoot is what tells the genuine root refs
+	// apart from those.
 	for i := 0; i < len(s); i++ {
 		if (s[i] < 'A' || s[i] > 'Z') && s[i] != '_' {
 			return false
 		}
 	}
 	return true
+}
+
+// IsRoot reports whether the reference name is one of the one-level references
+// that legitimately live in the root of the reference store, next to refs/.
+// It mirrors Git's is_root_ref (refs.c): the name must be spelled with
+// [A-Z_-] only and must either end in "_HEAD" (ORIG_HEAD, FETCH_HEAD,
+// MERGE_HEAD, CHERRY_PICK_HEAD, REBASE_HEAD, ...) or be one of the irregular
+// names Git lists explicitly (HEAD, AUTO_MERGE, BISECT_EXPECTED_REV,
+// NOTES_MERGE_PARTIAL, NOTES_MERGE_REF, MERGE_AUTOSTASH). Unlike Git's
+// is_root_ref, FETCH_HEAD and MERGE_HEAD are included.
+//
+// IsRoot reports false for every name under refs/, and is not a complete test
+// on its own: its alphabet admits '-', so "SOME-THING_HEAD" satisfies IsRoot
+// while IsSafe rejects it. Test IsSafe first, then accept the name if it is
+// under refs/ or satisfies IsRoot.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs.c#L887-L938
+func (r ReferenceName) IsRoot() bool {
+	// An allowlist by design: denying the names of known .git entries instead
+	// would be incomplete the moment Git adds a file, whereas the set of
+	// legitimate root refs changes only when Git grows a new one.
+	//
+	// FETCH_HEAD and MERGE_HEAD are kept because Git excludes them only via
+	// is_pseudo_ref, which marks the names its ref transactions refuse to
+	// update since they carry more than an object id. That is a write-policy
+	// rule rather than a naming rule. This predicate describes spelling and
+	// permits callers to store those names directly.
+	s := string(r)
+	if s == "" {
+		return false
+	}
+
+	// is_root_ref_syntax: uppercase, '-' and '_' only.
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; (c < 'A' || c > 'Z') && c != '_' && c != '-' {
+			return false
+		}
+	}
+
+	if strings.HasSuffix(s, "_HEAD") {
+		return true
+	}
+
+	// The one-level names is_root_ref accepts by exact spelling, i.e. those
+	// that do not match its "*_HEAD" suffix rule.
+	switch r {
+	case "HEAD", "AUTO_MERGE", "BISECT_EXPECTED_REV",
+		"NOTES_MERGE_PARTIAL", "NOTES_MERGE_REF", "MERGE_AUTOSTASH":
+		return true
+	}
+
+	return false
 }
 
 func (r ReferenceName) String() string {
@@ -302,7 +386,7 @@ func ValidateBranchName(name string) error {
 	// Git compares the shorthand for the "-" rule and the spliced name for the
 	// HEAD one; keep that, since the two disagree for a shorthand such as
 	// "refs/heads/HEAD", which Git accepts.
-	if strings.HasPrefix(name, "-") || r == refHeadPrefix+"HEAD" {
+	if strings.HasPrefix(name, "-") || r == RefHeadPrefix+"HEAD" {
 		return fmt.Errorf("%w: %q", ErrInvalidReferenceName, string(r))
 	}
 

--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -158,6 +158,48 @@ func (s *ReferenceSuite) TestIsTag() {
 	s.True(r.IsTag())
 }
 
+// The two creation helpers carry the rules Git keeps in check_branch_ref and
+// check_tag_ref rather than in check_refname_format: a shorthand beginning with
+// "-", and the spelling that would land on HEAD. They apply to authoring a
+// name, not to handling one that already exists, which is why they sit here
+// rather than in Validate.
+func (s *ReferenceSuite) TestValidateBranchName() {
+	for _, name := range []string{"foo", "foo/bar", "release-1.0", "v1.0"} {
+		s.NoError(ValidateBranchName(name), "branch name %q", name)
+	}
+
+	for _, name := range []string{"-foo", "-", "HEAD", "", "foo..bar", "foo.lock", "foo bar"} {
+		err := ValidateBranchName(name)
+		s.ErrorIs(err, ErrInvalidReferenceName, "branch name %q", name)
+	}
+}
+
+func (s *ReferenceSuite) TestValidateTagName() {
+	for _, name := range []string{"v1.0.0", "release/v1", "v1-rc1"} {
+		s.NoError(ValidateTagName(name), "tag name %q", name)
+	}
+
+	for _, name := range []string{"-1.0", "-", "HEAD", "", "v1..0", "v1.lock", "v 1"} {
+		err := ValidateTagName(name)
+		s.ErrorIs(err, ErrInvalidReferenceName, "tag name %q", name)
+	}
+}
+
+// The names the two helpers refuse for their own reasons are names Validate
+// accepts, which is what keeps a repository that already holds one usable.
+func (s *ReferenceSuite) TestCreationRulesAreNotNamingRules() {
+	for _, r := range []ReferenceName{
+		"refs/heads/-foo", "refs/heads/HEAD", "refs/tags/-1.0", "refs/tags/HEAD",
+	} {
+		s.NoError(r.Validate(), "reference name %q", r)
+	}
+
+	s.ErrorIs(ValidateBranchName("-foo"), ErrInvalidReferenceName)
+	s.ErrorIs(ValidateBranchName("HEAD"), ErrInvalidReferenceName)
+	s.ErrorIs(ValidateTagName("-1.0"), ErrInvalidReferenceName)
+	s.ErrorIs(ValidateTagName("HEAD"), ErrInvalidReferenceName)
+}
+
 func (s *ReferenceSuite) TestValidReferenceNames() {
 	valid := []ReferenceName{
 		"refs/heads/master",
@@ -169,12 +211,25 @@ func (s *ReferenceSuite) TestValidReferenceNames() {
 		"refs/pulls/1/merge",
 		"refs/pulls/1/abc.123",
 		"refs/pulls",
-		"refs/-", // should this be allowed?
 		"refs/ab/-testing",
 		"refs/123-testing",
+		// A leading "-" is not a check_refname_format rule at any position,
+		// and git clone, git fetch and git update-ref all handle these. What
+		// refuses them is branch and tag creation; see TestValidateBranchName.
+		"refs/-",
+		"refs/heads/-",
+		"refs/heads/-foo",
+		"refs/tags/-",
+		"refs/tags/-foo",
+		// Rule 9 is about a name that is the single character "@", so "@" is
+		// an ordinary component. git branch -- @ creates the first of these.
+		"refs/heads/@",
+		"refs/heads/@/x",
+		"refs/heads/@foo",
+		"refs/remotes/origin/@",
 	}
 	for _, v := range valid {
-		s.Nil(v.Validate())
+		s.NoError(v.Validate(), "reference name %q", v)
 	}
 
 	invalid := []ReferenceName{
@@ -202,14 +257,11 @@ func (s *ReferenceSuite) TestValidReferenceNames() {
 		"refs/heads/foo*",
 		"refs/heads/foo[bar",
 		"refs/heads/foo\t",
-		"refs/heads/@",
 		"refs/heads/@{bar}",
 		"refs/heads/\n",
-		"refs/heads/-foo",
 		"refs/heads/foo..bar",
-		"refs/heads/-",
-		"refs/tags/-",
-		"refs/tags/-foo",
+		// Rule 9, the whole name and nothing shorter.
+		"@",
 	}
 
 	for i, v := range invalid {

--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -28,52 +28,110 @@ func (s *ReferenceSuite) TestReferenceNameShort() {
 	s.Equal("v4", ExampleReferenceName.Short())
 }
 
-func (s *ReferenceSuite) TestReferenceNameIsSafe() {
+// TestReferenceNameIsSafeAndIsRoot pins IsSafe and IsRoot against the same
+// names, because the point of having both is where they disagree. IsSafe is
+// Git's refname_is_safe and accepts any shouting one-level name, "CONFIG" and
+// "SHALLOW" included — those fold onto .git/config and .git/shallow on a
+// case-insensitive filesystem, so the safe/!root rows are the gap IsRoot
+// closes. IsRoot in turn uses is_root_ref_syntax's wider alphabet, so a name
+// with a '-' can be a root ref by spelling and still not be safe: neither
+// predicate is a gate on its own.
+func (s *ReferenceSuite) TestReferenceNameIsSafeAndIsRoot() {
 	for _, tc := range []struct {
 		name ReferenceName
 		safe bool
+		root bool
 	}{
-		// One-level pseudo-refs ([A-Z_] only).
-		{"HEAD", true},
-		{"ORIG_HEAD", true},
-		{"FETCH_HEAD", true},
-		{"MERGE_HEAD", true},
-		{"CHERRY_PICK_HEAD", true},
-		// Well-formed refs/ names.
-		{"refs/heads/main", true},
-		{"refs/heads/release-1.2", true},
-		{"refs/tags/v1.0.0", true},
-		{"refs/remotes/origin/HEAD", true},
-		{"refs/stash", true},
-		// Empty, and one-level names that are not pseudo-refs (would land on
-		// top-level .git metadata).
-		{"", false},
-		{"config", false},
-		{"index", false},
-		{"packed-refs", false},
-		{"config.worktree", false},
-		{"bar", false},
-		{"head", false},
-		{"HEAD2", false},
+		// The root refs: the "*_HEAD" suffix rule, then the irregular names
+		// Git's is_root_ref lists explicitly.
+		{"HEAD", true, true},
+		{"ORIG_HEAD", true, true},
+		{"FETCH_HEAD", true, true},
+		{"MERGE_HEAD", true, true},
+		{"CHERRY_PICK_HEAD", true, true},
+		{"REVERT_HEAD", true, true},
+		{"REBASE_HEAD", true, true},
+		{"BISECT_HEAD", true, true},
+		{"_HEAD", true, true},
+		{"AUTO_MERGE", true, true},
+		{"BISECT_EXPECTED_REV", true, true},
+		{"NOTES_MERGE_PARTIAL", true, true},
+		{"NOTES_MERGE_REF", true, true},
+		{"MERGE_AUTOSTASH", true, true},
+		// is_root_ref_syntax allows '-'; refname_is_safe's [A-Z_] arm does
+		// not. A caller that reads IsRoot's "root ref" as permission would
+		// accept a name IsSafe refuses.
+		{"SOME-THING_HEAD", false, true},
+		// Well-formed refs/ names. IsRoot is about the root of the reference
+		// store only, so it is false for every one of them.
+		{"refs/heads/main", true, false},
+		{"refs/heads/release-1.2", true, false},
+		{"refs/tags/v1.0.0", true, false},
+		{"refs/remotes/origin/HEAD", true, false},
+		{"refs/heads/FETCH_HEAD", true, false},
+		{"refs/stash", true, false},
+		// The uppercase spellings of .git metadata: safe by refname_is_safe,
+		// and not root refs. On a case-insensitive filesystem (APFS, NTFS)
+		// each folds onto the real file, which is why IsSafe cannot be the
+		// only gate a create or update goes through.
+		{"CONFIG", true, false},
+		{"INDEX", true, false},
+		{"SHALLOW", true, false},
+		{"PACKED_REFS", true, false},
+		{"DESCRIPTION", true, false},
+		{"COMMONDIR", true, false},
+		{"GITDIR", true, false},
+		{"LOGS", true, false},
+		{"OBJECTS", true, false},
+		{"REFS", true, false},
+		{"HOOKS", true, false},
+		{"INFO", true, false},
+		{"WORKTREES", true, false},
+		{"MODULES", true, false},
+		{"BRANCHES", true, false},
+		{"REMOTES", true, false},
+		{"COMMIT_EDITMSG", true, false},
+		{"MERGE_MSG", true, false},
+		{"MERGE_RR", true, false},
+		{"SEQUENCER", true, false},
+		// A '-' is outside refname_is_safe's one-level alphabet, so the
+		// uppercase spelling of "packed-refs" is not safe either.
+		{"PACKED-REFS", false, false},
+		// Empty, and one-level names that would land on top-level .git
+		// metadata without even needing a case-insensitive filesystem.
+		{"", false, false},
+		{"config", false, false},
+		{"index", false, false},
+		{"packed-refs", false, false},
+		{"config.worktree", false, false},
+		{"bar", false, false},
+		{"head", false, false},
+		{"Head", false, false},
+		{"orig_head", false, false},
+		{"HEAD2", false, false},
+		{"HEAD.lock", false, false},
+		{"HEAD/x", false, false},
 		// refs/ names that escape or have empty components.
-		{"refs/", false},
-		{"refs/heads/.", false},
-		{"refs/heads/..", false},
-		{"refs/heads/../../config", false},
-		{"refs/heads//main", false},
-		{"refs/heads/", false},
+		{"refs/", false, false},
+		{"refs/heads/.", false, false},
+		{"refs/heads/..", false, false},
+		{"refs/heads/../../config", false, false},
+		{"refs/heads//main", false, false},
+		{"refs/heads/", false, false},
 		// Absolute and drive-prefixed forms.
-		{"/config", false},
-		{"/refs/heads/main", false},
-		{"\\config", false},
-		{"C:config", false},
+		{"/HEAD", false, false},
+		{"/config", false, false},
+		{"/refs/heads/main", false, false},
+		{"\\config", false, false},
+		{"C:config", false, false},
 		// Backslash inside a refs/ name: a Windows path separator that could
 		// escape the sub-tree or alias another name once turned into a path.
-		{"refs/heads/foo\\bar", false},
-		{"refs/heads\\..\\config", false},
-		{"refs/heads\\foo", false},
+		{"refs/heads/foo\\bar", false, false},
+		{"refs/heads\\..\\config", false, false},
+		{"refs/heads\\foo", false, false},
 	} {
 		s.Equal(tc.safe, tc.name.IsSafe(), "IsSafe(%q)", tc.name)
+		s.Equal(tc.root, tc.name.IsRoot(), "IsRoot(%q)", tc.name)
 	}
 }
 
@@ -293,4 +351,32 @@ func BenchmarkReferenceObjectID(b *testing.B) {
 
 func BenchmarkReferenceStringInvalid(b *testing.B) {
 	benchMarkReferenceString(&Reference{}, b)
+}
+
+// The four gates that draw a line at refs/ used to each carry their own copy
+// of the string. This is the one they share.
+func (s *ReferenceSuite) TestIsUnderRefs() {
+	for _, tc := range []struct {
+		name ReferenceName
+		want bool
+	}{
+		{"refs/heads/main", true},
+		{"refs/stash", true},
+		{"refs/", true},
+		{"HEAD", false},
+		{"ORIG_HEAD", false},
+		{"CONFIG", false},
+		{"", false},
+		{"refs", false},
+		{"Refs/heads/main", false},
+		{"xrefs/heads/main", false},
+	} {
+		s.Equal(tc.want, tc.name.IsUnderRefs(), "IsUnderRefs(%q)", tc.name)
+	}
+
+	// The exported prefixes are what the constructors build from, so a change
+	// to one cannot silently disagree with the other.
+	s.Equal(RefPrefix+"heads/", RefHeadPrefix)
+	s.True(NewBranchReferenceName("x").IsUnderRefs())
+	s.Equal(ReferenceName(RefHeadPrefix+"x"), NewBranchReferenceName("x"))
 }

--- a/plumbing/transport/file/file.go
+++ b/plumbing/transport/file/file.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
 // ServerFunc is a function that runs a git server-side command over pipes.
@@ -107,7 +108,12 @@ func (t *Transport) connect(ctx context.Context, req *transport.Request) (io.Rea
 
 	go func() {
 		defer close(done)
-		err := serverFn(ctx, st, io.NopCloser(pr), sw, gitProtocol)
+		// Both pipe ends stay this goroutine's to close: CloseWithError below is
+		// how a server error reaches the client's reader, and a server that
+		// closed sw itself would first store a plain EOF there. The server
+		// commands close the writer they are handed on every exit, so it is
+		// wrapped, exactly as pr already is.
+		err := serverFn(ctx, st, io.NopCloser(pr), ioutil.WriteNopCloser(sw), gitProtocol)
 		_ = sw.CloseWithError(err)
 		_ = pr.Close()
 	}()

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -81,11 +82,18 @@ type PostReceiveInfo struct {
 // ReceivePack is a server command that serves the receive-pack service.
 // It closes w on every return, including malformed requests and advertisement-only
 // exchanges. A close error is returned only if no earlier error occurred.
+// Callers that retain ownership of their streams should wrap r with [io.NopCloser]
+// and w with [ioutil.WriteNopCloser].
 //
 // Commands may name only references under refs/ with valid syntax and safe path
 // components. Refusals are reported per command when report-status is negotiated.
 // A request naming the same reference twice is rejected before hooks or reference
 // updates run. See ErrFunnyRefname and ErrDuplicateRefname.
+// Commands execute even when report-status is not requested. Updates use the
+// storer's compare-and-set operation on the resolved target. Symbolic resolution
+// is separate from the update, and deletes check the old value before a separate
+// removal. ReferenceStorer has no transaction covering these steps: callers must
+// serialize concurrent writers if they require the entire operation to be atomic.
 func ReceivePack(
 	ctx context.Context,
 	st storage.Storer,
@@ -193,10 +201,7 @@ func ReceivePack(
 		return fmt.Errorf("closing reader: %w", err)
 	}
 
-	// Report status if the client supports it
-	if !updreq.Capabilities.Supports(capability.ReportStatus) && !updreq.Capabilities.Supports(capability.ReportStatusV2) {
-		return unpackErr
-	}
+	reportStatus := caps.Supports(capability.ReportStatus) || caps.Supports(capability.ReportStatusV2)
 
 	var (
 		useSideband bool
@@ -227,8 +232,10 @@ func ReceivePack(
 	// exits through one function is what stops one of them from answering
 	// without that second flush.
 	report := func(unpackErr error, cmdStatus map[plumbing.ReferenceName]error) error {
-		if err := sendReportStatus(writeCloser, updreq.Commands, unpackErr, cmdStatus); err != nil {
-			return err
+		if reportStatus {
+			if err := sendReportStatus(writeCloser, updreq.Commands, unpackErr, cmdStatus); err != nil {
+				return err
+			}
 		}
 		if !useSideband {
 			return nil
@@ -408,15 +415,6 @@ func setStatus(cmdStatus map[plumbing.ReferenceName]error, firstErr *error, ref 
 	}
 }
 
-func referenceExists(s storer.ReferenceStorer, n plumbing.ReferenceName) (bool, error) {
-	_, err := s.Reference(n)
-	if err == plumbing.ErrReferenceNotFound {
-		return false, nil
-	}
-
-	return err == nil, err
-}
-
 // checkRefname returns [ErrFunnyRefname] if receive-pack must refuse a command
 // naming ref, and nil if the name may reach the storer.
 //
@@ -513,8 +511,17 @@ func updateReferences(st storage.Storer, req *packp.UpdateRequests, cmdStatus ma
 			continue
 		}
 
-		exists, err := referenceExists(st, cmd.Name)
-		if err != nil {
+		var current *plumbing.Reference
+		var err error
+		if cmd.Action() == packp.Create {
+			// An existing symbolic ref still occupies the name when its
+			// target is missing. A create must not overwrite that alias.
+			current, err = st.Reference(cmd.Name)
+		} else {
+			current, err = storer.ResolveReference(st, cmd.Name)
+		}
+		exists := err == nil
+		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			setStatus(cmdStatus, firstErr, cmd.Name, err)
 			continue
 		}
@@ -535,7 +542,22 @@ func updateReferences(st storage.Storer, req *packp.UpdateRequests, cmdStatus ma
 				continue
 			}
 
-			err := st.RemoveReference(cmd.Name)
+			if current.Hash() != cmd.Old {
+				// Git permits removal of a corrupt ref when the supplied old
+				// object is missing. A present old object must match the ref.
+				// See https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/builtin/receive-pack.c#L1604-L1619.
+				_, objectErr := st.EncodedObject(plumbing.AnyObject, cmd.Old)
+				if objectErr == nil {
+					setStatus(cmdStatus, firstErr, cmd.Name, storage.ErrReferenceHasChanged)
+					continue
+				}
+				if !errors.Is(objectErr, plumbing.ErrObjectNotFound) {
+					setStatus(cmdStatus, firstErr, cmd.Name, objectErr)
+					continue
+				}
+			}
+
+			err := st.RemoveReference(current.Name())
 			setStatus(cmdStatus, firstErr, cmd.Name, err)
 		case packp.Update:
 			if !exists {
@@ -543,8 +565,9 @@ func updateReferences(st storage.Storer, req *packp.UpdateRequests, cmdStatus ma
 				continue
 			}
 
-			ref := plumbing.NewHashReference(cmd.Name, cmd.New)
-			err := st.SetReference(ref)
+			ref := plumbing.NewHashReference(current.Name(), cmd.New)
+			old := plumbing.NewHashReference(current.Name(), cmd.Old)
+			err := st.CheckAndSetReference(ref, old)
 			setStatus(cmdStatus, firstErr, cmd.Name, err)
 		}
 	}

--- a/plumbing/transport/receive_pack.go
+++ b/plumbing/transport/receive_pack.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
@@ -78,18 +79,40 @@ type PostReceiveInfo struct {
 }
 
 // ReceivePack is a server command that serves the receive-pack service.
+// It closes w on every return, including malformed requests and advertisement-only
+// exchanges. A close error is returned only if no earlier error occurred.
+//
+// Commands may name only references under refs/ with valid syntax and safe path
+// components. Refusals are reported per command when report-status is negotiated.
+// A request naming the same reference twice is rejected before hooks or reference
+// updates run. See ErrFunnyRefname and ErrDuplicateRefname.
 func ReceivePack(
 	ctx context.Context,
 	st storage.Storer,
 	r io.ReadCloser,
 	w io.WriteCloser,
 	opts *ReceivePackRequest,
-) error {
+) (err error) {
 	if w == nil {
 		return fmt.Errorf("nil writer")
 	}
 
 	w = ioutil.NewContextWriteCloser(ctx, w)
+
+	// Every exit from here on closes the writer, because the close is what ends
+	// the response for the caller's transport: a return that skips it leaves a
+	// client waiting on a stream that will never end. That holds for the early
+	// returns too, where nothing has been written yet, and for a refused ref,
+	// where the "ng <ref> <reason>" line is the response.
+	//
+	// The close error only surfaces when nothing else went wrong: a rejected
+	// command or a malformed request describes the exchange better than a
+	// failure to hang up does.
+	defer func() {
+		if closeErr := closeWriter(w); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
 
 	if opts == nil {
 		opts = &ReceivePackRequest{}
@@ -195,10 +218,67 @@ func ReceivePack(
 	}
 
 	writeCloser := ioutil.NewWriteCloser(writer, w)
+
+	// report is how every remaining exit answers the client: the report-status,
+	// then the flush that ends the sideband stream when one is in use.
+	// ReportStatus.Encode writes a flush of its own, but on a sideband exchange
+	// that one is muxed into band 1 along with the rest of the report, so it
+	// does not terminate the stream the client is demuxing. Routing all three
+	// exits through one function is what stops one of them from answering
+	// without that second flush.
+	report := func(unpackErr error, cmdStatus map[plumbing.ReferenceName]error) error {
+		if err := sendReportStatus(writeCloser, updreq.Commands, unpackErr, cmdStatus); err != nil {
+			return err
+		}
+		if !useSideband {
+			return nil
+		}
+		if err := pktline.WriteFlush(w); err != nil {
+			return fmt.Errorf("flushing sideband: %w", err)
+		}
+		return nil
+	}
+
 	if unpackErr != nil {
-		res := sendReportStatus(writeCloser, unpackErr, nil)
-		_ = closeWriter(w)
-		return res
+		// No command was attempted, so there is no per-ref outcome to give and
+		// the unpack line carries the whole reason. The error still goes back
+		// to the caller: writing the report successfully does not turn a failed
+		// push into a successful exchange, and the two failure exits below
+		// answer the same way.
+		if err := report(unpackErr, nil); err != nil {
+			return err
+		}
+		return unpackErr
+	}
+
+	// A name carried by more than one command makes the push unapplyable: the
+	// commands contradict each other, and cmdStatus holds a single outcome per
+	// name, so running both would report one of them and hide the other.
+	//
+	// git refuses such a push outright. It batches the ref updates into a
+	// transaction, and a repeated name aborts the transaction with "multiple
+	// updates for ref <name> not allowed", so no ref in the batch moves and
+	// every command is answered "ng" — including the commands that named a
+	// reference only once. Refuse the whole request the same way, rather than
+	// only the duplicated name, so a push either applies as sent or not at all.
+	//
+	// Unlike git this runs before PreReceive. A hook is a policy gate that may
+	// have side effects of its own, so it is not asked to authorise a request
+	// that cannot be applied whatever it answers.
+	if dup, ok := duplicateRefname(updreq.Commands); ok {
+		rejected := make(map[plumbing.ReferenceName]error, len(updreq.Commands))
+		for _, cmd := range updreq.Commands {
+			// sendReportStatus writes Error() into the "ng <ref> <reason>"
+			// line, so the reason stays the bare sentinel: the line already
+			// names the ref it speaks for. Git sends "failed to update refs"
+			// here; this says more, and both are opaque to a client. Which
+			// name was duplicated goes to the caller instead.
+			rejected[cmd.Name] = ErrDuplicateRefname
+		}
+		if err := report(nil, rejected); err != nil {
+			return err
+		}
+		return fmt.Errorf("%w: %q", ErrDuplicateRefname, dup)
 	}
 
 	if opts.Hooks.PreReceive != nil {
@@ -213,17 +293,7 @@ func ReceivePack(
 			for _, cmd := range updreq.Commands {
 				rejected[cmd.Name] = hookErr
 			}
-			if err := sendReportStatus(writeCloser, nil, rejected); err != nil {
-				_ = closeWriter(w)
-				return err
-			}
-			if useSideband {
-				if err := pktline.WriteFlush(w); err != nil {
-					_ = closeWriter(w)
-					return fmt.Errorf("flushing sideband: %w", err)
-				}
-			}
-			if err := closeWriter(w); err != nil {
+			if err := report(nil, rejected); err != nil {
 				return err
 			}
 			return hookErr
@@ -250,19 +320,16 @@ func ReceivePack(
 		_ = opts.Hooks.PostReceive(ctx, info)
 	}
 
-	if err := sendReportStatus(writeCloser, firstErr, cmdStatus); err != nil {
+	// The unpack status reports on the packfile, not on the ref updates: it is
+	// "ok" here because unpackErr was handled above. Per-command failures are
+	// carried by cmdStatus as "ng <ref> <reason>" lines, exactly as the
+	// PreReceive rejection path does; folding firstErr into the unpack status
+	// would make a client treat a single refused ref as a corrupt push.
+	if err := report(nil, cmdStatus); err != nil {
 		return err
 	}
 
-	if useSideband {
-		if err := pktline.WriteFlush(w); err != nil {
-			return fmt.Errorf("flushing sideband: %w", err)
-		}
-	}
-	if firstErr != nil {
-		return firstErr
-	}
-	return closeWriter(w)
+	return firstErr
 }
 
 type sidebandProgress struct{ mux *sideband.Muxer }
@@ -278,20 +345,37 @@ func closeWriter(w io.WriteCloser) error {
 	return nil
 }
 
-func sendReportStatus(w io.WriteCloser, unpackErr error, cmdStatus map[plumbing.ReferenceName]error) error {
+// sendReportStatus writes the report-status for the exchange: the unpack line,
+// then one status line per command.
+//
+// The lines follow cmds, not the cmdStatus map. Git reports in the order the
+// commands arrived and a client is entitled to pair the two up positionally,
+// whereas ranging over the map orders them differently on every push. A command
+// with no entry in cmdStatus was never attempted and is not reported.
+//
+// One line is written per command, not per distinct name, which is what keeps
+// that pairing positional: git answers a name carried by two commands with two
+// ng lines. Both lines say the same thing here, because a duplicated name is
+// refused before any command runs and the map holds one outcome for it.
+func sendReportStatus(w io.WriteCloser, cmds []*packp.Command, unpackErr error, cmdStatus map[plumbing.ReferenceName]error) error {
 	rs := &packp.ReportStatus{}
 	rs.UnpackStatus = "ok"
 	if unpackErr != nil {
 		rs.UnpackStatus = unpackErr.Error()
 	}
 
-	for ref, err := range cmdStatus {
+	for _, cmd := range cmds {
+		err, ok := cmdStatus[cmd.Name]
+		if !ok {
+			continue
+		}
+
 		msg := "ok"
 		if err != nil {
 			msg = err.Error()
 		}
 		status := &packp.CommandStatus{
-			ReferenceName: ref,
+			ReferenceName: cmd.Name,
 			Status:        msg,
 		}
 		rs.CommandStatuses = append(rs.CommandStatuses, status)
@@ -302,6 +386,19 @@ func sendReportStatus(w io.WriteCloser, unpackErr error, cmdStatus map[plumbing.
 	}
 
 	return nil
+}
+
+// duplicateRefname returns the first reference name that more than one command
+// in cmds updates, and whether there was one.
+func duplicateRefname(cmds []*packp.Command) (plumbing.ReferenceName, bool) {
+	seen := make(map[plumbing.ReferenceName]struct{}, len(cmds))
+	for _, cmd := range cmds {
+		if _, ok := seen[cmd.Name]; ok {
+			return cmd.Name, true
+		}
+		seen[cmd.Name] = struct{}{}
+	}
+	return "", false
 }
 
 func setStatus(cmdStatus map[plumbing.ReferenceName]error, firstErr *error, ref plumbing.ReferenceName, err error) {
@@ -320,8 +417,102 @@ func referenceExists(s storer.ReferenceStorer, n plumbing.ReferenceName) (bool, 
 	return err == nil, err
 }
 
+// checkRefname returns [ErrFunnyRefname] if receive-pack must refuse a command
+// naming ref, and nil if the name may reach the storer.
+//
+// It mirrors the gate in Git's builtin/receive-pack.c (execute_commands_non_atomic
+// -> update, "only refs/... are allowed"), which refuses a command whose name
+// is not under refs/ or fails check_refname_format, reporting "funny refname".
+// Without it, a push can name HEAD, CONFIG, INDEX or SHALLOW and reach the
+// storer: writing HEAD repoints the repository's default branch for every
+// later clone on any filesystem, and on a case-insensitive one the shouting
+// names land on .git/config, .git/index and .git/shallow. A Delete command
+// needs no packfile at all, so the same names also give an unauthenticated
+// "remove .git/config" primitive.
+//
+// The name is checked in four steps:
+//
+//   - the refs/ prefix, which is what stops HEAD and every other root ref.
+//     Git relaxes its format check for deletes (REFNAME_ALLOW_ONELEVEL) but
+//     never relaxes this prefix, and neither do we: deleting a ref is the
+//     cheapest form of this attack, not the most benign.
+//   - ReferenceName.IsSafe, Git's refname_is_safe, for names that escape the
+//     refs/ sub-tree or alias another path once joined.
+//   - pathutil.HasUnsafeComponent, for the escapes IsSafe's literal ".."
+//     comparison misses: control characters, and the components an HFS+ or
+//     NTFS filesystem folds back to "." or "..". The dotgit storage layer
+//     applies the same helper, but this gate cannot lean on it: ReceivePack is
+//     exported and can be handed any storer, including one that never reaches
+//     a filesystem.
+//   - ReferenceName.Validate, go-git's check_refname_format, for the remaining
+//     character and component rules.
+//
+// Three of the four are decisive somewhere. The refs/ prefix is the only thing
+// that refuses HEAD, which IsSafe accepts, HasUnsafeComponent passes, and
+// Validate carves out by name. IsSafe is the exception: with the prefix already
+// required, every name it rejects is one Validate also rejects, by rules 1, 3,
+// 6 and 10. It stays because this gate should not depend on that overlap
+// holding as either function changes.
+//
+// Validating the full name, rather than Git's suffix after refs/, has two
+// compatibility differences:
+//
+//   - Git runs check_refname_format on the part after "refs/" and passes
+//     REFNAME_ALLOW_ONELEVEL only for deletes, so it refuses to *create*
+//     refs/stash ("funny refname") while allowing it to be deleted. go-git
+//     validates the whole name, which accepts one level under refs/ for every
+//     action. refs/stash is a first-class ref here, and a single component
+//     under refs/ cannot escape the sub-tree, so the asymmetry would cost
+//     compatibility and buy no safety.
+//   - For refs/@, Git tests the suffix "@" and rejects it for every action.
+//     go-git accepts it because "@" is not the entire reference name. This
+//     preserves the existing support for names accepted by Validate.
+//
+// An additional filesystem-safety restriction applies to every action:
+//
+//   - HasUnsafeComponent refuses a component whose first non-ignorable code
+//     point is a lone ".", which check_refname_format accepts:
+//     refs/heads/<U+200C>./x is "ok" to Git and "funny refname" here. On HFS+
+//     that component normalises away and the name lands on refs/heads/x, which
+//     is a filesystem hazard Git's format check does not model.
+//
+// Git relaxes only the component count for a delete and keeps every other
+// format rule at its receive-pack gate. The wider
+// relaxation it grants in ref_transaction_update — refname_is_safe on its own —
+// is for a local caller rather than a remote one.
+//
+// The error is returned bare on purpose: sendReportStatus writes Error()
+// verbatim into the "ng <ref> <reason>" line, so wrapping it with extra context
+// would hand the client a status git never sends.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/builtin/receive-pack.c#L1491-L1499
+func checkRefname(ref plumbing.ReferenceName) error {
+	if !ref.IsUnderRefs() {
+		return ErrFunnyRefname
+	}
+
+	if !ref.IsSafe() {
+		return ErrFunnyRefname
+	}
+
+	if pathutil.HasUnsafeComponent(ref.String()) {
+		return ErrFunnyRefname
+	}
+
+	if err := ref.Validate(); err != nil {
+		return ErrFunnyRefname
+	}
+
+	return nil
+}
+
 func updateReferences(st storage.Storer, req *packp.UpdateRequests, cmdStatus map[plumbing.ReferenceName]error, firstErr *error) {
 	for _, cmd := range req.Commands {
+		if err := checkRefname(cmd.Name); err != nil {
+			setStatus(cmdStatus, firstErr, cmd.Name, err)
+			continue
+		}
+
 		exists, err := referenceExists(st, cmd.Name)
 		if err != nil {
 			setStatus(cmdStatus, firstErr, cmd.Name, err)

--- a/plumbing/transport/receive_pack_test.go
+++ b/plumbing/transport/receive_pack_test.go
@@ -1154,6 +1154,304 @@ func TestDuplicateRefname(t *testing.T) {
 	}
 }
 
+func storeReceiveObject(t *testing.T, st storage.Storer, content string) plumbing.Hash {
+	t.Helper()
+	obj := st.NewEncodedObject()
+	obj.SetType(plumbing.BlobObject)
+	obj.SetSize(int64(len(content)))
+	w, err := obj.Writer()
+	require.NoError(t, err)
+	_, err = io.WriteString(w, content)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	hash, err := st.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
+}
+
+func receiveExpectedOld(t *testing.T, st storage.Storer, cmd *packp.Command) (string, error) {
+	t.Helper()
+	var response bytes.Buffer
+	err := ReceivePack(context.Background(), st, receivePackRequest(t, []*packp.Command{cmd}),
+		ioutil.WriteNopCloser(&response), &ReceivePackRequest{StatelessRPC: true})
+	return response.String(), err
+}
+
+func TestReceivePackChecksExpectedOld(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{"update", "delete"} {
+		for _, matches := range []bool{false, true} {
+			name := action + "/mismatch"
+			if matches {
+				name = action + "/match"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				st := memory.NewStorage()
+				current := storeReceiveObject(t, st, "current")
+				old := storeReceiveObject(t, st, "stale")
+				if matches {
+					old = current
+				}
+				next := storeReceiveObject(t, st, "next")
+				if action == "delete" {
+					next = plumbing.ZeroHash
+				}
+				require.NoError(t, st.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/tags/main"), current)))
+				out, err := receiveExpectedOld(t, st, &packp.Command{Name: plumbing.ReferenceName("refs/tags/main"), Old: old, New: next})
+				if !matches {
+					assert.ErrorIs(t, err, storage.ErrReferenceHasChanged)
+					assert.Contains(t, out, "ng refs/tags/main ")
+					ref, err := st.Reference(plumbing.ReferenceName("refs/tags/main"))
+					require.NoError(t, err)
+					assert.Equal(t, current, ref.Hash())
+					return
+				}
+				require.NoError(t, err)
+				assert.Contains(t, out, "ok refs/tags/main\n")
+				ref, err := st.Reference(plumbing.ReferenceName("refs/tags/main"))
+				if action == "delete" {
+					assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, next, ref.Hash())
+				}
+			})
+		}
+	}
+}
+
+func TestReceivePackCreatePreservesDanglingSymbolicReference(t *testing.T) {
+	t.Parallel()
+	st := memory.NewStorage()
+	alias := plumbing.NewSymbolicReference("refs/tags/alias", "refs/tags/missing")
+	require.NoError(t, st.SetReference(alias))
+	next := storeReceiveObject(t, st, "next")
+	out, err := receiveExpectedOld(t, st, &packp.Command{Name: alias.Name(), Old: plumbing.ZeroHash, New: next})
+	assert.ErrorIs(t, err, ErrUpdateReference)
+	assert.Contains(t, out, "ng refs/tags/alias ")
+	actual, err := st.Reference(alias.Name())
+	require.NoError(t, err)
+	assert.Equal(t, alias, actual)
+	_, err = st.Reference(alias.Target())
+	assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+}
+
+type receiveConcurrentReferenceStorage struct {
+	storage.Storer
+	change func() error
+	called bool
+}
+
+func (s *receiveConcurrentReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
+	s.called = true
+	if err := s.change(); err != nil {
+		return err
+	}
+	return s.Storer.CheckAndSetReference(ref, old)
+}
+
+func TestReceivePackUpdatePreservesConcurrentReferenceChange(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{"change", "delete"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			base := memory.NewStorage()
+			old := storeReceiveObject(t, base, "old")
+			next := storeReceiveObject(t, base, "next")
+			concurrent := storeReceiveObject(t, base, "concurrent")
+			require.NoError(t, base.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/tags/main"), old)))
+			st := &receiveConcurrentReferenceStorage{Storer: base, change: func() error {
+				if action == "delete" {
+					return base.RemoveReference(plumbing.ReferenceName("refs/tags/main"))
+				}
+				return base.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/tags/main"), concurrent))
+			}}
+			out, err := receiveExpectedOld(t, st, &packp.Command{Name: plumbing.ReferenceName("refs/tags/main"), Old: old, New: next})
+			assert.True(t, st.called)
+			require.Error(t, err)
+			assert.Contains(t, out, "ng refs/tags/main ")
+			ref, readErr := base.Reference(plumbing.ReferenceName("refs/tags/main"))
+			if action == "delete" {
+				assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+				assert.ErrorIs(t, readErr, plumbing.ErrReferenceNotFound)
+			} else {
+				assert.ErrorIs(t, err, storage.ErrReferenceHasChanged)
+				require.NoError(t, readErr)
+				assert.Equal(t, concurrent, ref.Hash())
+			}
+		})
+	}
+}
+
+func TestReceivePackChangesTerminalSymbolicReference(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{"update", "delete"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			st := memory.NewStorage()
+			old := storeReceiveObject(t, st, "old")
+			next := storeReceiveObject(t, st, "next")
+			if action == "delete" {
+				next = plumbing.ZeroHash
+			}
+			alias := plumbing.NewSymbolicReference("refs/tags/alias", plumbing.ReferenceName("refs/tags/main"))
+			require.NoError(t, st.SetReference(alias))
+			require.NoError(t, st.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/tags/main"), old)))
+			out, err := receiveExpectedOld(t, st, &packp.Command{Name: alias.Name(), Old: old, New: next})
+			require.NoError(t, err)
+			assert.Contains(t, out, "ok refs/tags/alias\n")
+			actual, err := st.Reference(alias.Name())
+			require.NoError(t, err)
+			assert.Equal(t, alias, actual)
+			terminal, err := st.Reference(plumbing.ReferenceName("refs/tags/main"))
+			if action == "delete" {
+				assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, next, terminal.Hash())
+			}
+		})
+	}
+}
+
+type receiveOldObjectErrorStorage struct {
+	storage.Storer
+	old    plumbing.Hash
+	err    error
+	called bool
+}
+
+func (s *receiveOldObjectErrorStorage) EncodedObject(typ plumbing.ObjectType, hash plumbing.Hash) (plumbing.EncodedObject, error) {
+	if hash == s.old {
+		s.called = true
+		return nil, s.err
+	}
+	return s.Storer.EncodedObject(typ, hash)
+}
+
+func TestReceivePackDeleteOldObjectLookup(t *testing.T) {
+	t.Parallel()
+	for _, missing := range []bool{false, true} {
+		name := "read-error"
+		if missing {
+			name = "missing-object"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			base := memory.NewStorage()
+			current := storeReceiveObject(t, base, "current")
+			old := plumbing.NewHash(receivePackTestHash)
+			require.NoError(t, base.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/tags/main"), current)))
+			lookupErr := errors.New("object read failed")
+			if missing {
+				lookupErr = plumbing.ErrObjectNotFound
+			}
+			st := &receiveOldObjectErrorStorage{Storer: base, old: old, err: lookupErr}
+			out, err := receiveExpectedOld(t, st, deleteCmd(plumbing.ReferenceName("refs/tags/main"), old))
+			assert.True(t, st.called)
+			ref, readErr := base.Reference(plumbing.ReferenceName("refs/tags/main"))
+			if missing {
+				require.NoError(t, err)
+				assert.Contains(t, out, "ok refs/tags/main\n")
+				assert.ErrorIs(t, readErr, plumbing.ErrReferenceNotFound)
+			} else {
+				assert.ErrorIs(t, err, lookupErr)
+				assert.Contains(t, out, "ng refs/tags/main object read failed\n")
+				require.NoError(t, readErr)
+				assert.Equal(t, current, ref.Hash())
+			}
+		})
+	}
+}
+
+func TestReceivePackWithoutReportStatus(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{"create", "update", "delete", "sideband-delete", "hook-rejection", "invalid-name"} {
+		t.Run(action, func(t *testing.T) {
+			t.Parallel()
+			st := memory.NewStorage()
+			name := plumbing.ReferenceName("refs/tags/main")
+			old := plumbing.NewHash(receivePackTestHash)
+			newHash := plumbing.NewHash("1111111111111111111111111111111111111111")
+			if action == "create" {
+				old = plumbing.ZeroHash
+			} else {
+				require.NoError(t, st.SetReference(plumbing.NewHashReference(name, old)))
+			}
+			if action == "delete" || action == "sideband-delete" || action == "hook-rejection" || action == "invalid-name" {
+				newHash = plumbing.ZeroHash
+			}
+			commandName := name
+			if action == "invalid-name" {
+				commandName = "refs/tags/main.lock"
+			}
+			var request bytes.Buffer
+			caps := ""
+			if action == "sideband-delete" {
+				caps = "side-band-64k"
+			}
+			_, err := pktline.Writef(&request, "%s %s %s\x00%s\n", old, newHash, commandName, caps)
+			require.NoError(t, err)
+			require.NoError(t, pktline.WriteFlush(&request))
+			if !newHash.IsZero() {
+				header := []byte("PACK\x00\x00\x00\x02\x00\x00\x00\x00")
+				sum := sha1.Sum(header)
+				request.Write(header)
+				request.Write(sum[:])
+			}
+			preCalled, postCalled := false, false
+			var applied []*packp.Command
+			rejected := errors.New("policy rejected update")
+			opts := &ReceivePackRequest{StatelessRPC: true, Hooks: ReceivePackHooks{
+				PreReceive: func(context.Context, *PreReceiveInfo) error {
+					preCalled = true
+					if action == "hook-rejection" {
+						return rejected
+					}
+					return nil
+				},
+				PostReceive: func(_ context.Context, info *PostReceiveInfo) error {
+					postCalled = true
+					applied = info.Commands
+					return nil
+				},
+			}}
+			response := &closeCountingWriter{}
+			err = ReceivePack(context.Background(), st, io.NopCloser(&request), response, opts)
+			assert.True(t, preCalled)
+			assert.Equal(t, 1, response.closes)
+			if action == "sideband-delete" {
+				assert.Equal(t, "0000", response.buf.String())
+			} else {
+				assert.Empty(t, response.buf.String())
+			}
+			if action == "hook-rejection" || action == "invalid-name" {
+				want := rejected
+				if action == "invalid-name" {
+					want = ErrFunnyRefname
+				}
+				assert.ErrorIs(t, err, want)
+				assert.Empty(t, applied)
+				ref, err := st.Reference(name)
+				require.NoError(t, err)
+				assert.Equal(t, old, ref.Hash())
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, postCalled)
+			require.Len(t, applied, 1)
+			ref, err := st.Reference(name)
+			if action == "delete" || action == "sideband-delete" {
+				assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, newHash, ref.Hash())
+			}
+		})
+	}
+}
+
 func TestReceivePackRejectsCompleteWhitespaceRefname(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/transport/receive_pack_test.go
+++ b/plumbing/transport/receive_pack_test.go
@@ -3,14 +3,17 @@ package transport
 import (
 	"bytes"
 	"context"
+	"crypto/sha1"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp/sideband"
@@ -22,10 +25,25 @@ import (
 const receivePackTestHash = "0123456789012345678901234567890123456789"
 
 // receivePackRequest builds a wire-format receive-pack body for the given
-// commands, with ReportStatus advertised plus any extra caps. Tests use
-// Delete-only commands so no packfile follows, which keeps focus on hook
-// plumbing rather than pack handling.
+// commands, with ReportStatus advertised plus any extra caps. A packfile
+// follows unless every command is a Delete, because receive-pack expects one
+// there; the pack is empty so that these tests stay on ref handling rather than
+// pack decoding.
 func receivePackRequest(t *testing.T, cmds []*packp.Command, extra ...capability.Capability) io.ReadCloser {
+	t.Helper()
+
+	// A zero-object packfile: the "PACK" signature, version 2 and an object
+	// count of 0, followed by the SHA-1 of those twelve bytes.
+	header := []byte("PACK\x00\x00\x00\x02\x00\x00\x00\x00")
+	sum := sha1.Sum(header)
+
+	return receivePackBody(t, cmds, append(header, sum[:]...), extra...)
+}
+
+// receivePackBody builds a wire-format receive-pack body carrying pack where
+// the packfile belongs, so a caller can hand receive-pack something that will
+// not decode. The pack is written only if some command needs one.
+func receivePackBody(t *testing.T, cmds []*packp.Command, pack []byte, extra ...capability.Capability) io.ReadCloser {
 	t.Helper()
 
 	caps := capability.List{}
@@ -41,6 +59,14 @@ func receivePackRequest(t *testing.T, cmds []*packp.Command, extra ...capability
 
 	var buf bytes.Buffer
 	require.NoError(t, req.Encode(&buf))
+
+	for _, cmd := range cmds {
+		if cmd.Action() != packp.Delete {
+			buf.Write(pack)
+			break
+		}
+	}
+
 	return io.NopCloser(&buf)
 }
 
@@ -231,6 +257,9 @@ func TestReceivePackPostReceivePartialSuccess(t *testing.T) {
 	require.Len(t, info.Commands, 1, "PostReceive must only see refs that applied")
 	assert.Equal(t, good, info.Commands[0].Name)
 
+	// A refused ref is reported per-command; the unpack status describes the
+	// packfile only and must stay "ok".
+	assert.Contains(t, out.String(), "unpack ok")
 	assert.Contains(t, out.String(), "ok refs/heads/good")
 	assert.Contains(t, out.String(), "ng refs/heads/bad")
 }
@@ -278,4 +307,900 @@ func readSideband(t *testing.T, r io.Reader) sidebandPayload {
 	_, err := io.Copy(&p.data, demux)
 	require.NoError(t, err)
 	return p
+}
+
+// funnyNames are refnames receive-pack must refuse whatever storer sits behind
+// it: upstream's builtin/receive-pack.c reports "funny refname" for a command
+// whose name is not under refs/ or fails its format check. Every test here
+// drives ReceivePack against memory.NewStorage(), so a refusal can only come
+// from the transport gate — the dotgit layer's own checks are not in the way.
+var funnyNames = []plumbing.ReferenceName{
+	// Root refs and top-level metadata: not under refs/ at all.
+	"HEAD",
+	"CONFIG",
+	"config",
+	"INDEX",
+	"SHALLOW",
+	"ORIG_HEAD",
+	// Escapes from the refs/ sub-tree, spelled literally...
+	"refs/../CONFIG",
+	"refs/heads/../../config",
+	// ...and disguised with the code points HFS+ drops during path
+	// normalisation. Each component below is a ".." to the filesystem while
+	// holding no literal "..", which is exactly what carries it past IsSafe
+	// (a literal comparison) and Validate (rule 3, "contains ..").
+	// ZERO WIDTH NON-JOINER around the dots:
+	"refs/\u200c.\u200c./CONFIG",
+	"refs/heads/\u200c.\u200c./\u200c.\u200c./config",
+	// ZERO WIDTH NO-BREAK SPACE (the UTF-8 BOM):
+	"refs/\ufeff.\ufeff.\ufeff/CONFIG",
+	// LEFT-TO-RIGHT MARK:
+	"refs/\u200e.\u200e./config",
+	// A component the filesystem reads as a single "." aliases the directory
+	// it sits in, so each of these names resolves to a ref one level up while
+	// holding no literal "." component. The leading-ignorable spellings pass
+	// every other gate: IsSafe compares literally, and Validate's rule 1 sees
+	// a component starting with a code point rather than a dot.
+	"refs/\u200c./heads/main",
+	"refs/heads/\u200c./main",
+	"refs/heads/\u200c.\u200c/main",
+	"refs/\ufeff./heads/main",
+	"refs/heads/.:$DATA/main",
+	// Whitespace-containing names are covered by
+	// TestReceivePackRejectsCompleteWhitespaceRefname, which checks that
+	// decoding preserves the complete name for validation.
+	// Malformed by check_refname_format.
+	"refs/",
+	"refs/heads/foo..bar",
+	"refs/heads/foo.lock",
+	"refs/heads/foo\\bar",
+}
+
+// benignNames are refnames this gate must let through. Each has been mistaken
+// for malformed at some point. Git restricts a leading hyphen in branch and
+// tag shorthands at creation time; check_refname_format permits both leading
+// hyphens and "@" components in full names.
+//
+// refs/stash is the exception, and it is here on purpose. Real git answers
+// "ng refs/stash funny refname" to a create, because it strips "refs/" before
+// the format check and one level is left; go-git validates the whole name and
+// accepts it. That divergence is the one documented at checkRefname.
+var benignNames = []plumbing.ReferenceName{
+	"refs/heads/main",
+	"refs/heads/-foo",
+	"refs/tags/-1.0",
+	"refs/heads/@",
+	"refs/remotes/origin/@",
+	"refs/stash",
+	"refs/notes/commits",
+}
+
+func TestReceivePackRefusesFunnyRefnameCreate(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range funnyNames {
+		t.Run(name.String(), func(t *testing.T) {
+			t.Parallel()
+
+			st := memory.NewStorage()
+			hash := plumbing.NewHash(receivePackTestHash)
+
+			var out bytes.Buffer
+			err := ReceivePack(
+				context.Background(),
+				st,
+				receivePackRequest(t, []*packp.Command{
+					{Name: name, Old: plumbing.ZeroHash, New: hash},
+				}),
+				ioutil.WriteNopCloser(&out),
+				&ReceivePackRequest{StatelessRPC: true},
+			)
+			require.ErrorIs(t, err, ErrFunnyRefname)
+
+			assert.Contains(t, out.String(), "unpack ok")
+			assert.Contains(t, out.String(), "ng "+name.String()+" funny refname")
+
+			_, refErr := st.Reference(name)
+			assert.ErrorIs(t, refErr, plumbing.ErrReferenceNotFound,
+				"%q must not be created", name)
+		})
+	}
+}
+
+func TestReceivePackRefusesFunnyRefnameUpdate(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range funnyNames {
+		t.Run(name.String(), func(t *testing.T) {
+			t.Parallel()
+
+			old := plumbing.NewHash("1111111111111111111111111111111111111111")
+			st := seedRef(t, name, old)
+
+			var out bytes.Buffer
+			err := ReceivePack(
+				context.Background(),
+				st,
+				receivePackRequest(t, []*packp.Command{
+					{Name: name, Old: old, New: plumbing.NewHash(receivePackTestHash)},
+				}),
+				ioutil.WriteNopCloser(&out),
+				&ReceivePackRequest{StatelessRPC: true},
+			)
+			require.ErrorIs(t, err, ErrFunnyRefname)
+
+			assert.Contains(t, out.String(), "ng "+name.String()+" funny refname")
+
+			got, refErr := st.Reference(name)
+			require.NoError(t, refErr)
+			assert.Equal(t, old, got.Hash(), "%q must not move", name)
+		})
+	}
+}
+
+func TestReceivePackRefusesFunnyRefnameDelete(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range funnyNames {
+		t.Run(name.String(), func(t *testing.T) {
+			t.Parallel()
+
+			hash := plumbing.NewHash(receivePackTestHash)
+			st := seedRef(t, name, hash)
+
+			var out bytes.Buffer
+			err := ReceivePack(
+				context.Background(),
+				st,
+				receivePackRequest(t, []*packp.Command{deleteCmd(name, hash)}),
+				ioutil.WriteNopCloser(&out),
+				&ReceivePackRequest{StatelessRPC: true},
+			)
+			require.ErrorIs(t, err, ErrFunnyRefname)
+
+			assert.Contains(t, out.String(), "ng "+name.String()+" funny refname")
+
+			_, refErr := st.Reference(name)
+			assert.NoError(t, refErr, "%q must not be deleted", name)
+		})
+	}
+}
+
+func TestReceivePackAcceptsBenignRefnames(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range benignNames {
+		t.Run(name.String(), func(t *testing.T) {
+			t.Parallel()
+
+			st := memory.NewStorage()
+			hash := plumbing.NewHash(receivePackTestHash)
+
+			var out bytes.Buffer
+			err := ReceivePack(
+				context.Background(),
+				st,
+				receivePackRequest(t, []*packp.Command{
+					{Name: name, Old: plumbing.ZeroHash, New: hash},
+				}),
+				ioutil.WriteNopCloser(&out),
+				&ReceivePackRequest{StatelessRPC: true},
+			)
+			require.NoError(t, err)
+
+			assert.Contains(t, out.String(), "ok "+name.String())
+
+			got, refErr := st.Reference(name)
+			require.NoError(t, refErr, "%q must be created", name)
+			assert.Equal(t, hash, got.Hash())
+		})
+	}
+}
+
+func TestReceivePackFunnyRefnameDoesNotBlockGoodRefs(t *testing.T) {
+	t.Parallel()
+
+	good := plumbing.ReferenceName("refs/heads/ok")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := memory.NewStorage()
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: "CONFIG", Old: plumbing.ZeroHash, New: hash},
+			{Name: good, Old: plumbing.ZeroHash, New: hash},
+		}),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.ErrorIs(t, err, ErrFunnyRefname)
+
+	assert.Contains(t, out.String(), "ng CONFIG funny refname")
+	assert.Contains(t, out.String(), "ok refs/heads/ok")
+
+	ref, refErr := st.Reference(good)
+	require.NoError(t, refErr)
+	assert.Equal(t, hash, ref.Hash())
+}
+
+func TestReceivePackFunnyRefnameReportsOnSideband(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: "CONFIG", Old: plumbing.ZeroHash, New: plumbing.NewHash(receivePackTestHash)},
+		}, capability.Sideband64k),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.ErrorIs(t, err, ErrFunnyRefname)
+
+	demuxed := readSideband(t, &out)
+	assert.Contains(t, demuxed.data.String(), "unpack ok")
+	assert.Contains(t, demuxed.data.String(), "ng CONFIG funny refname")
+}
+
+// TestReceivePackFunnyRefnameWireFormat pins the bytes rather than the error,
+// because the report-status wire format is what a real git client parses: the
+// unpack line stays "ok" (the packfile was fine, one command was not), the
+// refusal is a single "ng" line carrying ErrFunnyRefname's message verbatim,
+// and the report ends with a flush.
+func TestReceivePackFunnyRefnameWireFormat(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: "CONFIG", Old: plumbing.ZeroHash, New: plumbing.NewHash(receivePackTestHash)},
+		}),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.ErrorIs(t, err, ErrFunnyRefname)
+
+	assert.Equal(t, "000eunpack ok\n001cng CONFIG funny refname\n0000", out.String())
+}
+
+func TestReceivePackAcceptsWellFormedRefs(t *testing.T) {
+	t.Parallel()
+
+	hash := plumbing.NewHash(receivePackTestHash)
+	other := plumbing.NewHash("1111111111111111111111111111111111111111")
+
+	for _, name := range []plumbing.ReferenceName{
+		"refs/heads/main",
+		"refs/heads/feature/nested/name",
+		"refs/heads/release-1.2",
+		"refs/tags/v1.0.0",
+		"refs/stash",
+		"refs/remotes/origin/HEAD",
+		// Namespaces outside refs/heads and refs/tags that tools push to, all
+		// accepted by upstream git's receive-pack.
+		"refs/notes/commits",
+		"refs/replace/deadbeef",
+		"refs/meta/config",
+		"refs/for/main",
+		"refs/pull/1/head",
+		"refs/keep-around/abc123",
+	} {
+		t.Run(name.String(), func(t *testing.T) {
+			t.Parallel()
+
+			st := memory.NewStorage()
+
+			var out bytes.Buffer
+			require.NoError(t, ReceivePack(
+				context.Background(), st,
+				receivePackRequest(t, []*packp.Command{
+					{Name: name, Old: plumbing.ZeroHash, New: other},
+				}),
+				ioutil.WriteNopCloser(&out),
+				&ReceivePackRequest{StatelessRPC: true},
+			))
+			assert.Contains(t, out.String(), "ok "+name.String())
+
+			out.Reset()
+			require.NoError(t, ReceivePack(
+				context.Background(), st,
+				receivePackRequest(t, []*packp.Command{
+					{Name: name, Old: other, New: hash},
+				}),
+				ioutil.WriteNopCloser(&out),
+				&ReceivePackRequest{StatelessRPC: true},
+			))
+			assert.Contains(t, out.String(), "ok "+name.String())
+			ref, refErr := st.Reference(name)
+			require.NoError(t, refErr)
+			assert.Equal(t, hash, ref.Hash())
+
+			out.Reset()
+			require.NoError(t, ReceivePack(
+				context.Background(), st,
+				receivePackRequest(t, []*packp.Command{deleteCmd(name, hash)}),
+				ioutil.WriteNopCloser(&out),
+				&ReceivePackRequest{StatelessRPC: true},
+			))
+			assert.Contains(t, out.String(), "ok "+name.String())
+			_, refErr = st.Reference(name)
+			assert.ErrorIs(t, refErr, plumbing.ErrReferenceNotFound)
+		})
+	}
+}
+
+// closeCountingWriter records how often the response was closed, which is what
+// ends it for a real caller's transport, and can fail the close on demand.
+type closeCountingWriter struct {
+	buf      bytes.Buffer
+	closes   int
+	closeErr error
+	writeErr error
+}
+
+func (w *closeCountingWriter) Write(p []byte) (int, error) {
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	return w.buf.Write(p)
+}
+
+func (w *closeCountingWriter) Close() error {
+	w.closes++
+	return w.closeErr
+}
+
+// receivePackRequestWithoutReportStatus builds a request that advertises no
+// capabilities at all, so ReceivePack returns before it writes a status.
+func receivePackRequestWithoutReportStatus(t *testing.T, cmds []*packp.Command) io.ReadCloser {
+	t.Helper()
+
+	req := &packp.UpdateRequests{Capabilities: capability.List{}, Commands: cmds}
+	var buf bytes.Buffer
+	require.NoError(t, req.Encode(&buf))
+	return io.NopCloser(&buf)
+}
+
+// TestReceivePackClosesWriterOnEveryExit pins the contract that every return
+// from ReceivePack closes the writer exactly once, the early ones that never
+// write a byte included: a caller whose transport ends the response on close
+// would otherwise leave a client reading a stream that never ends.
+func TestReceivePackClosesWriterOnEveryExit(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+
+	noBody := func(*testing.T) io.ReadCloser { return nil }
+
+	tests := []struct {
+		name    string
+		body    func(*testing.T) io.ReadCloser
+		opts    *ReceivePackRequest
+		wantErr bool
+	}{
+		{
+			name:    "nil reader",
+			body:    noBody,
+			opts:    &ReceivePackRequest{StatelessRPC: true},
+			wantErr: true,
+		},
+		{
+			name: "advertisement only",
+			body: noBody,
+			opts: &ReceivePackRequest{AdvertiseRefs: true, StatelessRPC: true},
+		},
+		{
+			name: "client sends flush",
+			body: func(t *testing.T) io.ReadCloser {
+				var buf bytes.Buffer
+				require.NoError(t, pktline.WriteFlush(&buf))
+				return io.NopCloser(&buf)
+			},
+			opts: &ReceivePackRequest{StatelessRPC: true},
+		},
+		{
+			name: "malformed request",
+			body: func(t *testing.T) io.ReadCloser {
+				var buf bytes.Buffer
+				_, err := pktline.WriteString(&buf, "junk\n")
+				require.NoError(t, err)
+				return io.NopCloser(&buf)
+			},
+			opts:    &ReceivePackRequest{StatelessRPC: true},
+			wantErr: true,
+		},
+		{
+			name: "no report-status capability",
+			body: func(t *testing.T) io.ReadCloser {
+				return receivePackRequestWithoutReportStatus(t,
+					[]*packp.Command{deleteCmd(ref, hash)})
+			},
+			opts: &ReceivePackRequest{StatelessRPC: true},
+		},
+		{
+			name: "reference updated",
+			body: func(t *testing.T) io.ReadCloser {
+				return receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)})
+			},
+			opts: &ReceivePackRequest{StatelessRPC: true},
+		},
+		{
+			name: "refname refused",
+			body: func(t *testing.T) io.ReadCloser {
+				return receivePackRequest(t, []*packp.Command{
+					{Name: plumbing.HEAD, Old: plumbing.ZeroHash, New: hash},
+				})
+			},
+			opts:    &ReceivePackRequest{StatelessRPC: true},
+			wantErr: true,
+		},
+		{
+			name: "pre-receive rejects",
+			body: func(t *testing.T) io.ReadCloser {
+				return receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)})
+			},
+			opts: &ReceivePackRequest{
+				StatelessRPC: true,
+				Hooks: ReceivePackHooks{
+					PreReceive: func(context.Context, *PreReceiveInfo) error {
+						return errors.New("refused by policy")
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := &closeCountingWriter{}
+			err := ReceivePack(context.Background(), seedRef(t, ref, hash),
+				tc.body(t), w, tc.opts)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, 1, w.closes, "writer must be closed exactly once")
+		})
+	}
+}
+
+// TestReceivePackClosesWriterWhenStatusFails covers the exit a failed status
+// write takes. The report never reaches the client there, which leaves the
+// close as the only thing that can end the response.
+func TestReceivePackClosesWriterWhenStatusFails(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	writeErr := errors.New("connection reset")
+
+	w := &closeCountingWriter{writeErr: writeErr}
+	err := ReceivePack(context.Background(), seedRef(t, ref, hash),
+		receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)}),
+		w, &ReceivePackRequest{StatelessRPC: true})
+
+	require.ErrorIs(t, err, writeErr)
+	assert.Equal(t, 1, w.closes, "writer must be closed when the status write fails")
+}
+
+// TestReceivePackCloseErrorYieldsToRequestError keeps the close from speaking
+// over the exchange it ends: a refused ref describes the push, while a failure
+// to hang up only describes the caller's own writer.
+func TestReceivePackCloseErrorYieldsToRequestError(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	closeErr := errors.New("broken pipe")
+
+	t.Run("surfaces when nothing else failed", func(t *testing.T) {
+		t.Parallel()
+
+		w := &closeCountingWriter{closeErr: closeErr}
+		err := ReceivePack(context.Background(), seedRef(t, ref, hash),
+			receivePackRequest(t, []*packp.Command{deleteCmd(ref, hash)}),
+			w, &ReceivePackRequest{StatelessRPC: true})
+
+		require.ErrorIs(t, err, closeErr)
+		assert.Contains(t, err.Error(), "closing writer")
+		assert.Contains(t, w.buf.String(), "ok refs/heads/main")
+	})
+
+	t.Run("yields to a refused refname", func(t *testing.T) {
+		t.Parallel()
+
+		w := &closeCountingWriter{closeErr: closeErr}
+		err := ReceivePack(context.Background(), seedRef(t, ref, hash),
+			receivePackRequest(t, []*packp.Command{
+				{Name: plumbing.HEAD, Old: plumbing.ZeroHash, New: hash},
+			}),
+			w, &ReceivePackRequest{StatelessRPC: true})
+
+		require.ErrorIs(t, err, ErrFunnyRefname)
+		assert.NotErrorIs(t, err, closeErr)
+		assert.Equal(t, 1, w.closes)
+	})
+}
+
+// TestReceivePackReportsStatusInCommandOrder pins the order of the report, not
+// just its contents: git emits one status line per command in the order the
+// commands arrived, and a client pairing them up positionally depends on that.
+// The statuses are collected in a map, so the lines have to be driven off the
+// command list to come out in a stable order at all.
+func TestReceivePackReportsStatusInCommandOrder(t *testing.T) {
+	t.Parallel()
+
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := memory.NewStorage()
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: "refs/heads/one", Old: plumbing.ZeroHash, New: hash},
+			{Name: "CONFIG", Old: plumbing.ZeroHash, New: hash},
+			{Name: "refs/heads/two", Old: plumbing.ZeroHash, New: hash},
+			{Name: "refs/heads/three", Old: plumbing.ZeroHash, New: hash},
+			{Name: "HEAD", Old: plumbing.ZeroHash, New: hash},
+		}),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.ErrorIs(t, err, ErrFunnyRefname)
+
+	assert.Equal(t, "000eunpack ok\n"+
+		"0016ok refs/heads/one\n"+
+		"001cng CONFIG funny refname\n"+
+		"0016ok refs/heads/two\n"+
+		"0018ok refs/heads/three\n"+
+		"001ang HEAD funny refname\n"+
+		"0000", out.String())
+}
+
+// TestReceivePackUnpackFailure covers the exit taken when the packfile does not
+// decode, which is the one failure exit with no test of its own. It has to
+// behave like the other two: report the reason to the client, terminate the
+// sideband stream, and hand the caller the error rather than a nil that reads
+// as a clean push.
+func TestReceivePackUnpackFailure(t *testing.T) {
+	t.Parallel()
+
+	hash := plumbing.NewHash(receivePackTestHash)
+	cmds := []*packp.Command{
+		{Name: "refs/heads/main", Old: plumbing.ZeroHash, New: hash},
+	}
+	badPack := []byte("this is not a packfile")
+
+	t.Run("plain", func(t *testing.T) {
+		t.Parallel()
+
+		st := memory.NewStorage()
+
+		var out bytes.Buffer
+		err := ReceivePack(
+			context.Background(), st,
+			receivePackBody(t, cmds, badPack),
+			ioutil.WriteNopCloser(&out),
+			&ReceivePackRequest{StatelessRPC: true},
+		)
+		require.Error(t, err)
+
+		// The unpack line carries the reason, and no command is reported at
+		// all: nothing was attempted, so there is no per-ref outcome to give.
+		assert.Contains(t, out.String(), "unpack ")
+		assert.NotContains(t, out.String(), "refs/heads/main")
+		assert.Contains(t, out.String(), err.Error(),
+			"the error handed back must be the one reported to the client")
+
+		_, refErr := st.Reference("refs/heads/main")
+		assert.ErrorIs(t, refErr, plumbing.ErrReferenceNotFound)
+	})
+
+	t.Run("sideband", func(t *testing.T) {
+		t.Parallel()
+
+		var out bytes.Buffer
+		err := ReceivePack(
+			context.Background(), memory.NewStorage(),
+			receivePackBody(t, cmds, badPack, capability.Sideband64k),
+			ioutil.WriteNopCloser(&out),
+			&ReceivePackRequest{StatelessRPC: true},
+		)
+		require.Error(t, err)
+
+		// ReportStatus.Encode ends with a flush, but on this path that flush is
+		// muxed into band 1 like the rest of the report. The byte stream needs
+		// a bare flush after it, or the client is left demuxing a sideband
+		// stream with no terminator.
+		assert.True(t, strings.HasSuffix(out.String(), "\x0100000000"),
+			"sideband stream must end with a muxed flush then a bare one, got %q", out.String())
+
+		demuxed := readSideband(t, &out)
+		assert.Contains(t, demuxed.data.String(), "unpack ")
+	})
+}
+
+// TestReceivePackRefusesDuplicateRefname pins the bytes, because one status
+// line per command is the property at stake: a client pairs the lines with the
+// commands it sent positionally, so two commands must produce two lines even
+// when both name the same ref and both carry the same reason.
+func TestReceivePackRefusesDuplicateRefname(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	old := plumbing.NewHash(receivePackTestHash)
+	st := seedRef(t, ref, old)
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: ref, Old: old, New: plumbing.NewHash("1111111111111111111111111111111111111111")},
+			{Name: ref, Old: old, New: plumbing.NewHash("2222222222222222222222222222222222222222")},
+		}),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.ErrorIs(t, err, ErrDuplicateRefname)
+	// The caller is told which name was duplicated; the wire reason is not.
+	assert.Contains(t, err.Error(), `"refs/heads/main"`)
+
+	assert.Equal(t, "000eunpack ok\n"+
+		"003cng refs/heads/main multiple updates for ref not allowed\n"+
+		"003cng refs/heads/main multiple updates for ref not allowed\n"+
+		"0000", out.String())
+
+	// Neither command ran, so the ref still holds what it held before.
+	got, refErr := st.Reference(ref)
+	require.NoError(t, refErr)
+	assert.Equal(t, old, got.Hash())
+}
+
+// TestReceivePackDuplicateRefnameRefusesWholePush covers the refs that named a
+// reference only once. Git batches the updates into a transaction that the
+// duplicate aborts, so those refs do not move either and are answered "ng"
+// alongside it; a push applies as sent or not at all.
+func TestReceivePackDuplicateRefnameRefusesWholePush(t *testing.T) {
+	t.Parallel()
+
+	dup := plumbing.ReferenceName("refs/heads/dup")
+	innocent := plumbing.ReferenceName("refs/heads/innocent")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := memory.NewStorage()
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: dup, Old: plumbing.ZeroHash, New: hash},
+			{Name: innocent, Old: plumbing.ZeroHash, New: hash},
+			{Name: dup, Old: plumbing.ZeroHash, New: hash},
+		}),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.ErrorIs(t, err, ErrDuplicateRefname)
+
+	assert.Equal(t, "000eunpack ok\n"+
+		"003bng refs/heads/dup multiple updates for ref not allowed\n"+
+		"0040ng refs/heads/innocent multiple updates for ref not allowed\n"+
+		"003bng refs/heads/dup multiple updates for ref not allowed\n"+
+		"0000", out.String())
+
+	for _, n := range []plumbing.ReferenceName{dup, innocent} {
+		_, refErr := st.Reference(n)
+		assert.ErrorIs(t, refErr, plumbing.ErrReferenceNotFound, "ref %q", n)
+	}
+}
+
+// TestReceivePackDuplicateRefnameMixedActions covers a duplicate whose two
+// commands disagree about the action. Real git splits deletes from updates into
+// separate transactions, so there the delete lands while every command still
+// reports failure; refusing the request before anything runs keeps the report
+// and the repository saying the same thing.
+func TestReceivePackDuplicateRefnameMixedActions(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	old := plumbing.NewHash(receivePackTestHash)
+	st := seedRef(t, ref, old)
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: ref, Old: old, New: plumbing.NewHash("1111111111111111111111111111111111111111")},
+			deleteCmd(ref, old),
+		}),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.ErrorIs(t, err, ErrDuplicateRefname)
+
+	got, refErr := st.Reference(ref)
+	require.NoError(t, refErr, "the delete must not have run")
+	assert.Equal(t, old, got.Hash(), "the update must not have run")
+}
+
+// TestReceivePackDuplicateRefnameSkipsHooks asserts the request is refused
+// before PreReceive. A hook decides policy and may have side effects of its
+// own, so it is not consulted about a push that cannot apply whatever it
+// answers.
+func TestReceivePackDuplicateRefnameSkipsHooks(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := memory.NewStorage()
+
+	var preCalled, postCalled bool
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: ref, Old: plumbing.ZeroHash, New: hash},
+			{Name: ref, Old: plumbing.ZeroHash, New: hash},
+		}),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{
+			StatelessRPC: true,
+			Hooks: ReceivePackHooks{
+				PreReceive: func(context.Context, *PreReceiveInfo) error {
+					preCalled = true
+					return nil
+				},
+				PostReceive: func(context.Context, *PostReceiveInfo) error {
+					postCalled = true
+					return nil
+				},
+			},
+		},
+	)
+	require.ErrorIs(t, err, ErrDuplicateRefname)
+	assert.False(t, preCalled, "PreReceive must not run for an unapplyable push")
+	assert.False(t, postCalled, "PostReceive must not run when no ref moved")
+}
+
+// TestReceivePackDuplicateRefnameOnSideband checks the refusal takes the same
+// route as the other reporting exits: muxed into band 1, then the flush that
+// ends the stream the client is demuxing.
+func TestReceivePackDuplicateRefnameOnSideband(t *testing.T) {
+	t.Parallel()
+
+	ref := plumbing.ReferenceName("refs/heads/main")
+	hash := plumbing.NewHash(receivePackTestHash)
+	st := memory.NewStorage()
+
+	var out bytes.Buffer
+	err := ReceivePack(
+		context.Background(),
+		st,
+		receivePackRequest(t, []*packp.Command{
+			{Name: ref, Old: plumbing.ZeroHash, New: hash},
+			{Name: ref, Old: plumbing.ZeroHash, New: hash},
+		}, capability.Sideband64k),
+		ioutil.WriteNopCloser(&out),
+		&ReceivePackRequest{StatelessRPC: true},
+	)
+	require.ErrorIs(t, err, ErrDuplicateRefname)
+
+	demuxed := readSideband(t, &out)
+	assert.Contains(t, demuxed.data.String(), "unpack ok")
+	assert.Equal(t, 2, strings.Count(demuxed.data.String(),
+		"ng refs/heads/main multiple updates for ref not allowed"))
+}
+
+func TestDuplicateRefname(t *testing.T) {
+	t.Parallel()
+
+	cmd := func(n string) *packp.Command {
+		return &packp.Command{Name: plumbing.ReferenceName(n)}
+	}
+
+	for _, tc := range []struct {
+		name string
+		cmds []*packp.Command
+		want string
+	}{
+		{name: "nil", cmds: nil, want: ""},
+		{name: "one", cmds: []*packp.Command{cmd("refs/heads/a")}, want: ""},
+		{
+			name: "distinct",
+			cmds: []*packp.Command{cmd("refs/heads/a"), cmd("refs/heads/b")},
+			want: "",
+		},
+		{
+			name: "adjacent",
+			cmds: []*packp.Command{cmd("refs/heads/a"), cmd("refs/heads/a")},
+			want: "refs/heads/a",
+		},
+		{
+			name: "apart",
+			cmds: []*packp.Command{cmd("refs/heads/a"), cmd("refs/heads/b"), cmd("refs/heads/a")},
+			want: "refs/heads/a",
+		},
+		{
+			name: "reports the second name repeated, not the first seen",
+			cmds: []*packp.Command{cmd("refs/heads/a"), cmd("refs/heads/b"), cmd("refs/heads/b")},
+			want: "refs/heads/b",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := duplicateRefname(tc.cmds)
+			assert.Equal(t, tc.want != "", ok)
+			assert.Equal(t, plumbing.ReferenceName(tc.want), got)
+		})
+	}
+}
+
+func TestReceivePackRejectsCompleteWhitespaceRefname(t *testing.T) {
+	t.Parallel()
+
+	hash := plumbing.NewHash(receivePackTestHash)
+	alias := plumbing.ReferenceName("refs/heads/main")
+	for _, name := range []string{
+		"refs/heads/main extra", "refs/heads/main\textra", "refs/heads/main\nextra",
+		"refs/heads/main\rextra", "refs/heads/main\vextra", "refs/heads/main\fextra",
+		"refs/heads/main ", "refs/heads/main\n", " refs/heads/main",
+	} {
+		for _, action := range []string{"create", "update", "delete"} {
+			t.Run(action+"/"+name, func(t *testing.T) {
+				t.Parallel()
+
+				st := memory.NewStorage()
+				oldHash, newHash := plumbing.ZeroHash, hash
+				if action != "create" {
+					require.NoError(t, st.SetReference(plumbing.NewHashReference(alias, hash)))
+					oldHash = hash
+				}
+				if action == "delete" {
+					newHash = plumbing.ZeroHash
+				}
+
+				var request, response bytes.Buffer
+				_, err := pktline.Writef(&request, "%s %s %s\x00report-status\n", oldHash, newHash, name)
+				require.NoError(t, err)
+				require.NoError(t, pktline.WriteFlush(&request))
+				if action != "delete" {
+					header := []byte("PACK\x00\x00\x00\x02\x00\x00\x00\x00")
+					sum := sha1.Sum(header)
+					request.Write(header)
+					request.Write(sum[:])
+				}
+
+				err = ReceivePack(context.Background(), st, io.NopCloser(&request),
+					ioutil.WriteNopCloser(&response), &ReceivePackRequest{StatelessRPC: true})
+				assert.ErrorIs(t, err, ErrFunnyRefname)
+				assert.Contains(t, response.String(), "ng "+name+" funny refname\n")
+				ref, err := st.Reference(alias)
+				if action == "create" {
+					assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, hash, ref.Hash())
+				}
+			})
+		}
+	}
 }

--- a/plumbing/transport/serve.go
+++ b/plumbing/transport/serve.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-git/go-git/v6/internal/reference"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/config"
 	"github.com/go-git/go-git/v6/plumbing/object"
@@ -14,10 +15,19 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 // ErrUpdateReference is returned when a reference update fails.
 var ErrUpdateReference = errors.New("failed to update ref")
+
+// ErrFunnyRefname is returned when a push names a reference the server refuses
+// to touch: one that is not under refs/, or one whose name is malformed.
+var ErrFunnyRefname = errors.New("funny refname")
+
+// ErrDuplicateRefname is reported for every command of a push whose command
+// list updates one reference more than once.
+var ErrDuplicateRefname = errors.New("multiple updates for ref not allowed")
 
 // AdvertiseRefs is a server command that implements the reference
 // discovery phase of the v0/v1 Git transfer protocol. Protocol v2 advertises
@@ -161,6 +171,41 @@ func objectFormat(st storage.Storer) config.ObjectFormat {
 	return cfg.Extensions.ObjectFormat
 }
 
+// advertisable reports whether a reference name may be put on the wire.
+//
+// The reference store reports what is on disk, malformed names included,
+// because a caller that cannot see a name cannot repair it and because
+// anything that prunes or repacks from that listing has to see every name that
+// is really there. The advertisement excludes malformed wire names. A valid
+// Git name is retained even if the filesystem storer applies stricter path
+// safety rules, such as rejecting an HFS+ component that folds to a dot.
+//
+// Git's upload-pack.c send_ref does not consult REF_BAD_NAME: malformed names
+// that reach it can be advertised with a zero object id, leaving the dropping
+// to fetch-pack.c's filter_refs. The files backend excludes some entries,
+// including loose .lock files, before send_ref. The ref-filter.c pass that
+// warns and skips is the porcelain layer behind for-each-ref and git branch,
+// not upload-pack's path.
+//
+// Dropping rather than zeroing is the choice here, because a zero id is a
+// thing every client has to be taught to read, while a name a peer cannot
+// store is one it has no use for. The cost is that git ls-remote against a
+// go-git server does not show such a name at all, where Git may show it with
+// a zero object id.
+//
+// HEAD is the one name outside refs/ that belongs on the wire, and Validate
+// carves it out already.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/upload-pack.c#L1196-L1242
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs/files-backend.c#L345-L350
+func advertisable(name plumbing.ReferenceName) bool {
+	if name == plumbing.HEAD {
+		return true
+	}
+
+	return name.IsUnderRefs() && name.Validate() == nil
+}
+
 func addReferences(st storage.Storer, ar *packp.AdvRefs, addHead bool) error {
 	iter, err := st.IterReferences()
 	if err != nil {
@@ -170,15 +215,30 @@ func addReferences(st storage.Storer, ar *packp.AdvRefs, addHead bool) error {
 	// Add references and their peeled values
 	return iter.ForEach(func(r *plumbing.Reference) error {
 		hash, name := r.Hash(), r.Name()
+		var target plumbing.ReferenceName
+
+		if !advertisable(name) {
+			// One malformed name must not prevent advertising the usable refs.
+			trace.General.Printf("ignoring ref with broken name %q", string(name))
+			return nil
+		}
 		if r.Type() == plumbing.SymbolicReference {
 			ref, err := storer.ResolveReference(st, r.Target())
-			if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			// Missing, rejected and cyclic referents cost this one entry.
+			// Other errors still propagate: an unavailable store must not
+			// turn into a successful but incomplete advertisement.
+			if reference.IsUnresolvableForAdvertisement(err) {
+				trace.General.Printf("ignoring ref %q with unresolvable target %q",
+					string(name), r.Target().String())
 				return nil
 			}
 			if err != nil {
 				return err
 			}
 			hash = ref.Hash()
+			// Git advertises the terminal name, including for symbolic chains.
+			// See https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/upload-pack.c#L1245-L1259.
+			target = ref.Name()
 		}
 		if name == plumbing.HEAD {
 			if !addHead {
@@ -188,8 +248,15 @@ func addReferences(st storage.Storer, ar *packp.AdvRefs, addHead bool) error {
 			// (HashReference) has no branch target to advertise; emitting
 			// "HEAD:" with an empty target corrupts the capability list and
 			// causes the client to store an unresolvable HEAD symref.
-			if r.Type() == plumbing.SymbolicReference {
-				ar.Capabilities.Add(capability.SymRef, fmt.Sprintf("%s:%s", name, r.Target()))
+			//
+			// The target is checked too. It is a name leaving the process
+			// like any other, and naming a ref that was just withheld would
+			// produce an advertisement contradicting itself: the client is
+			// told HEAD points somewhere it will never be told about, and
+			// go-git's own client fails such a clone outright. HEAD keeps its
+			// object id, so the peer still has a starting point.
+			if r.Type() == plumbing.SymbolicReference && advertisable(target) {
+				ar.Capabilities.Add(capability.SymRef, fmt.Sprintf("%s:%s", name, target))
 			}
 			ar.References = append([]*plumbing.Reference{plumbing.NewHashReference(name, hash)}, ar.References...)
 			return nil

--- a/plumbing/transport/serve_test.go
+++ b/plumbing/transport/serve_test.go
@@ -3,15 +3,24 @@ package transport
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"os"
+	"syscall"
 	"testing"
 
 	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
+	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
+	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
+	"github.com/go-git/go-git/v6/storage/memory"
 	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
@@ -71,4 +80,298 @@ func testAdvertise[T UploadPackRequest | ReceivePackRequest](
 		o.StatelessRPC = stateless
 	}
 	return testServe(t, st, fun, io.NopCloser(bytes.NewBuffer(nil)), opts)
+}
+
+// A reference store reports what is on disk. The advertisement excludes
+// malformed Git names, including stale lock files.
+func TestAdvertiseRefsSkipsUnadvertisableNames(t *testing.T) {
+	t.Parallel()
+
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	st := memory.NewStorage()
+	for _, n := range []plumbing.ReferenceName{
+		"refs/heads/main",
+		"refs/heads/main.lock",
+		"refs/heads/.hidden",
+		"refs/heads/bad~name",
+		"refs/heads/a..b",
+		"CONFIG",
+	} {
+		require.NoError(t, st.SetReference(plumbing.NewHashReference(n, hash)))
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, AdvertiseRefs(
+		context.Background(), st, ioutil.WriteNopCloser(&buf),
+		UploadPackService, false, protocol.V0,
+	))
+
+	// The first advertised line carries the capability list after a NUL, so
+	// match the name against what precedes it.
+	out := buf.String()
+	assert.Contains(t, out, hash.String()+" refs/heads/main\x00")
+	for _, n := range []string{
+		"refs/heads/main.lock", "refs/heads/.hidden",
+		"refs/heads/bad~name", "refs/heads/a..b", "CONFIG",
+	} {
+		assert.NotContains(t, out, n, "%q must not be advertised", n)
+	}
+}
+
+func TestAdvertisable(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name plumbing.ReferenceName
+		want bool
+	}{
+		{"HEAD", true},
+		{"refs/heads/main", true},
+		{"refs/heads/@", true},
+		{"refs/heads/-foo", true},
+		{"refs/heads/\u200c./main", true},
+		{"refs/stash", true},
+		{"refs/heads/main.lock", false},
+		{"refs/heads/.hidden", false},
+		{"refs/heads/bad~name", false},
+		{"CONFIG", false},
+		{"ORIG_HEAD", false},
+		// Well-formed by Validate, but not under refs/ and not HEAD, so the
+		// prefix arm is the only thing that decides it.
+		{"foo/bar", false},
+		{"refs/../config", false},
+	} {
+		assert.Equal(t, tc.want, advertisable(tc.name), "advertisable(%q)", tc.name)
+	}
+}
+
+// The advertisement filter also covers protocol v2 ls-refs. The v2 grammar
+// raises the stakes: a ref line is "obj-id SP refname *(SP ref-attribute)",
+// so a name holding a space arrives at the peer as a different ref plus an
+// attribute it never sent.
+func TestServeLsRefsV2SkipsUnadvertisableNames(t *testing.T) {
+	t.Parallel()
+
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	st := memory.NewStorage()
+	for _, n := range []plumbing.ReferenceName{
+		"refs/heads/main",
+		"refs/heads/main.lock",
+		"refs/heads/bad~name",
+		"refs/heads/sp ace",
+		"CONFIG",
+	} {
+		require.NoError(t, st.SetReference(plumbing.NewHashReference(n, hash)))
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, serveLsRefsV2(context.Background(), st, &buf, &packp.LsRefsArgs{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "refs/heads/main\n")
+	for _, n := range []string{"refs/heads/main.lock", "bad~name", "sp ace", "CONFIG"} {
+		assert.NotContains(t, out, n, "%q must not be advertised over v2", n)
+	}
+}
+
+// The symref capability names a reference too. Advertising a target that was
+// just withheld contradicts the rest of the advertisement, and go-git's own
+// client refuses such a clone outright.
+func TestAdvertiseRefsSkipsUnadvertisableSymrefTarget(t *testing.T) {
+	t.Parallel()
+
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	st := memory.NewStorage()
+	require.NoError(t, st.SetReference(plumbing.NewHashReference("refs/heads/main.lock", hash)))
+	require.NoError(t, st.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main.lock")))
+
+	var buf bytes.Buffer
+	require.NoError(t, AdvertiseRefs(
+		context.Background(), st, ioutil.WriteNopCloser(&buf),
+		UploadPackService, false, protocol.V0,
+	))
+
+	out := buf.String()
+	assert.NotContains(t, out, "symref=HEAD:refs/heads/main.lock")
+	assert.NotContains(t, out, "refs/heads/main.lock")
+}
+
+// A symref whose target the store will not hand back costs that entry, not
+// the advertisement. Before this, one such reference made the server serve
+// nothing at all.
+func TestAdvertiseRefsSurvivesUnresolvableSymref(t *testing.T) {
+	t.Parallel()
+
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	st := memory.NewStorage()
+	require.NoError(t, st.SetReference(plumbing.NewHashReference("refs/heads/main", hash)))
+	require.NoError(t, st.SetReference(plumbing.NewSymbolicReference("refs/heads/sym", "CONFIG")))
+
+	var buf bytes.Buffer
+	require.NoError(t, AdvertiseRefs(
+		context.Background(), st, ioutil.WriteNopCloser(&buf),
+		UploadPackService, false, protocol.V0,
+	))
+
+	assert.Contains(t, buf.String(), "refs/heads/main")
+}
+
+func TestAdvertiseRefsSkipsCyclicSymrefs(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	require.NoError(t, st.SetReference(plumbing.NewHashReference("refs/heads/main", hash)))
+	require.NoError(t, st.SetReference(plumbing.NewSymbolicReference("refs/heads/loop", "refs/heads/loop")))
+	var buf bytes.Buffer
+	require.NoError(t, AdvertiseRefs(context.Background(), st, ioutil.WriteNopCloser(&buf), UploadPackService, false, protocol.V0))
+	assert.Contains(t, buf.String(), "refs/heads/main")
+	assert.NotContains(t, buf.String(), "refs/heads/loop")
+}
+
+type referenceReadErrorStorage struct {
+	storage.Storer
+	err error
+}
+
+func (s referenceReadErrorStorage) Reference(plumbing.ReferenceName) (*plumbing.Reference, error) {
+	return nil, s.err
+}
+
+func TestAdvertiseRefsPropagatesSymrefReadError(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	require.NoError(t, st.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main")))
+	want := errors.New("reference storage unavailable")
+	var buf bytes.Buffer
+	err := AdvertiseRefs(context.Background(), referenceReadErrorStorage{st, want}, ioutil.WriteNopCloser(&buf), UploadPackService, false, protocol.V0)
+	require.ErrorIs(t, err, want)
+}
+
+func TestServeLsRefsV2PropagatesSymrefReadError(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	require.NoError(t, st.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main")))
+	want := errors.New("reference storage unavailable")
+	var buf bytes.Buffer
+	err := serveLsRefsV2(context.Background(), referenceReadErrorStorage{st, want}, &buf, &packp.LsRefsArgs{Symrefs: true})
+	require.ErrorIs(t, err, want)
+}
+
+func TestServeLsRefsV2SkipsUnresolvableSymrefs(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	require.NoError(t, st.SetReference(plumbing.NewHashReference("refs/heads/main", hash)))
+	require.NoError(t, st.SetReference(plumbing.NewSymbolicReference("refs/heads/loop", "refs/heads/loop")))
+	require.NoError(t, st.SetReference(plumbing.NewSymbolicReference("refs/heads/missing", "refs/heads/absent")))
+	var buf bytes.Buffer
+	require.NoError(t, serveLsRefsV2(context.Background(), st, &buf, &packp.LsRefsArgs{Symrefs: true}))
+	assert.Contains(t, buf.String(), hash.String()+" refs/heads/main\n")
+	assert.NotContains(t, buf.String(), "refs/heads/loop")
+	assert.NotContains(t, buf.String(), "refs/heads/missing")
+}
+
+type referenceIterationErrorStorage struct {
+	storage.Storer
+	err error
+}
+
+func (s referenceIterationErrorStorage) IterReferences() (storer.ReferenceIter, error) {
+	return referenceIterationError{storer.NewReferenceSliceIter(nil), s.err}, nil
+}
+
+type referenceIterationError struct {
+	storer.ReferenceIter
+	err error
+}
+
+func (i referenceIterationError) ForEach(func(*plumbing.Reference) error) error {
+	return i.err
+}
+
+func TestServeLsRefsV2PropagatesIterationError(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("reference iteration failed")
+	st := referenceIterationErrorStorage{memory.NewStorage(), want}
+	var buf bytes.Buffer
+	err := serveLsRefsV2(context.Background(), st, &buf, &packp.LsRefsArgs{})
+	require.ErrorIs(t, err, want)
+}
+
+func TestServeLsRefsV2SymrefTargets(t *testing.T) {
+	t.Parallel()
+
+	for _, target := range []plumbing.ReferenceName{"refs/heads/main", "refs/heads/\u200c./main", "refs/heads/main.lock", "refs/heads/sp ace", "CONFIG"} {
+		t.Run(target.String(), func(t *testing.T) {
+			t.Parallel()
+
+			st := memory.NewStorage()
+			hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+			require.NoError(t, st.SetReference(plumbing.NewHashReference(target, hash)))
+			require.NoError(t, st.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, target)))
+			var buf bytes.Buffer
+			require.NoError(t, serveLsRefsV2(context.Background(), st, &buf, &packp.LsRefsArgs{Symrefs: true}))
+			assert.Contains(t, buf.String(), hash.String()+" HEAD")
+			if target == "refs/heads/main" || target == "refs/heads/\u200c./main" {
+				assert.Contains(t, buf.String(), "symref-target:"+target.String()+"\n")
+			} else {
+				assert.NotContains(t, buf.String(), "symref-target:")
+				assert.NotContains(t, buf.String(), target.String())
+			}
+		})
+	}
+}
+
+func TestAdvertisementsResolveSymbolicTargets(t *testing.T) {
+	t.Parallel()
+
+	for _, intermediate := range []plumbing.ReferenceName{"refs/heads/alias", "ORIG_HEAD"} {
+		for _, target := range []plumbing.ReferenceName{"refs/heads/main", "refs/heads/main.lock"} {
+			t.Run(intermediate.String()+"/"+target.String(), func(t *testing.T) {
+				t.Parallel()
+
+				st := memory.NewStorage()
+				hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+				require.NoError(t, st.SetReference(plumbing.NewHashReference(target, hash)))
+				require.NoError(t, st.SetReference(plumbing.NewSymbolicReference(intermediate, target)))
+				require.NoError(t, st.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, intermediate)))
+				var v0, v2 bytes.Buffer
+				require.NoError(t, AdvertiseRefs(context.Background(), st, ioutil.WriteNopCloser(&v0), UploadPackService, false, protocol.V0))
+				require.NoError(t, serveLsRefsV2(context.Background(), st, &v2, &packp.LsRefsArgs{Symrefs: true}))
+				assert.Contains(t, v0.String(), hash.String()+" HEAD")
+				assert.Contains(t, v2.String(), hash.String()+" HEAD")
+				assert.NotContains(t, v0.String(), "symref=HEAD:"+intermediate.String())
+				assert.NotContains(t, v2.String(), "symref-target:"+intermediate.String())
+				if target == "refs/heads/main" {
+					assert.Contains(t, v0.String(), "symref=HEAD:"+target.String())
+					assert.Contains(t, v2.String(), "HEAD symref-target:"+target.String()+"\n")
+				} else {
+					assert.NotContains(t, v0.String(), "symref=HEAD:")
+					assert.NotContains(t, v2.String(), "symref-target:")
+				}
+			})
+		}
+	}
+}
+
+func TestAdvertisementsSkipFilesystemSymlinkLoops(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	require.NoError(t, st.SetReference(plumbing.NewHashReference("refs/heads/main", hash)))
+	require.NoError(t, st.SetReference(plumbing.NewSymbolicReference("refs/heads/alias", "ORIG_HEAD")))
+	broken := referenceReadErrorStorage{st, &os.PathError{Op: "stat", Path: "ORIG_HEAD", Err: syscall.ELOOP}}
+	var v0, v2 bytes.Buffer
+	require.NoError(t, AdvertiseRefs(context.Background(), broken, ioutil.WriteNopCloser(&v0), UploadPackService, false, protocol.V0))
+	require.NoError(t, serveLsRefsV2(context.Background(), broken, &v2, &packp.LsRefsArgs{Symrefs: true}))
+	for _, out := range []string{v0.String(), v2.String()} {
+		assert.Contains(t, out, "refs/heads/main")
+		assert.NotContains(t, out, "refs/heads/alias")
+	}
 }

--- a/plumbing/transport/serverinfo_test.go
+++ b/plumbing/transport/serverinfo_test.go
@@ -1,8 +1,12 @@
 package transport
 
 import (
+	"bytes"
+	"errors"
 	"io"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/go-git/go-billy/v6"
@@ -10,6 +14,7 @@ import (
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/go-git/go-git/v6/internal/repository"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -174,4 +179,72 @@ func assertObjectPacks(s *ServerInfoSuite, st storage.Storer, fs billy.Filesyste
 		_, ok := localPacks[p.String()]
 		s.True(ok)
 	}
+}
+
+func (s *ServerInfoSuite) TestUpdateServerInfoFiltersReferenceNames() {
+	st := memory.NewStorage()
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	valid := []plumbing.ReferenceName{"refs/heads/main", "refs/heads/@", "refs/heads/-foo", "refs/heads/\u200c./main"}
+	invalid := []plumbing.ReferenceName{"refs/heads/main.lock", "refs/heads/bad\ninjected", "refs/heads/sp ace", "CONFIG", plumbing.HEAD}
+	for _, name := range append(valid, invalid...) {
+		s.Require().NoError(st.SetReference(plumbing.NewHashReference(name, hash)))
+	}
+	fs := memfs.New()
+	s.Require().NoError(UpdateServerInfo(st, fs))
+	f, err := fs.Open("info/refs")
+	s.Require().NoError(err)
+	defer f.Close()
+	out, err := io.ReadAll(f)
+	s.Require().NoError(err)
+	for _, name := range valid {
+		s.Contains(string(out), hash.String()+"\t"+name.String()+"\n")
+	}
+	for _, name := range invalid {
+		s.NotContains(string(out), name.String())
+	}
+	iter, err := st.IterReferences()
+	s.Require().NoError(err)
+	count := 0
+	s.Require().NoError(iter.ForEach(func(*plumbing.Reference) error { count++; return nil }))
+	s.Equal(len(valid)+len(invalid), count)
+}
+
+func (s *ServerInfoSuite) TestUpdateServerInfoSkipsUnresolvableSymrefs() {
+	st := memory.NewStorage()
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	s.Require().NoError(st.SetReference(plumbing.NewHashReference("refs/heads/main", hash)))
+	s.Require().NoError(st.SetReference(plumbing.NewSymbolicReference("refs/heads/loop", "refs/heads/loop")))
+	s.Require().NoError(st.SetReference(plumbing.NewSymbolicReference("refs/heads/missing", "refs/heads/absent")))
+	s.Require().NoError(st.SetReference(plumbing.NewSymbolicReference("refs/heads/alias", "refs/heads/main")))
+	fs := memfs.New()
+	s.Require().NoError(UpdateServerInfo(st, fs))
+	f, err := fs.Open("info/refs")
+	s.Require().NoError(err)
+	defer f.Close()
+	out, err := io.ReadAll(f)
+	s.Require().NoError(err)
+	s.Contains(string(out), hash.String()+"\trefs/heads/main\n")
+	s.Contains(string(out), hash.String()+"\trefs/heads/alias\n")
+	s.NotContains(string(out), "refs/heads/loop")
+	s.NotContains(string(out), "refs/heads/missing")
+}
+
+func (s *ServerInfoSuite) TestWriteInfoRefsPropagatesSymrefReadError() {
+	st := memory.NewStorage()
+	s.Require().NoError(st.SetReference(plumbing.NewSymbolicReference("refs/heads/alias", "refs/heads/main")))
+	want := errors.New("reference storage unavailable")
+	var out bytes.Buffer
+	err := repository.WriteInfoRefs(&out, referenceReadErrorStorage{st, want})
+	s.ErrorIs(err, want)
+}
+
+func (s *ServerInfoSuite) TestWriteInfoRefsSkipsFilesystemSymlinkLoop() {
+	st := memory.NewStorage()
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	s.Require().NoError(st.SetReference(plumbing.NewHashReference("refs/heads/main", hash)))
+	s.Require().NoError(st.SetReference(plumbing.NewSymbolicReference("refs/heads/alias", "ORIG_HEAD")))
+	broken := referenceReadErrorStorage{st, &os.PathError{Op: "stat", Path: "ORIG_HEAD", Err: syscall.ELOOP}}
+	var out bytes.Buffer
+	s.Require().NoError(repository.WriteInfoRefs(&out, broken))
+	s.Equal(hash.String()+"\trefs/heads/main\n", out.String())
 }

--- a/plumbing/transport/upload_pack.go
+++ b/plumbing/transport/upload_pack.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/internal/reference"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/format/packfile"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
@@ -23,6 +24,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/utils/ioutil"
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 // UploadPackRequest is a set of options for the UploadPack service.
@@ -515,10 +517,18 @@ func serveLsRefsV2(_ context.Context, st storage.Storer, w io.Writer, args *pack
 	defer iter.Close()
 
 	var refs []*plumbing.Reference
-	_ = iter.ForEach(func(r *plumbing.Reference) error {
+	if err := iter.ForEach(func(r *plumbing.Reference) error {
+		// Use the same name gate as the v0/v1 advertisement. In the v2
+		// grammar a space in a name also introduces a ref-attribute.
+		if !advertisable(r.Name()) {
+			trace.General.Printf("ignoring ref with broken name %q", r.Name().String())
+			return nil
+		}
 		refs = append(refs, r)
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
 
 	prefixes := args.RefPrefixes
 
@@ -560,15 +570,21 @@ func refMatchesAnyPrefix(name string, prefixes []string) bool {
 	return false
 }
 
+// writeV2Ref writes an ls-refs response with the requested reference attributes.
+// See https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/ls-refs.c#L91-L117.
 func writeV2Ref(w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, peel bool) error {
 	var hash plumbing.Hash
 	var target string
 	if r.Type() == plumbing.SymbolicReference {
 		ref, err := storer.ResolveReference(st, r.Target())
-		if err == nil {
-			hash = ref.Hash()
+		if reference.IsUnresolvableForAdvertisement(err) {
+			return nil
 		}
-		target = r.Target().String()
+		if err != nil {
+			return err
+		}
+		hash = ref.Hash()
+		target = ref.Name().String()
 	} else {
 		hash = r.Hash()
 	}
@@ -582,7 +598,7 @@ func writeV2Ref(w io.Writer, st storage.Storer, r *plumbing.Reference, symrefs, 
 	// (symref-target first, matching upstream's send_ref ordering), not
 	// separate lines as in the v0/v1 advertisement format.
 	line := fmt.Sprintf("%s %s", hash, r.Name())
-	if symrefs && target != "" {
+	if symrefs && target != "" && advertisable(plumbing.ReferenceName(target)) {
 		line += " symref-target:" + target
 	}
 	if peel {

--- a/prune.go
+++ b/prune.go
@@ -36,6 +36,9 @@ func (r *Repository) DeleteObject(hash plumbing.Hash) error {
 }
 
 // Prune removes unreferenced loose objects from the repository.
+// It follows symbolic references when finding reachable objects. Missing targets,
+// including an unborn HEAD, are ignored. Other resolution errors, including the
+// recursion limit, abort pruning before Handler is called for any object.
 func (r *Repository) Prune(opt PruneOptions) error {
 	los, ok := r.Storer.(storer.LooseObjectStorer)
 	if !ok {

--- a/prune_test.go
+++ b/prune_test.go
@@ -1,14 +1,20 @@
 package git
 
 import (
+	"errors"
+	"io"
 	"testing"
 	"time"
 
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
 	fixtures "github.com/go-git/go-git-fixtures/v6"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
@@ -76,4 +82,127 @@ func (s *PruneSuite) TestPrune() {
 
 func (s *PruneSuite) TestPruneWithNoDelete() {
 	s.testPrune(time.Unix(0, 1))
+}
+
+func newPruneSymrefRepository(t *testing.T) (*Repository, plumbing.Hash, plumbing.Hash) {
+	t.Helper()
+	st := filesystem.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+	r, err := Init(st, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+	tree := st.NewEncodedObject()
+	require.NoError(t, (&object.Tree{}).Encode(tree))
+	treeHash, err := st.SetEncodedObject(tree)
+	require.NoError(t, err)
+	commit := st.NewEncodedObject()
+	require.NoError(t, (&object.Commit{TreeHash: treeHash, Message: "reachable"}).Encode(commit))
+	commitHash, err := st.SetEncodedObject(commit)
+	require.NoError(t, err)
+	return r, commitHash, treeHash
+}
+
+func (s *PruneSuite) TestPrunePreservesObjectsThroughRootSymref() {
+	r, commit, tree := newPruneSymrefRepository(s.T())
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewHashReference("ORIG_HEAD", commit)))
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference("refs/heads/main", "ORIG_HEAD")))
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main")))
+
+	s.Require().NoError(r.Prune(PruneOptions{Handler: r.DeleteObject}))
+	s.Require().NoError(r.Storer.HasEncodedObject(commit))
+	s.Require().NoError(r.Storer.HasEncodedObject(tree))
+}
+
+func (s *PruneSuite) TestPruneAllowsUnbornAndDanglingSymrefs() {
+	r, commit, tree := newPruneSymrefRepository(s.T())
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference("refs/heads/dangling", "refs/heads/missing")))
+	s.Require().NoError(r.Prune(PruneOptions{Handler: r.DeleteObject}))
+	s.Require().ErrorIs(r.Storer.HasEncodedObject(commit), plumbing.ErrObjectNotFound)
+	s.Require().ErrorIs(r.Storer.HasEncodedObject(tree), plumbing.ErrObjectNotFound)
+	s.Require().NoError(r.Prune(PruneOptions{Handler: r.DeleteObject}))
+}
+
+type pruneReferenceReadError struct {
+	*filesystem.Storage
+	err error
+}
+
+func (s pruneReferenceReadError) Reference(plumbing.ReferenceName) (*plumbing.Reference, error) {
+	return nil, s.err
+}
+
+func (s *PruneSuite) TestPruneStopsBeforeDeletingOnSymrefReadError() {
+	for _, want := range []error{io.ErrUnexpectedEOF, plumbing.ErrInvalidReferenceName} {
+		s.Run(want.Error(), func() {
+			r, commit, tree := newPruneSymrefRepository(s.T())
+			r.Storer = pruneReferenceReadError{r.Storer.(*filesystem.Storage), want}
+			called := false
+			err := r.Prune(PruneOptions{Handler: func(hash plumbing.Hash) error {
+				called = true
+				return r.DeleteObject(hash)
+			}})
+			s.Require().ErrorIs(err, want)
+			s.Require().False(called)
+			s.Require().NoError(r.Storer.HasEncodedObject(commit))
+			s.Require().NoError(r.Storer.HasEncodedObject(tree))
+		})
+	}
+}
+
+func (s *PruneSuite) TestPruneStopsBeforeDeletingOnCyclicSymref() {
+	r, commit, tree := newPruneSymrefRepository(s.T())
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/loop")))
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference("refs/heads/loop", plumbing.HEAD)))
+	called := false
+	err := r.Prune(PruneOptions{Handler: func(plumbing.Hash) error {
+		called = true
+		return errors.New("destructive handler called")
+	}})
+	s.Require().ErrorIs(err, storer.ErrMaxResolveRecursion)
+	s.Require().False(called)
+	s.Require().NoError(r.Storer.HasEncodedObject(commit))
+	s.Require().NoError(r.Storer.HasEncodedObject(tree))
+}
+
+type pruneRootRefOpenError struct {
+	billy.Filesystem
+	opened bool
+}
+
+func (s *pruneRootRefOpenError) Open(name string) (billy.File, error) {
+	if s.Join(name) == "ORIG_HEAD" {
+		s.opened = true
+		return nil, io.ErrUnexpectedEOF
+	}
+	return s.Filesystem.Open(name)
+}
+
+func (s *PruneSuite) TestMaintenanceStopsOnSymbolicTargetFileReadError() {
+	for _, operation := range []string{"prune", "repack"} {
+		s.Run(operation, func() {
+			r, commit, tree := newPruneSymrefRepository(s.T())
+			s.Require().NoError(r.Storer.SetReference(plumbing.NewHashReference("ORIG_HEAD", commit)))
+			s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference("refs/heads/main", "ORIG_HEAD")))
+			s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main")))
+			fs := &pruneRootRefOpenError{Filesystem: r.Storer.(*filesystem.Storage).Filesystem()}
+			r.Storer = filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
+			called := false
+			var err error
+			if operation == "prune" {
+				err = r.Prune(PruneOptions{Handler: func(hash plumbing.Hash) error {
+					called = true
+					return r.DeleteObject(hash)
+				}})
+			} else {
+				err = r.RepackObjects(&RepackConfig{})
+			}
+			s.Require().True(fs.opened)
+			s.Require().ErrorIs(err, io.ErrUnexpectedEOF)
+			s.Require().False(called)
+			s.Require().NoError(r.Storer.HasEncodedObject(commit))
+			s.Require().NoError(r.Storer.HasEncodedObject(tree))
+			packs, err := r.Storer.(storer.PackedObjectStorer).ObjectPacks()
+			s.Require().NoError(err)
+			s.Require().Empty(packs)
+		})
+	}
 }

--- a/remote.go
+++ b/remote.go
@@ -79,12 +79,14 @@ func (r *Remote) String() string {
 
 // Push performs a push to the remote. Returns NoErrAlreadyUpToDate if the
 // remote was already up-to-date.
+// Malformed wildcard source patterns are rejected before contacting the remote.
 func (r *Remote) Push(o *PushOptions) error {
 	return r.PushContext(context.Background(), o)
 }
 
 // PushContext performs a push to the remote. Returns NoErrAlreadyUpToDate if
 // the remote was already up-to-date.
+// Malformed wildcard source patterns are rejected before contacting the remote.
 //
 // The provided Context must be non-nil. If the context expires before the
 // operation is complete, an error is returned. The context only affects the
@@ -99,6 +101,23 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) (err error) {
 
 	if err := o.Validate(); err != nil {
 		return err
+	}
+
+	for _, spec := range o.RefSpecs {
+		if !spec.IsWildcard() {
+			continue
+		}
+		// A source glob must satisfy Git's refname rules with one wildcard
+		// and one-level names allowed. A fixed invalid prefix or suffix must
+		// fail before pruning can mistake filtered sources for missing refs.
+		// See https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refspec.c#L119-L134.
+		name := strings.ReplaceAll(spec.Src(), "*", "x")
+		if !strings.Contains(name, "/") {
+			name = plumbing.RefPrefix + name
+		}
+		if err := plumbing.ReferenceName(name).Validate(); err != nil {
+			return fmt.Errorf("%w: invalid source pattern %q", plumbing.ErrInvalidReferenceName, spec.Src())
+		}
 	}
 
 	if o.RemoteName != r.c.Name {
@@ -167,6 +186,27 @@ func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRef
 	if err != nil {
 		return err
 	}
+	// Storage enumeration is also used by repository maintenance and must
+	// remain complete. Only push candidates exclude malformed ordinary refs,
+	// including stale lock files that Git's files ref iterator skips.
+	pushRefs := localRefs[:0]
+	for _, ref := range localRefs {
+		if ref.Name().IsUnderRefs() {
+			if err := ref.Name().Validate(); err != nil {
+				// An explicit source must fail rather than disappear: prune
+				// would interpret its absence as a request to delete its
+				// mapped destination. Wildcards still skip malformed entries.
+				for _, spec := range o.RefSpecs {
+					if !spec.IsWildcard() && spec.Match(ref.Name()) {
+						return err
+					}
+				}
+				continue
+			}
+		}
+		pushRefs = append(pushRefs, ref)
+	}
+	localRefs = pushRefs
 
 	cmds := make([]*packp.Command, 0)
 	if err := r.addReferencesToUpdate(o.RefSpecs, localRefs, remoteRefs, &cmds, o.Prune, o.ForceWithLease); err != nil {
@@ -175,6 +215,13 @@ func (r *Remote) sendPack(ctx context.Context, sess transport.Session, remoteRef
 
 	if o.FollowTags {
 		if err := r.addReachableTags(localRefs, remoteRefs, &cmds); err != nil {
+			return err
+		}
+	}
+	// Refspecs can turn a valid source into an invalid destination. Validate
+	// the complete command list before any update is sent to the remote.
+	for _, cmd := range cmds {
+		if err := cmd.Name.Validate(); err != nil {
 			return err
 		}
 	}
@@ -379,7 +426,7 @@ func fetchRefPrefixes(specs []config.RefSpec, tags plumbing.TagMode) []string {
 		// v2 server that strictly honours ref-prefix omits the resolved branch
 		// and it cannot be fetched. Matches git clone.
 		if src == "HEAD" {
-			prefixes = append(prefixes, "refs/heads/")
+			prefixes = append(prefixes, plumbing.RefHeadPrefix)
 			continue
 		}
 
@@ -594,9 +641,75 @@ func referenceStorageFromRefs(refs []*plumbing.Reference, filterPeeled bool) mem
 		if filterPeeled && strings.HasSuffix(ref.Name().String(), peeledSuffix) {
 			continue
 		}
+		if !usableRemoteRef(ref.Name()) {
+			trace.General.Printf("ignoring ref with broken name %q", ref.Name().String())
+			continue
+		}
 		_ = refStore.SetReference(ref)
 	}
 	return refStore
+}
+
+// unstorableRefName reports whether err says the storer refused name for what
+// the name is, rather than for anything about the fetch.
+//
+// A refspec builds a destination name the remote did not choose, so a name the
+// storer will not take can arrive even after the advertisement has been
+// filtered — "+refs/*:refs/*" onto a remote name go-git holds to a stricter
+// rule than check_refname_format, say. Git answers per-reference rather than
+// per-fetch, in get_fetch_map:
+//
+//	error(_("* Ignoring funny ref '%s' locally"), (*rmp)->peer_ref->name);
+//
+// and finishes with the references that remain, exiting 0.
+//
+// Every arm of the storer's name gate wraps plumbing.ErrInvalidReferenceName,
+// so this recognises all of them rather than the format rule alone. That
+// matters because go-git refuses a wider set than Git does — the components an
+// HFS+ or NTFS filesystem folds to a dot — and those names reach here having
+// passed the advertisement filter, which is a faithful check_refname_format.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/remote.c#L2165-L2176
+func unstorableRefName(name, source plumbing.ReferenceName, err error) bool {
+	if !errors.Is(err, plumbing.ErrInvalidReferenceName) {
+		return false
+	}
+
+	trace.General.Printf("ignoring local ref %q from remote ref %q: %q", name.String(), source.String(), err.Error())
+	return true
+}
+
+// usableRemoteRef reports whether an advertised reference name is one this
+// side can do anything with.
+//
+// A remote is free to advertise a name go-git will not store, and one that
+// serves a repository holding a stale lock file or a name some other tool left
+// behind will do exactly that. Dropping it here, where the advertisement first
+// becomes a list, keeps it out of refspec matching, out of the want list and
+// out of the storer, so a single unusable name costs that one reference rather
+// than the whole fetch.
+//
+// This is filter_refs in fetch-pack.c, which checks the same thing in the same
+// place and says nothing about it:
+//
+//	if (starts_with(ref->name, "refs/") &&
+//	    check_refname_format(ref->name, 0)) {
+//		/* trash or a peeled value; do not even add it to unmatched list */
+//		free_one_ref(ref);
+//		continue;
+//	}
+//
+// Only names under refs/ are judged, as there: HEAD is advertised and is not
+// one. Git also relies on this to drop the null-object-id entries it emits for
+// a broken name, which go-git would otherwise ask the remote to send.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/fetch-pack.c#L711-L718
+func usableRemoteRef(name plumbing.ReferenceName) bool {
+	if !name.IsUnderRefs() {
+		return true
+	}
+
+	return name.Validate() == nil
 }
 
 func depthChanged(before []plumbing.Hash, s storage.Storer) (bool, error) {
@@ -936,7 +1049,7 @@ func (r *Remote) checkForceWithLease(localRef *plumbing.Reference, cmd *packp.Co
 
 	ref, err := storer.ResolveReference(
 		r.s,
-		plumbing.ReferenceName(remotePrefix+strings.ReplaceAll(localRef.Name().String(), "refs/heads/", "")),
+		plumbing.ReferenceName(remotePrefix+strings.ReplaceAll(localRef.Name().String(), plumbing.RefHeadPrefix, "")),
 	)
 	if err != nil {
 		return err
@@ -1347,7 +1460,7 @@ func (r *Remote) updateLocalReferenceStorage(
 			// a caller uses a bare-hash dst such as "+<hash>:<hash>"). Creating
 			// a branch named after a commit hash is always wrong and produces
 			// spurious refs that confuse ResolveRevision and other callers.
-			if !strings.HasPrefix(localName.String(), "refs/") {
+			if !localName.IsUnderRefs() {
 				if plumbing.IsHash(localName.String()) {
 					// Bare-hash dst: the intent is to fetch the object only;
 					// no local reference should be created.
@@ -1378,6 +1491,9 @@ func (r *Remote) updateLocalReferenceStorage(
 			}
 
 			refUpdated, err := checkAndUpdateReferenceStorerIfNeeded(r.s, newRef, old)
+			if unstorableRefName(localName, ref.Name(), err) {
+				continue
+			}
 			if err != nil {
 				return updated, err
 			}
@@ -1431,6 +1547,9 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage, allTags, force b
 		}
 
 		old, err := r.s.Reference(ref.Name())
+		if unstorableRefName(ref.Name(), ref.Name(), err) {
+			continue
+		}
 		if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return updated, forceNeeded, err
 		}
@@ -1447,6 +1566,9 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage, allTags, force b
 		}
 
 		refUpdated, err := updateReferenceStorerIfNeeded(r.s, ref)
+		if unstorableRefName(ref.Name(), ref.Name(), err) {
+			continue
+		}
 		if err != nil {
 			return updated, forceNeeded, err
 		}

--- a/remote_test.go
+++ b/remote_test.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -15,6 +18,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/osfs"
 	"github.com/go-git/go-billy/v6/util"
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/suite"
@@ -30,6 +34,7 @@ import (
 	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/filesystem"
 	"github.com/go-git/go-git/v6/storage/memory"
+	"github.com/go-git/go-git/v6/utils/trace"
 )
 
 type RemoteSuite struct {
@@ -1411,6 +1416,127 @@ func (s *RemoteSuite) TestPushForceWithLease_failure() {
 	}
 }
 
+func (s *RemoteSuite) TestPushWildcardIgnoresMalformedLocalReferences() {
+	for _, prune := range []bool{false, true} {
+		s.Run(fmt.Sprintf("prune=%t", prune), func() {
+			srcFs, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+			s.Require().NoError(err)
+			src, err := Open(filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault()), nil)
+			s.Require().NoError(err)
+			defer func() { _ = src.Close() }()
+			head, err := src.Reference(plumbing.NewBranchReferenceName("master"), true)
+			s.Require().NoError(err)
+			invalid := []string{"main.lock", ".hidden", "bad~name", "a..b"}
+			if runtime.GOOS != "windows" {
+				invalid = append(invalid, "a\\b", "a\x01b")
+			}
+			for _, name := range append(append([]string(nil), invalid...), "@", "-foo") {
+				s.Require().NoError(util.WriteFile(srcFs, srcFs.Join("refs", "heads", name),
+					[]byte(head.Hash().String()+"\n"), 0o644))
+			}
+
+			dstDir := s.T().TempDir()
+			dst, err := PlainClone(dstDir, &CloneOptions{URL: srcFs.Root(), Bare: true})
+			s.Require().NoError(err)
+			defer func() { _ = dst.Close() }()
+			for _, name := range []string{"@", "-foo"} {
+				s.Require().NoError(dst.Storer.RemoveReference(plumbing.NewBranchReferenceName(name)))
+			}
+			s.Require().NoError(dst.Storer.SetReference(plumbing.NewHashReference(plumbing.NewBranchReferenceName("gone"), head.Hash())))
+			remote := NewRemote(src.Storer, &config.RemoteConfig{Name: "target", URLs: []string{dstDir}})
+			s.Require().NoError(remote.Push(&PushOptions{
+				RemoteName: "target", RefSpecs: []config.RefSpec{"refs/heads/*:refs/heads/*"}, Prune: prune,
+			}))
+			for _, name := range []string{"master", "@", "-foo"} {
+				ref, err := dst.Reference(plumbing.NewBranchReferenceName(name), false)
+				s.Require().NoError(err)
+				s.Equal(head.Hash(), ref.Hash())
+			}
+			_, err = dst.Reference(plumbing.NewBranchReferenceName("gone"), false)
+			if prune {
+				s.ErrorIs(err, plumbing.ErrReferenceNotFound)
+			} else {
+				s.NoError(err)
+			}
+			iter, err := dst.References()
+			s.Require().NoError(err)
+			s.Require().NoError(iter.ForEach(func(ref *plumbing.Reference) error {
+				s.NoError(ref.Name().Validate())
+				return nil
+			}))
+			for _, name := range invalid {
+				_, err := srcFs.Stat(srcFs.Join("refs", "heads", name))
+				s.NoError(err)
+			}
+		})
+	}
+}
+
+func (s *RemoteSuite) TestPushRejectsMalformedMappedDestinations() {
+	srcFs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
+	s.Require().NoError(err)
+	src := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	head, err := src.Reference(plumbing.NewBranchReferenceName("master"))
+	s.Require().NoError(err)
+	for _, spec := range []config.RefSpec{
+		"refs/heads/master:refs/heads/main.lock",
+		"refs/heads/master:refs/heads/bad\nname",
+		"refs/heads/*:refs/heads/*.lock",
+		config.RefSpec(head.Hash().String() + ":refs/heads/main.lock"),
+	} {
+		s.Run(spec.String(), func() {
+			dir := s.T().TempDir()
+			dst, err := PlainInit(dir, true)
+			s.Require().NoError(err)
+			defer func() { _ = dst.Close() }()
+			remote := NewRemote(src, &config.RemoteConfig{Name: DefaultRemoteName, URLs: []string{dir}})
+			err = remote.Push(&PushOptions{RefSpecs: []config.RefSpec{
+				"refs/heads/master:refs/heads/allowed", spec,
+			}})
+			s.ErrorIs(err, plumbing.ErrInvalidReferenceName)
+			iter, err := dst.References()
+			s.Require().NoError(err)
+			s.Require().NoError(iter.ForEach(func(ref *plumbing.Reference) error {
+				s.Equal(plumbing.HEAD, ref.Name())
+				return nil
+			}))
+		})
+	}
+}
+
+func (s *RemoteSuite) TestPushRejectsExplicitMalformedSourceBeforePrune() {
+	srcFs, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
+	s.Require().NoError(err)
+	src := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
+	head, err := src.Reference(plumbing.NewBranchReferenceName("master"))
+	s.Require().NoError(err)
+	for _, name := range []string{"main.lock", ".hidden", "bad~name", "a..b"} {
+		fullName := plumbing.NewBranchReferenceName(name)
+		s.Require().NoError(util.WriteFile(srcFs, fullName.String(), []byte(head.Hash().String()+"\n"), 0o644))
+		for _, prune := range []bool{false, true} {
+			s.Run(fmt.Sprintf("%s/prune=%t", name, prune), func() {
+				dir := s.T().TempDir()
+				dst, err := PlainClone(dir, &CloneOptions{URL: s.GetBasicLocalRepositoryURL(), Bare: true})
+				s.Require().NoError(err)
+				defer func() { _ = dst.Close() }()
+				keep := plumbing.NewHashReference("refs/heads/keep", head.Hash())
+				s.Require().NoError(dst.Storer.SetReference(keep))
+				remote := NewRemote(src, &config.RemoteConfig{Name: DefaultRemoteName, URLs: []string{dir}})
+				err = remote.Push(&PushOptions{Prune: prune, RefSpecs: []config.RefSpec{
+					"refs/heads/master:refs/heads/allowed",
+					config.RefSpec(fullName.String() + ":refs/heads/keep"),
+				}})
+				s.ErrorIs(err, plumbing.ErrInvalidReferenceName)
+				ref, err := dst.Storer.Reference(keep.Name())
+				s.Require().NoError(err)
+				s.Equal(keep, ref)
+				_, err = dst.Storer.Reference("refs/heads/allowed")
+				s.ErrorIs(err, plumbing.ErrReferenceNotFound)
+			})
+		}
+	}
+}
+
 func (s *RemoteSuite) TestPushPrune() {
 	server, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: s.GetBasicLocalRepositoryURL()})
 	s.Require().NoError(err)
@@ -2268,4 +2394,313 @@ func writeCommitToRef(t *testing.T, repo *Repository, refName string, treeID plu
 	}
 
 	return commitID
+}
+
+// A remote is free to advertise a name go-git will not store. Dropping it
+// where the advertisement becomes a list is what keeps one such name from
+// costing the whole fetch, and mirrors filter_refs in fetch-pack.c.
+func (s *RemoteSuite) TestReferenceStorageFromRefsDropsUnusableNames() {
+	hash := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
+	refs := make([]*plumbing.Reference, 0, 8)
+	for _, n := range []plumbing.ReferenceName{
+		"HEAD",
+		"refs/heads/main",
+		"refs/heads/@",
+		"refs/heads/-foo",
+		"refs/heads/stale.lock",
+		"refs/heads/bad~name",
+		"refs/heads/.hidden",
+		"refs/heads/a..b",
+	} {
+		refs = append(refs, plumbing.NewHashReference(n, hash))
+	}
+
+	got := referenceStorageFromRefs(refs, true)
+
+	for _, n := range []plumbing.ReferenceName{"HEAD", "refs/heads/main", "refs/heads/@", "refs/heads/-foo"} {
+		_, err := got.Reference(n)
+		s.NoError(err, "%q must survive", n)
+	}
+	for _, n := range []plumbing.ReferenceName{
+		"refs/heads/stale.lock", "refs/heads/bad~name",
+		"refs/heads/.hidden", "refs/heads/a..b",
+	} {
+		_, err := got.Reference(n)
+		s.ErrorIs(err, plumbing.ErrReferenceNotFound, "%q must be dropped", n)
+	}
+}
+
+// A refspec names a destination the remote did not choose, so the storer can
+// refuse one even after the advertisement has been filtered. That must cost
+// the single reference and not the fetch, which is what git does in
+// get_fetch_map. Asserted through a real fetch rather than through the
+// predicate, because the predicate was never the part that broke.
+func (s *RemoteSuite) TestFetchSkipsUnstorableDestination() {
+	const traceMode = "GO_GIT_TEST_FETCH_TRACE"
+	mode := os.Getenv(traceMode)
+	if mode == "" {
+		// Trace configuration is process-wide, so each mode runs in isolation
+		// from the other parallel repository suites.
+		executable, err := os.Executable()
+		s.Require().NoError(err)
+		for _, mode := range []string{"enabled", "disabled"} {
+			s.Run(mode, func() {
+				cmd := exec.Command(executable, "-test.v", "-test.run=^TestRemoteSuite$/^TestFetchSkipsUnstorableDestination$")
+				cmd.Env = append(os.Environ(), traceMode+"="+mode)
+				output, err := cmd.CombinedOutput()
+				s.Require().NoError(err, "%s", output)
+				s.Contains(string(output), "--- PASS: TestRemoteSuite/TestFetchSkipsUnstorableDestination (")
+			})
+		}
+		return
+	}
+
+	var diagnostic bytes.Buffer
+	trace.SetLogger(log.New(&diagnostic, "", 0))
+	if mode == "enabled" {
+		trace.SetTarget(trace.General)
+	} else {
+		trace.SetTarget(0)
+	}
+
+	url := s.GetBasicLocalRepositoryURL()
+	// A filesystem storer, because the name gate this exercises is the dotgit
+	// one; memory storage accepts any name.
+	dir := s.T().TempDir()
+	st := filesystem.NewStorage(osfs.New(dir), cache.NewObjectLRUDefault())
+	r := NewRemote(st, &config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{url},
+	})
+
+	err := r.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{
+		// Refused by the format rules, and by the dot-fold rule that only
+		// the storer applies. Both must be skipped, not fatal.
+		"+refs/heads/master:refs/heads/broken.lock",
+		"+refs/heads/master:refs/heads/nz/\u200c./sub",
+		"+refs/heads/master:refs/heads/good",
+	}})
+	s.Require().NoError(err)
+
+	_, err = r.s.Reference("refs/heads/good")
+	s.NoError(err, "the usable destination must be stored")
+
+	// Checked on disk rather than through Reference, which gates the same
+	// names and would report an error either way.
+	for _, p := range []string{"refs/heads/broken.lock", "refs/heads/nz/\u200c./sub"} {
+		_, err := os.Stat(filepath.Join(dir, filepath.FromSlash(p)))
+		s.True(os.IsNotExist(err), "%q must not have become a path", p)
+	}
+
+	if mode == "enabled" {
+		for _, name := range []string{"refs/heads/broken.lock", "refs/heads/nz/\u200c./sub"} {
+			err := st.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(name), plumbing.ZeroHash))
+			s.Require().ErrorIs(err, plumbing.ErrInvalidReferenceName)
+			s.Contains(diagnostic.String(), fmt.Sprintf("ignoring local ref %q from remote ref %q: %q\n",
+				name, "refs/heads/master", err.Error()))
+		}
+	} else {
+		s.Empty(diagnostic.String())
+	}
+}
+
+func (s *RemoteSuite) TestCloneAndFetchSkipUnstorableTags() {
+	srcFS, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+	s.Require().NoError(err)
+	src := filesystem.NewStorage(srcFS, cache.NewObjectLRUDefault())
+	defer func() { s.Require().NoError(src.Close()) }()
+	head, err := src.Reference(plumbing.Master)
+	s.Require().NoError(err)
+	validTag := plumbing.ReferenceName("refs/tags/valid-name")
+	invalidTag := plumbing.ReferenceName("refs/tags/nz/\u200c./tag")
+	for _, name := range []plumbing.ReferenceName{validTag, invalidTag} {
+		s.Require().NoError(util.WriteFile(srcFS, name.String(), []byte(head.Hash().String()+"\n"), 0o644))
+	}
+
+	for _, operation := range []string{"clone", "fetch"} {
+		for _, mode := range []struct {
+			name string
+			tags plumbing.TagMode
+		}{{"default", plumbing.InvalidTagMode}, {"all", plumbing.AllTags}, {"none", plumbing.NoTags}} {
+			s.Run(operation+"/"+mode.name, func() {
+				var dst *Repository
+				var err error
+				branch := plumbing.Master
+				if operation == "clone" {
+					dst, err = PlainClone(s.T().TempDir(), &CloneOptions{URL: srcFS.Root(), Bare: true, Tags: mode.tags})
+				} else {
+					dst, err = PlainInit(s.T().TempDir(), true)
+					s.Require().NoError(err)
+					remote := NewRemote(dst.Storer, &config.RemoteConfig{Name: DefaultRemoteName, URLs: []string{srcFS.Root()}})
+					err = remote.Fetch(&FetchOptions{Tags: mode.tags, RefSpecs: []config.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}})
+					branch = plumbing.NewRemoteReferenceName(DefaultRemoteName, "master")
+				}
+				s.Require().NoError(err)
+				defer func() { s.Require().NoError(dst.Close()) }()
+				ref, err := dst.Storer.Reference(branch)
+				s.Require().NoError(err)
+				s.Require().Equal(head.Hash(), ref.Hash())
+				ref, err = dst.Storer.Reference(validTag)
+				if mode.tags == plumbing.NoTags {
+					s.Require().ErrorIs(err, plumbing.ErrReferenceNotFound)
+				} else {
+					s.Require().NoError(err)
+					s.Require().Equal(head.Hash(), ref.Hash())
+				}
+				iter, err := dst.References()
+				s.Require().NoError(err)
+				s.Require().NoError(iter.ForEach(func(ref *plumbing.Reference) error {
+					s.Require().NotEqual(invalidTag, ref.Name())
+					return nil
+				}))
+			})
+		}
+	}
+}
+
+type tagRefErrorStorage struct {
+	storage.Storer
+	name                        plumbing.ReferenceName
+	readErr, writeErr           error
+	readFailures, writeFailures int
+}
+
+func (s *tagRefErrorStorage) Reference(name plumbing.ReferenceName) (*plumbing.Reference, error) {
+	if name == s.name && s.readErr != nil {
+		s.readFailures++
+		return nil, s.readErr
+	}
+	return s.Storer.Reference(name)
+}
+
+func (s *tagRefErrorStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
+	if ref.Name() == s.name && s.writeErr != nil {
+		s.writeFailures++
+		return s.writeErr
+	}
+	return s.Storer.CheckAndSetReference(ref, old)
+}
+
+func (s *RemoteSuite) TestFetchTagStorageErrors() {
+	srcFS, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+	s.Require().NoError(err)
+	src := filesystem.NewStorage(srcFS, cache.NewObjectLRUDefault())
+	defer func() { s.Require().NoError(src.Close()) }()
+	head, err := src.Reference(plumbing.Master)
+	s.Require().NoError(err)
+	target := plumbing.ReferenceName("refs/tags/rejected")
+	validTag := plumbing.ReferenceName("refs/tags/allowed")
+	for _, name := range []plumbing.ReferenceName{target, validTag} {
+		s.Require().NoError(src.SetReference(plumbing.NewHashReference(name, head.Hash())))
+	}
+
+	for _, phase := range []string{"read", "write"} {
+		for _, rejectedName := range []bool{false, true} {
+			s.Run(fmt.Sprintf("%s/name-error=%t", phase, rejectedName), func() {
+				cause := errors.New("reference storage unavailable")
+				if rejectedName {
+					cause = plumbing.ErrInvalidReferenceName
+				}
+				dst := memory.NewStorage()
+				st := &tagRefErrorStorage{Storer: dst, name: target}
+				if phase == "read" {
+					st.readErr = fmt.Errorf("reading tag: %w", cause)
+				} else {
+					st.writeErr = fmt.Errorf("writing tag: %w", cause)
+				}
+				remote := NewRemote(st, &config.RemoteConfig{Name: DefaultRemoteName, URLs: []string{srcFS.Root()}})
+				err := remote.Fetch(&FetchOptions{RefSpecs: []config.RefSpec{"+refs/heads/*:refs/remotes/origin/*"}})
+				if rejectedName {
+					s.Require().NoError(err)
+					ref, err := dst.Reference(validTag)
+					s.Require().NoError(err)
+					s.Require().Equal(head.Hash(), ref.Hash())
+				} else {
+					s.Require().ErrorIs(err, cause)
+				}
+				_, err = dst.Reference(target)
+				s.Require().ErrorIs(err, plumbing.ErrReferenceNotFound)
+				ref, err := dst.Reference(plumbing.NewRemoteReferenceName(DefaultRemoteName, "master"))
+				s.Require().NoError(err)
+				s.Require().Equal(head.Hash(), ref.Hash())
+				if phase == "read" {
+					s.Require().Positive(st.readFailures)
+					s.Require().Zero(st.writeFailures)
+				} else {
+					s.Require().Zero(st.readFailures)
+					s.Require().Positive(st.writeFailures)
+				}
+			})
+		}
+	}
+}
+
+func (s *RemoteSuite) TestPushRejectsMalformedWildcardSourcesBeforePrune() {
+	for _, tc := range []struct {
+		spec   config.RefSpec
+		source string
+	}{
+		{"refs/heads/*.lock:refs/heads/*", "refs/heads/keep.lock"},
+		{"refs/heads/.*:refs/heads/*", "refs/heads/.keep"},
+		{"refs/heads/a..*:refs/heads/*", "refs/heads/a..keep"},
+		{"*.lock:refs/heads/*", "keep.lock"},
+	} {
+		s.Run(tc.spec.String(), func() {
+			srcFS, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+			s.Require().NoError(err)
+			src := filesystem.NewStorage(srcFS, cache.NewObjectLRUDefault())
+			defer func() { s.Require().NoError(src.Close()) }()
+			head, err := src.Reference(plumbing.Master)
+			s.Require().NoError(err)
+			dir := s.T().TempDir()
+			dst, err := PlainClone(dir, &CloneOptions{URL: srcFS.Root(), Bare: true})
+			s.Require().NoError(err)
+			defer func() { s.Require().NoError(dst.Close()) }()
+			keep := plumbing.NewHashReference("refs/heads/keep", head.Hash())
+			s.Require().NoError(dst.Storer.SetReference(keep))
+			s.Require().NoError(util.WriteFile(srcFS, tc.source, []byte(head.Hash().String()+"\n"), 0o644))
+			remote := NewRemote(src, &config.RemoteConfig{Name: DefaultRemoteName, URLs: []string{dir}})
+			err = remote.Push(&PushOptions{Prune: true, RefSpecs: []config.RefSpec{
+				"refs/heads/master:refs/heads/allowed", tc.spec,
+			}})
+			s.Require().ErrorIs(err, plumbing.ErrInvalidReferenceName)
+			ref, err := dst.Storer.Reference(keep.Name())
+			s.Require().NoError(err)
+			s.Require().Equal(keep, ref)
+			_, err = dst.Storer.Reference("refs/heads/allowed")
+			s.Require().ErrorIs(err, plumbing.ErrReferenceNotFound)
+		})
+	}
+}
+
+func (s *RemoteSuite) TestPushPreservesValidWildcardSources() {
+	for _, tc := range []struct {
+		spec                config.RefSpec
+		source, destination plumbing.ReferenceName
+	}{
+		{"refs/heads/*/topic:refs/heads/*", "refs/heads/feature/topic", "refs/heads/feature"},
+		{"*:refs/backup/*", "refs/heads/master", "refs/backup/refs/heads/master"},
+		{"refs/heads/-*:refs/heads/kept-*", "refs/heads/-foo", "refs/heads/kept-foo"},
+		{"refs/heads/@*:refs/heads/kept-*", "refs/heads/@", "refs/heads/kept-"},
+		{"refs/heads/*lock:refs/heads/kept-*", "refs/heads/clock", "refs/heads/kept-c"},
+	} {
+		s.Run(tc.spec.String(), func() {
+			srcFS, err := fixtures.Basic().One().DotGit(fixtures.WithMemFS())
+			s.Require().NoError(err)
+			src := filesystem.NewStorage(srcFS, cache.NewObjectLRUDefault())
+			defer func() { s.Require().NoError(src.Close()) }()
+			head, err := src.Reference(plumbing.Master)
+			s.Require().NoError(err)
+			s.Require().NoError(src.SetReference(plumbing.NewHashReference(tc.source, head.Hash())))
+			dir := s.T().TempDir()
+			dst, err := PlainInit(dir, true)
+			s.Require().NoError(err)
+			defer func() { s.Require().NoError(dst.Close()) }()
+			remote := NewRemote(src, &config.RemoteConfig{Name: DefaultRemoteName, URLs: []string{dir}})
+			s.Require().NoError(remote.Push(&PushOptions{RefSpecs: []config.RefSpec{tc.spec}}))
+			ref, err := dst.Storer.Reference(tc.destination)
+			s.Require().NoError(err)
+			s.Require().Equal(head.Hash(), ref.Hash())
+		})
+	}
 }

--- a/repository.go
+++ b/repository.go
@@ -2065,7 +2065,10 @@ type RepackConfig struct {
 	OnlyDeletePacksOlderThan time.Time
 }
 
-// RepackObjects repacks all objects in the repository into a single packfile.
+// RepackObjects packs reachable objects and removes old packs according to cfg.
+// Reachability follows symbolic references. Missing targets are ignored, but
+// other resolution errors, including the recursion limit, stop the operation
+// before it creates a replacement pack or removes existing objects.
 func (r *Repository) RepackObjects(cfg *RepackConfig) (err error) {
 	pos, ok := r.Storer.(storer.PackedObjectStorer)
 	if !ok {

--- a/repository.go
+++ b/repository.go
@@ -864,7 +864,9 @@ func (r *Repository) Branch(name string) (*config.Branch, error) {
 	return b, nil
 }
 
-// CreateBranch creates a new Branch
+// CreateBranch creates a new branch configuration. The name must satisfy
+// plumbing.ValidateBranchName; these creation rules do not apply when reading
+// existing branch configurations.
 func (r *Repository) CreateBranch(c *config.Branch) error {
 	if err := c.Validate(); err != nil {
 		return err
@@ -909,6 +911,7 @@ func (r *Repository) DeleteBranch(name string) error {
 
 // CreateTag creates a tag. If opts is included, the tag is an annotated tag,
 // otherwise a lightweight tag is created.
+// The shorthand name must satisfy plumbing.ValidateTagName.
 func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagOptions) (*plumbing.Reference, error) {
 	if err := plumbing.ValidateTagName(name); err != nil {
 		return nil, err

--- a/repository.go
+++ b/repository.go
@@ -870,6 +870,13 @@ func (r *Repository) CreateBranch(c *config.Branch) error {
 		return err
 	}
 
+	// The creation rules live here rather than in Branch.Validate, which also
+	// runs when a config file is read: a repository whose config already names
+	// a branch go-git would decline to create still has to open.
+	if err := plumbing.ValidateBranchName(c.Name); err != nil {
+		return err
+	}
+
 	cfg, err := r.Config()
 	if err != nil {
 		return err
@@ -903,10 +910,11 @@ func (r *Repository) DeleteBranch(name string) error {
 // CreateTag creates a tag. If opts is included, the tag is an annotated tag,
 // otherwise a lightweight tag is created.
 func (r *Repository) CreateTag(name string, hash plumbing.Hash, opts *CreateTagOptions) (*plumbing.Reference, error) {
-	rname := plumbing.NewTagReferenceName(name)
-	if err := rname.Validate(); err != nil {
+	if err := plumbing.ValidateTagName(name); err != nil {
 		return nil, err
 	}
+
+	rname := plumbing.NewTagReferenceName(name)
 
 	_, err := r.Storer.Reference(rname)
 	switch err {

--- a/repository_test.go
+++ b/repository_test.go
@@ -1017,11 +1017,30 @@ func (s *RepositorySuite) TestEmptyCreateBranch() {
 func (s *RepositorySuite) TestInvalidCreateBranch() {
 	r, _ := Init(memory.NewStorage())
 	defer func() { _ = r.Close() }()
-	err := r.CreateBranch(&config.Branch{
-		Name: "-foo",
-	})
 
-	s.NotNil(err)
+	// The rules check_branch_ref applies to a shorthand, which are creation
+	// rules rather than naming rules: the reference names they stand for
+	// satisfy Validate, and git clone replicates both.
+	for _, name := range []string{"-foo", "HEAD"} {
+		err := r.CreateBranch(&config.Branch{
+			Name:   name,
+			Remote: "origin",
+			Merge:  "refs/heads/main",
+		})
+		s.ErrorIs(err, plumbing.ErrInvalidReferenceName, "branch %q", name)
+	}
+}
+
+// check_tag_ref's equivalent, which CreateTag applies to the shorthand before
+// it builds the reference name.
+func (s *RepositorySuite) TestInvalidCreateTag() {
+	r, _ := Init(memory.NewStorage())
+	defer func() { _ = r.Close() }()
+
+	for _, name := range []string{"-1.0", "HEAD"} {
+		_, err := r.CreateTag(name, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"), nil)
+		s.ErrorIs(err, plumbing.ErrInvalidReferenceName, "tag %q", name)
+	}
 }
 
 func (s *RepositorySuite) TestCreateBranchAndBranch() {

--- a/repository_test.go
+++ b/repository_test.go
@@ -15,8 +15,10 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -4593,4 +4595,74 @@ func (s *RepositorySuite) testPlainCloneFromRepoWithUnstorableRefs(checkFiltered
 			}
 		})
 	}
+}
+
+func (s *RepositorySuite) TestCloneSkipsSymbolicRefToEmptyRoot() {
+	srcFS, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+	s.Require().NoError(err)
+	src := filesystem.NewStorage(srcFS, cache.NewObjectLRUDefault())
+	defer func() { s.Require().NoError(src.Close()) }()
+	head, err := src.Reference(plumbing.Master)
+	s.Require().NoError(err)
+	s.Require().NoError(util.WriteFile(srcFS, "ORIG_HEAD", nil, 0o644))
+	s.Require().NoError(src.SetReference(plumbing.NewSymbolicReference("refs/heads/alias", "ORIG_HEAD")))
+
+	dst, err := PlainClone(s.T().TempDir(), &CloneOptions{URL: srcFS.Root(), Bare: true})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(dst.Close()) }()
+	ref, err := dst.Storer.Reference(plumbing.Master)
+	s.Require().NoError(err)
+	s.Require().Equal(head.Hash(), ref.Hash())
+	_, err = dst.Storer.Reference("refs/heads/alias")
+	s.Require().ErrorIs(err, plumbing.ErrReferenceNotFound)
+}
+
+func (s *RepositorySuite) TestPlainCloneSkipsFilesystemSymlinkLoopReferent() {
+	if runtime.GOOS == "windows" {
+		s.T().Skip("requires POSIX symlink loop errors")
+	}
+
+	srcFS, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+	s.Require().NoError(err)
+	src := filesystem.NewStorage(srcFS, cache.NewObjectLRUDefault())
+	defer func() { s.Require().NoError(src.Close()) }()
+	head, err := src.Reference(plumbing.Master)
+	s.Require().NoError(err)
+	s.Require().NoError(util.WriteFile(srcFS, "refs/heads/alias", []byte("ref: ORIG_HEAD\n"), 0o644))
+	s.Require().NoError(srcFS.Remove("ORIG_HEAD"))
+	s.Require().NoError(srcFS.Symlink("ORIG_HEAD", "ORIG_HEAD"))
+	_, err = src.Reference("ORIG_HEAD")
+	s.Require().ErrorIs(err, syscall.ELOOP)
+
+	dst, err := PlainClone(filepath.Join(s.T().TempDir(), "clone"), &CloneOptions{URL: srcFS.Root(), Bare: true})
+	s.Require().NoError(err)
+	defer func() { s.Require().NoError(dst.Close()) }()
+	got, err := dst.Reference(plumbing.Master, true)
+	s.Require().NoError(err)
+	s.Require().Equal(head.Hash(), got.Hash())
+	_, err = dst.Reference("refs/heads/alias", false)
+	s.Require().ErrorIs(err, plumbing.ErrReferenceNotFound)
+	_, err = src.Reference("ORIG_HEAD")
+	s.Require().ErrorIs(err, syscall.ELOOP)
+}
+
+func (s *RepositorySuite) TestRepackPreservesObjectsThroughRootSymref() {
+	r, commit, tree := newPruneSymrefRepository(s.T())
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewHashReference("ORIG_HEAD", commit)))
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference("refs/heads/main", "ORIG_HEAD")))
+	s.Require().NoError(r.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main")))
+
+	s.Require().NoError(r.RepackObjects(&RepackConfig{}))
+	packs, err := r.Storer.(storer.PackedObjectStorer).ObjectPacks()
+	s.Require().NoError(err)
+	s.Require().Len(packs, 1)
+	var loose []plumbing.Hash
+	s.Require().NoError(r.Storer.(storer.LooseObjectStorer).ForEachObjectHash(func(hash plumbing.Hash) error {
+		loose = append(loose, hash)
+		return nil
+	}))
+	s.Require().NotContains(loose, commit)
+	s.Require().NotContains(loose, tree)
+	s.Require().NoError(r.Storer.HasEncodedObject(commit))
+	s.Require().NoError(r.Storer.HasEncodedObject(tree))
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -4516,3 +4516,81 @@ func setupArchiveRepo(t *testing.T) *Repository {
 	require.NoError(t, err)
 	return r
 }
+
+// A remote is free to hold a reference name go-git will not store: a leftover
+// ".lock" file, or a name some other tool wrote. Cloning such a repository has
+// to keep working, because Git's does — filter_refs drops the name on the way
+// in and get_fetch_map drops the destination, and neither ends the fetch.
+//
+// This is the scenario the branch exists for, so it is asserted end to end
+// rather than through either filter's predicate.
+func (s *RepositorySuite) TestPlainCloneFromRepoWithUnstorableRefs() {
+	s.testPlainCloneFromRepoWithUnstorableRefs(false)
+}
+
+func (s *RepositorySuite) TestPlainCloneFiltersUnstorableRefs() {
+	s.testPlainCloneFromRepoWithUnstorableRefs(true)
+}
+
+func (s *RepositorySuite) testPlainCloneFromRepoWithUnstorableRefs(checkFiltered bool) {
+	s.T().Helper()
+	dir := s.T().TempDir()
+
+	// A real repository to clone, with objects, then names planted behind
+	// go-git's back the way another tool would leave them.
+	srcFs, err := fixtures.Basic().One().DotGit(fixtures.WithTargetDir(s.T().TempDir))
+	s.Require().NoError(err)
+	src := srcFs.Root()
+
+	head, err := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault()).
+		Reference(plumbing.ReferenceName("refs/heads/master"))
+	s.Require().NoError(err)
+	branch, err := filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault()).
+		Reference(plumbing.ReferenceName("refs/heads/branch"))
+	s.Require().NoError(err)
+
+	for _, name := range []string{
+		"main.lock",      // a lock file, or what a crashed process left behind
+		"bad~name",       // check_refname_format rule 4
+		".hidden",        // rule 1
+		"a..b",           // rule 3
+		"nz/\u200c./sub", // a component HFS+ folds to a dot
+	} {
+		s.Require().NoError(util.WriteFile(srcFs,
+			srcFs.Join("refs", "heads", filepath.FromSlash(name)),
+			[]byte(head.Hash().String()+"\n"), 0o644))
+	}
+
+	for _, tc := range []struct {
+		name string
+		opts *CloneOptions
+	}{
+		{"default refspec", &CloneOptions{URL: src}},
+		{"mirror", &CloneOptions{URL: src, Mirror: true, Bare: true}},
+	} {
+		s.Run(tc.name, func() {
+			r, err := PlainClone(filepath.Join(dir, "dst-"+tc.name), tc.opts)
+			s.Require().NoError(err)
+			defer func() { _ = r.Close() }()
+
+			iter, err := r.References()
+			s.Require().NoError(err)
+			got := make(map[plumbing.ReferenceName]plumbing.Hash)
+			s.Require().NoError(iter.ForEach(func(ref *plumbing.Reference) error {
+				got[ref.Name()] = ref.Hash()
+				return nil
+			}))
+			prefix := "refs/remotes/origin/"
+			if tc.opts.Mirror {
+				prefix = "refs/heads/"
+			}
+			s.Equal(head.Hash(), got[plumbing.ReferenceName(prefix+"master")])
+			s.Equal(branch.Hash(), got[plumbing.ReferenceName(prefix+"branch")])
+			if checkFiltered {
+				for _, name := range []string{"main.lock", "bad~name", ".hidden", "a..b", "nz/\u200c./sub"} {
+					s.NotContains(got, plumbing.ReferenceName(prefix+name))
+				}
+			}
+		})
+	}
+}

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -1631,7 +1631,10 @@ func (d *DotGit) CountLooseRefs() (int, error) {
 	return len(refs), nil
 }
 
-// PackRefs packs all loose refs into the packed-refs file.
+// PackRefs packs loose nonzero hash references with valid Git names into
+// packed-refs. Symbolic references, zero hashes and malformed names remain
+// loose. It does not verify whether referenced objects exist. Existing packed
+// references are retained unless replaced by a packable loose reference.
 //
 // This implementation only works under the assumption that the view
 // of the file system won't be updated during this operation.  This
@@ -1654,12 +1657,23 @@ func (d *DotGit) PackRefs() (err error) {
 	}
 	defer ioutil.CheckClose(f, &err)
 
-	// Gather all refs using addRefsFromRefDir and addRefsFromPackedRefs.
+	// Keep enumeration complete, but pack only loose references representable
+	// in packed-refs. A skipped loose reference must not suppress the existing
+	// packed value it shadows; it continues to shadow that value on disk.
 	var refs []*plumbing.Reference
 	seen := make(map[plumbing.ReferenceName]bool)
 	if err = d.addRefsFromRefDir(&refs, seen); err != nil {
 		return err
 	}
+	packable := refs[:0]
+	for _, ref := range refs {
+		if ref.Type() != plumbing.HashReference || ref.Hash().IsZero() || ref.Name().Validate() != nil {
+			delete(seen, ref.Name())
+			continue
+		}
+		packable = append(packable, ref)
+	}
+	refs = packable
 	if len(refs) == 0 {
 		// Nothing to do!
 		return nil
@@ -1698,8 +1712,7 @@ func (d *DotGit) PackRefs() (err error) {
 		return err
 	}
 
-	// Delete all the loose refs, while still holding the packed-refs
-	// lock.
+	// Delete only the loose refs packed above, while holding the packed-refs lock.
 	for _, ref := range refs[:numLooseRefs] {
 		path := d.fs.Join(".", ref.Name().String())
 		err = d.fs.Remove(path)

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -96,13 +96,12 @@ var (
 	// resolve outside the modules/ subtree, mirroring canonical Git's
 	// "ignoring suspicious submodule name" defence.
 	ErrModuleNameEscape = errors.New("submodule name escapes modules/ directory")
-	// ErrReferenceNameEscape is returned when a reference name would
-	// resolve outside its reference sub-tree once turned into a path
-	// under the .git directory (e.g. a name with a ".." component).
+	// ErrReferenceNameEscape is returned when a reference name fails the
+	// filesystem storage's name checks. Reads and deletes require a safe path;
+	// writes also require a valid reference name. These errors also wrap
+	// plumbing.ErrInvalidReferenceName.
 	ErrReferenceNameEscape = errors.New("reference name escapes the reference storage")
 )
-
-func isPathSep(r rune) bool { return r == '/' || r == '\\' }
 
 // validReferenceName rejects reference names that cannot be safely turned into
 // a path under the .git directory. A loose reference (and its reflog) is stored
@@ -110,35 +109,97 @@ func isPathSep(r rune) bool { return r == '/' || r == '\\' }
 // a malicious remote — could climb out of its reference sub-tree and read,
 // overwrite, or delete unrelated metadata such as .git/config.
 //
-// The storage-safety gate is plumbing.ReferenceName.IsSafe, mirroring Git's
+// The first gate is plumbing.ReferenceName.IsSafe, mirroring Git's
 // refname_is_safe: a name must be under refs/ without escaping it, or be a
-// [A-Z_] pseudo-ref. This alone rejects absolute, drive-prefixed, escaping and
-// single-level metadata names. On top of it, this adds filesystem-specific
-// hardening that IsSafe's literal check does not cover: control characters, and
-// components a case-insensitive/NTFS/HFS+ filesystem would fold back to "." or
-// ".." (trailing dots/spaces, Alternate Data Streams, ignorable Unicode code
-// points). The per-component check is delegated to pathutil.IsHFSDot and
-// pathutil.IsNTFSDot with "." as the needle, exactly as validSubmoduleName
-// does, and runs regardless of host OS because a name can be authored on one OS
-// and reach this layer on another.
+// one-level [A-Z_] name. That rejects absolute, drive-prefixed, escaping and
+// lowercase single-level names such as "config".
+//
+// IsSafe is not sufficient on its own. Its [A-Z_] arm accepts *any* shouting
+// one-level name, so "CONFIG", "INDEX" and "SHALLOW" all pass
+// it — and on a case-insensitive filesystem (APFS by default on macOS, NTFS on
+// Windows) each of those resolves to the real .git/config, .git/index,
+// or .git/shallow. Writing a reference there corrupts the
+// repository; ".git/shallow" is worse still, because a bare object id followed
+// by a newline is a *valid* shallow file and silently turns the repository into
+// a shallow one at an attacker-chosen commit. So a one-level name is accepted
+// only when plumbing.ReferenceName.IsRoot says it is a genuine root ref (HEAD,
+// the *_HEAD pseudo-refs, AUTO_MERGE and friends), mirroring Git's
+// is_root_ref. An allowlist is deliberate: denying known .git entries would be
+// incomplete by construction and would drift as Git adds files.
+//
+// On top of that, pathutil.HasUnsafeComponent adds the filesystem-specific
+// hardening IsSafe's literal ".." comparison does not cover: control
+// characters, and components a case-insensitive/NTFS/HFS+ filesystem would fold
+// back to "." or ".." (trailing dots/spaces, Alternate Data Streams, ignorable
+// Unicode code points). The receive-pack refname gate calls the same helper, so
+// the two layers cannot drift apart.
+//
+// This is the whole gate for reading and deleting a reference. Creating or
+// updating one goes through validNewReferenceName, which adds the format rules
+// on top. Enumeration goes through neither: Refs reports what is on disk, and
+// the transport decides what may leave the process.
 func validReferenceName(name plumbing.ReferenceName) error {
+	// Every rejection wraps plumbing.ErrInvalidReferenceName as well as
+	// ErrReferenceNameEscape, because every one of them is a statement about
+	// the name and a caller has to be able to recognise that with one test.
+	// A fetch is the caller that matters: it turns "this name" into "skip
+	// this reference" rather than "abandon the fetch", and it must not have
+	// to know which of these rules the name broke.
 	if !name.IsSafe() {
-		return fmt.Errorf("%w: %q is not under refs/ nor a valid pseudo-ref", ErrReferenceNameEscape, string(name))
+		return fmt.Errorf("%w: %w: %q is not a safe reference name",
+			ErrReferenceNameEscape, plumbing.ErrInvalidReferenceName, string(name))
 	}
 
-	s := string(name)
-	for i := 0; i < len(s); i++ {
-		if s[i] < 0x20 || s[i] == 0x7f {
-			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
-		}
+	if !name.IsUnderRefs() && !name.IsRoot() {
+		return fmt.Errorf("%w: %w: %q is not under refs/ nor a root ref",
+			ErrReferenceNameEscape, plumbing.ErrInvalidReferenceName, string(name))
 	}
-	for _, part := range strings.FieldsFunc(s, isPathSep) {
-		// IsNTFSDot/IsHFSDot with a "." needle match ".." and its disguises
-		// but not a bare ".", so reject that component explicitly too.
-		if part == "." || pathutil.IsHFSDot(part, ".") || pathutil.IsNTFSDot(part, ".", "") {
-			return fmt.Errorf("%w: %q", ErrReferenceNameEscape, s)
-		}
+
+	if pathutil.HasUnsafeComponent(string(name)) {
+		return fmt.Errorf("%w: %w: %q has a control character or a path component that folds to a dot",
+			ErrReferenceNameEscape, plumbing.ErrInvalidReferenceName, string(name))
 	}
+
+	return nil
+}
+
+// validNewReferenceName is validReferenceName plus
+// plumbing.ReferenceName.Validate, go-git's check_refname_format, for the
+// character and component rules the path-safety checks do not cover. SetRef and
+// ReflogWriter use it for creates, updates, and reflog appends.
+//
+// Of those rules the ".lock" suffix is the one that does damage without looking
+// like an escape, and a fetch reaches here with a name the remote chose. Git's
+// loose-reference iterator skips names ending in ".lock", so the name looks
+// inert, but .git/refs/heads/main.lock is the lock file Git creates to update
+// refs/heads/main:
+// storing one makes every later update of that ref fail with "File exists"
+// until someone deletes it by hand.
+// See https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs/files-backend.c#L385-L391.
+//
+// Git's transaction_refname_valid first honors REF_SKIP_REFNAME_VERIFICATION
+// and otherwise rejects pseudorefs. For the remaining refs it applies
+// check_refname_format when the new object ID is present and nonzero, and
+// refname_is_safe otherwise. A name too malformed to create can therefore
+// remain safe to delete with git update-ref -d. Keeping that distinction here
+// allows a repository holding a planted "main.lock" to remove it.
+// See https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/refs.c#L1368-L1396.
+//
+// Validate requires a "/", so a root ref would fail rule 2. IsRoot is what
+// gates a one-level name instead.
+func validNewReferenceName(name plumbing.ReferenceName) error {
+	if err := validReferenceName(name); err != nil {
+		return err
+	}
+
+	if !name.IsUnderRefs() {
+		return nil
+	}
+
+	if err := name.Validate(); err != nil {
+		return fmt.Errorf("%w: %w", ErrReferenceNameEscape, err)
+	}
+
 	return nil
 }
 
@@ -176,6 +237,21 @@ type Options struct {
 
 // The DotGit type represents a local git repository on disk. This
 // type is not zero-value-safe, use the New function to initialize it.
+//
+// Ref and RemoveRef permit malformed names such as refs/heads/main.lock but
+// reject unsafe paths, including backslashes, control characters and components
+// that HFS+ or NTFS could fold to "." or "..", on every operating system.
+// SetRef and ReflogWriter additionally require valid reference-name syntax.
+// Refs applies neither name check, so a returned entry may be inaccessible
+// through Ref and RemoveRef.
+//
+// Existing entries rejected by the path checks need external repair. On a
+// filesystem that preserves the exact spelling without aliasing, native Git's
+// update-ref -d may remove them. Otherwise, back up the repository and remove
+// the exact loose file or packed-refs entry with filesystem tools while the
+// repository is idle. Never normalize such a name to a different path.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/Documentation/git-update-ref.adoc#L39-L40
 type DotGit struct {
 	options Options
 	fs      billy.Filesystem
@@ -337,7 +413,7 @@ func (d *DotGit) ReflogReader(name plumbing.ReferenceName) (billy.File, error) {
 // ReflogWriter returns a file pointer for appending to the reflog for the given reference.
 // It creates the file and any necessary parent directories if they don't exist.
 func (d *DotGit) ReflogWriter(name plumbing.ReferenceName) (billy.File, error) {
-	if err := validReferenceName(name); err != nil {
+	if err := validNewReferenceName(name); err != nil {
 		return nil, err
 	}
 	p := d.fs.Join(logsPath, string(name))
@@ -1184,8 +1260,9 @@ func (d *DotGit) checkReferenceAndTruncate(f billy.File, old *plumbing.Reference
 }
 
 // SetRef stores a reference, optionally checking that old matches the current value.
+// The reference name must pass the write checks described by DotGit.
 func (d *DotGit) SetRef(r, old *plumbing.Reference) error {
-	if err := validReferenceName(r.Name()); err != nil {
+	if err := validNewReferenceName(r.Name()); err != nil {
 		return err
 	}
 
@@ -1223,6 +1300,8 @@ func (d *DotGit) Refs() ([]*plumbing.Reference, error) {
 }
 
 // Ref returns the reference for a given reference name.
+// It rejects names that fail the path-safety checks described by DotGit, even
+// when Refs returns an entry with that name.
 func (d *DotGit) Ref(name plumbing.ReferenceName) (*plumbing.Reference, error) {
 	if err := validReferenceName(name); err != nil {
 		return nil, err
@@ -1290,6 +1369,7 @@ func (d *DotGit) packedRef(name plumbing.ReferenceName) (*plumbing.Reference, er
 }
 
 // RemoveRef removes a reference by name.
+// It permits invalid-format names but rejects unsafe paths as described by DotGit.
 func (d *DotGit) RemoveRef(name plumbing.ReferenceName) error {
 	if err := validReferenceName(name); err != nil {
 		return err
@@ -1814,7 +1894,7 @@ func isHexAlpha(b byte) bool {
 func incBytes(in []byte) (out []byte, overflow bool) {
 	out = make([]byte, len(in))
 	copy(out, in)
-	for i := len(out) - 1; i >= 0; i-- {
+	for i := range slices.Backward(out) {
 		out[i]++
 		if out[i] != 0 {
 			return out, overflow // Didn't overflow.

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -1302,6 +1302,9 @@ func (d *DotGit) Refs() ([]*plumbing.Reference, error) {
 // Ref returns the reference for a given reference name.
 // It rejects names that fail the path-safety checks described by DotGit, even
 // when Refs returns an entry with that name.
+// It falls back to packed-refs when the loose reference is missing, empty, or
+// its path is a directory. Other loose-reference read errors are returned to the
+// caller.
 func (d *DotGit) Ref(name plumbing.ReferenceName) (*plumbing.Reference, error) {
 	if err := validReferenceName(name); err != nil {
 		return nil, err
@@ -1310,6 +1313,9 @@ func (d *DotGit) Ref(name plumbing.ReferenceName) (*plumbing.Reference, error) {
 	ref, err := d.readReferenceFile(".", name.String())
 	if err == nil {
 		return ref, nil
+	}
+	if !os.IsNotExist(err) && !errors.Is(err, ErrIsDir) && !errors.Is(err, ErrEmptyRefFile) {
+		return nil, err
 	}
 
 	return d.packedRef(name)

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -510,6 +510,108 @@ func (s *SuiteDotGit) TestRefsFromReferenceFile() {
 	s.Equal("refs/remotes/origin/master", string(ref.Target()))
 }
 
+type referenceReadErrorFS struct {
+	billy.Filesystem
+	phase string
+	err   error
+}
+
+func (f referenceReadErrorFS) Stat(name string) (os.FileInfo, error) {
+	if f.Join(name) == f.Join("refs", "heads", "main") && f.phase == "stat" {
+		return nil, f.err
+	}
+	return f.Filesystem.Stat(name)
+}
+
+func (f referenceReadErrorFS) Open(name string) (billy.File, error) {
+	if f.Join(name) != f.Join("refs", "heads", "main") {
+		return f.Filesystem.Open(name)
+	}
+	if f.phase == "open" {
+		return nil, f.err
+	}
+	file, err := f.Filesystem.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return referenceReadErrorFile{File: file, phase: f.phase, err: f.err}, nil
+}
+
+type referenceReadErrorFile struct {
+	billy.File
+	phase string
+	err   error
+}
+
+func (f referenceReadErrorFile) Read(p []byte) (int, error) {
+	if f.phase == "read" {
+		return 0, f.err
+	}
+	return f.File.Read(p)
+}
+
+func (f referenceReadErrorFile) Close() error {
+	if err := f.File.Close(); err != nil {
+		return err
+	}
+	if f.phase == "close" {
+		return f.err
+	}
+	return nil
+}
+
+func (s *SuiteDotGit) TestRefPreservesLooseReadErrors() {
+	for _, phase := range []string{"stat", "open", "read", "close"} {
+		for _, packed := range []bool{false, true} {
+			s.Run(fmt.Sprintf("%s/packed=%t", phase, packed), func() {
+				fs := s.EmptyFS()
+				s.Require().NoError(util.WriteFile(fs, "refs/heads/main", []byte("1111111111111111111111111111111111111111\n"), 0o644))
+				if packed {
+					s.Require().NoError(util.WriteFile(fs, "packed-refs", []byte("2222222222222222222222222222222222222222 refs/heads/main\n"), 0o644))
+				}
+				d := New(referenceReadErrorFS{Filesystem: fs, phase: phase, err: fmt.Errorf("reading loose reference: %w", io.ErrUnexpectedEOF)})
+				ref, err := d.Ref("refs/heads/main")
+				s.Require().ErrorIs(err, io.ErrUnexpectedEOF)
+				s.Require().Nil(ref)
+			})
+		}
+	}
+}
+
+func (s *SuiteDotGit) TestRefPackedFallback() {
+	for _, kind := range []string{"missing", "directory", "empty", "loose"} {
+		s.Run(kind, func() {
+			fs := s.EmptyFS()
+			packedHash := plumbing.NewHash("1111111111111111111111111111111111111111")
+			looseHash := plumbing.NewHash("2222222222222222222222222222222222222222")
+			s.Require().NoError(util.WriteFile(fs, "packed-refs", []byte(packedHash.String()+" refs/heads/main\n"), 0o644))
+			switch kind {
+			case "directory":
+				s.Require().NoError(fs.MkdirAll("refs/heads/main", 0o755))
+			case "empty":
+				s.Require().NoError(util.WriteFile(fs, "refs/heads/main", nil, 0o644))
+			case "loose":
+				s.Require().NoError(util.WriteFile(fs, "refs/heads/main", []byte(looseHash.String()+"\n"), 0o644))
+			}
+			ref, err := New(fs).Ref("refs/heads/main")
+			s.Require().NoError(err)
+			expected := packedHash
+			if kind == "loose" {
+				expected = looseHash
+			}
+			s.Require().Equal(expected, ref.Hash())
+		})
+	}
+}
+
+func (s *SuiteDotGit) TestRefEmptyWithoutPackedEntry() {
+	fs := s.EmptyFS()
+	s.Require().NoError(util.WriteFile(fs, "ORIG_HEAD", nil, 0o644))
+	ref, err := New(fs).Ref("ORIG_HEAD")
+	s.Require().ErrorIs(err, plumbing.ErrReferenceNotFound)
+	s.Require().Nil(ref)
+}
+
 func BenchmarkRefMultipleTimes(b *testing.B) {
 	fs, err := fixtures.Basic().ByTag(".git").One().DotGit()
 	if err != nil {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -1291,6 +1291,63 @@ func (s *SuiteDotGit) TestPackRefs() {
 	s.Equal("b8d3ffab552895c19b9fcf7aa264d277cde33881", ref.Hash().String())
 }
 
+func (s *SuiteDotGit) TestPackRefsPreservesUnpackableLooseRefs() {
+	fs := s.EmptyFS()
+	dir := New(fs)
+	oldHash := "a8d3ffab552895c19b9fcf7aa264d277cde33881"
+	newHash := "b8d3ffab552895c19b9fcf7aa264d277cde33881"
+	unpackable := map[string]string{
+		"refs/heads/alias":         "ref: refs/heads/main\n",
+		"refs/heads/bad\ninjected": newHash + "\n",
+		"refs/heads/main.lock":     newHash + "\n",
+		"refs/heads/bad~name":      newHash + "\n",
+		"refs/heads/zero":          plumbing.ZeroHash.String() + "\n",
+		"refs/heads/gibberish":     "not an object id\n",
+	}
+	for name, content := range unpackable {
+		s.Require().NoError(util.WriteFile(fs, name, []byte(content), 0o644))
+	}
+	packable := []string{"refs/heads/main", "refs/heads/@", "refs/heads/-foo", "refs/heads/\u200c./main"}
+	for _, name := range packable {
+		s.Require().NoError(util.WriteFile(fs, name, []byte(newHash+"\n"), 0o644))
+	}
+	packed := oldHash + " refs/heads/alias\n" + oldHash + " refs/heads/main.lock\n" + oldHash + " refs/heads/main\n" +
+		oldHash + " refs/heads/zero\n" + oldHash + " refs/heads/gibberish\n"
+	s.Require().NoError(util.WriteFile(fs, packedRefsPath, []byte(packed), 0o644))
+	before, err := dir.Refs()
+	s.Require().NoError(err)
+	s.Require().NoError(dir.PackRefs())
+	after, err := dir.Refs()
+	s.Require().NoError(err)
+	s.Require().ElementsMatch(before, after)
+	for name, content := range unpackable {
+		data, err := util.ReadFile(fs, name)
+		s.Require().NoError(err, "loose ref %q must survive", name)
+		s.Require().Equal(content, string(data))
+	}
+	for _, name := range packable {
+		_, err := fs.Stat(name)
+		s.Require().ErrorIs(err, os.ErrNotExist)
+	}
+	data, err := util.ReadFile(fs, packedRefsPath)
+	s.Require().NoError(err)
+	s.Require().Contains(string(data), oldHash+" refs/heads/alias\n")
+	s.Require().Contains(string(data), oldHash+" refs/heads/main.lock\n")
+	s.Require().Contains(string(data), newHash+" refs/heads/main\n")
+	s.Require().Contains(string(data), oldHash+" refs/heads/zero\n")
+	s.Require().Contains(string(data), oldHash+" refs/heads/gibberish\n")
+	s.Require().NotContains(string(data), "ref:")
+	s.Require().NotContains(string(data), "injected")
+	s.Require().NotContains(string(data), "bad~name")
+	s.Require().NoError(dir.PackRefs())
+	rerun, err := util.ReadFile(fs, packedRefsPath)
+	s.Require().NoError(err)
+	s.Require().Equal(data, rerun)
+	looseCount, err := dir.CountLooseRefs()
+	s.Require().NoError(err)
+	s.Require().Equal(len(unpackable), looseCount)
+}
+
 func TestAlternatesDefault(t *testing.T) {
 	t.Parallel()
 	// Create a new dotgit object.

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -147,6 +147,41 @@ func (s *SuiteDotGit) TestReferenceNameRejectsHFSDisguisedTraversal() {
 	s.Error(err, "traversal must not create .git/config")
 }
 
+func (s *SuiteDotGit) TestReferenceNameRejectsDisguisedSelfReference() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	// A component that folds to a single "." names the directory it sits in,
+	// so each of these resolves to refs/heads/main once joined: HFS+ drops the
+	// ignorable code points, and NTFS trims the trailing space or truncates at
+	// the Alternate Data Stream colon. HasUnsafeComponent is what stops them:
+	// IsSafe compares components literally, and Validate only refuses the
+	// spellings whose dot comes first, so rule 1 passes a component that
+	// leads with the zero-width non-joiner and carries the dot second.
+	for _, n := range []plumbing.ReferenceName{
+		"refs/heads/\u200c./main",
+		"refs/heads/.\u200c/main",
+		"refs/\u200c./heads/main",
+		"refs/heads/. /main",
+		"refs/heads/.:$DATA/main",
+	} {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		s.ErrorIs(d.SetRef(ref, nil), ErrReferenceNameEscape, "SetRef %q", n)
+
+		_, err := d.Ref(n)
+		s.ErrorIs(err, ErrReferenceNameEscape, "Ref %q", n)
+
+		s.ErrorIs(d.RemoveRef(n), ErrReferenceNameEscape, "RemoveRef %q", n)
+	}
+
+	// The aliasing itself only happens on HFS+ or NTFS, so what this asserts
+	// on any host is that the name never became a path: nothing was stored
+	// under refs/heads at all.
+	entries, err := d.fs.ReadDir(d.fs.Join(refsPath, "heads"))
+	s.NoError(err)
+	s.Empty(entries)
+}
+
 func (s *SuiteDotGit) TestReferenceNameRejectsAbsoluteAndDriveNames() {
 	d := New(s.EmptyFS())
 	s.Require().NoError(d.Initialize())
@@ -176,20 +211,126 @@ func (s *SuiteDotGit) TestReferenceNameRejectsTopLevelMetadata() {
 	d := New(s.EmptyFS())
 	s.Require().NoError(d.Initialize())
 
-	// A single-level name that is neither under refs/ nor a [A-Z_] pseudo-ref
-	// would land on top-level .git metadata once joined; the IsSafe gate
-	// rejects it, matching upstream refname_is_safe.
+	// A single-level name that is neither under refs/ nor a root ref would
+	// land on top-level .git metadata once joined. The lowercase spellings are
+	// stopped by IsSafe; the uppercase ones are not (refname_is_safe accepts
+	// any [A-Z_] one-level name) and are stopped by the root-ref allowlist —
+	// they matter because a case-insensitive filesystem folds "CONFIG" onto
+	// .git/config.
 	bad := []plumbing.ReferenceName{
 		"config", "config.worktree", "index", "packed-refs",
 		"shallow", "hooks", "objects", "bar", "HEAD2", "head",
+		"CONFIG", "INDEX", "SHALLOW", "DESCRIPTION", "COMMONDIR",
+		"GITDIR", "LOGS", "MODULES", "BRANCHES", "REMOTES", "HOOKS",
+		"INFO", "OBJECTS", "REFS", "WORKTREES", "PACKED_REFS",
+		"COMMIT_EDITMSG", "MERGE_MSG",
+		// A '-' satisfies is_root_ref_syntax, so IsRoot alone would let this
+		// through; IsSafe running first is what stops it.
+		"SOME-THING_HEAD",
 	}
 	for _, n := range bad {
 		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
 		s.ErrorIs(d.SetRef(ref, nil), ErrReferenceNameEscape, "SetRef %q", n)
+		s.ErrorIs(d.RemoveRef(n), ErrReferenceNameEscape, "RemoveRef %q", n)
+		_, err := d.Ref(n)
+		s.ErrorIs(err, ErrReferenceNameEscape, "Ref %q", n)
 	}
 
-	_, err := d.fs.Stat(configPath)
-	s.Error(err, "must not create .git/config")
+	for _, p := range []string{configPath, indexPath, shallowPath, packedRefsPath} {
+		_, err := d.fs.Stat(p)
+		s.Error(err, "must not create .git/%s", p)
+	}
+}
+
+func (s *SuiteDotGit) TestReferenceNameRejectsNamesOnlyValidateCatches() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	// These are under refs/, escape nothing, and hold no component that folds
+	// to a dot, so IsSafe and HasUnsafeComponent both pass them and only
+	// Validate refuses them. The storage layer needs it because a fetch
+	// reaches here with a name the remote chose, after refspec mapping.
+	//
+	// A ".lock" suffix is the one that does damage without looking like an
+	// escape. Git never reads .git/refs/heads/main.lock as a reference, so the
+	// name looks harmless, but that path is the lock file git creates to
+	// update refs/heads/main: once one is left behind, every later update of
+	// that ref fails with "File exists" and the advice that a lock file may be
+	// stale, until someone deletes it by hand.
+	bad := []plumbing.ReferenceName{
+		"refs/heads/main.lock",
+		"refs/remotes/origin/main.lock",
+		"refs/heads/sub/main.lock",
+		"refs/heads/.hidden",
+		"refs/heads/foo bar",
+		"refs/heads/foo~1",
+		"refs/heads/foo^",
+		"refs/heads/foo:bar",
+		"refs/heads/foo?",
+		"refs/heads/foo*",
+		"refs/heads/foo[",
+		"refs/heads/foo@{1}",
+	}
+	for _, n := range bad {
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+
+		err := d.SetRef(ref, nil)
+		s.ErrorIs(err, ErrReferenceNameEscape, "SetRef %q", n)
+		// Assert the wrapped cause too, so the case keeps testing Validate
+		// rather than passing on whichever check happens to run first.
+		s.ErrorIs(err, plumbing.ErrInvalidReferenceName, "SetRef %q", n)
+
+		_, err = d.ReflogWriter(n)
+		s.ErrorIs(err, ErrReferenceNameEscape, "ReflogWriter %q", n)
+		s.ErrorIs(err, plumbing.ErrInvalidReferenceName, "ReflogWriter %q", n)
+	}
+
+	entries, err := d.fs.ReadDir(d.fs.Join(refsPath, "heads"))
+	s.NoError(err)
+	s.Empty(entries, "no refused name may have become a path")
+}
+
+// A name too malformed to write stays readable and removable, because that is
+// the only way a repository already holding one gets cleaned up. Git splits the
+// two the same way: transaction_refname_valid applies check_refname_format when
+// the update carries a new object id and refname_is_safe alone when it does
+// not, which is why git update-ref -d and git branch -D delete a broken ref.
+func (s *SuiteDotGit) TestRefusedNamesStayReadableAndRemovable() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	hash := plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881")
+	for _, n := range []plumbing.ReferenceName{
+		"refs/heads/main.lock",
+		"refs/heads/.hidden",
+		"refs/heads/foo bar",
+		"refs/heads/foo~1",
+	} {
+		// Plant the file the way something other than go-git would have: a
+		// pre-fix go-git, another tool, or a crashed git.
+		p := d.fs.Join(strings.Split(string(n), "/")...)
+		s.Require().NoError(util.WriteFile(d.fs, p, []byte(hash.String()+"\n"), 0o644))
+
+		ref, err := d.Ref(n)
+		s.Require().NoError(err, "Ref %q", n)
+		s.Equal(hash, ref.Hash(), "Ref %q", n)
+
+		s.NoError(d.RemoveRef(n), "RemoveRef %q", n)
+
+		_, err = d.fs.Stat(p)
+		s.True(os.IsNotExist(err), "%q must be gone from disk", n)
+	}
+
+	// The path-safety gate still applies to both, so a name that escapes is
+	// refused whichever way it arrives.
+	for _, n := range []plumbing.ReferenceName{
+		"refs/heads/../../config",
+		"CONFIG",
+	} {
+		_, err := d.Ref(n)
+		s.ErrorIs(err, ErrReferenceNameEscape, "Ref %q", n)
+		s.ErrorIs(d.RemoveRef(n), ErrReferenceNameEscape, "RemoveRef %q", n)
+	}
 }
 
 func (s *SuiteDotGit) TestReferenceNameAcceptsBenignNames() {
@@ -197,11 +338,19 @@ func (s *SuiteDotGit) TestReferenceNameAcceptsBenignNames() {
 	s.Require().NoError(d.Initialize())
 	for _, n := range []plumbing.ReferenceName{
 		"HEAD", "ORIG_HEAD", "FETCH_HEAD", "MERGE_HEAD", "CHERRY_PICK_HEAD",
+		"AUTO_MERGE", "MERGE_AUTOSTASH", "BISECT_EXPECTED_REV",
+		"NOTES_MERGE_REF", "NOTES_MERGE_PARTIAL",
 		"refs/heads/main", "refs/heads/release-1.2",
 		"refs/tags/v1.0.0", "refs/remotes/origin/HEAD", "refs/stash",
 	} {
 		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
 		s.Require().NoError(d.SetRef(ref, nil), "SetRef %q", n)
+
+		got, err := d.Ref(n)
+		s.Require().NoError(err, "Ref %q", n)
+		s.Equal(n, got.Name(), "Ref %q", n)
+
+		s.Require().NoError(d.RemoveRef(n), "RemoveRef %q", n)
 	}
 }
 

--- a/storage/filesystem/reference.go
+++ b/storage/filesystem/reference.go
@@ -7,21 +7,46 @@ import (
 )
 
 // ReferenceStorage implements storer.ReferenceStorer for filesystem storage.
+//
+// Writes require valid reference names. Reads and deletes use less restrictive
+// path-safety checks so that existing names such as refs/heads/main.lock can be
+// inspected and removed. IterReferences reports stored entries without applying
+// either name check; an enumerated name is not necessarily readable or writable.
+//
+// Path-safety checks apply on every operating system. They reject backslashes,
+// control characters, non-reference root names, and path components that HFS+
+// or NTFS could interpret as "." or "..". For example, a component consisting
+// of U+200C followed by a dot is rejected even on Linux. Existing references
+// with these names cannot be read or removed through this storage API.
+//
+// To repair such a repository, use native Git on a filesystem that represents
+// the name without aliasing (for example, git update-ref -d with the exact name
+// on Linux). If native Git cannot remove it, back up the repository and remove
+// the exact loose reference or packed-refs entry with filesystem tools while
+// no process is modifying the repository. Do not normalize the name to another
+// path: that could remove a different reference.
+//
+// https://github.com/git/git/blob/1630431f326e15fcde608827b5ff38422528eb59/Documentation/git-update-ref.adoc#L39-L40
 type ReferenceStorage struct {
 	dir *dotgit.DotGit
 }
 
-// SetReference stores a reference.
+// SetReference stores a reference whose name passes the write checks described
+// by ReferenceStorage. A rejected name returns an error wrapping
+// plumbing.ErrInvalidReferenceName and dotgit.ErrReferenceNameEscape.
 func (r *ReferenceStorage) SetReference(ref *plumbing.Reference) error {
 	return r.dir.SetRef(ref, nil)
 }
 
 // CheckAndSetReference stores a reference after verifying the old value matches.
+// It applies the same name checks as SetReference.
 func (r *ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
 	return r.dir.SetRef(ref, old)
 }
 
-// Reference returns the reference with the given name.
+// Reference returns the reference with the given name. Names rejected by the
+// path-safety checks described by ReferenceStorage cannot be read, even if they
+// are returned by IterReferences.
 func (r *ReferenceStorage) Reference(n plumbing.ReferenceName) (*plumbing.Reference, error) {
 	return r.dir.Ref(n)
 }
@@ -36,7 +61,9 @@ func (r *ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 	return storer.NewReferenceSliceIter(refs), nil
 }
 
-// RemoveReference deletes the reference with the given name.
+// RemoveReference deletes the reference with the given name. Invalid-format
+// names such as refs/heads/main.lock can be removed, but names rejected by the
+// path-safety checks described by ReferenceStorage cannot.
 func (r *ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 	return r.dir.RemoveRef(n)
 }

--- a/storage/filesystem/reference.go
+++ b/storage/filesystem/reference.go
@@ -73,7 +73,11 @@ func (r *ReferenceStorage) CountLooseRefs() (int, error) {
 	return r.dir.CountLooseRefs()
 }
 
-// PackRefs packs all loose references into a single packed-refs file.
+// PackRefs packs loose hash references with valid names and nonzero hashes into
+// packed-refs. Symbolic references, malformed names and zero hashes remain loose.
+// Existing packed references are retained unless replaced by a packed loose ref.
+// It does not check whether referenced objects exist. The repository must not
+// be modified concurrently while PackRefs runs.
 func (r *ReferenceStorage) PackRefs() error {
 	return r.dir.PackRefs()
 }

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -411,7 +411,10 @@ func (r ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) err
 
 	if old != nil {
 		tmp := r[ref.Name()]
-		if tmp != nil && tmp.Hash() != old.Hash() {
+		if tmp == nil {
+			return plumbing.ErrReferenceNotFound
+		}
+		if tmp.Hash() != old.Hash() {
 			return storage.ErrReferenceHasChanged
 		}
 	}

--- a/storage/memory/storage_test.go
+++ b/storage/memory/storage_test.go
@@ -209,6 +209,27 @@ func TestSupportsExtension(t *testing.T) {
 	}
 }
 
+func TestCheckAndSetReferenceDoesNotRecreateRemovedReference(t *testing.T) {
+	t.Parallel()
+
+	s := memory.NewStorage()
+	old := plumbing.NewHashReference(plumbing.Master, plumbing.NewHash("1111111111111111111111111111111111111111"))
+	updated := plumbing.NewHashReference(plumbing.Master, plumbing.NewHash("2222222222222222222222222222222222222222"))
+	require.NoError(t, s.SetReference(old))
+	observed, err := s.Reference(plumbing.Master)
+	require.NoError(t, err)
+	require.NoError(t, s.RemoveReference(plumbing.Master))
+
+	require.ErrorIs(t, s.CheckAndSetReference(updated, observed), plumbing.ErrReferenceNotFound)
+	_, err = s.Reference(plumbing.Master)
+	require.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
+
+	require.NoError(t, s.CheckAndSetReference(updated, nil))
+	current, err := s.Reference(plumbing.Master)
+	require.NoError(t, err)
+	require.Equal(t, updated, current)
+}
+
 func TestReflogStorage(t *testing.T) {
 	t.Parallel()
 

--- a/worktree.go
+++ b/worktree.go
@@ -265,7 +265,19 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 }
 
 func (w *Worktree) createBranch(opts *CheckoutOptions) error {
-	if err := opts.Branch.Validate(); err != nil {
+	// Git applies its branch-name rules to the shorthand a user types, so
+	// recover the shorthand before checking a name that is one. A name that is
+	// not under refs/heads/ gets the reference-name rules alone: handing it to
+	// ValidateBranchName would splice a second "refs/heads/" in front and
+	// judge that instead, which accepts the one-level spellings Validate
+	// exists to refuse. That arm is not a second gate — "HEAD" reaches it and
+	// passes, because Validate carves HEAD out; what stops it is the existing-
+	// reference check below.
+	if name, ok := strings.CutPrefix(opts.Branch.String(), "refs/heads/"); ok {
+		if err := plumbing.ValidateBranchName(name); err != nil {
+			return err
+		}
+	} else if err := opts.Branch.Validate(); err != nil {
 		return err
 	}
 

--- a/worktree.go
+++ b/worktree.go
@@ -273,7 +273,7 @@ func (w *Worktree) createBranch(opts *CheckoutOptions) error {
 	// exists to refuse. That arm is not a second gate — "HEAD" reaches it and
 	// passes, because Validate carves HEAD out; what stops it is the existing-
 	// reference check below.
-	if name, ok := strings.CutPrefix(opts.Branch.String(), "refs/heads/"); ok {
+	if name, ok := strings.CutPrefix(opts.Branch.String(), plumbing.RefHeadPrefix); ok {
 		if err := plumbing.ValidateBranchName(name); err != nil {
 			return err
 		}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1283,13 +1283,46 @@ func (s *WorktreeSuite) TestCheckoutCreateInvalidBranch() {
 		"refs/heads/..",
 		"refs/heads/a..b",
 		"refs/heads/.",
+		// The creation rules, which apply to the shorthand recovered from a
+		// refs/heads/ name. Validate accepts both: git clone replicates
+		// refs/heads/-foo, and refs/heads/HEAD is a name git will store.
+		"refs/heads/-foo",
+		"refs/heads/HEAD",
 	} {
 		err := w.Checkout(&CheckoutOptions{
 			Create: true,
 			Branch: name,
 		})
 
-		s.ErrorIs(err, plumbing.ErrInvalidReferenceName)
+		s.ErrorIs(err, plumbing.ErrInvalidReferenceName, "branch %q", name)
+		s.ErrorContains(err, string(name), "branch %q", name)
+	}
+}
+
+// A name outside refs/heads/ takes the other arm of createBranch and keeps the
+// reference-name rules alone. The creation rules must not reach it: they would
+// splice a second "refs/heads/" in front and judge that instead, which accepts
+// the one-level spellings Validate exists to refuse.
+func (s *WorktreeSuite) TestCheckoutCreateAppliesBranchRulesOnlyToBranches() {
+	w := &Worktree{
+		r:          s.Repository,
+		filesystem: newWorktreeFilesystem(memfs.New(), defaultProtectNTFS(), defaultProtectHFS()),
+	}
+
+	// Accepted by check_refname_format and created by git branch -- @.
+	s.NoError(w.Checkout(&CheckoutOptions{Create: true, Branch: "refs/heads/@"}))
+
+	// Not a branch, so the shorthand rules do not apply and a leading "-" is
+	// only a reference-name question, which Validate answers by accepting it.
+	s.NoError(w.Checkout(&CheckoutOptions{Create: true, Branch: "refs/remotes/origin/-x"}))
+
+	// The property this test exists for. A one-level name must keep the
+	// reference-name rules: routed through ValidateBranchName instead, it
+	// would be spliced to "refs/heads/CONFIG" and accepted, which is exactly
+	// the spelling Validate's rule 2 is there to refuse.
+	for _, name := range []plumbing.ReferenceName{"CONFIG", "ORIG_HEAD"} {
+		err := w.Checkout(&CheckoutOptions{Create: true, Branch: name})
+		s.ErrorIs(err, plumbing.ErrInvalidReferenceName, "branch %q", name)
 	}
 }
 


### PR DESCRIPTION
## Summary

Malformed reference names received from a remote or already present in a repository can overwrite metadata, block legitimate updates, or disrupt cloning. This change validates names at storage and transport boundaries while preserving usable references and repair access where path safety permits.

## Correctness fixes

- **Reference-format validation:** Fix `ReferenceName.Validate` rejecting valid `@` components and leading-hyphen reference names. Existing references such as `refs/heads/@` and `refs/heads/-foo` can now pass validation.
- **Creation validation:** Apply branch and tag shorthand rules when creating names, instead of relying solely on full-reference validation. For example, `refs/tags/HEAD` is a valid reference name, but `CreateTag("HEAD", ...)` must reject the reserved shorthand. Creation-only restrictions do not apply when reading existing branch configurations.
- **Receive-command decoding:** Preserve the complete reference name for validation instead of truncating it at whitespace, and require complete object IDs. Malformed commands cannot be accepted through partial decoding.
- **Receive-command reporting:** Report reference-update failures as per-reference `ng` statuses rather than describing a successfully decoded pack as corrupt. Return pack decoding errors that were previously suppressed, and emit reference statuses in command order.
- **Execution without status reporting:** Fix receive commands not executing when `report-status` is absent. The capability controls whether results are reported; it must not control whether the requested push happens.
- **Expected-old checks:** Use conditional updates and check the expected old value before deletion, instead of updating or deleting without that check. Preserve the documented deletion exception when the supplied old object is missing. Resolve existing symbolic references and operate on their targets without replacing the aliases.
- **Memory-storage conditional updates:** Fix memory storage's conditional updates to fail when an expected reference is missing, instead of recreating it. Supplying an old value requires an existing matching reference.
- **Response completion:** Fix direct `ReceivePack` calls leaving the response writer open on some return paths. Close the supplied writer consistently and terminate negotiated sideband responses even when no status report is requested.
- **Backend stream ownership:** Fix `Backend.Serve` closing caller-owned streams despite its documented contract. Pass no-close adapters to transport services so the caller can handle the returned error and finish the underlying response.
- **Symbolic-reference advertisements:** Advertise the terminal symbolic target rather than an intermediate alias. Skip missing, invalid, or cyclic referents individually so one broken referent does not prevent advertising usable references. Apply this handling to protocol v0/v1, v2, and dumb-HTTP `info/refs`.
- **Fetch resilience:** Skip destinations rejected for their names, including automatically followed tags, instead of aborting an otherwise usable fetch. A rejected destination remains absent while usable references are stored.
- **Push pruning:** Reject malformed wildcard source patterns before pruning, so filtered local sources cannot be mistaken for missing references and trigger unintended remote deletions.
- **Reference packing:** Fix `PackRefs` serializing unsuitable references and deleting their loose files. Leave symbolic references, malformed names, and zero hashes loose, and retain existing packed entries shadowed by skipped loose references.
- **Object preservation:** Follow symbolic references when calculating reachability for pruning and repacking, including targets in root references. Preserve reachable objects instead of treating them as unreferenced. Stop maintenance on resolution failures other than missing targets, rather than proceeding with an incomplete reachability calculation.
- **Reference-read errors:** Propagate loose-reference I/O errors instead of hiding them behind a packed-reference fallback. Keep the fallback for missing paths, directories, and empty reference files.

## Hardening and compatibility changes

- **Reference-write restrictions:** Reject malformed filesystem writes and names that could address repository metadata. Receive-pack commands must name references under `refs/`; pushes cannot directly write `HEAD`, `CONFIG`, or other root entries. Direct filesystem callers can still use legitimate root references such as `HEAD`.
- **Duplicate receive commands:** Reject a request naming the same reference more than once before hooks or reference updates run. Callers must send one command per reference rather than relying on ambiguous multiple-update behavior.
- **Transport filtering:** Omit unusable reference names from advertisements and push candidates. Storage enumeration remains complete, but a remote listing can contain fewer entries than the underlying store.

These include intentional behavior changes even where the underlying change is a bug fix:

- Callers that previously wrote malformed names or created reserved branch/tag shorthands now receive errors.
- Reads and deletes retain path-safety checks. Malformed names such as `refs/heads/main.lock` remain removable, but unsafe existing names may require external repair, as documented.
- Direct `ReceivePack` callers retaining ownership of the underlying streams must supply no-close adapters. `Backend.Serve` supplies these internally; its callers remain responsible for closing their streams.
- Callers must handle failed conditional updates and maintenance errors that were previously missed or suppressed. `PackRefs` no longer implies that every loose reference was packed.

Filesystem portability checks apply on every platform and can reject names native Git accepts on a particular filesystem. Receive-pack validates the complete reference name, retaining the documented compatibility exception for names such as `refs/stash`.

Expected-old checks do not provide a transaction spanning symbolic-reference resolution and mutation, or an atomic conditional delete. Callers requiring those guarantees must serialize writers.

## Additive API and diagnostics

- Add `ValidateBranchName` and `ValidateTagName` for literal creation shorthands. Callers validating a creation request should use these rather than treating `ReferenceName.Validate` as a creation-policy check.
- Add `ReferenceName.IsRoot`, `ReferenceName.IsUnderRefs`, `RefPrefix`, and `RefHeadPrefix` for reference classification and shared prefixes.
- Add `transport.ErrFunnyRefname` and `transport.ErrDuplicateRefname` for the new receive-command rejections.
- Improve existing opt-in fetch tracing with the remote source, local destination, and storage rejection reason. Enable `trace.General` to diagnose skipped references. This adds diagnostic detail without changing fetch return semantics or using `Progress` for local messages; `Progress` remains server-sent output.
