### PR TITLE
build: Fix workflows for Go 1.27 (v5)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [oldstable, stable]
+        go-version: ['1.25.x', '1.26.x', '1.27.x']
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     permissions:

--- a/cli/go-git/go.mod
+++ b/cli/go-git/go.mod
@@ -1,5 +1,6 @@
 module github.com/go-git/go-git/cli/go-git
 
+// go-git supports the last 3 stable Go versions.
 go 1.25.0
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/go-git/go-git/v5
 
+// go-git supports the last 3 stable Go versions.
 go 1.25.0
 
 require (

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -2,6 +2,7 @@ package packfile
 
 import (
 	"bytes"
+	"compress/zlib"
 	"io"
 
 	"github.com/go-git/go-git/v5/plumbing"
@@ -59,9 +60,12 @@ func (s *EncoderSuite) TestCorrectPackWithOneEmptyObject(c *C) {
 	// OBJECT HEADER(TYPE + SIZE)= 0001 0000
 	expectedResult = append(expectedResult, []byte{16}...)
 
-	// Zlib header
-	expectedResult = append(expectedResult,
-		[]byte{120, 156, 1, 0, 0, 255, 255, 0, 0, 0, 1}...)
+	// Zlib stream of the empty object contents. The exact bytes depend on the
+	// compress/flate implementation, so compress it here instead of hardcoding.
+	var zbuf bytes.Buffer
+	zw := zlib.NewWriter(&zbuf)
+	c.Assert(zw.Close(), IsNil)
+	expectedResult = append(expectedResult, zbuf.Bytes()...)
 
 	// + HASH
 	hb := [hash.Size]byte(h)

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -2,6 +2,8 @@ package dotgit
 
 import (
 	"bufio"
+	"bytes"
+	"compress/zlib"
 	"encoding/hex"
 	"errors"
 	"io"
@@ -593,6 +595,16 @@ func (s *SuiteDotGit) TestObjectPackNotFound(c *C) {
 	c.Assert(idx, IsNil)
 }
 
+func looseObjectSize(t require.TestingT, content string) int64 {
+	var buf bytes.Buffer
+	w := zlib.NewWriter(&buf)
+	_, err := w.Write([]byte(content))
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	return int64(buf.Len())
+}
+
 func (s *SuiteDotGit) TestNewObject(c *C) {
 	fs := s.TemporalFilesystem(c)
 
@@ -613,7 +625,7 @@ func (s *SuiteDotGit) TestNewObject(c *C) {
 
 	i, err := fs.Stat("objects/a8/a940627d132695a9769df883f85992f0ff4a43")
 	c.Assert(err, IsNil)
-	c.Assert(i.Size(), Equals, int64(34))
+	c.Assert(i.Size(), Equals, looseObjectSize(c, "blob 14\x00this is a test"))
 }
 
 func (s *SuiteDotGit) TestObjects(c *C) {
@@ -1163,7 +1175,7 @@ func TestIssue55(t *testing.T) {
 			writeObject(tc.fs)
 			i, err := tc.fs.Stat(path)
 			require.NoError(t, err)
-			assert.Equal(t, int64(34), i.Size())
+			assert.Equal(t, looseObjectSize(t, "blob 14\x00this is a test"), i.Size())
 
 			ro, err := isReadOnly(tc.fs, path)
 			require.NoError(t, err)
@@ -1173,7 +1185,7 @@ func TestIssue55(t *testing.T) {
 			writeObject(tc.fs)
 			i, err = tc.fs.Stat(path)
 			require.NoError(t, err)
-			assert.Equal(t, int64(34), i.Size())
+			assert.Equal(t, looseObjectSize(t, "blob 14\x00this is a test"), i.Size())
 
 			ro, err = isReadOnly(tc.fs, path)
 			require.NoError(t, err)


### PR DESCRIPTION
Back-ports of https://github.com/go-git/go-git/pull/2178 and part of https://github.com/go-git/go-git/pull/2329.