### PR TITLE
worktree: status, Preserve re-included files below /**

### DIFF
--- a/plumbing/format/gitignore/matcher.go
+++ b/plumbing/format/gitignore/matcher.go
@@ -25,11 +25,26 @@ type matcher struct {
 }
 
 func (m *matcher) Match(path []string, isDir bool) bool {
+	excluded, _ := m.matchForTraversal(path, isDir)
+	return excluded
+}
+
+func (m *matcher) matchForTraversal(path []string, isDir bool) (bool, bool) {
 	n := len(m.patterns)
 	for i := n - 1; i >= 0; i-- {
-		if match := m.patterns[i].Match(path, isDir); match > NoMatch {
-			return match == Exclude
+		var match MatchResult
+		var canPrune bool
+		if p, ok := m.patterns[i].(*pattern); ok {
+			match, canPrune = p.matchForTraversal(path, isDir)
+		} else {
+			match = m.patterns[i].Match(path, isDir)
+			// Preserve the historical treatment of custom Pattern
+			// implementations, for which no richer match information exists.
+			canPrune = match == Exclude
+		}
+		if match > NoMatch {
+			return match == Exclude, canPrune
 		}
 	}
-	return false
+	return false, false
 }

--- a/plumbing/format/gitignore/pattern.go
+++ b/plumbing/format/gitignore/pattern.go
@@ -77,26 +77,41 @@ func ParsePattern(p string, domain []string) Pattern {
 }
 
 func (p *pattern) Match(path []string, isDir bool) MatchResult {
+	match, _ := p.matchForTraversal(path, isDir)
+	return match
+}
+
+// matchForTraversal also reports whether a matching exclusion makes it safe
+// to prune a directory from a filesystem walk. A trailing /** may match its
+// parent directory only because isDir stands in for the otherwise empty
+// remainder; that match excludes the directory's contents, not the directory
+// itself, so a later pattern may still re-include a child.
+func (p *pattern) matchForTraversal(path []string, isDir bool) (MatchResult, bool) {
 	if len(path) <= len(p.domain) {
-		return NoMatch
+		return NoMatch, false
 	}
 	for i, e := range p.domain {
 		if path[i] != e {
-			return NoMatch
+			return NoMatch, false
 		}
 	}
 
 	path = path[len(p.domain):]
-	if p.isGlob && !p.globMatch(path, isDir) {
-		return NoMatch
-	} else if !p.isGlob && !p.simpleNameMatch(path, isDir) {
-		return NoMatch
+	canPrune := true
+	if p.isGlob {
+		matched, emptyTrailingStar := p.globMatchForTraversal(path, isDir)
+		if !matched {
+			return NoMatch, false
+		}
+		canPrune = !emptyTrailingStar
+	} else if !p.simpleNameMatch(path, isDir) {
+		return NoMatch, false
 	}
 
 	if p.inclusion {
-		return Include
+		return Include, false
 	}
-	return Exclude
+	return Exclude, canPrune
 }
 
 // The wildmatch implementation below ports the matcher from canonical Git's
@@ -491,10 +506,11 @@ func (p *pattern) simpleNameMatch(path []string, isDir bool) bool {
 	return false
 }
 
-func (p *pattern) globMatch(path []string, isDir bool) bool {
+func (p *pattern) globMatchForTraversal(path []string, isDir bool) (bool, bool) {
 	matched := false
 	canTraverse := false
 	trailingStar := false
+	emptyTrailingStar := false
 	for i, pattern := range p.pattern {
 		if pattern == "" {
 			canTraverse = false
@@ -508,7 +524,8 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 				// Assigning matched rather than only raising it stops an
 				// exhausted path from inheriting the previous segment's
 				// result, which would make `a/**/*/**` match `a/f.txt`.
-				matched = len(path) > 0 || isDir
+				emptyTrailingStar = len(path) == 0 && isDir
+				matched = len(path) > 0 || emptyTrailingStar
 				trailingStar = matched
 				break
 			}
@@ -518,7 +535,7 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 		// Note: If pattern contains ** but isn't exactly **, it's treated as a regular wildcard pattern
 		// (e.g., foo** or **bar) and wildmatch will handle it
 		if len(path) == 0 {
-			return false
+			return false, false
 		}
 		if canTraverse {
 			canTraverse = false
@@ -535,12 +552,12 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 					// clearing matched keeps a trailing `**` from reviving
 					// the pattern once the path is exhausted, which would
 					// make `**/bar/**` match directories containing no bar.
-					return false
+					return false, false
 				}
 			}
 		} else {
 			if !wildmatch(pattern, path[0]) {
-				return false
+				return false, false
 			}
 			matched = true
 			path = path[1:]
@@ -554,5 +571,5 @@ func (p *pattern) globMatch(path []string, isDir bool) bool {
 	if matched && p.dirOnly && !isDir && (len(path) == 0 || trailingStar) {
 		matched = false
 	}
-	return matched
+	return matched, matched && emptyTrailingStar
 }

--- a/plumbing/format/gitignore/scope.go
+++ b/plumbing/format/gitignore/scope.go
@@ -56,7 +56,7 @@ func NewScope(base []Pattern) *Scope {
 // when the subdirectory has no ignore file, which callers already know from
 // the directory listing they hold.
 func (s *Scope) Descend(dir []string, readOwn func() ([]Pattern, error)) (*Scope, error) {
-	if s.excluded || s.matches(dir, true) {
+	if s.canPrune(dir) {
 		// Nothing below an excluded directory can change an outcome, so the
 		// pattern set is frozen here and readOwn is never called.
 		return &Scope{patterns: s.patterns, matcher: s.matcher, excluded: true}, nil
@@ -96,6 +96,24 @@ func (s *Scope) Match(path []string, isDir bool) bool {
 		return true
 	}
 	return s.matches(path, isDir)
+}
+
+// canPrune reports whether dir is excluded in a way that makes it safe to
+// omit the entire directory from a filesystem walk. It differs from matching
+// the directory for a pattern ending in /**: such a pattern excludes the
+// contents, but a later pattern may still re-include one of them.
+func (s *Scope) canPrune(dir []string) bool {
+	if s.excluded {
+		return true
+	}
+	if s.matcher == nil {
+		return false
+	}
+	if m, ok := s.matcher.(*matcher); ok {
+		_, canPrune := m.matchForTraversal(dir, true)
+		return canPrune
+	}
+	return s.matcher.Match(dir, true)
 }
 
 // Patterns returns the patterns in effect, ancestors first. The result must

--- a/plumbing/format/gitignore/scope_test.go
+++ b/plumbing/format/gitignore/scope_test.go
@@ -161,6 +161,34 @@ func TestScopeDoesNotReadIgnoreFilesBelowExcluded(t *testing.T) {
 	assert.True(t, deeper.Match([]string{"outer", "ignored", "deep", "any.txt"}, false))
 }
 
+func TestScopeDoesNotExcludeContentsWildcardParent(t *testing.T) {
+	t.Parallel()
+
+	s := NewScope([]Pattern{
+		ParsePattern("volumes/functions/**", nil),
+		ParsePattern("!volumes/functions/deno.json*", nil),
+	})
+
+	assert.True(t, s.Match([]string{"volumes", "functions"}, true),
+		"the public matcher continues to report the directory as matched")
+	contents, err := s.Descend([]string{"volumes", "functions"}, nil)
+	require.NoError(t, err)
+	assert.False(t, contents.Excluded(),
+		"/** excludes contents, so its parent must still be traversed")
+	nested, err := s.Descend([]string{"volumes", "functions", "nested"}, nil)
+	require.NoError(t, err)
+	assert.True(t, nested.Excluded(),
+		"a nested directory is itself part of the excluded contents")
+	assert.False(t, s.Match([]string{"volumes", "functions", "deno.jsonsample"}, false))
+	assert.True(t, s.Match([]string{"volumes", "functions", "otro.txt"}, false))
+
+	dirOnly := NewScope([]Pattern{ParsePattern("volumes/functions/", nil)})
+	excluded, err := dirOnly.Descend([]string{"volumes", "functions"}, nil)
+	require.NoError(t, err)
+	assert.True(t, excluded.Excluded(),
+		"a directory-only rule excludes the directory itself")
+}
+
 // TestScopeDescendReusesParent checks the allocation-free path: a directory
 // that declares no patterns of its own shares its parent's Scope.
 func TestScopeDescendReusesParent(t *testing.T) {

--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -308,7 +308,20 @@ func (n *node) shouldSkipIgnored(name string, isDir bool) bool {
 		return false
 	}
 	childPath := path.Join(n.path, name)
-	if !n.scope.Match(strings.Split(childPath, "/"), isDir) {
+	childComponents := strings.Split(childPath, "/")
+	var ignored bool
+	if isDir {
+		// Descend with no reader cannot fail; the only possible error comes
+		// from reading a child .gitignore.
+		childScope, err := n.scope.Descend(childComponents, nil)
+		if err != nil {
+			return false
+		}
+		ignored = childScope.Excluded()
+	} else {
+		ignored = n.scope.Match(childComponents, false)
+	}
+	if !ignored {
 		return false
 	}
 	// An entry whose own path is in the index is tracked, regardless of

--- a/utils/merkletrie/filesystem/node_ignore_test.go
+++ b/utils/merkletrie/filesystem/node_ignore_test.go
@@ -350,6 +350,29 @@ func TestExcludedParentBeatsNestedNegation(t *testing.T) {
 		"the ignore file itself is untracked and below an excluded directory")
 }
 
+// TestContentsWildcardDoesNotPruneReincludedChild verifies that a trailing
+// /** excludes a directory's contents without excluding the directory itself.
+// The walk must therefore enter the directory so a later pattern can
+// re-include one of its direct children.
+func TestContentsWildcardDoesNotPruneReincludedChild(t *testing.T) {
+	t.Parallel()
+	fs := memfs.New()
+	require.NoError(t, WriteFile(fs, "volumes/functions/deno.jsonsample", []byte("x\n"), 0o644))
+	require.NoError(t, WriteFile(fs, "volumes/functions/otro.txt", []byte("x\n"), 0o644))
+
+	root := NewRootNodeWithOptions(fs, nil, Options{
+		Index: &index.Index{},
+		IgnoreScope: scope(
+			"volumes/functions/**",
+			"!volumes/functions/deno.json*",
+		),
+	})
+
+	names := childNames(t, root, "volumes", "functions")
+	require.Contains(t, names, "deno.jsonsample")
+	require.NotContains(t, names, "otro.txt")
+}
+
 // childNames returns the names of the children of the node reached by
 // following path from root.
 func childNames(t *testing.T, root noder.Noder, path ...string) []string {

--- a/worktree_status_test.go
+++ b/worktree_status_test.go
@@ -269,6 +269,13 @@ func TestStatusMatchesReferenceGitForIgnoreLayouts(t *testing.T) {
 			"foo/bar/baz.txt": "x\n",
 			"foo/other.txt":   "x\n",
 		},
+	}, {
+		name: "contents wildcard permits direct child re-inclusion",
+		files: map[string]string{
+			".gitignore":                        "volumes/functions/**\n!volumes/functions/deno.json*\n",
+			"volumes/functions/deno.jsonsample": "x\n",
+			"volumes/functions/otro.txt":        "x\n",
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
## Summary

Fixes #2369. `Worktree.Status()` prunes `volumes/functions` for a rule ending in `volumes/functions/**`, so a later `!volumes/functions/deno.json*` cannot expose a matching file. Git's trailing `/**` excludes the contents, not the parent itself.

Evaluate built-in ignore patterns against the current entry in `Scope`; excluded ancestors remain handled by `Descend`. This lets the walk reach re-included files without applying a directory's negation to its descendants. For example, with `f/**` and `!f/deno.json*`, a file named `f/deno.jsonsample` is visible, but `f/deno.jsonsample/keep` remains ignored when `deno.jsonsample` is a directory. Earlier explicit exclusions such as `f/` still take effect.

Public `Pattern.Match` and `Matcher.Match` behavior stays unchanged. No filesystem-walker special case is needed.

## Reference behavior

https://git-scm.com/docs/gitignore#_pattern_format documents trailing `/**` and the restriction on re-including files below excluded directories. The regression tests compare complete untracked sets with `git ls-files --others --exclude-standard`, including the reported directory-negation cases and nested `.gitignore` files.

## Validation

On Windows, Go 1.26.5:

- New reference-Git regression cases failed against the previous PR commit and pass with the fix.
- `go test . -run 'TestStatus|TestWorktree.*Status' -count=1`: passed.
- `go test ./utils/merkletrie/filesystem -count=1`: passed.
- `go test ./plumbing/format/gitignore ./utils/merkletrie/filesystem -short -skip 'TestMatcherSuite/TestDir_ReadRelativeGlobalGitIgnore' -count=1`: passed.
- `golangci-lint run`: 0 issues.
- `git diff --check`: passed.

The unfiltered gitignore package run has two failures also reproduced on the unchanged PR commit: `TestDir_ReadRelativeGlobalGitIgnore` on this Windows environment, and `TestIgnoreDoubleStarPrefix` with the installed Git 2.38.1 (the test documents the upstream Git fix in 2.52.0). These are not reported as passing.

Paired runs of [gitignore-conformance](https://github.com/KaizenShogun/gitignore-conformance) at `8d202f238ff3827e6e58bdb39a7cee5285f6317b`, using its adapter with v6 imports and repository cleanup:

- `Status()`: 6,714 file queries across 33 repositories, **5 → 4 divergences compared with `main`**: one existing divergence fixed, with no new regressions. The remaining four `apps/docs/.../generated/.gitkeep` divergences are pre-existing, identical to `main`, and untouched by this PR.
- `ReadPatterns` + `Matcher.Match`: 8,953 queries, **the same 12 divergences before and after** (the same paths, not just the same count).

## AI disclosure

Parts of the implementation and tests were assisted by Codex GPT-5 and GPT-6. The validation results above were obtained by running the tests and paired conformance measurements.
