### PR TITLE
internal: test, Resolve Apple Git before isolating its environment

### DIFF
--- a/internal/test/gitenv/apple_git.go
+++ b/internal/test/gitenv/apple_git.go
@@ -10,6 +10,12 @@ import (
 	"time"
 )
 
+// resolveTimeout bounds the xcrun call below, for the caller whose context
+// carries no deadline: a launcher that is running a license check is slow
+// rather than stuck, and a resolution that never returns would hang the test
+// binary in place of the startup delay this avoids.
+const resolveTimeout = 30 * time.Second
+
 // resolveAppleGit bypasses only Apple's tool launcher, not another Git selected
 // through PATH. With an isolated HOME, the launcher can run xcodebuild -license
 // check before starting Git. Under concurrent test load this exceeded the git
@@ -18,17 +24,22 @@ import (
 //
 // Resolve with the caller's environment, then apply isolation to Git itself.
 // Do not cache: PATH and Xcode selection variables can change between tests.
-func resolveAppleGit(cmd *exec.Cmd) {
+//
+// xcrun runs under ctx, so a caller that supplies one is not left waiting on a
+// subprocess outside it, with resolveTimeout capping a context that carries no
+// deadline of its own. Whichever ends first, the context reports why: exec
+// kills xcrun and would otherwise report only the signal.
+func resolveAppleGit(ctx context.Context, cmd *exec.Cmd) {
 	if runtime.GOOS != "darwin" || cmd.Err != nil || cmd.Path != "/usr/bin/git" {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, resolveTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, "/usr/bin/xcrun", "--find", "git").Output()
 	if err != nil {
 		if ctx.Err() != nil {
-			err = ctx.Err()
+			err = context.Cause(ctx)
 		}
 		cmd.Err = fmt.Errorf("gitenv: resolve Apple Git with xcrun: %w", err)
 		return

--- a/internal/test/gitenv/apple_git.go
+++ b/internal/test/gitenv/apple_git.go
@@ -1,0 +1,44 @@
+package gitenv
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// resolveAppleGit bypasses only Apple's tool launcher, not another Git selected
+// through PATH. With an isolated HOME, the launcher can run xcodebuild -license
+// check before starting Git. Under concurrent test load this exceeded the git
+// transport tests' readiness deadline (go-git/go-git#2361); invoking the selected
+// Git directly retained isolation without that startup delay.
+//
+// Resolve with the caller's environment, then apply isolation to Git itself.
+// Do not cache: PATH and Xcode selection variables can change between tests.
+func resolveAppleGit(cmd *exec.Cmd) {
+	if runtime.GOOS != "darwin" || cmd.Err != nil || cmd.Path != "/usr/bin/git" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "/usr/bin/xcrun", "--find", "git").Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+		}
+		cmd.Err = fmt.Errorf("gitenv: resolve Apple Git with xcrun: %w", err)
+		return
+	}
+
+	path := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(path) || path == "/usr/bin/git" {
+		cmd.Err = fmt.Errorf("gitenv: resolve Apple Git: xcrun returned invalid executable %q", path)
+		return
+	}
+
+	cmd.Path = path
+}

--- a/internal/test/gitenv/command_darwin_test.go
+++ b/internal/test/gitenv/command_darwin_test.go
@@ -1,0 +1,83 @@
+package gitenv_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
+)
+
+func TestCommandResolvesAppleGit(t *testing.T) {
+	t.Parallel()
+
+	if _, err := os.Stat("/usr/bin/git"); err != nil {
+		t.Skip("Apple Git launcher not installed")
+	}
+	resolved, err := exec.Command("/usr/bin/xcrun", "--find", "git").Output()
+	require.NoError(t, err)
+
+	cmd := gitenv.Command("/usr/bin/git", "--version")
+	require.NoError(t, cmd.Err)
+	require.Equal(t, strings.TrimSpace(string(resolved)), cmd.Path)
+	require.NotEqual(t, "/usr/bin/git", cmd.Path)
+	require.Equal(t, "/usr/bin/git", cmd.Args[0])
+	require.NotEqual(t, os.Getenv("HOME"), valueOf(t, cmd.Env, "HOME"))
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "%s", out)
+}
+
+func TestCommandPreservesPATHSelectedGit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "git")
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o700))
+	t.Setenv("PATH", dir)
+	t.Setenv("DEVELOPER_DIR", filepath.Join(dir, "missing-developer"))
+	t.Setenv("GIT_EXEC_PATH", filepath.Join(dir, "git-core"))
+
+	cmd := gitenv.Command("git", "--version")
+	require.NoError(t, cmd.Err)
+	require.Equal(t, path, cmd.Path)
+	require.Equal(t, os.Getenv("GIT_EXEC_PATH"), valueOf(t, cmd.Env, "GIT_EXEC_PATH"))
+	require.NoError(t, cmd.Run())
+}
+
+func TestCommandReportsAppleGitResolutionFailure(t *testing.T) {
+	t.Setenv("DEVELOPER_DIR", filepath.Join(t.TempDir(), "missing-developer"))
+
+	cmd := gitenv.Command("/usr/bin/git", "--version")
+	require.ErrorContains(t, cmd.Err, "resolve Apple Git")
+	require.Error(t, cmd.Start())
+	require.Nil(t, cmd.Process)
+}
+
+func TestCommandResolvesPATHSelectedAppleGit(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("GIT_EXEC_PATH", filepath.Join(t.TempDir(), "git-core"))
+
+	cmd := gitenv.Command("git", "--version")
+	require.NoError(t, cmd.Err)
+	require.True(t, filepath.IsAbs(cmd.Path))
+	require.NotEqual(t, "/usr/bin/git", cmd.Path)
+	require.Equal(t, os.Getenv("GIT_EXEC_PATH"), valueOf(t, cmd.Env, "GIT_EXEC_PATH"))
+}
+
+func TestCommandPreservesMissingGitError(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	cmd := gitenv.Command("git", "--version")
+	require.ErrorIs(t, cmd.Err, exec.ErrNotFound)
+}
+
+func TestCommandLeavesOtherProgramsAlone(t *testing.T) {
+	t.Setenv("DEVELOPER_DIR", filepath.Join(t.TempDir(), "missing-developer"))
+
+	cmd := gitenv.Command("/bin/sh", "-c", "exit 0")
+	require.NoError(t, cmd.Err)
+	require.Equal(t, "/bin/sh", cmd.Path)
+	require.NoError(t, cmd.Run())
+}

