### PR TITLE
plumbing: transport/http, Bound the media type and redirect parts in refusals

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -51,8 +51,9 @@ func (e *Err) Error() string {
 // redirect target — so it is not read to EOF.
 const maxErrorBodySize = 8 << 10
 
-// maxRedactedComponent caps how long a part of a URL — host, path, query,
-// username — may be and still be rendered. Anything longer is replaced whole.
+// maxRedactedComponent caps how long a part of a URL — scheme, opaque part,
+// host, path, query, username — may be and still be rendered. Anything longer
+// is replaced whole.
 //
 // A URL printed here is often a redirect target, so its length is the server's
 // choice, and net/http accepts 10 MB of response headers by default. Redacting
@@ -244,11 +245,11 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 		// an authentication challenge, so a caller sees one instead of a
 		// redirect target that leaves no base to recover.
 		if strings.HasSuffix(finalPath, "/_signin") {
-			return nil, fmt.Errorf("%w: redirect to %q", transport.ErrAuthenticationRequired, finalPath)
+			return nil, fmt.Errorf("%w: redirect to %q", transport.ErrAuthenticationRequired, bounded(finalPath))
 		}
 		return nil, fmt.Errorf(
 			"http transport: redirect target %q does not end with %s",
-			finalPath, infoRefsPath,
+			bounded(finalPath), infoRefsPath,
 		)
 	}
 	// Cut from the escaped spelling: an index taken there does not fall in the
@@ -262,12 +263,12 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 	}
 
 	if final.Scheme != "http" && final.Scheme != "https" {
-		return nil, fmt.Errorf("http transport: redirect to unsupported scheme %q", final.Scheme)
+		return nil, fmt.Errorf("http transport: redirect to unsupported scheme %q", bounded(final.Scheme))
 	}
 	if final.Scheme != baseURL.Scheme && !schemeUpgrade(baseURL.Scheme, final.Scheme) {
 		return nil, fmt.Errorf(
 			"http transport: redirect changes scheme from %q to %q",
-			baseURL.Scheme, final.Scheme,
+			bounded(baseURL.Scheme), bounded(final.Scheme),
 		)
 	}
 
@@ -280,7 +281,7 @@ func applyRedirect(resp *http.Response, baseURL *url.URL) (*url.URL, error) {
 	if err := setEscapedPath(&redirected, targetPath); err != nil {
 		return nil, fmt.Errorf(
 			"http transport: redirect target %q has an unusable path: %w",
-			finalPath, err,
+			bounded(finalPath), err,
 		)
 	}
 
@@ -580,6 +581,11 @@ func redactURL(u *url.URL) *url.URL {
 		return nil
 	}
 	redacted := *u
+	// A Location's scheme and opaque part are the server's bytes like every
+	// other part, and net/url accepts either at any length, so both are
+	// capped here rather than trusted to be short.
+	redacted.Scheme = bounded(u.Scheme)
+	redacted.Opaque = bounded(u.Opaque)
 	redacted.Host = bounded(u.Host)
 	if path := u.EscapedPath(); len(path) > maxRedactedComponent {
 		redacted.Path, redacted.RawPath = bounded(path), ""

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -281,6 +281,72 @@ func TestApplyRedirect(t *testing.T) {
 	}
 }
 
+// A redirect target's path and scheme are read off a Location header, so a
+// refusal that names them is a string whose length the server chose. The cap
+// every other rendered part goes through has to hold on these branches too.
+func TestApplyRedirectBoundsWhatItRenders(t *testing.T) {
+	t.Parallel()
+
+	oversized := strings.Repeat("a", maxRedactedComponent+1)
+
+	tests := []struct {
+		name     string
+		baseURL  string
+		finalURL string
+		wantErr  string
+	}{
+		{
+			name:     "an oversized path in a tail mismatch is replaced whole",
+			baseURL:  "https://example.com/repo.git",
+			finalURL: "https://evil.com/" + oversized,
+			wantErr:  "does not end with",
+		},
+		{
+			name:     "an oversized path in an azure _signin redirect is replaced whole",
+			baseURL:  "https://dev.azure.com/org/project/_git/repo",
+			finalURL: "https://dev.azure.com/" + oversized + "/_signin",
+			wantErr:  "redirect to",
+		},
+		{
+			name:     "an oversized scheme is replaced whole",
+			baseURL:  "https://example.com/repo.git",
+			finalURL: oversized + "://evil.com/repo.git/info/refs",
+			wantErr:  "unsupported scheme",
+		},
+		{
+			// The base half of this message is the caller's URL rather than
+			// the target's, and it is capped with the other half: one
+			// rendering holds one rule.
+			name:     "an oversized scheme on the base is replaced whole",
+			baseURL:  oversized + "://example.com/repo.git",
+			finalURL: "https://example.com/repo.git/info/refs",
+			wantErr:  "changes scheme",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			base, err := url.Parse(tt.baseURL)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest("GET", tt.finalURL, nil)
+			require.NoError(t, err)
+
+			_, err = applyRedirect(&http.Response{Request: req}, base)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Contains(t, err.Error(), "TRUNCATED",
+				"an oversized part is replaced whole, like every other rendered part")
+			assert.NotContains(t, err.Error(), oversized,
+				"a refusal must not embed a string whose length the server chose")
+			assert.Less(t, len(err.Error()), maxRedactedComponent,
+				"the message must stay the size of a refusal, not the size of its input")
+		})
+	}
+}
+
 // originRelations enumerates the relation this transport applies to decide
 // whether a credential held for one URL may be supplied for a request to
 // another. It is the whole of that rule: every entry point below is checked
