### PR TITLE
• *: Fix path validation across storage and worktree operations

### DIFF
--- a/config/modules.go
+++ b/config/modules.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/go-git/go-git/v6/internal/pathutil"
@@ -109,15 +110,13 @@ func (m *Submodule) Validate() error {
 	// so it falls through to ErrModuleEmptyPath below.
 	//
 	// The per-segment predicate is pathutil.IsDotOrDotDotName, the
-	// same one ValidTreePath applies to this Path at
-	// Submodule.Repository: a literal ".." and the NTFS and HFS+
-	// spellings a filesystem folds back to a parent hop. m.Path is
-	// worktree-relative and attacker-controlled via .gitmodules, so
-	// the check runs regardless of host OS.
-	for _, seg := range strings.FieldsFunc(m.Path, isPathSep) {
-		if pathutil.IsDotOrDotDotName(seg) {
-			return ErrModuleBadPath
-		}
+	// same one ValidTreePath applies to this Path in
+	// Submodule.Repository: dot and parent components plus the shared
+	// NTFS/HFS+ disguise policy. m.Path is worktree-relative and is
+	// attacker-controlled via .gitmodules, so the check runs
+	// regardless of host OS.
+	if slices.ContainsFunc(strings.FieldsFunc(m.Path, isPathSep), pathutil.IsDotOrDotDotName) {
+		return ErrModuleBadPath
 	}
 
 	if m.Path == "" {
@@ -131,24 +130,14 @@ func (m *Submodule) Validate() error {
 	return nil
 }
 
-// validSubmoduleName mirrors canonical Git's check_submodule_name in
-// submodule-config.c [1]: reject empty names and any name with a ".."
-// path component, using both '/' and '\\' as separators so the rule
-// is consistent across platforms. The component check is delegated to
-// `pathutil.IsHFSDot` and `pathutil.IsNTFSDot` with `.` as the needle,
-// which both cover the bare ".." case and reject components that
-// resolve to ".." after HFS+ Unicode normalisation (ignored code
-// points, e.g. `.<U+200C>.`) or NTFS trailing-space/dot/ADS
-// canonicalisation (e.g. `.. `, `..::$INDEX_ALLOCATION`).
-// `.gitmodules` is attacker-controlled by definition, so both checks
-// run unconditionally regardless of host OS.
-//
-// The additional checks (bare ".", NUL byte, leading or trailing
-// separator, drive-letter prefix) close go-git-specific edge cases
-// the canonical loop does not exercise: canonical Git treats names
-// as opaque C strings, while Go strings carry NULs through and the
-// billy filesystem layer is path-aware in ways Git's working storage
-// is not.
+// validSubmoduleName validates storage names below .git/modules.
+// Upstream Git's check_submodule_name at submodule-config.c#L214-L237
+// in tag v2.54.0[1] rejects empty names and literal parent
+// components. go-git additionally rejects dot and periods-only
+// components, parent disguises, NULs, leading/trailing separators and
+// drive prefixes. Both separators are recognized on every host.
+// C Git accepts some of these extra names; the periods-only
+// restriction is policy, not an assertion of NTFS parent folding.
 //
 // [1]: https://github.com/git/git/blob/v2.54.0/submodule-config.c#L214-L237
 func validSubmoduleName(name string) error {
@@ -156,7 +145,7 @@ func validSubmoduleName(name string) error {
 		return ErrModuleBadName
 	}
 	for _, seg := range strings.FieldsFunc(name, isPathSep) {
-		if pathutil.IsHFSDot(seg, ".") || pathutil.IsNTFSDot(seg, ".", "") {
+		if pathutil.IsDotsOnlyName(seg) || pathutil.IsDotOrDotDotName(seg) {
 			return ErrModuleBadName
 		}
 	}

--- a/config/modules.go
+++ b/config/modules.go
@@ -102,29 +102,28 @@ func (m *Submodule) Validate() error {
 		return fmt.Errorf("%w: %q", ErrModuleBadName, m.Name)
 	}
 
-	// The path check runs ahead of the empty-field checks because
-	// unmarshalSubmodules drops a stanza only on ErrModuleBadPath or
-	// ErrModuleBadName: a stanza carrying `path = ..` and no `url =`
-	// would otherwise be reported as ErrModuleEmptyURL and retained
-	// with its unsafe Path intact. An empty Path yields no segments,
-	// so it falls through to ErrModuleEmptyPath below.
-	//
-	// The per-segment predicates are the ones
-	// pathutil.ValidSubmodulePath applies to this Path in
-	// Submodule.Repository: parent components and the components a
-	// filesystem folds to ".", each with the shared NTFS/HFS+ disguise
-	// policy. Runs of periods are not among them, so this loop agrees
-	// with that validator rather than being stricter than it. m.Path
-	// is worktree-relative and is attacker-controlled via
-	// .gitmodules, so the check runs regardless of host OS.
-	if slices.ContainsFunc(strings.FieldsFunc(m.Path, isPathSep), func(seg string) bool {
-		return pathutil.IsDotOrDotDotName(seg) || pathutil.IsDotName(seg)
-	}) {
-		return ErrModuleBadPath
-	}
-
 	if m.Path == "" {
 		return ErrModuleEmptyPath
+	}
+
+	// The path is validated before the URL is checked for emptiness.
+	// unmarshalSubmodules drops a stanza only on ErrModuleBadPath or
+	// ErrModuleBadName, so a stanza carrying `path = ..` and no `url =`
+	// would otherwise be reported as ErrModuleEmptyURL and kept with its
+	// unsafe Path intact.
+	//
+	// pathutil.ValidSubmodulePath is the validator Submodule.Repository
+	// runs on this Path before it chroots to it, so the parser applies the
+	// same gate: a stanza it keeps is one whose Path can reach that chroot.
+	// The error is flattened to ErrModuleBadPath, the sentinel the parser
+	// drops a stanza on.
+	//
+	// Path is worktree-relative and is attacker-controlled via .gitmodules,
+	// so its component rules run on every host. Only the volume prefix rule
+	// is host-dependent, because filepath.VolumeName recognises a drive
+	// letter on Windows alone.
+	if err := pathutil.ValidSubmodulePath(m.Path); err != nil {
+		return ErrModuleBadPath
 	}
 
 	if m.URL == "" {

--- a/config/modules.go
+++ b/config/modules.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/go-git/go-git/v6/internal/pathutil"
@@ -22,9 +21,6 @@ var (
 	// for use as a path component.
 	ErrModuleBadName = errors.New("ignoring suspicious submodule name")
 )
-
-// Matches module paths with dotdot ".." components.
-var dotdotPath = regexp.MustCompile(`(^|[/\\])\.\.([/\\]|$)`)
 
 // Modules defines the submodules properties, represents a .gitmodules file
 // https://www.kernel.org/pub/software/scm/git/docs/gitmodules.html
@@ -105,16 +101,31 @@ func (m *Submodule) Validate() error {
 		return fmt.Errorf("%w: %q", ErrModuleBadName, m.Name)
 	}
 
+	// The path check runs ahead of the empty-field checks because
+	// unmarshalSubmodules drops a stanza only on ErrModuleBadPath or
+	// ErrModuleBadName: a stanza carrying `path = ..` and no `url =`
+	// would otherwise be reported as ErrModuleEmptyURL and retained
+	// with its unsafe Path intact. An empty Path yields no segments,
+	// so it falls through to ErrModuleEmptyPath below.
+	//
+	// The per-segment predicate is pathutil.IsDotOrDotDotName, the
+	// same one ValidTreePath applies to this Path at
+	// Submodule.Repository: a literal ".." and the NTFS and HFS+
+	// spellings a filesystem folds back to a parent hop. m.Path is
+	// worktree-relative and attacker-controlled via .gitmodules, so
+	// the check runs regardless of host OS.
+	for _, seg := range strings.FieldsFunc(m.Path, isPathSep) {
+		if pathutil.IsDotOrDotDotName(seg) {
+			return ErrModuleBadPath
+		}
+	}
+
 	if m.Path == "" {
 		return ErrModuleEmptyPath
 	}
 
 	if m.URL == "" {
 		return ErrModuleEmptyURL
-	}
-
-	if dotdotPath.MatchString(m.Path) {
-		return ErrModuleBadPath
 	}
 
 	return nil

--- a/config/modules.go
+++ b/config/modules.go
@@ -109,13 +109,17 @@ func (m *Submodule) Validate() error {
 	// with its unsafe Path intact. An empty Path yields no segments,
 	// so it falls through to ErrModuleEmptyPath below.
 	//
-	// The per-segment predicate is pathutil.IsDotOrDotDotName, the
-	// same one ValidTreePath applies to this Path in
-	// Submodule.Repository: dot and parent components plus the shared
-	// NTFS/HFS+ disguise policy. m.Path is worktree-relative and is
-	// attacker-controlled via .gitmodules, so the check runs
-	// regardless of host OS.
-	if slices.ContainsFunc(strings.FieldsFunc(m.Path, isPathSep), pathutil.IsDotOrDotDotName) {
+	// The per-segment predicates are the ones
+	// pathutil.ValidSubmodulePath applies to this Path in
+	// Submodule.Repository: parent components and the components a
+	// filesystem folds to ".", each with the shared NTFS/HFS+ disguise
+	// policy. Runs of periods are not among them, so this loop agrees
+	// with that validator rather than being stricter than it. m.Path
+	// is worktree-relative and is attacker-controlled via
+	// .gitmodules, so the check runs regardless of host OS.
+	if slices.ContainsFunc(strings.FieldsFunc(m.Path, isPathSep), func(seg string) bool {
+		return pathutil.IsDotOrDotDotName(seg) || pathutil.IsDotName(seg)
+	}) {
 		return ErrModuleBadPath
 	}
 
@@ -133,21 +137,21 @@ func (m *Submodule) Validate() error {
 // validSubmoduleName validates storage names below .git/modules.
 // Upstream Git's check_submodule_name at submodule-config.c#L214-L237
 // in tag v2.54.0[1] rejects empty names and literal parent
-// components. go-git additionally rejects dot and periods-only
-// components, parent disguises, NULs, leading/trailing separators and
-// drive prefixes. Both separators are recognized on every host.
-// C Git accepts some of these extra names; the periods-only
-// restriction is policy, not an assertion of NTFS parent folding.
+// components. go-git additionally applies
+// pathutil.IsUnsafeStorageName, which adds periods-only components,
+// parent disguises and the components a filesystem folds to ".", and
+// rejects NULs, leading/trailing separators and drive prefixes. Both
+// separators are recognized on every host. C Git accepts some of
+// these extra names; the periods-only restriction is policy, not an
+// assertion of NTFS parent folding.
 //
 // [1]: https://github.com/git/git/blob/v2.54.0/submodule-config.c#L214-L237
 func validSubmoduleName(name string) error {
-	if name == "" || name == "." {
+	if name == "" {
 		return ErrModuleBadName
 	}
-	for _, seg := range strings.FieldsFunc(name, isPathSep) {
-		if pathutil.IsDotsOnlyName(seg) || pathutil.IsDotOrDotDotName(seg) {
-			return ErrModuleBadName
-		}
+	if slices.ContainsFunc(strings.FieldsFunc(name, isPathSep), pathutil.IsUnsafeStorageName) {
+		return ErrModuleBadName
 	}
 	// go-git-specific defensive checks beyond canonical Git.
 	if strings.ContainsRune(name, 0) {

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -15,33 +15,114 @@ func TestModulesSuite(t *testing.T) {
 	suite.Run(t, new(ModulesSuite))
 }
 
+// dotdotDisguises are the spellings a filesystem folds back to a
+// parent hop. Both a submodule name and a submodule path must refuse
+// every one of them, so both tables consume this slice.
+//
+// The two tables are deliberately not otherwise symmetric: a name is
+// held to the stricter rule because it becomes a directory under
+// .git/modules via dotgit.DotGit.Module, while a path is held to
+// ValidTreePath's rule because Submodule.Repository runs
+// ValidTreePath on it. A component of periods alone is therefore
+// rejected as a name and accepted as a path.
+var dotdotDisguises = []string{
+	// Literal, at every position and with both separators.
+	`..`,
+	`../`,
+	`../bar`,
+	`/..`,
+	`/../bar`,
+	`foo/..`,
+	`foo/../`,
+	`foo/../bar`,
+	`.\..\foo`,
+
+	// HFS+ drops ignorable code points during normalisation, so
+	// these all resolve to ".." on macOS.
+	".\u200c.",
+	"\u200c..",
+	"..\u200c",
+	"\u200c.\u200d.\u200e",
+	"foo/.\u200c.",
+	"a/.\u200c./b",
+
+	// NTFS strips trailing spaces and an alternate-data-stream
+	// suffix during canonicalisation, so these all resolve to ".."
+	// on Windows.
+	".. ",
+	"..  ",
+	".. .",
+	"..:foo",
+	"..::$INDEX_ALLOCATION",
+	"foo/.. /bar",
+	"a/.. /b",
+}
+
 func (s *ModulesSuite) TestValidateMissingURL() {
 	m := &Submodule{Name: "foo", Path: "foo"}
 	s.Equal(ErrModuleEmptyURL, m.Validate())
 }
 
 func (s *ModulesSuite) TestValidateBadPath() {
-	input := []string{
-		`..`,
-		`../`,
-		`../bar`,
-
-		`/..`,
-		`/../bar`,
-
-		`foo/..`,
-		`foo/../`,
-		`foo/../bar`,
-	}
-
-	for _, p := range input {
+	for _, p := range dotdotDisguises {
 		m := &Submodule{
 			Name: "ok",
 			Path: p,
 			URL:  "https://example.com/",
 		}
-		s.Equal(ErrModuleBadPath, m.Validate())
+		s.Equal(ErrModuleBadPath, m.Validate(), "path %q", p)
 	}
+}
+
+func (s *ModulesSuite) TestValidateGoodPath() {
+	// The boundary rows: a component of periods alone, and a ".."
+	// prefix whose tail does not fold, are legitimate names that
+	// C Git accepts on POSIX. ValidTreePath accepts them too, and
+	// this loop must agree with it because Submodule.Repository runs
+	// ValidTreePath on the same string.
+	for _, p := range []string{
+		"foo", "foo/bar", "a..b", "deps/x.y", "lib-foo/sub",
+		"...", "....", "a/.../b", "x..", "foo..", "..x", ".. x",
+		". ", ". .",
+	} {
+		m := &Submodule{
+			Name: "ok",
+			Path: p,
+			URL:  "https://example.com/",
+		}
+		s.NoError(m.Validate(), "path %q", p)
+	}
+}
+
+// unmarshalSubmodules drops a stanza only on ErrModuleBadPath or
+// ErrModuleBadName, so an unsafe Path must be reported as
+// ErrModuleBadPath even when a required field is also missing.
+// Otherwise the stanza is retained with the unsafe Path intact.
+func (s *ModulesSuite) TestValidateBadPathBeatsEmptyURL() {
+	m := &Submodule{Name: "ok", Path: "..", URL: ""}
+	s.Equal(ErrModuleBadPath, m.Validate())
+}
+
+func (s *ModulesSuite) TestValidateBadPathBeatsEmptyURLDisguised() {
+	m := &Submodule{Name: "ok", Path: ".. ", URL: ""}
+	s.Equal(ErrModuleBadPath, m.Validate())
+}
+
+func (s *ModulesSuite) TestValidateEmptyPathStillReportsEmptyPath() {
+	m := &Submodule{Name: "ok", Path: "", URL: ""}
+	s.Equal(ErrModuleEmptyPath, m.Validate())
+}
+
+func (s *ModulesSuite) TestUnmarshalDropsBadPathStanzaWithMissingURL() {
+	m := NewModules()
+	s.Require().NoError(m.Unmarshal([]byte("[submodule \"m\"]\n\tpath = ..\n")))
+	s.Empty(m.Submodules, "stanza with an unsafe path must be dropped")
+}
+
+func (s *ModulesSuite) TestUnmarshalDropsDisguisedBadPathStanzaWithMissingURL() {
+	m := NewModules()
+	s.Require().NoError(m.Unmarshal([]byte("[submodule \"m\"]\n\tpath = .. \n")))
+	s.Empty(m.Submodules, "stanza with a disguised unsafe path must be dropped")
 }
 
 func (s *ModulesSuite) TestValidateMissingName() {
@@ -50,40 +131,22 @@ func (s *ModulesSuite) TestValidateMissingName() {
 }
 
 func (s *ModulesSuite) TestValidateBadName() {
-	input := []string{
-		// Plain shapes the parser must reject regardless of OS.
+	// A submodule name becomes a directory under .git/modules, so it
+	// is held to a stricter rule than a path: a component of periods
+	// alone folds to ".." on NTFS and there is no repository C Git
+	// wrote that go-git must accept one to read.
+	input := append([]string{
 		"",
 		".",
-		"..",
-		"../x",
-		"a/../../b",
+		"....",
 		"/abs",
 		`C:\win`,
 		"x\x00y",
 		"x/",
 		"/x",
-		`.\..\foo`,
 		"modules/../escape",
-
-		// HFS+ ignores certain Unicode code points during path
-		// normalisation, so these all resolve to ".." on macOS.
-		".\u200c.",             // ZWNJ between dots
-		"\u200c..",             // leading ZWNJ
-		"..\u200c",             // trailing ZWNJ
-		"\u200c.\u200d.\u200e", // ZWNJ + ZWJ + LRM
-		"a/.\u200c./b",         // hidden ".." mid-path
-
-		// NTFS strips trailing spaces, dots, and an alternate-data
-		// -stream suffix during canonicalisation, so these all
-		// resolve to ".." on Windows.
-		".. ",
-		"..  ",
-		"....",
-		".. .",
-		"..::$INDEX_ALLOCATION",
-		"..:foo",
-		"a/.. /b",
-	}
+		"a/../../b",
+	}, dotdotDisguises...)
 	for _, n := range input {
 		m := &Submodule{
 			Name: n,

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -37,8 +37,7 @@ var dotdotDisguises = []string{
 	`foo/../bar`,
 	`.\..\foo`,
 
-	// HFS+ drops ignorable code points during normalisation, so
-	// these all resolve to ".." on macOS.
+	// HFS+ parent-disguise policy, independent of native alias resolution.
 	".\u200c.",
 	"\u200c..",
 	"..\u200c",
@@ -46,9 +45,7 @@ var dotdotDisguises = []string{
 	"foo/.\u200c.",
 	"a/.\u200c./b",
 
-	// NTFS strips trailing spaces and an alternate-data-stream
-	// suffix during canonicalisation, so these all resolve to ".."
-	// on Windows.
+	// NTFS parent-disguise policy, applied on every host.
 	".. ",
 	"..  ",
 	".. .",
@@ -64,7 +61,8 @@ func (s *ModulesSuite) TestValidateMissingURL() {
 }
 
 func (s *ModulesSuite) TestValidateBadPath() {
-	for _, p := range dotdotDisguises {
+	input := append([]string{".", "./sub", "sub/."}, dotdotDisguises...)
+	for _, p := range input {
 		m := &Submodule{
 			Name: "ok",
 			Path: p,
@@ -131,14 +129,12 @@ func (s *ModulesSuite) TestValidateMissingName() {
 }
 
 func (s *ModulesSuite) TestValidateBadName() {
-	// A submodule name becomes a directory under .git/modules, so it
-	// is held to a stricter rule than a path: a component of periods
-	// alone folds to ".." on NTFS and there is no repository C Git
-	// wrote that go-git must accept one to read.
+	// Submodule storage names apply an additional periods-only policy.
 	input := append([]string{
 		"",
 		".",
 		"....",
+		"a/.", "./a", "a/./b",
 		"/abs",
 		`C:\win`,
 		"x\x00y",

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/go-git/go-git/v6/internal/pathutil"
 )
 
 type ModulesSuite struct {
@@ -108,8 +110,8 @@ func (s *ModulesSuite) TestValidateGoodPath() {
 	// The boundary rows: a component of periods alone, and a ".."
 	// prefix whose tail does not fold, are legitimate names that
 	// C Git accepts on POSIX. pathutil.ValidSubmodulePath accepts
-	// them too, and this loop must agree with it because
-	// Submodule.Repository runs that validator on the same string.
+	// them, so Validate accepts them too, and they survive parsing to
+	// reach Submodule.Repository.
 	//
 	// ". " and ". ." are not on this list: they fold to the directory
 	// holding them, which would scope the submodule worktree to the
@@ -282,4 +284,56 @@ func (s *ModulesSuite) TestUnmarshalDropsDotDisguisedPathStanza() {
 	m := NewModules()
 	s.Require().NoError(m.Unmarshal([]byte("[submodule \"m\"]\n\tpath = . \n\turl = u\n")))
 	s.Empty(m.Submodules, "stanza whose path folds to the worktree root must be dropped")
+}
+
+// Validate delegates the path to pathutil.ValidSubmodulePath, the same
+// validator Submodule.Repository runs before it chroots to that path.
+// Every shape the validator refuses must therefore be ErrModuleBadPath
+// here, so that a stanza the parser keeps is one whose Path can reach
+// the chroot.
+func (s *ModulesSuite) TestValidateBadPathMatchesSubmodulePathPolicy() {
+	for _, p := range []string{
+		// .git and its aliases, at every position and in both
+		// separator forms.
+		".git",
+		".git/config",
+		"a/.git",
+		"a/.git/b",
+		`a\.git\b`,
+		".GIT",
+		"git~1",
+		"sub/git~1/HEAD",
+
+		// NTFS and HFS+ .git disguises.
+		"sub/.git . ",
+		".git::$INDEX_ALLOCATION",
+		"git~1 ",
+		"git~1.",
+		".g\u200cit",
+
+		// Control bytes.
+		"a\x01b",
+		"foo\x7fbar",
+	} {
+		s.Require().Error(pathutil.ValidSubmodulePath(p), "path %q", p)
+
+		m := &Submodule{
+			Name: "ok",
+			Path: p,
+			URL:  "https://example.com/",
+		}
+		s.Equal(ErrModuleBadPath, m.Validate(), "path %q", p)
+	}
+}
+
+func (s *ModulesSuite) TestUnmarshalDropsDotGitPathStanza() {
+	m := NewModules()
+	s.Require().NoError(m.Unmarshal([]byte("[submodule \"m\"]\n\tpath = a/.git/b\n\turl = u\n")))
+	s.Empty(m.Submodules, "stanza whose path carries a .git component must be dropped")
+}
+
+func (s *ModulesSuite) TestUnmarshalDropsDotGitPathStanzaWithMissingURL() {
+	m := NewModules()
+	s.Require().NoError(m.Unmarshal([]byte("[submodule \"m\"]\n\tpath = .git\n")))
+	s.Empty(m.Submodules, "stanza whose path names .git must be dropped")
 }

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -22,8 +22,8 @@ func TestModulesSuite(t *testing.T) {
 // The two tables are deliberately not otherwise symmetric: a name is
 // held to the stricter rule because it becomes a directory under
 // .git/modules via dotgit.DotGit.Module, while a path is held to
-// ValidTreePath's rule because Submodule.Repository runs
-// ValidTreePath on it. A component of periods alone is therefore
+// pathutil.ValidSubmodulePath's rule because Submodule.Repository runs
+// that validator on it. A component of periods alone is therefore
 // rejected as a name and accepted as a path.
 var dotdotDisguises = []string{
 	// Literal, at every position and with both separators.
@@ -55,6 +55,37 @@ var dotdotDisguises = []string{
 	"a/.. /b",
 }
 
+// dotDisguises are the spellings a filesystem folds back to the
+// directory holding them. A path built from one addresses that
+// directory: Submodule.Repository would chroot the submodule worktree
+// to the superproject worktree root, and DotGit.Module would chroot
+// the module storer to .git/modules itself. Both a name and a path
+// must refuse every one of them.
+//
+// The literal "." belongs here too, but the existing tables already
+// carry it, so it is not repeated.
+var dotDisguises = []string{
+	// HFS+ drops ignorable code points during normalisation.
+	".\u200c",
+	"\u200c.",
+	".\u200e",
+	".\ufeff",
+	"\u200d.\u200d",
+	"foo/.\u200c",
+	"a/.\u200c/b",
+
+	// NTFS trims a trailing run of spaces and periods, and reads a
+	// colon as an Alternate Data Stream suffix.
+	". ",
+	".  ",
+	". .",
+	".:foo",
+	".:$DATA",
+	".::$INDEX_ALLOCATION",
+	"foo/. /bar",
+	"a/. /b",
+}
+
 func (s *ModulesSuite) TestValidateMissingURL() {
 	m := &Submodule{Name: "foo", Path: "foo"}
 	s.Equal(ErrModuleEmptyURL, m.Validate())
@@ -62,6 +93,7 @@ func (s *ModulesSuite) TestValidateMissingURL() {
 
 func (s *ModulesSuite) TestValidateBadPath() {
 	input := append([]string{".", "./sub", "sub/."}, dotdotDisguises...)
+	input = append(input, dotDisguises...)
 	for _, p := range input {
 		m := &Submodule{
 			Name: "ok",
@@ -75,13 +107,16 @@ func (s *ModulesSuite) TestValidateBadPath() {
 func (s *ModulesSuite) TestValidateGoodPath() {
 	// The boundary rows: a component of periods alone, and a ".."
 	// prefix whose tail does not fold, are legitimate names that
-	// C Git accepts on POSIX. ValidTreePath accepts them too, and
-	// this loop must agree with it because Submodule.Repository runs
-	// ValidTreePath on the same string.
+	// C Git accepts on POSIX. pathutil.ValidSubmodulePath accepts
+	// them too, and this loop must agree with it because
+	// Submodule.Repository runs that validator on the same string.
+	//
+	// ". " and ". ." are not on this list: they fold to the directory
+	// holding them, which would scope the submodule worktree to the
+	// superproject root. dotDisguises carries them.
 	for _, p := range []string{
 		"foo", "foo/bar", "a..b", "deps/x.y", "lib-foo/sub",
 		"...", "....", "a/.../b", "x..", "foo..", "..x", ".. x",
-		". ", ". .",
 	} {
 		m := &Submodule{
 			Name: "ok",
@@ -143,6 +178,7 @@ func (s *ModulesSuite) TestValidateBadName() {
 		"modules/../escape",
 		"a/../../b",
 	}, dotdotDisguises...)
+	input = append(input, dotDisguises...)
 	for _, n := range input {
 		m := &Submodule{
 			Name: n,
@@ -228,4 +264,22 @@ func (s *ModulesSuite) TestUnmarshalMarshal() {
 	output, err := cfg.Marshal()
 	s.NoError(err)
 	s.Equal(string(input), string(output))
+}
+
+func (s *ModulesSuite) TestUnmarshalDropsDotDisguisedNameStanza() {
+	m := NewModules()
+	s.Require().NoError(m.Unmarshal([]byte("[submodule \". \"]\n\tpath = ok\n\turl = u\n")))
+	s.Empty(m.Submodules, "stanza whose name folds to the modules root must be dropped")
+}
+
+func (s *ModulesSuite) TestUnmarshalDropsHFSDotDisguisedNameStanza() {
+	m := NewModules()
+	s.Require().NoError(m.Unmarshal([]byte("[submodule \".\u200c\"]\n\tpath = ok\n\turl = u\n")))
+	s.Empty(m.Submodules, "stanza whose name folds to the modules root must be dropped")
+}
+
+func (s *ModulesSuite) TestUnmarshalDropsDotDisguisedPathStanza() {
+	m := NewModules()
+	s.Require().NoError(m.Unmarshal([]byte("[submodule \"m\"]\n\tpath = . \n\turl = u\n")))
+	s.Empty(m.Submodules, "stanza whose path folds to the worktree root must be dropped")
 }

--- a/internal/pathutil/dotdot.go
+++ b/internal/pathutil/dotdot.go
@@ -10,9 +10,10 @@ package pathutil
 // Runs of periods ("...", "....") and spellings that fold to "."
 // rather than ".." (". ", ". .", ".<U+200C>") are excluded, because
 // C Git carries them in POSIX trees and indexes. ValidTreePath and
-// the worktree wrapper's validPath therefore accept them, while
-// IsDotsOnlyName refuses runs of periods as submodule and reference
-// storage names below .git. On a Win32 host with core.protectNTFS,
+// the worktree wrapper's validPath therefore accept them. Below .git
+// the policy is stricter: IsDotsOnlyName refuses runs of periods as
+// submodule and reference storage names, and IsDotName refuses the
+// spellings that fold to ".". On a Win32 host with core.protectNTFS,
 // validPath additionally consults Win32ValidPath, which refuses a
 // component ending in a space or a period.
 func IsDotOrDotDotName(name string) bool {
@@ -40,4 +41,45 @@ func IsDotsOnlyName(name string) bool {
 		}
 	}
 	return true
+}
+
+// IsDotName reports whether one path component names the current
+// directory. It matches the literal ".", and the NTFS and HFS+
+// spellings those filesystems fold back to "." — ". ", ". .", ".:",
+// ".<U+200C>" and "<U+200C>.". IsDotOrDotDotName owns the parent
+// equivalents.
+//
+// Runs of periods ("...", "....") are excluded, for the reason
+// IsDotOrDotDotName excludes them: C Git carries them in POSIX trees
+// and indexes. IsDotsOnlyName refuses them as storage names below
+// .git.
+//
+// A component that folds to "." resolves to the directory holding it,
+// so a path built from one addresses that directory rather than
+// something below it. Submodule paths and storage names apply this;
+// tree and worktree paths do not, where such a component only names
+// an ordinary file.
+func IsDotName(name string) bool {
+	return name == "." || IsHFSDotCurrent(name) || IsNTFSDotCurrent(name)
+}
+
+// IsUnsafeStorageName reports whether one component is unsafe as a
+// directory name below .git, where submodule storage paths are built.
+// It composes the periods-only, parent and current-directory policies
+// so every caller that resolves a name to repository metadata applies
+// the same set.
+//
+// This is stricter than C Git, whose check_submodule_name refuses only
+// an empty name and a literal ".." component. Storage names below .git
+// have no legitimate spelling among these, so they are refused here
+// rather than reasoned about per filesystem.
+//
+// Reference: upstream Git check_submodule_name at
+// submodule-config.c#L214-L237 in tag v2.54.0[1].
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/submodule-config.c#L214-L237
+func IsUnsafeStorageName(part string) bool {
+	return IsDotsOnlyName(part) ||
+		IsDotOrDotDotName(part) ||
+		IsDotName(part)
 }

--- a/internal/pathutil/dotdot.go
+++ b/internal/pathutil/dotdot.go
@@ -12,7 +12,9 @@ package pathutil
 // C Git carries them in POSIX trees and indexes. ValidTreePath and
 // the worktree wrapper's validPath therefore accept them, while
 // IsDotsOnlyName refuses runs of periods as submodule and reference
-// storage names below .git.
+// storage names below .git. On a Win32 host with core.protectNTFS,
+// validPath additionally consults Win32ValidPath, which refuses a
+// component ending in a space or a period.
 func IsDotOrDotDotName(name string) bool {
 	return name == "." || name == ".." ||
 		IsHFSDotDot(name) || IsNTFSDotDot(name)

--- a/internal/pathutil/dotdot.go
+++ b/internal/pathutil/dotdot.go
@@ -9,8 +9,33 @@ package pathutil
 //
 // Runs of periods ("...", "....") and spellings that fold to "."
 // rather than ".." (". ", ". .", ".<U+200C>") are excluded, because
-// C Git carries them in POSIX trees and indexes.
+// C Git carries them in POSIX trees and indexes. ValidTreePath and
+// the worktree wrapper's validPath therefore accept them, while
+// IsDotsOnlyName refuses runs of periods as submodule and reference
+// storage names below .git.
 func IsDotOrDotDotName(name string) bool {
 	return name == "." || name == ".." ||
 		IsHFSDotDot(name) || IsNTFSDotDot(name)
+}
+
+// IsDotsOnlyName reports whether a nonempty component consists only of
+// ASCII periods. Submodule and reference storage names, which become
+// directories below .git, apply it on top of IsDotOrDotDotName.
+//
+// This is a go-git policy, not a claim that NTFS resolves every such
+// name to "..": C Git accepts a periods-only submodule name, and
+// Win32 trims a trailing period run only for a component that also
+// ends in one. Storage names below .git are cheap to constrain and
+// have no legitimate periods-only spelling, so they are refused here
+// rather than reasoned about per filesystem.
+func IsDotsOnlyName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if name[i] != '.' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/pathutil/dotdot.go
+++ b/internal/pathutil/dotdot.go
@@ -1,0 +1,16 @@
+package pathutil
+
+// IsDotOrDotDotName reports whether one path component names the
+// current or the parent directory. It takes a single component, never
+// a whole path. It matches the literal "." and "..", and the NTFS and
+// HFS+ spellings those filesystems fold back to "..". Tree, worktree,
+// submodule and reference validation share it, so widening it widens
+// every gate at once.
+//
+// Runs of periods ("...", "....") and spellings that fold to "."
+// rather than ".." (". ", ". .", ".<U+200C>") are excluded, because
+// C Git carries them in POSIX trees and indexes.
+func IsDotOrDotDotName(name string) bool {
+	return name == "." || name == ".." ||
+		IsHFSDotDot(name) || IsNTFSDotDot(name)
+}

--- a/internal/pathutil/dotdot_test.go
+++ b/internal/pathutil/dotdot_test.go
@@ -1,0 +1,155 @@
+package pathutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsHFSDotDot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"..", true},
+		{".\u200c.", true},
+		{"\u200c..", true},
+		{"..\u200c", true},
+		{"\u200c.\u200d.\u200e", true},
+		{".", false},
+		{"...", false},
+		{"....", false},
+		{".. ", false},
+		{"a..b", false},
+		{".git", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsHFSDotDot(tc.name))
+		})
+	}
+}
+
+func TestIsNTFSDotDot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// A tail of spaces and periods containing at least one space.
+		{".. ", true},
+		{"..  ", true},
+		{".. .", true},
+		{"... ", true},
+		{".. ..", true},
+		// An Alternate Data Stream suffix names the entry itself.
+		{"..:x", true},
+		{"..:$DATA", true},
+		{"..::$INDEX_ALLOCATION", true},
+		// The literal name is the job of the == comparison in
+		// IsDotOrDotDotName, not of this predicate.
+		{"..", false},
+		{".", false},
+		// Periods alone: NTFS folds these, WindowsValidPath rejects
+		// them under core.protectNTFS.
+		{"...", false},
+		{"....", false},
+		// The tail is not spaces and periods alone, so nothing folds.
+		{".. x", false},
+		{"..x", false},
+		{"x..", false},
+		{"a..b", false},
+		{"foo..", false},
+		{"foo", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsNTFSDotDot(tc.name))
+		})
+	}
+}
+
+func TestIsDotOrDotDotName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Literal self- and parent-references.
+		{".", true},
+		{"..", true},
+
+		// NTFS strips trailing spaces from a path component.
+		{".. ", true},
+		{"..  ", true},
+		{".. .", true},
+		{"... ", true},
+		{".. ..", true},
+
+		// An Alternate Data Stream suffix names the entry itself, so
+		// "..:<stream>" is a reference to the parent directory.
+		{"..:x", true},
+		{"..:$DATA", true},
+		{"..::$INDEX_ALLOCATION", true},
+
+		// HFS+ drops ignorable code points during normalisation.
+		{".\u200c.", true},
+		{"\u200c..", true},
+		{"..\u200c", true},
+		{"\u200c.\u200d.\u200e", true},
+
+		// A component of periods alone is accepted. NTFS folds it,
+		// but it is a legitimate name everywhere else and C Git
+		// 2.54.0 accepts it in a tree and in an index on POSIX.
+		// WindowsValidPath refuses it under core.protectNTFS.
+		{"...", false},
+		{"....", false},
+		{".....", false},
+
+		// Not a ".." prefix, or a tail that does not fold.
+		{"x..", false},
+		{"a..b", false},
+		{"..x", false},
+		{".. x", false},
+		{"foo..", false},
+
+		// These fold to "." rather than to "..", so they produce no
+		// parent hop. Two tree entries can materialise to the same
+		// on-disk name, which is a collision and not an escape, so
+		// they are deliberately accepted at every layer.
+		{". ", false},
+		{". .", false},
+		{".\u200c", false},
+		{".:x", false},
+
+		// Ordinary names, and names owned by other predicates.
+		{"foo", false},
+		{".git", false},
+		{".gitmodules", false},
+		{"CON", false},
+
+		// Callers split with strings.FieldsFunc, which never yields
+		// an empty field. Pinned so a caller switching to
+		// strings.Split does not silently change meaning.
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.name), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsDotOrDotDotName(tc.name),
+				"IsDotOrDotDotName(%q)", tc.name)
+		})
+	}
+}

--- a/internal/pathutil/dotdot_test.go
+++ b/internal/pathutil/dotdot_test.go
@@ -215,3 +215,186 @@ func generateComponents(t *testing.T, alphabet string, maxLen int) []string {
 	}
 	return out
 }
+
+func TestIsHFSDotCurrent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{".", true},
+		{".\u200c", true},
+		{"\u200c.", true},
+		{".\u200e", true},
+		{".\ufeff", true},
+		{"\u200d.\u200d", true},
+		// Two periods fold to the parent, not to the current
+		// directory; IsHFSDotDot owns those.
+		{"..", false},
+		{".\u200c.", false},
+		// HFS+ strips ignorable code points, not spaces or colons.
+		{". ", false},
+		{".:", false},
+		{"...", false},
+		{".git", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.name), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsHFSDotCurrent(tc.name))
+		})
+	}
+}
+
+func TestIsNTFSDotCurrent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// A tail of spaces and periods containing at least one space.
+		{". ", true},
+		{".  ", true},
+		{". .", true},
+		{".  .", true},
+		{".. ", true},
+		// An Alternate Data Stream suffix names the entry itself.
+		{".:x", true},
+		{".:$DATA", true},
+		{".::$INDEX_ALLOCATION", true},
+		// The literal name is the job of the == comparison in
+		// IsDotName, not of this predicate.
+		{".", false},
+		{"..", false},
+		// Periods alone pass the tree gate; IsDotsOnlyName refuses
+		// them as a storage name.
+		{"...", false},
+		{"....", false},
+		// NTFS trims spaces and periods from the end, not the start,
+		// and ignores no code points.
+		{" .", false},
+		{".\u200c", false},
+		{".git", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.name), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsNTFSDotCurrent(tc.name))
+		})
+	}
+}
+
+func TestIsDotName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{".", true},
+		// NTFS trims a trailing run of spaces and periods, and reads
+		// a colon as an Alternate Data Stream suffix.
+		{". ", true},
+		{". .", true},
+		{".  .", true},
+		{".:", true},
+		{".:$DATA", true},
+		{".::$INDEX_ALLOCATION", true},
+		// HFS+ drops ignorable code points during normalisation.
+		{".\u200c", true},
+		{"\u200c.", true},
+		{".\ufeff", true},
+		// The parent spellings belong to IsDotOrDotDotName. An NTFS
+		// tail makes a component fold to both, so those overlap.
+		{"..", false},
+		{"..\u200c", false},
+		{".\u200c.", false},
+		{".. ", true},
+		// Runs of periods are carried in POSIX trees; IsDotsOnlyName
+		// refuses them as a storage name.
+		{"...", false},
+		{"....", false},
+		// Ordinary names, including ones that merely contain periods.
+		{"a..b", false},
+		{"..x", false},
+		{"x..", false},
+		{".a", false},
+		{" .", false},
+		{".git", false},
+		{"foo", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.name), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsDotName(tc.name))
+		})
+	}
+}
+
+func TestIsUnsafeStorageName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Periods only.
+		{".", true},
+		{"..", true},
+		{"...", true},
+		{"....", true},
+		// Parent spellings.
+		{".. ", true},
+		{"..:", true},
+		{"..\u200c", true},
+		{".\u200c.", true},
+		// Current-directory spellings.
+		{". ", true},
+		{". .", true},
+		{".:", true},
+		{".\u200c", true},
+		{"\u200c.", true},
+		// Names that only contain periods are ordinary storage names.
+		{"a..b", false},
+		{"..x", false},
+		{"x..", false},
+		{".git", false},
+		{"lib", false},
+		{"foo", false},
+		// The empty component never reaches this predicate, because
+		// FieldsFunc drops it. Callers check the whole name's shape.
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.name), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsUnsafeStorageName(tc.name))
+		})
+	}
+}
+
+// Every component that HFS+ or NTFS folds to "." or ".." must be
+// refused as a storage name, whichever of the three policies catches
+// it. The corpus covers the runes those folds are built from.
+func TestIsUnsafeStorageNameCoversEveryDotFold(t *testing.T) {
+	t.Parallel()
+
+	for _, part := range generateComponents(t, ". :.\u200c", 4) {
+		folds := IsHFSDot(part, "") || IsNTFSDot(part, "", "") ||
+			IsHFSDot(part, ".") || IsNTFSDot(part, ".", "")
+		if !folds {
+			continue
+		}
+		assert.True(t, IsUnsafeStorageName(part),
+			"component %q folds to a directory name", part)
+	}
+}

--- a/internal/pathutil/dotdot_test.go
+++ b/internal/pathutil/dotdot_test.go
@@ -57,8 +57,7 @@ func TestIsNTFSDotDot(t *testing.T) {
 		// IsDotOrDotDotName, not of this predicate.
 		{"..", false},
 		{".", false},
-		// Periods alone: NTFS folds these, WindowsValidPath rejects
-		// them under core.protectNTFS.
+		// Periods alone pass the tree gate; Win32ValidPath rejects them.
 		{"...", false},
 		{"....", false},
 		// The tail is not spaces and periods alone, so nothing folds.
@@ -109,10 +108,8 @@ func TestIsDotOrDotDotName(t *testing.T) {
 		{"..\u200c", true},
 		{"\u200c.\u200d.\u200e", true},
 
-		// A component of periods alone is accepted. NTFS folds it,
-		// but it is a legitimate name everywhere else and C Git
-		// 2.54.0 accepts it in a tree and in an index on POSIX.
-		// WindowsValidPath refuses it under core.protectNTFS.
+		// Periods alone pass this predicate. validPath applies the
+		// Win32 trailing rule only on Windows with core.protectNTFS.
 		{"...", false},
 		{"....", false},
 		{".....", false},
@@ -152,4 +149,69 @@ func TestIsDotOrDotDotName(t *testing.T) {
 				"IsDotOrDotDotName(%q)", tc.name)
 		})
 	}
+}
+
+func TestIsDotsOnlyName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{".", true},
+		{"..", true},
+		{"...", true},
+		{"....", true},
+		{".....", true},
+		{"", false},
+		{". ", false},
+		{" .", false},
+		{".a", false},
+		{"a.", false},
+		{"a..b", false},
+		{".\u200c.", false},
+		{"..:x", false},
+		{"foo", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.name), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsDotsOnlyName(tc.name))
+		})
+	}
+}
+
+// Reference names already rejected literal dot; submodule names gain it.
+func TestIsDotsOnlyNameComplementsIsDotOrDotDotName(t *testing.T) {
+	t.Parallel()
+	for _, part := range generateComponents(t, ". :a~gt$\u200c", 4) {
+		got := IsDotsOnlyName(part) || IsDotOrDotDotName(part)
+		reference := part == "." || IsHFSDot(part, ".") || IsNTFSDot(part, ".", "")
+		submodule := IsHFSDot(part, ".") || IsNTFSDot(part, ".", "")
+		assert.Equal(t, reference, got, "reference component %q", part)
+		assert.Equal(t, part == ".", got != submodule, "submodule delta %q", part)
+	}
+}
+
+// generateComponents returns every string of length 0 to maxLen over
+// the runes of alphabet. It exists so the two cross-checks in this
+// package can assert an invariant over a closed corpus rather than
+// over a hand-picked table.
+func generateComponents(t *testing.T, alphabet string, maxLen int) []string {
+	t.Helper()
+
+	out := make([]string, 1, 1+len(alphabet)*maxLen)
+	cur := []string{""}
+	for range maxLen {
+		next := make([]string, 0, len(alphabet)*len(cur))
+		for _, prefix := range cur {
+			for _, r := range alphabet {
+				next = append(next, prefix+string(r))
+			}
+		}
+		out = append(out, next...)
+		cur = next
+	}
+	return out
 }

