### PR TITLE
git: worktree, Fix unreadable subtree handling and recovery

### DIFF
--- a/options.go
+++ b/options.go
@@ -460,12 +460,6 @@ type ResetOptions struct {
 
 	// SkipSparseDirValidation will skip the validation for SparseDirs.
 	SkipSparseDirValidation bool
-
-	// fromTree is used internally by Checkout to pass the tree that the
-	// worktree is currently at, before HEAD is updated. This ensures that
-	// HardReset and KeepReset properly diff from the actual previous state
-	// rather than the new HEAD.
-	fromTree *object.Tree
 }
 
 // Validate validates the fields and sets the default values.

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -181,6 +181,16 @@ func (t *Tree) TreeEntryFile(e *TreeEntry) (*File, error) {
 // Duplicate names are not rejected, so lookup depends on their modes and order.
 // Call Validate on each tree along the path to reject duplicates; validating
 // only the root does not validate its subtrees.
+//
+// Use errors.Is to match errors. A missing final entry returns ErrEntryNotFound;
+// a missing intermediate entry or one with a non-directory mode reports
+// ErrDirectoryNotFound. An intermediate directory pointing to another object
+// type reports ErrInvalidTree; an absent subtree reports plumbing.ErrObjectNotFound.
+// Path-validation errors are returned unchanged.
+//
+// Subtree read and decode errors identify the entry and wrap the cause, except
+// that causes matching io.EOF are included only as text to distinguish read
+// failures from normal iterator exhaustion.
 func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
 	if err := pathutil.ValidTreePath(path); err != nil {
 		return nil, err
@@ -235,15 +245,7 @@ func (t *Tree) dir(baseName string) (*Tree, error) {
 		return nil, fmt.Errorf("%w: entry %q has mode %s", ErrDirectoryNotFound, baseName, entry.Mode)
 	}
 
-	obj, err := t.s.EncodedObject(plumbing.TreeObject, entry.Hash)
-	if err != nil {
-		return nil, err
-	}
-
-	tree := &Tree{s: t.s}
-	err = tree.Decode(obj)
-
-	return tree, err
+	return readSubtree(t.s, entry)
 }
 
 func (t *Tree) entry(baseName string) (*TreeEntry, error) {
@@ -666,21 +668,25 @@ func NewTreeWalker(t *Tree, recursive bool, seen map[plumbing.Hash]bool) *TreeWa
 	}
 }
 
-// Next returns the next object from the tree. Objects are returned in order
-// and subtrees are included. After the last object has been returned further
-// calls to Next() will return io.EOF.
+// Next returns the next entry in tree order, including directory entries.
+// After the last entry, Next returns io.EOF.
 //
-// Each entry's name is validated against pathutil.ValidTreePath as it
-// surfaces, so callers that funnel the returned name into filesystem
-// or archive output can trust it is free of `.git`-shaped components,
-// HFS+/NTFS variants, Windows reserved names, and traversal sequences.
-// A malformed entry stops the walk with the validator's error;
-// inspection-only callers that need to enumerate raw, unvalidated
-// names can read Tree.Entries directly or set skipPathValidation.
+// Entry names are checked with pathutil.ValidTreePath unless the internal
+// skipPathValidation flag is set. Callers inspecting unvalidated names can
+// read Tree.Entries directly. Path checks do not validate filesystem state.
 //
-// In the current implementation any objects which cannot be found in the
-// underlying repository will be skipped automatically. It is possible that this
-// may change in future versions.
+// Unreadable subtrees return errors identifying the entry. A directory entry
+// pointing to another object type reports ErrInvalidTree; an absent subtree
+// reports plumbing.ErrObjectNotFound. Other read and decode errors wrap their
+// cause, except that causes matching io.EOF are included only as text so that
+// errors.Is(err, io.EOF) identifies only normal exhaustion.
+//
+// After a path-validation or subtree-read error, calling Next again skips
+// the failed entry and continues with its siblings. ErrMaxTreeDepth is terminal:
+// it reports no entry and repeats on subsequent calls.
+//
+// Missing subtrees are errors even in partial clones: go-git does not lazily
+// fetch them, and omitting their entries could produce an incomplete index.
 func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 	var obj *Tree
 	for {
@@ -721,13 +727,12 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 		}
 
 		if entry.Mode == filemode.Dir {
-			obj, err = GetTree(w.s, entry.Hash)
+			obj, err = readSubtree(w.s, &entry)
 		}
 
 		name = simpleJoin(w.base, entry.Name)
 
 		if err != nil {
-			err = io.EOF
 			return name, entry, err
 		}
 
@@ -745,6 +750,93 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 
 	return name, entry, err
 }