--- a/internal/test/gitenv/command_darwin_test.go
+++ b/internal/test/gitenv/command_darwin_test.go
@@ -7,11 +7,31 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/internal/test/gitenv"
 )
+
+// xcrunTimeout bounds the xcrun calls these tests make for themselves, at the
+// same 30 seconds the package bounds its own by. The reason is the reason
+// there: xcrun may be running a license check rather than answering, and an
+// unbounded call here would hang the run in place of failing it.
+const xcrunTimeout = 30 * time.Second
+
+// findGit is what the resolution under test is compared against: the same
+// question asked directly, under a deadline of its own.
+func findGit(t *testing.T) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), xcrunTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "/usr/bin/xcrun", "--find", "git").Output()
+	require.NoError(t, err)
+
+	return strings.TrimSpace(string(out))
+}
 
 func TestCommandResolvesAppleGit(t *testing.T) {
 	t.Parallel()
@@ -19,8 +39,7 @@ func TestCommandResolvesAppleGit(t *testing.T) {
 	if _, err := os.Stat("/usr/bin/git"); err != nil {
 		t.Skip("Apple Git launcher not installed")
 	}
-	resolved, err := exec.Command("/usr/bin/xcrun", "--find", "git").Output()
-	require.NoError(t, err)
+	resolved := findGit(t)
 
 	cmd := gitenv.Command("/usr/bin/git", "--version")
 	require.NoError(t, cmd.Err)

--- a/internal/test/gitenv/command_darwin_test.go
+++ b/internal/test/gitenv/command_darwin_test.go
@@ -1,6 +1,7 @@
 package gitenv_test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +30,26 @@ func TestCommandResolvesAppleGit(t *testing.T) {
 	require.NotEqual(t, os.Getenv("HOME"), valueOf(t, cmd.Env, "HOME"))
 	out, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "%s", out)
+}
+
+// TestCommandContextResolvesAppleGitUnderTheCallersContext is the context
+// reaching the one command this package runs of its own accord. Resolution
+// shells out to xcrun, so a caller whose context is already over is told that
+// rather than made to wait on a launcher it no longer has a use for.
+func TestCommandContextResolvesAppleGitUnderTheCallersContext(t *testing.T) {
+	t.Parallel()
+
+	if _, err := os.Stat("/usr/bin/git"); err != nil {
+		t.Skip("Apple Git launcher not installed")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cmd := gitenv.CommandContext(ctx, "/usr/bin/git", "--version")
+	require.ErrorContains(t, cmd.Err, "resolve Apple Git")
+	require.ErrorIs(t, cmd.Err, context.Canceled)
+	require.Equal(t, "/usr/bin/git", cmd.Path)
 }
 
 func TestCommandPreservesPATHSelectedGit(t *testing.T) {

--- a/internal/test/gitenv/gitenv.go
+++ b/internal/test/gitenv/gitenv.go
@@ -12,8 +12,9 @@
 // built, so a stray value redirects the command rather than colouring it.
 //
 // Command returns a command with all of that removed and an identity supplied.
-// Env returns the environment on its own, for a caller that builds the command
-// itself. Every variable this package names is set unconditionally, whatever
+// CommandContext is the same command bound to a context, for a test that has
+// the harness's own to hand it. Env returns the environment on its own, for a
+// caller that builds the command itself. Every variable this package names is set unconditionally, whatever
 // the machine had: a value inherited from the environment is the thing being
 // isolated, so honouring it would defeat the purpose. A caller who needs
 // something different appends it, since the last entry for a variable is the
@@ -26,6 +27,7 @@
 package gitenv
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -171,9 +173,31 @@ var isolatedHome = sync.OnceValue(func() string {
 // may append to Env for anything it needs on top: later entries win.
 // On macOS, Apple's /usr/bin/git launcher is resolved before applying Env;
 // resolution failures are returned through Cmd.Err and prevent execution.
+//
+// The command's lifetime is the caller's to manage: this is CommandContext
+// with a context that is never done, which exec spends nothing on — it starts
+// no watcher for a context whose Done channel is nil. CommandContext ties the
+// command to a real one instead.
 func Command(name string, args ...string) *exec.Cmd {
-	cmd := exec.Command(name, args...)
-	resolveAppleGit(cmd)
+	return CommandContext(context.Background(), name, args...)
+}
+
+// CommandContext is Command with the command bound to ctx, as
+// exec.CommandContext binds one, and with the same context governing the
+// resolution Command performs on its own account: on macOS that runs xcrun,
+// and a caller who supplies a context should not be waiting on a subprocess
+// outside it. The resolution keeps a deadline of its own on top, so a context
+// without one still cannot wait indefinitely.
+//
+// A test passes the context its harness gives it — t.Context(), cancelled when
+// the test ends — so that a git which outlives the test does not outlive the
+// run. Note what exec does with a context that ends: it kills the process,
+// which leaves any grandchildren of a git that spawns them running. A command
+// whose shutdown has to be more careful than that, git daemon and its
+// upload-pack children among them, wants Command and a cleanup of its own.
+func CommandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	resolveAppleGit(ctx, cmd)
 	cmd.Env = Env()
 
 	return cmd

--- a/internal/test/gitenv/gitenv.go
+++ b/internal/test/gitenv/gitenv.go
@@ -169,8 +169,11 @@ var isolatedHome = sync.OnceValue(func() string {
 // read the machine's configuration or be pointed at another repository, where
 // one built with exec.Command has to remember not to. The caller sets Dir, and
 // may append to Env for anything it needs on top: later entries win.
+// On macOS, Apple's /usr/bin/git launcher is resolved before applying Env;
+// resolution failures are returned through Cmd.Err and prevent execution.
 func Command(name string, args ...string) *exec.Cmd {
 	cmd := exec.Command(name, args...)
+	resolveAppleGit(cmd)
 	cmd.Env = Env()
 
 	return cmd

--- a/internal/test/gitenv/gitenv_test.go
+++ b/internal/test/gitenv/gitenv_test.go
@@ -1,11 +1,13 @@
 package gitenv_test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -266,6 +268,68 @@ func TestCommandTakesAnAppendedOverride(t *testing.T) {
 	require.NoErrorf(t, err, "git commit: %s", out)
 
 	require.Equal(t, "Appended", gitIn(t, dir, "log", "-1", "--format=%an"))
+}
+
+// TestCommandContextIsolatesAsCommandDoes holds CommandContext to Command's
+// side of the bargain: a context changes when the command is killed, not what
+// it is allowed to read.
+func TestCommandContextIsolatesAsCommandDoes(t *testing.T) {
+	t.Parallel()
+	requireGit(t)
+
+	cmd := gitenv.CommandContext(t.Context(), "git", "version")
+	require.NoError(t, cmd.Err)
+	require.Equal(t, gitenv.Env(), cmd.Env)
+
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git version: %s", out)
+}
+
+// TestCommandContextDoesNotStartOnADoneContext is the near half of binding the
+// command to a context: a context already over is a command that never runs.
+func TestCommandContextDoesNotStartOnADoneContext(t *testing.T) {
+	t.Parallel()
+	requireGit(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cmd := gitenv.CommandContext(ctx, "git", "version")
+	require.ErrorIs(t, cmd.Start(), context.Canceled)
+	require.Nil(t, cmd.Process)
+}
+
+// TestCommandContextKillsTheProcessWithTheContext is the far half, and what a
+// test injecting the harness's context gets out of it: a git still running
+// when the test ends is killed with the context rather than left behind.
+//
+// `git hash-object --stdin` reads until end of input, so with the pipe held
+// open the process is waiting on nothing else when the context ends.
+func TestCommandContextKillsTheProcessWithTheContext(t *testing.T) {
+	t.Parallel()
+	requireGit(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cmd := gitenv.CommandContext(ctx, "git", "hash-object", "--stdin")
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = stdin.Close() })
+	require.NoError(t, cmd.Start())
+
+	cancel()
+
+	// Waiting in the background, so that a command which is not bound to the
+	// context fails here rather than hanging the package until the test
+	// binary's own timeout.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		require.Error(t, err, "the context ending must end the command")
+	case <-time.After(30 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatal("the command outlived its context")
+	}
 }
 
 // TestEnvSetsWhatItPromises is the environment read directly, for the entries

--- a/plumbing/transport/git/git_test.go
+++ b/plumbing/transport/git/git_test.go
@@ -32,27 +32,34 @@ func freePort(t *testing.T) int {
 	return port
 }
 
+// daemonShutdown is how long the daemon is given to act on the interrupt
+// below before exec kills it instead. No test waits that delay out: nothing
+// calls Wait on the daemon, so it is spent in exec's own goroutine once the
+// test has already ended.
+const daemonShutdown = 5 * time.Second
+
 func startDaemon(t *testing.T, base string, port int) {
 	t.Helper()
-	daemon := gitenv.Command("git", "daemon",
+	// Bound to the test's own context, which the testing package cancels
+	// before the test's cleanups run, so the daemon ends with the test that
+	// started it rather than through a cleanup remembering to end it.
+	daemon := gitenv.CommandContext(t.Context(), "git", "daemon",
 		fmt.Sprintf("--base-path=%s", base),
 		"--export-all", "--enable=receive-pack", "--enable=upload-archive", "--reuseaddr",
 		fmt.Sprintf("--port=%d", port),
 		"--max-connections=1", "--listen=127.0.0.1",
 	)
+	// Interrupt in place of the Kill exec would use, which leaves the daemon's
+	// git-upload-pack and git-receive-pack children orphaned. WaitDelay bounds
+	// the gentler ending: a daemon that does not act on the interrupt — the
+	// signal is unsupported on Windows, and a shutdown can stall anywhere — is
+	// killed rather than left running, which sending the signal and returning
+	// had no answer for.
+	daemon.Cancel = func() error { return daemon.Process.Signal(os.Interrupt) }
+	daemon.WaitDelay = daemonShutdown
 	require.NoError(t, daemon.Start())
 
-	t.Cleanup(func() {
-		if daemon.Process != nil {
-			// Signal graceful shutdown; do not use Kill which leaves
-			// child processes (git-upload-pack, git-receive-pack) orphaned.
-			// Do not Wait — on Windows os.Interrupt is a no-op so Wait
-			// would block forever.
-			_ = daemon.Process.Signal(os.Interrupt)
-		}
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 	require.NoError(t, waitForPort(ctx, port))
 }

--- a/plumbing/transport/git/git_test.go
+++ b/plumbing/transport/git/git_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -33,10 +34,31 @@ func freePort(t *testing.T) int {
 }
 
 // daemonShutdown is how long the daemon is given to act on the interrupt
-// below before exec kills it instead. No test waits that delay out: nothing
-// calls Wait on the daemon, so it is spent in exec's own goroutine once the
-// test has already ended.
+// below before exec kills it instead, and so the longest a test can be held
+// at waitForShutdown. A daemon that stops when it is asked to, which is the
+// ordinary case, is not waited on for any of it.
 const daemonShutdown = 5 * time.Second
+
+// waitForShutdown reaps cmd once the test that started it ends.
+//
+// A command built by exec.CommandContext watches its context in a goroutine
+// of its own, and that goroutine hands its result to Wait. With no Wait to
+// receive it, the watcher blocks on the send for good (os/exec/exec.go, the
+// last line of watchCtx), and the process it killed is never collected: it
+// stays a zombie until the test binary exits, taking a goroutine with it.
+// Killing is not reaping, and WaitDelay does not stand in for a Wait.
+//
+// So Wait runs in the background from the moment the command starts, and the
+// cleanup joins it. Joining is what keeps the test binary alive long enough
+// for the escalation above to happen at all, and the wait is bounded by it:
+// WaitDelay is handed to Wait, which kills the process when it elapses.
+func waitForShutdown(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+
+	waited := make(chan error, 1)
+	go func() { waited <- cmd.Wait() }()
+	t.Cleanup(func() { <-waited })
+}
 
 func startDaemon(t *testing.T, base string, port int) {
 	t.Helper()
@@ -58,6 +80,7 @@ func startDaemon(t *testing.T, base string, port int) {
 	daemon.Cancel = func() error { return daemon.Process.Signal(os.Interrupt) }
 	daemon.WaitDelay = daemonShutdown
 	require.NoError(t, daemon.Start())
+	waitForShutdown(t, daemon)
 
 	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()


### PR DESCRIPTION
## Why

Follow-up to #2361. On darwin/arm64 with Apple Git 2.50.1, HOME isolation exposed failures in the git transport tests' existing one-second daemon readiness budget under concurrent-package testing.

Failure-only instrumentation (no changes to startup or stdio) captured `/usr/bin/git` with an `xcodebuild -license check` child while readiness timed out, before the actual Git daemon started. Invoking the same selected Xcode Git executable directly, retaining isolation and the deadline, passed 6/6 concurrent runs; restoring the launcher failed 2/3 runs. This localises the delay to Apple's launcher/license-check path. The exact HOME-dependent behaviour inside Apple's launcher remains unconfirmed.

## Change

- On Darwin only, when exec resolves the requested command to `/usr/bin/git`, resolve the actual Git executable with `/usr/bin/xcrun --find git` before applying the isolated environment.
- Keep other PATH-selected Git binaries and non-Git commands unchanged.
- Preserve HOME/config isolation, GIT_EXEC_PATH, and the readiness deadline.
- Bound resolution to 30 seconds and report failures through `exec.Cmd.Err`, rather than silently falling back to the launcher.
- Do not cache resolution, so changes to PATH and Xcode selection between tests remain effective.

Regression tests cover explicit and PATH-selected Apple Git, custom PATH-selected Git, GIT_EXEC_PATH preservation, missing executables, unrelated commands, and resolution failure. The resolution tests were observed failing before the implementation.

## Validation

- Fixed concurrent workload: **6/6 runs passed**:
  ```sh
  go test -count=1 ./ ./plumbing/transport/http/... ./plumbing/transport/ssh/... ./plumbing/transport/git/... ./tests/...
  ```
- `go test -race -short ./...` passed.
- `go test -race -count=1 ./internal/test/gitenv` passed.
- Targeted golangci-lint v2.11.4: zero issues.
- gitenv test binaries cross-compiled for Linux/amd64 and Windows/amd64; not executed on those systems.
- Full `go test -race ./...` passed gitenv and the daemon package but was not entirely green: the Git-ignore oracle mismatch also reproduces on the unmodified PR with this Apple Git version; a repository clone pack-checksum failure did not recur in five targeted race reruns.

## Draft review points

This deliberately resolves only the exact Apple launcher path, not arbitrary wrappers or symlinks. Resolution runs per command, outside isolated Git execution. Please review that trade-off and the macOS-specific handling before merging. No Linux runtime validation has been performed locally.

AI-assisted implementation, investigation, tests, and write-up using OpenAI ChatGPT.