--- a/internal/pathutil/hfs.go
+++ b/internal/pathutil/hfs.go
@@ -105,6 +105,13 @@ func IsHFSDotGit(part string) bool { return IsHFSDot(part, "git") }
 // HFS+ volume.
 func IsHFSDotDot(part string) bool { return IsHFSDot(part, ".") }
 
+// IsHFSDotCurrent reports whether part is an HFS+ equivalent of ".".
+// The empty needle leaves IsHFSDot matching a lone period surrounded
+// by ignorable code points, so ".<U+200C>" and "<U+200C>." name the
+// current directory on an HFS+ volume. The literal "." matches too;
+// IsDotName owns that comparison.
+func IsHFSDotCurrent(part string) bool { return IsHFSDot(part, "") }
+
 // IsHFSDotGitmodules reports whether part is an HFS+ equivalent of
 // ".gitmodules", catching attempts to plant the file via Unicode
 // code points that HFS+ would strip during normalisation.

--- a/internal/pathutil/hfs.go
+++ b/internal/pathutil/hfs.go
@@ -93,6 +93,12 @@ func IsHFSDot(part, needle string) bool {
 // IsHFSDotGit reports whether part is an HFS+ equivalent of ".git".
 func IsHFSDotGit(part string) bool { return IsHFSDot(part, "git") }
 
+// IsHFSDotDot reports whether part is an HFS+ equivalent of "..".
+// HFS+ drops a fixed set of ignorable code points during
+// normalisation, so ".<U+200C>." names the parent directory on an
+// HFS+ volume.
+func IsHFSDotDot(part string) bool { return IsHFSDot(part, ".") }
+
 // IsHFSDotGitmodules reports whether part is an HFS+ equivalent of
 // ".gitmodules", catching attempts to plant the file via Unicode
 // code points that HFS+ would strip during normalisation.

--- a/internal/pathutil/hfs.go
+++ b/internal/pathutil/hfs.go
@@ -1,6 +1,9 @@
 package pathutil
 
-import "unicode"
+import (
+	"unicode"
+	"unicode/utf8"
+)
 
 // hfsIgnoredCodepoints contains Unicode code points that HFS+ ignores
 // during path normalization. A path component containing these
@@ -10,7 +13,7 @@ import "unicode"
 //
 // See upstream Git utf8.c next_hfs_char in tag v2.54.0[1].
 //
-// [1]: https://github.com/git/git/blob/v2.54.0/utf8.c#L703-L740
+// [1]: https://github.com/git/git/blob/v2.54.0/utf8.c#L703-L739
 var hfsIgnoredCodepoints = map[rune]struct{}{
 	0x200c: {}, // ZERO WIDTH NON-JOINER
 	0x200d: {}, // ZERO WIDTH JOINER
@@ -37,11 +40,14 @@ var hfsIgnoredCodepoints = map[rune]struct{}{
 // mirrors upstream Git's is_hfs_dot_generic and is the building
 // block of IsHFSDotGit / IsHFSDotGitmodules.
 //
-// Reference: upstream Git utf8.c is_hfs_dot_generic at L741-L774 and
-// the dotgit family at L784-L809 in tag v2.54.0[1].
+// Reference: upstream Git utf8.c is_hfs_dot_generic at L741-L773 and
+// the dotgit family at L784-L807 in tag v2.54.0[1].
 //
-// [1]: https://github.com/git/git/blob/v2.54.0/utf8.c#L741-L809
+// [1]: https://github.com/git/git/blob/v2.54.0/utf8.c#L741-L807
 func IsHFSDot(part, needle string) bool {
+	if part == "" || (part[0] < utf8.RuneSelf && part[0] != '.') {
+		return false
+	}
 	runes := []rune(part)
 	i := 0
 

--- a/internal/pathutil/hfs_test.go
+++ b/internal/pathutil/hfs_test.go
@@ -1,9 +1,11 @@
 package pathutil
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsHFSDotGit(t *testing.T) {
@@ -79,6 +81,18 @@ func TestIsHFSDot(t *testing.T) {
 			assert.Equal(t, tc.want, got, "IsHFSDot(%q, %q)", tc.part, tc.needle)
 		})
 	}
+}
+
+// IsHFSDot runs on every component of every path that reaches tree,
+// worktree, submodule and reference validation, so the ASCII fast
+// path has to stay allocation-free: without it the []rune conversion
+// allocates for every ordinary name.
+//
+//nolint:paralleltest // AllocsPerRun must run without parallel tests.
+func TestIsHFSDotAllocations(t *testing.T) {
+	part := strings.Repeat("a", 40)
+	allocations := testing.AllocsPerRun(1000, func() { IsHFSDot(part, ".") })
+	require.Zero(t, allocations)
 }
 
 func TestIsHFSDotGitmodules(t *testing.T) {

--- a/internal/pathutil/ntfs.go
+++ b/internal/pathutil/ntfs.go
@@ -50,37 +50,44 @@ func IsNTFSDotGit(part string) bool {
 // "..:$DATA" and "..::$INDEX_ALLOCATION" match. ".." itself does
 // not; the literal comparison in IsDotOrDotDotName owns that.
 //
-// A tail of periods alone ("...", "....") does not match. NTFS
-// strips trailing periods too, so such a name does fold to ".."
-// there, but it is a well-formed name on every other filesystem and
-// upstream Git accepts it in a tree and in an index on POSIX.
-// Rejecting it at an always-on cross-platform layer would make a
-// repository carrying one unreadable, so WindowsValidPath refuses it
-// at the materialisation boundary under core.protectNTFS instead --
-// which is where upstream's own is_valid_win32_path sits.
+// A tail of periods alone ("...", "....") does not match. C Git
+// carries such names on POSIX. Win32 trims trailing spaces and
+// periods, except for exactly "." and "..". validPath consults
+// Win32ValidPath under core.protectNTFS.
 func IsNTFSDotDot(part string) bool {
-	// IsNTFSDot with a "." needle matches ".." followed by any run
-	// of spaces and periods, optionally terminated by an ADS colon.
-	// Only its first pattern can match a needle this short: the
-	// second needs len(dotgit) >= 6 and the third returns early on
-	// len(shortnamePrefix) < 6. That pattern requires part[0] and
-	// part[1] to be periods, so the tail starts at index 2 and the
-	// slice below needs no length guard.
+	// Only the literal-dot pattern in IsNTFSDot matches a needle
+	// this short. It requires two leading periods, so the slice
+	// below needs no additional length guard.
 	if !IsNTFSDot(part, ".", "") {
 		return false
 	}
 	return strings.ContainsAny(part[2:], " :")
 }
 
-// WindowsValidPath reports whether part is a valid Windows / NTFS
-// path component for the worktree filesystem abstraction. It rejects
-// NTFS-disguised variants of `.git` and `git~1` (trailing spaces,
-// periods, Alternate Data Streams) and Windows reserved device
-// names. Bare `.git` and `git~1` are allowed at this layer; the
-// caller decides whether they are permissible at the current path
-// position.
-func WindowsValidPath(part string) bool {
-	if IsNTFSDotGit(part) && !IsDotGitName(part) {
+// Win32ValidPath reports whether one path component avoids trailing
+// spaces and periods and Windows reserved device names. The worktree
+// wrapper's validPath applies it under core.protectNTFS; the .git
+// disguise checks stay separately config-gated.
+//
+// Both rules come from upstream Git's is_valid_win32_path at
+// compat/mingw.c#L3347-L3469 in tag v2.54.0[1]. Upstream skips the
+// DOS drive prefix before scanning components; this predicate never
+// receives that prefix, because validPath refuses a path carrying one
+// before the components are examined.
+//
+// Two parts of upstream's scanner are not ported. Its illegal
+// characters — the control bytes and `< > " | ? *`, plus a colon
+// outside an Alternate Data Stream — are not checked here; validPath
+// covers the control bytes itself and accepts the rest, so a
+// component such as `a:b` passes where upstream would refuse it. The
+// reserved-name policy also differs at two edges: it is stricter for
+// a reserved name followed by a space and a further character
+// ("con c", "aux b", "prn x"), which upstream accepts, and laxer for
+// "LPT0", which upstream refuses even though it accepts "COM0".
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3347-L3469
+func Win32ValidPath(part string) bool {
+	if endsInSpaceOrPeriod(part) {
 		return false
 	}
 	return !isWindowsReservedName(part)
@@ -91,7 +98,10 @@ func WindowsValidPath(part string) bool {
 // spaces, extensions, and NTFS Alternate Data Streams) matches one of
 // these case-insensitively.
 //
-// See upstream Git compat/mingw.c is_valid_win32_path().
+// See upstream Git's is_valid_win32_path reserved-name scanner at
+// compat/mingw.c#L3372-L3449 in tag v2.54.0[1].
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3372-L3449
 var windowsReservedNames = []string{
 	"CON", "PRN", "AUX", "NUL",
 	"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
@@ -107,7 +117,7 @@ func isWindowsReservedName(part string) bool {
 		if !strings.EqualFold(part[:len(name)], name) {
 			continue
 		}
-		// Exact match or followed by space, dot, colon (ADS), or separator.
+		// Exact match or followed by space, dot or colon (ADS).
 		if len(part) == len(name) {
 			return true
 		}
@@ -117,6 +127,33 @@ func isWindowsReservedName(part string) bool {
 		}
 	}
 	return false
+}
+
+// endsInSpaceOrPeriod reports whether part ends in a space or a
+// period, with "." and ".." excepted. Win32 path canonicalisation
+// strips both characters from the end of a component, so a component
+// that ends in one names something other than what it spells: "foo "
+// opens "foo", and ".gitattributes " collides with
+// ".gitattributes".
+//
+// Ports the segment-boundary condition of upstream Git's
+// is_valid_win32_path at compat/mingw.c L3363-L3366 in tag
+// v2.54.0[1]:
+//
+//	preceding_space_or_period && (i != periods || periods > 2)
+//
+// `i != periods` is false only for a component of periods alone, and
+// `periods > 2` then caps that exception at "." and "..", so the
+// condition reduces to the two-name exception written literally
+// below.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3363-L3366
+func endsInSpaceOrPeriod(part string) bool {
+	if part == "" || part == "." || part == ".." {
+		return false
+	}
+	c := part[len(part)-1]
+	return c == ' ' || c == '.'
 }
 
 // IsNTFSDot ports upstream Git's is_ntfs_dot_generic. It detects NTFS
@@ -135,7 +172,8 @@ func IsNTFSDot(name, dotgit, shortnamePrefix string) bool {
 	// onlySpacesAndPeriods returns true when the suffix from start
 	// onwards consists only of trailing spaces and periods, possibly
 	// terminated by a NTFS Alternate Data Stream colon. Mirrors the
-	// only_spaces_and_periods label in upstream's is_ntfs_dot_generic.
+	// only_spaces_and_periods label in upstream's
+	// is_ntfs_dot_generic.
 	onlySpacesAndPeriods := func(start int) bool {
 		for i := start; i < len(name); i++ {
 			c := name[i]
@@ -149,7 +187,8 @@ func IsNTFSDot(name, dotgit, shortnamePrefix string) bool {
 		return true
 	}
 
-	// Pattern 1: ".<dotgit>" prefix + trailing spaces / periods / ADS.
+	// Pattern 1: ".<dotgit>" prefix + trailing spaces / periods /
+	// ADS.
 	if len(name) >= len(dotgit)+1 && name[0] == '.' &&
 		strings.EqualFold(name[1:1+len(dotgit)], dotgit) {
 		if onlySpacesAndPeriods(len(dotgit) + 1) {
@@ -208,8 +247,8 @@ func IsNTFSDotGitmodules(part string) bool {
 }
 
 // IsNTFSDotGitattributes reports whether part is an NTFS equivalent
-// of ".gitattributes". The short-name prefix "gi7d29" mirrors upstream
-// Git's is_ntfs_dotgitattributes.
+// of ".gitattributes". The short-name prefix "gi7d29" mirrors
+// upstream Git's is_ntfs_dotgitattributes.
 func IsNTFSDotGitattributes(part string) bool {
 	return IsNTFSDot(part, "gitattributes", "gi7d29")
 }

--- a/internal/pathutil/ntfs.go
+++ b/internal/pathutil/ntfs.go
@@ -64,30 +64,27 @@ func IsNTFSDotDot(part string) bool {
 	return strings.ContainsAny(part[2:], " :")
 }
 
-// Win32ValidPath reports whether one path component avoids trailing
-// spaces and periods and Windows reserved device names. The worktree
-// wrapper's validPath applies it on a Win32 host with
-// core.protectNTFS enabled; the .git disguise checks stay separately
-// config-gated on every host.
+// Win32ValidPath checks one path component for illegal Win32 characters,
+// trailing spaces or periods, and reserved device names. The worktree
+// wrapper applies it on Windows with core.protectNTFS enabled; metadata
+// aliases are checked separately on every host.
 //
-// Both rules come from upstream Git's is_valid_win32_path at
-// compat/mingw.c#L3347-L3469 in tag v2.54.0[1]. Upstream skips the
-// DOS drive prefix before scanning components; this predicate never
-// receives that prefix, because HasVolumeName refuses a path carrying
-// one before the components are examined.
+// Follows upstream Git's is_valid_win32_path with allow_literal_nul=false.
+// The caller splits path separators and rejects volume prefixes before
+// checking components, so every colon here is invalid. Embedded NUL bytes
+// are also rejected rather than treated as C string terminators.
 //
-// Two parts of upstream's scanner are not ported. Its illegal
-// characters — the control bytes and `< > " | ? *`, plus a colon
-// outside an Alternate Data Stream — are not checked here; validPath
-// covers the control bytes itself and accepts the rest, so a
-// component such as `a:b` passes where upstream would refuse it. The
-// reserved-name policy also differs at two edges: it is stricter for
-// a reserved name followed by a space and a further character
-// ("con c", "aux b", "prn x"), which upstream accepts, and laxer for
-// "LPT0", which upstream refuses even though it accepts "COM0".
-//
-// [1]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3347-L3469
+// https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3155-L3272
 func Win32ValidPath(part string) bool {
+	for i := 0; i < len(part); i++ {
+		if part[i] < 0x20 {
+			return false
+		}
+		switch part[i] {
+		case ':', '<', '>', '"', '|', '?', '*':
+			return false
+		}
+	}
 	if endsInSpaceOrPeriod(part) {
 		return false
 	}
@@ -100,13 +97,13 @@ func Win32ValidPath(part string) bool {
 // these case-insensitively.
 //
 // See upstream Git's is_valid_win32_path reserved-name scanner at
-// compat/mingw.c#L3372-L3449 in tag v2.54.0[1].
+// compat/mingw.c#L3178-L3252 in tag v2.54.0[1].
 //
-// [1]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3372-L3449
+// [1]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3178-L3252
 var windowsReservedNames = []string{
 	"CON", "PRN", "AUX", "NUL",
 	"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-	"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+	"LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
 	"CONIN$", "CONOUT$",
 }
 
@@ -118,12 +115,12 @@ func isWindowsReservedName(part string) bool {
 		if !strings.EqualFold(part[:len(name)], name) {
 			continue
 		}
-		// Exact match or followed by space, dot or colon (ADS).
-		if len(part) == len(name) {
+		suffix := strings.TrimLeft(part[len(name):], " ")
+		if suffix == "" {
 			return true
 		}
-		switch part[len(name)] {
-		case ' ', '.', ':':
+		switch suffix[0] {
+		case '.', ':':
 			return true
 		}
 	}

--- a/internal/pathutil/ntfs.go
+++ b/internal/pathutil/ntfs.go
@@ -53,7 +53,7 @@ func IsNTFSDotGit(part string) bool {
 // A tail of periods alone ("...", "....") does not match. C Git
 // carries such names on POSIX. Win32 trims trailing spaces and
 // periods, except for exactly "." and "..". validPath consults
-// Win32ValidPath under core.protectNTFS.
+// Win32ValidPath only on Windows with core.protectNTFS enabled.
 func IsNTFSDotDot(part string) bool {
 	// Only the literal-dot pattern in IsNTFSDot matches a needle
 	// this short. It requires two leading periods, so the slice
@@ -66,14 +66,15 @@ func IsNTFSDotDot(part string) bool {
 
 // Win32ValidPath reports whether one path component avoids trailing
 // spaces and periods and Windows reserved device names. The worktree
-// wrapper's validPath applies it under core.protectNTFS; the .git
-// disguise checks stay separately config-gated.
+// wrapper's validPath applies it on a Win32 host with
+// core.protectNTFS enabled; the .git disguise checks stay separately
+// config-gated on every host.
 //
 // Both rules come from upstream Git's is_valid_win32_path at
 // compat/mingw.c#L3347-L3469 in tag v2.54.0[1]. Upstream skips the
 // DOS drive prefix before scanning components; this predicate never
-// receives that prefix, because validPath refuses a path carrying one
-// before the components are examined.
+// receives that prefix, because HasVolumeName refuses a path carrying
+// one before the components are examined.
 //
 // Two parts of upstream's scanner are not ported. Its illegal
 // characters — the control bytes and `< > " | ? *`, plus a colon

--- a/internal/pathutil/ntfs.go
+++ b/internal/pathutil/ntfs.go
@@ -43,6 +43,35 @@ func IsNTFSDotGit(part string) bool {
 	return true
 }
 
+// IsNTFSDotDot reports whether part is an NTFS spelling of ".."
+// that a comparison against the literal ".." misses: ".." followed
+// by a tail of spaces and periods containing at least one space, or
+// ".." followed by an Alternate Data Stream colon. ".. ", ".. .",
+// "..:$DATA" and "..::$INDEX_ALLOCATION" match. ".." itself does
+// not; the literal comparison in IsDotOrDotDotName owns that.
+//
+// A tail of periods alone ("...", "....") does not match. NTFS
+// strips trailing periods too, so such a name does fold to ".."
+// there, but it is a well-formed name on every other filesystem and
+// upstream Git accepts it in a tree and in an index on POSIX.
+// Rejecting it at an always-on cross-platform layer would make a
+// repository carrying one unreadable, so WindowsValidPath refuses it
+// at the materialisation boundary under core.protectNTFS instead --
+// which is where upstream's own is_valid_win32_path sits.
+func IsNTFSDotDot(part string) bool {
+	// IsNTFSDot with a "." needle matches ".." followed by any run
+	// of spaces and periods, optionally terminated by an ADS colon.
+	// Only its first pattern can match a needle this short: the
+	// second needs len(dotgit) >= 6 and the third returns early on
+	// len(shortnamePrefix) < 6. That pattern requires part[0] and
+	// part[1] to be periods, so the tail starts at index 2 and the
+	// slice below needs no length guard.
+	if !IsNTFSDot(part, ".", "") {
+		return false
+	}
+	return strings.ContainsAny(part[2:], " :")
+}
+
 // WindowsValidPath reports whether part is a valid Windows / NTFS
 // path component for the worktree filesystem abstraction. It rejects
 // NTFS-disguised variants of `.git` and `git~1` (trailing spaces,

--- a/internal/pathutil/ntfs.go
+++ b/internal/pathutil/ntfs.go
@@ -64,6 +64,28 @@ func IsNTFSDotDot(part string) bool {
 	return strings.ContainsAny(part[2:], " :")
 }
 
+// IsNTFSDotCurrent reports whether part is an NTFS spelling of "."
+// that a comparison against the literal "." misses: "." followed by a
+// tail of spaces and periods containing at least one space, or "."
+// followed by an Alternate Data Stream colon. ". ", ". .", ".:$DATA"
+// and ".::$INDEX_ALLOCATION" match.
+//
+// The empty needle degenerates IsNTFSDot: the length guards skip both
+// short-name patterns, leaving a leading period followed only by
+// spaces, periods or an ADS colon. That admits ".", ".." and runs of
+// periods, which this function excludes the way IsNTFSDotDot does —
+// by requiring a space or a colon in the tail. IsDotName and
+// IsDotOrDotDotName own the literal spellings.
+func IsNTFSDotCurrent(part string) bool {
+	// Only the literal-dot pattern in IsNTFSDot matches an empty
+	// needle. It requires one leading period, so the slice below
+	// needs no additional length guard.
+	if !IsNTFSDot(part, "", "") {
+		return false
+	}
+	return strings.ContainsAny(part[1:], " :")
+}
+
 // Win32ValidPath checks one path component for illegal Win32 characters,
 // trailing spaces or periods, and reserved device names. The worktree
 // wrapper applies it on Windows with core.protectNTFS enabled; metadata

--- a/internal/pathutil/ntfs_test.go
+++ b/internal/pathutil/ntfs_test.go
@@ -31,10 +31,24 @@ func TestWin32ValidPath(t *testing.T) {
 		{"NUL", false},
 		{"COM1", false},
 		{"COM9", false},
+		{"LPT0", false},
 		{"LPT1", false},
 		{"LPT9", false},
 		{"CONIN$", false},
 		{"CONOUT$", false},
+		{"lPt0.txt", false},
+		{"CON .txt", false},
+		{"AUX  .log", false},
+		{"CONIN$ .txt", false},
+		{"CONOUT$ .txt", false},
+		{"foo:bar", false},
+		{"foo::$DATA", false},
+		{"foo<bar", false},
+		{"foo>bar", false},
+		{"foo\"bar", false},
+		{"foo|bar", false},
+		{"foo?bar", false},
+		{"foo*bar", false},
 		// Upstream's is_valid_win32_path refuses a component ending
 		// in a space or a period, excepting exactly "." and "..".
 		// Win32 canonicalisation strips both characters, so such a
@@ -65,7 +79,17 @@ func TestWin32ValidPath(t *testing.T) {
 		{"comic", true},
 		{"COM", true},
 		{"COM0", true},
-		{"LPT0", true},
+		{"LPT10", true},
+		{"con c", true},
+		{"aux b", true},
+		{"prn x", true},
+		{"nul x", true},
+		{"COM1 port", true},
+		{"LPT0 port", true},
+		{"CONIN$ input", true},
+		{"CONOUT$ output", true},
+		{"foo\x7fbar", true}, // The worktree's always-on control check rejects DEL.
+		{"résumé.txt", true},
 		// Bare ".git" / "git~1" stay valid here; the caller decides
 		// whether they are permissible at the current path position.
 		{".git", true},
@@ -78,6 +102,14 @@ func TestWin32ValidPath(t *testing.T) {
 			got := Win32ValidPath(tc.path)
 			assert.Equal(t, tc.want, got)
 		})
+	}
+}
+
+func TestWin32ValidPathControlCharacters(t *testing.T) {
+	t.Parallel()
+	for c := range byte(0x20) {
+		name := "foo" + string(c) + "bar"
+		assert.False(t, Win32ValidPath(name), "component %q", name)
 	}
 }
 

--- a/internal/pathutil/ntfs_test.go
+++ b/internal/pathutil/ntfs_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWindowsValidPath(t *testing.T) {
+func TestWin32ValidPath(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		path string
@@ -18,12 +18,9 @@ func TestWindowsValidPath(t *testing.T) {
 		{".git  ", false},
 		{".git . .", false},
 		{".git . .", false},
-		{".git::$INDEX_ALLOCATION", false},
-		{".git:", false},
 		{"git~1 ", false},
 		{"git~1.", false},
 		{"GIT~1 ", false},
-		{"git~1::$DATA", false},
 		{"CON", false},
 		{"con", false},
 		{"CON.txt", false},
@@ -38,6 +35,28 @@ func TestWindowsValidPath(t *testing.T) {
 		{"LPT9", false},
 		{"CONIN$", false},
 		{"CONOUT$", false},
+		// Upstream's is_valid_win32_path refuses a component ending
+		// in a space or a period, excepting exactly "." and "..".
+		// Win32 canonicalisation strips both characters, so such a
+		// component names something other than what it spells.
+		{"foo ", false},
+		{"foo.", false},
+		{"foo  ", false},
+		{"foo ..", false},
+		{"sub ", false},
+		{".gitattributes ", false},
+		{".gitignore ", false},
+		{".gitmodules.", false},
+		{"...", false},
+		{"....", false},
+		{". ", false},
+		{". .", false},
+		{".. ", false},
+		// The two upstream exceptions. NTFS resolves these to the
+		// directory itself and to its parent, which is the caller's
+		// business, not a spelling problem.
+		{".", true},
+		{"..", true},
 		{"a", true},
 		{"a\\b", true},
 		{"a/b", true},
@@ -56,7 +75,7 @@ func TestWindowsValidPath(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.path, func(t *testing.T) {
 			t.Parallel()
-			got := WindowsValidPath(tc.path)
+			got := Win32ValidPath(tc.path)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -210,5 +229,43 @@ func TestIsNTFSDotMetadataFamily(t *testing.T) {
 			assert.False(t, tc.fn(".gitmodules"), "%s(%q)", tc.name, ".gitmodules")
 			assert.False(t, tc.fn(""), "%s(empty)", tc.name)
 		})
+	}
+}
+
+// TestWin32ValidPathTrailingRuleMatchesUpstream compares the
+// trailing-space/period rule against a direct transcription of
+// upstream Git's segment-boundary condition in is_valid_win32_path
+// at compat/mingw.c#L3363-L3366 in tag v2.54.0[1], over every
+// component in a closed corpus. A table of hand-picked rows catches
+// a wrong verdict; only this catches a subtly wrong port.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3363-L3366
+func TestWin32ValidPathTrailingRuleMatchesUpstream(t *testing.T) {
+	t.Parallel()
+
+	// upstreamRejects transcribes
+	//   preceding_space_or_period && (i != periods || periods > 2)
+	// where i is the component length in bytes and periods is the
+	// count of periods in it.
+	upstreamRejects := func(part string) bool {
+		periods, precedingSpaceOrPeriod := 0, false
+		for i := 0; i < len(part); i++ {
+			switch part[i] {
+			case '.':
+				periods++
+				precedingSpaceOrPeriod = true
+			case ' ':
+				precedingSpaceOrPeriod = true
+			default:
+				precedingSpaceOrPeriod = false
+			}
+		}
+		return precedingSpaceOrPeriod &&
+			(len(part) != periods || periods > 2)
+	}
+
+	for _, part := range generateComponents(t, ". a:", 5) {
+		assert.Equal(t, upstreamRejects(part), endsInSpaceOrPeriod(part),
+			"component %q", part)
 	}
 }

--- a/internal/pathutil/tree.go
+++ b/internal/pathutil/tree.go
@@ -52,7 +52,7 @@ func ValidTreePath(p string) error {
 		}
 	}
 
-	parts := strings.FieldsFunc(p, func(r rune) bool { return r == '\\' || r == '/' })
+	parts := strings.FieldsFunc(p, isPathSep)
 	if len(parts) == 0 {
 		return fmt.Errorf("%w: %q", ErrInvalidPath, p)
 	}
@@ -70,6 +70,34 @@ func ValidTreePath(p string) error {
 
 		if IsDotGitName(part) || IsHFSDotGit(part) || IsNTFSDotGit(part) {
 			return fmt.Errorf("%w component: %q", ErrInvalidPath, p)
+		}
+	}
+
+	return nil
+}
+
+// ValidSubmodulePath applies ValidTreePath and the one rule a
+// submodule path needs beyond it: no component that a filesystem folds
+// to ".". Submodule.Repository chroots the submodule worktree to this
+// path, so such a component scopes the submodule to the superproject
+// worktree root instead of a directory below it, and a checkout then
+// materialises the submodule's blobs over the superproject's own
+// files.
+//
+// ValidTreePath stays tolerant of these because an ordinary tree entry
+// only names a file there, and C Git's verify_path carries such names
+// on POSIX. C Git does not validate the .gitmodules path at all — the
+// gitlink path it uses comes from the index — so this rule is go-git
+// policy for the one place a tree-controlled string becomes a chroot
+// base.
+func ValidSubmodulePath(p string) error {
+	if err := ValidTreePath(p); err != nil {
+		return err
+	}
+
+	for _, part := range strings.FieldsFunc(p, isPathSep) {
+		if IsDotName(part) {
+			return fmt.Errorf("%w %q: cannot use %q", ErrInvalidPath, p, part)
 		}
 	}
 

--- a/internal/pathutil/tree.go
+++ b/internal/pathutil/tree.go
@@ -30,11 +30,12 @@ var ErrInvalidPath = fmt.Errorf("invalid path")
 // stricter than C Git, which gates the disguise checks on those two
 // settings and can store such names on POSIX.
 //
-// Windows reserved device names (CON, NUL, etc.) are not policed
-// here: they are legitimate filenames on non-Windows and upstream Git
-// accepts them. A component of periods alone passes for the same
-// reason. The wrapper layer (validPath in package git) applies those
-// rules at materialisation time.
+// Win32ValidPath's trailing-space/period and reserved-device rules do
+// not belong here — applying them would make an ordinary POSIX
+// repository unreadable, and upstream likewise compiles
+// is_valid_win32_path only for MinGW and MSVC. A component of periods
+// alone therefore passes this gate. The worktree wrapper's validPath
+// applies those rules on a Win32 host with core.protectNTFS.
 //
 // A rejected entry interrupts tree iteration and checkout; entries
 // yielded before it have already been seen by the caller.

--- a/internal/pathutil/tree.go
+++ b/internal/pathutil/tree.go
@@ -6,35 +6,44 @@ import (
 	"strings"
 )
 
-// ErrInvalidPath is returned by ValidTreePath when its argument is
-// not a safe path to materialise into the worktree.
+// ErrInvalidPath is returned by ValidTreePath, and wrapped by the
+// worktree filesystem wrapper's own path refusals, when a path is not
+// safe to materialise into the worktree.
 var ErrInvalidPath = fmt.Errorf("invalid path")
 
 // ValidTreePath rejects path strings that, if materialised into a
 // worktree, would let an attacker-controlled tree entry escape the
 // worktree or rewrite repository metadata. It rejects:
 //
-//   - control characters (< 0x20, 0x7f);
-//   - empty paths and "." / ".." components;
-//   - Windows volume name prefixes (e.g. C:);
-//   - .git, its 8.3 NTFS short-name git~1, plus their HFS+ and NTFS
-//     variants — at every position, not just the root.
+//   - empty paths and control bytes (< 0x20, 0x7f);
+//   - "." and ".." components, and the NTFS and HFS+ spellings
+//     IsDotOrDotDotName folds back to them;
+//   - .git, its 8.3 NTFS short name git~1, and their HFS+ and NTFS
+//     variants — at every position, not just the root;
+//   - Windows volume name prefixes (e.g. C:), which
+//     filepath.VolumeName recognises only on Windows.
 //
-// HFS+/NTFS variants of `.git` are always rejected at this layer
-// regardless of runtime config: tree paths are canonical UTF-8 with
-// no zero-width characters or NTFS short-name forms, so an entry
-// that looks like a disguised `.git` is suspicious anywhere. Windows
-// reserved device names (CON, NUL, etc.) are not policed here — they
-// are legitimate filenames on non-Windows filesystems and upstream
-// Git accepts them. The wrapper layer (validPath in package git)
-// rejects them at materialisation time when core.protectNTFS is on.
+// Both slash forms separate components. Every rule applies regardless
+// of core.protectHFS and core.protectNTFS: tree paths are canonical
+// UTF-8 with no zero-width characters or NTFS short-name forms, so an
+// entry that looks like a disguise is suspicious anywhere. That is
+// stricter than C Git, which gates the disguise checks on those two
+// settings and can store such names on POSIX.
 //
-// Mirrors upstream Git's verify_path_internal at read-cache.c#L987
-// in tag v2.54.0[1] with protect_hfs / protect_ntfs treated as
-// always-on for `.git`-disguise detection (tree paths are not
-// application-supplied) and is_valid_win32_path left to the wrapper.
+// Windows reserved device names (CON, NUL, etc.) are not policed
+// here: they are legitimate filenames on non-Windows and upstream Git
+// accepts them. A component of periods alone passes for the same
+// reason. The wrapper layer (validPath in package git) applies those
+// rules at materialisation time.
 //
-// [1]: https://github.com/git/git/blob/v2.54.0/read-cache.c#L987
+// A rejected entry interrupts tree iteration and checkout; entries
+// yielded before it have already been seen by the caller.
+//
+// Mirrors upstream Git's verify_path_internal at read-cache.c#L987-L1048
+// in tag v2.54.0[1], with protect_hfs and protect_ntfs treated as
+// always-on and is_valid_win32_path left to the wrapper.
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/read-cache.c#L987-L1048
 func ValidTreePath(p string) error {
 	for i := 0; i < len(p); i++ {
 		if p[i] < 0x20 || p[i] == 0x7f {
@@ -47,13 +56,14 @@ func ValidTreePath(p string) error {
 		return fmt.Errorf("%w: %q", ErrInvalidPath, p)
 	}
 
-	// Volume names are not supported, in both formats: \\ and <DRIVE_LETTER>:.
+	// Volume names are not supported, in both formats: \\ and
+	// <DRIVE_LETTER>:.
 	if vol := filepath.VolumeName(p); vol != "" {
 		return fmt.Errorf("%w: %q", ErrInvalidPath, p)
 	}
 
 	for _, part := range parts {
-		if part == "." || part == ".." {
+		if IsDotOrDotDotName(part) {
 			return fmt.Errorf("%w %q: cannot use %q", ErrInvalidPath, p, part)
 		}
 

--- a/internal/pathutil/tree.go
+++ b/internal/pathutil/tree.go
@@ -30,7 +30,7 @@ var ErrInvalidPath = fmt.Errorf("invalid path")
 // stricter than C Git, which gates the disguise checks on those two
 // settings and can store such names on POSIX.
 //
-// Win32ValidPath's trailing-space/period and reserved-device rules do
+// Win32ValidPath's character, trailing-space/period and device rules do
 // not belong here — applying them would make an ordinary POSIX
 // repository unreadable, and upstream likewise compiles
 // is_valid_win32_path only for MinGW and MSVC. A component of periods

--- a/internal/pathutil/tree_test.go
+++ b/internal/pathutil/tree_test.go
@@ -26,6 +26,25 @@ func TestValidTreePath(t *testing.T) {
 		{"reject ..", "a/../b", true},
 		{"reject .", ".", true},
 		{"reject empty", "", true},
+
+		// NTFS folds trailing spaces/dots and an ADS suffix back to "..".
+		{"reject .. trailing space", ".. /x", true},
+		{"reject nested .. trailing space", "a/.. /b", true},
+		// Three periods and two spaces. The tail after ".." contains
+		// a space, so the component folds to ".." on NTFS.
+		{"reject .. periods then spaces", "...  /x", true},
+		{"reject ..:: ADS", "..::$INDEX_ALLOCATION/x", true},
+		// HFS+ ignores certain code points, so these resolve to "..".
+		{"reject .zwnj. hfs", ".\u200c./x", true},
+		{"reject nested .zwnj. hfs", "a/.\u200c./b", true},
+		{"reject ..:$DATA ADS", "..:$DATA/x", true},
+		{"reject ..:x ADS", "..:x/x", true},
+		{"reject ..zwnj hfs", "..\u200c/x", true},
+		{"reject zwnj.. hfs", "\u200c../x", true},
+		// ValidTreePath treats '\' as a separator too, so a disguise
+		// behind a backslash must be refused as well.
+		{"reject backslash .. trailing space", "a\\.. \\b", true},
+		{"reject backslash .zwnj. hfs", "a\\.\u200c.\\b", true},
 		{"reject control char SOH", "a\x01b", true},
 		{"reject DEL", "foo\x7fbar", true},
 
@@ -56,6 +75,22 @@ func TestValidTreePath(t *testing.T) {
 		{"allow CON file", "CON/file", false},
 		{"allow CON.txt", "CON.txt", false},
 		{"allow nested NUL", "dir/NUL", false},
+		// A component of periods alone is well-formed on filesystems
+		// other than NTFS and C Git 2.54.0 accepts it in a tree and
+		// in an index on POSIX. WindowsValidPath refuses it at the
+		// materialisation boundary under core.protectNTFS.
+		{"allow ... component", ".../x", false},
+		{"allow .... component", "....", false},
+		{"allow nested ...", "a/.../b", false},
+		{"allow x..", "x../y", false},
+		{"allow foo..", "foo..", false},
+		{"allow ..x", "..x/y", false},
+		{"allow .. x", ".. x", false},
+		// These fold to "." rather than to "..", so they cause no
+		// parent hop and are deliberately accepted.
+		{"allow . space", ". /x", false},
+		{"allow . space .", ". .", false},
+		{"allow .zwnj", ".\u200c", false},
 	}
 
 	for _, tc := range tests {

--- a/internal/pathutil/tree_test.go
+++ b/internal/pathutil/tree_test.go
@@ -27,11 +27,10 @@ func TestValidTreePath(t *testing.T) {
 		{"reject .", ".", true},
 		{"reject empty", "", true},
 
-		// NTFS folds trailing spaces/dots and an ADS suffix back to "..".
+		// NTFS parent disguises remain an always-on policy.
 		{"reject .. trailing space", ".. /x", true},
 		{"reject nested .. trailing space", "a/.. /b", true},
-		// Three periods and two spaces. The tail after ".." contains
-		// a space, so the component folds to ".." on NTFS.
+		// A space in the tail distinguishes this from periods alone.
 		{"reject .. periods then spaces", "...  /x", true},
 		{"reject ..:: ADS", "..::$INDEX_ALLOCATION/x", true},
 		// HFS+ ignores certain code points, so these resolve to "..".
@@ -71,14 +70,14 @@ func TestValidTreePath(t *testing.T) {
 		{"allow Çircle/file high-codepoint", "Çircle/file", false},
 		// Windows reserved device names are not policed at this layer:
 		// they are legitimate on non-Windows and upstream Git accepts
-		// them. The wrapper enforces them when core.protectNTFS is on.
+		// them. The wrapper enforces them on Windows with core.protectNTFS.
 		{"allow CON file", "CON/file", false},
 		{"allow CON.txt", "CON.txt", false},
 		{"allow nested NUL", "dir/NUL", false},
 		// A component of periods alone is well-formed on filesystems
 		// other than NTFS and C Git 2.54.0 accepts it in a tree and
-		// in an index on POSIX. WindowsValidPath refuses it at the
-		// materialisation boundary under core.protectNTFS.
+		// in an index on POSIX. Win32ValidPath refuses it on Windows
+		// when core.protectNTFS is enabled.
 		{"allow ... component", ".../x", false},
 		{"allow .... component", "....", false},
 		{"allow nested ...", "a/.../b", false},

--- a/internal/pathutil/tree_test.go
+++ b/internal/pathutil/tree_test.go
@@ -104,3 +104,71 @@ func TestValidTreePath(t *testing.T) {
 		})
 	}
 }
+
+func TestValidSubmodulePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		// Everything ValidTreePath refuses stays refused.
+		{"reject .git component", "sub/.git", true},
+		{"reject parent", "a/../b", true},
+		{"reject parent disguise", "a/.. /b", true},
+		{"reject control byte", "a/\x01/b", true},
+		{"reject empty", "", true},
+
+		// The rule this adds: a component the filesystem folds to
+		// ".". Submodule.Repository chroots to this path, so such a
+		// component scopes the submodule to the directory above it.
+		{"reject dot", ".", true},
+		{"reject dot trailing space", ". ", true},
+		{"reject dot space period", ". .", true},
+		{"reject dot ADS", ".:$DATA", true},
+		{"reject dot zwnj hfs", ".\u200c", true},
+		{"reject zwnj dot hfs", "\u200c.", true},
+		{"reject nested dot trailing space", "sub/. /x", true},
+		{"reject trailing dot component", "sub/.\u200c", true},
+
+		// Runs of periods stay valid, as they do in a tree: C Git
+		// carries them on POSIX and ValidTreePath accepts them.
+		{"accept periods only", "...", false},
+		{"accept four periods", "....", false},
+		{"accept nested periods only", "a/.../b", false},
+		{"accept trailing periods", "x..", false},
+		{"accept leading periods", "..x", false},
+		{"accept periods then space", ".. x", false},
+
+		// Ordinary submodule paths.
+		{"accept plain", "sub", false},
+		{"accept nested", "deps/sub", false},
+		{"accept dotfile", "sub/.gitignore", false},
+		{"accept period in name", "deps/x.y", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidSubmodulePath(tc.path)
+			if tc.wantErr {
+				assert.ErrorIs(t, err, ErrInvalidPath, "path %q", tc.path)
+				return
+			}
+			assert.NoError(t, err, "path %q", tc.path)
+		})
+	}
+}
+
+// ValidSubmodulePath is ValidTreePath plus one rule, so it must never
+// accept a path the tree gate refuses.
+func TestValidSubmodulePathIsStricterThanValidTreePath(t *testing.T) {
+	t.Parallel()
+
+	for _, part := range generateComponents(t, "./ :a\u200c", 3) {
+		if ValidTreePath(part) != nil {
+			assert.Error(t, ValidSubmodulePath(part), "path %q", part)
+		}
+	}
+}

--- a/internal/pathutil/volume.go
+++ b/internal/pathutil/volume.go
@@ -1,0 +1,129 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found at
+// https://github.com/golang/go/blob/go1.26.5/LICENSE.
+//
+// Derived from src/internal/filepathlite/path_windows.go in Go
+// 1.26.5[1], with only the two unexported helpers renamed.
+//
+// [1]: https://github.com/golang/go/blob/go1.26.5/src/internal/filepathlite/path_windows.go
+
+package pathutil
+
+// HasVolumeName takes one whole path and reports whether it has a
+// Windows volume prefix, independent of the host. It is equivalent
+// to filepath.VolumeName(p) != "" evaluated on Windows. Like Go, it
+// treats a drive prefix as a single byte followed by a colon; it
+// does not recognize a multibyte UTF-8 drive letter.
+func HasVolumeName(p string) bool { return volumeNameLen(p) != 0 }
+
+// volumeNameLen returns length of the leading volume name on Windows.
+// It returns 0 elsewhere.
+//
+// See:
+// https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+// https://googleprojectzero.blogspot.com/2016/02/the-definitive-guide-on-win32-to-nt.html
+func volumeNameLen(path string) int {
+	switch {
+	case len(path) >= 2 && path[1] == ':':
+		// Path starts with a drive letter.
+		//
+		// Not all Windows functions necessarily enforce the requirement that
+		// drive letters be in the set A-Z, and we don't try to here.
+		//
+		// We don't handle the case of a path starting with a non-ASCII character,
+		// in which case the "drive letter" might be multiple bytes long.
+		return 2
+
+	case len(path) == 0 || !isPathSeparator(path[0]):
+		// Path does not have a volume component.
+		return 0
+
+	case pathHasPrefixFold(path, `\\.\UNC`):
+		// We're going to treat the UNC host and share as part of the volume
+		// prefix for historical reasons, but this isn't really principled;
+		// Windows's own GetFullPathName will happily remove the first
+		// component of the path in this space, converting
+		// \\.\unc\a\b\..\c into \\.\unc\a\c.
+		return uncLen(path, len(`\\.\UNC\`))
+
+	case pathHasPrefixFold(path, `\\.`) ||
+		pathHasPrefixFold(path, `\\?`) || pathHasPrefixFold(path, `\??`):
+		// Path starts with \\.\, and is a Local Device path; or
+		// path starts with \\?\ or \??\ and is a Root Local Device path.
+		//
+		// We treat the next component after the \\.\ prefix as
+		// part of the volume name, which means Clean(`\\?\c:\`)
+		// won't remove the trailing \. (See #64028.)
+		if len(path) == 3 {
+			return 3 // exactly \\.
+		}
+		_, rest, ok := cutPath(path[4:])
+		if !ok {
+			return len(path)
+		}
+		return len(path) - len(rest) - 1
+
+	case len(path) >= 2 && isPathSeparator(path[1]):
+		// Path starts with \\, and is a UNC path.
+		return uncLen(path, 2)
+	}
+	return 0
+}
+
+// pathHasPrefixFold tests whether the path s begins with prefix,
+// ignoring case and treating all path separators as equivalent.
+// If s is longer than prefix, then s[len(prefix)] must be a path separator.
+func pathHasPrefixFold(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		if isPathSeparator(prefix[i]) {
+			if !isPathSeparator(s[i]) {
+				return false
+			}
+		} else if asciiToUpper(prefix[i]) != asciiToUpper(s[i]) {
+			return false
+		}
+	}
+	if len(s) > len(prefix) && !isPathSeparator(s[len(prefix)]) {
+		return false
+	}
+	return true
+}
+
+// uncLen returns the length of the volume prefix of a UNC path.
+// prefixLen is the prefix prior to the start of the UNC host;
+// for example, for "//host/share", the prefixLen is len("//")==2.
+func uncLen(path string, prefixLen int) int {
+	count := 0
+	for i := prefixLen; i < len(path); i++ {
+		if isPathSeparator(path[i]) {
+			count++
+			if count == 2 {
+				return i
+			}
+		}
+	}
+	return len(path)
+}
+
+// cutPath slices path around the first path separator.
+func cutPath(path string) (before, after string, found bool) {
+	for i := range path {
+		if isPathSeparator(path[i]) {
+			return path[:i], path[i+1:], true
+		}
+	}
+	return path, "", false
+}
+
+func isPathSeparator(c byte) bool { return c == '\\' || c == '/' }
+
+func asciiToUpper(c byte) byte {
+	if 'a' <= c && c <= 'z' {
+		return c - ('a' - 'A')
+	}
+	return c
+}

--- a/internal/pathutil/volume.go
+++ b/internal/pathutil/volume.go
@@ -11,10 +11,13 @@
 package pathutil
 
 // HasVolumeName takes one whole path and reports whether it has a
-// Windows volume prefix, independent of the host. It is equivalent
-// to filepath.VolumeName(p) != "" evaluated on Windows. Like Go, it
-// treats a drive prefix as a single byte followed by a colon; it
-// does not recognize a multibyte UTF-8 drive letter.
+// Windows volume prefix, independent of the host. It is equivalent to
+// filepath.VolumeName(p) != "" evaluated on Windows with Go 1.26; Go
+// 1.27 reports no volume name for a candidate holding a ".." component
+// (golang/go#58451), and this package keeps the Go 1.26 answer, which
+// refuses such a path on both toolchains. Like Go, it treats a drive
+// prefix as a single byte followed by a colon; it does not recognize
+// a multibyte UTF-8 drive letter.
 func HasVolumeName(p string) bool { return volumeNameLen(p) != 0 }
 
 // volumeNameLen returns length of the leading volume name on Windows.

--- a/internal/pathutil/volume_test.go
+++ b/internal/pathutil/volume_test.go
@@ -1,0 +1,55 @@
+package pathutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasVolumeName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// A drive prefix is a single byte and a colon, whichever
+		// byte it is; upstream does not restrict it to A-Z either.
+		{`C:foo`, true},
+		{`1:foo`, true},
+		{`%:x`, true},
+		{`x:`, true},
+		{`.:x`, true},
+		{`::`, true},
+
+		// UNC, Local Device and Root Local Device prefixes.
+		{`\\host\share`, true},
+		{`//host/share`, true},
+		{`\\srv`, true},
+		{`\\`, true},
+		{`//`, true},
+		{`\/`, true},
+		{`\\.`, true},
+		{`\\?`, true},
+		{`\??`, true},
+		{`\??\C:\x`, true},
+		{`\\?\C:\x`, true},
+		{`\\.\UNC\h\s`, true},
+
+		// A colon past the first byte is not a drive prefix, and a
+		// single separator is not the start of a UNC path.
+		{`a/b:c`, false},
+		{`/foo`, false},
+		{`foo`, false},
+		{`\?`, false},
+		{`\`, false},
+		{`:`, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, HasVolumeName(tc.path))
+		})
+	}
+}

--- a/internal/pathutil/volume_windows_test.go
+++ b/internal/pathutil/volume_windows_test.go
@@ -11,6 +11,10 @@ import (
 // filepath.VolumeName over a closed corpus. It can only run here:
 // off Windows the stdlib answers for the host it was compiled for,
 // so the comparison would pass for a predicate that always said no.
+//
+// Candidate volume names holding a ".." component are left out: the
+// stdlib answer for those depends on the toolchain, and go-git builds
+// on both sides of the change. See volumeNameHasDotDot.
 func TestHasVolumeNameMatchesStdlib(t *testing.T) {
 	t.Parallel()
 
@@ -18,6 +22,32 @@ func TestHasVolumeNameMatchesStdlib(t *testing.T) {
 	corpus = append(corpus, `\\host\share`, `\\.\UNC\h\s`, `\??\C:\x`, `\\?\C:\x`, "ä:foo")
 
 	for _, p := range corpus {
+		if volumeNameHasDotDot(p) {
+			continue
+		}
 		require.Equal(t, filepath.VolumeName(p) != "", HasVolumeName(p), "path %q", p)
 	}
+}
+
+// volumeNameHasDotDot reports whether the volume name this package
+// reads off p holds a ".." component, such as `\\..` or `//a/../b`.
+//
+// Go 1.27 reports no volume name for those, so filepath.Clean reduces
+// the parent components lexically; Go 1.26 reports one. go-git builds
+// on both, so no single answer matches the stdlib everywhere, and this
+// package keeps the Go 1.26 one.
+//
+// Reference: golang/go#58451, fixed by CL 788701 in Go 1.27[1][2].
+//
+// [1]: https://github.com/golang/go/issues/58451
+// [2]: https://go-review.googlesource.com/c/go/+/788701
+func volumeNameHasDotDot(p string) bool {
+	for v := p[:volumeNameLen(p)]; v != ""; {
+		var part string
+		part, v, _ = cutPath(v)
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/pathutil/volume_windows_test.go
+++ b/internal/pathutil/volume_windows_test.go
@@ -1,0 +1,23 @@
+package pathutil
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHasVolumeNameMatchesStdlib pins the port against the real
+// filepath.VolumeName over a closed corpus. It can only run here:
+// off Windows the stdlib answers for the host it was compiled for,
+// so the comparison would pass for a predicate that always said no.
+func TestHasVolumeNameMatchesStdlib(t *testing.T) {
+	t.Parallel()
+
+	corpus := generateComponents(t, `./\?:a1%`, 5)
+	corpus = append(corpus, `\\host\share`, `\\.\UNC\h\s`, `\??\C:\x`, `\\?\C:\x`, "ä:foo")
+
+	for _, p := range corpus {
+		require.Equal(t, filepath.VolumeName(p) != "", HasVolumeName(p), "path %q", p)
+	}
+}

--- a/plumbing/object/treenoder.go
+++ b/plumbing/object/treenoder.go
@@ -110,7 +110,10 @@ func transformChildren(t *Tree) ([]noder.Noder, error) {
 	// filesystem, so it must enumerate the tree faithfully — including entries
 	// with names that are unsafe to check out but valid per upstream Git (e.g.
 	// control characters). Path safety is enforced at materialisation
-	// boundaries (FindEntry, TreeEntryFile, archive, FileIter), not here.
+	// boundaries (FindEntry, TreeEntryFile, archive, FileIter, and the
+	// worktree filesystem wrapper's validPath, which the tree-derived
+	// deletes in resetWorktreeToTree reach without passing any of the
+	// others), not here.
 	walker.skipPathValidation = true
 	// don't defer walker.Close() for efficiency reasons.
 	for {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -1737,7 +1737,16 @@ func (d *DotGit) PackRefs() (err error) {
 // cleaned. The config-layer parser also validates submodule names,
 // but Module may be reached from any caller that constructs a
 // Submodule struct programmatically and so bypasses the parser.
+//
+// path.Clean does not account for filesystem-specific parent-directory
+// aliases. Check components before constructing the path, and reject
+// periods-only components under the same storage policy as references.
 func (d *DotGit) Module(name string) (billy.Filesystem, error) {
+	for _, part := range strings.FieldsFunc(name, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if pathutil.IsDotsOnlyName(part) || pathutil.IsDotOrDotDotName(part) {
+			return nil, ErrModuleNameEscape
+		}
+	}
 	p := d.fs.Join(modulePath, name)
 	cleaned := path.Clean(filepath.ToSlash(p))
 	if cleaned != modulePath && !strings.HasPrefix(cleaned, modulePath+"/") {

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -1741,11 +1741,19 @@ func (d *DotGit) PackRefs() (err error) {
 // path.Clean does not account for filesystem-specific aliases of the
 // current or the parent directory, so check components against
 // pathutil.IsUnsafeStorageName before constructing the path.
+//
+// The name's own shape is checked first. FieldsFunc discards leading
+// and trailing separators and yields nothing at all for an empty or
+// separator-only name, so the component loop would not see one, and
+// the joined path cleans back to the modules root that every submodule
+// shares. validSubmoduleName refuses these shapes at the config layer.
 func (d *DotGit) Module(name string) (billy.Filesystem, error) {
-	for _, part := range strings.FieldsFunc(name, func(r rune) bool { return r == '/' || r == '\\' }) {
-		if pathutil.IsUnsafeStorageName(part) {
-			return nil, ErrModuleNameEscape
-		}
+	isSep := func(r rune) bool { return r == '/' || r == '\\' }
+	if name == "" || isSep(rune(name[0])) || isSep(rune(name[len(name)-1])) {
+		return nil, ErrModuleNameEscape
+	}
+	if slices.ContainsFunc(strings.FieldsFunc(name, isSep), pathutil.IsUnsafeStorageName) {
+		return nil, ErrModuleNameEscape
 	}
 	p := d.fs.Join(modulePath, name)
 	cleaned := path.Clean(filepath.ToSlash(p))

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -1738,12 +1738,12 @@ func (d *DotGit) PackRefs() (err error) {
 // but Module may be reached from any caller that constructs a
 // Submodule struct programmatically and so bypasses the parser.
 //
-// path.Clean does not account for filesystem-specific parent-directory
-// aliases. Check components before constructing the path, and reject
-// periods-only components under the same storage policy as references.
+// path.Clean does not account for filesystem-specific aliases of the
+// current or the parent directory, so check components against
+// pathutil.IsUnsafeStorageName before constructing the path.
 func (d *DotGit) Module(name string) (billy.Filesystem, error) {
 	for _, part := range strings.FieldsFunc(name, func(r rune) bool { return r == '/' || r == '\\' }) {
-		if pathutil.IsDotsOnlyName(part) || pathutil.IsDotOrDotDotName(part) {
+		if pathutil.IsUnsafeStorageName(part) {
 			return nil, ErrModuleNameEscape
 		}
 	}

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -2122,3 +2122,27 @@ func (s *SuiteDotGit) TestReferenceNameRejectsDotsOnlyComponent() {
 	_, err := d.fs.Stat(configPath)
 	s.Error(err, "traversal must not create .git/config")
 }
+
+// TestModuleRejectsRootShapedNames pins the names whose own shape
+// resolves to the modules root rather than to a module below it.
+// FieldsFunc yields no components for them, so the per-component
+// policy never sees them, and the joined path cleans back to
+// modules/ — a chroot over every submodule's storage at once.
+func (s *SuiteDotGit) TestModuleRejectsRootShapedNames() {
+	d := New(s.EmptyFS())
+	for _, n := range []string{
+		"",
+		"/",
+		"//",
+		`\`,
+		`\\`,
+		`/\`,
+		"/foo",
+		"foo/",
+		`\foo`,
+		`foo\`,
+	} {
+		_, err := d.Module(n)
+		s.ErrorIs(err, ErrModuleNameEscape, "name %q", n)
+	}
+}

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -61,9 +61,40 @@ func (s *SuiteDotGit) TestModuleRejectsEscapingNames() {
 	}
 }
 
+// TestModuleRejectsDisguisedEscapingNames pins the names path.Clean
+// leaves inside modules/ but a filesystem folds back out of it. The
+// returned chroot is writable, so a name that resolves to .git hands
+// the caller .git/hooks; validSubmoduleName refuses these at the
+// config layer, and Module is the gate for a caller that builds a
+// Submodule without the parser.
+func (s *SuiteDotGit) TestModuleRejectsDisguisedEscapingNames() {
+	d := New(s.EmptyFS())
+	bad := []string{
+		".. ",
+		"..  ",
+		".. .",
+		"..:foo",
+		"..::$INDEX_ALLOCATION",
+		".\u200c.",
+		"\u200c..",
+		"..\u200e",
+		"foo/.. ",
+		"a/.\u200c./b",
+		".",
+		"a/./b",
+		"...",
+		"....",
+		"a/.../b",
+	}
+	for _, n := range bad {
+		_, err := d.Module(n)
+		s.ErrorIs(err, ErrModuleNameEscape, "name %q", n)
+	}
+}
+
 func (s *SuiteDotGit) TestModuleAcceptsBenignNames() {
 	d := New(s.EmptyFS())
-	for _, n := range []string{"foo", "lib/foo", "x.y"} {
+	for _, n := range []string{"foo", "lib/foo", "x.y", "a..b", "..x", "x.."} {
 		_, err := d.Module(n)
 		s.Require().NoError(err, "name %q", n)
 	}
@@ -2051,4 +2082,31 @@ func TestWalkPackHandles_JoinsErrors(t *testing.T) {
 	// Crucially: the walk did not stop on the first error.
 	assert.Equal(t, int32(totalEntries), visits.Load(),
 		"walk should not stop on first error")
+}
+
+// Periods-only components are rejected for reads as well as writes.
+// Reads do not apply ReferenceName.Validate, so this also exercises
+// the storage path checks independently of Git's refname format rules.
+func (s *SuiteDotGit) TestReferenceNameRejectsDotsOnlyComponent() {
+	d := New(s.EmptyFS())
+	s.Require().NoError(d.Initialize())
+
+	bad := []plumbing.ReferenceName{
+		"refs/heads/...",
+		"refs/heads/....",
+		"refs/heads/.../config",
+		"refs/heads/x/.../y",
+	}
+	for _, n := range bad {
+		s.Require().True(n.IsSafe(), "IsSafe must not be what rejects %q", n)
+
+		ref := plumbing.NewHashReference(n, plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+		s.ErrorIs(d.SetRef(ref, nil), ErrReferenceNameEscape, "SetRef %q", n)
+
+		_, err := d.Ref(n)
+		s.ErrorIs(err, ErrReferenceNameEscape, "Ref %q", n)
+	}
+
+	_, err := d.fs.Stat(configPath)
+	s.Error(err, "traversal must not create .git/config")
 }

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -85,6 +85,18 @@ func (s *SuiteDotGit) TestModuleRejectsDisguisedEscapingNames() {
 		"...",
 		"....",
 		"a/.../b",
+		// Spellings a filesystem folds back to ".", which resolve the
+		// chroot to the modules root shared by every submodule rather
+		// than to one module below it.
+		". ",
+		".  ",
+		". .",
+		".:foo",
+		".::$INDEX_ALLOCATION",
+		".\u200c",
+		"\u200c.",
+		"foo/. ",
+		"a/.\u200c/b",
 	}
 	for _, n := range bad {
 		_, err := d.Module(n)

--- a/submodule.go
+++ b/submodule.go
@@ -124,12 +124,9 @@ func (s *Submodule) Repository() (*Repository, error) {
 		exists = true
 	}
 
-	// s.c.Path is sourced from the worktree's .gitmodules and is
-	// therefore tree-controlled. Apply the strict tree-path validator
-	// before chroot — the wrapper's tolerant validPath would let a
-	// final-position .git component through (e.g. "submodule/.git"),
-	// which a malicious .gitmodules could use to chroot the submodule
-	// worktree into the repository's actual .git directory.
+	// .gitmodules supplies the path. Apply the tree policy before chroot;
+	// its alias checks remain active even with worktree protection disabled.
+	// The worktree wrapper independently checks every .git position.
 	if err := pathutil.ValidTreePath(s.c.Path); err != nil {
 		return nil, err
 	}

--- a/submodule.go
+++ b/submodule.go
@@ -124,10 +124,13 @@ func (s *Submodule) Repository() (*Repository, error) {
 		exists = true
 	}
 
-	// .gitmodules supplies the path. Apply the tree policy before chroot;
-	// its alias checks remain active even with worktree protection disabled.
-	// The worktree wrapper independently checks every .git position.
-	if err := pathutil.ValidTreePath(s.c.Path); err != nil {
+	// .gitmodules supplies the path. Apply the submodule policy before
+	// chroot; its alias checks remain active even with worktree
+	// protection disabled. The worktree wrapper independently checks
+	// every .git position, but accepts a component that folds to "."
+	// because an ordinary worktree path may carry one, so the chroot
+	// base is validated here.
+	if err := pathutil.ValidSubmodulePath(s.c.Path); err != nil {
 		return nil, err
 	}
 

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/go-git/go-billy/v6/memfs"
@@ -878,11 +879,28 @@ func TestSubmoduleRepositoryRefusesDotDisguisedPath(t *testing.T) {
 // The rule above is one component rule, not a widening of the tree
 // policy: a run of periods stays a legal submodule path, as it is a
 // legal tree entry on POSIX.
+//
+// A Win32 host is where that stops being the whole story. The worktree
+// wrapper refuses a component ending in a period under core.protectNTFS,
+// so the chroot fails there for every path carrying one. That is the host
+// gate rather than the submodule policy: "..x" spells the same run of
+// periods without ending in one, and is accepted on every host.
 func TestSubmoduleRepositoryAcceptsPeriodsOnlyPath(t *testing.T) {
 	t.Parallel()
 
-	for _, p := range []string{"...", "....", "sub/.../x", "x..", "..x"} {
-		t.Run(p, func(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		// win32 marks a path with a component ending in a period, which
+		// Win32ValidPath refuses under core.protectNTFS.
+		win32 bool
+	}{
+		{path: "...", win32: true},
+		{path: "....", win32: true},
+		{path: "sub/.../x", win32: true},
+		{path: "x..", win32: true},
+		{path: "..x"},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
 			t.Parallel()
 
 			sub := &Submodule{
@@ -891,10 +909,16 @@ func TestSubmoduleRepositoryAcceptsPeriodsOnlyPath(t *testing.T) {
 					filesystem: newWorktreeFilesystem(memfs.New(), true, true),
 					r:          &Repository{Storer: memory.NewStorage(), wt: memfs.New()},
 				},
-				c: &config.Submodule{Name: "child", Path: p, URL: "https://example.com/"},
+				c: &config.Submodule{Name: "child", Path: tc.path, URL: "https://example.com/"},
 			}
 
 			subRepo, err := sub.Repository()
+			if runtime.GOOS == "windows" && tc.win32 {
+				require.ErrorContains(t, err, "core.protectNTFS")
+				require.Nil(t, subRepo)
+				return
+			}
+
 			require.NoError(t, err)
 			require.NotNil(t, subRepo)
 			t.Cleanup(func() { _ = subRepo.Close() })

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/format/index"
@@ -832,4 +834,70 @@ func TestSubmoduleRepositoryRejectsEscapingName(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, headBefore.Target(), headAfter.Target(),
 		"parent HEAD must not be overwritten")
+}
+
+// Submodule.Repository chroots the submodule worktree to the
+// .gitmodules path. A component a filesystem folds to "." resolves
+// that chroot to the superproject worktree root, so a submodule
+// checkout would write over the superproject's own files. The worktree
+// wrapper accepts such a component — an ordinary worktree path may
+// carry one — so pathutil.ValidSubmodulePath is the gate.
+func TestSubmoduleRepositoryRefusesDotDisguisedPath(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range []string{
+		".",
+		". ",
+		". .",
+		".:$DATA",
+		".::$INDEX_ALLOCATION",
+		".\u200c",
+		"\u200c.",
+		"sub/. ",
+		"sub/.\u200c",
+	} {
+		t.Run(fmt.Sprintf("%q", p), func(t *testing.T) {
+			t.Parallel()
+
+			sub := &Submodule{
+				initialized: true,
+				w: &Worktree{
+					filesystem: newWorktreeFilesystem(memfs.New(), true, true),
+					r:          &Repository{Storer: memory.NewStorage(), wt: memfs.New()},
+				},
+				c: &config.Submodule{Name: "child", Path: p, URL: "https://example.com/"},
+			}
+
+			subRepo, err := sub.Repository()
+			require.ErrorIs(t, err, pathutil.ErrInvalidPath)
+			require.Nil(t, subRepo)
+		})
+	}
+}
+
+// The rule above is one component rule, not a widening of the tree
+// policy: a run of periods stays a legal submodule path, as it is a
+// legal tree entry on POSIX.
+func TestSubmoduleRepositoryAcceptsPeriodsOnlyPath(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range []string{"...", "....", "sub/.../x", "x..", "..x"} {
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+
+			sub := &Submodule{
+				initialized: true,
+				w: &Worktree{
+					filesystem: newWorktreeFilesystem(memfs.New(), true, true),
+					r:          &Repository{Storer: memory.NewStorage(), wt: memfs.New()},
+				},
+				c: &config.Submodule{Name: "child", Path: p, URL: "https://example.com/"},
+			}
+
+			subRepo, err := sub.Repository()
+			require.NoError(t, err)
+			require.NotNil(t, subRepo)
+			t.Cleanup(func() { _ = subRepo.Close() })
+		})
+	}
 }

--- a/utils/merkletrie/filesystem/filter_external_test.go
+++ b/utils/merkletrie/filesystem/filter_external_test.go
@@ -1,0 +1,100 @@
+package filesystem_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/go-git/go-billy/v6/util"
+	"github.com/stretchr/testify/require"
+
+	f "github.com/go-git/go-git/v6/utils/merkletrie/filesystem"
+	"github.com/go-git/go-git/v6/utils/merkletrie/noder"
+)
+
+func TestOptionsComparable(t *testing.T) {
+	t.Parallel()
+	a, b := f.Options{AutoCRLF: true}, f.Options{AutoCRLF: true}
+	require.True(t, a == b)
+	require.Equal(t, "typed", map[f.Options]string{a: "typed"}[b])
+	require.Equal(t, "dynamic", map[any]string{a: "dynamic"}[b])
+}
+
+func TestRootNodeDotGitDefaults(t *testing.T) {
+	t.Parallel()
+	for _, directory := range []bool{false, true} {
+		for _, constructor := range []string{"legacy", "options", "nil-filter"} {
+			t.Run(fmt.Sprintf("%s/directory=%t", constructor, directory), func(t *testing.T) {
+				t.Parallel()
+				fs := memfs.New()
+				name := ".GIT"
+				if directory {
+					name += "/inner.txt"
+				}
+				require.NoError(t, util.WriteFile(fs, name, []byte("visible"), 0o644))
+				require.NoError(t, util.WriteFile(fs, ".git/HEAD", []byte("hidden"), 0o644))
+				var root noder.Noder
+				switch constructor {
+				case "legacy":
+					root = f.NewRootNode(fs, nil)
+				case "options":
+					root = f.NewRootNodeWithOptions(fs, nil, f.Options{})
+				case "nil-filter":
+					root = f.NewRootNodeWithDotGitFilter(fs, nil, f.Options{}, nil)
+				}
+				children, err := root.Children()
+				require.NoError(t, err)
+				require.Len(t, children, 1)
+				require.Equal(t, ".GIT", children[0].Name())
+				if directory {
+					nested, err := children[0].Children()
+					require.NoError(t, err)
+					require.Len(t, nested, 1)
+					require.Equal(t, "inner.txt", nested[0].Name())
+				}
+			})
+		}
+	}
+}
+
+func TestRootNodeDotGitFilterPropagates(t *testing.T) {
+	t.Parallel()
+	for _, directory := range []bool{false, true} {
+		t.Run(fmt.Sprint(directory), func(t *testing.T) {
+			t.Parallel()
+			fs := memfs.New()
+			for _, parent := range []string{"", "sub/", "sub/deep/"} {
+				for _, name := range []string{".git", ".GIT", "git~1"} {
+					p := parent + name
+					if directory {
+						p += "/inner.txt"
+					}
+					require.NoError(t, util.WriteFile(fs, p, []byte("hidden"), 0o644))
+				}
+			}
+			require.NoError(t, util.WriteFile(fs, "sub/deep/visible", []byte("visible"), 0o644))
+			var visited []string
+			root := f.NewRootNodeWithDotGitFilter(fs, nil, f.Options{}, func(name string) bool {
+				visited = append(visited, name)
+				return strings.EqualFold(name, ".git") || name == "git~1"
+			})
+			for _, want := range []string{"sub", "deep", "visible"} {
+				children, err := root.Children()
+				require.NoError(t, err)
+				require.Len(t, children, 1)
+				require.Equal(t, want, children[0].Name())
+				root = children[0]
+			}
+			for _, name := range []string{".git", ".GIT", "git~1"} {
+				count := 0
+				for _, got := range visited {
+					if got == name {
+						count++
+					}
+				}
+				require.Equal(t, 3, count, name)
+			}
+		})
+	}
+}

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -22,8 +22,11 @@ import (
 	"github.com/go-git/go-git/v6/utils/sync"
 )
 
-var ignore = map[string]bool{
-	".git": true,
+func (n *node) skipDotGit(name string) bool {
+	if n.dotGitFilter != nil {
+		return n.dotGitFilter(name)
+	}
+	return name == ".git"
 }
 
 // Options contains configuration for the filesystem node.
@@ -70,7 +73,8 @@ type node struct {
 	// matches an ignore rule.
 	trackedDirs map[string]struct{}
 
-	options *Options
+	options      *Options
+	dotGitFilter func(string) bool
 
 	// scope is the ignore scope governing this node's entries. On a child it
 	// starts as the parent's scope and is replaced by this directory's own on
@@ -120,6 +124,21 @@ func NewRootNodeWithOptions(
 	submodules map[string]plumbing.Hash,
 	options Options,
 ) noder.Noder {
+	return NewRootNodeWithDotGitFilter(fs, submodules, options, nil)
+}
+
+// NewRootNodeWithDotGitFilter creates a root using options and a metadata-name
+// predicate matching the filesystem's configured path protections. The predicate
+// applies to entry base names at every depth, for both files and directories.
+// A nil predicate retains the exact ".git" exclusion used by the existing
+// constructors. Callers supply the filesystem and validation policy; this
+// callback is not a security boundary. It must remain stable during the walk.
+func NewRootNodeWithDotGitFilter(
+	fs billy.Filesystem,
+	submodules map[string]plumbing.Hash,
+	options Options,
+	skipDotGit func(string) bool,
+) noder.Noder {
 	var idxMap map[string]*index.Entry
 	var trackedDirs map[string]struct{}
 
@@ -143,13 +162,14 @@ func NewRootNodeWithOptions(
 	}
 
 	return &node{
-		fs:          fs,
-		submodules:  submodules,
-		idx:         options.Index,
-		idxMap:      idxMap,
-		trackedDirs: trackedDirs,
-		options:     &options,
-		isDir:       true,
+		fs:           fs,
+		submodules:   submodules,
+		idx:          options.Index,
+		idxMap:       idxMap,
+		trackedDirs:  trackedDirs,
+		options:      &options,
+		dotGitFilter: skipDotGit,
+		isDir:        true,
 		// The root scope already accounts for the root's own ignore files, so
 		// it must not descend again.
 		scope:         options.IgnoreScope,
@@ -224,7 +244,7 @@ func (n *node) calculateChildren() error {
 	}
 
 	for _, file := range files {
-		if _, ok := ignore[file.Name()]; ok {
+		if n.skipDotGit(file.Name()) {
 			continue
 		}
 
@@ -329,12 +349,13 @@ func (n *node) newChildNode(file os.FileInfo) (*node, error) {
 	path := path.Join(n.path, file.Name())
 
 	node := &node{
-		fs:          n.fs,
-		submodules:  n.submodules,
-		idx:         n.idx,
-		idxMap:      n.idxMap,
-		trackedDirs: n.trackedDirs,
-		options:     n.options,
+		fs:           n.fs,
+		submodules:   n.submodules,
+		idx:          n.idx,
+		idxMap:       n.idxMap,
+		trackedDirs:  n.trackedDirs,
+		options:      n.options,
+		dotGitFilter: n.dotGitFilter,
 
 		// The child inherits this directory's scope and resolves its own on
 		// its first listing.

--- a/worktree.go
+++ b/worktree.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/go-git/go-billy/v6"
 	"github.com/go-git/go-billy/v6/osfs"
-	"github.com/go-git/go-billy/v6/util"
 
 	"github.com/go-git/go-git/v6/config"
 	giturl "github.com/go-git/go-git/v6/internal/url"
@@ -898,14 +897,9 @@ func (w *Worktree) checkoutChange(cfg *config.Config, fs *worktreeFilesystem, ch
 
 		isSubmodule = e.Mode == filemode.Submodule
 	case merkletrie.Delete:
-		// checkoutChange.Delete is only reached from resetWorktree's
-		// filesystem-vs-index merkletrie diff (resetWorktreeToTree's
-		// tree-derived deletes call rmFileAndDirsIfEmpty directly).
-		// The path source is therefore the local worktree filesystem,
-		// where the tolerant worktreeFilesystem wrapper is the right
-		// fit: we want to be able to clean up legitimately-tracked
-		// shapes like "submodule/.git" rather than abort the whole
-		// reset on a single weird untracked file.
+		// These names come from the filesystem-vs-index diff. Apply the
+		// configured worktree gate. Tree-derived deletes use the same
+		// helper in resetWorktreeToTree.
 		return rmFileAndDirsIfEmpty(fs, ch.From.String())
 	}
 
@@ -1550,10 +1544,30 @@ func findMatchInFile(file *object.File, treeName string, opts *GrepOptions) ([]G
 	return grepResults, nil
 }
 
-// will walk up the directory tree removing all encountered empty
-// directories, not just the one containing this file
+// rmFileAndDirsIfEmpty removes a file or an empty directory, then walks up
+// removing the empty directories above it. A nonempty directory is kept,
+// along with everything under it, and the walk stops there.
+//
+// Removal is not recursive because the names reaching here are index and
+// tree entries, and upstream Git removes them one at a time: remove_or_warn
+// unlinks a regular entry and calls rmdir for a gitlink, so a submodule
+// worktree with contents of its own survives a reset that drops the
+// gitlink, as do untracked files left inside a directory that replaced a
+// tracked file. Where rmdir fails Git warns and continues; this returns nil.
+// Billy backends do not share a directory-not-empty sentinel, so the
+// condition is tested rather than inferred from the error.
+//
+// Reference: upstream Git entry.c remove_or_warn at L610-L613 and
+// unlink_entry at L595-L608 in tag v2.54.0[1].
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/entry.c#L595-L613
 func rmFileAndDirsIfEmpty(fs billy.Filesystem, name string) error {
-	if err := util.RemoveAll(fs, name); err != nil {
+	if fi, err := fs.Lstat(name); err == nil && fi.IsDir() {
+		if entries, err := fs.ReadDir(name); err == nil && len(entries) > 0 {
+			return nil
+		}
+	}
+	if err := fs.Remove(name); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/worktree.go
+++ b/worktree.go
@@ -743,7 +743,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 		if len(files) > 0 && !inFiles(filesMap, name) {
 			continue
 		}
-		if err := rmFileAndDirsIfEmpty(fs, name); err != nil {
+		if err := rmEntryAndDirsIfEmpty(fs, name, treeEntryMode(fromTree, name)); err != nil {
 			return err
 		}
 	}
@@ -812,7 +812,7 @@ func (w *Worktree) resetWorktreeToTree(cfg *config.Config, fromTree, toTree *obj
 		if _, statErr := fs.Lstat(e.Name); os.IsNotExist(statErr) {
 			continue
 		}
-		if err := rmFileAndDirsIfEmpty(fs, e.Name); err != nil {
+		if err := rmEntryAndDirsIfEmpty(fs, e.Name, e.Mode); err != nil {
 			return err
 		}
 	}
@@ -900,7 +900,12 @@ func (w *Worktree) checkoutChange(cfg *config.Config, fs *worktreeFilesystem, ch
 		// These names come from the filesystem-vs-index diff. Apply the
 		// configured worktree gate. Tree-derived deletes use the same
 		// helper in resetWorktreeToTree.
-		return rmFileAndDirsIfEmpty(fs, ch.From.String())
+		//
+		// resetWorktree is the only caller that reaches this. resetIndex
+		// has already removed these names from the index, and the target
+		// tree does not carry them either, so there is no entry to read a
+		// mode from.
+		return rmEntryAndDirsIfEmpty(fs, ch.From.String(), unknownMode)
 	}
 
 	if isSubmodule {
@@ -1544,29 +1549,39 @@ func findMatchInFile(file *object.File, treeName string, opts *GrepOptions) ([]G
 	return grepResults, nil
 }
 
-// rmFileAndDirsIfEmpty removes a file or an empty directory, then walks up
-// removing the empty directories above it. A nonempty directory is kept,
-// along with everything under it, and the walk stops there.
+// unknownMode is the mode rmEntryAndDirsIfEmpty takes for an entry whose own
+// mode the caller cannot read, leaving canRemove no removal to select. It is
+// filemode.Empty, which the filemode package defines as the mode of a tree
+// element after its deletion.
+const unknownMode = filemode.Empty
+
+// rmEntryAndDirsIfEmpty removes one tracked entry from the worktree, then
+// walks up removing the empty directories above it.
 //
-// Removal is not recursive because the names reaching here are index and
-// tree entries, and upstream Git removes them one at a time: remove_or_warn
-// unlinks a regular entry and calls rmdir for a gitlink, so a submodule
-// worktree with contents of its own survives a reset that drops the
-// gitlink, as do untracked files left inside a directory that replaced a
-// tracked file. Where rmdir fails Git warns and continues; this returns nil.
-// Billy backends do not share a directory-not-empty sentinel, so the
-// condition is tested rather than inferred from the error.
+// mode is the mode of the entry being removed. It selects the removal the way
+// upstream Git's remove_or_warn does: rmdir for a gitlink, which takes an
+// empty directory and nothing else, and unlink for every other mode, which
+// takes anything that is not a directory. A submodule worktree with contents
+// of its own therefore survives a reset that drops the gitlink, as do the
+// untracked files inside a directory standing at a regular entry's path, and
+// a file standing at a gitlink's path.
+//
+// Where the removal does not apply, the entry and everything under it is
+// kept and the upward walk stops there. Upstream warns in that case and
+// continues; this returns nil.
+//
+// Removal is never recursive: the names reaching here are index and tree
+// entries, which upstream removes one at a time.
 //
 // Reference: upstream Git entry.c remove_or_warn at L610-L613 and
 // unlink_entry at L595-L608 in tag v2.54.0[1].
 //
 // [1]: https://github.com/git/git/blob/v2.54.0/entry.c#L595-L613
-func rmFileAndDirsIfEmpty(fs billy.Filesystem, name string) error {
-	if fi, err := fs.Lstat(name); err == nil && fi.IsDir() {
-		if entries, err := fs.ReadDir(name); err == nil && len(entries) > 0 {
-			return nil
-		}
+func rmEntryAndDirsIfEmpty(fs billy.Filesystem, name string, mode filemode.FileMode) error {
+	if !canRemove(fs, name, mode) {
+		return nil
 	}
+
 	if err := fs.Remove(name); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -1589,6 +1604,53 @@ func rmFileAndDirsIfEmpty(fs billy.Filesystem, name string) error {
 	}
 
 	return nil
+}
+
+// canRemove reports whether what stands at name is a shape the removal
+// rmEntryAndDirsIfEmpty selects for mode accepts. Billy backends do not share
+// a directory-not-empty sentinel, so the condition is tested rather than
+// inferred from the error.
+//
+// unknownMode selects neither removal, and the only shape kept for it is the
+// one both refuse, a nonempty directory.
+func canRemove(fs billy.Filesystem, name string, mode filemode.FileMode) bool {
+	fi, err := fs.Lstat(name)
+	if err != nil {
+		// Nothing to inspect. fs.Remove reports the outcome, and a name
+		// that is already gone is not an error to the caller.
+		return true
+	}
+
+	if !fi.IsDir() {
+		// unlink takes any non-directory; rmdir takes none of them.
+		return mode != filemode.Submodule
+	}
+
+	if entries, err := fs.ReadDir(name); err != nil || len(entries) > 0 {
+		// Both removals refuse a nonempty directory, and one whose
+		// entries cannot be read is not worth the attempt.
+		return false
+	}
+
+	// An empty directory is what rmdir takes and what unlink refuses.
+	return mode == filemode.Submodule || mode == unknownMode
+}
+
+// treeEntryMode reports the mode t records for name, or unknownMode when
+// there is no entry to read one from. t may be nil, and a name a tree-to-tree
+// diff yields can fail object.Tree.FindEntry's path validation; a reset that
+// is only removing such a name has no reason to fail on it.
+func treeEntryMode(t *object.Tree, name string) filemode.FileMode {
+	if t == nil {
+		return unknownMode
+	}
+
+	e, err := t.FindEntry(name)
+	if err != nil {
+		return unknownMode
+	}
+
+	return e.Mode
 }
 
 // removeDirIfEmpty will remove the supplied directory `dir` if

--- a/worktree.go
+++ b/worktree.go
@@ -1368,7 +1368,7 @@ func (w *Worktree) Clean(opts *CleanOptions) error {
 
 func (w *Worktree) doClean(status Status, opts *CleanOptions, dir string, files []fs.DirEntry) error {
 	for _, fi := range files {
-		if fi.Name() == GitDirName {
+		if w.filesystem.isDotGitComponent(fi.Name()) {
 			continue
 		}
 

--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -43,7 +43,8 @@ func defaultProtectNTFS() bool {
 //   - validPath rejects dangerous path *strings*: .git and its HFS+/NTFS
 //     variants at every position, dot/parent components and control bytes.
 //     Windows additionally rejects volume prefixes and, with
-//     core.protectNTFS, trailing spaces/periods and reserved device names.
+//     core.protectNTFS, illegal characters, trailing spaces/periods and
+//     reserved device names.
 //   - validNoLeadingSymlink rejects paths whose leading directories
 //     already exist on disk as symlinks, so a write or delete cannot
 //     follow a planted link out of the tree.
@@ -64,7 +65,7 @@ type worktreeFilesystem struct {
 
 	// win32 enables the rules that describe the host's own path
 	// canonicalisation rather than a repository's contents: volume
-	// prefixes, and the trailing-space/period and reserved-device rules
+	// prefixes, and the character, trailing-space/period and device rules
 	// that Win32ValidPath applies under core.protectNTFS. Upstream Git
 	// compiles is_valid_win32_path only for MinGW and MSVC, so a POSIX
 	// host must keep checking out names such as aux.c. It is a field
@@ -218,7 +219,7 @@ var errUnsupportedOperation = errors.New("unsupported operation")
 // says. So are `.git` and `git~1` at every component position;
 // core.protectHFS and core.protectNTFS add the remaining aliases. A Win32
 // host additionally refuses volume prefixes, and with core.protectNTFS the
-// trailing-space/period and reserved-device rules.
+// illegal-character, trailing-space/period and reserved-device rules.
 //
 // ValidTreePath and this gate are not ordered by strictness. Tree
 // validation refuses an alias such as sub/.git<U+200C> with both
@@ -227,10 +228,10 @@ var errUnsupportedOperation = errors.New("unsupported operation")
 // submodule .git pointer file cannot be reached through this wrapper.
 //
 // Reference: upstream Git verify_path_internal at read-cache.c#L987-L1048
-// and is_valid_win32_path at compat/mingw.c#L3347-L3469 in tag v2.54.0[1][2].
+// and is_valid_win32_path at compat/mingw.c#L3155-L3272 in tag v2.54.0[1][2].
 //
 // [1]: https://github.com/git/git/blob/v2.54.0/read-cache.c#L987-L1048
-// [2]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3347-L3469
+// [2]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3155-L3272
 func (sfs *worktreeFilesystem) validPath(paths ...string) error {
 	for _, p := range paths {
 		for i := 0; i < len(p); i++ {

--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -61,10 +61,25 @@ type worktreeFilesystem struct {
 	billy.Filesystem
 	protectNTFS bool
 	protectHFS  bool
+
+	// win32 enables the rules that describe the host's own path
+	// canonicalisation rather than a repository's contents: volume
+	// prefixes, and the trailing-space/period and reserved-device rules
+	// that Win32ValidPath applies under core.protectNTFS. Upstream Git
+	// compiles is_valid_win32_path only for MinGW and MSVC, so a POSIX
+	// host must keep checking out names such as aux.c. It is a field
+	// rather than a runtime.GOOS test so both hosts' policies are
+	// reachable from a test on either.
+	win32 bool
 }
 
 func newWorktreeFilesystem(fs billy.Filesystem, protectNTFS, protectHFS bool) *worktreeFilesystem {
-	return &worktreeFilesystem{Filesystem: fs, protectNTFS: protectNTFS, protectHFS: protectHFS}
+	return &worktreeFilesystem{
+		Filesystem:  fs,
+		protectNTFS: protectNTFS,
+		protectHFS:  protectHFS,
+		win32:       runtime.GOOS == "windows",
+	}
 }
 
 func (sfs *worktreeFilesystem) Create(filename string) (billy.File, error) {
@@ -201,15 +216,15 @@ var errUnsupportedOperation = errors.New("unsupported operation")
 // Dot and parent components, including the NTFS and HFS+ spellings a
 // filesystem folds back to them, are refused whatever the configuration
 // says. So are `.git` and `git~1` at every component position;
-// core.protectHFS and core.protectNTFS add the remaining aliases. With
-// core.protectNTFS the Win32 trailing-space/period and reserved-device
-// rules apply too, and volume prefixes are refused.
+// core.protectHFS and core.protectNTFS add the remaining aliases. A Win32
+// host additionally refuses volume prefixes, and with core.protectNTFS the
+// trailing-space/period and reserved-device rules.
 //
 // ValidTreePath and this gate are not ordered by strictness. Tree
 // validation refuses an alias such as sub/.git<U+200C> with both
-// protections off, which this gate accepts; core.protectNTFS refuses
-// aux.c here, which tree validation accepts. A submodule .git pointer
-// file cannot be reached through this wrapper.
+// protections off, which this gate accepts; a Win32 host with
+// core.protectNTFS refuses aux.c here, which tree validation accepts. A
+// submodule .git pointer file cannot be reached through this wrapper.
 //
 // Reference: upstream Git verify_path_internal at read-cache.c#L987-L1048
 // and is_valid_win32_path at compat/mingw.c#L3347-L3469 in tag v2.54.0[1][2].
@@ -229,12 +244,8 @@ func (sfs *worktreeFilesystem) validPath(paths ...string) error {
 			return fmt.Errorf("%w: %q", pathutil.ErrInvalidPath, p)
 		}
 
-		if sfs.protectNTFS {
-			// Volume names are not supported, in both formats: \\ and
-			// <DRIVE_LETTER>:.
-			if vol := filepath.VolumeName(p); vol != "" {
-				return fmt.Errorf("%w: %q", pathutil.ErrInvalidPath, p)
-			}
+		if sfs.win32 && pathutil.HasVolumeName(p) {
+			return fmt.Errorf("%w %q: contains a volume name", pathutil.ErrInvalidPath, p)
 		}
 
 		for _, part := range parts {
@@ -249,7 +260,7 @@ func (sfs *worktreeFilesystem) validPath(paths ...string) error {
 				return fmt.Errorf("%w component: %q", pathutil.ErrInvalidPath, p)
 			}
 
-			if sfs.protectNTFS && !pathutil.Win32ValidPath(part) {
+			if sfs.win32 && sfs.protectNTFS && !pathutil.Win32ValidPath(part) {
 				return fmt.Errorf("%w %q: component %q is not a valid Windows path component (core.protectNTFS)", pathutil.ErrInvalidPath, p, part)
 			}
 		}

--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -41,7 +41,9 @@ func defaultProtectNTFS() bool {
 // boundary. Two layers apply:
 //
 //   - validPath rejects dangerous path *strings*: .git and its HFS+/NTFS
-//     variants, "..", control characters, volume names.
+//     variants at every position, dot/parent components and control bytes.
+//     Windows additionally rejects volume prefixes and, with
+//     core.protectNTFS, trailing spaces/periods and reserved device names.
 //   - validNoLeadingSymlink rejects paths whose leading directories
 //     already exist on disk as symlinks, so a write or delete cannot
 //     follow a planted link out of the tree.
@@ -121,13 +123,9 @@ func (sfs *worktreeFilesystem) Lstat(filename string) (os.FileInfo, error) {
 	return sfs.Filesystem.Lstat(filename)
 }
 
-// Symlink refuses a link name that names .gitmodules on any
-// filesystem before it applies the general path rules. Both checks
-// refuse the same names, but validSymlinkName reports
-// ErrGitModulesSymlink, which tells the caller which rule it broke,
-// and validPath reports only that the path is invalid. Ordering the
-// specific check first keeps the sentinel reachable for names that
-// break both, such as ".gitmodules " under core.protectNTFS.
+// Symlink checks .gitmodules names before the general path and filesystem
+// rules. The checks are independent and can overlap; checking the symlink
+// name first preserves ErrGitModulesSymlink for overlapping refusals.
 func (sfs *worktreeFilesystem) Symlink(target, link string) error {
 	if err := sfs.validSymlinkName(link); err != nil {
 		return fmt.Errorf("symlink: %w", err)
@@ -197,99 +195,88 @@ func (sfs *worktreeFilesystem) Chroot(path string) (billy.Filesystem, error) {
 
 var errUnsupportedOperation = errors.New("unsupported operation")
 
-// isDotGitVariant reports whether part is .git, git~1, or an HFS+
-// equivalent of .git (when protectHFS is true). NTFS variants of .git
-// (e.g. ".git " with trailing space, ".git::$INDEX_ALLOCATION") are
-// detected separately by windowsValidPath, which applies regardless
-// of position in the path. Both validators reuse this helper.
-func isDotGitVariant(part string, protectHFS bool) bool {
-	if pathutil.IsDotGitName(part) {
-		return true
-	}
-	if protectHFS && pathutil.IsHFSDotGit(part) {
-		return true
-	}
-	return false
-}
-
-// validPath checks whether paths are valid for the worktree
-// filesystem abstraction. It is intentionally tolerant of .git as
-// the final path component of a multi-component path
-// (e.g. "submodule/.git"), so that legitimate gitlink pointer files
-// can still be Stat'd, Read, and Removed via the wrapper during
-// submodule cleanup.
+// validPath validates worktree paths, including index-derived names and
+// tree-derived deletions that do not pass through ValidTreePath.
 //
-// This is the shared gate for the paths that reach the worktree
-// without meeting pathutil.ValidTreePath first, and two classes do.
-// resetWorktreeToTree's delete pass takes its names from diffTrees,
-// whose treeNoder sets TreeWalker.skipPathValidation, so a
-// tree-derived delete never passes through Tree.FindEntry.
-// Index-derived names arrive from a decoder that does not validate
-// entry names at all. The "." / ".." check therefore runs whatever
-// core.protectNTFS and core.protectHFS say, matching the stance
-// isDotGitVariant takes for a literal .git: core.protectNTFS is a
-// statement about NTFS canonicalisation, not consent to a parent
-// hop.
+// Dot and parent components, including the NTFS and HFS+ spellings a
+// filesystem folds back to them, are refused whatever the configuration
+// says. So are `.git` and `git~1` at every component position;
+// core.protectHFS and core.protectNTFS add the remaining aliases. With
+// core.protectNTFS the Win32 trailing-space/period and reserved-device
+// rules apply too, and volume prefixes are refused.
 //
-// Callers that do run pathutil.ValidTreePath — Tree.FindEntry,
-// Tree.TreeEntryFile, TreeWalker.Next, Index.Add and
-// Submodule.Repository — meet a stricter predicate before reaching
-// here, which is why this layer stays tolerant of the rest.
+// ValidTreePath and this gate are not ordered by strictness. Tree
+// validation refuses an alias such as sub/.git<U+200C> with both
+// protections off, which this gate accepts; core.protectNTFS refuses
+// aux.c here, which tree validation accepts. A submodule .git pointer
+// file cannot be reached through this wrapper.
 //
-// For upstream rules:
-// https://github.com/git/git/blob/v2.54.0/read-cache.c#L987
-// https://github.com/git/git/blob/v2.54.0/path.c#L1419
-// https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3363
+// Reference: upstream Git verify_path_internal at read-cache.c#L987-L1048
+// and is_valid_win32_path at compat/mingw.c#L3347-L3469 in tag v2.54.0[1][2].
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/read-cache.c#L987-L1048
+// [2]: https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3347-L3469
 func (sfs *worktreeFilesystem) validPath(paths ...string) error {
 	for _, p := range paths {
 		for i := 0; i < len(p); i++ {
 			if p[i] < 0x20 || p[i] == 0x7f {
-				return fmt.Errorf("invalid path %q: contains control character", p)
+				return fmt.Errorf("%w %q: contains control character", pathutil.ErrInvalidPath, p)
 			}
 		}
 
 		parts := strings.FieldsFunc(p, func(r rune) bool { return (r == '\\' || r == '/') })
 		if len(parts) == 0 {
-			return fmt.Errorf("invalid path: %q", p)
+			return fmt.Errorf("%w: %q", pathutil.ErrInvalidPath, p)
 		}
 
 		if sfs.protectNTFS {
-			// Volume names are not supported, in both formats: \\ and <DRIVE_LETTER>:.
+			// Volume names are not supported, in both formats: \\ and
+			// <DRIVE_LETTER>:.
 			if vol := filepath.VolumeName(p); vol != "" {
-				return fmt.Errorf("invalid path: %q", p)
+				return fmt.Errorf("%w: %q", pathutil.ErrInvalidPath, p)
 			}
 		}
 
-		for i, part := range parts {
+		for _, part := range parts {
 			// Always on, whatever core.protectNTFS and
 			// core.protectHFS say: see the doc comment above.
 			if pathutil.IsDotOrDotDotName(part) {
-				return fmt.Errorf("invalid path %q: cannot use %q", p, part)
+				return fmt.Errorf("%w %q: cannot use %q", pathutil.ErrInvalidPath, p, part)
 			}
 
-			// Reject .git (and equivalents) as a path component when it is
-			// either the first component (root-level .git) or a non-final
-			// component (traversal into a .git directory, e.g. "a/.git/config").
-			// A final non-first .git component (e.g. "submodule/.git") is
-			// allowed because submodule worktrees contain a .git pointer file.
-			if isDotGitVariant(part, sfs.protectHFS) && (i == 0 || i < len(parts)-1) {
-				return fmt.Errorf("invalid path component: %q", p)
+			// Check every position, including a final submodule .git pointer.
+			if sfs.isDotGitComponent(part) {
+				return fmt.Errorf("%w component: %q", pathutil.ErrInvalidPath, p)
 			}
 
-			if sfs.protectNTFS && !pathutil.WindowsValidPath(part) {
-				return fmt.Errorf("invalid path: %q", p)
+			if sfs.protectNTFS && !pathutil.Win32ValidPath(part) {
+				return fmt.Errorf("%w %q: component %q is not a valid Windows path component (core.protectNTFS)", pathutil.ErrInvalidPath, p, part)
 			}
 		}
 	}
 	return nil
 }
 
-// validWritePath validates paths for mutating operations. It layers the
-// filesystem-state check validNoLeadingSymlink on top of the string-only
-// checks in validPath, so a write can neither name a dangerous path nor
-// reach one by traversing an existing symlink. Every mutating method on
-// the wrapper funnels through here, so the leading-symlink invariant holds
-// for all worktree writers without each call site having to remember it.
+// isDotGitComponent reports whether a component names .git under this
+// worktree's protection settings. `.git` and its 8.3 short name `git~1`
+// are refused case-insensitively whatever the configuration says, as
+// pathutil.ValidTreePath refuses them; core.protectHFS and
+// core.protectNTFS add the HFS+ and NTFS spellings on top. validPath
+// checks every position; Clean and the filesystem noder apply the same
+// policy to entry base names.
+//
+// Reference: upstream Git verify_path_internal at read-cache.c#L987-L1048
+// in tag v2.54.0[1].
+//
+// [1]: https://github.com/git/git/blob/v2.54.0/read-cache.c#L987-L1048
+func (sfs *worktreeFilesystem) isDotGitComponent(part string) bool {
+	return pathutil.IsDotGitName(part) ||
+		(sfs.protectHFS && pathutil.IsHFSDotGit(part)) ||
+		(sfs.protectNTFS && pathutil.IsNTFSDotGit(part))
+}
+
+// validWritePath combines string validation with a check for existing leading
+// symlinks, so mutating operations cannot follow them outside the worktree.
 func (sfs *worktreeFilesystem) validWritePath(paths ...string) error {
 	if err := sfs.validPath(paths...); err != nil {
 		return err

--- a/worktree_fs.go
+++ b/worktree_fs.go
@@ -121,11 +121,18 @@ func (sfs *worktreeFilesystem) Lstat(filename string) (os.FileInfo, error) {
 	return sfs.Filesystem.Lstat(filename)
 }
 
+// Symlink refuses a link name that names .gitmodules on any
+// filesystem before it applies the general path rules. Both checks
+// refuse the same names, but validSymlinkName reports
+// ErrGitModulesSymlink, which tells the caller which rule it broke,
+// and validPath reports only that the path is invalid. Ordering the
+// specific check first keeps the sentinel reachable for names that
+// break both, such as ".gitmodules " under core.protectNTFS.
 func (sfs *worktreeFilesystem) Symlink(target, link string) error {
-	if err := sfs.validWritePath(link); err != nil {
+	if err := sfs.validSymlinkName(link); err != nil {
 		return fmt.Errorf("symlink: %w", err)
 	}
-	if err := sfs.validSymlinkName(link); err != nil {
+	if err := sfs.validWritePath(link); err != nil {
 		return fmt.Errorf("symlink: %w", err)
 	}
 	return sfs.Filesystem.Symlink(target, link)
@@ -210,14 +217,29 @@ func isDotGitVariant(part string, protectHFS bool) bool {
 // the final path component of a multi-component path
 // (e.g. "submodule/.git"), so that legitimate gitlink pointer files
 // can still be Stat'd, Read, and Removed via the wrapper during
-// submodule cleanup. Attacker-controlled tree-entry paths are
-// validated separately by pathutil.ValidTreePath at the boundaries
-// where data leaves the trusted store (Tree.FindEntry, the explicit
-// callers in CherryPick and Submodule.Repository).
+// submodule cleanup.
+//
+// This is the shared gate for the paths that reach the worktree
+// without meeting pathutil.ValidTreePath first, and two classes do.
+// resetWorktreeToTree's delete pass takes its names from diffTrees,
+// whose treeNoder sets TreeWalker.skipPathValidation, so a
+// tree-derived delete never passes through Tree.FindEntry.
+// Index-derived names arrive from a decoder that does not validate
+// entry names at all. The "." / ".." check therefore runs whatever
+// core.protectNTFS and core.protectHFS say, matching the stance
+// isDotGitVariant takes for a literal .git: core.protectNTFS is a
+// statement about NTFS canonicalisation, not consent to a parent
+// hop.
+//
+// Callers that do run pathutil.ValidTreePath — Tree.FindEntry,
+// Tree.TreeEntryFile, TreeWalker.Next, Index.Add and
+// Submodule.Repository — meet a stricter predicate before reaching
+// here, which is why this layer stays tolerant of the rest.
 //
 // For upstream rules:
 // https://github.com/git/git/blob/v2.54.0/read-cache.c#L987
 // https://github.com/git/git/blob/v2.54.0/path.c#L1419
+// https://github.com/git/git/blob/v2.54.0/compat/mingw.c#L3363
 func (sfs *worktreeFilesystem) validPath(paths ...string) error {
 	for _, p := range paths {
 		for i := 0; i < len(p); i++ {
@@ -239,7 +261,9 @@ func (sfs *worktreeFilesystem) validPath(paths ...string) error {
 		}
 
 		for i, part := range parts {
-			if part == "." || part == ".." {
+			// Always on, whatever core.protectNTFS and
+			// core.protectHFS say: see the doc comment above.
+			if pathutil.IsDotOrDotDotName(part) {
 				return fmt.Errorf("invalid path %q: cannot use %q", p, part)
 			}
 

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -764,7 +764,21 @@ func TestPathPolicyMatchesGitIndex(t *testing.T) {
 					gitAccepts := tc.rule != "literal" &&
 						(!ntfs || (tc.rule != "ntfs" && tc.rule != "shortname" && tc.rule != "backslash")) &&
 						(!hfs || tc.rule != "hfs")
-					require.Equal(t, gitAccepts, indexed == tc.name+"\x00", "Git index: %q", indexed)
+					// `core.protectNTFS` has covered `git~1` and the
+					// trailing space and period spellings since 2.2.1,
+					// but the Alternate Data Stream spelling only since
+					// 2.24.1 (7c3745fc6185, CVE-2019-1352)[1]. Earlier
+					// releases end a component at a directory separator
+					// and never at `:`, so `.git::$INDEX_ALLOCATION`
+					// reaches the index with the setting enabled. Ask
+					// Git only where it implements the check; the go-git
+					// verdicts below are asserted against every release.
+					//
+					// [1]: https://github.com/git/git/commit/7c3745fc6185495d5765628b4dfe1bd2c25a2981
+					ntfsStream := tc.rule == "ntfs" && strings.Contains(tc.name, ":")
+					if !ntfsStream || gitAtLeast(t, 2, 24) {
+						require.Equal(t, gitAccepts, indexed == tc.name+"\x00", "Git index: %q", indexed)
+					}
 
 					worktreeAccepts := gitAccepts && tc.rule != "tree-policy" &&
 						tc.rule != "backslash" && tc.rule != "shortname"

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -51,8 +51,8 @@ func TestValidPath(t *testing.T) {
 		{".", true},
 		{"a/.git/b", true},
 		{"a\\.git\\b", true},
-		{"a/.git", false},
-		{"a\\.git", false},
+		{"a/.git", true},
+		{"a\\.git", true},
 		{"a\x01b", true},     // explicit byte-oriented control-char rejection
 		{"foo\x7fbar", true}, // DEL byte
 	}
@@ -78,7 +78,6 @@ func TestWorktreeFilesystemRejectsInvalidPaths(t *testing.T) {
 	badPaths := []string{
 		".git/config",
 		".git/objects/pack/file",
-		"git~1/HEAD",
 		"../escape",
 		"a/../../etc/passwd",
 	}
@@ -234,7 +233,6 @@ func TestWorktreeFilesystemSymlinkRejectsDangerousLinkNames(t *testing.T) {
 		".git",
 		".git/config",
 		".git/hooks/pre-commit",
-		"git~1/HEAD",
 		"../escape",
 		"a/../../etc/passwd",
 	}
@@ -492,7 +490,7 @@ func TestWorktreeFilesystemAbsolutePaths(t *testing.T) {
 		{"allow /readme.md", "/readme.md", false},
 		{"allow /src/main.go", "/src/main.go", false},
 		{"allow /.gitignore", "/.gitignore", false},
-		{"allow /submodule/.git", "/submodule/.git", false},
+		{"reject /submodule/.git", "/submodule/.git", true},
 	}
 
 	for _, tc := range tests {
@@ -1004,6 +1002,19 @@ func gitCherryPick(t *testing.T, dir, hash string) error {
 	return nil
 }
 
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	overrides := []string{
+		"-c", "protocol.file.allow=always",
+		"-c", "submodule.recurse=false",
+		"-C", dir,
+	}
+	out, err := gitenv.CommandContext(t.Context(), "git", append(overrides, args...)...).CombinedOutput()
+	require.NoError(t, err, "git %q: %s", args, out)
+	return strings.TrimSpace(string(out))
+}
+
 // recordingFS records every path handed to a mutating operation, so a
 // test can assert on which strings actually reach the filesystem
 // after the wrapper's validators have had their say. Asserting on the
@@ -1145,6 +1156,89 @@ func TestResetHardRefusesTreeDerivedDotDotDisguise(t *testing.T) {
 				"the disguise %q must never reach the filesystem; calls=%q",
 				hostile, rec.calls)
 		})
+	}
+}
+
+// TestResetRejectsDotGitPositionShift walks a .git alias through the
+// positions a hostile tree can hide it in — behind a component that
+// NTFS or HFS+ folds away, behind an Alternate Data Stream name, and
+// at the root — for a regular entry and for a gitlink. The gate has
+// to hold with either protection off, because ValidTreePath refuses
+// the alias unconditionally and the wrapper is the only thing the
+// tree-derived delete passes through.
+func TestResetRejectsDotGitPositionShift(t *testing.T) {
+	t.Parallel()
+
+	names := []string{
+		"::$INDEX_ALLOCATION/.git",
+		":a/.git",
+		".\u200c/.git",
+		". /.git",
+		".../.git",
+		" /.git",
+		"sub/.GIT",
+		".git",
+	}
+
+	for _, name := range names {
+		for _, mode := range []filemode.FileMode{filemode.Regular, filemode.Submodule} {
+			for _, ntfs := range []bool{false, true} {
+				for _, hfs := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%q/%o/ntfs=%t/hfs=%t", name, mode, ntfs, hfs), func(t *testing.T) {
+						t.Parallel()
+
+						s := memory.NewStorage()
+						rec := &recordingFS{Filesystem: memfs.New()}
+
+						r, err := Init(s, WithWorkTree(rec))
+						require.NoError(t, err)
+
+						cfg, err := r.Config()
+						require.NoError(t, err)
+						cfg.Core.ProtectNTFS = config.NewOptBool(ntfs)
+						cfg.Core.ProtectHFS = config.NewOptBool(hfs)
+						require.NoError(t, r.SetConfig(cfg))
+
+						blob := writeBlob(t, s, []byte("payload"))
+						hostileTree := storeRawTree(t, s, []object.TreeEntry{
+							{Name: name, Mode: mode, Hash: blob},
+						})
+						benignTree := storeRawTree(t, s, nil)
+
+						sig := defaultSignature()
+						hostileCommit := storeCommit(t, s, &object.Commit{
+							Author:    *sig,
+							Committer: *sig,
+							Message:   "hostile\n",
+							TreeHash:  hostileTree,
+						})
+						benignCommit := storeCommit(t, s, &object.Commit{
+							Author:       *sig,
+							Committer:    *sig,
+							Message:      "benign\n",
+							TreeHash:     benignTree,
+							ParentHashes: []plumbing.Hash{hostileCommit},
+						})
+
+						head, err := r.Reference(plumbing.HEAD, false)
+						require.NoError(t, err)
+						require.NoError(t, s.SetReference(
+							plumbing.NewHashReference(head.Target(), hostileCommit),
+						))
+
+						w, err := r.Worktree()
+						require.NoError(t, err)
+
+						rec.calls = nil
+						err = w.Reset(&ResetOptions{Mode: HardReset, Commit: benignCommit})
+						require.Error(t, err, "the alias must be refused; calls=%q", rec.calls)
+						assert.False(t, rec.sawPath(name),
+							"the alias %q must never reach the filesystem; calls=%q",
+							name, rec.calls)
+					})
+				}
+			}
+		}
 	}
 }
 
@@ -1435,7 +1529,7 @@ func TestForceCheckoutReplacesLeadingSymlink(t *testing.T) {
 // Windows reserved device names are not exercised here: they are
 // legitimate filenames on non-Windows and upstream Git accepts them, so
 // the strict tree-side gate also accepts them. The wrapper rejects them
-// at materialisation time when core.protectNTFS is on; that path is
+// on Windows when core.protectNTFS is on; that path is
 // covered by TestValidPathProtectNTFS.
 func TestAddRejectsDangerousPaths(t *testing.T) {
 	t.Parallel()
@@ -1522,6 +1616,129 @@ func TestMoveRejectsDangerousDestinations(t *testing.T) {
 	}
 }
 
+// TestValidPathRejectsDotGitEveryPosition walks a .git alias through
+// every position a path can put it in. `.git` and the bare 8.3 short
+// name `git~1` are refused whatever the configuration says, because
+// ValidTreePath refuses them; core.protectNTFS and core.protectHFS
+// only add the spellings those filesystems fold back to one of the
+// two.
+func TestValidPathRejectsDotGitEveryPosition(t *testing.T) {
+	t.Parallel()
+
+	groups := []struct {
+		name  string
+		paths []string
+	}{
+		{"always", []string{
+			". /.git", ".\u200c/.git", ".../.git", "..../.git", " /.git",
+			"::$INDEX_ALLOCATION/.git", ":a/.git", "a/. /.git",
+			"sub/.git", "sub/.GIT", ".GIT", "a\\.git", "a/.git/config",
+			"git~1", "git~1/HEAD", "sub/git~1", "GIT~1",
+		}},
+		{"ntfs", []string{
+			"sub/GIT~1 ", ".git ", "git~1 ", ".git::$INDEX_ALLOCATION",
+		}},
+		{"hfs", []string{
+			"sub/.git\u200c", "sub/.gi\u200ct", "sub/.g\u200cit",
+			"sub/.\u200cgit", "sub/\u200c.git",
+		}},
+	}
+
+	for _, group := range groups {
+		for _, ntfs := range []bool{false, true} {
+			for _, hfs := range []bool{false, true} {
+				for _, p := range group.paths {
+					t.Run(fmt.Sprintf("%s/%q/ntfs=%t/hfs=%t", group.name, p, ntfs, hfs), func(t *testing.T) {
+						t.Parallel()
+
+						fs := newWorktreeFilesystem(memfs.New(), ntfs, hfs)
+						rejected := group.name == "always" ||
+							group.name == "ntfs" && ntfs ||
+							group.name == "hfs" && hfs
+
+						for _, check := range []func(...string) error{fs.validPath, fs.validWritePath} {
+							err := check(p)
+							if rejected {
+								require.Error(t, err)
+							} else {
+								require.NoError(t, err)
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+// TestWorktreeOperationsSurviveDotGitDisguises pins what the
+// every-position refusal costs the porcelain: a name the gate refuses
+// is invisible to Status and untouched by Clean, where git would list
+// and remove it. Neither operation may fail on account of it, and an
+// unrelated file in the same worktree stays reachable.
+func TestWorktreeOperationsSurviveDotGitDisguises(t *testing.T) {
+	t.Parallel()
+
+	names := []string{
+		".git", "git~1", ".GIT", "sub/.GIT",
+		"sub/git~1", "sub/.git", ".git\u200c", "sub/.git\u200c",
+	}
+
+	for _, name := range names {
+		for _, directory := range []bool{false, true} {
+			for _, op := range []string{"Clean", "Status", "AddUnrelated", "AddGlob", "AddAll", "AddName"} {
+				t.Run(fmt.Sprintf("%q/directory=%t/%s", name, directory, op), func(t *testing.T) {
+					t.Parallel()
+
+					fs := memfs.New()
+					r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+					require.NoError(t, err)
+
+					cfg, err := r.Config()
+					require.NoError(t, err)
+					cfg.Core.ProtectNTFS = config.OptBoolTrue
+					cfg.Core.ProtectHFS = config.OptBoolTrue
+					require.NoError(t, r.SetConfig(cfg))
+
+					w, err := r.Worktree()
+					require.NoError(t, err)
+
+					p := name
+					if directory {
+						p += "/inner.txt"
+					}
+					require.NoError(t, util.WriteFile(fs, p, []byte("preserved"), 0o644))
+					require.NoError(t, util.WriteFile(fs, "unrelated.txt", []byte("safe"), 0o644))
+
+					switch op {
+					case "Clean":
+						require.NoError(t, w.Clean(&CleanOptions{Dir: true}))
+						body, err := util.ReadFile(fs, p)
+						require.NoError(t, err)
+						require.Equal(t, "preserved", string(body))
+					case "Status":
+						status, err := w.Status()
+						require.NoError(t, err)
+						require.Equal(t, Status{
+							"unrelated.txt": &FileStatus{Staging: Untracked, Worktree: Untracked},
+						}, status)
+					case "AddUnrelated":
+						_, err = w.Add("unrelated.txt")
+						require.NoError(t, err)
+					case "AddGlob":
+						require.NoError(t, w.AddGlob("."))
+					case "AddAll":
+						require.NoError(t, w.AddWithOptions(&AddOptions{All: true}))
+					case "AddName":
+						_, err = w.Add(name)
+						require.ErrorIs(t, err, pathutil.ErrInvalidPath)
+					}
+				})
+			}
+		}
+	}
+}
+
 func TestValidPathProtectNTFS(t *testing.T) {
 	t.Parallel()
 
@@ -1541,6 +1758,15 @@ func TestValidPathProtectNTFS(t *testing.T) {
 		{"sub/NUL", true},
 		{"sub/COM1.txt", true},
 		{"CONIN$", true},
+		{"foo ", true},
+		{"foo.", true},
+		{"sub /x", true},
+		{".gitattributes ", true},
+		{".gitignore ", true},
+		{"...", true},
+		{"....", true},
+		{"a..b", false},
+		{"foo", false},
 		{"readme.md", false},
 		{".gitignore", false},
 		{"CONNECT", false},
@@ -1580,6 +1806,12 @@ func TestValidPathProtectNTFSDisabled(t *testing.T) {
 		".git ",
 		".git.",
 		".git::$INDEX_ALLOCATION",
+		"foo ",
+		"foo.",
+		"sub /x",
+		".gitattributes ",
+		"...",
+		"....",
 	}
 
 	for _, p := range paths {
@@ -1793,10 +2025,9 @@ func TestValidPathRejectsDotDotDisguisesWithProtectionOff(t *testing.T) {
 	}
 }
 
-// TestValidPathAllowsDotsOnlyWithProtectionOff is the other side of
-// the same line. A component of periods alone folds to ".." on NTFS
-// and nowhere else, so it belongs to WindowsValidPath under
-// core.protectNTFS rather than to the always-on check above.
+// TestValidPathAllowsDotsOnlyWithProtectionOff checks that the Win32
+// trailing rule is disabled with core.protectNTFS off. It applies only
+// on Windows and is separate from the always-on dot/parent check.
 func TestValidPathAllowsDotsOnlyWithProtectionOff(t *testing.T) {
 	t.Parallel()
 

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bytes"
 	"fmt"
+	gofs "io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/internal/pathutil"
 	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
@@ -1002,6 +1004,150 @@ func gitCherryPick(t *testing.T, dir, hash string) error {
 	return nil
 }
 
+// recordingFS records every path handed to a mutating operation, so a
+// test can assert on which strings actually reach the filesystem
+// after the wrapper's validators have had their say. Asserting on the
+// returned error is not enough: a delete that succeeds and a delete
+// that is refused can both leave Reset returning nil.
+type recordingFS struct {
+	billy.Filesystem
+	calls []string
+}
+
+func (r *recordingFS) record(op, p string) { r.calls = append(r.calls, op+" "+p) }
+
+func (r *recordingFS) Remove(p string) error {
+	r.record("Remove", p)
+	return r.Filesystem.Remove(p)
+}
+
+func (r *recordingFS) OpenFile(p string, flag int, perm gofs.FileMode) (billy.File, error) {
+	r.record("OpenFile", p)
+	return r.Filesystem.OpenFile(p, flag, perm)
+}
+
+func (r *recordingFS) MkdirAll(p string, perm gofs.FileMode) error {
+	r.record("MkdirAll", p)
+	return r.Filesystem.MkdirAll(p, perm)
+}
+
+func (r *recordingFS) sawPath(name string) bool {
+	for _, c := range r.calls {
+		if strings.HasSuffix(c, " "+name) {
+			return true
+		}
+	}
+	return false
+}
+
+// storeCommit writes commit to s and returns its hash.
+func storeCommit(t *testing.T, s storer.Storer, commit *object.Commit) plumbing.Hash {
+	t.Helper()
+
+	obj := s.NewEncodedObject()
+	require.NoError(t, commit.Encode(obj))
+	hash, err := s.SetEncodedObject(obj)
+	require.NoError(t, err)
+	return hash
+}
+
+// TestResetHardRefusesTreeDerivedDotDotDisguise closes the delete
+// half of checkout and reset. resetWorktreeToTree's first pass takes
+// ch.From.String() straight from diffTrees into rmFileAndDirsIfEmpty,
+// and diffTrees' treeNoder sets TreeWalker.skipPathValidation, so the
+// name never meets pathutil.ValidTreePath. The wrapper's validPath is
+// the only gate, and it must hold with both protections off as well
+// as on.
+//
+// Reachability does not require the hostile tree ever to have been
+// materialised: Reset sets HEAD before resetIndex, so an aborted
+// checkout leaves HEAD on the hostile commit and the next
+// reset --hard issues the delete. The test models exactly that by
+// pointing HEAD at the hostile commit directly.
+func TestResetHardRefusesTreeDerivedDotDotDisguise(t *testing.T) {
+	t.Parallel()
+
+	const hostile = ".. "
+
+	for _, tc := range []struct {
+		name        string
+		protectNTFS config.OptBool
+		protectHFS  config.OptBool
+	}{
+		{name: "repository defaults"},
+		{
+			name:        "protections off",
+			protectNTFS: config.NewOptBool(false),
+			protectHFS:  config.NewOptBool(false),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := memory.NewStorage()
+			rec := &recordingFS{Filesystem: memfs.New()}
+
+			r, err := Init(s, WithWorkTree(rec))
+			require.NoError(t, err)
+
+			if tc.protectNTFS.IsSet() || tc.protectHFS.IsSet() {
+				cfg, err := r.Config()
+				require.NoError(t, err)
+				cfg.Core.ProtectNTFS = tc.protectNTFS
+				cfg.Core.ProtectHFS = tc.protectHFS
+				require.NoError(t, r.SetConfig(cfg))
+			}
+
+			blob := writeBlob(t, s, []byte("payload\n"))
+			hostileTree := storeRawTree(t, s, []object.TreeEntry{
+				{Name: hostile, Mode: filemode.Regular, Hash: blob},
+			})
+			benignTree := storeRawTree(t, s, nil)
+
+			sig := defaultSignature()
+			hostileCommit := storeCommit(t, s, &object.Commit{
+				Author:    *sig,
+				Committer: *sig,
+				Message:   "hostile\n",
+				TreeHash:  hostileTree,
+			})
+			benignCommit := storeCommit(t, s, &object.Commit{
+				Author:       *sig,
+				Committer:    *sig,
+				Message:      "benign\n",
+				TreeHash:     benignTree,
+				ParentHashes: []plumbing.Hash{hostileCommit},
+			})
+
+			// The hostile name really is in the stored tree, and the
+			// tree-path validator really does refuse it.
+			tr, err := object.GetTree(s, hostileTree)
+			require.NoError(t, err)
+			require.Len(t, tr.Entries, 1)
+			require.Equal(t, hostile, tr.Entries[0].Name)
+			_, err = tr.FindEntry(hostile)
+			require.Error(t, err, "FindEntry must refuse the disguise")
+
+			head, err := r.Reference(plumbing.HEAD, false)
+			require.NoError(t, err)
+			require.NoError(t, s.SetReference(
+				plumbing.NewHashReference(head.Target(), hostileCommit),
+			))
+
+			w, err := r.Worktree()
+			require.NoError(t, err)
+
+			err = w.Reset(&ResetOptions{Mode: HardReset, Commit: benignCommit})
+			t.Logf("Reset returned: %v", err)
+			t.Logf("filesystem calls: %q", rec.calls)
+
+			assert.False(t, rec.sawPath(hostile),
+				"the disguise %q must never reach the filesystem; calls=%q",
+				hostile, rec.calls)
+		})
+	}
+}
+
 // TestResetAcceptsLegitPaths drives Reset(HardReset) onto a tree
 // containing a variety of legitimate path shapes and asserts each
 // one materialises on disk. pathutil.ValidTreePath rejects only
@@ -1602,4 +1748,65 @@ func TestWorktreeFilesystemHFSDotGitmodulesSymlinkAllowedWhenProtectionOff(t *te
 	fs := newWorktreeFilesystem(memfs.New(), false, false)
 	err := fs.Symlink("safe-target", ".g\u200citmodules")
 	assert.NoError(t, err, "HFS variant should be allowed when protectHFS is off")
+}
+
+// TestValidPathRejectsDotDotDisguisesWithProtectionOff pins the
+// disguise check as independent of core.protectNTFS and
+// core.protectHFS. It has to be: resetWorktreeToTree's first pass
+// takes its delete paths from diffTrees, whose treeNoder sets
+// TreeWalker.skipPathValidation, so those names never meet
+// pathutil.ValidTreePath and this wrapper is their only gate. The
+// index decoder does not validate entry names either. Turning
+// core.protectNTFS off is a statement about NTFS canonicalisation,
+// not consent to a parent hop.
+func TestValidPathRejectsDotDotDisguisesWithProtectionOff(t *testing.T) {
+	t.Parallel()
+
+	fs := newWorktreeFilesystem(memfs.New(), false, false)
+
+	paths := []string{
+		"..",
+		"../x",
+		".. ",
+		".. /x",
+		"..  /x",
+		".. ./x",
+		"..:$DATA/x",
+		"..:x/x",
+		"..::$INDEX_ALLOCATION/x",
+		".\u200c./x",
+		"\u200c../x",
+		"..\u200c/x",
+		"a/.. /b",
+		"a\\.. \\b",
+		"a/.\u200c./b",
+		".",
+		"a/./b",
+	}
+
+	for _, p := range paths {
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+			assert.Error(t, fs.validPath(p),
+				"validPath(%q) must be refused with both protections off", p)
+		})
+	}
+}
+
+// TestValidPathAllowsDotsOnlyWithProtectionOff is the other side of
+// the same line. A component of periods alone folds to ".." on NTFS
+// and nowhere else, so it belongs to WindowsValidPath under
+// core.protectNTFS rather than to the always-on check above.
+func TestValidPathAllowsDotsOnlyWithProtectionOff(t *testing.T) {
+	t.Parallel()
+
+	fs := newWorktreeFilesystem(memfs.New(), false, false)
+
+	for _, p := range []string{"...", "....", "a/.../b", "x..", ".. x", ". "} {
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+			assert.NoError(t, fs.validPath(p),
+				"validPath(%q) must be allowed with core.protectNTFS off", p)
+		})
+	}
 }

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -2254,6 +2254,39 @@ func TestValidPathProtectNTFSDisabled(t *testing.T) {
 	}
 }
 
+func TestWorktreeFilesystemWin32InvalidCharacters(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"foo:bar", "foo::$DATA", "foo<bar", "foo>bar", "foo\"bar",
+		"foo|bar", "foo?bar", "foo*bar", "LPT0", "con .txt",
+	} {
+		for _, prefix := range []string{"", "sub/", `sub\`} {
+			for _, win32 := range []bool{false, true} {
+				for _, ntfs := range []bool{false, true} {
+					t.Run(fmt.Sprintf("%q/win32=%t/ntfs=%t", prefix+name, win32, ntfs), func(t *testing.T) {
+						t.Parallel()
+						rec := &recordingFS{Filesystem: memfs.New()}
+						fs := newWorktreeFilesystem(rec, ntfs, false)
+						fs.win32 = win32
+						file, err := fs.OpenFile(prefix+name, os.O_CREATE|os.O_WRONLY, 0o644)
+						if file != nil {
+							require.NoError(t, file.Close())
+						}
+						if win32 && ntfs {
+							require.ErrorIs(t, err, pathutil.ErrInvalidPath)
+							require.Empty(t, rec.calls)
+						} else {
+							require.NoError(t, err)
+							require.Equal(t, []string{"OpenFile " + prefix + name}, rec.calls)
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
 func TestWorktreeFilesystemRejectsNTFSPaths(t *testing.T) {
 	t.Parallel()
 

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -563,7 +563,7 @@ func TestCherryPickPathValidationMatchesGit(t *testing.T) {
 		{
 			name:    "git~1 8.3 short name",
 			path:    "git~1/config",
-			skipGit: !gitAtLeast(t, 2, 24),
+			skipGit: !gitAtLeast(t, 2, 24, 1),
 		},
 		{
 			name: "dot-dot traversal",
@@ -587,7 +587,7 @@ func TestCherryPickPathValidationMatchesGit(t *testing.T) {
 			name:    "NTFS alternate data stream",
 			path:    ".git::$INDEX_ALLOCATION/config",
 			config:  map[string]string{"core.protectNTFS": "true"},
-			skipGit: !gitAtLeast(t, 2, 24),
+			skipGit: !gitAtLeast(t, 2, 24, 1),
 		},
 		{
 			name:             "NTFS reserved device name CON",
@@ -776,7 +776,7 @@ func TestPathPolicyMatchesGitIndex(t *testing.T) {
 					//
 					// [1]: https://github.com/git/git/commit/7c3745fc6185495d5765628b4dfe1bd2c25a2981
 					ntfsStream := tc.rule == "ntfs" && strings.Contains(tc.name, ":")
-					if !ntfsStream || gitAtLeast(t, 2, 24) {
+					if !ntfsStream || gitAtLeast(t, 2, 24, 1) {
 						require.Equal(t, gitAccepts, indexed == tc.name+"\x00", "Git index: %q", indexed)
 					}
 
@@ -1197,24 +1197,37 @@ func gitConfig(t *testing.T, dir, key, value string) {
 }
 
 // gitAtLeast reports whether the local `git` is at least the given version.
-// Used to skip upstream cherry-pick assertions for protections that older
-// Git releases (e.g. 2.11) do not implement, such as the git~1 8.3 short
-// name check (CVE-2014-9390 hardening) and the .git::$INDEX_ALLOCATION
-// NTFS Alternate Data Stream check (CVE-2019-1351).
-func gitAtLeast(t *testing.T, major, minor int) bool {
+// Used to skip upstream assertions for protections that older Git releases
+// do not apply. Both protections the callers gate on arrived in 2.24.1:
+// `core.protectNTFS` has covered the `git~1` short name since 2.2.1 but
+// only defaults to enabled since 9102f958ee5 (CVE-2019-1353)[1], and
+// is_ntfs_dotgit reads the `.git::$INDEX_ALLOCATION` Alternate Data Stream
+// spelling only since 7c3745fc6185 (CVE-2019-1352)[2].
+//
+// [1]: https://github.com/git/git/commit/9102f958ee5
+// [2]: https://github.com/git/git/commit/7c3745fc6185
+func gitAtLeast(t *testing.T, major, minor, patch int) bool {
 	t.Helper()
 	out, err := gitenv.Command("git", "--version").Output()
 	if err != nil {
 		return false
 	}
-	var maj, mnr int
-	if _, err := fmt.Sscanf(string(out), "git version %d.%d", &maj, &mnr); err != nil {
-		return false
+	// Release builds carry a patch component; builds from a development
+	// branch append further fields, which Sscanf leaves unread.
+	var maj, mnr, pch int
+	if _, err := fmt.Sscanf(string(out), "git version %d.%d.%d", &maj, &mnr, &pch); err != nil {
+		if _, err := fmt.Sscanf(string(out), "git version %d.%d", &maj, &mnr); err != nil {
+			return false
+		}
 	}
-	if maj != major {
+	switch {
+	case maj != major:
 		return maj > major
+	case mnr != minor:
+		return mnr > minor
+	default:
+		return pch >= patch
 	}
-	return mnr >= minor
 }
 
 func gitCherryPick(t *testing.T, dir, hash string) error {

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -3,8 +3,10 @@ package git
 import (
 	"bytes"
 	"fmt"
+	"io"
 	gofs "io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -535,7 +537,8 @@ func TestCherryPickPathValidationMatchesGit(t *testing.T) {
 		// checks that go-git enforces but upstream git does not on this
 		// platform (e.g. reserved device names are only checked by
 		// compat/mingw.c, which is not compiled on non-Windows).
-		skipGit bool
+		skipGit          bool
+		acceptOffWindows bool
 	}{
 		{
 			name: ".git at root",
@@ -587,16 +590,18 @@ func TestCherryPickPathValidationMatchesGit(t *testing.T) {
 			skipGit: !gitAtLeast(t, 2, 24),
 		},
 		{
-			name:    "NTFS reserved device name CON",
-			path:    "CON/file",
-			config:  map[string]string{"core.protectNTFS": "true"},
-			skipGit: runtime.GOOS != "windows",
+			name:             "NTFS reserved device name CON",
+			acceptOffWindows: true,
+			path:             "CON/file",
+			config:           map[string]string{"core.protectNTFS": "true"},
+			skipGit:          runtime.GOOS != "windows",
 		},
 		{
-			name:    "NTFS reserved device name NUL",
-			path:    "NUL",
-			config:  map[string]string{"core.protectNTFS": "true"},
-			skipGit: runtime.GOOS != "windows",
+			name:             "NTFS reserved device name NUL",
+			acceptOffWindows: true,
+			path:             "NUL",
+			config:           map[string]string{"core.protectNTFS": "true"},
+			skipGit:          runtime.GOOS != "windows",
 		},
 		{
 			name:   "HFS+ zero-width character in .git",
@@ -646,6 +651,12 @@ func TestCherryPickPathValidationMatchesGit(t *testing.T) {
 				&CommitOptions{Author: defaultSignature(), AllowEmptyCommits: true},
 				TheirsMergeStrategy, badCommit,
 			)
+			if tc.acceptOffWindows && runtime.GOOS != "windows" {
+				require.NoError(t, goGitErr)
+				_, err := w.Filesystem().Lstat(tc.path)
+				require.NoError(t, err)
+				return
+			}
 			assert.Error(t, goGitErr, "go-git should reject cherry-pick of %q", tc.path)
 
 			if !tc.skipGit {
@@ -654,6 +665,216 @@ func TestCherryPickPathValidationMatchesGit(t *testing.T) {
 				gitErr := gitCherryPick(t, dir, badCommit.Hash.String())
 				assert.Error(t, gitErr, "git should reject cherry-pick of %q", tc.path)
 			}
+		})
+	}
+}
+
+// TestPathPolicyMatchesGitIndex compares the three gates against
+// reference git's own index, row by row, under every combination of
+// core.protectNTFS and core.protectHFS. The rule column names the
+// expected verdict, so a wrong port shows up as a mismatch against
+// git rather than against a predicate this branch also changed.
+//
+// The divergences are deliberate: go-git refuses the bare 8.3 alias
+// git~1 whatever the configuration says, refuses a backslash
+// component, and ValidTreePath refuses the ".." disguises git carries
+// in a POSIX tree.
+//
+//nolint:paralleltest // Subtests share one Git index and config.
+func TestPathPolicyMatchesGitIndex(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("POSIX Git oracle; native Windows gates have separate tests")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required")
+	}
+
+	dir := t.TempDir()
+	gitRun(t, dir, "init", "-q")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "blob"), []byte("content"), 0o644))
+	blob := gitRun(t, dir, "hash-object", "-w", "blob")
+
+	cases := []struct{ name, rule string }{
+		{".git", "literal"},
+		{"sub/.git", "literal"},
+		{".GIT", "literal"},
+		{"sub/.GIT", "literal"},
+		{". /.git", "literal"},
+		{"::$INDEX_ALLOCATION/.git", "literal"},
+		{":a/.git", "literal"},
+		{"git~1", "shortname"},
+		{"git~1/HEAD", "shortname"},
+		{"git~1 ", "ntfs"},
+		{"sub/git~1 ", "ntfs"},
+		{".git ", "ntfs"},
+		{".git::$INDEX_ALLOCATION", "ntfs"},
+		{"a\\.git", "backslash"},
+		{".git\u200c", "hfs"},
+		{"sub/.git\u200c", "hfs"},
+		{".gi\u200ct", "hfs"},
+		{".g\u200cit", "hfs"},
+		{".\u200cgit", "hfs"},
+		{"\u200c.git", "hfs"},
+		{".. ", "tree-policy"},
+		{"..:x", "tree-policy"},
+		{".. .", "tree-policy"},
+		{"x/.. ", "tree-policy"},
+		{"..::$INDEX_ALLOCATION", "tree-policy"},
+		{".\u200c./inner.txt", "tree-policy"},
+		{"x/.\u200c.", "tree-policy"},
+		{"tab\tname", "tree-policy"},
+		{"del\x7fname", "tree-policy"},
+		{"a\\.", "tree-policy"},
+		{"a\\..", "tree-policy"},
+		{"trail.", "ordinary"},
+		{"trail ", "ordinary"},
+		{".../inner.txt", "ordinary"},
+		{"....", "ordinary"},
+		{"sub /x", "ordinary"},
+		{".gitattributes ", "ordinary"},
+		{".gitignore ", "ordinary"},
+		{".gitmodules ", "ordinary"},
+		{".mailmap ", "ordinary"},
+		{".GITIGNORE", "ordinary"},
+		{"aux.c", "ordinary"},
+		{"lib/con.go", "ordinary"},
+		{"con c", "ordinary"},
+		{"C:foo", "ordinary"},
+		{"a:b", "ordinary"},
+		{"C:/x", "ordinary"},
+		{`\\srv\share\x`, "ordinary"},
+		{`\??\C:\x`, "ordinary"},
+	}
+
+	for _, ntfs := range []bool{false, true} {
+		for _, hfs := range []bool{false, true} {
+			gitRun(t, dir, "config", "core.protectNTFS", fmt.Sprint(ntfs))
+			gitRun(t, dir, "config", "core.protectHFS", fmt.Sprint(hfs))
+			fs := newWorktreeFilesystem(memfs.New(), ntfs, hfs)
+
+			for _, tc := range cases {
+				t.Run(fmt.Sprintf("%q/ntfs=%t/hfs=%t", tc.name, ntfs, hfs), func(t *testing.T) {
+					gitRun(t, dir, "read-tree", "--empty")
+					cmd := gitenv.CommandContext(t.Context(), "git", "-C", dir, "update-index", "--add", "--cacheinfo", "100644", blob, tc.name)
+					_, _ = cmd.CombinedOutput()
+					indexed := gitRun(t, dir, "ls-files", "-z")
+
+					gitAccepts := tc.rule != "literal" &&
+						(!ntfs || (tc.rule != "ntfs" && tc.rule != "shortname" && tc.rule != "backslash")) &&
+						(!hfs || tc.rule != "hfs")
+					require.Equal(t, gitAccepts, indexed == tc.name+"\x00", "Git index: %q", indexed)
+
+					worktreeAccepts := gitAccepts && tc.rule != "tree-policy" &&
+						tc.rule != "backslash" && tc.rule != "shortname"
+					require.Equal(t, worktreeAccepts, fs.validPath(tc.name) == nil)
+					require.Equal(t, worktreeAccepts, fs.validWritePath(tc.name) == nil)
+					require.Equal(t, tc.rule == "ordinary", pathutil.ValidTreePath(tc.name) == nil)
+				})
+			}
+		}
+	}
+}
+
+// TestPlainClonePOSIXPathPolicy takes each name through a real git
+// commit and then clones it with both implementations. Reference git
+// always materialises the file; go-git clones the ordinary names and
+// refuses the ones ValidTreePath rejects, which also stops tree
+// iteration at the offending entry.
+func TestPlainClonePOSIXPathPolicy(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("POSIX filenames and Linux config defaults")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required")
+	}
+
+	tests := []struct {
+		name     string
+		rejected bool
+	}{
+		{"trail.", false},
+		{"trail ", false},
+		{".../inner.txt", false},
+		{". /inner.txt", false},
+		{".\u200c/inner.txt", false},
+		{"aux.c", false},
+		{"lib/con.go", false},
+		{"a:b.txt", false},
+		{".gitattributes ", false},
+		{"gi7eba~1", false},
+		{".. ", true},
+		{"..:x", true},
+		{".. .", true},
+		{"x/.. ", true},
+		{"..::$INDEX_ALLOCATION", true},
+		{".\u200c./inner.txt", true},
+		{"x/.\u200c.", true},
+		{"tab\tname", true},
+		{"del\x7fname", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			source := filepath.Join(root, "source")
+			require.NoError(t, os.Mkdir(source, 0o755))
+			gitRun(t, source, "init", "-q")
+
+			p := filepath.Join(source, tc.name)
+			require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+			require.NoError(t, os.WriteFile(p, []byte("payload"), 0o644))
+			gitRun(t, source, "add", "--all")
+			require.Equal(t, tc.name+"\x00", gitRun(t, source, "ls-files", "-z"))
+			gitRun(t, source, "commit", "-qm", "fixture")
+
+			oracle := filepath.Join(root, "git-clone")
+			gitRun(t, source, "clone", "-q", source, oracle)
+			content, err := os.ReadFile(filepath.Join(oracle, tc.name))
+			require.NoError(t, err)
+			require.Equal(t, "payload", string(content))
+
+			r, err := PlainOpen(source)
+			require.NoError(t, err)
+			head, err := r.Head()
+			require.NoError(t, err)
+			commit, err := r.CommitObject(head.Hash())
+			require.NoError(t, err)
+			tree, err := commit.Tree()
+			require.NoError(t, err)
+
+			iter := tree.Files()
+			defer iter.Close()
+			file, walkErr := iter.Next()
+
+			clone := filepath.Join(root, "go-clone")
+			_, cloneErr := PlainClone(clone, &CloneOptions{URL: source})
+
+			if tc.rejected {
+				// This single-offender fixture yields nothing. A mixed
+				// tree may yield the files preceding the offender; full
+				// iteration stays unavailable either way.
+				require.Nil(t, file)
+				require.Error(t, walkErr)
+				require.NotErrorIs(t, walkErr, io.EOF)
+				require.Error(t, cloneErr)
+				return
+			}
+
+			require.NoError(t, walkErr)
+			require.Equal(t, tc.name, file.Name)
+			_, err = iter.Next()
+			require.ErrorIs(t, err, io.EOF)
+
+			require.NoError(t, cloneErr)
+			content, err = os.ReadFile(filepath.Join(clone, tc.name))
+			require.NoError(t, err)
+			require.Equal(t, "payload", string(content))
 		})
 	}
 }
@@ -1301,6 +1522,65 @@ func TestResetAcceptsLegitPaths(t *testing.T) {
 	}
 }
 
+// TestCheckoutMaterialisesPOSIXTrailingNames drives a checkout of the
+// names the Win32 component rules refuse and the host gate now
+// allows. Off Windows every one has to reach the filesystem with its
+// contents intact: they are ordinary POSIX filenames that C Git
+// checks out, and refusing them made a repository containing aux.c
+// or ".gitattributes " unusable.
+func TestCheckoutMaterialisesPOSIXTrailingNames(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX contract")
+	}
+
+	paths := []string{
+		"trail.", "trail ", ".../inner.txt", ". /inner.txt",
+		".\u200c/inner.txt", "aux.c", "a:b.txt", ".gitattributes ",
+		"gi7eba~1",
+	}
+
+	fs := memfs.New()
+	s := memory.NewStorage()
+	r, err := Init(s, WithWorkTree(fs))
+	require.NoError(t, err)
+
+	blob := writeBlob(t, s, []byte("payload"))
+
+	var entries []object.TreeEntry
+	for _, p := range paths {
+		parent, child, nested := strings.Cut(p, "/")
+		if !nested {
+			entries = append(entries, object.TreeEntry{Name: p, Mode: filemode.Regular, Hash: blob})
+			continue
+		}
+		subtree := storeRawTree(t, s, []object.TreeEntry{
+			{Name: child, Mode: filemode.Regular, Hash: blob},
+		})
+		entries = append(entries, object.TreeEntry{Name: parent, Mode: filemode.Dir, Hash: subtree})
+	}
+	sort.Sort(object.TreeEntrySorter(entries))
+
+	sig := defaultSignature()
+	commit := storeCommit(t, s, &object.Commit{
+		Author:    *sig,
+		Committer: *sig,
+		Message:   "fixture\n",
+		TreeHash:  storeRawTree(t, s, entries),
+	})
+
+	w, err := r.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, w.Checkout(&CheckoutOptions{Hash: commit, Force: true}))
+
+	for _, p := range paths {
+		body, err := util.ReadFile(fs, p)
+		require.NoError(t, err, "path %q should exist after Checkout", p)
+		require.Equal(t, "payload", string(body), "path %q", p)
+	}
+}
+
 // TestForceCheckoutRejectsDangerousPaths pins that a Force checkout
 // (Checkout{Force:true}) and its underlying HardReset refuse to
 // materialise attacker-shaped tree entries into the worktree.
@@ -1739,60 +2019,184 @@ func TestWorktreeOperationsSurviveDotGitDisguises(t *testing.T) {
 	}
 }
 
-func TestValidPathProtectNTFS(t *testing.T) {
+// TestValidPathAcceptsPOSIXNamesOffWindows pins the other half of the
+// host gate. Every name here is an ordinary filename that C Git
+// carries, so validPath has to accept it off Windows however
+// core.protectNTFS is set. On a Win32 host the win32 rows become
+// refusals under core.protectNTFS, and the volume rows are refused by
+// the host alone, whatever the setting.
+func TestValidPathAcceptsPOSIXNamesOffWindows(t *testing.T) {
 	t.Parallel()
 
-	fs := newWorktreeFilesystem(memfs.New(), true, false)
-
 	tests := []struct {
-		path    string
-		wantErr bool
+		path string
+		// win32 marks a name only the Win32 component rules refuse;
+		// volume one carrying a Windows volume prefix.
+		win32, volume bool
 	}{
-		{".git . . .", true},
-		{".git . . ", true},
-		{".git ", true},
-		{".git.", true},
-		{".git::$INDEX_ALLOCATION", true},
-		{"CON", true},
-		{"aux.txt", true},
-		{"sub/NUL", true},
-		{"sub/COM1.txt", true},
-		{"CONIN$", true},
-		{"foo ", true},
-		{"foo.", true},
-		{"sub /x", true},
-		{".gitattributes ", true},
-		{".gitignore ", true},
-		{"...", true},
-		{"....", true},
-		{"a..b", false},
-		{"foo", false},
-		{"readme.md", false},
-		{".gitignore", false},
-		{"CONNECT", false},
-	}
-
-	if runtime.GOOS == "windows" {
-		// filepath.VolumeName only parses volume names on Windows.
-		tests = append(tests, []struct {
-			path    string
-			wantErr bool
-		}{
-			{"\\\\a\\b", true},
-			{"C:\\a\\b", true},
-		}...)
+		{"trail.", true, false},
+		{"trail ", true, false},
+		{".../inner.txt", true, false},
+		{"sub /x", true, false},
+		{". /inner.txt", true, false},
+		{".\u200c/inner.txt", false, false},
+		{".gitattributes ", true, false},
+		{".gitignore ", true, false},
+		{".mailmap ", true, false},
+		{"gi7eba~1", false, false},
+		{"aux.c", true, false},
+		{"lib/con.go", true, false},
+		{"C:foo", false, true},
+		{"a:b", false, true},
+		{"C:/x", false, true},
+		{`\\srv\share\x`, false, true},
+		{`\??\C:\x`, false, true},
+		{".gitattributes /inner.txt", true, false},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.path, func(t *testing.T) {
-			t.Parallel()
-			err := fs.validPath(tc.path)
-			if tc.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
+		for _, ntfs := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%q/ntfs=%t", tc.path, ntfs), func(t *testing.T) {
+				t.Parallel()
+
+				fs := newWorktreeFilesystem(memfs.New(), ntfs, false)
+				err := fs.validPath(tc.path)
+				if runtime.GOOS == "windows" && (tc.volume || ntfs && tc.win32) {
+					require.Error(t, err)
+					if !tc.volume {
+						require.Contains(t, err.Error(), "core.protectNTFS")
+					}
+					return
+				}
+				require.NoError(t, err)
+			})
+		}
+	}
+}
+
+// TestWorktreeAPISurvivesUntrackedEdgeNames is the counterpart to
+// TestWorktreeOperationsSurviveDotGitDisguises: these names are not
+// disguises, so off Windows the porcelain has to treat them as
+// ordinary untracked files — Status lists them, Clean removes them,
+// and Add takes them by name.
+func TestWorktreeAPISurvivesUntrackedEdgeNames(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX filenames")
+	}
+
+	names := []string{
+		"build ", ". ", ".\u200c", ".gitattributes ", ".gitignore ",
+		".mailmap ", "gi7eba~1", ".GITIGNORE ", "a:b", "aux.c",
+	}
+
+	for _, name := range names {
+		for _, directory := range []bool{false, true} {
+			for _, op := range []string{"Clean", "Status", "AddUnrelated", "AddGlob", "AddAll", "AddName"} {
+				t.Run(fmt.Sprintf("%q/directory=%t/%s", name, directory, op), func(t *testing.T) {
+					t.Parallel()
+
+					fs := memfs.New()
+					r, err := Init(memory.NewStorage(), WithWorkTree(fs))
+					require.NoError(t, err)
+
+					w, err := r.Worktree()
+					require.NoError(t, err)
+
+					p := name
+					if directory {
+						p += "/inner.txt"
+					}
+					require.NoError(t, util.WriteFile(fs, p, []byte("content"), 0o644))
+					require.NoError(t, util.WriteFile(fs, "unrelated.txt", []byte("safe"), 0o644))
+
+					switch op {
+					case "Clean":
+						require.NoError(t, w.Clean(&CleanOptions{Dir: true}))
+						_, err = fs.Lstat(name)
+						require.ErrorIs(t, err, os.ErrNotExist)
+					case "Status":
+						status, err := w.Status()
+						require.NoError(t, err)
+						require.Contains(t, status, p)
+					case "AddUnrelated":
+						_, err = w.Add("unrelated.txt")
+						require.NoError(t, err)
+					case "AddGlob":
+						require.NoError(t, w.AddGlob("."))
+					case "AddAll":
+						require.NoError(t, w.AddWithOptions(&AddOptions{All: true}))
+					case "AddName":
+						_, err = w.Add(name)
+						require.NoError(t, err)
+					}
+				})
 			}
-		})
+		}
+	}
+}
+
+// TestValidPathProtectNTFS runs every row against both hosts. Setting
+// worktreeFilesystem.win32 by hand rather than reading runtime.GOOS is
+// what makes the Win32 half reachable from a POSIX test run: with a
+// runtime.GOOS test in validPath, deleting the Windows policy outright
+// still passes the suite everywhere but Windows.
+func TestValidPathProtectNTFS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		path string
+		// win32 is the verdict on a Win32 host, posix on every other.
+		win32, posix bool
+	}{
+		{".git . . .", true, true},
+		{".git . . ", true, true},
+		{".git ", true, true},
+		{".git.", true, true},
+		{".git::$INDEX_ALLOCATION", true, true},
+		{"CON", true, false},
+		{"aux.txt", true, false},
+		{"sub/NUL", true, false},
+		{"sub/COM1.txt", true, false},
+		{"CONIN$", true, false},
+		{"foo ", true, false},
+		{"foo.", true, false},
+		{"sub /x", true, false},
+		{".gitattributes ", true, false},
+		{".gitignore ", true, false},
+		{"...", true, false},
+		{"....", true, false},
+		// Volume prefixes are a Win32 rule too, and independent of
+		// core.protectNTFS.
+		{"\\\\a\\b", true, false},
+		{"C:\\a\\b", true, false},
+		{"a..b", false, false},
+		{"foo", false, false},
+		{"readme.md", false, false},
+		{".gitignore", false, false},
+		{"CONNECT", false, false},
+	}
+
+	for _, win32 := range []bool{false, true} {
+		for _, tc := range tests {
+			t.Run(fmt.Sprintf("%s/win32=%t", tc.path, win32), func(t *testing.T) {
+				t.Parallel()
+				fs := newWorktreeFilesystem(memfs.New(), true, false)
+				fs.win32 = win32
+				wantErr := tc.posix
+				if win32 {
+					wantErr = tc.win32
+				}
+				err := fs.validPath(tc.path)
+				if wantErr {
+					assert.Error(t, err)
+					assert.ErrorIs(t, err, pathutil.ErrInvalidPath)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
 	}
 }
 

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -1319,7 +1319,7 @@ func storeCommit(t *testing.T, s storer.Storer, commit *object.Commit) plumbing.
 
 // TestResetHardRefusesTreeDerivedDotDotDisguise closes the delete
 // half of checkout and reset. resetWorktreeToTree's first pass takes
-// ch.From.String() straight from diffTrees into rmFileAndDirsIfEmpty,
+// ch.From.String() straight from diffTrees into rmEntryAndDirsIfEmpty,
 // and diffTrees' treeNoder sets TreeWalker.skipPathValidation, so the
 // name never meets pathutil.ValidTreePath. The wrapper's validPath is
 // the only gate, and it must hold with both protections off as well
@@ -1411,6 +1411,89 @@ func TestResetHardRefusesTreeDerivedDotDotDisguise(t *testing.T) {
 			assert.False(t, rec.sawPath(hostile),
 				"the disguise %q must never reach the filesystem; calls=%q",
 				hostile, rec.calls)
+		})
+	}
+}
+
+// TestResetHardHonoursTheRemovedEntryMode drives the two mode-dependent
+// removals through a reset --hard, where resetWorktreeToTree reads the mode
+// from the tree the diff is taken from.
+//
+// Both shapes are ones a user can leave in a worktree: a submodule directory
+// replaced by a file, and a tracked file replaced by a directory. Upstream
+// Git's remove_or_warn refuses each of them and warns, so the reset must
+// leave both in place.
+func TestResetHardHonoursTheRemovedEntryMode(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		mode filemode.FileMode
+		// directory is the shape standing in the worktree at the entry's
+		// path, in place of what mode describes.
+		directory bool
+	}{
+		{name: "file at a gitlink", mode: filemode.Submodule},
+		{name: "directory at a regular entry", mode: filemode.Regular, directory: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const name = "entry"
+
+			s := memory.NewStorage()
+			wt := memfs.New()
+
+			r, err := Init(s, WithWorkTree(wt))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = r.Close() })
+
+			// A gitlink names a commit in another repository, so its
+			// hash need not resolve here. A blob's must.
+			target := plumbing.NewHash("0123456789012345678901234567890123456789")
+			if tc.mode != filemode.Submodule {
+				target = writeBlob(t, s, []byte("tracked\n"))
+			}
+
+			fromTree := storeRawTree(t, s, []object.TreeEntry{
+				{Name: name, Mode: tc.mode, Hash: target},
+			})
+			toTree := storeRawTree(t, s, nil)
+
+			sig := defaultSignature()
+			from := storeCommit(t, s, &object.Commit{
+				Author:    *sig,
+				Committer: *sig,
+				Message:   "carries the entry\n",
+				TreeHash:  fromTree,
+			})
+			to := storeCommit(t, s, &object.Commit{
+				Author:       *sig,
+				Committer:    *sig,
+				Message:      "drops the entry\n",
+				TreeHash:     toTree,
+				ParentHashes: []plumbing.Hash{from},
+			})
+
+			head, err := r.Reference(plumbing.HEAD, false)
+			require.NoError(t, err)
+			require.NoError(t, s.SetReference(
+				plumbing.NewHashReference(head.Target(), from),
+			))
+
+			if tc.directory {
+				require.NoError(t, wt.MkdirAll(name, 0o755))
+			} else {
+				require.NoError(t, util.WriteFile(wt, name, []byte("user data\n"), 0o644))
+			}
+
+			w, err := r.Worktree()
+			require.NoError(t, err)
+			require.NoError(t, w.Reset(&ResetOptions{Mode: HardReset, Commit: to}))
+
+			fi, err := wt.Lstat(name)
+			require.NoError(t, err, "the reset must leave %q in place", name)
+			require.Equal(t, tc.directory, fi.IsDir(), "the reset must not change the shape at %q", name)
 		})
 	}
 }

--- a/worktree_fs_test.go
+++ b/worktree_fs_test.go
@@ -855,6 +855,7 @@ func TestPlainClonePOSIXPathPolicy(t *testing.T) {
 
 			r, err := PlainOpen(source)
 			require.NoError(t, err)
+			t.Cleanup(func() { _ = r.Close() })
 			head, err := r.Head()
 			require.NoError(t, err)
 			commit, err := r.CommitObject(head.Hash())
@@ -867,7 +868,13 @@ func TestPlainClonePOSIXPathPolicy(t *testing.T) {
 			file, walkErr := iter.Next()
 
 			clone := filepath.Join(root, "go-clone")
-			_, cloneErr := PlainClone(clone, &CloneOptions{URL: source})
+			cloned, cloneErr := PlainClone(clone, &CloneOptions{URL: source})
+			// PlainClone returns a non-nil repository alongside some
+			// errors, having closed it already; Close is idempotent,
+			// so the nil guard is the only one needed.
+			if cloned != nil {
+				t.Cleanup(func() { _ = cloned.Close() })
+			}
 
 			if tc.rejected {
 				// This single-offender fixture yields nothing. A mixed
@@ -1348,6 +1355,7 @@ func TestResetHardRefusesTreeDerivedDotDotDisguise(t *testing.T) {
 
 			r, err := Init(s, WithWorkTree(rec))
 			require.NoError(t, err)
+			t.Cleanup(func() { _ = r.Close() })
 
 			if tc.protectNTFS.IsSet() || tc.protectHFS.IsSet() {
 				cfg, err := r.Config()
@@ -1440,6 +1448,7 @@ func TestResetRejectsDotGitPositionShift(t *testing.T) {
 
 						r, err := Init(s, WithWorkTree(rec))
 						require.NoError(t, err)
+						t.Cleanup(func() { _ = r.Close() })
 
 						cfg, err := r.Config()
 						require.NoError(t, err)
@@ -1572,6 +1581,7 @@ func TestCheckoutMaterialisesPOSIXTrailingNames(t *testing.T) {
 	s := memory.NewStorage()
 	r, err := Init(s, WithWorkTree(fs))
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Close() })
 
 	blob := writeBlob(t, s, []byte("payload"))
 
@@ -2000,6 +2010,7 @@ func TestWorktreeOperationsSurviveDotGitDisguises(t *testing.T) {
 					fs := memfs.New()
 					r, err := Init(memory.NewStorage(), WithWorkTree(fs))
 					require.NoError(t, err)
+					t.Cleanup(func() { _ = r.Close() })
 
 					cfg, err := r.Config()
 					require.NoError(t, err)
@@ -2127,6 +2138,7 @@ func TestWorktreeAPISurvivesUntrackedEdgeNames(t *testing.T) {
 					fs := memfs.New()
 					r, err := Init(memory.NewStorage(), WithWorkTree(fs))
 					require.NoError(t, err)
+					t.Cleanup(func() { _ = r.Close() })
 
 					w, err := r.Worktree()
 					require.NoError(t, err)

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -176,7 +176,7 @@ func (w *Worktree) diffStagingWithWorktree(cfg *config.Config, reverse, excludeI
 		fsOpts.IgnoreScope = w.ignoreScope()
 	}
 
-	to := filesystem.NewRootNodeWithOptions(w.filesystem, submodules, fsOpts)
+	to := filesystem.NewRootNodeWithDotGitFilter(w.filesystem, submodules, fsOpts, w.filesystem.isDotGitComponent)
 
 	if reverse {
 		return merkletrie.DiffTree(to, from, diffTreeIsEquals)

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -1,9 +1,11 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -319,5 +321,62 @@ func TestStatusMatchesReferenceGitForIgnoreLayouts(t *testing.T) {
 
 			assert.Equal(t, want, got, "untracked set must match reference git")
 		})
+	}
+}
+
+// TestGitReportsFilteredUntrackedNames documents what reference git
+// does with the names go-git's path gate filters out. Git lists every
+// one of them as untracked and `clean -fdx` removes them, under all
+// four combinations of core.protectNTFS and core.protectHFS — the
+// settings gate what may enter the index, not what Status reports.
+// go-git diverges here: a name its gate refuses is invisible to
+// Status and survives Clean, which
+// TestWorktreeOperationsSurviveDotGitDisguises pins from the other
+// side.
+func TestGitReportsFilteredUntrackedNames(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "linux" {
+		t.Skip("literal POSIX names")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required")
+	}
+
+	names := []string{
+		"git~1", ".GIT", ".git ", ".git.", ".git::$DATA", "GIT~1 ",
+		".git\u200c", "sub/.GIT", "sub/git~1", "sub/.git\u200c",
+	}
+
+	for _, name := range names {
+		for _, directory := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%q/directory=%t", name, directory), func(t *testing.T) {
+				t.Parallel()
+
+				dir := t.TempDir()
+				gitRun(t, dir, "init", "-q")
+
+				p := name
+				if directory {
+					p += "/inner.txt"
+				}
+				require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(dir, p)), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, p), []byte("payload"), 0o644))
+
+				for _, ntfs := range []bool{false, true} {
+					for _, hfs := range []bool{false, true} {
+						gitRun(t, dir, "config", "core.protectNTFS", fmt.Sprint(ntfs))
+						gitRun(t, dir, "config", "core.protectHFS", fmt.Sprint(hfs))
+						require.NotEmpty(t, gitRun(t, dir, "clean", "-fdxn"))
+						reported := gitRun(t, dir, "status", "--porcelain", "-z", "--untracked-files=all")
+						require.Equal(t, "?? "+p+"\x00", reported)
+					}
+				}
+
+				require.Contains(t, gitRun(t, dir, "clean", "-fdx"), "Removing")
+				_, err := os.Stat(filepath.Join(dir, p))
+				require.ErrorIs(t, err, os.ErrNotExist)
+			})
+		}
 	}
 }

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2389,6 +2389,35 @@ func TestRemovalPreservesNonemptyDirectories(t *testing.T) {
 	}
 }
 
+func TestRemovalRefusesDotGitAliases(t *testing.T) {
+	t.Parallel()
+
+	for _, backend := range []string{"memfs", "osfs"} {
+		for _, name := range []string{".git", "a/.git/b", "sub/.GIT", "sub/git~1"} {
+			for _, directory := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/refuse/%q/directory=%t", backend, name, directory), func(t *testing.T) {
+					t.Parallel()
+
+					raw := memfs.New()
+					if backend == "osfs" {
+						raw = osfs.New(t.TempDir())
+					}
+
+					p := name
+					if directory {
+						p += "/inner.txt"
+					}
+					require.NoError(t, util.WriteFile(raw, p, []byte("keep"), 0o644))
+
+					before := snapshotSubtree(t, raw, name)
+					require.Error(t, rmFileAndDirsIfEmpty(newWorktreeFilesystem(raw, true, false), name))
+					require.Equal(t, before, snapshotSubtree(t, raw, name))
+				})
+			}
+		}
+	}
+}
+
 // Git preserves a removed submodule's worktree even when it contains local changes.
 func TestResetPreservesSubmoduleDirectory(t *testing.T) {
 	t.Parallel()

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -27,6 +29,7 @@ import (
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/cache"
 	"github.com/go-git/go-git/v6/plumbing/filemode"
@@ -2297,6 +2300,177 @@ func (s *WorktreeSuite) TestResetSparselyInvalidDir() {
 				return
 			}
 			s.Require().NoError(err)
+		})
+	}
+}
+
+func snapshotSubtree(t *testing.T, fs billy.Filesystem, root string) map[string]string {
+	t.Helper()
+
+	snapshot := map[string]string{}
+
+	var walk func(string)
+	walk = func(p string) {
+		fi, err := fs.Lstat(p)
+		require.NoError(t, err)
+
+		if !fi.IsDir() {
+			data, err := util.ReadFile(fs, p)
+			require.NoError(t, err)
+			snapshot[p] = string(data)
+			return
+		}
+
+		snapshot[p+"/"] = ""
+		children, err := fs.ReadDir(p)
+		require.NoError(t, err)
+		for _, child := range children {
+			walk(path.Join(p, child.Name()))
+		}
+	}
+	walk(root)
+
+	return snapshot
+}
+
+func TestRemovalPreservesNonemptyDirectories(t *testing.T) {
+	t.Parallel()
+
+	for _, backend := range []string{"memfs", "osfs"} {
+		t.Run(backend, func(t *testing.T) {
+			t.Parallel()
+
+			raw := memfs.New()
+			if backend == "osfs" {
+				raw = osfs.New(t.TempDir())
+			}
+			wrapped := newWorktreeFilesystem(raw, true, false)
+
+			for name, content := range map[string]string{
+				"sub/.git":         "gitdir: ../.git/modules/sub\n",
+				"sub/a.txt":        "tracked",
+				"sub/dirty.txt":    "uncommitted",
+				"sub/nested/b.txt": "nested",
+			} {
+				require.NoError(t, util.WriteFile(raw, name, []byte(content), 0o644))
+			}
+
+			expected := map[string]string{
+				"sub/":             "",
+				"sub/.git":         "gitdir: ../.git/modules/sub\n",
+				"sub/a.txt":        "tracked",
+				"sub/dirty.txt":    "uncommitted",
+				"sub/nested/":      "",
+				"sub/nested/b.txt": "nested",
+			}
+			require.Equal(t, expected, snapshotSubtree(t, raw, "sub"))
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "sub"))
+			require.Equal(t, expected, snapshotSubtree(t, raw, "sub"))
+
+			require.NoError(t, util.WriteFile(raw, "p/q/only.txt", []byte("remove"), 0o644))
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "p/q/only.txt"))
+			_, err := raw.Lstat("p")
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			require.NoError(t, raw.MkdirAll("empty", 0o755))
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "empty"))
+			_, err = raw.Lstat("empty")
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "missing"))
+
+			require.NoError(t, util.WriteFile(raw, "tracked.txt/precious", []byte("keep"), 0o644))
+			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "tracked.txt"))
+			require.Equal(t, map[string]string{
+				"tracked.txt/":         "",
+				"tracked.txt/precious": "keep",
+			}, snapshotSubtree(t, raw, "tracked.txt"))
+		})
+	}
+}
+
+// Git preserves a removed submodule's worktree even when it contains local changes.
+func TestResetPreservesSubmoduleDirectory(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required")
+	}
+
+	for _, implementation := range []string{"go-git", "git"} {
+		t.Run(implementation, func(t *testing.T) {
+			t.Parallel()
+
+			gitRun := func(dir string, args ...string) string {
+				t.Helper()
+				overrides := []string{
+					"-c", "protocol.file.allow=always",
+					"-c", "submodule.recurse=false",
+					"-C", dir,
+				}
+				out, err := gitenv.CommandContext(t.Context(), "git", append(overrides, args...)...).CombinedOutput()
+				require.NoError(t, err, "git %q: %s", args, out)
+				return strings.TrimSpace(string(out))
+			}
+
+			root := t.TempDir()
+			source, parent := filepath.Join(root, "source"), filepath.Join(root, "parent")
+			for _, dir := range []string{source, parent} {
+				require.NoError(t, os.Mkdir(dir, 0o755))
+				gitRun(dir, "init", "-q")
+			}
+
+			write := func(dir, name, content string) {
+				t.Helper()
+				p := filepath.Join(dir, filepath.FromSlash(name))
+				require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+				require.NoError(t, os.WriteFile(p, []byte(content), 0o644))
+			}
+
+			write(source, "a.txt", "tracked\n")
+			write(source, "nested/b.txt", "nested\n")
+			gitRun(source, "add", ".")
+			gitRun(source, "commit", "-qm", "source")
+
+			write(parent, "safe.txt", "keep\n")
+			gitRun(parent, "add", ".")
+			gitRun(parent, "commit", "-qm", "base")
+			base := plumbing.NewHash(gitRun(parent, "rev-parse", "HEAD"))
+
+			gitRun(parent, "submodule", "add", "-q", source, "sub")
+			write(parent, "removed.txt", "remove\n")
+			gitRun(parent, "add", ".")
+			gitRun(parent, "commit", "-qm", "submodule")
+
+			write(parent, "sub/a.txt", "dirty tracked\n")
+			write(parent, "sub/dirty.txt", "untracked work\n")
+			write(parent, "sub/nested/extra.txt", "nested untracked\n")
+			require.Equal(t, "true",
+				gitRun(filepath.Join(parent, "sub"), "rev-parse", "--is-inside-work-tree"))
+
+			raw := osfs.New(parent)
+			before := snapshotSubtree(t, raw, "sub")
+			require.Len(t, before, 7)
+
+			r, err := PlainOpen(parent)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, r.Close()) })
+			w, err := r.Worktree()
+			require.NoError(t, err)
+
+			if implementation == "git" {
+				gitRun(parent, "reset", "--hard", base.String())
+			} else {
+				require.NoError(t, w.Reset(&ResetOptions{Mode: HardReset, Commit: base}))
+			}
+
+			require.Equal(t, before, snapshotSubtree(t, raw, "sub"))
+			for _, name := range []string{"removed.txt", ".gitmodules"} {
+				_, err := raw.Lstat(name)
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+			require.Equal(t, base.String(), gitRun(parent, "rev-parse", "HEAD"))
+			require.Equal(t, "safe.txt", gitRun(parent, "ls-files"))
 		})
 	}
 }

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2364,27 +2364,78 @@ func TestRemovalPreservesNonemptyDirectories(t *testing.T) {
 				"sub/nested/b.txt": "nested",
 			}
 			require.Equal(t, expected, snapshotSubtree(t, raw, "sub"))
-			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "sub"))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "sub", filemode.Submodule))
 			require.Equal(t, expected, snapshotSubtree(t, raw, "sub"))
 
 			require.NoError(t, util.WriteFile(raw, "p/q/only.txt", []byte("remove"), 0o644))
-			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "p/q/only.txt"))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "p/q/only.txt", filemode.Regular))
 			_, err := raw.Lstat("p")
 			require.ErrorIs(t, err, os.ErrNotExist)
 
+			// An empty submodule worktree is what rmdir takes.
 			require.NoError(t, raw.MkdirAll("empty", 0o755))
-			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "empty"))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "empty", filemode.Submodule))
 			_, err = raw.Lstat("empty")
 			require.ErrorIs(t, err, os.ErrNotExist)
 
-			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "missing"))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "missing", filemode.Regular))
 
 			require.NoError(t, util.WriteFile(raw, "tracked.txt/precious", []byte("keep"), 0o644))
-			require.NoError(t, rmFileAndDirsIfEmpty(wrapped, "tracked.txt"))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "tracked.txt", filemode.Regular))
 			require.Equal(t, map[string]string{
 				"tracked.txt/":         "",
 				"tracked.txt/precious": "keep",
 			}, snapshotSubtree(t, raw, "tracked.txt"))
+		})
+	}
+}
+
+// TestRemovalHonoursTheEntryMode covers the two worktree shapes that separate
+// the removals: a directory at a regular entry, which unlink refuses, and a
+// file at a gitlink, which rmdir refuses. Upstream Git warns and continues in
+// both places, so both must survive. unknownMode selects neither removal
+// and keeps only what both refuse.
+func TestRemovalHonoursTheEntryMode(t *testing.T) {
+	t.Parallel()
+
+	for _, backend := range []string{"memfs", "osfs"} {
+		t.Run(backend, func(t *testing.T) {
+			t.Parallel()
+
+			raw := memfs.New()
+			if backend == "osfs" {
+				raw = osfs.New(t.TempDir())
+			}
+			wrapped := newWorktreeFilesystem(raw, true, false)
+
+			require.NoError(t, raw.MkdirAll("regular-entry", 0o755))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "regular-entry", filemode.Regular))
+			fi, err := raw.Lstat("regular-entry")
+			require.NoError(t, err, "unlink must not take a directory")
+			require.True(t, fi.IsDir())
+
+			require.NoError(t, util.WriteFile(raw, "gitlink-entry", []byte("keep"), 0o644))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "gitlink-entry", filemode.Submodule))
+			require.Equal(t, map[string]string{
+				"gitlink-entry": "keep",
+			}, snapshotSubtree(t, raw, "gitlink-entry"), "rmdir must not take a file")
+
+			// A symlink is a non-directory, so unlink takes it.
+			require.NoError(t, raw.Symlink("elsewhere", "link"))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "link", filemode.Symlink))
+			_, err = raw.Lstat("link")
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			// Both shapes go without a mode to select a removal.
+			require.NoError(t, raw.MkdirAll("no-mode-dir", 0o755))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "no-mode-dir", unknownMode))
+			_, err = raw.Lstat("no-mode-dir")
+			require.ErrorIs(t, err, os.ErrNotExist)
+
+			require.NoError(t, util.WriteFile(raw, "no-mode-file", []byte("go"), 0o644))
+			require.NoError(t, rmEntryAndDirsIfEmpty(wrapped, "no-mode-file", unknownMode))
+			_, err = raw.Lstat("no-mode-file")
+			require.ErrorIs(t, err, os.ErrNotExist)
 		})
 	}
 }
@@ -2410,7 +2461,7 @@ func TestRemovalRefusesDotGitAliases(t *testing.T) {
 					require.NoError(t, util.WriteFile(raw, p, []byte("keep"), 0o644))
 
 					before := snapshotSubtree(t, raw, name)
-					require.Error(t, rmFileAndDirsIfEmpty(newWorktreeFilesystem(raw, true, false), name))
+					require.Error(t, rmEntryAndDirsIfEmpty(newWorktreeFilesystem(raw, true, false), name, filemode.Regular))
 					require.Equal(t, before, snapshotSubtree(t, raw, name))
 				})
 			}


### PR DESCRIPTION
Extends #2266 by @Sahana2524 (thank you for your contribution, and sorry about the wait! :bow:)

Depends on #2375: nonrecursive removal preserves submodule directories without accessing their metadata files, allowing this change to remove the old exception for nested `.git` paths. Its two commits are temporarily included until that PR lands.

## Summary

Path validation did not consistently account for names that NTFS or HFS+ interprets differently from their spelling. This could let repository paths escape their intended directory or reach Git metadata. This change closes those validation gaps while restoring checkout of ordinary POSIX filenames that were incorrectly subject to Windows restrictions.

## Behaviour changes

- **Validate paths at filesystem operations as well as tree lookup.** Some paths used by worktree operations do not pass through tree validation. Apply the checks there too, including during deletion. Parent directory aliases remain prohibited with optional filesystem protections disabled.
- **Apply Windows filename rules on Windows.** POSIX checkouts now accept names such as `aux.c` and filenames ending in a space or period, following [Git's platform-specific validation](https://github.com/git/git/blob/v2.54.0/git-compat-util.h#L154-L164). Windows gains the missing trailing-space/period checks under `core.protectNTFS`; volume-prefix checks apply regardless of that setting. NTFS metadata protection remains available on every host because a process can access NTFS from another operating system.
- **Use one metadata policy for path validation, `Status` and `Clean`.** Protect `.git` aliases throughout worktree paths and exclude them from traversal and cleanup. These operations must agree on which entries may be repository metadata.

## Compatibility

- **Storage names have stricter rules than tree paths.** Components made entirely of periods are rejected below `.git` because [Windows normalisation treats them differently depending on their position](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#trim-characters). This deliberately rejects some submodule names Git accepts in exchange for consistent metadata lookup across filesystems. Ordinary tree paths retain these names so valid POSIX repositories remain readable.
- **Portable checks can reject names Git accepts locally.** go-git treats both slash styles as separators on every host. Names protected as `.git` aliases are omitted from `Status` and preserved by `Clean`, even where Git treats them as ordinary untracked names.
- **Unsafe submodule paths take precedence over missing fields.** Parsing `.gitmodules` discards such entries rather than retaining them as incomplete configuration. Filesystem module storage also validates names supplied directly by callers.

General nested-repository handling in `Clean` remains a separate issue; a directory preserved by reset can still be affected by a later clean.