+
+// readSubtree reads a directory entry's tree for lookup or enumeration.
+// Decode errors are preserved without another lookup, which could obscure
+// the original failure.
+func readSubtree(s storer.EncodedObjectStorer, e *TreeEntry) (*Tree, error) {
+	obj, err := s.EncodedObject(plumbing.TreeObject, e.Hash)
+	if err != nil {
+		return nil, subtreeReadError(s, e, err)
+	}
+	tree, err := DecodeTree(s, obj)
+	if err != nil {
+		return nil, subtreeError(e, err)
+	}
+	return tree, nil
+}
+
+// subtreeReadError distinguishes a missing object from a wrong-type object.
+// Typed lookups can return plumbing.ErrObjectNotFound for either, so an
+// untyped lookup is needed. If it finds a tree, preserve the original error;
+// otherwise report the wrong type or the untyped lookup's error.
+func subtreeReadError(s storer.EncodedObjectStorer, e *TreeEntry, err error) error {
+	obj, perr := s.EncodedObject(plumbing.AnyObject, e.Hash)
+	if perr != nil {
+		return subtreeError(e, perr)
+	}
+
+	if obj.Type() != plumbing.TreeObject {
+		return fmt.Errorf("%w: entry %q has mode %s but points at a %s",
+			ErrInvalidTree, e.Name, e.Mode, obj.Type())
+	}
+
+	return subtreeError(e, err)
+}
+
+// subtreeError identifies the entry and wraps cause unless it matches io.EOF.
+// EOF causes are included only as text so a failed read cannot be mistaken for
+// iterator exhaustion. No sentinel replaces them: EOF alone does not establish
+// that the object is missing or invalid. Causes joined with EOF keep the
+// identity of the errors joined alongside it, which callers match to tell a
+// missing subtree from an invalid one.
+func subtreeError(e *TreeEntry, cause error) error {
+	if !errors.Is(cause, io.EOF) {
+		return fmt.Errorf("%w: entry %q has mode %s", cause, e.Name, e.Mode)
+	}
+
+	text := fmt.Sprintf("entry %q has mode %s: %v", e.Name, e.Mode, cause)
+	kept := causesBesidesEOF(cause)
+	if kept == nil {
+		return errors.New(text)
+	}
+
+	return &subtreeEOFError{text: text, cause: kept}
+}
+
+// causesBesidesEOF returns the errors joined into err that do not match io.EOF,
+// or nil when it joins none. An error that wraps io.EOF along a single chain
+// cannot be separated from it, so it is left out.
+func causesBesidesEOF(err error) error {
+	joined, ok := err.(interface{ Unwrap() []error })
+	if !ok {
+		return nil
+	}
+
+	var kept []error
+	for _, c := range joined.Unwrap() {
+		if !errors.Is(c, io.EOF) {
+			kept = append(kept, c)
+			continue
+		}
+		if inner := causesBesidesEOF(c); inner != nil {
+			kept = append(kept, inner)
+		}
+	}
+
+	return errors.Join(kept...)
+}
+
+// subtreeEOFError reports a subtree read that failed with io.EOF among its
+// causes. Its message names every cause while its chain omits io.EOF.
+type subtreeEOFError struct {
+	text  string
+	cause error
+}
+
+func (e *subtreeEOFError) Error() string { return e.text }
+
+func (e *subtreeEOFError) Unwrap() error { return e.cause }
 
 // Tree returns the tree that the tree walker most recently operated on.
 func (w *TreeWalker) Tree() *Tree {

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -45,8 +45,14 @@ var (
 // [1]: https://github.com/git/git/blob/v2.54.0/fsck.c#L26
 const maxTreeEntryNameLen = 4096
 
-// Tree is basically like a directory - it references a bunch of other trees
-// and/or blobs (i.e. files and sub-directories)
+// Tree represents a Git tree, which contains entries for files and subtrees.
+//
+// Decode accepts some structurally invalid trees, including duplicate names
+// and names containing slashes, but rejects malformed encoding and empty names.
+// Validate checks structural constraints on this tree without loading subtrees.
+// Read methods do not call Validate: FindEntry, TreeEntryFile, and TreeWalker.Next
+// apply path checks, and FindEntry descends only through directory entries.
+// Internal diff walkers can disable path validation.
 type Tree struct {
 	Entries []TreeEntry
 	Hash    plumbing.Hash
@@ -84,8 +90,12 @@ type TreeEntry struct {
 	Hash plumbing.Hash
 }
 
-// File returns the hash of the file identified by the `path` argument.
-// The path is interpreted as relative to the tree receiver.
+// File returns the file at path, relative to the tree.
+//
+// Errors from FindEntry are reported as ErrFileNotFound. Call FindEntry
+// directly to distinguish invalid paths and unreadable subtrees from missing
+// entries. A missing or wrong-type blob also reports ErrFileNotFound;
+// other blob read errors are returned unchanged.
 func (t *Tree) File(path string) (*File, error) {
 	e, err := t.FindEntry(path)
 	if err != nil {
@@ -103,8 +113,12 @@ func (t *Tree) File(path string) (*File, error) {
 	return NewFile(path, e.Mode, blob), nil
 }
 
-// Size returns the plaintext size of an object, without reading it
-// into memory.
+// Size returns the plaintext size of the object at path without reading it
+// into memory. The path is relative to the tree.
+//
+// Errors from FindEntry are reported as ErrEntryNotFound. Call FindEntry
+// directly to distinguish invalid paths and unreadable subtrees from missing
+// entries.
 func (t *Tree) Size(path string) (int64, error) {
 	e, err := t.FindEntry(path)
 	if err != nil {
@@ -114,8 +128,15 @@ func (t *Tree) Size(path string) (int64, error) {
 	return t.s.EncodedObjectSize(e.Hash)
 }
 
-// Tree returns the tree identified by the `path` argument.
-// The path is interpreted as relative to the tree receiver.
+// Tree returns the tree at path, relative to the receiver.
+// Intermediate entries must have mode filemode.Dir. The final entry's object
+// is read as a tree regardless of its mode, allowing inspection of entries
+// whose mode does not match their object type. Callers materializing the tree
+// must check that entry's mode themselves.
+//
+// Errors from FindEntry and plumbing.ErrObjectNotFound from the final object
+// read are reported as ErrDirectoryNotFound. Other read and decode errors
+// are returned unchanged.
 func (t *Tree) Tree(path string) (*Tree, error) {
 	e, err := t.FindEntry(path)
 	if err != nil {
@@ -149,13 +170,17 @@ func (t *Tree) TreeEntryFile(e *TreeEntry) (*File, error) {
 	return NewFile(e.Name, e.Mode, blob), nil
 }
 
-// FindEntry search a TreeEntry in this tree or any subtree.
+// FindEntry returns the entry at path, relative to the tree.
+// The path is checked with pathutil.ValidTreePath, which rejects traversal
+// and reserved names such as .git. Use Entries to inspect unvalidated names.
 //
-// The lookup path is validated against pathutil.ValidTreePath to
-// prevent attacker-controlled tree contents from leaking past this
-// boundary as `.git`-shaped or path-traversal-shaped names. Callers
-// that legitimately need to look up unsafe paths should walk the
-// tree manually.
+// Only entries with mode filemode.Dir can be traversed, even if a symlink or
+// gitlink entry points to a tree object. The final entry is returned without
+// reading its object; use its hash with GetTree to inspect a referenced tree.
+//
+// Duplicate names are not rejected, so lookup depends on their modes and order.
+// Call Validate on each tree along the path to reject duplicates; validating
+// only the root does not validate its subtrees.
 func (t *Tree) FindEntry(path string) (*TreeEntry, error) {
 	if err := pathutil.ValidTreePath(path); err != nil {
 		return nil, err
@@ -200,6 +225,14 @@ func (t *Tree) dir(baseName string) (*Tree, error) {
 	entry, err := t.entry(baseName)
 	if err != nil {
 		return nil, ErrDirectoryNotFound
+	}
+
+	// The entry mode determines whether a path can descend, even when the
+	// referenced object's type disagrees. Unlike Git's object peeling, the
+	// typed read below requires a tree object, not a commit or tag naming one.
+	// See https://github.com/git/git/blob/v2.54.0/tree-walk.c#L568-L633.
+	if entry.Mode != filemode.Dir {
+		return nil, fmt.Errorf("%w: entry %q has mode %s", ErrDirectoryNotFound, baseName, entry.Mode)
 	}
 
 	obj, err := t.s.EncodedObject(plumbing.TreeObject, entry.Hash)
@@ -253,7 +286,10 @@ func (t *Tree) searchEntryIndex(name string) int {
 	})
 }
 
-// Files returns a FileIter allowing to iterate over the Tree
+// Files returns an iterator over the files in the tree and its subtrees.
+// Entry names may contain slashes in malformed trees. Call Validate on every
+// traversed tree to require single-component entry names; validating only the
+// root does not validate its subtrees.
 func (t *Tree) Files() *FileIter {
 	return NewFileIter(t.s, t)
 }
@@ -449,26 +485,15 @@ func (t *Tree) Encode(o plumbing.EncodedObject) (err error) {
 	return err
 }
 
-// Validate reports whether the tree object obeys the same structural
-// rules upstream Git's fsck_tree[1] enforces. It is the read-side
-// counterpart to Tree.Encode's producer-side gate: Decode is permissive
-// so that inspection and recovery tools can read trees with unusual
-// entries, and callers that want fsck-shaped reporting call Validate.
+// Validate checks this tree's entry names, modes, hashes, and ordering.
+// It does not load or validate the objects referenced by the entries.
 //
-// The returned error wraps ErrInvalidTree (and, where applicable,
-// ErrEntriesNotSorted, ErrDuplicateEntry, or pathutil.ErrInvalidPath)
-// so callers can match either the umbrella or specific rule with
-// errors.Is. When multiple rules are violated they are reported
-// together via errors.Join.
+// Errors wrap ErrInvalidTree and, where applicable, ErrEntriesNotSorted,
+// ErrDuplicateEntry, or pathutil.ErrInvalidPath. Multiple violations are
+// combined with errors.Join; use errors.Is to match individual errors.
 //
-// Two fsck_tree warnings — zero-padded modes and the non-canonical
-// 0100664 bits — are not surfaced here. Both rely on inspecting the
-// original octal string from the wire, which canonicalTreeMode
-// discards during Decode. Detecting them would require a parallel
-// raw-mode field on TreeEntry; the structural rules below are the
-// load-bearing ones for refusing malformed trees.
-//
-// [1]: https://github.com/git/git/blob/v2.54.0/fsck.c#L616-L800
+// Decode normalizes modes, so Validate cannot detect zero-padded modes or
+// non-canonical permission bits in the original encoding.
 func (t *Tree) Validate() error {
 	var errs []error
 	add := func(err error) {

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -620,8 +619,9 @@ func (t *Tree) PatchContext(ctx context.Context, to *Tree) (*Patch, error) {
 
 // treeEntryIter facilitates iterating through the TreeEntry objects in a Tree.
 type treeEntryIter struct {
-	t   *Tree
-	pos int
+	t             *Tree
+	pos           int
+	parentBaseLen int
 }
 
 func (iter *treeEntryIter) Next() (TreeEntry, error) {
@@ -656,7 +656,7 @@ type TreeWalker struct {
 // tree walker.
 func NewTreeWalker(t *Tree, recursive bool, seen map[plumbing.Hash]bool) *TreeWalker {
 	stack := make([]*treeEntryIter, 0, startingStackSize)
-	stack = append(stack, &treeEntryIter{t, 0})
+	stack = append(stack, &treeEntryIter{t: t})
 
 	return &TreeWalker{
 		stack:     stack,
@@ -705,10 +705,10 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 
 		entry, err = w.stack[current].Next()
 		if err == io.EOF {
-			// Finished with the current tree, move back up to the parent
+			// Restore one tree level, which can span several path components
+			// when a malformed directory entry's name contains slashes.
+			w.base = w.base[:w.stack[current].parentBaseLen]
 			w.stack = w.stack[:current]
-			w.base, _ = path.Split(w.base)
-			w.base = strings.TrimSuffix(w.base, "/")
 			continue
 		}
 
@@ -744,7 +744,7 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 	}
 
 	if obj != nil {
-		w.stack = append(w.stack, &treeEntryIter{obj, 0})
+		w.stack = append(w.stack, &treeEntryIter{t: obj, parentBaseLen: len(w.base)})
 		w.base = simpleJoin(w.base, entry.Name)
 	}
 

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -2466,6 +2466,72 @@ func TestTreeValidateReportsAllRules(t *testing.T) {
 	assert.Contains(t, verr.Error(), "null hash")
 }
 
+func TestTreeFindEntryMatchesWalkerErrors(t *testing.T) {
+	t.Parallel()
+
+	const missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	tests := []struct {
+		name       string
+		objectType plumbing.ObjectType
+		content    string
+		missing    bool
+		wantIs     error
+		wantNot    error
+	}{
+		{
+			name:       "wrong object type",
+			objectType: plumbing.BlobObject,
+			content:    "payload\n",
+			wantIs:     ErrInvalidTree,
+			wantNot:    plumbing.ErrObjectNotFound,
+		},
+		{
+			name:    "missing subtree",
+			missing: true,
+			wantIs:  plumbing.ErrObjectNotFound,
+			wantNot: ErrInvalidTree,
+		},
+		{
+			name:       "malformed subtree",
+			objectType: plumbing.TreeObject,
+			content:    "100644 foo\x00short",
+			wantIs:     ErrMalformedTree,
+			wantNot:    ErrInvalidTree,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			st := memory.NewStorage()
+			hash := plumbing.NewHash(missingObjectID)
+			if !tc.missing {
+				hash = storeTestObject(t, st, tc.objectType, []byte(tc.content))
+			}
+			root := storeTestTree(t, st, []TreeEntry{
+				{Name: "sub", Mode: filemode.Dir, Hash: hash},
+			})
+
+			tree, err := GetTree(st, root)
+			require.NoError(t, err)
+
+			_, findErr := tree.FindEntry("sub/x")
+			require.ErrorIs(t, findErr, tc.wantIs)
+			assert.NotErrorIs(t, findErr, tc.wantNot)
+			assert.Contains(t, findErr.Error(), `entry "sub"`)
+
+			walker := NewTreeWalker(tree, true, nil)
+			defer walker.Close()
+
+			_, _, walkErr := walker.Next()
+			require.ErrorIs(t, walkErr, tc.wantIs)
+			assert.NotErrorIs(t, walkErr, tc.wantNot)
+		})
+	}
+}
+
 func TestTreeFindEntryRefusesNonDirectoryDescent(t *testing.T) {
 	t.Parallel()
 
@@ -2602,4 +2668,227 @@ func TestTreeFilesSurfacesSlashBearingEntryName(t *testing.T) {
 	assert.Equal(t, []string{entryName, slashBearingName}, names)
 
 	assert.ErrorIs(t, tree.Validate(), ErrInvalidTree)
+}
+
+func TestTreeWalkerNextRejectsDirEntryPointingAtBlob(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	blob := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "evil", Mode: filemode.Dir, Hash: blob},
+		{Name: "later", Mode: filemode.Regular, Hash: blob},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	w := NewTreeWalker(tree, true, nil)
+	defer w.Close()
+
+	_, _, err = w.Next()
+	require.ErrorIs(t, err, ErrInvalidTree)
+	assert.NotErrorIs(t, err, io.EOF)
+	assert.Contains(t, err.Error(), "blob")
+}
+
+func TestTreeWalkerNextReportsUndecodableSubtree(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	truncated := storeTestObject(t, st, plumbing.TreeObject, []byte("100644 foo\x00short"))
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "dir", Mode: filemode.Dir, Hash: truncated},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	w := NewTreeWalker(tree, true, nil)
+	defer w.Close()
+
+	_, _, err = w.Next()
+	require.ErrorIs(t, err, ErrMalformedTree)
+	assert.NotErrorIs(t, err, io.EOF)
+}
+
+type unreadableStorer struct {
+	storer.EncodedObjectStorer
+	err error
+}
+
+func (s unreadableStorer) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
+	if t == plumbing.AnyObject {
+		return nil, s.err
+	}
+	return s.EncodedObjectStorer.EncodedObject(t, h)
+}
+
+func TestSubtreeReadersPreserveDecoderError(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	truncated := storeTestObject(t, st, plumbing.TreeObject, []byte("100644 foo\x00short"))
+	root := storeTestTree(t, st, []TreeEntry{{Name: "sub", Mode: filemode.Dir, Hash: truncated}})
+	probeErr := errors.New("untyped lookup failed")
+	tree, err := GetTree(unreadableStorer{EncodedObjectStorer: st, err: probeErr}, root)
+	require.NoError(t, err)
+
+	_, findErr := tree.FindEntry("sub/x")
+
+	walker := NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+
+	_, _, walkErr := walker.Next()
+
+	for _, err := range []error{findErr, walkErr} {
+		assert.ErrorIs(t, err, ErrMalformedTree)
+		assert.NotErrorIs(t, err, probeErr)
+		assert.NotErrorIs(t, err, io.EOF)
+		assert.Contains(t, err.Error(), `entry "sub"`)
+	}
+}
+
+func TestTreeWalkerNextReportsUnreadableStore(t *testing.T) {
+	t.Parallel()
+
+	const missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	st := memory.NewStorage()
+	absent := plumbing.NewHash(missingObjectID)
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "gone", Mode: filemode.Dir, Hash: absent},
+	})
+
+	damaged := errors.New("pack is damaged")
+	tree, err := GetTree(unreadableStorer{EncodedObjectStorer: st, err: damaged}, root)
+	require.NoError(t, err)
+
+	w := NewTreeWalker(tree, true, nil)
+	defer w.Close()
+
+	_, _, err = w.Next()
+	require.ErrorIs(t, err, damaged)
+	assert.NotErrorIs(t, err, io.EOF)
+}
+
+func TestTreeWalkerNextKeepsEOFOutOfTheChain(t *testing.T) {
+	t.Parallel()
+
+	const missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	st := memory.NewStorage()
+	blob := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	absent := plumbing.NewHash(missingObjectID)
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "gone", Mode: filemode.Dir, Hash: absent},
+		{Name: "later", Mode: filemode.Regular, Hash: blob},
+	})
+
+	tree, err := GetTree(unreadableStorer{EncodedObjectStorer: st, err: io.EOF}, root)
+	require.NoError(t, err)
+
+	w := NewTreeWalker(tree, true, nil)
+	defer w.Close()
+
+	name, _, err := w.Next()
+	require.Error(t, err)
+	assert.Equal(t, "gone", name)
+	assert.NotErrorIs(t, err, io.EOF)
+	assert.NotErrorIs(t, err, plumbing.ErrObjectNotFound)
+	assert.NotErrorIs(t, err, ErrInvalidTree)
+	assert.Contains(t, err.Error(), "EOF")
+}
+
+func TestTreeWalkerNextKeepsCausesJoinedWithEOF(t *testing.T) {
+	t.Parallel()
+
+	const missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	st := memory.NewStorage()
+	absent := plumbing.NewHash(missingObjectID)
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "gone", Mode: filemode.Dir, Hash: absent},
+	})
+
+	// An alternate object directory that cannot be read reports both errors,
+	// as storage/filesystem does when no alternate holds the object.
+	joined := errors.Join(io.EOF, plumbing.ErrObjectNotFound)
+	tree, err := GetTree(unreadableStorer{EncodedObjectStorer: st, err: joined}, root)
+	require.NoError(t, err)
+
+	w := NewTreeWalker(tree, true, nil)
+	defer w.Close()
+
+	_, _, err = w.Next()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+	assert.NotErrorIs(t, err, io.EOF)
+	assert.Contains(t, err.Error(), "EOF")
+	assert.Contains(t, err.Error(), `entry "gone"`)
+}
+
+type promisorStorer struct {
+	storer.EncodedObjectStorer
+}
+
+func (promisorStorer) PromisorObjectPacks() ([]plumbing.Hash, error) {
+	const promisorPackID = "cccccccccccccccccccccccccccccccccccccccc"
+
+	return []plumbing.Hash{plumbing.NewHash(promisorPackID)}, nil
+}
+
+func TestTreeWalkerNextReportsAbsentSubtree(t *testing.T) {
+	t.Parallel()
+
+	const missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	st := memory.NewStorage()
+	blob := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	absent := plumbing.NewHash(missingObjectID)
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "gone", Mode: filemode.Dir, Hash: absent},
+		{Name: "later", Mode: filemode.Regular, Hash: blob},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	w := NewTreeWalker(tree, true, nil)
+	defer w.Close()
+
+	name, _, err := w.Next()
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+	assert.Equal(t, "gone", name)
+	assert.NotErrorIs(t, err, io.EOF)
+
+	name, _, err = w.Next()
+	require.NoError(t, err)
+	assert.Equal(t, "later", name)
+
+	_, _, err = w.Next()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestTreeWalkerNextReportsAbsentSubtreeInPartialClone(t *testing.T) {
+	t.Parallel()
+
+	const missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	st := memory.NewStorage()
+	absent := plumbing.NewHash(missingObjectID)
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "gone", Mode: filemode.Dir, Hash: absent},
+	})
+
+	tree, err := GetTree(promisorStorer{EncodedObjectStorer: st}, root)
+	require.NoError(t, err)
+
+	w := NewTreeWalker(tree, true, nil)
+	defer w.Close()
+
+	_, _, err = w.Next()
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+	assert.NotErrorIs(t, err, io.EOF)
+	assert.NotErrorIs(t, err, ErrInvalidTree)
 }

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -2670,6 +2670,54 @@ func TestTreeFilesSurfacesSlashBearingEntryName(t *testing.T) {
 	assert.ErrorIs(t, tree.Validate(), ErrInvalidTree)
 }
 
+func TestTreeWalkerRestoresParentPathAfterSlashBearingDirectory(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	blob := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	leaf := storeTestTree(t, st, []TreeEntry{{Name: "child", Mode: filemode.Regular, Hash: blob}})
+	empty := storeTestTree(t, st, nil)
+	subtree := storeTestTree(t, st, []TreeEntry{
+		{Name: "c/d", Mode: filemode.Dir, Hash: leaf},
+		{Name: "empty/dir", Mode: filemode.Dir, Hash: empty},
+		{Name: "z", Mode: filemode.Regular, Hash: blob},
+	})
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "a/b", Mode: filemode.Dir, Hash: subtree},
+		{Name: "z", Mode: filemode.Regular, Hash: blob},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	walker := NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+
+	wantNames := []string{
+		"a/b",
+		"a/b/c/d",
+		"a/b/c/d/child",
+		"a/b/empty/dir",
+		"a/b/z",
+		"z",
+	}
+	for _, want := range wantNames {
+		name, _, err := walker.Next()
+		require.NoError(t, err)
+		assert.Equal(t, want, name)
+	}
+
+	_, _, err = walker.Next()
+	require.ErrorIs(t, err, io.EOF)
+
+	var names []string
+	require.NoError(t, tree.Files().ForEach(func(f *File) error {
+		names = append(names, f.Name)
+		return nil
+	}))
+	assert.Equal(t, []string{"a/b/c/d/child", "a/b/z", "z"}, names)
+}
+
 func TestTreeWalkerNextRejectsDirEntryPointingAtBlob(t *testing.T) {
 	t.Parallel()
 

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -2465,3 +2465,141 @@ func TestTreeValidateReportsAllRules(t *testing.T) {
 	assert.ErrorIs(t, verr, pathutil.ErrInvalidPath)
 	assert.Contains(t, verr.Error(), "null hash")
 }
+
+func TestTreeFindEntryRefusesNonDirectoryDescent(t *testing.T) {
+	t.Parallel()
+
+	const (
+		entryName  = "evil"
+		lookupPath = entryName + "/foo"
+	)
+
+	st := memory.NewStorage()
+	payload := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	subtree := storeTestTree(t, st, []TreeEntry{
+		{Name: "foo", Mode: filemode.Regular, Hash: payload},
+	})
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: entryName, Mode: filemode.Symlink, Hash: subtree},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	_, err = tree.FindEntry(lookupPath)
+	assert.ErrorIs(t, err, ErrDirectoryNotFound)
+
+	_, err = tree.File(lookupPath)
+	assert.ErrorIs(t, err, ErrFileNotFound)
+
+	_, err = tree.Size(lookupPath)
+	assert.ErrorIs(t, err, ErrEntryNotFound)
+
+	leaf, err := tree.FindEntry(entryName)
+	require.NoError(t, err)
+	assert.Equal(t, filemode.Symlink, leaf.Mode)
+	assert.Equal(t, subtree, leaf.Hash)
+
+	got, err := tree.Tree(entryName)
+	require.NoError(t, err)
+	assert.Len(t, got.Entries, 1)
+}
+
+func TestTreeFindEntryDescendsIntoDirectories(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	payload := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	leaf := storeTestTree(t, st, []TreeEntry{
+		{Name: "foo", Mode: filemode.Regular, Hash: payload},
+	})
+	mid := storeTestTree(t, st, []TreeEntry{
+		{Name: "bar", Mode: filemode.Dir, Hash: leaf},
+	})
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "baz", Mode: filemode.Dir, Hash: mid},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	// Exercise both uncached and cached lookup.
+	for range 2 {
+		entry, err := tree.FindEntry("baz/bar/foo")
+		require.NoError(t, err)
+		assert.Equal(t, filemode.Regular, entry.Mode)
+		assert.Equal(t, payload, entry.Hash)
+	}
+}
+
+func TestTreeFindEntryCacheDoesNotBypassModeCheck(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	payload := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	shared := storeTestTree(t, st, []TreeEntry{
+		{Name: "foo", Mode: filemode.Regular, Hash: payload},
+	})
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "dir", Mode: filemode.Dir, Hash: shared},
+		{Name: "evil", Mode: filemode.Symlink, Hash: shared},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	entry, err := tree.FindEntry("dir/foo")
+	require.NoError(t, err)
+	assert.Equal(t, payload, entry.Hash)
+
+	_, err = tree.FindEntry("evil/foo")
+	assert.ErrorIs(t, err, ErrDirectoryNotFound)
+}
+
+func TestTreeFindEntryRefusesSubmoduleDescent(t *testing.T) {
+	t.Parallel()
+
+	st := memory.NewStorage()
+	payload := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	subtree := storeTestTree(t, st, []TreeEntry{
+		{Name: "foo", Mode: filemode.Regular, Hash: payload},
+	})
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: "sub", Mode: filemode.Submodule, Hash: subtree},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	_, err = tree.FindEntry("sub/foo")
+	assert.ErrorIs(t, err, ErrDirectoryNotFound)
+}
+
+func TestTreeFilesSurfacesSlashBearingEntryName(t *testing.T) {
+	t.Parallel()
+
+	const (
+		entryName        = "evil"
+		slashBearingName = entryName + "/shadow"
+	)
+
+	st := memory.NewStorage()
+	link := storeTestObject(t, st, plumbing.BlobObject, []byte("/victim"))
+	payload := storeTestObject(t, st, plumbing.BlobObject, []byte("payload\n"))
+	root := storeTestTree(t, st, []TreeEntry{
+		{Name: entryName, Mode: filemode.Symlink, Hash: link},
+		{Name: slashBearingName, Mode: filemode.Regular, Hash: payload},
+	})
+
+	tree, err := GetTree(st, root)
+	require.NoError(t, err)
+
+	var names []string
+	require.NoError(t, tree.Files().ForEach(func(f *File) error {
+		names = append(names, f.Name)
+		return nil
+	}))
+	assert.Equal(t, []string{entryName, slashBearingName}, names)
+
+	assert.ErrorIs(t, tree.Validate(), ErrInvalidTree)
+}

