### PR TITLE
git: worktree, Preserve nonempty directories on removal

### DIFF
--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -1814,7 +1814,7 @@ func isHexAlpha(b byte) bool {
 func incBytes(in []byte) (out []byte, overflow bool) {
 	out = make([]byte, len(in))
 	copy(out, in)
-	for i := len(out) - 1; i >= 0; i-- {
+	for i := range slices.Backward(out) {
 		out[i]++
 		if out[i] != 0 {
 			return out, overflow // Didn't overflow.

--- a/worktree.go
+++ b/worktree.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/osfs"
-	"github.com/go-git/go-billy/v6/util"
 
 	"github.com/go-git/go-git/v6/config"
 	giturl "github.com/go-git/go-git/v6/internal/url"
@@ -886,14 +885,9 @@ func (w *Worktree) checkoutChange(cfg *config.Config, fs *worktreeFilesystem, ch
 
 		isSubmodule = e.Mode == filemode.Submodule
 	case merkletrie.Delete:
-		// checkoutChange.Delete is only reached from resetWorktree's
-		// filesystem-vs-index merkletrie diff (resetWorktreeToTree's
-		// tree-derived deletes call rmFileAndDirsIfEmpty directly).
-		// The path source is therefore the local worktree filesystem,
-		// where the tolerant worktreeFilesystem wrapper is the right
-		// fit: we want to be able to clean up legitimately-tracked
-		// shapes like "submodule/.git" rather than abort the whole
-		// reset on a single weird untracked file.
+		// These names come from the filesystem-vs-index diff. Apply the
+		// configured worktree gate. Tree-derived deletes use the same
+		// helper in resetWorktreeToTree.
 		return rmFileAndDirsIfEmpty(fs, ch.From.String())
 	}
 
@@ -1538,17 +1532,39 @@ func findMatchInFile(file *object.File, treeName string, opts *GrepOptions) ([]G
 	return grepResults, nil
 }
 
-// will walk up the directory tree removing all encountered empty
-// directories, not just the one containing this file
+// rmFileAndDirsIfEmpty removes a file or an empty directory, then walks up
+// removing the empty directories above it. A nonempty directory is kept,
+// along with everything under it, and the walk stops there.
+//
+// Removal is not recursive because the names reaching here are index and
+// tree entries, and upstream Git removes them one at a time: remove_or_warn
+// unlinks a regular entry and calls rmdir for a gitlink, so a submodule
+// worktree with contents of its own survives a reset that drops the
+// gitlink, as do untracked files left inside a directory that replaced a
+// tracked file. Where rmdir fails Git warns and continues; this returns nil.
+// Billy backends do not share a directory-not-empty sentinel, so the
+// condition is tested rather than inferred from the error, and a directory a
+// failed removal leaves behind is kept whatever its entries read as: one
+// written to since the test and one that refuses the test outright both
+// arrive here as a removal that failed.
+//
+// Reference: upstream Git entry.c remove_or_warn at L610-L613 and
+// unlink_entry at L595-L608 in tag v2.54.0[1].
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/entry.c#L595-L613
 func rmFileAndDirsIfEmpty(fs billy.Filesystem, name string) error {
-	if err := util.RemoveAll(fs, name); err != nil {
+	if nonemptyDir(fs, name) {
+		return nil
+	}
+
+	if err := fs.Remove(name); err != nil && !os.IsNotExist(err) && !isDir(fs, name) {
 		return err
 	}
 
 	dir := filepath.Dir(name)
 	for dir != "." && dir != "" {
 		removed, err := removeDirIfEmpty(fs, dir)
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !os.IsNotExist(err) && !isDir(fs, dir) {
 			return err
 		}
 
@@ -1584,6 +1600,31 @@ func removeDirIfEmpty(fs billy.Filesystem, dir string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// isDir reports whether name is a directory. This is what a removal that has
+// already failed asks: a directory it could not take away is one Git would
+// have warned about and carried on from, and its contents are beside the
+// point once the removal has been refused.
+func isDir(fs billy.Filesystem, name string) bool {
+	fi, err := fs.Lstat(name)
+
+	return err == nil && fi.IsDir()
+}
+
+// nonemptyDir reports whether name is a directory with entries in it, the
+// shape rmFileAndDirsIfEmpty keeps without attempting a removal at all.
+//
+// A directory whose entries cannot be read reports false. It reaches the
+// removal, which fails, and isDir keeps it from there.
+func nonemptyDir(fs billy.Filesystem, name string) bool {
+	if !isDir(fs, name) {
+		return false
+	}
+
+	entries, err := fs.ReadDir(name)
+
+	return err == nil && len(entries) > 0
 }
 
 type indexBuilder struct {

--- a/worktree.go
+++ b/worktree.go
@@ -1532,40 +1532,46 @@ func findMatchInFile(file *object.File, treeName string, opts *GrepOptions) ([]G
 	return grepResults, nil
 }
 
-// rmFileAndDirsIfEmpty removes a file or an empty directory, then walks up
-// removing the empty directories above it. A nonempty directory is kept,
-// along with everything under it, and the walk stops there.
+// rmFileAndDirsIfEmpty removes name and its empty parent directories.
+// It preserves nonempty directories and ignores removal errors for directories
+// that remain in place. This keeps submodule worktrees and untracked files
+// when a reset removes their index entries.
 //
-// Removal is not recursive because the names reaching here are index and
-// tree entries, and upstream Git removes them one at a time: remove_or_warn
-// unlinks a regular entry and calls rmdir for a gitlink, so a submodule
-// worktree with contents of its own survives a reset that drops the
-// gitlink, as do untracked files left inside a directory that replaced a
-// tracked file. Where rmdir fails Git warns and continues; this returns nil.
-// Billy backends do not share a directory-not-empty sentinel, so the
-// condition is tested rather than inferred from the error, and a directory a
-// failed removal leaves behind is kept whatever its entries read as: one
-// written to since the test and one that refuses the test outright both
-// arrive here as a removal that failed.
+// Removal is not recursive. Billy filesystems have no shared directory-not-empty
+// error, so directories are checked before removal and again if removal fails.
+// Where Git warns about a failed directory removal and continues, this returns nil.
 //
-// Reference: upstream Git entry.c remove_or_warn at L610-L613 and
-// unlink_entry at L595-L608 in tag v2.54.0[1].
+// Paths rejected by the worktree filesystem because of a leading symlink are
+// left untouched, as in Git's [unlink_entry]. The symlink error stops parent
+// cleanup too, so the blocking symlink is preserved.
 //
-// [1]: https://github.com/git/git/blob/v2.54.0/entry.c#L595-L613
+// [unlink_entry]: https://github.com/git/git/blob/v2.54.0/entry.c
 func rmFileAndDirsIfEmpty(fs billy.Filesystem, name string) error {
 	if nonemptyDir(fs, name) {
 		return nil
 	}
 
-	if err := fs.Remove(name); err != nil && !os.IsNotExist(err) && !isDir(fs, name) {
-		return err
+	if err := fs.Remove(name); err != nil {
+		if errors.Is(err, errLeadingSymlink) {
+			return nil
+		}
+
+		if !os.IsNotExist(err) && !isDir(fs, name) {
+			return err
+		}
 	}
 
 	dir := filepath.Dir(name)
 	for dir != "." && dir != "" {
 		removed, err := removeDirIfEmpty(fs, dir)
-		if err != nil && !os.IsNotExist(err) && !isDir(fs, dir) {
-			return err
+		if err != nil {
+			if errors.Is(err, errLeadingSymlink) {
+				return nil
+			}
+
+			if !os.IsNotExist(err) && !isDir(fs, dir) {
+				return err
+			}
 		}
 
 		if !removed {
@@ -1581,9 +1587,7 @@ func rmFileAndDirsIfEmpty(fs billy.Filesystem, name string) error {
 	return nil
 }
 
-// removeDirIfEmpty will remove the supplied directory `dir` if
-// `dir` is empty
-// returns true if the directory was removed
+// removeDirIfEmpty removes dir if it is empty and reports whether it was removed.
 func removeDirIfEmpty(fs billy.Filesystem, dir string) (bool, error) {
 	files, err := fs.ReadDir(dir)
 	if err != nil {

--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -190,6 +190,9 @@ func (sfs *worktreeFilesystem) Chroot(path string) (billy.Filesystem, error) {
 
 var errUnsupportedOperation = errors.New("unsupported operation")
 
+// errLeadingSymlink indicates that a path has a symlink in a leading component.
+var errLeadingSymlink = errors.New("leading component is a symlink")
+
 // isDotGitVariant reports whether part is .git, git~1, or an HFS+
 // equivalent of .git (when protectHFS is true). NTFS variants of .git
 // (e.g. ".git " with trailing space, ".git::$INDEX_ALLOCATION") are
@@ -297,7 +300,7 @@ func (sfs *worktreeFilesystem) validNoLeadingSymlink(paths ...string) error {
 				continue
 			}
 			if fi.Mode()&os.ModeSymlink != 0 {
-				return fmt.Errorf("invalid path %q: leading component %q is a symlink", p, dir)
+				return fmt.Errorf("invalid path %q: %w: %q", p, errLeadingSymlink, dir)
 			}
 		}
 	}

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -962,7 +962,7 @@ func gitConfig(t *testing.T, dir, key, value string) {
 }
 
 // gitAtLeast reports whether the local `git` is at least the given version.
-// Used to skip upstream cherry-pick assertions for protections that older
+// Used to skip upstream assertions for protections that older
 // Git releases (e.g. 2.11) do not implement, such as the git~1 8.3 short
 // name check (CVE-2014-9390 hardening) and the .git::$INDEX_ALLOCATION
 // NTFS Alternate Data Stream check (CVE-2019-1351).

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2514,6 +2514,117 @@ func TestResetPreservesSubmoduleDirectory(t *testing.T) {
 	}
 }
 
+func TestRemovalPreservesLeadingSymlink(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"link/file.txt", "link/nested/file.txt", "dangling/file.txt"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := memfs.New()
+			require.NoError(t, util.WriteFile(raw, "target/file.txt", []byte("keep"), 0o644))
+			require.NoError(t, util.WriteFile(raw, "target/nested/file.txt", []byte("nested"), 0o644))
+			require.NoError(t, raw.Symlink("target", "link"))
+			require.NoError(t, raw.Symlink("missing", "dangling"))
+			before := snapshotSubtree(t, raw, "target")
+			wrapped := newWorktreeFilesystem(raw, true, false)
+
+			require.ErrorIs(t, wrapped.Remove(name), errLeadingSymlink)
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, name))
+			require.Equal(t, before, snapshotSubtree(t, raw, "target"))
+			for link, target := range map[string]string{"link": "target", "dangling": "missing"} {
+				got, err := raw.Readlink(link)
+				require.NoError(t, err)
+				require.Equal(t, target, got)
+			}
+		})
+	}
+}
+
+func TestResetPreservesLeadingSymlink(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required")
+	}
+
+	for _, implementation := range []string{"go-git", "git"} {
+		t.Run(implementation, func(t *testing.T) {
+			t.Parallel()
+
+			gitRun := func(dir string, args ...string) string {
+				t.Helper()
+				out, err := gitenv.CommandContext(t.Context(), "git",
+					append([]string{"-C", dir}, args...)...).CombinedOutput()
+				require.NoError(t, err, "git %q: %s", args, out)
+				return strings.TrimSpace(string(out))
+			}
+
+			root := t.TempDir()
+			repo, outside := filepath.Join(root, "repo"), filepath.Join(root, "outside")
+			require.NoError(t, os.Mkdir(repo, 0o755))
+			require.NoError(t, os.Mkdir(outside, 0o755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(outside, "file.txt"), []byte("outside\n"), 0o644,
+			))
+
+			gitRun(repo, "init", "-q")
+			require.NoError(t, os.WriteFile(
+				filepath.Join(repo, "safe.txt"), []byte("keep\n"), 0o644,
+			))
+			gitRun(repo, "add", ".")
+			gitRun(repo, "commit", "-qm", "base")
+			base := plumbing.NewHash(gitRun(repo, "rev-parse", "HEAD"))
+
+			require.NoError(t, os.Mkdir(filepath.Join(repo, "dir"), 0o755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(repo, "dir", "file.txt"), []byte("tracked\n"), 0o644,
+			))
+			gitRun(repo, "add", ".")
+			gitRun(repo, "commit", "-qm", "adds dir")
+
+			// Replace the tracked directory with a symlink out of the tree,
+			// so removing dir/file.txt would have to follow it.
+			require.NoError(t, os.RemoveAll(filepath.Join(repo, "dir")))
+			if err := os.Symlink(outside, filepath.Join(repo, "dir")); err != nil {
+				if isSymlinkWindowsNonAdmin(err) {
+					t.Skipf("symlink creation requires elevated privileges: %v", err)
+				}
+				require.NoError(t, err)
+			}
+
+			if implementation == "git" {
+				gitRun(repo, "reset", "--hard", base.String())
+			} else {
+				r, err := PlainOpen(repo)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, r.Close()) })
+				w, err := r.Worktree()
+				require.NoError(t, err)
+				require.NoError(t, w.Reset(&ResetOptions{Mode: HardReset, Commit: base}))
+			}
+
+			require.Equal(t, base.String(), gitRun(repo, "rev-parse", "HEAD"))
+
+			fi, err := os.Lstat(filepath.Join(repo, "dir"))
+			require.NoError(t, err)
+			require.NotZero(t, fi.Mode()&os.ModeSymlink, "the symlink was replaced")
+			target, err := os.Readlink(filepath.Join(repo, "dir"))
+			require.NoError(t, err)
+			require.Equal(t, outside, target)
+			require.Equal(t, "safe.txt", gitRun(repo, "ls-files"))
+
+			entries, err := os.ReadDir(outside)
+			require.NoError(t, err)
+			require.Len(t, entries, 1, "the symlink was followed")
+			require.Equal(t, "file.txt", entries[0].Name())
+			content, err := os.ReadFile(filepath.Join(outside, "file.txt"))
+			require.NoError(t, err)
+			require.Equal(t, "outside\n", string(content))
+		})
+	}
+}
+
 func (s *WorktreeSuite) TestStatusAfterCheckout() {
 	fs := memfs.New()
 	w := &Worktree{

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2552,6 +2552,12 @@ func TestResetPreservesLeadingSymlink(t *testing.T) {
 		t.Run(implementation, func(t *testing.T) {
 			t.Parallel()
 
+			// Git 2.32 fixed unlink_entry following leading symlinks
+			// when removing entries (upstream commit fab78a0c3d).
+			if implementation == "git" && !gitAtLeast(t, 2, 32) {
+				t.Skip("Git 2.32 or newer is required for symlink-safe removal")
+			}
+
 			gitRun := func(dir string, args ...string) string {
 				t.Helper()
 				out, err := gitenv.CommandContext(t.Context(), "git",

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -6,7 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -27,6 +30,7 @@ import (
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -2264,6 +2268,248 @@ func (s *WorktreeSuite) TestResetSparselyInvalidDir() {
 				return
 			}
 			s.Require().NoError(err)
+		})
+	}
+}
+
+func snapshotSubtree(t *testing.T, fs billy.Filesystem, root string) map[string]string {
+	t.Helper()
+
+	snapshot := map[string]string{}
+
+	var walk func(string)
+	walk = func(p string) {
+		fi, err := fs.Lstat(p)
+		require.NoError(t, err)
+
+		if !fi.IsDir() {
+			data, err := util.ReadFile(fs, p)
+			require.NoError(t, err)
+			snapshot[p] = string(data)
+			return
+		}
+
+		snapshot[p+"/"] = ""
+		children, err := fs.ReadDir(p)
+		require.NoError(t, err)
+		for _, child := range children {
+			walk(path.Join(p, child.Name()))
+		}
+	}
+	walk(root)
+
+	return snapshot
+}
+
+func TestRemovalPreservesNonemptyDirectories(t *testing.T) {
+	t.Parallel()
+
+	for _, backend := range []string{"memfs", "osfs"} {
+		t.Run(backend, func(t *testing.T) {
+			t.Parallel()
+
+			raw := memfs.New()
+			if backend == "osfs" {
+				raw = osfs.New(t.TempDir())
+			}
+			wrapped := newWorktreeFilesystem(raw, true, false)
+
+			for name, content := range map[string]string{
+				"sub/.git":         "gitdir: ../.git/modules/sub\n",
+				"sub/a.txt":        "tracked",
+				"sub/dirty.txt":    "uncommitted",
+				"sub/nested/b.txt": "nested",
+			} {
+				require.NoError(t, util.WriteFile(raw, name, []byte(content), 0o644))
+			}
+
+			expected := map[string]string{
+				"sub/":             "",
+				"sub/.git":         "gitdir: ../.git/modules/sub\n",
+				"sub/a.txt":        "tracked",
+				"sub/dirty.txt":    "uncommitted",
+				"sub/nested/":      "",
+				"sub/nested/b.txt": "nested",
+			}
+			require.Equal(t, expected, snapshotSubtree(t, raw, "sub"))
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "sub"))
+			require.Equal(t, expected, snapshotSubtree(t, raw, "sub"))
+
+			require.NoError(t, util.WriteFile(raw, "p/q/only.txt", []byte("remove"), 0o644))
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "p/q/only.txt"))
+			_, err := raw.Lstat("p")
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			require.NoError(t, raw.MkdirAll("empty", 0o755))
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "empty"))
+			_, err = raw.Lstat("empty")
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "missing"))
+
+			require.NoError(t, util.WriteFile(raw, "tracked.txt/precious", []byte("keep"), 0o644))
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "tracked.txt"))
+			require.Equal(t, map[string]string{
+				"tracked.txt/":         "",
+				"tracked.txt/precious": "keep",
+			}, snapshotSubtree(t, raw, "tracked.txt"))
+		})
+	}
+}
+
+// stubReadDirFS answers ReadDir of dir with err instead of its contents, for
+// the first call only when once is set. Both shapes leave a directory that a
+// removal will refuse: one written to between the check and that removal, and
+// one whose entries cannot be read at all.
+type stubReadDirFS struct {
+	billy.Filesystem
+
+	dir  string
+	err  error
+	once bool
+	hits int
+}
+
+func (f *stubReadDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	if name == f.dir && (!f.once || f.hits == 0) {
+		f.hits++
+		return nil, f.err
+	}
+
+	return f.Filesystem.ReadDir(name)
+}
+
+// A directory a removal leaves behind is kept, whether it is the name being
+// removed or one above it, and whether it was found empty and then written to
+// or never read at all. The removal fails with an error no backend spells the
+// same way, and upstream Git warns where rmdir fails and carries on.
+func TestRemovalKeepsDirectoriesItCannotRemove(t *testing.T) {
+	t.Parallel()
+
+	full := map[string]string{
+		"sub/":         "",
+		"sub/gone.txt": "gone",
+		"sub/keep.txt": "keep",
+	}
+	kept := map[string]string{
+		"sub/":         "",
+		"sub/keep.txt": "keep",
+	}
+
+	for _, test := range []struct {
+		name     string
+		target   string
+		readDir  error
+		once     bool
+		expected map[string]string
+	}{
+		{name: "filled directory", target: "sub", once: true, expected: full},
+		{name: "filled parent", target: "sub/gone.txt", once: true, expected: kept},
+		{name: "unreadable directory", target: "sub", readDir: os.ErrPermission, expected: full},
+		{name: "unreadable parent", target: "sub/gone.txt", readDir: os.ErrPermission, expected: kept},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := memfs.New()
+			for name, content := range map[string]string{
+				"sub/gone.txt": "gone",
+				"sub/keep.txt": "keep",
+			} {
+				require.NoError(t, util.WriteFile(raw, name, []byte(content), 0o644))
+			}
+
+			stub := &stubReadDirFS{Filesystem: raw, dir: "sub", err: test.readDir, once: test.once}
+			require.NoError(t, rmFileAndDirsIfEmpty(newWorktreeFilesystem(stub, true, false), test.target))
+
+			require.Positive(t, stub.hits, "sub was never read")
+			require.Equal(t, test.expected, snapshotSubtree(t, raw, "sub"))
+		})
+	}
+}
+
+// Git preserves a removed submodule's worktree even when it contains local changes.
+func TestResetPreservesSubmoduleDirectory(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required")
+	}
+
+	for _, implementation := range []string{"go-git", "git"} {
+		t.Run(implementation, func(t *testing.T) {
+			t.Parallel()
+
+			gitRun := func(dir string, args ...string) string {
+				t.Helper()
+				overrides := []string{
+					"-c", "protocol.file.allow=always",
+					"-c", "submodule.recurse=false",
+					"-C", dir,
+				}
+				out, err := gitenv.CommandContext(t.Context(), "git", append(overrides, args...)...).CombinedOutput()
+				require.NoError(t, err, "git %q: %s", args, out)
+				return strings.TrimSpace(string(out))
+			}
+
+			root := t.TempDir()
+			source, parent := filepath.Join(root, "source"), filepath.Join(root, "parent")
+			for _, dir := range []string{source, parent} {
+				require.NoError(t, os.Mkdir(dir, 0o755))
+				gitRun(dir, "init", "-q")
+			}
+
+			write := func(dir, name, content string) {
+				t.Helper()
+				p := filepath.Join(dir, filepath.FromSlash(name))
+				require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+				require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+			}
+
+			write(source, "a.txt", "tracked\n")
+			write(source, "nested/b.txt", "nested\n")
+			gitRun(source, "add", ".")
+			gitRun(source, "commit", "-qm", "source")
+
+			write(parent, "safe.txt", "keep\n")
+			gitRun(parent, "add", ".")
+			gitRun(parent, "commit", "-qm", "base")
+			base := plumbing.NewHash(gitRun(parent, "rev-parse", "HEAD"))
+
+			gitRun(parent, "submodule", "add", "-q", source, "sub")
+			write(parent, "removed.txt", "remove\n")
+			gitRun(parent, "add", ".")
+			gitRun(parent, "commit", "-qm", "submodule")
+
+			write(parent, "sub/a.txt", "dirty tracked\n")
+			write(parent, "sub/dirty.txt", "untracked work\n")
+			write(parent, "sub/nested/extra.txt", "nested untracked\n")
+			require.Equal(t, "true",
+				gitRun(filepath.Join(parent, "sub"), "rev-parse", "--is-inside-work-tree"))
+
+			raw := osfs.New(parent)
+			before := snapshotSubtree(t, raw, "sub")
+			require.Len(t, before, 7)
+
+			r, err := PlainOpen(parent)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, r.Close()) })
+			w, err := r.Worktree()
+			require.NoError(t, err)
+
+			if implementation == "git" {
+				gitRun(parent, "reset", "--hard", base.String())
+			} else {
+				require.NoError(t, w.Reset(&ResetOptions{Mode: HardReset, Commit: base}))
+			}
+
+			require.Equal(t, before, snapshotSubtree(t, raw, "sub"))
+			for _, name := range []string{"removed.txt", ".gitmodules"} {
+				_, err := raw.Lstat(name)
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+			require.Equal(t, base.String(), gitRun(parent, "rev-parse", "HEAD"))
+			require.Equal(t, "safe.txt", gitRun(parent, "ls-files"))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #2374.

Reset could recursively delete a removed submodule's worktree, including uncommitted and untracked files. The same removal helper could also delete untracked contents when a tracked file had been replaced by a directory.

Removal now preserves nonempty directories while continuing to remove files, empty directories and empty parents. This follows [Git's nonrecursive removal behaviour](https://github.com/git/git/blob/v2.54.0/entry.c#L595-L613). Nested-repository handling in `Clean` remains a separate issue.
