### PR TITLE
Fix the OSS-Fuzz build and keep fuzz targets discoverable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,17 @@ fuzz:
 		go test -fuzz=Fuzz -fuzztime=$(FUZZ_TIME) $$path; \
 	done
 
-validate: validate-lint validate-dirty ## Run validation checks.
+validate: validate-lint validate-fuzz validate-dirty ## Run validation checks.
 
 validate-lint: $(GOLANGCI)
 	$(GOLANGCI) run
+
+# Fuzz targets have to stay discoverable by the OSS-Fuzz build, which is
+# stricter about their names than `go test -fuzz` is. A target breaking those
+# rules is dropped from the fuzzing fleet, or breaks the build, without any
+# local test failing. See tests/fuzz for the rules and where they come from.
+validate-fuzz:
+	$(GOTEST) ./tests/fuzz/...
 
 validate-dirty:
 ifneq ($(shell git status --porcelain --untracked-files=no),)

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -411,7 +411,7 @@ func (s *ParserSuite) TestParseRefWithInvalidName() {
 	}
 }
 
-func FuzzParser(f *testing.F) {
+func FuzzRevisionParser(f *testing.F) {
 	f.Add("@{2016-12-16T21:42:47Z}")
 	f.Add("@~3")
 	f.Add("v0.99.8^{}")

--- a/plumbing/format/config/decoder_test.go
+++ b/plumbing/format/config/decoder_test.go
@@ -112,7 +112,7 @@ func decodeSucceeds(s *DecoderSuite, text string) {
 	s.Equal("value", remote.Option("key"))
 }
 
-func FuzzDecoder(f *testing.F) {
+func FuzzConfigDecoder(f *testing.F) {
 	f.Fuzz(func(_ *testing.T, input []byte) {
 		d := NewDecoder(bytes.NewReader(input))
 		cfg := &Config{}

--- a/plumbing/format/idxfile/fuzz_helpers.go
+++ b/plumbing/format/idxfile/fuzz_helpers.go
@@ -82,7 +82,9 @@ func buildMinimalRev(count, hashSize int) []byte {
 //
 // Lives outside `_test.go` so the OSS-Fuzz harness, which does not
 // see other test files when extracting fuzz targets, can reach it
-// from FuzzMemoryIndex's seed corpus.
+// from the seed corpus. The harness finds a target by grepping the
+// package for its name, so naming one here would break the build.
+// See `make validate-fuzz`.
 func buildOOBOffset64Idx() ([]byte, plumbing.Hash) {
 	const hashSize = 20
 

--- a/plumbing/format/index/decoder_fuzz_test.go
+++ b/plumbing/format/index/decoder_fuzz_test.go
@@ -11,7 +11,7 @@ import (
 	gogithash "github.com/go-git/go-git/v6/plumbing/hash"
 )
 
-func FuzzDecoder(f *testing.F) {
+func FuzzIndexDecoder(f *testing.F) {
 	// Seed from a real index file when available.
 	if dotgit, err := fixtures.Basic().One().DotGit(); err == nil {
 		if fh, err := dotgit.Open(dotgit.Join("index")); err == nil {

--- a/plumbing/format/packfile/parser_fuzz_test.go
+++ b/plumbing/format/packfile/parser_fuzz_test.go
@@ -15,7 +15,7 @@ import (
 	gogitbinary "github.com/go-git/go-git/v6/utils/binary"
 )
 
-func FuzzParser(f *testing.F) {
+func FuzzPackfileParser(f *testing.F) {
 	if pf, err := fixtures.Basic().One().Packfile(); err == nil {
 		if data, rerr := io.ReadAll(pf); rerr == nil {
 			f.Add(data)

--- a/plumbing/format/packfile/scanner_fuzz_test.go
+++ b/plumbing/format/packfile/scanner_fuzz_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
-func FuzzScanner(f *testing.F) {
+func FuzzPackfileScanner(f *testing.F) {
 	// Seed from a real packfile when available.
 	if pf, err := fixtures.Basic().One().Packfile(); err == nil {
 		if data, err := io.ReadAll(pf); err == nil {

--- a/plumbing/format/pktline/pktline_fuzz_test.go
+++ b/plumbing/format/pktline/pktline_fuzz_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 )
 
-func FuzzRead(f *testing.F) {
+// Not named FuzzRead: the OSS-Fuzz harness resolves a target by
+// grepping for `func <name>`, which would also match FuzzReadLine.
+// See `make validate-fuzz`.
+func FuzzReadPacket(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte("0000"))
 	f.Add([]byte("0001"))

--- a/plumbing/format/pktline/pktline_fuzz_test.go
+++ b/plumbing/format/pktline/pktline_fuzz_test.go
@@ -76,7 +76,7 @@ func FuzzReadLine(f *testing.F) {
 	})
 }
 
-func FuzzScanner(f *testing.F) {
+func FuzzPktlineScanner(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte("0000"))
 	f.Add([]byte("0001"))

--- a/plumbing/format/reflog/reflog_test.go
+++ b/plumbing/format/reflog/reflog_test.go
@@ -294,7 +294,7 @@ func TestDecodeLongLine(t *testing.T) {
 	assert.Equal(t, message, entries[0].Message)
 }
 
-func FuzzDecode(f *testing.F) {
+func FuzzReflogDecode(f *testing.F) {
 	// Valid entries.
 	f.Add([]byte("0000000000000000000000000000000000000000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa Author Name <author@example.com> 1234567890 +0000\tcommit (initial): Initial commit\n"))
 	f.Add([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb Author <a@b.com> 1234567890 +0000\n"))

--- a/plumbing/format/revfile/decoder_fuzz_test.go
+++ b/plumbing/format/revfile/decoder_fuzz_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 )
 
-func FuzzDecode(f *testing.F) {
+func FuzzRevfileDecode(f *testing.F) {
 	// Minimal valid rev header: 4-byte magic + version(uint32 BE = 1) +
 	// hash-func(uint32 BE = 1, SHA1).
 	f.Add([]byte("RIDX\x00\x00\x00\x01\x00\x00\x00\x01"))

--- a/tests/fuzz/ossfuzz_test.go
+++ b/tests/fuzz/ossfuzz_test.go
@@ -1,0 +1,258 @@
+// Package fuzz_test asserts the rules the OSS-Fuzz build imposes on this
+// repository's fuzz targets, which `go test -fuzz` does not.
+//
+// OSS-Fuzz strips each fuzz test file down to its target bodies and passes the
+// package to compile_native_go_fuzzer, which resolves a target by grepping the
+// package directory for the target name:
+//
+//	https://github.com/google/oss-fuzz/blob/master/projects/go-git/build.sh
+//
+// A name that does not grep uniquely either breaks that build or, worse, makes
+// the harness drop the target and carry on. Both outcomes are invisible to a
+// normal test run, so they are checked here.
+package fuzz_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// namePrefix is the prefix Go gives every fuzz target. It is kept apart from
+// the "func " it follows in a declaration because OSS-Fuzz finds fuzz test
+// files by grepping every *_test.go file for that pair, and this file holds no
+// targets of its own.
+const namePrefix = "Fuzz"
+
+type target struct {
+	name string
+	file string // File declaring the target, relative to the module root.
+	dir  string // Package directory holding that file.
+}
+
+func TestTargetsAreDiscoverable(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	targets := findTargets(t, root)
+	require.NotEmpty(t, targets, "no fuzz targets found under %s", root)
+
+	for _, tg := range targets {
+		t.Run(tg.name, func(t *testing.T) {
+			t.Parallel()
+
+			// compile_native_go_fuzzer resolves a target to a file with
+			//
+			//	grep -r -l --include='*.go' -s "<name>" <package dir>
+			//
+			// and the coverage build copies that path into $OUT. A second
+			// match turns the copy into one of two sources onto a single
+			// destination, which fails the build for the whole project.
+			named := filesContaining(t, root, goFiles(t, root, tg.dir), tg.name)
+			require.Equal(t, []string{tg.file}, named,
+				"%s names the target %s. The OSS-Fuzz coverage build fails unless the name appears only in the file declaring it",
+				strings.Join(without(named, tg.file), ", "), tg.name)
+
+			// The harness then counts what grep reports for the declaration
+			// itself. On anything other than a single match it prints
+			// "Could not find the function" and moves on, leaving the target
+			// out of the build without failing it.
+			require.Equal(t, 1, declarations(t, root, named, tg.name),
+				"%q matches more than one target, so OSS-Fuzz silently skips %s. Rename it so that no target name is a prefix of another",
+				"func "+tg.name, tg.name)
+		})
+	}
+}
+
+func TestTargetNamesAreUnique(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+
+	// compile_native_go_fuzzer writes every fuzzer to $OUT/<target name>, and
+	// the package a target belongs to is no part of that name. Two targets
+	// sharing a name leave one binary, so whichever OSS-Fuzz builds first is
+	// replaced by the other and never fuzzed.
+	declaredBy := make(map[string][]string)
+	for _, tg := range findTargets(t, root) {
+		declaredBy[tg.name] = append(declaredBy[tg.name], tg.file)
+	}
+
+	duplicates := make(map[string][]string)
+	for name, files := range declaredBy {
+		if len(files) > 1 {
+			duplicates[name] = files
+		}
+	}
+	require.Empty(t, duplicates,
+		"each target listed here is declared in more than one package, and OSS-Fuzz keeps one binary per name. Qualify the names with the package they cover")
+}
+
+// findTargets collects every fuzz target declared under root.
+func findTargets(t *testing.T, root string) []target {
+	t.Helper()
+
+	var targets []target
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if strings.HasPrefix(d.Name(), ".") && path != root {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+
+		file := relative(t, root, path)
+		for _, name := range declaredIn(t, path) {
+			targets = append(targets, target{name: name, file: file, dir: filepath.Dir(file)})
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	return targets
+}
+
+// declaredIn returns the names of the fuzz targets declared in file.
+func declaredIn(t *testing.T, file string) []string {
+	t.Helper()
+
+	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+	require.NoError(t, err)
+
+	var names []string
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, namePrefix) {
+			continue
+		}
+		if fn.Type.Params == nil || len(fn.Type.Params.List) != 1 {
+			continue
+		}
+		if isFuzzParam(fn.Type.Params.List[0].Type) {
+			names = append(names, fn.Name.Name)
+		}
+	}
+
+	return names
+}
+
+// isFuzzParam reports whether expr is the *testing.F a fuzz target takes.
+func isFuzzParam(expr ast.Expr) bool {
+	ptr, ok := expr.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	sel, ok := ptr.X.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "F" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+
+	return ok && pkg.Name == "testing"
+}
+
+// goFiles lists the Go files under dir, as `grep -r --include='*.go'` sees them.
+func goFiles(t *testing.T, root, dir string) []string {
+	t.Helper()
+
+	var files []string
+	err := filepath.WalkDir(filepath.Join(root, dir), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && strings.HasSuffix(d.Name(), ".go") {
+			files = append(files, relative(t, root, path))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	sort.Strings(files)
+
+	return files
+}
+
+// filesContaining narrows files to those holding name anywhere in their text.
+func filesContaining(t *testing.T, root string, files []string, name string) []string {
+	t.Helper()
+
+	var found []string
+	for _, file := range files {
+		content, err := os.ReadFile(filepath.Join(root, file))
+		require.NoError(t, err)
+		if strings.Contains(string(content), name) {
+			found = append(found, file)
+		}
+	}
+
+	return found
+}
+
+// declarations counts the target declarations grep attributes to name.
+func declarations(t *testing.T, root string, files []string, name string) int {
+	t.Helper()
+
+	count := 0
+	for _, file := range files {
+		content, err := os.ReadFile(filepath.Join(root, file))
+		require.NoError(t, err)
+		for line := range strings.Lines(string(content)) {
+			if strings.Contains(line, "func "+name) && strings.Contains(line, "testing.F") {
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+// without drops keep from files, leaving the unexpected matches to report.
+func without(files []string, keep string) []string {
+	rest := make([]string, 0, len(files))
+	for _, file := range files {
+		if file != keep {
+			rest = append(rest, file)
+		}
+	}
+
+	return rest
+}
+
+// relative rewrites path so failures name files the way the repository does.
+func relative(t *testing.T, root, path string) string {
+	t.Helper()
+
+	rel, err := filepath.Rel(root, path)
+	require.NoError(t, err)
+
+	return filepath.ToSlash(rel)
+}
+
+// repoRoot walks up from the test's directory to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := filepath.Abs(".")
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "no go.mod above the test directory")
+		dir = parent
+	}
+}


### PR DESCRIPTION
Fixes [build issues](https://github.com/google/oss-fuzz/actions/runs/34342029026/job/102434785165?pr=16114) for go-git fuzzers in the oss-fuzz project:

| Defect | Effect |
| --- | --- |
| A comment in `fuzz_helpers.go` named `FuzzMemoryIndex`, so `fuzzer_filename` resolved to two paths | the coverage build's `cp` got two sources and one destination: **build fails**, taking the 25 targets queued behind it |
| `FuzzRead` is a strict prefix of `FuzzReadLine`, so `grep "func FuzzRead"` matched twice | harness prints `Could not find the function` and **exits 0**, target never built |
| Four target names duplicated across packages | `$OUT/<name>` is overwritten. The [2026-09-09 build](https://oss-fuzz-build-logs.storage.googleapis.com/log-829968df-5f20-402e-accb-b4ef3d560fe0.txt) compiled **46 targets into 42 binaries** |

To avoid future regressions, a new `make validate-fuzz` was wired into `make validate` to assert the three rules the harness imposes on target names:
- only the file declaring a target may contain its name
- no target name may be a prefix of another
- target names are unique across the repository

Unblocks: https://github.com/google/oss-fuzz/pull/16114