--- a/utils/merkletrie/doubleiter.go
+++ b/utils/merkletrie/doubleiter.go
@@ -42,17 +42,17 @@ func newDoubleIter(from, to noder.Noder, hashEqual noder.Equal) (
 	var err error
 
 	if ii.from.iter, err = NewIter(from); err != nil {
-		return nil, fmt.Errorf("from: %s", err)
+		return nil, fmt.Errorf("from: %w", err)
 	}
 	if ii.from.current, err = ii.from.iter.Next(); turnEOFIntoNil(err) != nil {
-		return nil, fmt.Errorf("from: %s", err)
+		return nil, fmt.Errorf("from: %w", err)
 	}
 
 	if ii.to.iter, err = NewIter(to); err != nil {
-		return nil, fmt.Errorf("to: %s", err)
+		return nil, fmt.Errorf("to: %w", err)
 	}
 	if ii.to.current, err = ii.to.iter.Next(); turnEOFIntoNil(err) != nil {
-		return nil, fmt.Errorf("to: %s", err)
+		return nil, fmt.Errorf("to: %w", err)
 	}
 
 	ii.hashEqual = hashEqual
@@ -149,12 +149,12 @@ func (d *doubleIter) compare() (s comparison, err error) {
 
 	fromNumChildren, err := d.from.current.NumChildren()
 	if err != nil {
-		return comparison{}, fmt.Errorf("from: %s", err)
+		return comparison{}, fmt.Errorf("from: %w", err)
 	}
 
 	toNumChildren, err := d.to.current.NumChildren()
 	if err != nil {
-		return comparison{}, fmt.Errorf("to: %s", err)
+		return comparison{}, fmt.Errorf("to: %w", err)
 	}
 
 	s.fromIsEmptyDir = fromIsDir && fromNumChildren == 0

--- a/utils/merkletrie/doubleiter_test.go
+++ b/utils/merkletrie/doubleiter_test.go
@@ -1,0 +1,79 @@
+package merkletrie_test
+
+import (
+	ctx "context"
+	"errors"
+
+	"github.com/go-git/go-git/v6/utils/merkletrie"
+	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
+)
+
+type fakeNoder struct {
+	name     string
+	children []noder.Noder
+	childErr error
+	numErr   error
+}
+
+func (n fakeNoder) Hash() []byte   { return []byte(n.name) }
+func (n fakeNoder) Name() string   { return n.name }
+func (n fakeNoder) String() string { return n.name }
+func (n fakeNoder) IsDir() bool    { return true }
+func (n fakeNoder) Skip() bool     { return false }
+
+func (n fakeNoder) Children() ([]noder.Noder, error) {
+	if n.childErr != nil {
+		return nil, n.childErr
+	}
+	return n.children, nil
+}
+
+func (n fakeNoder) NumChildren() (int, error) {
+	if n.numErr != nil {
+		return 0, n.numErr
+	}
+	return len(n.children), nil
+}
+
+func (s *DiffTreeSuite) TestDiffTreeWrapsRootErrors() {
+	const (
+		fromName      = "from"
+		toName        = "to"
+		directoryName = "d"
+	)
+
+	sentinel := errors.New("store cannot answer")
+	hashEqual := func(_, _ noder.Hasher) bool { return false }
+
+	tests := []struct {
+		name     string
+		fromErr  error
+		toErr    error
+		children bool
+	}{
+		{name: "from root children", fromErr: sentinel},
+		{name: "to root children", toErr: sentinel},
+		{name: "from directory child count", fromErr: sentinel, children: true},
+		{name: "to directory child count", toErr: sentinel, children: true},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			var from, to noder.Noder
+			if tc.children {
+				from = fakeNoder{name: fromName, children: []noder.Noder{
+					fakeNoder{name: directoryName, numErr: tc.fromErr},
+				}}
+				to = fakeNoder{name: toName, children: []noder.Noder{
+					fakeNoder{name: directoryName, numErr: tc.toErr},
+				}}
+			} else {
+				from = fakeNoder{name: fromName, childErr: tc.fromErr}
+				to = fakeNoder{name: toName, childErr: tc.toErr}
+			}
+
+			_, err := merkletrie.DiffTreeContext(ctx.Background(), from, to, hashEqual)
+			s.ErrorIs(err, sentinel)
+		})
+	}
+}

