### PR TITLE
plumbing: packfile, Fix streaming delta base rewinds.

### DIFF
--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -182,6 +182,7 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 						return
 					}
 					baseBuf.Reset(baseRd)
+					basePos = 0
 					discard = offset
 				}
 				for discard > math.MaxInt32 {

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -138,7 +138,11 @@ func ReaderFromDelta(base plumbing.EncodedObject, deltaRC io.Reader) (io.ReadClo
 			_ = dstWr.CloseWithError(ErrInvalidDelta)
 			return
 		}
-		defer func() { _ = baseRd.Close() }()
+		defer func() {
+			if baseRd != nil {
+				_ = baseRd.Close()
+			}
+		}()
 
 		baseBuf := bufio.NewReader(baseRd)
 		basePos := uint(0)

--- a/plumbing/format/packfile/patch_delta_test.go
+++ b/plumbing/format/packfile/patch_delta_test.go
@@ -181,57 +181,20 @@ func TestReaderFromDeltaRejectsOversizedCopies(t *testing.T) {
 		"ReaderFromDelta yielded more bytes than the declared target size")
 }
 
-func TestReaderFromDeltaCopyPositions(t *testing.T) {
+func TestReaderFromDeltaRepeatedRewinds(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name  string
-		delta []byte
-		want  string
-	}{
-		{
-			name: "forward copies",
-			delta: buildDelta(20, 3,
-				encodeCopyOperation(0, 1), encodeCopyOperation(10, 1), encodeCopyOperation(13, 1)),
-			want: "akn",
-		},
-		{
-			name: "rewind to start then copy forward",
-			delta: buildDelta(20, 3,
-				encodeCopyOperation(10, 1), encodeCopyOperation(0, 1), encodeCopyOperation(13, 1)),
-			want: "kan",
-		},
-		{
-			name: "rewind to nonzero offset then copy forward",
-			delta: buildDelta(20, 3,
-				encodeCopyOperation(10, 1), encodeCopyOperation(2, 1), encodeCopyOperation(15, 1)),
-			want: "kcp",
-		},
-		{
-			name: "rewind with multiple byte copies",
-			delta: buildDelta(20, 6,
-				encodeCopyOperation(10, 2), encodeCopyOperation(0, 2), encodeCopyOperation(15, 2)),
-			want: "klabpq",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			base := &plumbing.MemoryObject{}
-			_, err := base.Write([]byte("abcdefghijklmnopqrst"))
-			require.NoError(t, err)
-
-			r, err := ReaderFromDelta(base, bytes.NewReader(tt.delta))
-			require.NoError(t, err)
-			defer func() { require.NoError(t, r.Close()) }()
-
-			got, err := io.ReadAll(r)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, string(got))
-		})
-	}
+	base := &plumbing.MemoryObject{}
+	_, err := base.Write([]byte("abcdefghijklmnopqrst"))
+	require.NoError(t, err)
+	delta := buildDelta(20, 5,
+		encodeCopyOperation(10, 1), encodeCopyOperation(0, 1),
+		encodeCopyOperation(13, 1), encodeCopyOperation(2, 1), encodeCopyOperation(18, 1))
+	r, err := ReaderFromDelta(base, bytes.NewReader(delta))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, r.Close()) }()
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "kancs", string(got))
 }
 
 // TestPatchDeltaRejectsTrailingBytes asserts that a delta whose

--- a/plumbing/format/packfile/patch_delta_test.go
+++ b/plumbing/format/packfile/patch_delta_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"testing"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -263,4 +264,33 @@ func TestPatchDeltaAcceptsEmptyTarget(t *testing.T) {
 	out, err := PatchDelta(src, delta)
 	assert.NoError(t, err)
 	assert.Empty(t, out)
+}
+
+func TestReaderFromDeltaFailedReopen(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		base := &plumbing.MemoryObject{}
+		_, err := base.Write([]byte("abc"))
+		require.NoError(t, err)
+		delta := buildDelta(3, 2, encodeCopyOperation(2, 1), encodeCopyOperation(0, 1))
+		r, err := ReaderFromDelta(&reopenFailureObject{EncodedObject: base}, bytes.NewReader(delta))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, r.Close()) }()
+		got, err := io.ReadAll(r)
+		require.ErrorIs(t, err, ErrInvalidDelta)
+		assert.Equal(t, "c", string(got))
+	})
+}
+
+type reopenFailureObject struct {
+	plumbing.EncodedObject
+	opened bool
+}
+
+func (o *reopenFailureObject) Reader() (io.ReadCloser, error) {
+	if o.opened {
+		return nil, io.ErrClosedPipe
+	}
+	o.opened = true
+	return o.EncodedObject.Reader()
 }

