### PR TITLE
storage: filesystem/mmap, Unmap each file once

### DIFF
--- a/storage/filesystem/mmap/files.go
+++ b/storage/filesystem/mmap/files.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"sync"
 
 	"github.com/go-git/go-billy/v6"
 	"golang.org/x/sys/unix"
@@ -34,11 +36,18 @@ func mmapFile(f billy.File) ([]byte, func() error, error) {
 		return nil, nil, errors.Join(err, f.Close())
 	}
 
+	// Unmapping is single-shot: a second call must not munmap an address
+	// range that a later mapping may already own.
+	var once sync.Once
 	cleanup := func() error {
-		return errors.Join(
-			unix.Munmap(data),
-			f.Close(),
-		)
+		err := os.ErrClosed
+		once.Do(func() {
+			err = errors.Join(
+				unix.Munmap(data),
+				f.Close(),
+			)
+		})
+		return err
 	}
 
 	return data, cleanup, nil


### PR DESCRIPTION
The cleanup `mmapFile` returns calls `unix.Munmap` every time it runs, so a second `PackScanner.Close` unmaps an address range the process no longer owns. `x/sys/unix` keys its table of live mappings on a pointer into the mapping itself, and the kernel hands a freed address straight back to the next mapping of the same length, so the second call removes a mapping belonging to another scanner. That scanner then reads a torn down range or gets `EINVAL` from its own `Close`.

Run the unmap once and report `os.ErrClosed` afterwards. Callers that close twice still see an error, and the error paths in `NewPackScanner`, which invoke each cleanup on its own, are unaffected.

`TestPackScannerClose` closes twice while `TestNewPackScanner` maps the same fixtures in parallel, which reproduces both outcomes in roughly one run in a hundred:

    go test ./storage/filesystem/mmap/ -count=300 \
        -run 'TestNewPackScanner|TestPackScannerClose'