--- a/utils/merkletrie/index/node.go
+++ b/utils/merkletrie/index/node.go
@@ -29,6 +29,12 @@ type node struct {
 // RootNodeOptions contains configuration for the root node.
 type RootNodeOptions struct {
 	UpholdExecutableBit bool
+
+	// IgnoreSkipWorktree reports every entry to the diff, including those
+	// flagged SkipWorktree. Callers that bring the index to a tree need
+	// those entries; callers that compare the index with the worktree must
+	// leave it unset, because a skipped path is absent from disk by design.
+	IgnoreSkipWorktree bool
 }
 
 // NewRootNode returns the root node of a computed tree from a index.Index,
@@ -44,6 +50,7 @@ func NewRootNodeWithOptions(idx *index.Index, options RootNodeOptions) noder.Nod
 
 	for _, e := range idx.Entries {
 		parts := strings.Split(e.Name, string("/"))
+		skip := e.SkipWorktree && !options.IgnoreSkipWorktree
 
 		var fullpath string
 		for _, part := range parts {
@@ -56,13 +63,13 @@ func NewRootNodeWithOptions(idx *index.Index, options RootNodeOptions) noder.Nod
 			// of the tree needs to have this value set to false so that subdirectories
 			// are not ignored.
 			if parentNode, ok := m[fullpath]; ok {
-				if !e.SkipWorktree {
+				if !skip {
 					parentNode.skip = false
 				}
 				continue
 			}
 
-			n := &node{path: fullpath, skip: e.SkipWorktree, upholdExecutableBit: options.UpholdExecutableBit}
+			n := &node{path: fullpath, skip: skip, upholdExecutableBit: options.UpholdExecutableBit}
 			if fullpath == e.Name {
 				n.entry = e
 			} else {

--- a/utils/merkletrie/index/node_test.go
+++ b/utils/merkletrie/index/node_test.go
@@ -93,6 +93,35 @@ func (s *NoderSuite) TestDiffSkipIssue1455() {
 	s.Equal(a, merkletrie.Insert)
 }
 
+// TestDiffIgnoreSkipWorktree covers the option reset uses to bring the index
+// to a tree: every entry is reported, so a path the sparse-checkout excludes
+// still follows its target.
+func (s *NoderSuite) TestDiffIgnoreSkipWorktree() {
+	idx := &index.Index{
+		Entries: []*index.Entry{
+			{
+				Name:         path.Join("bar", "baz", "bar"),
+				Hash:         plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"),
+				SkipWorktree: true,
+			},
+			{
+				Name:         path.Join("bar", "biz", "bat"),
+				Hash:         plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d"),
+				SkipWorktree: false,
+			},
+		},
+	}
+
+	options := RootNodeOptions{UpholdExecutableBit: true, IgnoreSkipWorktree: true}
+	ch, err := merkletrie.DiffTree(
+		NewRootNodeWithOptions(&index.Index{}, options),
+		NewRootNodeWithOptions(idx, options),
+		isEquals,
+	)
+	s.NoError(err)
+	s.Len(ch, 2)
+}
+
 func (s *NoderSuite) TestDiffDir() {
 	indexA := &index.Index{
 		Entries: []*index.Entry{{

--- a/worktree.go
+++ b/worktree.go
@@ -64,6 +64,15 @@ type Worktree struct {
 }
 
 // Filesystem returns the underlying filesystem for the worktree.
+// It bypasses the worktree wrapper's reserved-path and leading-symlink checks.
+//
+// PlainInit and PlainOpen use a filesystem bound to the worktree root, but
+// root containment does not protect an in-root .git directory from direct
+// writes or writes through an in-root symlink. Caller-supplied filesystems
+// provide their own containment guarantees, which may be none.
+//
+// Use Checkout or Reset to materialize tree contents with worktree path
+// validation and blocking-symlink handling.
 func (w *Worktree) Filesystem() billy.Filesystem {
 	return w.filesystem.Filesystem
 }

--- a/worktree.go
+++ b/worktree.go
@@ -185,14 +185,16 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		return err
 	}
 
-	if err := w.updateHEAD(ref.Hash()); err != nil {
-		return err
-	}
-
-	if err := w.Reset(&ResetOptions{
+	if err := w.reset(&ResetOptions{
 		Mode:   MergeReset,
 		Commit: ref.Hash(),
 	}); err != nil {
+		return err
+	}
+
+	// Publish the fetched commit only after the reset succeeds. updateHEAD
+	// also creates the current branch when pulling into an unborn HEAD.
+	if err := w.updateHEAD(ref.Hash()); err != nil {
 		return err
 	}
 
@@ -353,7 +355,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 }
 
 // reset updates the index and worktree without changing references. Checkout
-// switches HEAD afterward; Reset moves the current branch afterward.
+// switches HEAD afterward; Reset and Pull move the current branch afterward.
 func (w *Worktree) reset(opts *ResetOptions) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()

--- a/worktree.go
+++ b/worktree.go
@@ -399,16 +399,27 @@ func (w *Worktree) reset(opts *ResetOptions) error {
 		}
 	}
 
-	var prevTree *object.Tree
-	if opts.Mode == HardReset || opts.Mode == KeepReset {
-		prevTree, err = w.headTree()
+	var trackedChanges merkletrie.Changes
+	if opts.Mode == HardReset {
+		// The index identifies tracked paths even when the old HEAD tree is
+		// unreadable. Capture its diff before resetIndex replaces it, including
+		// staged additions that must be removed when absent from the target.
+		trackedChanges, err = w.diffTreeWithStaging(t, true)
 		if err != nil {
 			return err
 		}
 	}
 
 	if opts.Mode == KeepReset {
+		prevTree, err := w.headTree()
+		if err != nil {
+			return err
+		}
 		if err := w.checkKeepResetConflicts(prevTree, t, opts.SparseDirs, opts.Files); err != nil {
+			return err
+		}
+		trackedChanges, err = diffTrees(prevTree, t)
+		if err != nil {
 			return err
 		}
 	}
@@ -427,7 +438,7 @@ func (w *Worktree) reset(opts *ResetOptions) error {
 	}
 
 	if opts.Mode == HardReset || opts.Mode == KeepReset {
-		if err := w.resetWorktreeToTree(cfg, prevTree, t, opts.Files); err != nil {
+		if err := w.resetWorktreeToTree(cfg, t, trackedChanges, opts.Files); err != nil {
 			return err
 		}
 	}
@@ -685,37 +696,21 @@ func (w *Worktree) checkKeepResetConflicts(fromTree, toTree *object.Tree, sparse
 	return nil
 }
 
-// resetWorktreeToTree updates the worktree to match toTree, mirroring
-// real git reset --hard / checkout -f:
+// resetWorktreeToTree applies tracked deletions and writes the new index's
+// contents to the worktree. trackedChanges must be computed before resetting
+// the index: HardReset compares the old index with toTree; KeepReset compares
+// the old HEAD tree with toTree.
 //
-//  1. Tree-to-tree diff (fromTree→toTree): remove files that were tracked in
-//     fromTree but deleted in toTree. Because the diff is purely object-graph,
-//     untracked files never appear and are never deleted.
-//
-//  2. New-index-to-worktree diff: write files that are in the new index but
-//     absent or different on disk. For Delete actions (file on disk, but absent
-//     from the index): the file is truly untracked and is preserved.
-//     (SkipWorktree entries are invisible to the merkletrie diff; they are
-//     handled in step 3.)
-//
-//  3. Remove SkipWorktree files from disk: diffStagingWithWorktree never
-//     surfaces SkipWorktree-flagged entries as Delete actions because the
-//     merkletrie marks them skip=true. Mirror git's behaviour: any tracked
-//     file with SkipWorktree=true must not exist in the worktree.
-//
-// files optionally restricts the operation to a specific subset of paths.
-func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *object.Tree, files []string) error {
+// Untracked paths absent from the target are preserved. SkipWorktree entries
+// are removed separately because they are excluded from the worktree diff.
+// A nonempty files slice restricts updates to the selected paths.
+func (w *Worktree) resetWorktreeToTree(cfg *config.Config, toTree *object.Tree, trackedChanges merkletrie.Changes, files []string) error {
 	filesMap := buildFilePathMap(files)
 
 	fs, closeFS := w.reusableRootFS()
 	defer closeFS()
 
-	// Step 1: delete files removed from the tracked tree.
-	treeChanges, err := diffTrees(fromTree, toTree)
-	if err != nil {
-		return err
-	}
-	for _, ch := range treeChanges {
+	for _, ch := range trackedChanges {
 		a, err := ch.Action()
 		if err != nil {
 			return err

--- a/worktree.go
+++ b/worktree.go
@@ -220,7 +220,7 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 	}
 
 	if opts.Create {
-		if err := w.createBranch(opts); err != nil {
+		if err := w.validateNewBranch(opts); err != nil {
 			return err
 		}
 	}
@@ -241,30 +241,24 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 		ro.Mode = SoftReset
 	}
 
-	// For HardReset and KeepReset, capture the current tree BEFORE updating
-	// HEAD. This ensures resetWorktreeToTree correctly diffs from where we
-	// actually are, not from where HEAD will point after the update.
-	if ro.Mode == HardReset || ro.Mode == KeepReset {
-		ro.fromTree, err = w.headTree()
-		if err != nil {
-			return err
-		}
-	}
-
-	if !opts.Hash.IsZero() && !opts.Create {
-		err = w.setHEADToCommit(opts.Hash)
-	} else {
-		err = w.setHEADToBranch(opts.Branch, c)
-	}
-
-	if err != nil {
+	if err := w.reset(ro); err != nil {
 		return err
 	}
 
-	return w.Reset(ro)
+	// A failed tree read must not switch HEAD or create a branch. Resetting
+	// through the current HEAD would also move the branch we are leaving.
+	if opts.Create {
+		if err := w.r.Storer.SetReference(plumbing.NewHashReference(opts.Branch, c)); err != nil {
+			return err
+		}
+	}
+	if !opts.Hash.IsZero() && !opts.Create {
+		return w.setHEADToCommit(c)
+	}
+	return w.setHEADToBranch(opts.Branch, c)
 }
 
-func (w *Worktree) createBranch(opts *CheckoutOptions) error {
+func (w *Worktree) validateNewBranch(opts *CheckoutOptions) error {
 	if err := opts.Branch.Validate(); err != nil {
 		return err
 	}
@@ -287,9 +281,7 @@ func (w *Worktree) createBranch(opts *CheckoutOptions) error {
 		opts.Hash = ref.Hash()
 	}
 
-	return w.r.Storer.SetReference(
-		plumbing.NewHashReference(opts.Branch, opts.Hash),
-	)
+	return nil
 }
 
 func (w *Worktree) getCommitFromCheckoutOptions(opts *CheckoutOptions) (plumbing.Hash, error) {
@@ -345,6 +337,15 @@ func (w *Worktree) setHEADToBranch(branch plumbing.ReferenceName, commit plumbin
 
 // Reset the worktree to a specified state.
 func (w *Worktree) Reset(opts *ResetOptions) error {
+	if err := w.reset(opts); err != nil {
+		return err
+	}
+	return w.setHEADCommit(opts.Commit)
+}
+
+// reset updates the index and worktree without changing references. Checkout
+// switches HEAD afterward; Reset moves the current branch afterward.
+func (w *Worktree) reset(opts *ResetOptions) error {
 	if trace.Performance.Enabled() {
 		start := time.Now()
 		defer func() {
@@ -373,7 +374,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 	}
 
 	if opts.Mode == SoftReset {
-		return w.setHEADCommit(opts.Commit)
+		return nil
 	}
 
 	t, err := w.r.getTreeFromCommitHash(opts.Commit)
@@ -387,24 +388,11 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		}
 	}
 
-	// For HardReset and KeepReset, capture the current HEAD tree before
-	// resetting HEAD. resetWorktreeToTree will diff prevTree→t and apply only
-	// those changes to the worktree. Since the diff is tree-to-tree, untracked
-	// files are invisible and are never deleted — matching real git reset --hard.
-	//
-	// If opts.fromTree is set (by Checkout), use that instead of calling
-	// headTree(). This handles the case where HEAD was already updated before
-	// Reset was called (e.g., in Checkout), ensuring we diff from the actual
-	// previous state rather than the new HEAD.
 	var prevTree *object.Tree
 	if opts.Mode == HardReset || opts.Mode == KeepReset {
-		if opts.fromTree != nil {
-			prevTree = opts.fromTree
-		} else {
-			prevTree, err = w.headTree()
-			if err != nil {
-				return err
-			}
+		prevTree, err = w.headTree()
+		if err != nil {
+			return err
 		}
 	}
 
@@ -412,10 +400,6 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		if err := w.checkKeepResetConflicts(prevTree, t, opts.SparseDirs, opts.Files); err != nil {
 			return err
 		}
-	}
-
-	if err := w.setHEADCommit(opts.Commit); err != nil {
-		return err
 	}
 
 	var removedFiles []string

--- a/worktree.go
+++ b/worktree.go
@@ -403,8 +403,9 @@ func (w *Worktree) reset(opts *ResetOptions) error {
 	if opts.Mode == HardReset {
 		// The index identifies tracked paths even when the old HEAD tree is
 		// unreadable. Capture its diff before resetIndex replaces it, including
-		// staged additions that must be removed when absent from the target.
-		trackedChanges, err = w.diffTreeWithStaging(t, true)
+		// staged additions that must be removed when absent from the target and
+		// SkipWorktree paths that the target no longer records.
+		trackedChanges, err = w.diffTreeWithIndex(t, true)
 		if err != nil {
 			return err
 		}
@@ -509,9 +510,21 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs, files []string) ([]string, e
 
 	b := newIndexBuilder(idx)
 
-	changes, err := w.diffTreeWithStaging(t, true)
+	// The index must match the reset target for every path it records, so the
+	// diff reports SkipWorktree entries too. The flag itself is preserved
+	// below, and resetWorktreeToTree keeps the paths it marks off disk.
+	changes, err := w.diffTreeWithIndex(t, true)
 	if err != nil {
 		return nil, err
+	}
+
+	// Index entries are the only record of the sparse-checkout state, which a
+	// reset that does not restate dirs leaves untouched.
+	skipped := make(map[string]bool, len(idx.Entries))
+	for _, e := range idx.Entries {
+		if e.SkipWorktree {
+			skipped[e.Name] = true
+		}
 	}
 
 	removedFiles := make([]string, 0, len(changes))
@@ -550,9 +563,10 @@ func (w *Worktree) resetIndex(t *object.Tree, dirs, files []string) ([]string, e
 		}
 
 		b.Add(&index.Entry{
-			Name: name,
-			Hash: e.Hash,
-			Mode: e.Mode,
+			Name:         name,
+			Hash:         e.Hash,
+			Mode:         e.Mode,
+			SkipWorktree: skipped[name],
 		})
 	}
 

--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -205,19 +205,18 @@ func isDotGitVariant(part string, protectHFS bool) bool {
 	return false
 }
 
-// validPath checks whether paths are valid for the worktree
-// filesystem abstraction. It is intentionally tolerant of .git as
-// the final path component of a multi-component path
-// (e.g. "submodule/.git"), so that legitimate gitlink pointer files
-// can still be Stat'd, Read, and Removed via the wrapper during
-// submodule cleanup. Attacker-controlled tree-entry paths are
-// validated separately by pathutil.ValidTreePath at the boundaries
-// where data leaves the trusted store (Tree.FindEntry, the explicit
-// callers in CherryPick and Submodule.Repository).
+// validPath checks path strings, allowing a final, non-root .git component
+// such as "submodule/.git" for submodule pointer-file operations.
 //
-// For upstream rules:
-// https://github.com/git/git/blob/v2.54.0/read-cache.c#L987
-// https://github.com/git/git/blob/v2.54.0/path.c#L1419
+// Tree paths have separate checks: FindEntry validates lookup paths,
+// TreeEntryFile validates file names, and TreeWalker.Next validates entry names
+// unless its internal skipPathValidation flag is set. Tree.Validate checks
+// names when explicitly called. CherryPick reaches the object API checks
+// through its merge operations. Submodule.Repository validates paths from
+// .gitmodules, and index.Index.Add rejects unsafe names before tree creation.
+//
+// validWritePath and validReadPath also check for leading symlinks on disk;
+// validPath alone cannot detect them.
 func (sfs *worktreeFilesystem) validPath(paths ...string) error {
 	for _, p := range paths {
 		for i := 0; i < len(p); i++ {

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/filemode"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/go-git/go-git/v6/plumbing/storer"
+	"github.com/go-git/go-git/v6/storage"
 	"github.com/go-git/go-git/v6/storage/memory"
 )
 
@@ -1602,4 +1603,184 @@ func TestWorktreeFilesystemHFSDotGitmodulesSymlinkAllowedWhenProtectionOff(t *te
 	fs := newWorktreeFilesystem(memfs.New(), false, false)
 	err := fs.Symlink("safe-target", ".g\u200citmodules")
 	assert.NoError(t, err, "HFS variant should be allowed when protectHFS is off")
+}
+
+func TestCheckoutRejectsAbsentSubtree(t *testing.T) {
+	t.Parallel()
+
+	const (
+		missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		siblingPath     = "zsibling"
+	)
+
+	dir := t.TempDir()
+	r, w, initCommit := initRepoWithReadme(t, dir)
+
+	payload := writeBlob(t, r.Storer, []byte("payload\n"))
+	absent := plumbing.NewHash(missingObjectID)
+	bad := buildCommitWithEntries(t, r.Storer, initCommit, initCommit.Hash,
+		[]object.TreeEntry{
+			{Name: "adir", Mode: filemode.Dir, Hash: absent},
+			{Name: siblingPath, Mode: filemode.Regular, Hash: payload},
+		},
+		"subtree the repository does not hold\n")
+
+	beforeIndex, err := r.Storer.Index()
+	require.NoError(t, err)
+
+	err = w.Checkout(&CheckoutOptions{Hash: bad.Hash, Force: true})
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+
+	_, statErr := os.Lstat(filepath.Join(dir, siblingPath))
+	assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+	afterIndex, err := r.Storer.Index()
+	require.NoError(t, err)
+	assert.Equal(t, beforeIndex, afterIndex)
+}
+
+type promisorStorage struct {
+	storage.Storer
+}
+
+func (promisorStorage) PromisorObjectPacks() ([]plumbing.Hash, error) {
+	const promisorPackID = "cccccccccccccccccccccccccccccccccccccccc"
+
+	return []plumbing.Hash{plumbing.NewHash(promisorPackID)}, nil
+}
+
+func TestCheckoutRejectsAbsentSubtreeInPartialClone(t *testing.T) {
+	t.Parallel()
+
+	const (
+		missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		siblingPath     = "zsibling"
+	)
+
+	dir := t.TempDir()
+	r, _, initCommit := initRepoWithReadme(t, dir)
+
+	payload := writeBlob(t, r.Storer, []byte("payload\n"))
+	absent := plumbing.NewHash(missingObjectID)
+	bad := buildCommitWithEntries(t, r.Storer, initCommit, initCommit.Hash,
+		[]object.TreeEntry{
+			{Name: "adir", Mode: filemode.Dir, Hash: absent},
+			{Name: siblingPath, Mode: filemode.Regular, Hash: payload},
+		},
+		"subtree withheld by a promisor remote\n")
+
+	pr, err := Open(promisorStorage{r.Storer}, osfs.New(dir))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pr.Close()) })
+
+	pw, err := pr.Worktree()
+	require.NoError(t, err)
+
+	err = pw.Checkout(&CheckoutOptions{Hash: bad.Hash, Force: true})
+	require.ErrorIs(t, err, plumbing.ErrObjectNotFound)
+
+	idx, err := pr.Storer.Index()
+	require.NoError(t, err)
+
+	for _, e := range idx.Entries {
+		assert.NotEqual(t, siblingPath, e.Name)
+	}
+}
+
+func TestCheckoutRejectsDirectoryEntryPointingAtBlob(t *testing.T) {
+	t.Parallel()
+
+	const entryName = "evil"
+
+	t.Run("in the root tree", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		r, w, initCommit := initRepoWithReadme(t, dir)
+
+		payload := writeBlob(t, r.Storer, []byte("payload\n"))
+		bad := buildCommitWithEntries(t, r.Storer, initCommit, initCommit.Hash,
+			[]object.TreeEntry{{Name: entryName, Mode: filemode.Dir, Hash: payload}},
+			"directory entry over a blob\n")
+
+		err := w.Checkout(&CheckoutOptions{Hash: bad.Hash, Force: true})
+		require.ErrorIs(t, err, object.ErrInvalidTree)
+
+		_, statErr := os.Lstat(filepath.Join(dir, entryName))
+		assert.ErrorIs(t, statErr, os.ErrNotExist)
+	})
+
+	t.Run("replacing a symlink out of the worktree", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			victimName    = "shadow"
+			victimContent = "victim\n"
+		)
+
+		victim := t.TempDir()
+		victimFile := filepath.Join(victim, victimName)
+		err := os.WriteFile(victimFile, []byte(victimContent), 0o644)
+		require.NoError(t, err)
+
+		dir := t.TempDir()
+		r, w, initCommit := initRepoWithReadme(t, dir)
+
+		link := writeBlob(t, r.Storer, []byte(victim))
+		withLink := buildCommitWithEntries(t, r.Storer, initCommit, initCommit.Hash,
+			[]object.TreeEntry{{Name: entryName, Mode: filemode.Symlink, Hash: link}},
+			"add evil symlink\n")
+
+		err = w.Checkout(&CheckoutOptions{Hash: withLink.Hash, Force: true})
+		require.NoError(t, err)
+
+		fi, err := os.Lstat(filepath.Join(dir, entryName))
+		require.NoError(t, err)
+		require.NotZero(t, fi.Mode()&os.ModeSymlink)
+
+		payload := writeBlob(t, r.Storer, []byte("payload\n"))
+		bad := buildCommitReplacingRootEntry(t, r.Storer, withLink, withLink.Hash,
+			object.TreeEntry{Name: entryName, Mode: filemode.Dir, Hash: payload})
+
+		err = w.Checkout(&CheckoutOptions{Hash: bad.Hash, Force: true})
+		require.ErrorIs(t, err, object.ErrInvalidTree)
+
+		data, err := os.ReadFile(victimFile)
+		require.NoError(t, err)
+		assert.Equal(t, victimContent, string(data))
+
+		names, err := os.ReadDir(victim)
+		require.NoError(t, err)
+		require.Len(t, names, 1)
+		assert.Equal(t, victimName, names[0].Name())
+	})
+}
+
+// initRepoWithReadme initialises a repository at dir with a single
+// committed file, and returns it alongside its worktree and that commit.
+func initRepoWithReadme(t *testing.T, dir string) (*Repository, *Worktree, *object.Commit) {
+	t.Helper()
+
+	const readmePath = "README"
+
+	r, err := PlainInit(dir, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = r.Close() })
+
+	w, err := r.Worktree()
+	require.NoError(t, err)
+
+	require.NoError(t, util.WriteFile(w.Filesystem(), readmePath, []byte("init"), 0o644))
+
+	_, err = w.Add(readmePath)
+	require.NoError(t, err)
+
+	hash, err := w.Commit("initial commit\n", &CommitOptions{Author: defaultSignature()})
+	require.NoError(t, err)
+
+	commit, err := r.CommitObject(hash)
+	require.NoError(t, err)
+
+	return r, w, commit
 }

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -249,7 +249,27 @@ func (w *Worktree) diffCommitWithStaging(commit plumbing.Hash, reverse bool) (me
 	return w.diffTreeWithStaging(t, reverse)
 }
 
+// diffTreeWithStaging returns the changes between t and the index as the
+// worktree sees it. SkipWorktree entries are left out, because a path the
+// sparse-checkout excludes is absent from disk by design.
 func (w *Worktree) diffTreeWithStaging(t *object.Tree, reverse bool) (merkletrie.Changes, error) {
+	return w.diffTreeWithIndexNode(t, reverse, mindex.RootNodeOptions{
+		UpholdExecutableBit: true,
+	})
+}
+
+// diffTreeWithIndex returns the changes between t and every index entry,
+// including those flagged SkipWorktree. Reset uses it to bring the index to
+// its target while the flag continues to decide which paths reach the
+// worktree, as git does.
+func (w *Worktree) diffTreeWithIndex(t *object.Tree, reverse bool) (merkletrie.Changes, error) {
+	return w.diffTreeWithIndexNode(t, reverse, mindex.RootNodeOptions{
+		UpholdExecutableBit: true,
+		IgnoreSkipWorktree:  true,
+	})
+}
+
+func (w *Worktree) diffTreeWithIndexNode(t *object.Tree, reverse bool, options mindex.RootNodeOptions) (merkletrie.Changes, error) {
 	var from noder.Noder
 	if t != nil {
 		from = object.NewTreeRootNode(t)
@@ -260,7 +280,7 @@ func (w *Worktree) diffTreeWithStaging(t *object.Tree, reverse bool) (merkletrie
 		return nil, err
 	}
 
-	to := mindex.NewRootNode(idx)
+	to := mindex.NewRootNodeWithOptions(idx, options)
 
 	if reverse {
 		return merkletrie.DiffTree(to, from, diffTreeIsEquals)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -297,6 +297,104 @@ func (s *RepositorySuite) TestPullAdd() {
 	s.NotEqual("6ecf0ef2c2dffb796033e5a02219af86ec6584e5", branch.Hash().String())
 }
 
+func (s *WorktreeSuite) TestPullAbsentSubtreePreservesCurrentBranch() {
+	const (
+		readmePath     = "README"
+		directoryName  = "adir"
+		childName      = "child"
+		siblingPath    = "zsibling"
+		payloadContent = "payload\n"
+	)
+
+	t := s.T()
+	dir := t.TempDir()
+	remote, _, initial := initRepoWithReadme(t, dir)
+
+	local, err := Clone(memory.NewStorage(), memfs.New(), &CloneOptions{URL: dir})
+	s.Require().NoError(err)
+	t.Cleanup(func() { require.NoError(t, local.Close()) })
+
+	w, err := local.Worktree()
+	s.Require().NoError(err)
+
+	beforeBranch, err := local.Head()
+	s.Require().NoError(err)
+
+	beforeHEAD, err := local.Storer.Reference(plumbing.HEAD)
+	s.Require().NoError(err)
+
+	beforeIndex := snapshotIndex(t, local)
+
+	payload := writeBlob(t, remote.Storer, []byte(payloadContent))
+	subtree := storeRawTree(t, remote.Storer, []object.TreeEntry{
+		{Name: childName, Mode: filemode.Regular, Hash: payload},
+	})
+	target := buildCommitWithEntries(t, remote.Storer, initial, initial.Hash, []object.TreeEntry{
+		{Name: directoryName, Mode: filemode.Dir, Hash: subtree},
+		{Name: siblingPath, Mode: filemode.Regular, Hash: payload},
+	}, "withheld subtree")
+
+	err = remote.Storer.SetReference(plumbing.NewHashReference(beforeBranch.Name(), target.Hash))
+	s.Require().NoError(err)
+
+	// Model a filtered fetch by copying the commit, root tree, and blobs
+	// while withholding the subtree.
+	for _, hash := range []plumbing.Hash{payload, target.TreeHash, target.Hash} {
+		obj, err := remote.Storer.EncodedObject(plumbing.AnyObject, hash)
+		s.Require().NoError(err)
+
+		_, err = local.Storer.SetEncodedObject(obj)
+		s.Require().NoError(err)
+	}
+
+	for range 2 {
+		err = w.Pull(&PullOptions{})
+		s.Require().ErrorIs(err, plumbing.ErrObjectNotFound)
+
+		afterHEAD, err := local.Storer.Reference(plumbing.HEAD)
+		s.Require().NoError(err)
+		s.Equal(beforeHEAD, afterHEAD)
+
+		afterBranch, err := local.Head()
+		s.Require().NoError(err)
+		s.Equal(beforeBranch, afterBranch)
+
+		s.Equal(beforeIndex, snapshotIndex(t, local))
+
+		readme, err := util.ReadFile(w.Filesystem(), readmePath)
+		s.Require().NoError(err)
+		s.Equal("init", string(readme))
+
+		_, err = w.Filesystem().Lstat(siblingPath)
+		s.ErrorIs(err, os.ErrNotExist)
+	}
+
+	_, err = w.Commit("after failed pull", &CommitOptions{Author: defaultSignature()})
+	s.ErrorIs(err, ErrEmptyCommit)
+
+	err = w.Checkout(&CheckoutOptions{Branch: beforeBranch.Name(), Force: true})
+	s.Require().NoError(err)
+
+	obj, err := remote.Storer.EncodedObject(plumbing.TreeObject, subtree)
+	s.Require().NoError(err)
+
+	_, err = local.Storer.SetEncodedObject(obj)
+	s.Require().NoError(err)
+
+	err = w.Pull(&PullOptions{})
+	s.Require().NoError(err)
+
+	afterBranch, err := local.Head()
+	s.Require().NoError(err)
+	s.Equal(target.Hash, afterBranch.Hash())
+
+	for _, path := range []string{directoryName + "/" + childName, siblingPath} {
+		data, err := util.ReadFile(w.Filesystem(), path)
+		s.Require().NoError(err)
+		s.Equal(payloadContent, string(data), "path: %s", path)
+	}
+}
+
 func (s *WorktreeSuite) TestPullAlreadyUptodate() {
 	url := s.GetLocalRepositoryURL(fixtures.Basic().ByTag("worktree").One())
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2575,6 +2575,113 @@ func (s *WorktreeSuite) TestMergeResetRemovesTrackedFileInIgnoredDir() {
 	s.True(os.IsNotExist(err), "vendor/keep.txt must be removed after MergeReset, got err=%v", err)
 }
 
+// commitSparseFixture writes path with content, stages it and commits, so
+// the sparse reset tests have two commits that differ outside the sparse
+// directories.
+func (s *WorktreeSuite) commitSparseFixture(w *Worktree, fs billy.Filesystem, path, content string) plumbing.Hash {
+	s.Require().NoError(fs.MkdirAll(filepath.Dir(path), os.ModePerm))
+	s.Require().NoError(util.WriteFile(fs, path, []byte(content), 0o644))
+	_, err := w.Add(path)
+	s.Require().NoError(err)
+	h, err := w.Commit(content, &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
+	s.Require().NoError(err)
+
+	return h
+}
+
+// TestResetSparselyUpdatesExcludedEntry checks that a sparse reset brings an
+// index entry outside the sparse directories to its target. git keeps the
+// index matching the commit it resets to and lets SkipWorktree decide only
+// which paths reach the worktree, so status is clean afterwards.
+func (s *WorktreeSuite) TestResetSparselyUpdatesExcludedEntry() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
+	}
+
+	s.Require().NoError(w.Checkout(&CheckoutOptions{}))
+
+	first := s.commitSparseFixture(w, fs, "excluded/f.txt", "v1")
+	second := s.commitSparseFixture(w, fs, "excluded/f.txt", "v2")
+
+	sparse := []string{"php"}
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: HardReset, Commit: first, SparseDirs: sparse}))
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: HardReset, Commit: second, SparseDirs: sparse}))
+
+	target, err := s.Repository.getTreeFromCommitHash(second)
+	s.Require().NoError(err)
+	want, err := target.FindEntry("excluded/f.txt")
+	s.Require().NoError(err)
+
+	idx, err := s.Repository.Storer.Index()
+	s.Require().NoError(err)
+	e, err := idx.Entry("excluded/f.txt")
+	s.Require().NoError(err)
+	s.Equal(want.Hash, e.Hash, "index entry must match the reset target")
+	s.True(e.SkipWorktree, "the path stays outside the sparse directories")
+
+	_, err = fs.Stat("excluded/f.txt")
+	s.True(os.IsNotExist(err), "excluded path must stay off disk, got err=%v", err)
+}
+
+// TestResetSparselyRemovesExcludedEntry checks that a sparse reset drops an
+// index entry the target no longer records, even though the path is outside
+// the sparse directories.
+func (s *WorktreeSuite) TestResetSparselyRemovesExcludedEntry() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
+	}
+
+	s.Require().NoError(w.Checkout(&CheckoutOptions{}))
+
+	withFile := s.commitSparseFixture(w, fs, "excluded/f.txt", "v1")
+	_, err := w.Remove("excluded/f.txt")
+	s.Require().NoError(err)
+	withoutFile, err := w.Commit("without file", &CommitOptions{Author: &object.Signature{Name: "name", Email: "email"}})
+	s.Require().NoError(err)
+
+	sparse := []string{"php"}
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: HardReset, Commit: withFile, SparseDirs: sparse}))
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: HardReset, Commit: withoutFile, SparseDirs: sparse}))
+
+	idx, err := s.Repository.Storer.Index()
+	s.Require().NoError(err)
+	_, err = idx.Entry("excluded/f.txt")
+	s.ErrorIs(err, index.ErrEntryNotFound, "index must not track a path the target dropped")
+}
+
+// TestResetKeepsSkipWorktreeWithoutSparseDirs checks that a reset which does
+// not restate SparseDirs leaves the flag alone. The index entries are the
+// only record of the sparse set, so rewriting one must carry its flag over
+// or the next worktree update would materialise the path.
+func (s *WorktreeSuite) TestResetKeepsSkipWorktreeWithoutSparseDirs() {
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		filesystem: newWorktreeFilesystem(fs, defaultProtectNTFS(), defaultProtectHFS()),
+	}
+
+	s.Require().NoError(w.Checkout(&CheckoutOptions{}))
+
+	first := s.commitSparseFixture(w, fs, "excluded/f.txt", "v1")
+	second := s.commitSparseFixture(w, fs, "excluded/f.txt", "v2")
+
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: HardReset, Commit: first, SparseDirs: []string{"php"}}))
+	s.Require().NoError(w.Reset(&ResetOptions{Mode: HardReset, Commit: second}))
+
+	idx, err := s.Repository.Storer.Index()
+	s.Require().NoError(err)
+	e, err := idx.Entry("excluded/f.txt")
+	s.Require().NoError(err)
+	s.True(e.SkipWorktree, "a reset without SparseDirs must not clear the flag")
+
+	_, err = fs.Stat("excluded/f.txt")
+	s.True(os.IsNotExist(err), "excluded path must stay off disk, got err=%v", err)
+}
+
 func (s *WorktreeSuite) TestResetSparsely() {
 	fs := memfs.New()
 	w := &Worktree{

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2176,6 +2176,125 @@ func (s *WorktreeSuite) TestResetKeepUntrackedOverwrite() {
 	s.Equal(commitA, head.Hash())
 }
 
+func (s *WorktreeSuite) TestResetHardRecoversFromUnreadableHEADTree() {
+	const (
+		readmePath       = "README"
+		initialContent   = "initial\n"
+		directoryName    = "dir"
+		childPath        = directoryName + "/child"
+		stagedPath       = "staged"
+		untrackedPath    = "untracked"
+		untrackedContent = "keep\n"
+	)
+
+	tests := []struct {
+		name          string
+		missingRoot   bool
+		forceCheckout bool
+	}{
+		{name: "subtree/reset"},
+		{name: "subtree/force checkout", forceCheckout: true},
+		{name: "root/reset", missingRoot: true},
+		{name: "root/force checkout", missingRoot: true, forceCheckout: true},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			t := s.T()
+			st := memory.NewStorage()
+			fs := memfs.New()
+			r, err := Init(st, WithWorkTree(fs))
+			s.Require().NoError(err)
+			t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+			w, err := r.Worktree()
+			s.Require().NoError(err)
+
+			err = util.WriteFile(fs, readmePath, []byte(initialContent), 0o644)
+			s.Require().NoError(err)
+
+			_, err = w.Add(readmePath)
+			s.Require().NoError(err)
+
+			target, err := w.Commit("initial", &CommitOptions{Author: defaultSignature()})
+			s.Require().NoError(err)
+
+			err = util.WriteFile(fs, readmePath, []byte("changed\n"), 0o644)
+			s.Require().NoError(err)
+
+			err = util.WriteFile(fs, childPath, []byte("tracked\n"), 0o644)
+			s.Require().NoError(err)
+
+			_, err = w.Add(".")
+			s.Require().NoError(err)
+
+			current, err := w.Commit("with subtree", &CommitOptions{Author: defaultSignature()})
+			s.Require().NoError(err)
+
+			commit, err := r.CommitObject(current)
+			s.Require().NoError(err)
+
+			tree, err := commit.Tree()
+			s.Require().NoError(err)
+
+			entry, err := tree.FindEntry(directoryName)
+			s.Require().NoError(err)
+
+			err = util.WriteFile(fs, stagedPath, []byte("staged\n"), 0o644)
+			s.Require().NoError(err)
+
+			_, err = w.Add(stagedPath)
+			s.Require().NoError(err)
+
+			err = util.WriteFile(fs, untrackedPath, []byte(untrackedContent), 0o644)
+			s.Require().NoError(err)
+
+			missingHash := entry.Hash
+			if tc.missingRoot {
+				missingHash = tree.Hash
+			}
+			delete(st.Objects, missingHash)
+			delete(st.Trees, missingHash)
+
+			for range 2 {
+				if tc.forceCheckout {
+					err = w.Checkout(&CheckoutOptions{Hash: target, Force: true})
+				} else {
+					err = w.Reset(&ResetOptions{Commit: target, Mode: HardReset})
+				}
+				s.Require().NoError(err)
+
+				head, err := r.Head()
+				s.Require().NoError(err)
+				s.Equal(target, head.Hash())
+
+				idx, err := st.Index()
+				s.Require().NoError(err)
+				s.Require().Len(idx.Entries, 1)
+				s.Equal(readmePath, idx.Entries[0].Name)
+
+				data, err := util.ReadFile(fs, readmePath)
+				s.Require().NoError(err)
+				s.Equal(initialContent, string(data))
+
+				for _, path := range []string{childPath, stagedPath} {
+					_, err := fs.Lstat(path)
+					s.ErrorIs(err, os.ErrNotExist, "path: %s", path)
+				}
+
+				data, err = util.ReadFile(fs, untrackedPath)
+				s.Require().NoError(err)
+				s.Equal(untrackedContent, string(data))
+
+				status, err := w.Status()
+				s.Require().NoError(err)
+				s.Require().Len(status, 1)
+				s.Equal(Untracked, status.File(untrackedPath).Worktree)
+			}
+		})
+	}
+}
+
 func (s *WorktreeSuite) TestResetHard() {
 	fs := memfs.New()
 	w := &Worktree{

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"errors"
 	"fmt"
 	"io"
@@ -1527,6 +1528,159 @@ func (s *WorktreeSuite) TestStatusUnmodified() {
 
 	s.Equal(Untracked, status.File("LICENSE").Staging)
 	s.Equal(Untracked, status.File("LICENSE").Worktree)
+}
+
+func (s *WorktreeSuite) TestResetUnreadableTreePreservesReferences() {
+	const (
+		targetBranch    = "refs/heads/target"
+		newBranch       = "refs/heads/new"
+		missingObjectID = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		readmePath      = "README"
+		readmeContent   = "initial\n"
+		siblingPath     = "zsibling"
+	)
+
+	tests := []struct {
+		name string
+		run  func(*Worktree, plumbing.Hash) error
+	}{
+		{
+			name: "checkout hash",
+			run: func(w *Worktree, hash plumbing.Hash) error {
+				return w.Checkout(&CheckoutOptions{Hash: hash})
+			},
+		},
+		{
+			name: "force checkout hash",
+			run: func(w *Worktree, hash plumbing.Hash) error {
+				return w.Checkout(&CheckoutOptions{Hash: hash, Force: true})
+			},
+		},
+		{
+			name: "checkout branch",
+			run: func(w *Worktree, _ plumbing.Hash) error {
+				return w.Checkout(&CheckoutOptions{Branch: targetBranch, Force: true})
+			},
+		},
+		{
+			name: "create branch",
+			run: func(w *Worktree, hash plumbing.Hash) error {
+				return w.Checkout(&CheckoutOptions{Branch: newBranch, Hash: hash, Create: true, Force: true})
+			},
+		},
+		{
+			name: "hard reset",
+			run: func(w *Worktree, hash plumbing.Hash) error {
+				return w.Reset(&ResetOptions{Commit: hash, Mode: HardReset})
+			},
+		},
+		{
+			name: "mixed reset",
+			run: func(w *Worktree, hash plumbing.Hash) error {
+				return w.Reset(&ResetOptions{Commit: hash, Mode: MixedReset})
+			},
+		},
+		{
+			name: "merge reset",
+			run: func(w *Worktree, hash plumbing.Hash) error {
+				return w.Reset(&ResetOptions{Commit: hash, Mode: MergeReset})
+			},
+		},
+		{
+			name: "keep reset",
+			run: func(w *Worktree, hash plumbing.Hash) error {
+				return w.Reset(&ResetOptions{Commit: hash, Mode: KeepReset})
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			t := s.T()
+			fs := memfs.New()
+			r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+			s.Require().NoError(err)
+			t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+			w, err := r.Worktree()
+			s.Require().NoError(err)
+
+			err = util.WriteFile(fs, readmePath, []byte(readmeContent), 0o644)
+			s.Require().NoError(err)
+
+			_, err = w.Add(readmePath)
+			s.Require().NoError(err)
+
+			initialHash, err := w.Commit("initial", &CommitOptions{Author: defaultSignature()})
+			s.Require().NoError(err)
+
+			initial, err := r.CommitObject(initialHash)
+			s.Require().NoError(err)
+
+			payload := writeBlob(t, r.Storer, []byte("payload\n"))
+			target := buildCommitWithEntries(t, r.Storer, initial, initialHash, []object.TreeEntry{
+				{Name: "adir", Mode: filemode.Dir, Hash: plumbing.NewHash(missingObjectID)},
+				{Name: siblingPath, Mode: filemode.Regular, Hash: payload},
+			}, "absent subtree")
+
+			err = r.Storer.SetReference(plumbing.NewHashReference(targetBranch, target.Hash))
+			s.Require().NoError(err)
+
+			snapshotReferences := func() map[plumbing.ReferenceName]string {
+				t.Helper()
+
+				iter, err := r.Storer.IterReferences()
+				s.Require().NoError(err)
+
+				refs := make(map[plumbing.ReferenceName]string)
+				err = iter.ForEach(func(ref *plumbing.Reference) error {
+					refs[ref.Name()] = ref.String()
+					return nil
+				})
+				s.Require().NoError(err)
+
+				return refs
+			}
+			beforeRefs := snapshotReferences()
+			beforeIndex := snapshotIndex(t, r)
+
+			err = tc.run(w, target.Hash)
+			s.Require().ErrorIs(err, plumbing.ErrObjectNotFound)
+
+			s.Equal(beforeRefs, snapshotReferences())
+			s.Equal(beforeIndex, snapshotIndex(t, r))
+
+			readme, err := util.ReadFile(fs, readmePath)
+			s.Require().NoError(err)
+			s.Equal(readmeContent, string(readme))
+
+			_, err = fs.Lstat(siblingPath)
+			s.ErrorIs(err, os.ErrNotExist)
+
+			_, err = w.Commit("after failed reset", &CommitOptions{Author: defaultSignature()})
+			s.ErrorIs(err, ErrEmptyCommit)
+
+			err = w.Checkout(&CheckoutOptions{Hash: initialHash, Force: true})
+			s.Require().NoError(err)
+
+			status, err := w.Status()
+			s.Require().NoError(err)
+			s.True(status.IsClean())
+		})
+	}
+}
+
+func snapshotIndex(t *testing.T, r *Repository) []byte {
+	t.Helper()
+
+	idx, err := r.Storer.Index()
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = index.NewEncoder(&buf, crypto.SHA1.New()).Encode(idx)
+	require.NoError(t, err)
+
+	return buf.Bytes()
 }
 
 func (s *WorktreeSuite) TestReset() {


### PR DESCRIPTION
Missing, corrupt, or malformed tree objects could cause several misleading or unrecoverable outcomes:

- **Incomplete results reported as success.** An unreadable subtree could end enumeration without an error, leaving checkout or archive output incomplete. An index rebuilt from partial results could cause a later commit to record omitted paths as deleted.
- **A failed operation could still move HEAD.** Checkout, reset, or pull could change references before failing to read the target tree. After a failed pull, retrying could incorrectly report that the repository was already up to date.
- **Hard reset could fail to recover.** Even with a healthy target commit, hard reset and forced checkout could fail because they needed to read the unreadable old HEAD tree.

This change reports unreadable subtrees as errors and updates references only after reset processing succeeds. Hard reset and forced checkout identify tracked deletions from the pre-reset index, allowing recovery without reading the old HEAD tree. `KeepReset` retains its old-tree conflict checks. Index and worktree updates are not atomic.

It also fixes path handling for malformed trees: lookup descends only through directory entries, and walking a directory whose name contains slashes no longer corrupts subsequent sibling paths. Directory-mode descent follows Git’s [find_tree_entry](https://github.com/git/git/blob/v2.54.0/tree-walk.c#L568-L633). Direct object access remains available for inspection.

Missing subtrees remain errors in partial clones because go-git cannot fetch them lazily. Documentation clarifies validation boundaries, error identities, iterator recovery, and the protections bypassed by direct use of `Worktree.Filesystem`.

Regression tests cover repeated failures, reference and index preservation, recovery after missing objects become available, and malformed-entry path handling