### PR TITLE
git: remote, Keep locally held shallow boundaries reachable. Fixes #2367

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1250,16 +1250,10 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, sha
 		return false, err
 	}
 
-	// Build a set of shallow commits so we can detect when the walk actually
-	// reaches a shallow boundary (as opposed to merely knowing shallows exist).
-	shallowsSet := make(map[plumbing.Hash]struct{}, len(shallows))
-	for _, sh := range shallows {
-		shallowsSet[sh] = struct{}{}
-	}
-
-	// For each known shallow commit, mark its parent hashes as boundaries so
-	// the walker never tries to load commits that are not stored locally.
-	parentsToIgnore := make([]plumbing.Hash, 0, len(shallows))
+	// Load the shallow commits we still hold, so the walk can both detect when
+	// it reaches a shallow boundary (as opposed to merely knowing shallows
+	// exist) and tell a boundary apart from a commit that is genuinely absent.
+	shallowCommits := make(map[plumbing.Hash]*object.Commit, len(shallows))
 	for _, sh := range shallows {
 		shallowCommit, err := object.GetCommit(s, sh)
 		if err != nil {
@@ -1269,14 +1263,36 @@ func isFastForward(s storer.EncodedObjectStorer, old, newHash plumbing.Hash, sha
 			}
 			return false, err
 		}
-		parentsToIgnore = append(parentsToIgnore, shallowCommit.ParentHashes...)
+
+		shallowCommits[sh] = shallowCommit
+	}
+
+	// For each known shallow commit, mark its parent hashes as boundaries so
+	// the walker never tries to load commits that are not stored locally.
+	parentsToIgnore := make([]plumbing.Hash, 0, len(shallows))
+	for _, sh := range shallows {
+		shallowCommit, ok := shallowCommits[sh]
+		if !ok {
+			continue
+		}
+
+		for _, parent := range shallowCommit.ParentHashes {
+			// git truncates at a boundary by making it parentless rather than by
+			// dropping it, so a boundary we hold stays reachable even when
+			// another boundary names it as a parent. See #2367.
+			if _, held := shallowCommits[parent]; held {
+				continue
+			}
+
+			parentsToIgnore = append(parentsToIgnore, parent)
+		}
 	}
 
 	found := false
 	boundedByShallow := false
 	iter := object.NewCommitPreorderIter(c, nil, parentsToIgnore)
 	err = iter.ForEach(func(c *object.Commit) error {
-		if _, isShallow := shallowsSet[c.Hash]; isShallow {
+		if _, isShallow := shallowCommits[c.Hash]; isShallow {
 			// The walk reached a shallow commit; history is truncated here.
 			boundedByShallow = true
 		}

--- a/remote_test.go
+++ b/remote_test.go
@@ -2130,6 +2130,76 @@ func (s *RemoteSuite) TestFetchAfterShallowClone_NoForceRefspec() {
 	s.Equal(sha4, head.Hash(), "local master must point to the new remote tip")
 }
 
+// TestPushToShallowBoundaryWithDependentBoundary is a regression test for
+// https://github.com/go-git/go-git/issues/2367.
+//
+// A depth-one fetch of two branches whose tips are base and its child records
+// both as shallow boundaries, which makes one boundary the parent of another.
+// git grafts a boundary's parents away but keeps the boundary itself reachable,
+// so a child of it is still a fast-forward.
+func (s *RemoteSuite) TestPushToShallowBoundaryWithDependentBoundary() {
+	tempDir := s.T().TempDir()
+	remoteURL := filepath.Join(tempDir, "remote")
+
+	remoteRepo, err := PlainInit(remoteURL, true)
+	s.Require().NoError(err)
+	defer func() { _ = remoteRepo.Close() }()
+
+	now := time.Now()
+	tree := writeEmptyTree(s.T(), remoteRepo)
+	writeCommitToRef(s.T(), remoteRepo, "refs/heads/base", tree, now)
+	base := writeCommitToRef(s.T(), remoteRepo, "refs/heads/base", tree, now.Add(time.Second))
+	s.Require().NoError(remoteRepo.Storer.SetReference(
+		plumbing.NewHashReference("refs/heads/target", base),
+	))
+	s.Require().NoError(remoteRepo.Storer.SetReference(
+		plumbing.NewHashReference("refs/heads/blocker", base),
+	))
+	blocker := writeCommitToRef(s.T(), remoteRepo, "refs/heads/blocker", tree, now.Add(2*time.Second))
+	s.Require().NoError(remoteRepo.Storer.SetReference(
+		plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/base"),
+	))
+
+	repo, err := PlainInit(filepath.Join(tempDir, "repo"), false)
+	s.Require().NoError(err)
+	defer func() { _ = repo.Close() }()
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URLs: []string{remoteURL},
+	})
+	s.Require().NoError(err)
+
+	err = repo.Fetch(&FetchOptions{
+		Depth: 1,
+		Tags:  plumbing.NoTags,
+		RefSpecs: []config.RefSpec{
+			"+refs/heads/target:refs/remotes/origin/target",
+			"+refs/heads/blocker:refs/remotes/origin/blocker",
+		},
+	})
+	s.Require().NoError(err)
+
+	shallows, err := repo.Storer.Shallow()
+	s.Require().NoError(err)
+	s.ElementsMatch([]plumbing.Hash{base, blocker}, shallows)
+
+	s.Require().NoError(repo.Storer.SetReference(
+		plumbing.NewHashReference("refs/heads/target", base),
+	))
+	child := writeCommitToRef(s.T(), repo, "refs/heads/target", tree, now.Add(3*time.Second))
+
+	err = repo.Push(&PushOptions{
+		RemoteName: DefaultRemoteName,
+		RefSpecs:   []config.RefSpec{"refs/heads/target:refs/heads/target"},
+	})
+	s.Require().NoError(err)
+
+	updated, err := remoteRepo.Reference("refs/heads/target", true)
+	s.Require().NoError(err)
+	s.Equal(child, updated.Hash())
+}
+
 func TestFetchFastForwardForCustomRef(t *testing.T) {
 	t.Parallel()
 	customRef := "refs/custom/branch"

--- a/remote_test.go
+++ b/remote_test.go
@@ -2200,6 +2200,27 @@ func (s *RemoteSuite) TestPushToShallowBoundaryWithDependentBoundary() {
 	s.Equal(child, updated.Hash())
 }
 
+func (s *RemoteSuite) TestIsFastForwardSkipsMissingShallowMarker() {
+	storage := memory.NewStorage()
+	missing := plumbing.NewHash("0000000000000000000000000000000000000001")
+
+	boundary := &object.Commit{ParentHashes: []plumbing.Hash{missing}}
+	encodedBoundary := storage.NewEncodedObject()
+	s.Require().NoError(boundary.Encode(encodedBoundary))
+	boundaryHash, err := storage.SetEncodedObject(encodedBoundary)
+	s.Require().NoError(err)
+
+	child := &object.Commit{ParentHashes: []plumbing.Hash{boundaryHash}}
+	encodedChild := storage.NewEncodedObject()
+	s.Require().NoError(child.Encode(encodedChild))
+	childHash, err := storage.SetEncodedObject(encodedChild)
+	s.Require().NoError(err)
+
+	fastForward, err := isFastForward(storage, missing, childHash, []plumbing.Hash{boundaryHash, missing})
+	s.Require().NoError(err)
+	s.True(fastForward)
+}
+
 func TestFetchFastForwardForCustomRef(t *testing.T) {
 	t.Parallel()
 	customRef := "refs/custom/branch"


### PR DESCRIPTION
Fixes #2367

## Problem

A depth-one fetch of two branches whose tips are `B` and its child `C` records **both** as shallow boundaries, so `B` is a boundary *and* `C`'s parent. `isFastForward` builds `parentsToIgnore` from the parent hashes of every shallow commit, which puts `B` in the ignore list even though it is stored locally and is the exact `old` the walk is looking for. The walk from the new commit never sees it and `found` stays `false`.

https://github.com/go-git/go-git/blob/d15c624290f14f5eec6f51a660b20b8449ee7d98/remote.go#L1260-L1273

The fallback added in bc7ce77b does not help: `boundedByShallow` only becomes true if the walk *reaches* a shallow commit, and the ignore list is what stops it getting there.

## Fix

Load the shallow commits once, then ignore a parent only when it is not a boundary we hold. The map also replaces `shallowsSet`, which was doing the same membership check with less information.

The smaller version — skip any parent that appears in `shallows` — **reintroduces #207's error**: if a marker names a commit we no longer hold and that commit is another boundary's parent, the walk tries to load it and fails. Measured against a store built for that case:

```
this PR:     isFastForward -> ok=false  err=<nil>
naive skip:  isFastForward -> ok=false  err=object not found
```

## Alignment with upstream git

git does not drop a boundary from the graph — it makes the commit parentless and leaves it in place. `register_shallow()` records the graft with `nr_parent = -1` and clears the commit's parents ([shallow.c#L34-L46](https://github.com/git/git/blob/e9019fcafe0040228b8631c30f97ae1adb61bcdc/shallow.c#L34-L46)); `parse_commit_buffer()` then skips its `parent` lines ([commit.c#L554-L577](https://github.com/git/git/blob/e9019fcafe0040228b8631c30f97ae1adb61bcdc/commit.c#L554-L577)). Confirmed with git 2.55.0 on the same graph: both boundaries recorded, `git rev-parse "$B^@"` empty, `merge-base --is-ancestor` yes, non-force push accepted.

## Tests

`RemoteSuite.TestPushToShallowBoundaryWithDependentBoundary` builds the graph with `PlainInit` and a depth-1 fetch over the file transport, so it needs no `git daemon`. Without the change it fails with the reported error, not a proxy assertion:

```
Error: Received unexpected error:
       non-fast-forward update: refs/heads/target
```

`TestFetchAfterShallowClone_NoForceRefspec` still passes, so #207's fallback is intact. `make validate` and `make test` are green.

## Notes for reviewers

- No backport needed: `git branch -r --contains bc7ce77b` does not list `releases/v5.x`, which still has the earlier single-`earliestShallow` implementation. The regression is v6 only.
- I left the absent-boundary corner above untested — it needs a hand-built store and reads synthetic next to the real one. Happy to add it if you would rather have it pinned.
- @Yiivgeny diagnosed this and offered to test a PR against the original downstream case (flipt-io/flipt#6478).

## AI assistance disclosure

Developed with AI assistance (Claude Code). I understand every line, verified the behaviour against reference git 2.55.0 as described, and confirmed the new test fails without the fix. I will answer review comments personally.