### PR TITLE
plumbing: transport/git, Cover receive-pack in the connect test

### DIFF
--- a/plumbing/transport/git/git_test.go
+++ b/plumbing/transport/git/git_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-git/go-git/v6/internal/test/gitenv"
 	"github.com/go-git/go-git/v6/internal/transport/test"
+	"github.com/go-git/go-git/v6/plumbing/format/pktline"
 	"github.com/go-git/go-git/v6/plumbing/protocol"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 )
@@ -115,7 +116,7 @@ func TestGitTransport_Connect(t *testing.T) {
 		command string
 	}{
 		{"UploadPack", "git-upload-pack"},
-		{"ReceivePack", "git-upload-pack"},
+		{"ReceivePack", "git-receive-pack"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -141,10 +142,14 @@ func TestGitTransport_Connect(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, sess)
 
-			buf := make([]byte, 4)
-			n, err := sess.Reader().Read(buf)
+			// A daemon that refuses the command still answers, with an
+			// ERR pkt-line. Reading the first line as a pkt-line is what
+			// tells acceptance from refusal: ReadLine reports an ERR
+			// payload as *pktline.ErrorLine, where counting bytes off the
+			// reader cannot distinguish the two.
+			_, line, err := pktline.ReadLine(sess.Reader())
 			require.NoError(t, err)
-			assert.Greater(t, n, 0, "should read pkt-line data from server")
+			assert.NotEmpty(t, line, "server should advertise refs")
 
 			require.NoError(t, sess.Close())
 		})


### PR DESCRIPTION
`TestGitTransport_Connect` names its two cases `UploadPack` and `ReceivePack`, but both sent `git-upload-pack`, so the receive-pack command was never requested.

Correcting the command alone does not cover it. The daemon answers a refused command with an `ERR` pkt-line, which is data like any other, so reading four bytes and asserting the count is above zero passes either way. With `--enable=receive-pack` dropped from the daemon the case still passed, on:

    003cERR access denied or repository not exported: /basic.git

Read the first pkt-line through `pktline.ReadLine`, which reports an `ERR` payload as `*pktline.ErrorLine`, and assert the payload is not empty. Both cases then distinguish an advertisement from a refusal: dropping `--enable=receive-pack` fails `ReceivePack` and leaves `UploadPack` passing.