### PR TITLE
plumbing: transport/http, Fix response handling

### DIFF
--- a/internal/transport/v2.go
+++ b/internal/transport/v2.go
@@ -224,24 +224,9 @@ func FetchV2(ctx context.Context, st storage.Storer, req *FetchRequest, round Fe
 
 		if out.Packfile {
 			streamErr := streamPackfile(ctx, st, packReader, req.Progress, req.Filter)
-			// Skip draining/closing on cancellation: streamPackfile wraps
-			// packReader in a NewContextReader, whose background goroutine
-			// can still be blocked in the underlying Read after the
-			// <-ctx.Done() branch returns (see its doc comment). Closing
-			// here would race that goroutine's in-flight Read -- the same
-			// class of race fixed in plumbing/transport/http's Fetch/Push
-			// for the v0/v1 path. On a non-cancellation error or success,
-			// streamPackfile's last Read has already returned via the
-			// result channel and the goroutine is quiescent, so closing is
-			// safe and necessary. On cancellation, a packReader backed by
-			// a context-bound request (e.g. HTTP) gets torn down by that
-			// request's own context handling instead, so it is not leaked.
-			//
-			// Checked against streamErr itself, not ctx.Err(): ctx can be
-			// cancelled an instant after a successful/non-cancel return,
-			// and checking ctx.Err() at that point would skip the close
-			// for a read that was already fully quiescent.
-			if !errors.Is(streamErr, context.Canceled) && !errors.Is(streamErr, context.DeadlineExceeded) {
+			// streamPackfile wraps packReader in a NewContextReader, so
+			// whether this may be closed is that wrapper's question to answer.
+			if ioutil.ReadFinished(ctx, streamErr) {
 				closeReader(packReader)
 			}
 			if streamErr != nil {

--- a/plumbing/protocol/packp/fuzz_test.go
+++ b/plumbing/protocol/packp/fuzz_test.go
@@ -183,6 +183,60 @@ func FuzzLsRefsOutputDecode(f *testing.F) {
 	})
 }
 
+func FuzzInfoRefsDecode(f *testing.F) {
+	// Seeds are inline literals, like the rest of this file, so the OSS-Fuzz
+	// harness that lifts the Fuzz function out compiles them standalone.
+	f.Add([]byte("6ecf0ef2c2dffb796033e5a02219af86ec6584e5\trefs/heads/main\n"))
+	f.Add([]byte("6ecf0ef2c2dffb796033e5a02219af86ec6584e5\trefs/tags/v1^{}\n"))
+	// A SHA-256 sized hash, so the fuzzer can mutate either accepted length.
+	f.Add([]byte("6ecf0ef2c2dffb796033e5a02219af86ec6584e56ecf0ef2c2dffb796033e5a0\trefs/heads/main\n"))
+	// Short-but-valid hex: plumbing.FromHex pads it, so only the length check
+	// stands between this and a reference at a hash nobody sent.
+	f.Add([]byte("deadbeef\trefs/heads/main\n"))
+	// Markup whose indentation puts hex-looking text before a tab.
+	f.Add([]byte("<html>\n\tabcdef\tSign in\n</html>\n"))
+	f.Add([]byte("0000000000000000000000000000000000000000\trefs/heads/main\n"))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var refs InfoRefs
+		if err := refs.Decode(bytes.NewReader(data)); err != nil {
+			return
+		}
+
+		// Whatever is accepted must be built from bytes the server actually
+		// sent. A decoder that pads, truncates or otherwise invents a hash
+		// hands the caller a reference to an object the remote never named,
+		// which is indistinguishable downstream from a real one.
+		lower := bytes.ToLower(data)
+		for _, ref := range refs.References {
+			hash := ref.Hash().String()
+			if !bytes.Contains(lower, []byte(hash)) {
+				t.Fatalf("decoded hash %q is not present in the input", hash)
+			}
+			if ref.Name() == "" {
+				t.Fatal("decoded a reference with no name")
+			}
+		}
+
+		// And what is accepted must be re-readable: Encode is this package's
+		// own writer, so its output failing Decode would mean the two
+		// disagree about the format.
+		var out bytes.Buffer
+		if err := refs.Encode(&out); err != nil {
+			t.Fatalf("encoding decoded references failed: %v", err)
+		}
+		var round InfoRefs
+		if err := round.Decode(bytes.NewReader(out.Bytes())); err != nil {
+			t.Fatalf("re-decoding encoded references failed: %v", err)
+		}
+		if len(round.References) != len(refs.References) {
+			t.Fatalf("round trip changed the reference count: %d then %d",
+				len(refs.References), len(round.References))
+		}
+	})
+}
+
 func FuzzParseLsRefsLine(f *testing.F) {
 	const oid = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
 	f.Add(oid + " refs/heads/main")

--- a/plumbing/protocol/packp/inforefs.go
+++ b/plumbing/protocol/packp/inforefs.go
@@ -43,6 +43,11 @@ type InfoRefs struct {
 // short hex string rather than rejecting it, so "deadbeef" would otherwise
 // decode to a reference at a hash the server never sent.
 //
+// A line too long to scan — over bufio.MaxScanTokenSize — is malformed on the
+// same grounds: no advertisement holds one, and a page minified onto a single
+// line arrives this way. A failure to read the body is returned unchanged,
+// because what did arrive may have been a valid advertisement.
+//
 // A rejected advertisement leaves i as it was. The references ahead of the
 // offending line are not a shorter ref list; they are part of a body that
 // turned out not to be a ref list at all.
@@ -55,7 +60,9 @@ func (i *InfoRefs) Decode(r io.Reader) error {
 	var refs []*plumbing.Reference
 
 	s := bufio.NewScanner(r)
-	for line := 1; s.Scan(); line++ {
+	line := 0
+	for s.Scan() {
+		line++
 		text := s.Text()
 		if text == "" {
 			continue
@@ -82,6 +89,13 @@ func (i *InfoRefs) Decode(r io.Reader) error {
 	}
 
 	if err := s.Err(); err != nil {
+		// A line the scanner cannot hold fails as a malformed line, not as a
+		// scanner error the caller has no reason to match on. A read failure
+		// is returned unchanged.
+		if errors.Is(err, bufio.ErrTooLong) {
+			return fmt.Errorf("%w: line %d is longer than %d bytes",
+				ErrInvalidInfoRefs, line+1, bufio.MaxScanTokenSize)
+		}
 		return err
 	}
 

--- a/plumbing/protocol/packp/inforefs.go
+++ b/plumbing/protocol/packp/inforefs.go
@@ -2,12 +2,18 @@ package packp
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	format "github.com/go-git/go-git/v6/plumbing/format/config"
 )
+
+// ErrInvalidInfoRefs is returned when an info/refs advertisement holds a line
+// that is not an object ID, a tab and a reference name.
+var ErrInvalidInfoRefs = errors.New("invalid info/refs")
 
 // InfoRefs represents the information of the references advertised by an
 // HTTP dumb server.
@@ -19,22 +25,69 @@ type InfoRefs struct {
 }
 
 // Decode decodes an InfoRefs from reader.
+//
+// Every non-empty line must be an object ID in hexadecimal, a tab, and a
+// reference name, as git update-server-info writes it. A line that is not
+// fails the whole advertisement with ErrInvalidInfoRefs rather than being
+// skipped, which mirrors canonical git: parse_info_refs dies on the first line
+// whose hash field is not exactly the hash size in hex digits.
+//
+// Skipping is not a safe alternative here, because a body that is not an
+// info/refs at all decodes to something plausible. An HTML page yields no
+// references when it holds no tabs, and references named after fragments of
+// its own markup when it does — indented markup regularly puts hex-looking
+// text before a tab. Either way the caller cannot tell that apart from a
+// repository with nothing to advertise.
+//
+// The hash length is checked before parsing because plumbing.FromHex pads a
+// short hex string rather than rejecting it, so "deadbeef" would otherwise
+// decode to a reference at a hash the server never sent.
+//
+// A rejected advertisement leaves i as it was. The references ahead of the
+// offending line are not a shorter ref list; they are part of a body that
+// turned out not to be a ref list at all.
+//
+// Errors describe the offending line by position only. The bytes are supplied
+// by the server, and the caller is better placed to decide whether any of them
+// can be shown: the HTTP transport, for one, quotes a rejected body back only
+// when it is plain text.
 func (i *InfoRefs) Decode(r io.Reader) error {
+	var refs []*plumbing.Reference
+
 	s := bufio.NewScanner(r)
-	for s.Scan() {
-		parts := strings.SplitN(s.Text(), "\t", 2)
-		if len(parts) != 2 {
+	for line := 1; s.Scan(); line++ {
+		text := s.Text()
+		if text == "" {
 			continue
 		}
 
-		hash := plumbing.NewHash(parts[0])
-		refname := parts[1]
-		i.References = append(i.References, plumbing.NewHashReference(
-			plumbing.ReferenceName(refname), hash,
+		hash, name, ok := strings.Cut(text, "\t")
+		if !ok {
+			return fmt.Errorf("%w: line %d has no tab", ErrInvalidInfoRefs, line)
+		}
+		if len(hash) != format.SHA1HexSize && len(hash) != format.SHA256HexSize {
+			return fmt.Errorf("%w: line %d has a %d-digit hash", ErrInvalidInfoRefs, line, len(hash))
+		}
+		id, valid := plumbing.FromHex(hash)
+		if !valid {
+			return fmt.Errorf("%w: line %d has a non-hexadecimal hash", ErrInvalidInfoRefs, line)
+		}
+		if name == "" {
+			return fmt.Errorf("%w: line %d has no reference name", ErrInvalidInfoRefs, line)
+		}
+
+		refs = append(refs, plumbing.NewHashReference(
+			plumbing.ReferenceName(name), id,
 		))
 	}
 
-	return s.Err()
+	if err := s.Err(); err != nil {
+		return err
+	}
+
+	i.References = append(i.References, refs...)
+
+	return nil
 }
 
 // Encode encodes an InfoRefs to writer.

--- a/plumbing/protocol/packp/inforefs_test.go
+++ b/plumbing/protocol/packp/inforefs_test.go
@@ -1,0 +1,185 @@
+package packp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sha1Head   = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+	sha256Head = "6ecf0ef2c2dffb796033e5a02219af86ec6584e56ecf0ef2c2dffb796033e5a0"
+)
+
+func TestInfoRefsDecode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantRefs []string
+		wantErr  bool
+	}{
+		{
+			name:     "single sha1 reference",
+			input:    sha1Head + "\trefs/heads/master\n",
+			wantRefs: []string{"refs/heads/master"},
+		},
+		{
+			name:     "single sha256 reference",
+			input:    sha256Head + "\trefs/heads/master\n",
+			wantRefs: []string{"refs/heads/master"},
+		},
+		{
+			name: "several references",
+			input: sha1Head + "\trefs/heads/master\n" +
+				sha1Head + "\trefs/tags/v1\n",
+			wantRefs: []string{"refs/heads/master", "refs/tags/v1"},
+		},
+		{
+			name:     "peeled reference",
+			input:    sha1Head + "\trefs/tags/v1^{}\n",
+			wantRefs: []string{"refs/tags/v1^{}"},
+		},
+		{
+			// A repository with no references. git update-server-info writes a
+			// zero-byte file, and that must stay distinguishable from a body
+			// that is not an info/refs at all.
+			name:     "empty input",
+			input:    "",
+			wantRefs: nil,
+		},
+		{
+			name:     "trailing blank line",
+			input:    sha1Head + "\trefs/heads/master\n\n",
+			wantRefs: []string{"refs/heads/master"},
+		},
+		{
+			// plumbing.FromHex pads a short hex string rather than rejecting
+			// it, so the length is what disqualifies this, not the parse.
+			name:    "hash shorter than the hash size",
+			input:   "deadbeef\trefs/heads/master\n",
+			wantErr: true,
+		},
+		{
+			name:    "hash longer than the hash size",
+			input:   sha1Head + "ff\trefs/heads/master\n",
+			wantErr: true,
+		},
+		{
+			name:    "hash is not hexadecimal",
+			input:   strings.Repeat("z", 40) + "\trefs/heads/master\n",
+			wantErr: true,
+		},
+		{
+			name:    "odd number of hex digits",
+			input:   strings.Repeat("a", 41) + "\trefs/heads/master\n",
+			wantErr: true,
+		},
+		{
+			name:    "no tab",
+			input:   "<html><body>nope</body></html>\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty reference name",
+			input:   sha1Head + "\t\n",
+			wantErr: true,
+		},
+		{
+			// The case that motivated this: markup whose indentation happens to
+			// put valid-looking hex before a tab.
+			name:    "html with hex before a tab",
+			input:   "<html>\n\tabcdef\tSign in to continue\n</html>\n",
+			wantErr: true,
+		},
+		{
+			// A byte order mark ahead of an otherwise valid line.
+			name:    "byte order mark",
+			input:   "\ufeff" + sha1Head + "\trefs/heads/master\n",
+			wantErr: true,
+		},
+		{
+			// One malformed line fails the advertisement; the valid lines
+			// around it do not rescue it.
+			name:    "junk line before a valid one",
+			input:   "<!-- injected -->\n" + sha1Head + "\trefs/heads/master\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var refs InfoRefs
+			err := refs.Decode(strings.NewReader(tt.input))
+
+			if tt.wantErr {
+				require.ErrorIs(t, err, ErrInvalidInfoRefs)
+				return
+			}
+
+			require.NoError(t, err)
+			names := make([]string, 0, len(refs.References))
+			for _, ref := range refs.References {
+				names = append(names, ref.Name().String())
+			}
+			assert.Equal(t, tt.wantRefs, nilIfEmpty(names))
+		})
+	}
+}
+
+func nilIfEmpty(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}
+
+// TestInfoRefsDecodeErrorOmitsBody keeps server-controlled bytes out of the
+// error. The HTTP transport decides separately whether a response body is safe
+// to quote back, and an error carrying the line would bypass that.
+func TestInfoRefsDecodeErrorOmitsBody(t *testing.T) {
+	t.Parallel()
+
+	const secret = "private_token=SECRET"
+
+	var refs InfoRefs
+	err := refs.Decode(strings.NewReader("<html>" + secret + "</html>\n"))
+
+	require.ErrorIs(t, err, ErrInvalidInfoRefs)
+	assert.NotContains(t, err.Error(), secret)
+	assert.NotContains(t, err.Error(), "<html>")
+}
+
+// TestInfoRefsDecodeErrorKeepsNoReferences covers what a rejected body leaves
+// behind. The lines ahead of the offending one parse, and keeping them would
+// hand the caller a ref list assembled from a body that is not one.
+func TestInfoRefsDecodeErrorKeepsNoReferences(t *testing.T) {
+	t.Parallel()
+
+	var refs InfoRefs
+	err := refs.Decode(strings.NewReader(
+		sha1Head + "\trefs/heads/master\n<html>sign in to continue</html>\n",
+	))
+
+	require.ErrorIs(t, err, ErrInvalidInfoRefs)
+	assert.Empty(t, refs.References,
+		"a rejected advertisement must contribute no references")
+}
+
+func TestInfoRefsDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	in := sha1Head + "\trefs/heads/master\n" + sha1Head + "\trefs/tags/v1\n"
+
+	var refs InfoRefs
+	require.NoError(t, refs.Decode(strings.NewReader(in)))
+
+	var out strings.Builder
+	require.NoError(t, refs.Encode(&out))
+	assert.Equal(t, in, out.String())
+}

--- a/plumbing/protocol/packp/inforefs_test.go
+++ b/plumbing/protocol/packp/inforefs_test.go
@@ -1,8 +1,12 @@
 package packp
 
 import (
+	"bufio"
+	"errors"
+	"io"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -76,6 +80,14 @@ func TestInfoRefsDecode(t *testing.T) {
 		{
 			name:    "odd number of hex digits",
 			input:   strings.Repeat("a", 41) + "\trefs/heads/master\n",
+			wantErr: true,
+		},
+		{
+			// A page minified onto one line. bufio.Scanner gives up on a line
+			// this long, and that has to reach the caller as a malformed
+			// advertisement like any other.
+			name:    "line longer than the scanner can hold",
+			input:   "<html>" + strings.Repeat("x", bufio.MaxScanTokenSize) + "</html>\n",
 			wantErr: true,
 		},
 		{
@@ -182,4 +194,22 @@ func TestInfoRefsDecodeRoundTrip(t *testing.T) {
 	var out strings.Builder
 	require.NoError(t, refs.Encode(&out))
 	assert.Equal(t, in, out.String())
+}
+
+// TestInfoRefsDecodeReadError keeps a failed read apart from a malformed body.
+// The bytes that did arrive may well have been a valid advertisement, so the
+// read error is returned as itself.
+func TestInfoRefsDecodeReadError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("connection reset by peer")
+
+	var refs InfoRefs
+	err := refs.Decode(io.MultiReader(
+		strings.NewReader(sha1Head+"\trefs/heads/master\n"),
+		iotest.ErrReader(readErr),
+	))
+
+	require.ErrorIs(t, err, readErr)
+	assert.NotErrorIs(t, err, ErrInvalidInfoRefs)
 }

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -24,9 +24,10 @@ type Err struct {
 	// Status is the status code of the response.
 	Status int
 
-	// Reason is the response body, truncated to a bounded size and with every
-	// character that would not print as itself replaced by a space. Reading
-	// the field is as safe as reading the message.
+	// Reason is the message the server sent with the status, empty unless it
+	// arrived as text/plain. See checkError. It is truncated to a bounded size
+	// and has every character that would not print as itself replaced by a
+	// space, so reading the field is as safe as reading the message.
 	Reason string
 }
 
@@ -36,7 +37,11 @@ func (e *Err) StatusCode() int { return e.Status }
 func (e *Err) Error() string {
 	format := "unexpected requesting %q status code: %d"
 	if e.Reason != "" {
-		return fmt.Sprintf(format+": %s", redactedURL(e.URL), e.Status, e.Reason)
+		// Quoted, because the text is the server's, not this package's. git
+		// marks the same distinction by prefixing each line with "remote: ";
+		// an error has no such channel, and quoting also stops a multi-line
+		// message from forging records in a caller's log.
+		return fmt.Sprintf(format+": %q", redactedURL(e.URL), e.Status, e.Reason)
 	}
 	return fmt.Sprintf(format, redactedURL(e.URL), e.Status)
 }
@@ -99,23 +104,40 @@ func smartContentType(header, service string) bool {
 
 // checkError maps HTTP response status codes to typed transport errors.
 //
-// The body is consumed and closed: as much of it as maxErrorBodySize allows
-// becomes the error's Reason, the remainder is discarded, and the body is
-// closed. Discarding it keeps the connection: a 404 is ordinary control flow
+// The server's message is kept only when it arrives as text/plain, the rule
+// git applies in show_http_message. Anything else is markup meant for a
+// browser — an SSO interstitial, a CDN error page — and hosting providers send
+// the messages they do want a git client to show as text/plain because of that
+// rule. Canonical git's own http-backend sends no body at all here, writing
+// its reason to the server's stderr instead.
+//
+// The declared charset is ignored, where git reencodes to its log output
+// encoding. A library has no such setting, and its caller is free to reencode
+// what it is handed.
+//
+// git shows a message on the /info/refs GET alone, and discards an RPC
+// response body as soon as the status reaches 300. That asymmetry follows from
+// streaming the RPC body into the pack parser rather than from a decision to
+// hide it, so the rule is applied to every request here: a text/plain refusal
+// of a receive-pack POST is what a caller most needs to be told.
+//
+// The body is consumed and closed whichever it is: the message it yields is
+// capped at maxErrorBodySize, the rest is discarded, and then it is closed.
+// Discarding it is what keeps the connection — a 404 is ordinary control flow
 // for the dumb walk, which asks for every object as a loose file before
-// falling back to the packs, so dropping the connection of a failed request
-// would cost a handshake per object.
+// falling back to the packs, so a connection dropped here costs a handshake
+// per object.
 func checkError(r *http.Response) error {
 	if r.StatusCode >= http.StatusOK && r.StatusCode < http.StatusMultipleChoices {
 		return nil
 	}
 
 	var reason string
-	var messageBuffer bytes.Buffer
 	if r.Body != nil {
-		messageLength, _ := messageBuffer.ReadFrom(io.LimitReader(r.Body, maxErrorBodySize))
-		if messageLength > 0 {
-			reason = sanitizeReason(messageBuffer.String())
+		if contentMediaType(r.Header.Get("Content-Type")) == "text/plain" {
+			var message bytes.Buffer
+			_, _ = message.ReadFrom(io.LimitReader(r.Body, maxErrorBodySize))
+			reason = strings.TrimSpace(sanitizeReason(message.String()))
 		}
 		drainAndClose(r.Body)
 	}

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -57,13 +57,37 @@ const maxErrorBodySize = 8 << 10
 // A kilobyte is far past any real repository URL.
 const maxRedactedComponent = 1 << 10
 
-// maxDrainSize caps how much of an error response body is read and discarded
-// after the message has been taken. Closing a body with bytes unread discards
-// the connection instead of returning it to the pool, so a large error page
-// would cost a new connection on every attempt.
-const maxDrainSize = 1 << 20
+// maxDrainSize caps how much of a spent response body is discarded to keep its
+// connection reusable. Sized against what it buys: discarding the tail saves
+// one handshake, so spending more transfer than a handshake costs is a bad
+// trade. net/http draws the same line tighter still (maxBodySlurpSize, 2 KiB).
+const maxDrainSize = 64 << 10
+
+// drainAndClose releases a response body nobody will read again.
+//
+// What is left of it is discarded before the close, because net/http returns a
+// connection to the pool only once its body has reached EOF: closing with
+// bytes outstanding drops the connection instead. Those bytes are usually the
+// tail of a body that was read for something else — a message taken up to a
+// byte cap, a response a decoder left at its flush-pkt — and often just the
+// terminating chunk, for which the next request would pay a whole handshake.
+//
+// The discard stops at maxDrainSize, which bounds a server that keeps sending.
+// A server that stops sending without closing is bounded by the request's
+// context instead, since net/http ends the read when that context does.
+func drainAndClose(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, maxDrainSize))
+	_ = body.Close()
+}
 
 // checkError maps HTTP response status codes to typed transport errors.
+//
+// The body is consumed and closed: as much of it as maxErrorBodySize allows
+// becomes the error's Reason, the remainder is discarded, and the body is
+// closed. Discarding it keeps the connection: a 404 is ordinary control flow
+// for the dumb walk, which asks for every object as a loose file before
+// falling back to the packs, so dropping the connection of a failed request
+// would cost a handshake per object.
 func checkError(r *http.Response) error {
 	if r.StatusCode >= http.StatusOK && r.StatusCode < http.StatusMultipleChoices {
 		return nil
@@ -76,7 +100,7 @@ func checkError(r *http.Response) error {
 		if messageLength > 0 {
 			reason = sanitizeReason(messageBuffer.String())
 		}
-		_, _ = io.Copy(io.Discard, io.LimitReader(r.Body, maxDrainSize))
+		drainAndClose(r.Body)
 	}
 
 	err := &Err{
@@ -593,6 +617,10 @@ func redactClientError(err error) error {
 //
 // Every non-2xx status is turned into an error here, so a caller that saw a nil
 // error has a 2xx response and need not check the status again.
+//
+// A response is returned alongside that error, for what it says about the
+// request rather than for its body: checkError has taken what it needs of the
+// body and closed it. Closing it again is a no-op.
 func doRequest(client *http.Client, req *http.Request) (*http.Response, error) {
 	traceHTTP := trace.HTTP.Enabled()
 	if traceHTTP {

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -80,6 +80,23 @@ func drainAndClose(body io.ReadCloser) {
 	_ = body.Close()
 }
 
+// contentMediaType returns the media type of a Content-Type header, without
+// parameters and lower-cased, mirroring git's extract_content_type().
+//
+// Not mime.ParseMediaType: it reports ErrInvalidMediaParameter alongside a
+// usable media type, which would force a choice between rejecting a smart
+// server over a broken charset and ignoring parse errors wholesale.
+func contentMediaType(header string) string {
+	mediaType, _, _ := strings.Cut(header, ";")
+	return strings.ToLower(strings.TrimSpace(mediaType))
+}
+
+// smartContentType reports whether a response advertises the smart protocol
+// for service.
+func smartContentType(header, service string) bool {
+	return contentMediaType(header) == "application/x-"+service+"-advertisement"
+}
+
 // checkError maps HTTP response status codes to typed transport errors.
 //
 // The body is consumed and closed: as much of it as maxErrorBodySize allows

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -59,7 +60,12 @@ func TestCheckError(t *testing.T) {
 			err = checkError(&http.Response{
 				Request:    req,
 				StatusCode: tt.status,
-				Body:       io.NopCloser(strings.NewReader(tt.body)),
+				// The reason a status carries is the server's text, which
+				// reaches the error only as text/plain. Which media types
+				// qualify is TestCheckErrorMessageIsPlainTextOnly's subject;
+				// here every row states one so the mapping is what is tested.
+				Header: http.Header{"Content-Type": []string{"text/plain"}},
+				Body:   io.NopCloser(strings.NewReader(tt.body)),
 			})
 			require.Error(t, err)
 			if tt.wantIs != nil {
@@ -504,8 +510,11 @@ func TestCheckErrorStopsShortOfEOF(t *testing.T) {
 	require.NoError(t, err)
 	resp := &http.Response{
 		StatusCode: http.StatusInternalServerError,
-		Body:       body,
-		Request:    &http.Request{URL: u},
+		// Plain text, so the message is read at all: checkError does not
+		// touch a body it could not show.
+		Header:  http.Header{"Content-Type": []string{"text/plain"}},
+		Body:    body,
+		Request: &http.Request{URL: u},
 	}
 
 	err = checkError(resp)
@@ -1325,6 +1334,7 @@ func TestCheckErrorSanitizesTheReason(t *testing.T) {
 	gotErr := checkError(&http.Response{
 		Request:    req,
 		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{"Content-Type": []string{"text/plain"}},
 		Body:       io.NopCloser(strings.NewReader("boom\x1b[2J\rHACKED\nremote: forged")),
 	})
 	require.Error(t, gotErr)
@@ -1354,6 +1364,7 @@ func TestCheckErrorSanitizesARuneTheCapSplit(t *testing.T) {
 	gotErr := checkError(&http.Response{
 		Request:    req,
 		StatusCode: http.StatusInternalServerError,
+		Header:     http.Header{"Content-Type": []string{"text/plain"}},
 		Body:       io.NopCloser(strings.NewReader(body)),
 	})
 	require.Error(t, gotErr)
@@ -1364,6 +1375,7 @@ func TestCheckErrorSanitizesARuneTheCapSplit(t *testing.T) {
 	assert.True(t, utf8.ValidString(httpErr.Reason), "no partial rune survives")
 	assert.Equal(t, strings.Repeat("a", maxErrorBodySize-1)+string(utf8.RuneError), httpErr.Reason)
 }
+
 func TestSmartContentType(t *testing.T) {
 	t.Parallel()
 
@@ -1390,4 +1402,132 @@ func TestSmartContentType(t *testing.T) {
 			assert.Equal(t, tc.want, smartContentType(tc.header, "git-upload-pack"))
 		})
 	}
+}
+
+// TestCheckErrorMessageIsPlainTextOnly covers the rule git applies in
+// show_http_message: a server's message reaches the caller only as text/plain.
+// Anything else is markup meant for a browser, and an interstitial can echo
+// the request's own query back inside it.
+func TestCheckErrorMessageIsPlainTextOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		wantReason  string
+	}{
+		{
+			name:        "plain text",
+			contentType: "text/plain",
+			body:        "repository is archived",
+			wantReason:  "repository is archived",
+		},
+		{
+			// A charset does not change the media type.
+			name:        "plain text with parameters",
+			contentType: "text/plain; charset=utf-8",
+			body:        "pay up",
+			wantReason:  "pay up",
+		},
+		{
+			name:        "upper case media type",
+			contentType: "TEXT/PLAIN",
+			body:        "pay up",
+			wantReason:  "pay up",
+		},
+		{
+			// show_http_message trims before printing, so a message that is
+			// only whitespace is no message at all.
+			name:        "surrounding whitespace",
+			contentType: "text/plain",
+			body:        "\n  push declined: the branch is protected  \n",
+			wantReason:  "push declined: the branch is protected",
+		},
+		{
+			name:        "whitespace only",
+			contentType: "text/plain",
+			body:        "\n \n",
+		},
+		{
+			name:        "markup",
+			contentType: "text/html; charset=utf-8",
+			body:        "<html><body>Sign in to continue</body></html>",
+		},
+		{
+			name:        "json",
+			contentType: "application/json",
+			body:        `{"message":"rate limit exceeded"}`,
+		},
+		{
+			// git's http-backend sends its 403 and 404 without a body, and a
+			// proxy answering for it may send one without saying what it is.
+			name: "no content type",
+			body: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse("https://example.com/repo.git")
+			require.NoError(t, err)
+			resp := &http.Response{
+				StatusCode: http.StatusForbidden,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+				Request:    &http.Request{URL: u},
+			}
+			if tt.contentType != "" {
+				resp.Header.Set("Content-Type", tt.contentType)
+			}
+
+			err = checkError(resp)
+			require.Error(t, err)
+
+			var httpErr *Err
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, tt.wantReason, httpErr.Reason)
+
+			if tt.wantReason == "" {
+				if trimmed := strings.TrimSpace(tt.body); trimmed != "" {
+					assert.NotContains(t, err.Error(), trimmed,
+						"a message that cannot be shown must not reach the error")
+				}
+				return
+			}
+			// Quoted, so a multi-line message cannot forge a record in a
+			// caller's log.
+			assert.Contains(t, err.Error(), strconv.Quote(tt.wantReason))
+		})
+	}
+}
+
+// TestCheckErrorDiscardsUnshowableBody pairs with the bound on a message that
+// can be shown: one that cannot reaches the error nowhere, and is discarded
+// like any other spent body so that its connection survives.
+func TestCheckErrorDiscardsUnshowableBody(t *testing.T) {
+	t.Parallel()
+
+	body := &countingBody{remaining: bodySize}
+	u, err := url.Parse("https://example.com/repo.git")
+	require.NoError(t, err)
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       body,
+		Request:    &http.Request{URL: u},
+	}
+
+	err = checkError(resp)
+	require.Error(t, err)
+
+	var httpErr *Err
+	require.ErrorAs(t, err, &httpErr)
+	assert.Empty(t, httpErr.Reason, "a body that cannot be shown reaches no error")
+
+	assert.Less(t, body.read, bodySize, "the discard must not read to EOF")
+	assert.LessOrEqual(t, body.read, 1<<20, "the discard must stay within a sane bound")
+	assert.True(t, body.closed, "the body must be closed")
 }

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -1,13 +1,16 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"unicode/utf8"
 
@@ -459,6 +462,216 @@ func TestEffectivePort(t *testing.T) {
 	}
 }
 
+// countingBody is a finite response body that records how much was read and
+// whether it was closed. It is finite on purpose: an endless body would make
+// an unbounded read hang instead of fail, and a hanging test reports nothing.
+type countingBody struct {
+	remaining int
+	read      int
+	closed    bool
+}
+
+func (b *countingBody) Read(p []byte) (int, error) {
+	if b.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := min(len(p), b.remaining)
+	for i := range p[:n] {
+		p[i] = 'x'
+	}
+	b.remaining -= n
+	b.read += n
+	return n, nil
+}
+
+func (b *countingBody) Close() error {
+	b.closed = true
+	return nil
+}
+
+// bodySize is the fixture body for the bound tests: far larger than any cap
+// the package sets, so a test that stops short of it proves a bound exists.
+// Deliberately not written in terms of maxDrainSize or maxErrorBodySize —
+// asserting against the same constant the code reads is true for any value,
+// including a cap raised to gigabytes.
+const bodySize = 4 << 20
+
+func TestCheckErrorStopsShortOfEOF(t *testing.T) {
+	t.Parallel()
+
+	body := &countingBody{remaining: bodySize}
+	u, err := url.Parse("https://example.com/repo.git")
+	require.NoError(t, err)
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       body,
+		Request:    &http.Request{URL: u},
+	}
+
+	err = checkError(resp)
+	require.Error(t, err)
+
+	assert.Less(t, body.read, bodySize,
+		"checkError must not read a server-controlled body to EOF")
+	assert.LessOrEqual(t, body.read, 1<<20,
+		"the message and the discard after it must stay within a sane bound")
+
+	// Reading only the message and not closing would hold the connection for
+	// the life of the process: nobody reads this body again.
+	assert.True(t, body.closed, "the body must be closed")
+
+	var e *Err
+	require.ErrorAs(t, err, &e)
+	assert.LessOrEqual(t, len(e.Reason), 64<<10,
+		"the retained message must be bounded")
+}
+
+// TestDoRequestErrorReleasesBody covers the path a real caller takes. On an
+// unsuccessful status checkError takes its message and closes the body, so the
+// response doRequest hands back with its error has nothing left to read: it is
+// there for the request it names, not for its body.
+func TestDoRequestErrorReleasesBody(t *testing.T) {
+	t.Parallel()
+
+	var released atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusInternalServerError)
+		// Far larger than any cap the package sets, so the read cannot reach
+		// EOF and the close has to do the releasing.
+		chunk := bytes.Repeat([]byte("x"), 64<<10)
+		for written := 0; written < bodySize; written += len(chunk) {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &closeTrackingRoundTripper{base: client.Transport, closed: &released}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := doRequest(client, req)
+	require.Error(t, err, "a 500 must surface as an error")
+	require.NotNil(t, resp, "the request the response names is what a caller reads next")
+
+	assert.Equal(t, int64(1), released.Load(),
+		"doRequest's error path must leave the body closed")
+
+	n, readErr := resp.Body.Read(make([]byte, 1))
+	assert.Zero(t, n, "a spent body has nothing left to hand back")
+	assert.Error(t, readErr, "reading a closed body must fail")
+}
+
+// closeTrackingRoundTripper counts closes of the response bodies it hands out.
+type closeTrackingRoundTripper struct {
+	base   http.RoundTripper
+	closed *atomic.Int64
+}
+
+func (rt *closeTrackingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &closeTrackingBody{ReadCloser: resp.Body, closed: rt.closed}
+	return resp, nil
+}
+
+type closeTrackingBody struct {
+	io.ReadCloser
+	closed *atomic.Int64
+}
+
+func (b *closeTrackingBody) Close() error {
+	b.closed.Add(1)
+	return b.ReadCloser.Close()
+}
+
+// connCountingServer counts the connections opened to it. Reuse is only
+// visible from the server's side: a client that drops a connection and dials
+// another one looks the same to its caller either way.
+func connCountingServer(t *testing.T, h http.HandlerFunc) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+
+	var conns atomic.Int64
+	srv := httptest.NewUnstartedServer(h)
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			conns.Add(1)
+		}
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+
+	return srv, &conns
+}
+
+// TestErrorResponseKeepsConnection covers the discard checkError owes the
+// request that follows a failed one. A body left with bytes outstanding takes
+// its connection with it, and a failed request is not the end of a session:
+// the dumb walk answers a miss with a 404 and asks for the next object over
+// the same connection.
+func TestErrorResponseKeepsConnection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contentType string
+		size        int
+	}{
+		{
+			// Longer than the message cap, so the read for Reason cannot
+			// reach the end of the body on its own.
+			name:        "plain text past the message cap",
+			contentType: "text/plain",
+			size:        32 << 10,
+		},
+		{
+			// Markup is never kept, so nothing reads this body at all.
+			name:        "markup of any size",
+			contentType: "text/html",
+			size:        500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv, conns := connCountingServer(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				// Chunked, as a server streaming an error page sends it. A
+				// Content-Length would let net/http find the end of the body
+				// without being asked, and the discard would not be what
+				// keeps the connection.
+				w.Header().Set("Transfer-Encoding", "chunked")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write(bytes.Repeat([]byte("x"), tt.size))
+			})
+
+			const requests = 10
+			client := srv.Client()
+			for range requests {
+				req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+				require.NoError(t, err)
+
+				resp, err := doRequest(client, req)
+				require.ErrorIs(t, err, transport.ErrRepositoryNotFound)
+				if resp != nil {
+					_ = resp.Body.Close()
+				}
+			}
+
+			assert.Equal(t, int64(1), conns.Load(),
+				"%d failed requests must share one connection", requests)
+		})
+	}
+}
+
 func TestCheckErrorBoundsBodyRead(t *testing.T) {
 	t.Parallel()
 
@@ -481,9 +694,9 @@ func TestCheckErrorBoundsBodyRead(t *testing.T) {
 }
 
 // A capped message read leaves the rest of the body unread, and closing an
-// unread body discards the connection instead of pooling it. The body must be
-// larger than the message cap or the drain has nothing to do and this test
-// cannot fail.
+// unread body discards the connection instead of pooling it, so checkError
+// discards what is left before it closes. The body must be larger than the
+// message cap or the discard has nothing to do and this test cannot fail.
 func TestCheckErrorDrainsPastTheMessageCap(t *testing.T) {
 	t.Parallel()
 
@@ -501,8 +714,11 @@ func TestCheckErrorDrainsPastTheMessageCap(t *testing.T) {
 	require.Error(t, checkError(resp))
 
 	n, readErr := resp.Body.Read(make([]byte, 1))
-	assert.Zero(t, n, "checkError must leave the body fully consumed")
-	assert.ErrorIs(t, readErr, io.EOF)
+	assert.Zero(t, n, "checkError must leave nothing of the body to read")
+	// net/http keeps the error for a read after close unexported, so its
+	// message is what there is to match.
+	assert.ErrorContains(t, readErr, "closed response body",
+		"the discard is followed by the close")
 }
 
 func TestBasicAuthNilUserinfoYieldsNoAuthorizer(t *testing.T) {

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -1364,3 +1364,30 @@ func TestCheckErrorSanitizesARuneTheCapSplit(t *testing.T) {
 	assert.True(t, utf8.ValidString(httpErr.Reason), "no partial rune survives")
 	assert.Equal(t, strings.Repeat("a", maxErrorBodySize-1)+string(utf8.RuneError), httpErr.Reason)
 }
+func TestSmartContentType(t *testing.T) {
+	t.Parallel()
+
+	// Git compares a parameter-stripped, lower-cased media type
+	// (http.c extract_content_type), so all of these are the smart protocol.
+	for _, tc := range []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"exact", "application/x-git-upload-pack-advertisement", true},
+		{"charset parameter", "application/x-git-upload-pack-advertisement; charset=utf-8", true},
+		{"upper case", "APPLICATION/X-GIT-UPLOAD-PACK-ADVERTISEMENT", true},
+		{"spaced parameter", "application/x-git-upload-pack-advertisement ; charset=utf-8", true},
+		{"malformed parameter", "application/x-git-upload-pack-advertisement; charset", true},
+		{"dumb text", "text/plain", false},
+		{"html", "text/html; charset=utf-8", false},
+		{"wrong service", "application/x-git-receive-pack-advertisement", false},
+		{"result not advertisement", "application/x-git-upload-pack-result", false},
+		{"empty", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, smartContentType(tc.header, "git-upload-pack"))
+		})
+	}
+}

--- a/plumbing/transport/http/dumb.go
+++ b/plumbing/transport/http/dumb.go
@@ -134,7 +134,8 @@ func (r *fetchWalker) downloadFile(fp string) (rErr error) {
 
 	f, err := r.fs.TempFile(filepath.Dir(fp), filepath.Base(fp)+".temp")
 	if err != nil {
-		_, _ = io.Copy(io.Discard, res.Body)
+		// The body is an object or pack, so there is nothing to gain from
+		// draining a file this walk has given up on writing.
 		_ = res.Body.Close()
 		return err
 	}
@@ -145,6 +146,9 @@ func (r *fetchWalker) downloadFile(fp string) (rErr error) {
 	}()
 
 	if _, err := ioutil.CopyBufferPool(f, res.Body); err != nil {
+		// As above: an object or a pack, so a walk that has given up on
+		// writing it gains nothing from draining what is left.
+		_ = res.Body.Close()
 		return err
 	}
 	if err := res.Body.Close(); err != nil {

--- a/plumbing/transport/http/dumb_test.go
+++ b/plumbing/transport/http/dumb_test.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/go-git/go-billy/v6/memfs"
 	fixtures "github.com/go-git/go-git-fixtures/v6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -153,4 +156,44 @@ func TestDumbObjectGetCarriesTheSessionCredential(t *testing.T) {
 	require.NotNil(t, objectGet, "the object GET must have reached the server")
 	assert.Equal(t, "Basic dTpw", objectGet.Header.Get("Authorization"),
 		"an object GET must carry the credential the discovery request carried")
+}
+
+// TestDownloadFileReleasesATruncatedBody covers the copy's own error path. The
+// walk asks for every object as a file of its own, so a body left open there
+// holds a connection per object.
+func TestDownloadFileReleasesATruncatedBody(t *testing.T) {
+	t.Parallel()
+
+	// Written raw, because the body has to be shorter than the Content-Length
+	// it announces: net/http's own server will not send a response it knows is
+	// short, and a copy that reaches the end of a body does not fail.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		conn, buf, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 4096\r\n\r\nshort")
+		_ = buf.Flush()
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	var closed atomic.Int64
+	w := &fetchWalker{
+		ctx: context.Background(),
+		client: &http.Client{Transport: &closeTrackingRoundTripper{
+			base:   srv.Client().Transport,
+			closed: &closed,
+		}},
+		baseURL: u,
+		fs:      memfs.New(),
+	}
+
+	err = w.downloadFile("objects/ab/cdef")
+	require.Error(t, err, "a body shorter than its Content-Length must fail the copy")
+	assert.Equal(t, int64(1), closed.Load(),
+		"the copy's error path must close the response body")
 }

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -653,7 +653,7 @@ func (s *dumbPackSession) Fetch(ctx context.Context, st storage.Storer, req *tra
 }
 
 func (s *dumbPackSession) Push(_ context.Context, _ storage.Storer, _ *transport.PushRequest) error {
-	return fmt.Errorf("dumb HTTP does not support push")
+	return fmt.Errorf("dumb HTTP does not support push: %w", transport.ErrCommandUnsupported)
 }
 
 func (s *dumbPackSession) Close() error { return nil }

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -226,8 +226,7 @@ func finishHandshake(resp *http.Response, base sessionBase, d discovery) (transp
 		return handshakeDumb(resp, base)
 	}
 
-	expected := fmt.Sprintf("application/x-%s-advertisement", d.service)
-	if resp.Header.Get("Content-Type") == expected {
+	if smartContentType(resp.Header.Get("Content-Type"), d.service) {
 		return handshakeSmart(resp, base, d)
 	}
 	return handshakeDumb(resp, base)

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -382,12 +382,15 @@ func (s *smartPackSession) Command(ctx context.Context, cmd string, req packp.Co
 	if err := cr.Encode(r); err != nil {
 		return err
 	}
-	// Command never streams the body out, so drain and close on every path; a
-	// bare return on a decode error would leak the body and its connection.
+	// Command consumes the whole response (it never streams the body out), so
+	// release it on every path. A bare return on a decode error would otherwise
+	// leak the response body and its connection. Releasing it includes the
+	// discard: a decoder stops at the response's flush-pkt, and the request
+	// that reuses the connection — the fetch POST after an ls-refs — follows
+	// immediately.
 	defer func() {
 		if r.resp != nil {
-			_, _ = io.Copy(io.Discard, r.resp.Body)
-			_ = r.resp.Body.Close()
+			drainAndClose(r.resp.Body)
 		}
 	}()
 	if resp != nil {
@@ -600,8 +603,9 @@ type httpNegotiator struct {
 
 func (n *httpNegotiator) Write(p []byte) (int, error) {
 	if n.current != nil && n.current.resp != nil {
-		_, _ = io.Copy(io.Discard, n.current.resp.Body)
-		_ = n.current.resp.Body.Close()
+		// The previous round is complete, and this round is the request that
+		// reuses its connection.
+		drainAndClose(n.current.resp.Body)
 		n.current = nil
 	}
 	if n.current == nil {

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	internal "github.com/go-git/go-git/v6/internal/transport"
 	"github.com/go-git/go-git/v6/plumbing/format/pktline"
@@ -303,13 +304,55 @@ func handshakeSmart(resp *http.Response, base sessionBase, d discovery) (transpo
 	}, nil
 }
 
+// maxQuotedBodySize caps how much of a rejected /info/refs body is quoted back
+// in the error. Enough to recognise what the server sent, not enough to paste
+// a page into a log line, and no larger than a bufio.Reader's buffer, since
+// that is what bounds the Peek this size is asked of.
+const maxQuotedBodySize = 256
+
+// describeInfoRefsError turns a decode failure into one a caller can act on.
+//
+// packp reports which line was malformed and nothing about its contents,
+// because the bytes belong to the server. What the transport knows, and packp
+// does not, is which URL was fetched and what the server said it was serving —
+// the difference between "invalid info/refs" and "that host answered your
+// clone with an HTML sign-in page".
+//
+// The body is quoted only when it is plain text, matching git's
+// show_http_message: other types are markup meant for a browser, and an
+// interstitial can echo the request's own query back inside it.
+func describeInfoRefsError(err error, resp *http.Response, base sessionBase, head []byte) error {
+	// Name the URL actually fetched, which carries the /info/refs tail and the
+	// service query the session's base does not.
+	fetched := base.baseURL
+	if resp.Request != nil && resp.Request.URL != nil {
+		fetched = resp.Request.URL
+	}
+
+	mediaType := contentMediaType(resp.Header.Get("Content-Type"))
+	if mediaType == "text/plain" {
+		return fmt.Errorf("%w: %s served content type %q: %w: %q",
+			transport.ErrInvalidResponse, redactedURL(fetched), mediaType, err,
+			strings.TrimSpace(sanitizeReason(string(head))))
+	}
+	return fmt.Errorf("%w: %s served content type %q: %w",
+		transport.ErrInvalidResponse, redactedURL(fetched), mediaType, err)
+}
+
 func handshakeDumb(resp *http.Response, base sessionBase) (transport.Session, error) {
 	defer resp.Body.Close() //nolint:errcheck
+
+	// Buffer the head of the body so a rejection can quote it. Peek leaves it
+	// in place for the decode, and returns what it has on a shorter body. The
+	// reader keeps bufio's own buffer size, which is what bounds a Peek; how
+	// much of a body is worth quoting is a separate question from how much of
+	// it is worth buffering.
 	rd := bufio.NewReader(resp.Body)
+	head, _ := rd.Peek(maxQuotedBodySize)
 
 	var infoRefs packp.InfoRefs
 	if err := infoRefs.Decode(rd); err != nil {
-		return nil, err
+		return nil, describeInfoRefsError(err, resp, base, head)
 	}
 
 	ar := &packp.AdvRefs{}

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	transport "github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/go-git/go-git/v6/storage"
+	"github.com/go-git/go-git/v6/utils/ioutil"
 )
 
 // wrapDropped annotates err with the origin crossing that withheld credentials,
@@ -410,8 +411,9 @@ func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *tr
 
 	shallows, err := transport.NegotiatePack(ctx, st, s.caps, true, neg, neg, req)
 	if err != nil {
-		// Don't close the response body here — context-wrapper goroutines
-		// inside NegotiatePack may still be reading from it.
+		if ioutil.ReadFinished(ctx, err) {
+			neg.closeResponse()
+		}
 		return err
 	}
 	if neg.current == nil || neg.current.resp == nil {
@@ -421,17 +423,7 @@ func (s *smartPackSession) Fetch(ctx context.Context, st storage.Storer, req *tr
 		}
 	}
 	err = transport.FetchPack(ctx, st, s.caps, io.NopCloser(neg), shallows, req)
-	// Close the response unless the read itself was a cancellation. Only then is
-	// there a race: a ctxReader goroutine inside FetchPack can still be blocked
-	// in the underlying Read after the <-ctx.Done() branch, and the request
-	// context is what unblocks it, so nothing leaks. Otherwise FetchPack's last
-	// Read returned through the result channel, its goroutine is quiescent, and
-	// closing is both safe and necessary.
-	//
-	// Classified against err with errors.Is, never a fresh ctx.Err(): ctx can
-	// turn Err() non-nil an instant after FetchPack returned quiescent, and
-	// re-checking there would skip the close and leak the response.
-	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+	if ioutil.ReadFinished(ctx, err) {
 		neg.closeResponse()
 	}
 	return err
@@ -484,13 +476,7 @@ func (s *smartPackSession) fetchV2(ctx context.Context, st storage.Storer, req *
 func (s *smartPackSession) Push(ctx context.Context, st storage.Storer, req *transport.PushRequest) error {
 	rwc := &httpRequester{session: s, ctx: ctx}
 	err := transport.SendPack(ctx, st, s.caps, rwc, io.NopCloser(rwc), req)
-	// Close the response unless the read itself was a cancellation: a ctxReader
-	// goroutine inside SendPack can still be blocked in the underlying Read
-	// after the <-ctx.Done() branch, and closing here would race it — the request
-	// context tears the connection down instead. Otherwise SendPack's last Read
-	// returned through the result channel and closing is both safe and necessary
-	// (mirrors Fetch and internal.FetchV2's round loop).
-	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && rwc.resp != nil {
+	if ioutil.ReadFinished(ctx, err) && rwc.resp != nil {
 		_ = rwc.resp.Body.Close()
 	}
 	return err
@@ -628,8 +614,13 @@ func (n *httpNegotiator) Close() error {
 	return n.current.Close()
 }
 
-// closeResponse closes the current HTTP response body.
-// The caller (FetchPack) is expected to have already drained the body.
+// closeResponse closes the current round's response body, without discarding
+// what is left of it: Fetch calls this when it is finished with the negotiator
+// altogether, so no request follows that the connection could serve.
+//
+// Whether the body was read to its end is the caller's affair. So is whether
+// closing is safe at all — ioutil.ReadFinished answers that, and a caller that
+// does not ask races the context reader wrapped around this body.
 func (n *httpNegotiator) closeResponse() {
 	if n.current != nil && n.current.resp != nil {
 		_ = n.current.resp.Body.Close()

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -234,7 +234,11 @@ func finishHandshake(resp *http.Response, base sessionBase, d discovery) (transp
 }
 
 func handshakeSmart(resp *http.Response, base sessionBase, d discovery) (transport.Session, error) {
-	defer resp.Body.Close() //nolint:errcheck
+	// The advertisement ends at a flush-pkt, which leaves the rest of the body
+	// — the terminating chunk, on a chunked response — outstanding. The POST
+	// that opens the session follows immediately, so the discard is what
+	// decides whether it reuses this connection.
+	defer drainAndClose(resp.Body)
 	rd := bufio.NewReader(resp.Body)
 
 	_, prefix, err := pktline.PeekLine(rd)

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/protocol/capability"
 	"github.com/go-git/go-git/v6/plumbing/protocol/packp"
 	"github.com/go-git/go-git/v6/plumbing/storer"
@@ -211,6 +213,32 @@ func TestHTTPNegotiatorCloseResponse(t *testing.T) {
 
 	// closeResponse on an already-cleaned negotiator is safe.
 	assert.NotPanics(t, func() { neg.closeResponse() })
+}
+
+// TestNegotiatorReleasesPreviousRound covers the one discard in the package:
+// the body of a finished round is dropped so the next round reuses its
+// connection, but only up to a bound, because a stalled server must not hold
+// the next round up.
+func TestNegotiatorReleasesPreviousRound(t *testing.T) {
+	t.Parallel()
+
+	spent := &countingBody{remaining: bodySize}
+	neg := &httpNegotiator{
+		session: &smartPackSession{
+			sessionBase: sessionBase{service: transport.UploadPackService},
+		},
+		ctx:     context.Background(),
+		current: &httpRequester{resp: &http.Response{Body: spent}},
+	}
+
+	// Starting the next round is what releases the previous one.
+	_, err := neg.Write([]byte("0000"))
+	require.NoError(t, err)
+
+	assert.True(t, spent.closed, "the finished round's body must be closed")
+	assert.Positive(t, spent.read, "some of it must be discarded so the connection is reusable")
+	assert.Less(t, spent.read, bodySize, "the discard must not read to EOF")
+	assert.LessOrEqual(t, spent.read, 1<<20, "the discard must stay within a sane bound")
 }
 
 // TestHTTPNegotiatorNoRounds verifies that closeResponse is safe when
@@ -625,4 +653,67 @@ func TestHandshakeClosesBodyOnErrorStatus(t *testing.T) {
 	for i, b := range bodies {
 		assert.True(t, b.closed.Load(), "response body %d was not closed", i)
 	}
+}
+
+// decoderFunc adapts a function to packp.Decoder, so a test can observe when
+// a command's decode returns.
+type decoderFunc func(io.Reader) error
+
+func (f decoderFunc) Decode(r io.Reader) error { return f(r) }
+
+// TestCommandKeepsConnection covers the discard a v2 command owes the request
+// that follows it. The decoder stops at the response's flush-pkt, so the
+// terminating chunk is still outstanding when the command is done, and closing
+// there costs the fetch POST after an ls-refs a connection of its own.
+func TestCommandKeepsConnection(t *testing.T) {
+	t.Parallel()
+
+	const ref = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/master\n"
+	body := fmt.Sprintf("%04x%s0000", len(ref)+4, ref)
+
+	// Sent after the client has decoded the flush-pkt. Written in the same
+	// flush as the refs, the terminating chunk is already buffered when the
+	// decoder takes the last packet, and net/http's chunked reader consumes
+	// it without being asked — which a server on a real network does not
+	// oblige.
+	decoded := make(chan struct{}, 1)
+	srv, conns := connCountingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+		w.Header().Set("Transfer-Encoding", "chunked")
+		_, _ = io.WriteString(w, body)
+		w.(http.Flusher).Flush()
+		select {
+		case <-decoded:
+		case <-time.After(10 * time.Second):
+			t.Error("the command never decoded the response")
+		}
+	})
+
+	base, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	session := &smartPackSession{
+		sessionBase: sessionBase{
+			client:  srv.Client(),
+			baseURL: base,
+			service: transport.UploadPackService,
+		},
+		version: protocol.V2,
+	}
+
+	const commands = 10
+	for range commands {
+		out := &packp.LsRefsOutput{}
+		err := session.Command(context.Background(), "ls-refs", &packp.LsRefsArgs{},
+			decoderFunc(func(rd io.Reader) error {
+				err := out.Decode(rd)
+				decoded <- struct{}{}
+				return err
+			}))
+		require.NoError(t, err)
+		require.Len(t, out.References, 1)
+	}
+
+	assert.Equal(t, int64(1), conns.Load(),
+		"%d commands on one session must share one connection", commands)
 }

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -717,3 +717,43 @@ func TestCommandKeepsConnection(t *testing.T) {
 	assert.Equal(t, int64(1), conns.Load(),
 		"%d commands on one session must share one connection", commands)
 }
+
+func TestFetchClosesResponseOnNegotiationError(t *testing.T) {
+	t.Parallel()
+
+	var posts atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		posts.Add(1)
+		_, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+		// Not a pktline stream, so negotiation fails without cancellation.
+		_, _ = w.Write([]byte("this is not a pktline stream"))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	var closed atomic.Int64
+	rt := &closeTrackingRoundTripper{base: srv.Client().Transport, closed: &closed}
+	session := &smartPackSession{
+		sessionBase: sessionBase{
+			client:  &http.Client{Transport: rt},
+			baseURL: u,
+			service: transport.UploadPackService,
+		},
+	}
+
+	err = session.Fetch(context.Background(), memory.NewStorage(), &transport.FetchRequest{
+		Wants: []plumbing.Hash{plumbing.NewHash("0000000000000000000000000000000000000001")},
+	})
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, context.Canceled)
+	// Guard the premise: if negotiation failed before the POST was sent there
+	// would be no response to close and the assertion below would pass for the
+	// wrong reason.
+	require.Positive(t, posts.Load(), "the test must actually reach a POST")
+	assert.Equal(t, int64(1), closed.Load(),
+		"a non-cancellation negotiation error must close the response body")
+}

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -813,6 +813,15 @@ func TestHandshakeDumbInfoRefs(t *testing.T) {
 			wantNotMsg:  []string{"Sign in to continue"},
 		},
 		{
+			// A page minified onto one line, longer than the ref list decoder
+			// can hold. It has to reach the caller as a rejection like any
+			// other, not as the decoder's own scanner error.
+			name:        "single line longer than the decoder can hold",
+			contentType: "text/html",
+			body:        "<html>" + strings.Repeat("x", 64<<10) + "</html>",
+			wantInMsg:   []string{"text/html"},
+		},
+		{
 			name:        "markup without tabs",
 			contentType: "text/html",
 			body:        "<html><body>nope</body></html>",

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -643,7 +643,7 @@ func TestCommandKeepsConnection(t *testing.T) {
 	t.Parallel()
 
 	const ref = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5 refs/heads/master\n"
-	body := fmt.Sprintf("%04x%s0000", len(ref)+4, ref)
+	body := pktLine(ref) + "0000"
 
 	// Sent after the client has decoded the flush-pkt. Written in the same
 	// flush as the refs, the terminating chunk is already buffered when the
@@ -907,4 +907,101 @@ func TestHandshakeDumbInfoRefs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// pktLine frames s as a pkt-line.
+func pktLine(s string) string { return fmt.Sprintf("%04x%s", len(s)+4, s) }
+
+// releasingRoundTripper signals once a response body has yielded n bytes, so a
+// handler can hold back what follows them until the client has read that far.
+type releasingRoundTripper struct {
+	base    http.RoundTripper
+	after   int
+	release chan<- struct{}
+}
+
+func (rt *releasingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.base.RoundTrip(req)
+	if err != nil || req.Method != http.MethodGet {
+		return resp, err
+	}
+	resp.Body = &releasingBody{ReadCloser: resp.Body, left: rt.after, release: rt.release}
+	return resp, nil
+}
+
+type releasingBody struct {
+	io.ReadCloser
+	left    int
+	release chan<- struct{}
+	once    sync.Once
+}
+
+func (b *releasingBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if b.left -= n; b.left <= 0 {
+		b.once.Do(func() { b.release <- struct{}{} })
+	}
+	return n, err
+}
+
+// TestHandshakeSmartKeepsConnection covers the discard the advertisement owes
+// the POST that opens the session. The decode stops at the advertisement's
+// flush-pkt, so the body is short of EOF when the handshake is done, and a
+// v2 clone asks for refs over that same connection a moment later.
+func TestHandshakeSmartKeepsConnection(t *testing.T) {
+	t.Parallel()
+
+	const head = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+	advertisement := pktLine("# service=git-upload-pack\n") + "0000" +
+		pktLine("version 2\n") + pktLine("agent=go-git/test\n") + pktLine("ls-refs=unborn\n") + "0000"
+	refs := pktLine(head+" refs/heads/master\n") + "0000"
+
+	// The terminating chunk is held back until the client has read the
+	// advertisement, since a server that sends both at once lets net/http's
+	// chunked reader find EOF without anyone asking for it.
+	released := make(chan struct{}, 1)
+	srv, conns := connCountingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Transfer-Encoding", "chunked")
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			_, _ = io.WriteString(w, advertisement)
+			w.(http.Flusher).Flush()
+			select {
+			case <-released:
+			case <-time.After(10 * time.Second):
+				t.Error("the handshake never read the advertisement")
+			}
+			return
+		}
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/x-git-upload-pack-result")
+		_, _ = io.WriteString(w, refs)
+	})
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	client := srv.Client()
+	client.Transport = &releasingRoundTripper{
+		base:    client.Transport,
+		after:   len(advertisement),
+		release: released,
+	}
+
+	tr := NewTransport(Options{Client: client})
+	session, err := tr.Handshake(context.Background(), &transport.Request{
+		URL:     u,
+		Command: transport.UploadPackService,
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	// A v2 clone asks for refs next, which is the POST that reuses the
+	// connection the advertisement arrived on.
+	remote, err := session.GetRemoteRefs(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, remote.References)
+
+	assert.Equal(t, int64(1), conns.Load(),
+		"the ls-refs POST must reuse the connection the advertisement arrived on")
 }

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -215,32 +215,6 @@ func TestHTTPNegotiatorCloseResponse(t *testing.T) {
 	assert.NotPanics(t, func() { neg.closeResponse() })
 }
 
-// TestNegotiatorReleasesPreviousRound covers the one discard in the package:
-// the body of a finished round is dropped so the next round reuses its
-// connection, but only up to a bound, because a stalled server must not hold
-// the next round up.
-func TestNegotiatorReleasesPreviousRound(t *testing.T) {
-	t.Parallel()
-
-	spent := &countingBody{remaining: bodySize}
-	neg := &httpNegotiator{
-		session: &smartPackSession{
-			sessionBase: sessionBase{service: transport.UploadPackService},
-		},
-		ctx:     context.Background(),
-		current: &httpRequester{resp: &http.Response{Body: spent}},
-	}
-
-	// Starting the next round is what releases the previous one.
-	_, err := neg.Write([]byte("0000"))
-	require.NoError(t, err)
-
-	assert.True(t, spent.closed, "the finished round's body must be closed")
-	assert.Positive(t, spent.read, "some of it must be discarded so the connection is reusable")
-	assert.Less(t, spent.read, bodySize, "the discard must not read to EOF")
-	assert.LessOrEqual(t, spent.read, 1<<20, "the discard must stay within a sane bound")
-}
-
 // TestHTTPNegotiatorNoRounds verifies that closeResponse is safe when
 // no rounds have been executed.
 func TestHTTPNegotiatorNoRounds(t *testing.T) {
@@ -718,6 +692,32 @@ func TestCommandKeepsConnection(t *testing.T) {
 		"%d commands on one session must share one connection", commands)
 }
 
+// TestNegotiatorReleasesPreviousRound covers the one drain in the package: the
+// body of a finished round is discarded so the next round reuses its
+// connection, but only up to a bound, because a stalled server must not hold
+// the next round up.
+func TestNegotiatorReleasesPreviousRound(t *testing.T) {
+	t.Parallel()
+
+	spent := &countingBody{remaining: bodySize}
+	neg := &httpNegotiator{
+		session: &smartPackSession{
+			sessionBase: sessionBase{service: transport.UploadPackService},
+		},
+		ctx:     context.Background(),
+		current: &httpRequester{resp: &http.Response{Body: spent}},
+	}
+
+	// Starting the next round is what releases the previous one.
+	_, err := neg.Write([]byte("0000"))
+	require.NoError(t, err)
+
+	assert.True(t, spent.closed, "the finished round's body must be closed")
+	assert.Positive(t, spent.read, "some of it must be discarded so the connection is reusable")
+	assert.Less(t, spent.read, bodySize, "the discard must not read to EOF")
+	assert.LessOrEqual(t, spent.read, 1<<20, "the discard must stay within a sane bound")
+}
+
 func TestFetchClosesResponseOnNegotiationError(t *testing.T) {
 	t.Parallel()
 
@@ -768,4 +768,134 @@ func TestDumbPushIsUnsupported(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, transport.ErrCommandUnsupported,
 		"a caller picking another transport tests the sentinel, not the message")
+}
+
+// serveInfoRefs answers /info/refs with the given content type and body, and
+// nothing else, so the handshake is decided purely by that response.
+func serveInfoRefs(t testing.TB, contentType, body string) *url.URL {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", contentType)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	return u
+}
+
+// TestHandshakeDumbInfoRefs covers what a dumb handshake makes of the body it
+// is served. packp.InfoRefs.Decode decides what counts as a ref list; this
+// covers the transport's half — that a rejection names the URL and the content
+// type, quotes only plain text, and is not reported as an empty repository.
+func TestHandshakeDumbInfoRefs(t *testing.T) {
+	t.Parallel()
+
+	const head = "6ecf0ef2c2dffb796033e5a02219af86ec6584e5"
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		wantRefs    bool // handshake succeeds and advertises references
+		wantInMsg   []string
+		wantNotMsg  []string
+	}{
+		{
+			// Indented markup puts hex-looking text before a tab, so this used
+			// to decode to a reference named after the markup.
+			name:        "sso interstitial",
+			contentType: "text/html; charset=utf-8",
+			body:        "<!DOCTYPE html>\n<html>\n\t<body>Sign in to continue</body>\n</html>\n",
+			wantInMsg:   []string{"text/html"},
+			wantNotMsg:  []string{"Sign in to continue"},
+		},
+		{
+			name:        "markup without tabs",
+			contentType: "text/html",
+			body:        "<html><body>nope</body></html>",
+			wantInMsg:   []string{"text/html"},
+			wantNotMsg:  []string{"nope"},
+		},
+		{
+			name:        "plain text is quoted back",
+			contentType: "text/plain",
+			body:        "repository is archived\n",
+			wantInMsg:   []string{"repository is archived"},
+		},
+		{
+			// A malformed ref list, not markup: the rejection reaches the
+			// caller the same way, and the body is plain text so it is quoted.
+			name:        "hash shorter than the hash size",
+			contentType: "text/plain",
+			body:        "deadbeef\trefs/heads/master\n",
+			wantInMsg:   []string{"deadbeef"},
+		},
+		{
+			// A byte order mark ahead of an otherwise valid list.
+			name:        "byte order mark",
+			contentType: "text/plain",
+			body:        "\ufeff" + head + "\trefs/heads/master\n",
+		},
+		{
+			// A valid line after the junk does not rescue the advertisement.
+			name:        "junk line before a valid one",
+			contentType: "text/plain",
+			body:        "<!-- injected -->\n" + head + "\trefs/heads/master\n",
+		},
+		{
+			name:        "legitimate ref list",
+			contentType: "text/plain",
+			body:        head + "\trefs/heads/master\n",
+			wantRefs:    true,
+		},
+		{
+			// git update-server-info writes a zero-byte file for a repository
+			// with no references, so an empty body is not a malformed one.
+			name:        "empty body",
+			contentType: "text/plain",
+			body:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			u := serveInfoRefs(t, tt.contentType, tt.body)
+
+			tr := NewTransport(Options{})
+			session, err := tr.Handshake(context.Background(), &transport.Request{
+				URL:     u,
+				Command: transport.UploadPackService,
+			})
+
+			if tt.body == "" || tt.wantRefs {
+				require.NoError(t, err, "a dumb ref list, or the absence of one, must handshake")
+				defer session.Close()
+
+				refs, err := session.GetRemoteRefs(context.Background(), nil)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantRefs, len(refs.References) > 0)
+				return
+			}
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, transport.ErrInvalidResponse,
+				"callers switch on the transport sentinel")
+			assert.ErrorIs(t, err, packp.ErrInvalidInfoRefs,
+				"the decoder's reason stays in the chain")
+			assert.NotErrorIs(t, err, transport.ErrEmptyRemoteRepository,
+				"a body that is not a ref list is not an empty repository")
+			for _, want := range tt.wantInMsg {
+				assert.Contains(t, err.Error(), want)
+			}
+			for _, unwanted := range tt.wantNotMsg {
+				assert.NotContains(t, err.Error(), unwanted,
+					"markup is never echoed back, matching git's show_http_message")
+			}
+		})
+	}
 }

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -757,3 +757,15 @@ func TestFetchClosesResponseOnNegotiationError(t *testing.T) {
 	assert.Equal(t, int64(1), closed.Load(),
 		"a non-cancellation negotiation error must close the response body")
 }
+
+func TestDumbPushIsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	session := &dumbPackSession{}
+
+	err := session.Push(context.Background(), nil, nil)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, transport.ErrCommandUnsupported,
+		"a caller picking another transport tests the sentinel, not the message")
+}

--- a/utils/ioutil/context.go
+++ b/utils/ioutil/context.go
@@ -2,6 +2,7 @@ package ioutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
@@ -129,6 +130,39 @@ type ctxReader struct {
 // use a buffer from the memory pool.
 func NewContextReader(ctx context.Context, r io.Reader) io.Reader {
 	return &ctxReader{ctx: ctx, r: r}
+}
+
+// ReadFinished reports whether the reader wrapped by NewContextReader,
+// NewContextReaderWithCloser or NewContextReadCloser has finished with the
+// reader underneath it, so that reader — a network connection, typically — may
+// be closed after a read returned err.
+//
+// It has not when this context's cancellation is what ended the read: the
+// wrapper returns from its <-ctx.Done() branch while the goroutine it started
+// can still be blocked in the underlying Read, and closing would race that
+// goroutine. Nothing is leaked by leaving it, because a reader bound to the
+// same context is torn down by that context anyway. Any other outcome, success
+// included, means the last Read arrived over the result channel and the
+// goroutine is finished, so the underlying reader must be closed or it and its
+// connection are held for the life of the process.
+//
+// A cancellation error alone is not enough to answer no: a deadline belonging
+// to something else — a storer, a wrapped inner operation — can surface as
+// DeadlineExceeded while this context is still live, and treating that as
+// unsafe leaks the reader. A cancelled context alone is not enough either: it
+// can be cancelled an instant after a read that had already finished, and
+// skipping the close there leaks it too.
+//
+// The two together are not exact. Once this context is done, a cancellation
+// that came from somewhere else reads the same as its own, and the close is
+// skipped for a read that had in fact finished. The reader that answer is
+// wrong about is a reader bound to a context that is already done, which its
+// own teardown closes; a reader bound to something else is leaked.
+func ReadFinished(ctx context.Context, err error) bool {
+	if ctx.Err() == nil {
+		return true
+	}
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
 }
 
 func (r *ctxReader) Read(buf []byte) (int, error) {

--- a/utils/ioutil/context_test.go
+++ b/utils/ioutil/context_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -529,6 +530,82 @@ func TestWriterCancelRaceNoDeadlock(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Fatal("Write deadlocked under concurrent cancellation")
 		}
+	}
+}
+
+func TestReadFinished(t *testing.T) {
+	t.Parallel()
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{
+			name: "success on a live context",
+			ctx:  context.Background(),
+			err:  nil,
+			want: true,
+		},
+		{
+			name: "ordinary error on a live context",
+			ctx:  context.Background(),
+			err:  io.ErrUnexpectedEOF,
+			want: true,
+		},
+		{
+			// A deadline belonging to something else. The read finished, so
+			// the reader has to be closed.
+			name: "foreign deadline on a live context",
+			ctx:  context.Background(),
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "cancellation from this context",
+			ctx:  cancelled,
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "wrapped cancellation from this context",
+			ctx:  cancelled,
+			err:  fmt.Errorf("negotiate: %w", context.Canceled),
+			want: false,
+		},
+		{
+			// A deadline reported by a context that is done is taken for
+			// that context's own, whoever it belonged to. The answer is
+			// inexact in this one direction, and errs towards not closing.
+			name: "deadline on a cancelled context",
+			ctx:  cancelled,
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			// Cancelled just after a read that had already finished.
+			name: "ordinary error on a cancelled context",
+			ctx:  cancelled,
+			err:  io.ErrUnexpectedEOF,
+			want: true,
+		},
+		{
+			name: "success on a cancelled context",
+			ctx:  cancelled,
+			err:  nil,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ReadFinished(tt.ctx, tt.err))
+		})
 	}
 }
 


### PR DESCRIPTION
Six things the HTTP transport got wrong about a response it did not expect. Each is its own commit.

## Summary

- **An HTML page served at `/info/refs` was accepted as a ref list.** An SSO interstitial or a 200 error page fails the smart content-type test and is handled as a dumb server, and the dumb decoder skipped every line it could not parse. `Remote.List` returned no error and one reference named after an HTML fragment; `Clone` then failed with `reference not found`, naming nothing about the response. `deadbeef\trefs/heads/master` decoded to a reference at a hash the server never sent, because `plumbing.FromHex` pads a short hex string. Decoding now fails on the first malformed line, as canonical git's `parse_info_refs` does.

- **A failed fetch leaked a socket and three goroutines, every time.** `Fetch` returned on a `NegotiatePack` error without closing the response — including when it returns *success*: `ErrNoChange` arrives after the POST has already fired, so an up-to-date fetch into an existing shallow clone over protocol v0/v1 leaked on every call. Five failed fetches held five sockets and took goroutines from 3 to 18, never released. A dumb walk leaked the same way through `downloadFile`, which returned on a copy failure without closing the body it was reading — one connection per object, and the walk asks for every object as a file of its own.

- **An error response body was never closed, and was shown whatever it turned out to be.** Left open it holds its connection for the life of the process, and a CDN's HTML error page was spliced into the Go error — `<head>`, `<hr>` and all, as a CI run against gitlab.com showed. The body is now closed once its message has been taken, the discard that keeps its connection is bounded, and the message reaches the error only when the server sent `text/plain` — the rule git applies in `show_http_message` — quoted, so a multi-line body cannot forge a record in your logs.

- **Every spent response dropped its connection.** The advertisement ends at a flush-pkt and a decoder stops at one, so the rest of the body — often just the terminating chunk — was still outstanding at the close, and net/http returns a connection to the pool only once its body has reached EOF. The smart advertisement, each negotiation round and each v2 command now discard what is left, under a bound, so the request that follows reuses the connection instead of paying a fresh handshake. Ten 404s carrying a 32 KiB error page: one connection with the discard, ten without.

- **`errors.Is(err, transport.ErrCommandUnsupported)` was false for a dumb push.** `dumbPackSession.Push` failed with a bare `fmt.Errorf`, so a caller falling back to another transport could not detect the refusal.

- **A `charset` parameter made a smart server look dumb.** The smart/dumb test compared the whole `Content-Type` header for equality; it now stops at the first `;`, trims and lower-cases, as git's `extract_content_type()` does. The accepted set only grows, so nothing that works today can start failing.

## Errors you get instead

| before | after |
|---|---|
| `reference not found` | `invalid response: https://host/repo.git/info/refs?service=git-upload-pack served content type "text/html": invalid info/refs: line 1 has no tab` |
| an HTML error page spliced into the error, 8 KiB of it | `http transport: unexpected requesting "https://host/repo.git/info/refs?service=git-upload-pack" status code: 502` |
| the same, for a message worth reading | `http transport: authorization failed: unexpected requesting "https://host/repo.git/info/refs?service=git-upload-pack" status code: 403: "ERROR: The project you were looking for could not be found."` |

## What you may need to change

- **`packp.InfoRefs.Decode` returns an error** on a line that is not hash-tab-refname, where it skipped it. Exported plumbing; one in-tree consumer. Empty input still decodes to no references, because that is what `git update-server-info` writes for a repository with nothing to advertise. A leading UTF-8 BOM now fails, as it does in git.
- **`Err.Reason` is empty unless the message arrived as `text/plain`**, and `Err.Error()` quotes what it holds. It is an exported field; anything matching on it should read its new doc.
- **A non-git `/info/refs` surfaces `transport.ErrInvalidResponse`** wrapping `packp.ErrInvalidInfoRefs`, where it previously surfaced nothing.

## Known limitation

`Decode` checks the hash and requires a non-empty name; it does not validate the name's spelling. A page that prints a full-length commit id before a tab can still yield a reference named after markup. `ReferenceName.Validate()` would catch it, but it rejects `refs/tags/v1^{}` — a peeled tag `git update-server-info` writes for every annotated tag — so it cannot be used here. Canonical git's `parse_info_refs` does not validate the name either, and neither does the smart path.