--- a/plumbing/format/packfile/patch_delta_test.go
+++ b/plumbing/format/packfile/patch_delta_test.go
@@ -180,6 +180,59 @@ func TestReaderFromDeltaRejectsOversizedCopies(t *testing.T) {
 		"ReaderFromDelta yielded more bytes than the declared target size")
 }
 
+func TestReaderFromDeltaCopyPositions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		delta []byte
+		want  string
+	}{
+		{
+			name: "forward copies",
+			delta: buildDelta(20, 3,
+				encodeCopyOperation(0, 1), encodeCopyOperation(10, 1), encodeCopyOperation(13, 1)),
+			want: "akn",
+		},
+		{
+			name: "rewind to start then copy forward",
+			delta: buildDelta(20, 3,
+				encodeCopyOperation(10, 1), encodeCopyOperation(0, 1), encodeCopyOperation(13, 1)),
+			want: "kan",
+		},
+		{
+			name: "rewind to nonzero offset then copy forward",
+			delta: buildDelta(20, 3,
+				encodeCopyOperation(10, 1), encodeCopyOperation(2, 1), encodeCopyOperation(15, 1)),
+			want: "kcp",
+		},
+		{
+			name: "rewind with multiple byte copies",
+			delta: buildDelta(20, 6,
+				encodeCopyOperation(10, 2), encodeCopyOperation(0, 2), encodeCopyOperation(15, 2)),
+			want: "klabpq",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := &plumbing.MemoryObject{}
+			_, err := base.Write([]byte("abcdefghijklmnopqrst"))
+			require.NoError(t, err)
+
+			r, err := ReaderFromDelta(base, bytes.NewReader(tt.delta))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, r.Close()) }()
+
+			got, err := io.ReadAll(r)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
 // TestPatchDeltaRejectsTrailingBytes asserts that a delta whose
 // operations exactly fill the declared target size but is followed by
 // extra bytes is rejected, matching upstream's `data != top` post-loop


### PR DESCRIPTION
Fixes #2378.

`ReaderFromDelta` mishandles the base reader when a copy instruction moves backward:

- It reopens the reader at position zero but leaves `basePos` unchanged. Subsequent forward copies can silently select incorrect bytes. Copying one byte at offsets `10`, `0`, and `13` from `abcdefghijklmnopqrst` returns `kac` instead of `kan`.
- If reopening fails and returns a nil reader, deferred cleanup calls `Close` on nil and panics after the decoder reports its error.

Reset `basePos` alongside the reopened reader, and guard deferred cleanup when reopening did not return a reader. This preserves the existing error result and Git's [base-object copy semantics](https://git-scm.com/docs/pack-format#_instruction_to_copy_from_base_object).

One regression covers repeated rewinds to zero and nonzero offsets; a separate test covers failure on the second `Reader` call. The failed-reopen test uses `synctest` so deferred goroutine cleanup completes before the test ends; it reproduces the panic without the guard. The rewind regression fails without the position reset and with an incomplete zero-offset-only reset.

Independent comparisons with reference Git confirm the corrected output for both SHA-1 and SHA-256 packs. Both changes received independent correctness review.

**Validation**

- Full packfile tests with race detection: `go test -race ./plumbing/format/packfile -count=1`
- Focused race tests passed again after consolidating the rewind tests.
- Repository `golangci-lint` checks passed.

**AI assistance:** Codex assisted with the implementation, tests, and independent review.