@@ -987,6 +1053,20 @@ func TestRedactedURLBoundsWhatItRenders(t *testing.T) {
 			want: "https://TRUNCATED/repo.git",
 		},
 		{
+			// net/url accepts a scheme of any length as long as its
+			// characters are legal, so a Location can carry one this long.
+			name: "an oversized scheme is replaced whole",
+			in:   &url.URL{Scheme: long, Host: "example.com", Path: "/repo.git"},
+			want: "TRUNCATED://example.com/repo.git",
+		},
+		{
+			// An opaque URL keeps its bytes in Opaque rather than in a path,
+			// and String renders that part verbatim.
+			name: "an oversized opaque part is replaced whole",
+			in:   &url.URL{Scheme: "foo", Opaque: long},
+			want: "foo:TRUNCATED",
+		},
+		{
 			name: "an oversized username is replaced whole",
 			in:   &url.URL{Scheme: "https", Host: "example.com", Path: "/repo.git", User: url.User(long)},
 			want: "https://TRUNCATED@example.com/repo.git",
@@ -1026,7 +1106,7 @@ func TestRedactedURLBoundsAHostileLocation(t *testing.T) {
 
 	huge := strings.Repeat("&", 10<<20)
 	u := &url.URL{
-		Scheme:   "https",
+		Scheme:   strings.Repeat("s", 10<<20),
 		Host:     strings.Repeat("h", 10<<20),
 		Path:     "/" + strings.Repeat("p", 10<<20),
 		RawQuery: huge,
@@ -1037,9 +1117,21 @@ func TestRedactedURLBoundsAHostileLocation(t *testing.T) {
 	got := redactedURL(u)
 	assert.Less(t, len(got), 1<<10,
 		"a 50 MB URL must not become a 50 MB error string")
+	assert.NotContains(t, got, "ss")
 	assert.NotContains(t, got, "hh")
 	assert.NotContains(t, got, "pp")
 	assert.NotContains(t, got, "uu")
+
+	// An opaque URL keeps its bytes in Opaque, and String renders that part
+	// where it would otherwise render the host and path, so it is capped on
+	// its own: one rendering holds one rule, but the part it renders is this
+	// one.
+	opaque := &url.URL{Scheme: "https", Opaque: strings.Repeat("o", 10<<20)}
+
+	gotOpaque := redactedURL(opaque)
+	assert.Less(t, len(gotOpaque), 1<<10,
+		"a 10 MB opaque part must not become a 10 MB error string")
+	assert.NotContains(t, gotOpaque, "oo")
 }
 
 // redactedQuery walks the raw query without materialising an element per

--- a/plumbing/transport/http/handshake.go
+++ b/plumbing/transport/http/handshake.go
@@ -333,7 +333,11 @@ func describeInfoRefsError(err error, resp *http.Response, base sessionBase, hea
 		fetched = resp.Request.URL
 	}
 
-	mediaType := contentMediaType(resp.Header.Get("Content-Type"))
+	// The media type comes out of a response header, so its length is the
+	// server's choice; it is capped like every other part of a refusal this
+	// package builds. Gated on the capped value, which is what is rendered,
+	// so the two cannot disagree.
+	mediaType := bounded(contentMediaType(resp.Header.Get("Content-Type")))
 	if mediaType == "text/plain" {
 		return fmt.Errorf("%w: %s served content type %q: %w: %q",
 			transport.ErrInvalidResponse, redactedURL(fetched), mediaType, err,

--- a/plumbing/transport/http/handshake_test.go
+++ b/plumbing/transport/http/handshake_test.go
@@ -829,6 +829,16 @@ func TestHandshakeDumbInfoRefs(t *testing.T) {
 			wantNotMsg:  []string{"nope"},
 		},
 		{
+			// The media type is a response header, so its length is the
+			// server's choice too. It is rendered through bounded() like
+			// every other part of a refusal this package builds.
+			name:        "oversized content type is replaced whole",
+			contentType: strings.Repeat("a", maxRedactedComponent+1),
+			body:        "some body\n",
+			wantInMsg:   []string{`content type "TRUNCATED"`},
+			wantNotMsg:  []string{strings.Repeat("a", maxRedactedComponent+1)},
+		},
+		{
 			name:        "plain text is quoted back",
 			contentType: "text/plain",
 			body:        "repository is archived\n",


### PR DESCRIPTION
An HTTP server chooses the bytes of a `Content-Type` header and of a `Location` header, and both reach error strings this package builds. Three call sites embed them as they arrive:

- `describeInfoRefsError` interpolated the `Content-Type` verbatim (`handshake.go`), so a server could put an arbitrary number of bytes into the message a caller logs.
- `redactURL` bounded `Host`, `Path`, `RawQuery`, `Fragment` and `User`, but not `Scheme` or `Opaque`. `net/url` accepts either at any length, so both were rendered whole.
- `applyRedirect` printed the redirect target's path and both schemes as they arrived, on the tail-mismatch, Azure `/_signin`, unsupported-scheme and scheme-change branches.

Each of those now goes through the `bounded()`/`redactURL()` helpers the package already applies to the rest of a URL, so a refusal stays the size of a refusal rather than the size of its input. The branch that compares the media type to `text/plain` is gated on the capped value, which is the value rendered, so the comparison and the rendering cannot disagree.

The invariant is the one #2252 established for exactly this class of input, so this is a consistency fix rather than a new policy. The change touches no public API and no non-error behaviour.

## Tests

`go test ./plumbing/transport/http/` passes with the change; the package's existing tests are unchanged.

Added coverage, one oversized variant per rendered part:

- an oversized `Content-Type` in the dumb info/refs handshake (`handshake_test.go`),
- an oversized redirect path on both refusal branches, tail mismatch and Azure `/_signin`, plus an oversized scheme on both sides of the scheme comparison (`common_test.go`),
- an oversized `Scheme` and `Opaque` through `redactURL`, and inside the existing hostile-location test at 10 MB each.

All of them fail against the unpatched source and pass with the fix.

## Disclosure

AI-assisted, per AI_POLICY.md, and disclosed in the commit trailer. I ran the checks above and can explain every line during review.

Fixes #2382
